### PR TITLE
Add MCP storage contract split

### DIFF
--- a/Docs/superpowers/plans/2026-05-28-mcp-unified-stage2d-storage-contract-split-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-05-28-mcp-unified-stage2d-storage-contract-split-implementation-plan.md
@@ -1,0 +1,181 @@
+# MCP Unified Stage 2D Storage Contract Split Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add standalone package storage contracts for MCP profile assignments, approval policies, credential grants, external registry entries, and audit events without adding persistence or runtime execution wiring.
+
+**Architecture:** This slice keeps all behavior inside the `mcp_unified` package and existing package-boundary tests. It adds typed Pydantic storage payload models and expands storage protocols so future SQLite and host adapters can implement separate stores instead of overloading `ProfileStore`. No FastAPI routes, `MCPProtocol` enforcement, `MCPServer` behavior, SQLite migrations, external process lifecycle, or gateway entrypoints change.
+
+**Tech Stack:** Python 3.10+, Pydantic v2, pytest, Ruff, Mypy, Bandit, Backlog.md.
+
+---
+
+## Source Design
+
+- Spec: `Docs/superpowers/specs/2026-05-26-mcp-unified-standalone-library-gateway-design.md`
+- Prior slice: `Docs/superpowers/plans/2026-05-27-mcp-unified-stage2c-structured-resolution-implementation-plan.md`
+- Backlog task: `TASK-526`
+
+## Scope
+
+In scope:
+- Add package-local storage payload models for assignments, approval policies, credential grants, external server definitions, and audit events.
+- Expand `mcp_unified.interfaces.storage` with separate protocols for those stores.
+- Export the contracts from `mcp_unified.interfaces`.
+- Add tests proving import isolation, safe defaults, timestamp awareness, profile assignment defaults, credential grant non-secret shape, and protocol exports.
+- Update Backlog task state and verification evidence.
+
+Out of scope:
+- SQLite persistence and migrations.
+- Runtime profile enforcement in `MCPProtocol` or `MCPServer`.
+- FastAPI route changes.
+- MCP Hub/AuthNZ adapter rewiring.
+- External MCP process spawning, stdio lifecycle, or gateway entrypoints.
+
+## Files
+
+- Create: `mcp_unified/storage/__init__.py`
+- Create: `mcp_unified/storage/models.py`
+- Modify: `mcp_unified/interfaces/storage.py`
+- Modify: `mcp_unified/interfaces/__init__.py`
+- Create: `tldw_Server_API/app/core/MCP_unified/tests/test_storage_contracts.py`
+- Modify: `backlog/tasks/task-526 - Implement-MCP-Unified-Stage-2D-storage-contract-split.md`
+
+## Task 1: RED Tests For Split Storage Contracts
+
+**Files:**
+- Create: `tldw_Server_API/app/core/MCP_unified/tests/test_storage_contracts.py`
+
+- [x] **Step 1: Write failing storage-contract tests**
+
+Add tests that assert:
+- `mcp_unified.storage` imports without any `tldw_Server_API` imports.
+- `ProfileAssignment` preserves principal/workspace/default-profile binding fields and starts enabled.
+- `CredentialGrant` stores broker/slot metadata but has no `secret`, `token`, `api_key`, or `value` fields.
+- `ExternalServerDefinition` defaults lifecycle metadata safely without spawning anything.
+- `AuditEvent` timestamps are timezone-aware and payloads are caller-owned copies.
+- `mcp_unified.interfaces.storage` exports `ProfileAssignmentStore`, `ApprovalPolicyStore`, `CredentialGrantStore`, `ExternalRegistryStore`, and `AuditStore`.
+
+- [x] **Step 2: Run RED test**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/mcp-unified-stage2d-runtime-dependencies/.venv/bin/python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_storage_contracts.py -v
+```
+
+Expected: FAIL because `mcp_unified.storage` and the new store protocols do not exist yet.
+
+## Task 2: Add Storage Payload Models
+
+**Files:**
+- Create: `mcp_unified/storage/__init__.py`
+- Create: `mcp_unified/storage/models.py`
+
+- [x] **Step 1: Implement models**
+
+Add Pydantic models:
+- `ProfileAssignment`
+- `ApprovalPolicyDocument`
+- `CredentialGrant`
+- `ExternalServerDefinition`
+- `AuditEvent`
+
+Use aware UTC defaults, safe list/dict defaults, and explicit field names that avoid secret material in credential grants.
+
+- [x] **Step 2: Export models**
+
+Export all five models from `mcp_unified.storage`.
+
+- [x] **Step 3: Run storage model tests**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/mcp-unified-stage2d-runtime-dependencies/.venv/bin/python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_storage_contracts.py -v
+```
+
+Expected: tests still fail until protocol exports are added.
+
+## Task 3: Split Storage Protocols
+
+**Files:**
+- Modify: `mcp_unified/interfaces/storage.py`
+- Modify: `mcp_unified/interfaces/__init__.py`
+
+- [x] **Step 1: Add protocols**
+
+Keep `ProfileStore` unchanged and add:
+- `ProfileAssignmentStore`
+- `ApprovalPolicyStore`
+- `CredentialGrantStore`
+- `ExternalRegistryStore`
+- `AuditStore`
+
+Update the existing sparse external/audit protocols to use the typed models.
+
+- [x] **Step 2: Export protocols**
+
+Update `mcp_unified.interfaces.__init__` to export the new store protocols.
+
+- [x] **Step 3: Run GREEN tests**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/mcp-unified-stage2d-runtime-dependencies/.venv/bin/python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_storage_contracts.py -v
+```
+
+Expected: PASS.
+
+## Task 4: Regression And Quality Gates
+
+**Files:**
+- Modify: `backlog/tasks/task-526 - Implement-MCP-Unified-Stage-2D-storage-contract-split.md`
+
+- [x] **Step 1: Run focused regression tests**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/mcp-unified-stage2d-runtime-dependencies/.venv/bin/python -m pytest \
+  tldw_Server_API/app/core/MCP_unified/tests/test_storage_contracts.py \
+  tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py \
+  tldw_Server_API/app/core/MCP_unified/tests/test_profile_registry_resolver.py \
+  tldw_Server_API/app/core/MCP_unified/tests/test_profile_presets.py \
+  tldw_Server_API/app/core/MCP_unified/tests/test_profile_structured_resolution.py \
+  tldw_Server_API/app/core/MCP_unified/tests/test_extraction_contracts.py \
+  -v
+```
+
+Expected: PASS.
+
+- [x] **Step 2: Run static and security checks**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/mcp-unified-stage2d-runtime-dependencies/.venv/bin/python -m ruff check mcp_unified tldw_Server_API/app/core/MCP_unified/tests/test_storage_contracts.py
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/mcp-unified-stage2d-runtime-dependencies/.venv/bin/python -m mypy mcp_unified tldw_Server_API/app/core/MCP_unified/tests/test_storage_contracts.py
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/mcp-unified-stage2d-runtime-dependencies/.venv/bin/python -m bandit -r mcp_unified -f json -o /tmp/bandit_mcp_unified_stage2d_storage.json
+jq '.metrics._totals, (.results | length)' /tmp/bandit_mcp_unified_stage2d_storage.json
+git diff --check
+```
+
+Expected: Ruff passes, Mypy passes, Bandit reports 0 findings, and diff whitespace is clean.
+
+- [x] **Step 3: Update task and commit**
+
+Record implementation notes, verification, known skips, and final summary in `TASK-526`, then commit:
+
+```bash
+git add \
+  Docs/superpowers/plans/2026-05-28-mcp-unified-stage2d-storage-contract-split-implementation-plan.md \
+  mcp_unified/storage/__init__.py \
+  mcp_unified/storage/models.py \
+  mcp_unified/interfaces/storage.py \
+  mcp_unified/interfaces/__init__.py \
+  tldw_Server_API/app/core/MCP_unified/tests/test_storage_contracts.py \
+  "backlog/tasks/task-526 - Implement-MCP-Unified-Stage-2D-storage-contract-split.md"
+git commit -m "feat: add mcp storage contract split"
+```

--- a/backlog/tasks/task-526 - Implement-MCP-Unified-Stage-2D-storage-contract-split.md
+++ b/backlog/tasks/task-526 - Implement-MCP-Unified-Stage-2D-storage-contract-split.md
@@ -1,0 +1,47 @@
+---
+id: TASK-526
+title: Implement MCP Unified Stage 2D storage contract split
+status: Done
+labels:
+- mcp-unified
+- standalone
+- stage2
+- storage
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Add package-local MCP Unified storage contract primitives for profile assignments, approval policies, credential grants, external server registry entries, and audit events without SQLite persistence, runtime enforcement, FastAPI routes, external process lifecycle, or gateway entrypoints.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Stage 2D implementation plan is added and tied to the standalone MCP design spec.
+- [x] #2 mcp_unified exposes typed storage models and protocols for profile assignments, approval policies, credential grants, external registry entries, and audit events while preserving existing ProfileStore behavior.
+- [x] #3 Package-boundary tests prove storage models/protocols import without tldw_Server_API and preserve safe defaults/copy-friendly payloads.
+- [x] #4 Focused MCP package tests plus Ruff, Mypy, Bandit, and git diff checks pass.
+- [x] #5 No runtime execution, FastAPI route, SQLite persistence, external-server lifecycle, or gateway entrypoint behavior changes are introduced.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Created Stage 2D implementation plan at Docs/superpowers/plans/2026-05-28-mcp-unified-stage2d-storage-contract-split-implementation-plan.md. RED test run failed as expected with missing mcp_unified.storage and missing split store protocols. Added package-local storage models for ProfileAssignment, ApprovalPolicyDocument, CredentialGrant, ExternalServerDefinition, and AuditEvent with aware timestamps, safe list/dict defaults, caller-owned copied payloads, and credential grant metadata that excludes embedded secret fields. Expanded mcp_unified.interfaces.storage with ProfileAssignmentStore, ApprovalPolicyStore, CredentialGrantStore, typed ExternalRegistryStore, and typed AuditStore while preserving ProfileStore. Updated package and host compatibility interface exports. Verification: focused MCP package regression passed with 52 passed, 3 warnings; Ruff passed; Mypy passed with no issues in 14 source files; Bandit over mcp_unified reported 0 findings; git diff --check passed. Draft PR: https://github.com/rmusser01/tldw_server/pull/2085.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Implemented MCP Unified Stage 2D storage contract split in the standalone mcp_unified package. This adds typed storage payload and protocol contracts for future assignment, approval, credential, external registry, and audit stores without changing runtime execution, routes, SQLite persistence, external process lifecycle, or gateway entrypoints.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-527 - Address-PR-2085-MCP-storage-review-feedback.md
+++ b/backlog/tasks/task-527 - Address-PR-2085-MCP-storage-review-feedback.md
@@ -1,0 +1,56 @@
+---
+id: TASK-527
+title: Address PR 2085 MCP storage review feedback
+status: Done
+labels:
+- mcp
+- review-fix
+priority: high
+references:
+- https://github.com/rmusser01/tldw_server/pull/2085
+modified_files:
+- mcp_unified/storage/models.py
+- mcp_unified/interfaces/storage.py
+- tldw_Server_API/app/core/MCP_unified/tests/test_storage_contracts.py
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Fix live Gemini and Qodo review comments on PR #2085 for MCP Unified Stage 2D storage contracts: add storage model cross-field validators, align external-server transport literals with runtime support, preserve external registry list compatibility, and verify focused tests/security checks.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] Profile assignments reject records that do not target a principal, workspace, or default binding.
+- [x] External server definitions only accept runtime-supported transports.
+- [x] Enabled external server definitions enforce transport-specific command/url requirements.
+- [x] External registry protocol preserves the existing no-argument runtime list shape while exposing typed filtered listing separately.
+- [x] Focused tests, lint/type checks, and Bandit verification are recorded.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+- Removed `http` from `ExternalServerDefinition.transport` because the runtime adapter builder only supports `stdio` and `websocket`.
+- Added cross-field Pydantic validators for profile assignment targets and enabled external-server transport fields.
+- Kept disabled external-server definitions able to represent incomplete draft rows, while enabled rows must be runnable.
+- Changed `ExternalRegistryStore.list_servers()` back to the no-argument shape used by `ExternalServerManager.list_servers()` and added `list_server_definitions(*, enabled=None)` for future typed persistence stores.
+- Added regression tests for all live Gemini and Qodo inline comments on PR #2085.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Addressed PR #2085 review feedback for MCP storage contracts. Verification: storage contracts + external server manager tests passed; Ruff and Mypy passed on touched files; Bandit reported 0 findings for mcp_unified/storage and mcp_unified/interfaces.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/mcp_unified/interfaces/__init__.py
+++ b/mcp_unified/interfaces/__init__.py
@@ -18,13 +18,22 @@ from .runtime import (
     RedisClientFactory,
     TelemetryProvider,
 )
-from .storage import AuditStore, ExternalRegistryStore, ProfileStore
+from .storage import (
+    ApprovalPolicyStore,
+    AuditStore,
+    CredentialGrantStore,
+    ExternalRegistryStore,
+    ProfileAssignmentStore,
+    ProfileStore,
+)
 
 __all__ = [
     "ApiKeyScopeNormalizer",
+    "ApprovalPolicyStore",
     "ApprovalEvaluator",
     "AuditStore",
     "CircuitBreakerFactory",
+    "CredentialGrantStore",
     "DatabasePathResolver",
     "EffectivePolicyResolver",
     "ExternalAccessEvaluator",
@@ -33,6 +42,7 @@ __all__ = [
     "MetricsCollector",
     "ModuleRegistry",
     "PathScopeEnforcer",
+    "ProfileAssignmentStore",
     "ProfileStore",
     "RateLimiter",
     "RbacPolicy",

--- a/mcp_unified/interfaces/storage.py
+++ b/mcp_unified/interfaces/storage.py
@@ -2,10 +2,17 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Protocol
+from typing import TYPE_CHECKING, Protocol
 
 if TYPE_CHECKING:
     from mcp_unified.profiles.models import MCPProfile
+    from mcp_unified.storage.models import (
+        ApprovalPolicyDocument,
+        AuditEvent,
+        CredentialGrant,
+        ExternalServerDefinition,
+        ProfileAssignment,
+    )
 
 
 class ProfileStore(Protocol):
@@ -27,13 +34,92 @@ class ProfileStore(Protocol):
     async def delete_profile(self, profile_id: str) -> bool: ...
 
 
+class ProfileAssignmentStore(Protocol):
+    """Store for principal, workspace, and default-profile assignments."""
+
+    async def get_assignment(self, assignment_id: str) -> ProfileAssignment | None: ...
+
+    async def list_assignments(
+        self,
+        *,
+        profile_id: str | None = None,
+        principal_id: str | None = None,
+        workspace_id: str | None = None,
+    ) -> list[ProfileAssignment]: ...
+
+    async def upsert_assignment(
+        self,
+        assignment: ProfileAssignment,
+    ) -> ProfileAssignment: ...
+
+    async def delete_assignment(self, assignment_id: str) -> bool: ...
+
+
+class ApprovalPolicyStore(Protocol):
+    """Store for reusable approval policy documents and profile bindings."""
+
+    async def get_policy(self, policy_id: str) -> ApprovalPolicyDocument | None: ...
+
+    async def list_policies(
+        self,
+        *,
+        profile_id: str | None = None,
+    ) -> list[ApprovalPolicyDocument]: ...
+
+    async def upsert_policy(
+        self,
+        policy: ApprovalPolicyDocument,
+    ) -> ApprovalPolicyDocument: ...
+
+    async def delete_policy(self, policy_id: str) -> bool: ...
+
+
+class CredentialGrantStore(Protocol):
+    """Store for credential broker grant metadata, never secret values."""
+
+    async def get_grant(self, grant_id: str) -> CredentialGrant | None: ...
+
+    async def list_grants(
+        self,
+        *,
+        profile_id: str | None = None,
+        external_server_id: str | None = None,
+    ) -> list[CredentialGrant]: ...
+
+    async def upsert_grant(self, grant: CredentialGrant) -> CredentialGrant: ...
+
+    async def delete_grant(self, grant_id: str) -> bool: ...
+
+
 class ExternalRegistryStore(Protocol):
     """Store for external MCP server registry entries."""
 
-    async def list_servers(self) -> list[dict[str, Any]]: ...
+    async def get_server(self, server_id: str) -> ExternalServerDefinition | None: ...
+
+    async def list_servers(
+        self,
+        *,
+        enabled: bool | None = None,
+    ) -> list[ExternalServerDefinition]: ...
+
+    async def upsert_server(
+        self,
+        server: ExternalServerDefinition,
+    ) -> ExternalServerDefinition: ...
+
+    async def delete_server(self, server_id: str) -> bool: ...
 
 
 class AuditStore(Protocol):
     """Append-only audit sink for MCP policy and tool events."""
 
-    async def append_event(self, event: dict[str, Any]) -> None: ...
+    async def append_event(self, event: AuditEvent) -> AuditEvent: ...
+
+    async def query_events(
+        self,
+        *,
+        actor_id: str | None = None,
+        profile_id: str | None = None,
+        event_type: str | None = None,
+        limit: int | None = None,
+    ) -> list[AuditEvent]: ...

--- a/mcp_unified/interfaces/storage.py
+++ b/mcp_unified/interfaces/storage.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Protocol
+from typing import TYPE_CHECKING, Any, Protocol
 
 if TYPE_CHECKING:
     from mcp_unified.profiles.models import MCPProfile
@@ -92,11 +92,18 @@ class CredentialGrantStore(Protocol):
 
 
 class ExternalRegistryStore(Protocol):
-    """Store for external MCP server registry entries."""
+    """Store for external MCP server registry entries.
+
+    ``list_servers`` preserves the existing host runtime manager shape: no
+    filters and dict-compatible status rows. New typed stores can additionally
+    expose ``list_server_definitions`` for model-based persistence queries.
+    """
 
     async def get_server(self, server_id: str) -> ExternalServerDefinition | None: ...
 
-    async def list_servers(
+    async def list_servers(self) -> list[ExternalServerDefinition] | list[dict[str, Any]]: ...
+
+    async def list_server_definitions(
         self,
         *,
         enabled: bool | None = None,

--- a/mcp_unified/storage/__init__.py
+++ b/mcp_unified/storage/__init__.py
@@ -1,0 +1,17 @@
+"""Storage payload models for MCP Unified standalone stores."""
+
+from .models import (
+    ApprovalPolicyDocument,
+    AuditEvent,
+    CredentialGrant,
+    ExternalServerDefinition,
+    ProfileAssignment,
+)
+
+__all__ = [
+    "ApprovalPolicyDocument",
+    "AuditEvent",
+    "CredentialGrant",
+    "ExternalServerDefinition",
+    "ProfileAssignment",
+]

--- a/mcp_unified/storage/models.py
+++ b/mcp_unified/storage/models.py
@@ -6,7 +6,7 @@ from copy import deepcopy
 from datetime import datetime, timezone
 from typing import Any, Literal
 
-from pydantic import AwareDatetime, BaseModel, ConfigDict, Field, field_validator
+from pydantic import AwareDatetime, BaseModel, ConfigDict, Field, field_validator, model_validator
 
 
 def _utc_now() -> datetime:
@@ -26,6 +26,14 @@ def _copy_list(value: Any) -> list[Any]:
     if value is None:
         return []
     return deepcopy(value)
+
+
+def _normalize_optional_text(value: str | None) -> str | None:
+    """Strip optional text values and treat blank strings as omitted."""
+    if value is None:
+        return None
+    text = value.strip()
+    return text or None
 
 
 class ProfileAssignment(BaseModel):
@@ -49,6 +57,20 @@ class ProfileAssignment(BaseModel):
     def _coerce_mapping(cls, value: Any) -> dict[str, Any]:
         """Treat explicit null mapping fields as omitted safe defaults."""
         return _copy_mapping(value)
+
+    @field_validator("principal_id", "workspace_id", mode="after")
+    @classmethod
+    def _normalize_optional_text(cls, value: str | None) -> str | None:
+        """Treat blank assignment targets as omitted."""
+        return _normalize_optional_text(value)
+
+    @model_validator(mode="after")
+    def _validate_assignment_target(self) -> ProfileAssignment:
+        if not self.principal_id and not self.workspace_id and not self.is_default:
+            raise ValueError(
+                "ProfileAssignment must have principal_id, workspace_id, or is_default set"
+            )
+        return self
 
 
 class ApprovalPolicyDocument(BaseModel):
@@ -117,7 +139,7 @@ class ExternalServerDefinition(BaseModel):
 
     id: str
     name: str
-    transport: Literal["stdio", "websocket", "http"]
+    transport: Literal["stdio", "websocket"]
     command: list[str] = Field(default_factory=list)
     url: str | None = None
     cwd: str | None = None
@@ -141,6 +163,23 @@ class ExternalServerDefinition(BaseModel):
     def _coerce_mapping(cls, value: Any) -> dict[str, Any]:
         """Treat explicit null mapping fields as omitted safe defaults."""
         return _copy_mapping(value)
+
+    @field_validator("url", "cwd", mode="after")
+    @classmethod
+    def _normalize_optional_text(cls, value: str | None) -> str | None:
+        """Treat blank optional transport text fields as omitted."""
+        return _normalize_optional_text(value)
+
+    @model_validator(mode="after")
+    def _validate_transport_fields(self) -> ExternalServerDefinition:
+        self.command = [part.strip() for part in self.command if part.strip()]
+        if not self.enabled:
+            return self
+        if self.transport == "stdio" and not self.command:
+            raise ValueError("stdio transport requires a non-empty command")
+        if self.transport == "websocket" and not self.url:
+            raise ValueError("websocket transport requires a non-empty url")
+        return self
 
 
 class AuditEvent(BaseModel):

--- a/mcp_unified/storage/models.py
+++ b/mcp_unified/storage/models.py
@@ -1,0 +1,165 @@
+"""Storage payload models for standalone MCP stores."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from datetime import datetime, timezone
+from typing import Any, Literal
+
+from pydantic import AwareDatetime, BaseModel, ConfigDict, Field, field_validator
+
+
+def _utc_now() -> datetime:
+    """Return an aware UTC timestamp for storage payload defaults."""
+    return datetime.now(timezone.utc)
+
+
+def _copy_mapping(value: Any) -> dict[str, Any]:
+    """Return a caller-owned mapping, treating explicit null as an empty mapping."""
+    if value is None:
+        return {}
+    return deepcopy(value)
+
+
+def _copy_list(value: Any) -> list[Any]:
+    """Return a caller-owned list, treating explicit null as an empty list."""
+    if value is None:
+        return []
+    return deepcopy(value)
+
+
+class ProfileAssignment(BaseModel):
+    """Principal/workspace binding for a stored MCP profile."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    id: str
+    profile_id: str
+    principal_id: str | None = None
+    workspace_id: str | None = None
+    is_default: bool = False
+    binding: dict[str, Any] = Field(default_factory=dict)
+    provenance: dict[str, Any] = Field(default_factory=dict)
+    enabled: bool = True
+    created_at: AwareDatetime = Field(default_factory=_utc_now)
+    updated_at: AwareDatetime = Field(default_factory=_utc_now)
+
+    @field_validator("binding", "provenance", mode="before")
+    @classmethod
+    def _coerce_mapping(cls, value: Any) -> dict[str, Any]:
+        """Treat explicit null mapping fields as omitted safe defaults."""
+        return _copy_mapping(value)
+
+
+class ApprovalPolicyDocument(BaseModel):
+    """Reusable approval policy document for profile-bound actions."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    id: str
+    name: str
+    profile_id: str | None = None
+    required_for: list[str] = Field(default_factory=list)
+    rules: list[dict[str, Any]] = Field(default_factory=list)
+    metadata: dict[str, Any] = Field(default_factory=dict)
+    provenance: dict[str, Any] = Field(default_factory=dict)
+    enabled: bool = True
+    created_at: AwareDatetime = Field(default_factory=_utc_now)
+    updated_at: AwareDatetime = Field(default_factory=_utc_now)
+
+    @field_validator("required_for", "rules", mode="before")
+    @classmethod
+    def _coerce_list(cls, value: Any) -> list[Any]:
+        """Treat explicit null list fields as omitted safe defaults."""
+        return _copy_list(value)
+
+    @field_validator("metadata", "provenance", mode="before")
+    @classmethod
+    def _coerce_mapping(cls, value: Any) -> dict[str, Any]:
+        """Treat explicit null mapping fields as omitted safe defaults."""
+        return _copy_mapping(value)
+
+
+class CredentialGrant(BaseModel):
+    """Credential broker grant metadata without embedded secret material."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    id: str
+    profile_id: str
+    broker_id: str
+    credential_slot: str
+    external_server_id: str | None = None
+    scopes: list[str] = Field(default_factory=list)
+    metadata: dict[str, Any] = Field(default_factory=dict)
+    provenance: dict[str, Any] = Field(default_factory=dict)
+    enabled: bool = True
+    created_at: AwareDatetime = Field(default_factory=_utc_now)
+    updated_at: AwareDatetime = Field(default_factory=_utc_now)
+
+    @field_validator("scopes", mode="before")
+    @classmethod
+    def _coerce_list(cls, value: Any) -> list[Any]:
+        """Treat explicit null list fields as omitted safe defaults."""
+        return _copy_list(value)
+
+    @field_validator("metadata", "provenance", mode="before")
+    @classmethod
+    def _coerce_mapping(cls, value: Any) -> dict[str, Any]:
+        """Treat explicit null mapping fields as omitted safe defaults."""
+        return _copy_mapping(value)
+
+
+class ExternalServerDefinition(BaseModel):
+    """Stored definition for a configured upstream MCP server."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    id: str
+    name: str
+    transport: Literal["stdio", "websocket", "http"]
+    command: list[str] = Field(default_factory=list)
+    url: str | None = None
+    cwd: str | None = None
+    env_allowlist: list[str] = Field(default_factory=list)
+    credential_slots: list[str] = Field(default_factory=list)
+    metadata: dict[str, Any] = Field(default_factory=dict)
+    provenance: dict[str, Any] = Field(default_factory=dict)
+    enabled: bool = True
+    auto_start: bool = False
+    created_at: AwareDatetime = Field(default_factory=_utc_now)
+    updated_at: AwareDatetime = Field(default_factory=_utc_now)
+
+    @field_validator("command", "env_allowlist", "credential_slots", mode="before")
+    @classmethod
+    def _coerce_list(cls, value: Any) -> list[Any]:
+        """Treat explicit null list fields as omitted safe defaults."""
+        return _copy_list(value)
+
+    @field_validator("metadata", "provenance", mode="before")
+    @classmethod
+    def _coerce_mapping(cls, value: Any) -> dict[str, Any]:
+        """Treat explicit null mapping fields as omitted safe defaults."""
+        return _copy_mapping(value)
+
+
+class AuditEvent(BaseModel):
+    """Append-only audit event payload for MCP policy and tool activity."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    id: str
+    event_type: str
+    actor_id: str | None = None
+    profile_id: str | None = None
+    target_type: str | None = None
+    target_id: str | None = None
+    payload: dict[str, Any] = Field(default_factory=dict)
+    provenance: dict[str, Any] = Field(default_factory=dict)
+    created_at: AwareDatetime = Field(default_factory=_utc_now)
+
+    @field_validator("payload", "provenance", mode="before")
+    @classmethod
+    def _coerce_mapping(cls, value: Any) -> dict[str, Any]:
+        """Treat explicit null mapping fields as omitted safe defaults."""
+        return _copy_mapping(value)

--- a/tldw_Server_API/app/core/MCP_unified/interfaces/__init__.py
+++ b/tldw_Server_API/app/core/MCP_unified/interfaces/__init__.py
@@ -2,9 +2,11 @@
 
 from mcp_unified.interfaces import (
     ApiKeyScopeNormalizer,
+    ApprovalPolicyStore,
     ApprovalEvaluator,
     AuditStore,
     CircuitBreakerFactory,
+    CredentialGrantStore,
     DatabasePathResolver,
     EffectivePolicyResolver,
     ExternalAccessEvaluator,
@@ -13,6 +15,7 @@ from mcp_unified.interfaces import (
     MetricsCollector,
     ModuleRegistry,
     PathScopeEnforcer,
+    ProfileAssignmentStore,
     ProfileStore,
     RateLimiter,
     RbacPolicy,
@@ -22,9 +25,11 @@ from mcp_unified.interfaces import (
 
 __all__ = [
     "ApiKeyScopeNormalizer",
+    "ApprovalPolicyStore",
     "ApprovalEvaluator",
     "AuditStore",
     "CircuitBreakerFactory",
+    "CredentialGrantStore",
     "DatabasePathResolver",
     "EffectivePolicyResolver",
     "ExternalAccessEvaluator",
@@ -33,6 +38,7 @@ __all__ = [
     "MetricsCollector",
     "ModuleRegistry",
     "PathScopeEnforcer",
+    "ProfileAssignmentStore",
     "ProfileStore",
     "RateLimiter",
     "RbacPolicy",

--- a/tldw_Server_API/app/core/MCP_unified/interfaces/storage.py
+++ b/tldw_Server_API/app/core/MCP_unified/interfaces/storage.py
@@ -1,5 +1,19 @@
 """Compatibility re-exports for MCP Unified storage interfaces."""
 
-from mcp_unified.interfaces.storage import AuditStore, ExternalRegistryStore, ProfileStore
+from mcp_unified.interfaces.storage import (
+    ApprovalPolicyStore,
+    AuditStore,
+    CredentialGrantStore,
+    ExternalRegistryStore,
+    ProfileAssignmentStore,
+    ProfileStore,
+)
 
-__all__ = ["AuditStore", "ExternalRegistryStore", "ProfileStore"]
+__all__ = [
+    "ApprovalPolicyStore",
+    "AuditStore",
+    "CredentialGrantStore",
+    "ExternalRegistryStore",
+    "ProfileAssignmentStore",
+    "ProfileStore",
+]

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_storage_contracts.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_storage_contracts.py
@@ -1,0 +1,135 @@
+"""Tests for standalone MCP storage contract primitives."""
+
+from __future__ import annotations
+
+import ast
+import importlib
+from pathlib import Path
+from typing import Any
+
+
+def _tldw_imports_for(path: Path) -> list[str]:
+    """Return imports from a Python file that cross into the host package."""
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    imports: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imports.extend(
+                alias.name
+                for alias in node.names
+                if alias.name == "tldw_Server_API"
+                or alias.name.startswith("tldw_Server_API.")
+            )
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            if node.module == "tldw_Server_API" or node.module.startswith("tldw_Server_API."):
+                imports.append(node.module)
+    return imports
+
+
+def test_storage_package_has_no_tldw_server_imports() -> None:
+    storage = importlib.import_module("mcp_unified.storage")
+    assert storage.__file__ is not None
+    storage_root = Path(storage.__file__).resolve().parent
+    offenders: dict[str, list[str]] = {}
+    for path in storage_root.rglob("*.py"):
+        imports = _tldw_imports_for(path)
+        if imports:
+            offenders[str(path)] = imports
+    assert offenders == {}
+
+
+def test_profile_assignment_models_gateway_default_and_workspace_binding() -> None:
+    from mcp_unified.storage import ProfileAssignment
+
+    assignment = ProfileAssignment(
+        id="assignment-1",
+        profile_id="backend-engineer",
+        principal_id="user-1",
+        workspace_id="workspace-1",
+        binding={"workspace_id": "workspace-1", "path_scopes": [{"root": "/repo"}]},
+    )
+
+    assert assignment.enabled is True
+    assert assignment.profile_id == "backend-engineer"
+    assert assignment.principal_id == "user-1"
+    assert assignment.workspace_id == "workspace-1"
+    assert assignment.is_default is False
+    assert assignment.binding["workspace_id"] == "workspace-1"
+    assert assignment.created_at.tzinfo is not None
+    assert assignment.updated_at.tzinfo is not None
+
+
+def test_credential_grant_contract_excludes_secret_material_fields() -> None:
+    from mcp_unified.storage import CredentialGrant
+
+    grant = CredentialGrant(
+        id="grant-1",
+        profile_id="deep-researcher",
+        broker_id="host-broker",
+        credential_slot="search_api",
+        scopes=["web.search"],
+    )
+
+    dumped = grant.model_dump()
+    forbidden = {"secret", "token", "api_key", "value", "credential_value"}
+    assert forbidden.isdisjoint(dumped)
+    assert grant.enabled is True
+    assert grant.broker_id == "host-broker"
+    assert grant.credential_slot == "search_api"
+    assert grant.scopes == ["web.search"]
+
+
+def test_external_server_definition_defaults_do_not_start_lifecycle() -> None:
+    from mcp_unified.storage import ExternalServerDefinition
+
+    server = ExternalServerDefinition(
+        id="filesystem",
+        name="Filesystem",
+        transport="stdio",
+        command=["/usr/local/bin/mcp-filesystem"],
+        cwd="/workspace",
+    )
+
+    assert server.enabled is True
+    assert server.auto_start is False
+    assert server.transport == "stdio"
+    assert server.command == ["/usr/local/bin/mcp-filesystem"]
+    assert server.env_allowlist == []
+    assert server.credential_slots == []
+
+
+def test_audit_event_uses_aware_timestamp_and_caller_owned_payload() -> None:
+    from mcp_unified.storage import AuditEvent
+
+    payload: dict[str, Any] = {
+        "tool": "filesystem.write",
+        "args": {"path": "/repo/README.md"},
+    }
+    event = AuditEvent(
+        id="event-1",
+        event_type="tool.denied",
+        actor_id="user-1",
+        payload=payload,
+    )
+
+    payload["args"]["path"] = "/repo/CHANGED.md"
+
+    assert event.created_at.tzinfo is not None
+    assert event.payload["args"]["path"] == "/repo/README.md"
+    assert event.event_type == "tool.denied"
+
+
+def test_storage_interfaces_export_split_store_contracts() -> None:
+    storage = importlib.import_module("mcp_unified.interfaces.storage")
+    interfaces = importlib.import_module("mcp_unified.interfaces")
+
+    for name in (
+        "ProfileStore",
+        "ProfileAssignmentStore",
+        "ApprovalPolicyStore",
+        "CredentialGrantStore",
+        "ExternalRegistryStore",
+        "AuditStore",
+    ):
+        assert hasattr(storage, name)
+        assert getattr(interfaces, name) is getattr(storage, name)

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_storage_contracts.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_storage_contracts.py
@@ -4,8 +4,11 @@ from __future__ import annotations
 
 import ast
 import importlib
+import inspect
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
+
+import pytest
 
 
 def _tldw_imports_for(path: Path) -> list[str]:
@@ -59,6 +62,23 @@ def test_profile_assignment_models_gateway_default_and_workspace_binding() -> No
     assert assignment.updated_at.tzinfo is not None
 
 
+def test_profile_assignment_requires_assignment_target() -> None:
+    from mcp_unified.storage import ProfileAssignment
+
+    with pytest.raises(ValueError, match="principal_id, workspace_id, or is_default"):
+        ProfileAssignment(id="assignment-1", profile_id="backend-engineer")
+
+    default_assignment = ProfileAssignment(
+        id="assignment-2",
+        profile_id="orchestrator",
+        is_default=True,
+    )
+
+    assert default_assignment.is_default is True
+    assert default_assignment.principal_id is None
+    assert default_assignment.workspace_id is None
+
+
 def test_credential_grant_contract_excludes_secret_material_fields() -> None:
     from mcp_unified.storage import CredentialGrant
 
@@ -98,6 +118,68 @@ def test_external_server_definition_defaults_do_not_start_lifecycle() -> None:
     assert server.credential_slots == []
 
 
+def test_external_server_definition_rejects_unsupported_transport() -> None:
+    from mcp_unified.storage import ExternalServerDefinition
+
+    with pytest.raises(ValueError):
+        ExternalServerDefinition(
+            id="unsupported",
+            name="Unsupported",
+            transport=cast(Any, "http"),
+            url="https://example.com/mcp",
+        )
+
+
+def test_external_server_definition_validates_enabled_transport_fields() -> None:
+    from mcp_unified.storage import ExternalServerDefinition
+
+    with pytest.raises(ValueError, match="stdio.*command"):
+        ExternalServerDefinition(
+            id="stdio-empty",
+            name="Empty stdio",
+            transport="stdio",
+            command=["   "],
+        )
+
+    with pytest.raises(ValueError, match="websocket.*url"):
+        ExternalServerDefinition(
+            id="websocket-empty",
+            name="Empty websocket",
+            transport="websocket",
+            url="   ",
+        )
+
+    disabled_draft = ExternalServerDefinition(
+        id="draft",
+        name="Draft",
+        transport="stdio",
+        enabled=False,
+    )
+
+    assert disabled_draft.enabled is False
+    assert disabled_draft.command == []
+
+
+def test_external_server_definition_normalizes_transport_fields() -> None:
+    from mcp_unified.storage import ExternalServerDefinition
+
+    stdio_server = ExternalServerDefinition(
+        id="stdio",
+        name="Stdio",
+        transport="stdio",
+        command=["  /usr/local/bin/mcp  ", "  --verbose  "],
+    )
+    websocket_server = ExternalServerDefinition(
+        id="websocket",
+        name="Websocket",
+        transport="websocket",
+        url="  wss://example.com/mcp  ",
+    )
+
+    assert stdio_server.command == ["/usr/local/bin/mcp", "--verbose"]
+    assert websocket_server.url == "wss://example.com/mcp"
+
+
 def test_audit_event_uses_aware_timestamp_and_caller_owned_payload() -> None:
     from mcp_unified.storage import AuditEvent
 
@@ -133,3 +215,53 @@ def test_storage_interfaces_export_split_store_contracts() -> None:
     ):
         assert hasattr(storage, name)
         assert getattr(interfaces, name) is getattr(storage, name)
+
+
+def test_external_registry_store_list_servers_preserves_runtime_manager_shape() -> None:
+    from mcp_unified.interfaces.storage import ExternalRegistryStore
+
+    from tldw_Server_API.app.core.MCP_unified.external_servers.manager import ExternalServerManager
+
+    assert list(inspect.signature(ExternalRegistryStore.list_servers).parameters) == ["self"]
+    assert list(inspect.signature(ExternalServerManager.list_servers).parameters) == ["self"]
+
+
+def test_external_registry_store_exposes_typed_definition_listing() -> None:
+    from mcp_unified.interfaces.storage import ExternalRegistryStore
+
+    params = inspect.signature(ExternalRegistryStore.list_server_definitions).parameters
+
+    assert list(params) == ["self", "enabled"]
+    assert params["enabled"].kind is inspect.Parameter.KEYWORD_ONLY
+
+
+def test_external_registry_store_accepts_legacy_dict_listing_shape() -> None:
+    from mcp_unified.interfaces.storage import ExternalRegistryStore
+    from mcp_unified.storage import ExternalServerDefinition
+
+    class LegacyRegistryStore:
+        async def get_server(self, server_id: str) -> ExternalServerDefinition | None:
+            return None
+
+        async def list_servers(self) -> list[dict[str, Any]]:
+            return []
+
+        async def list_server_definitions(
+            self,
+            *,
+            enabled: bool | None = None,
+        ) -> list[ExternalServerDefinition]:
+            return []
+
+        async def upsert_server(
+            self,
+            server: ExternalServerDefinition,
+        ) -> ExternalServerDefinition:
+            return server
+
+        async def delete_server(self, server_id: str) -> bool:
+            return False
+
+    store: ExternalRegistryStore = LegacyRegistryStore()
+
+    assert store is not None


### PR DESCRIPTION
## Summary
- Add package-local storage payload models for MCP profile assignments, approval policies, credential grants, external server definitions, and audit events.
- Split storage protocols beyond ProfileStore for future assignment, approval, credential, external registry, and audit stores.
- Preserve runtime behavior: no FastAPI route, MCP execution, SQLite persistence, external process lifecycle, or gateway entrypoint changes.

## Verification
- [x] `python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_storage_contracts.py tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py tldw_Server_API/app/core/MCP_unified/tests/test_profile_registry_resolver.py tldw_Server_API/app/core/MCP_unified/tests/test_profile_presets.py tldw_Server_API/app/core/MCP_unified/tests/test_profile_structured_resolution.py tldw_Server_API/app/core/MCP_unified/tests/test_extraction_contracts.py -q`
- [x] `python -m ruff check mcp_unified tldw_Server_API/app/core/MCP_unified/tests/test_storage_contracts.py`
- [x] `python -m mypy mcp_unified tldw_Server_API/app/core/MCP_unified/tests/test_storage_contracts.py`
- [x] `python -m bandit -r mcp_unified -f json -o /tmp/bandit_mcp_unified_stage2d_storage.json`
- [x] `git diff --check`

## Change summary
Draft PR: human-authored change summary required before this is merge-ready under the AI-generated PR policy.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds typed storage models and splits storage interfaces into dedicated stores in `mcp_unified`, with no runtime or API changes. Aligns with TASK-526 and addresses review feedback in TASK-527 by tightening validations and preserving the host registry API shape.

- **New Features**
  - Added models in `mcp_unified/storage`: `ProfileAssignment`, `ApprovalPolicyDocument`, `CredentialGrant`, `ExternalServerDefinition`, `AuditEvent`.
  - Split store protocols in `mcp_unified.interfaces.storage`: `ProfileAssignmentStore`, `ApprovalPolicyStore`, `CredentialGrantStore`, `ExternalRegistryStore`, `AuditStore` (keeps `ProfileStore`), exported via `mcp_unified.interfaces` with compatibility re-exports and tests for isolation, safe defaults, and protocol exports.

- **Bug Fixes**
  - Added cross-field validators: `ProfileAssignment` requires a principal/workspace/default target; `ExternalServerDefinition` only allows `stdio`/`websocket` and enforces command/url when enabled.
  - Restored `ExternalRegistryStore.list_servers()` to the no-arg host shape and added typed `list_server_definitions(enabled=None)` for filtered listings.
  - Updated tests to cover transport constraints and legacy listing compatibility.

<sup>Written for commit 18198f54bd09c9e9d80f19b2964b2868cf9d113e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2085?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

