### PR TITLE
Flashcards UX Phase 0/1 first-time setup

### DIFF
--- a/apps/packages/ui/src/components/Flashcards/FlashcardsManager.tsx
+++ b/apps/packages/ui/src/components/Flashcards/FlashcardsManager.tsx
@@ -44,10 +44,10 @@ const parseInitialFlashcardsTab = (locationLike: { search?: string; hash?: strin
  * FlashcardsManager contains all the tabs and core flashcard logic.
  * Connection state is handled by FlashcardsWorkspace.
  *
- * Structure: Study | Manage | Create & Import
+ * Structure: Study | Manage | Transfer
  * - Study: Spaced repetition review and cram loops
  * - Manage: Browse, filter, create, edit, bulk operations
- * - Create & Import: manual setup, generation, CSV/APKG import, and export workflows
+ * - Transfer: Import, generate, Study Pack, and export workflows
  * - Scheduler: Deck-level scheduler policy editing and queue visibility
  */
 export const FlashcardsManager: React.FC = () => {
@@ -73,13 +73,7 @@ export const FlashcardsManager: React.FC = () => {
   const { data: initialDecks } = useDecksQuery({
     includeWorkspaceItems: currentStudyIntent?.forceShowWorkspaceItems ?? false
   })
-  const schedulerDisabled = initialDecks !== undefined && initialDecks.length === 0
-  // Reset activeTab if Scheduler tab is unavailable for editing (e.g., arrived via ?tab=scheduler with zero decks)
-  React.useEffect(() => {
-    if (activeTab === "scheduler" && initialDecks !== undefined && initialDecks.length === 0) {
-      setActiveTab("review")
-    }
-  }, [activeTab, initialDecks])
+  const showSchedulerTab = !(initialDecks !== undefined && initialDecks.length === 0)
   const [reviewDeckId, setReviewDeckId] = React.useState<number | null | undefined>(
     currentStudyIntent?.deckId ?? undefined
   )
@@ -163,6 +157,12 @@ export const FlashcardsManager: React.FC = () => {
     }
   }, [applyReviewDeckChange, currentGenerateIntent, currentStudyIntent?.deckId, currentStudyPackIntent, currentTab])
 
+  React.useEffect(() => {
+    if (!showSchedulerTab && activeTab === "scheduler") {
+      setActiveTab("review")
+    }
+  }, [activeTab, showSchedulerTab])
+
   const handleReviewCard = React.useCallback(
     (card: Flashcard) => {
       applyReviewDeckChange(card.deck_id ?? undefined)
@@ -223,30 +223,14 @@ export const FlashcardsManager: React.FC = () => {
   }, [currentStudyIntent?.attemptId, currentStudyIntent?.deckId, currentStudyIntent?.forceShowWorkspaceItems, currentStudyIntent?.quizId, reviewDeckId])
   const canOpenQuizCta = currentStudyIntent?.quizId !== undefined
   const effectiveActiveTab =
-    schedulerDisabled && activeTab === "scheduler" ? "review" : activeTab
+    !showSchedulerTab && activeTab === "scheduler" ? "review" : activeTab
   const effectiveSchedulerDeckId = schedulerDeckHandoff?.deckId ?? schedulerHandoffDeckId
   const effectiveSchedulerHandoffKey =
     schedulerDeckHandoff?.key ?? schedulerHandoffKey
-  const schedulerTabLabel = schedulerDisabled ? (
-    <Tooltip
-      title={t("option:flashcards.schedulerNeedsDeck", {
-        defaultValue: "Create or import a deck to configure scheduling."
-      })}
-    >
-      <span
-        aria-disabled="true"
-        className="cursor-not-allowed text-text-muted"
-      >
-        {t("option:flashcards.tabScheduler", { defaultValue: "Scheduler" })}
-      </span>
-    </Tooltip>
-  ) : (
-    t("option:flashcards.tabScheduler", { defaultValue: "Scheduler" })
-  )
 
   const handleTabChange = React.useCallback(
     (nextTab: string) => {
-      if (nextTab === "scheduler" && schedulerDisabled) return
+      if (nextTab === "scheduler" && !showSchedulerTab) return
 
       if (activeTab === "scheduler" && nextTab !== "scheduler" && schedulerDirty) {
         const shouldDiscard = window.confirm(
@@ -261,7 +245,7 @@ export const FlashcardsManager: React.FC = () => {
 
       setActiveTab(nextTab)
     },
-    [activeTab, schedulerDirty, schedulerDisabled, t]
+    [activeTab, schedulerDirty, showSchedulerTab, t]
   )
 
   return (
@@ -357,7 +341,7 @@ export const FlashcardsManager: React.FC = () => {
           },
           {
             key: "importExport",
-            label: t("option:flashcards.tabCreateImport", { defaultValue: "Create & Import" }),
+            label: t("option:flashcards.tabTransfer", { defaultValue: "Transfer" }),
             children: (
               <ImportExportTab
                 generateIntent={currentGenerateIntent}
@@ -372,19 +356,23 @@ export const FlashcardsManager: React.FC = () => {
             label: t("option:flashcards.tabTemplates", { defaultValue: "Templates" }),
             children: <TemplatesTab />
           },
-          {
-            key: "scheduler",
-            label: schedulerTabLabel,
-            children: schedulerDisabled ? null : (
-              <SchedulerTab
-                isActive={effectiveActiveTab === "scheduler"}
-                initialDeckId={effectiveSchedulerDeckId}
-                initialDeckHandoffKey={effectiveSchedulerHandoffKey}
-                onDirtyChange={setSchedulerDirty}
-                discardSignal={schedulerDiscardSignal}
-              />
-            )
-          }
+          ...(showSchedulerTab
+            ? [
+                {
+                  key: "scheduler",
+                  label: t("option:flashcards.tabScheduler", { defaultValue: "Scheduler" }),
+                  children: (
+                    <SchedulerTab
+                      isActive={effectiveActiveTab === "scheduler"}
+                      initialDeckId={effectiveSchedulerDeckId}
+                      initialDeckHandoffKey={effectiveSchedulerHandoffKey}
+                      onDirtyChange={setSchedulerDirty}
+                      discardSignal={schedulerDiscardSignal}
+                    />
+                  )
+                }
+              ]
+            : [])
         ]}
       />
 

--- a/apps/packages/ui/src/components/Flashcards/FlashcardsManager.tsx
+++ b/apps/packages/ui/src/components/Flashcards/FlashcardsManager.tsx
@@ -5,7 +5,7 @@ import { useTranslation } from "react-i18next"
 import { useLocation, useNavigate } from "react-router-dom"
 import { ReviewTab, ManageTab, ImportExportTab, SchedulerTab, TemplatesTab } from "./tabs"
 import { KeyboardShortcutsModal } from "./components"
-import { useDecksQuery } from "./hooks"
+import { useDecksQuery, type UseFlashcardQueriesOptions } from "./hooks"
 import type { Flashcard } from "@/services/flashcards"
 import { parseFlashcardsGenerateIntentFromLocation } from "@/services/tldw/flashcards-generate-handoff"
 import { parseStudyPackIntentFromLocation } from "@/services/tldw/study-pack-handoff"
@@ -70,9 +70,10 @@ export const FlashcardsManager: React.FC = () => {
   const [activeTab, setActiveTab] = React.useState<string>(() =>
     currentTab ?? (currentGenerateIntent || currentStudyPackIntent ? "importExport" : "review")
   )
-  const { data: initialDecks } = useDecksQuery({
+  const deckVisibilityOptions = React.useMemo<UseFlashcardQueriesOptions>(() => ({
     includeWorkspaceItems: currentStudyIntent?.forceShowWorkspaceItems ?? false
-  })
+  }), [currentStudyIntent?.forceShowWorkspaceItems])
+  const { data: initialDecks } = useDecksQuery(deckVisibilityOptions)
   const showSchedulerTab = initialDecks === undefined || initialDecks.length > 0
   const [reviewDeckId, setReviewDeckId] = React.useState<number | null | undefined>(
     currentStudyIntent?.deckId ?? undefined
@@ -114,6 +115,10 @@ export const FlashcardsManager: React.FC = () => {
     setManageDeckHandoff(null)
     setSchedulerDeckHandoff(null)
     setExportDeckHandoff(null)
+  }, [])
+  const discardSchedulerChanges = React.useCallback(() => {
+    setSchedulerDirty(false)
+    setSchedulerDiscardSignal((current) => current + 1)
   }, [])
   const applyReviewDeckChange = React.useCallback(
     (deckId: number | null | undefined) => {
@@ -159,9 +164,12 @@ export const FlashcardsManager: React.FC = () => {
 
   React.useEffect(() => {
     if (!showSchedulerTab && activeTab === "scheduler") {
+      if (schedulerDirty) {
+        discardSchedulerChanges()
+      }
       setActiveTab("review")
     }
-  }, [activeTab, showSchedulerTab])
+  }, [activeTab, discardSchedulerChanges, schedulerDirty, showSchedulerTab])
 
   const handleReviewCard = React.useCallback(
     (card: Flashcard) => {
@@ -239,13 +247,12 @@ export const FlashcardsManager: React.FC = () => {
           })
         )
         if (!shouldDiscard) return
-        setSchedulerDirty(false)
-        setSchedulerDiscardSignal((current) => current + 1)
+        discardSchedulerChanges()
       }
 
       setActiveTab(nextTab)
     },
-    [activeTab, schedulerDirty, showSchedulerTab, t]
+    [activeTab, discardSchedulerChanges, schedulerDirty, showSchedulerTab, t]
   )
 
   return (
@@ -366,6 +373,7 @@ export const FlashcardsManager: React.FC = () => {
                       isActive={effectiveActiveTab === "scheduler"}
                       initialDeckId={effectiveSchedulerDeckId}
                       initialDeckHandoffKey={effectiveSchedulerHandoffKey}
+                      deckVisibilityOptions={deckVisibilityOptions}
                       onDirtyChange={setSchedulerDirty}
                       discardSignal={schedulerDiscardSignal}
                     />

--- a/apps/packages/ui/src/components/Flashcards/FlashcardsManager.tsx
+++ b/apps/packages/ui/src/components/Flashcards/FlashcardsManager.tsx
@@ -73,7 +73,7 @@ export const FlashcardsManager: React.FC = () => {
   const { data: initialDecks } = useDecksQuery({
     includeWorkspaceItems: currentStudyIntent?.forceShowWorkspaceItems ?? false
   })
-  const showSchedulerTab = !(initialDecks !== undefined && initialDecks.length === 0)
+  const showSchedulerTab = initialDecks === undefined || initialDecks.length > 0
   const [reviewDeckId, setReviewDeckId] = React.useState<number | null | undefined>(
     currentStudyIntent?.deckId ?? undefined
   )

--- a/apps/packages/ui/src/components/Flashcards/FlashcardsWorkspace.tsx
+++ b/apps/packages/ui/src/components/Flashcards/FlashcardsWorkspace.tsx
@@ -43,8 +43,8 @@ const FlashcardsStudyFrame = ({
     },
     {
       key: "importExport",
-      label: t("option:flashcards.tabImportExport", {
-        defaultValue: "Import / Export"
+      label: t("option:flashcards.tabTransfer", {
+        defaultValue: "Transfer"
       })
     },
     {

--- a/apps/packages/ui/src/components/Flashcards/__tests__/FlashcardsManager.consistency.test.tsx
+++ b/apps/packages/ui/src/components/Flashcards/__tests__/FlashcardsManager.consistency.test.tsx
@@ -188,7 +188,7 @@ describe("FlashcardsManager consistency standards", () => {
     )
   })
 
-  it("opens Import / Export tab first when URL contains generate intent", () => {
+  it("opens Transfer tab first when URL contains generate intent", () => {
     window.history.replaceState(
       {},
       "",
@@ -363,36 +363,57 @@ describe("FlashcardsManager consistency standards", () => {
     expect(screen.getByTestId("mock-scheduler-handoff-key")).toHaveTextContent("review:21")
   })
 
-  it("uses Study/Manage/Create & Import/Scheduler tab labels", () => {
+  it("uses Study/Manage/Transfer/Scheduler tab labels", () => {
     window.history.replaceState({}, "", "/flashcards")
     render(<FlashcardsManager />)
 
     expect(screen.getByText("Study")).toBeInTheDocument()
     expect(screen.getByText("Manage")).toBeInTheDocument()
-    expect(screen.getByText("Create & Import")).toBeInTheDocument()
+    expect(screen.getByText("Transfer")).toBeInTheDocument()
     expect(screen.getByText("Templates")).toBeInTheDocument()
     expect(screen.getByText("Scheduler")).toBeInTheDocument()
   })
 
-  it("defaults to Study and keeps Scheduler discoverable when no decks are available", () => {
+  it("defaults empty accounts to Study and keeps transfer available without implying LLM-only import", () => {
     mocks.decks = []
     window.history.replaceState({}, "", "/flashcards")
 
     render(<FlashcardsManager />)
 
     expect(screen.getByTestId("mock-review-tab")).toBeInTheDocument()
-    expect(screen.queryByTestId("mock-transfer-tab")).not.toBeInTheDocument()
+    expect(screen.getByText("Transfer")).toBeInTheDocument()
+    expect(screen.queryByText("LLM")).not.toBeInTheDocument()
     expect(screen.getByText("Templates")).toBeInTheDocument()
-    const schedulerTab = screen.getByRole("tab", { name: /scheduler/i })
-    const schedulerLabel = screen.getByText("Scheduler")
-    expect(schedulerTab).not.toHaveAttribute("aria-disabled", "true")
-    expect(schedulerLabel).toHaveAttribute(
-      "aria-disabled",
-      "true"
-    )
-    fireEvent.click(schedulerTab)
-    expect(screen.getByTestId("mock-review-tab")).toBeInTheDocument()
+    expect(screen.queryByText("Scheduler")).not.toBeInTheDocument()
     expect(screen.queryByTestId("mock-scheduler-tab")).not.toBeInTheDocument()
+  })
+
+  it("still opens Transfer first for explicit generate and study-pack intents", () => {
+    mocks.decks = []
+    window.history.replaceState(
+      {},
+      "",
+      "/flashcards?generate=1&generate_text=Study%20notes"
+    )
+
+    const { unmount } = render(<FlashcardsManager />)
+    expect(screen.getByTestId("mock-transfer-tab")).toBeInTheDocument()
+
+    unmount()
+    const studyPackPayload = encodeURIComponent(
+      JSON.stringify({
+        title: "Lecture 5",
+        sourceItems: [{ sourceType: "media", sourceId: "42" }]
+      })
+    )
+    window.history.replaceState(
+      {},
+      "",
+      `/flashcards?study_pack=1&study_pack_payload=${studyPackPayload}`
+    )
+
+    render(<FlashcardsManager />)
+    expect(screen.getByTestId("mock-transfer-tab")).toBeInTheDocument()
   })
 
   it("routes template deep-links to the Templates tab", () => {
@@ -412,14 +433,8 @@ describe("FlashcardsManager consistency standards", () => {
 
     expect(screen.getByText("Templates")).toBeInTheDocument()
     expect(screen.getByTestId("mock-templates-tab")).toBeInTheDocument()
-    expect(screen.getByRole("tab", { name: /scheduler/i })).not.toHaveAttribute(
-      "aria-disabled",
-      "true"
-    )
-    expect(screen.getByText("Scheduler")).toHaveAttribute(
-      "aria-disabled",
-      "true"
-    )
+    expect(screen.queryByRole("tab", { name: /scheduler/i })).not.toBeInTheDocument()
+    expect(screen.queryByText("Scheduler")).not.toBeInTheDocument()
   })
 
   it("requests workspace decks when study links include workspace items", () => {
@@ -438,21 +453,12 @@ describe("FlashcardsManager consistency standards", () => {
     )
   })
 
-  it("clamps scheduler deep-links to Study when Scheduler is disabled", () => {
+  it("clamps scheduler deep-links to Study when Scheduler is hidden", () => {
     mocks.decks = []
     window.history.replaceState({}, "", "/flashcards?tab=scheduler&deck_id=9")
 
     render(<FlashcardsManager />)
 
-    expect(screen.getByTestId("mock-review-tab")).toBeInTheDocument()
-    expect(screen.queryByTestId("mock-scheduler-tab")).not.toBeInTheDocument()
-    const schedulerTab = screen.getByRole("tab", { name: /scheduler/i })
-    expect(schedulerTab).not.toHaveAttribute("aria-disabled", "true")
-    expect(screen.getByText("Scheduler")).toHaveAttribute(
-      "aria-disabled",
-      "true"
-    )
-    fireEvent.click(schedulerTab)
     expect(screen.getByTestId("mock-review-tab")).toBeInTheDocument()
     expect(screen.queryByTestId("mock-scheduler-tab")).not.toBeInTheDocument()
   })

--- a/apps/packages/ui/src/components/Flashcards/__tests__/FlashcardsManager.consistency.test.tsx
+++ b/apps/packages/ui/src/components/Flashcards/__tests__/FlashcardsManager.consistency.test.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { fireEvent, render, screen } from "@testing-library/react"
+import { fireEvent, render, screen, waitFor } from "@testing-library/react"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 import { FlashcardsManager } from "../FlashcardsManager"
 
@@ -103,6 +103,9 @@ vi.mock("../tabs", () => ({
   SchedulerTab: (props: {
     initialDeckId?: number | null
     initialDeckHandoffKey?: string | null
+    deckVisibilityOptions?: {
+      includeWorkspaceItems?: boolean
+    }
     onDirtyChange?: (dirty: boolean) => void
     discardSignal?: number
   }) => {
@@ -118,6 +121,10 @@ vi.mock("../tabs", () => ({
         Scheduler panel
         <span data-testid="mock-scheduler-initial-deck-id">{String(props.initialDeckId ?? "")}</span>
         <span data-testid="mock-scheduler-handoff-key">{String(props.initialDeckHandoffKey ?? "")}</span>
+        <span data-testid="mock-scheduler-include-workspace">
+          {String(props.deckVisibilityOptions?.includeWorkspaceItems ?? false)}
+        </span>
+        <span data-testid="mock-scheduler-discard-signal">{String(props.discardSignal ?? 0)}</span>
         <span data-testid="mock-scheduler-draft-state">{draftState}</span>
         <button
           onClick={() => {
@@ -222,6 +229,19 @@ describe("FlashcardsManager consistency standards", () => {
     expect(screen.getByTestId("mock-scheduler-tab")).toBeInTheDocument()
     expect(screen.getByTestId("mock-scheduler-initial-deck-id")).toHaveTextContent("9")
     expect(screen.getByTestId("mock-scheduler-handoff-key")).toHaveTextContent("initial-location")
+  })
+
+  it("passes workspace deck visibility to Scheduler for workspace handoffs", () => {
+    window.history.replaceState(
+      {},
+      "",
+      "/flashcards?tab=scheduler&deck_id=9&include_workspace_items=1"
+    )
+
+    render(<FlashcardsManager />)
+
+    expect(screen.getByTestId("mock-scheduler-tab")).toBeInTheDocument()
+    expect(screen.getByTestId("mock-scheduler-include-workspace")).toHaveTextContent("true")
   })
 
   it("refreshes Scheduler handoff identity when the same deck deep-link is requested again", () => {
@@ -518,5 +538,28 @@ describe("FlashcardsManager consistency standards", () => {
     expect(screen.getByTestId("mock-scheduler-draft-state")).toHaveTextContent("clean")
 
     confirmSpy.mockRestore()
+  })
+
+  it("discards scheduler draft state when Scheduler is auto-hidden", async () => {
+    window.history.replaceState({}, "", "/flashcards")
+    const { rerender } = render(<FlashcardsManager />)
+
+    fireEvent.click(screen.getByText("Scheduler"))
+    fireEvent.click(screen.getByText("Mark Scheduler Dirty"))
+    expect(screen.getByTestId("mock-scheduler-draft-state")).toHaveTextContent("dirty")
+
+    mocks.decks = []
+    rerender(<FlashcardsManager />)
+
+    await waitFor(() => {
+      expect(screen.queryByTestId("mock-scheduler-tab")).not.toBeInTheDocument()
+    })
+
+    mocks.decks = [{ id: 1, name: "Biology" }]
+    rerender(<FlashcardsManager />)
+    fireEvent.click(screen.getByText("Scheduler"))
+
+    expect(screen.getByTestId("mock-scheduler-discard-signal")).toHaveTextContent("1")
+    expect(screen.getByTestId("mock-scheduler-draft-state")).toHaveTextContent("clean")
   })
 })

--- a/apps/packages/ui/src/components/Flashcards/__tests__/FlashcardsWorkspace.connection-state.test.tsx
+++ b/apps/packages/ui/src/components/Flashcards/__tests__/FlashcardsWorkspace.connection-state.test.tsx
@@ -154,7 +154,7 @@ describe("FlashcardsWorkspace connection states", () => {
     expect(screen.getByText("Study workspace")).toBeInTheDocument()
 
     const modes = within(screen.getByRole("navigation", { name: "Flashcards modes" }))
-    for (const mode of ["Study", "Manage", "Import / Export", "Templates", "Scheduler"]) {
+    for (const mode of ["Study", "Manage", "Transfer", "Templates", "Scheduler"]) {
       expect(modes.getByText(mode)).toBeInTheDocument()
     }
   })

--- a/apps/packages/ui/src/components/Flashcards/components/StudyPackCreateDrawer.tsx
+++ b/apps/packages/ui/src/components/Flashcards/components/StudyPackCreateDrawer.tsx
@@ -241,10 +241,14 @@ export const StudyPackCreateDrawer: React.FC<StudyPackCreateDrawerProps> = ({
               className="min-w-[120px]"
             />
             <Input
-              aria-label="Source ID"
+              aria-label={t("option:flashcards.studyPackSourceIdAdvancedLabel", {
+                defaultValue: "Source ID (advanced/manual)"
+              })}
               value={sourceId}
               onChange={(event) => setSourceId(event.target.value)}
-              placeholder="Source ID"
+              placeholder={t("option:flashcards.studyPackSourceIdAdvancedPlaceholder", {
+                defaultValue: "Source ID (advanced/manual)"
+              })}
             />
             <Input
               aria-label="Source Title"
@@ -258,12 +262,23 @@ export const StudyPackCreateDrawer: React.FC<StudyPackCreateDrawerProps> = ({
               {t("common:add", { defaultValue: "Add source" })}
             </Button>
           </Space.Compact>
+          <Text
+            type="secondary"
+            className="mt-2 block text-xs"
+            data-testid="study-pack-source-id-guidance"
+          >
+            {t("option:flashcards.studyPackSourceIdGuidance", {
+              defaultValue:
+                "Advanced/manual source reference. Choose Media, Note, or Message, then paste the item ID from that source."
+            })}
+          </Text>
 
           <div className="mt-3 space-y-2">
             {sourceItems.length === 0 ? (
               <Text type="secondary">
                 {t("option:flashcards.studyPackSourcesEmpty", {
-                  defaultValue: "Add at least one supported source to create a study pack."
+                  defaultValue:
+                    "Add at least one supported source: Media, Note, or Message."
                 })}
               </Text>
             ) : (

--- a/apps/packages/ui/src/components/Flashcards/components/__tests__/FlashcardCreateDrawer.image-insert.test.tsx
+++ b/apps/packages/ui/src/components/Flashcards/components/__tests__/FlashcardCreateDrawer.image-insert.test.tsx
@@ -2,7 +2,12 @@ import { fireEvent, render, screen, waitFor } from "@testing-library/react"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
 import { FlashcardCreateDrawer } from "../FlashcardCreateDrawer"
-import { useCreateDeckMutation, useCreateFlashcardMutation, useDecksQuery } from "../../hooks"
+import {
+  useCreateDeckMutation,
+  useCreateFlashcardMutation,
+  useCreateFlashcardTemplateMutation,
+  useDecksQuery
+} from "../../hooks"
 import type { DeckSchedulerSettings, DeckSchedulerSettingsEnvelope } from "@/services/flashcards"
 
 const uploadFlashcardAsset = vi.hoisted(() => vi.fn())
@@ -51,6 +56,7 @@ vi.mock("@/hooks/useAntdMessage", () => ({
 vi.mock("../../hooks", () => ({
   useDecksQuery: vi.fn(),
   useCreateFlashcardMutation: vi.fn(),
+  useCreateFlashcardTemplateMutation: vi.fn(),
   useCreateDeckMutation: vi.fn(),
   useDebouncedFormField: vi.fn(() => undefined),
   useFlashcardDeckRecentCardsQuery: vi.fn(() => ({
@@ -140,6 +146,10 @@ describe("FlashcardCreateDrawer image insertion", () => {
       isLoading: false
     } as any)
     vi.mocked(useCreateFlashcardMutation).mockReturnValue({
+      mutateAsync: vi.fn(),
+      isPending: false
+    } as any)
+    vi.mocked(useCreateFlashcardTemplateMutation).mockReturnValue({
       mutateAsync: vi.fn(),
       isPending: false
     } as any)

--- a/apps/packages/ui/src/components/Flashcards/components/__tests__/FlashcardCreateDrawer.tags.test.tsx
+++ b/apps/packages/ui/src/components/Flashcards/components/__tests__/FlashcardCreateDrawer.tags.test.tsx
@@ -6,6 +6,7 @@ import { FlashcardCreateDrawer } from "../FlashcardCreateDrawer"
 import {
   useCreateDeckMutation,
   useCreateFlashcardMutation,
+  useCreateFlashcardTemplateMutation,
   useDecksQuery
 } from "../../hooks"
 
@@ -53,8 +54,23 @@ vi.mock("@/hooks/useAntdMessage", () => ({
 vi.mock("../../hooks", () => ({
   useDecksQuery: vi.fn(),
   useCreateFlashcardMutation: vi.fn(),
+  useCreateFlashcardTemplateMutation: vi.fn(),
   useCreateDeckMutation: vi.fn(),
-  useDebouncedFormField: vi.fn(() => undefined)
+  useDebouncedFormField: vi.fn(() => undefined),
+  useFlashcardDeckRecentCardsQuery: vi.fn(() => ({
+    data: [],
+    isLoading: false,
+    isError: false,
+    error: null,
+    refetch: vi.fn()
+  })),
+  useFlashcardDeckSearchQuery: vi.fn(() => ({
+    data: [],
+    isLoading: false,
+    isError: false,
+    error: null,
+    refetch: vi.fn()
+  }))
 }))
 
 vi.mock("../MarkdownWithBoundary", () => ({
@@ -142,6 +158,10 @@ describe("FlashcardCreateDrawer tags", () => {
     } as any)
     vi.mocked(useCreateFlashcardMutation).mockReturnValue({
       mutateAsync,
+      isPending: false
+    } as any)
+    vi.mocked(useCreateFlashcardTemplateMutation).mockReturnValue({
+      mutateAsync: vi.fn(),
       isPending: false
     } as any)
     vi.mocked(useCreateDeckMutation).mockReturnValue({

--- a/apps/packages/ui/src/components/Flashcards/components/__tests__/StudyPackCreateDrawer.test.tsx
+++ b/apps/packages/ui/src/components/Flashcards/components/__tests__/StudyPackCreateDrawer.test.tsx
@@ -132,7 +132,7 @@ describe("StudyPackCreateDrawer", () => {
 
     expect(screen.getByRole("button", { name: "Create study pack" })).toBeDisabled()
 
-    fireEvent.change(screen.getByLabelText("Source ID"), {
+    fireEvent.change(screen.getByLabelText(/Source ID/), {
       target: { value: "42" }
     })
     fireEvent.click(screen.getByRole("button", { name: "Add source" }))
@@ -214,7 +214,7 @@ describe("StudyPackCreateDrawer", () => {
     fireEvent.change(screen.getByLabelText("Title"), {
       target: { value: "Networks" }
     })
-    fireEvent.change(screen.getByLabelText("Source ID"), {
+    fireEvent.change(screen.getByLabelText(/Source ID/), {
       target: { value: "42" }
     })
     fireEvent.click(screen.getByRole("button", { name: "Add source" }))
@@ -224,5 +224,15 @@ describe("StudyPackCreateDrawer", () => {
       expect(messageSpies.error).toHaveBeenCalledWith("Study pack generation failed.")
     })
     expect(navigateMock).not.toHaveBeenCalled()
+  })
+
+  it("labels source IDs as an advanced manual reference with supported source guidance", () => {
+    render(<StudyPackCreateDrawer open onClose={vi.fn()} />)
+
+    expect(screen.getByLabelText("Source ID (advanced/manual)")).toBeInTheDocument()
+    expect(screen.getByTestId("study-pack-source-id-guidance")).toHaveTextContent(
+      "Media, Note, or Message"
+    )
+    expect(screen.getByText(/supported source/i)).toBeInTheDocument()
   })
 })

--- a/apps/packages/ui/src/components/Flashcards/tabs/ManageTab.tsx
+++ b/apps/packages/ui/src/components/Flashcards/tabs/ManageTab.tsx
@@ -214,15 +214,6 @@ export const ManageTab: React.FC<ManageTabProps> = ({
     setSelectedWorkspaceId(null)
     setPage(1)
   }, [initialDeckHandoffKey, initialDeckId, initialShowWorkspaceDecks])
-
-  React.useEffect(() => {
-    if (!isActive || viewMode !== "cards" || shortcutHintDensity === "hidden") return
-    void trackFlashcardsShortcutHintTelemetry({
-      type: "flashcards_shortcut_hints_exposed",
-      surface: "cards",
-      density: shortcutHintDensity
-    })
-  }, [isActive, viewMode, shortcutHintDensity])
   const cycleShortcutHintDensity = React.useCallback(() => {
     void setShortcutHintDensity((prev) => {
       const next =
@@ -588,6 +579,16 @@ export const ManageTab: React.FC<ManageTabProps> = ({
     !hasActiveFilters &&
     totalCount === 0 &&
     pageItems.length === 0
+  const showManageExpertChrome = viewMode === "cards" && !isNoCardFirstRun
+
+  React.useEffect(() => {
+    if (!isActive || !showManageExpertChrome || shortcutHintDensity === "hidden") return
+    void trackFlashcardsShortcutHintTelemetry({
+      type: "flashcards_shortcut_hints_exposed",
+      surface: "cards",
+      density: shortcutHintDensity
+    })
+  }, [isActive, shortcutHintDensity, showManageExpertChrome])
 
   const updateMutation = useUpdateFlashcardMutation()
   const bulkUpdateMutation = useUpdateFlashcardsBulkMutation()
@@ -1585,7 +1586,7 @@ export const ManageTab: React.FC<ManageTabProps> = ({
               ]}
             />
             {/* Keyboard shortcut hint */}
-            {viewMode === "cards" && !isNoCardFirstRun && (
+            {showManageExpertChrome && (
               <div
                 className="hidden md:flex items-center gap-1.5"
                 data-testid="flashcards-manage-shortcut-chips"
@@ -1658,7 +1659,7 @@ export const ManageTab: React.FC<ManageTabProps> = ({
         )}
 
         {/* Simplified Filter UI */}
-        {viewMode === "cards" && !isNoCardFirstRun && (
+        {showManageExpertChrome && (
         <div className="mb-3 space-y-3">
           {/* Primary filters: Search + Deck (always visible) */}
           <div className="flex items-center gap-2 flex-wrap">
@@ -1924,7 +1925,7 @@ export const ManageTab: React.FC<ManageTabProps> = ({
         )}
 
         {/* Selection Summary Bar - simplified to two modes */}
-        {viewMode === "cards" && !isNoCardFirstRun && (
+        {showManageExpertChrome && (
         <div
           className="mb-2 flex items-center gap-3"
           data-testid="flashcards-manage-selection-summary"

--- a/apps/packages/ui/src/components/Flashcards/tabs/ReviewTab.tsx
+++ b/apps/packages/ui/src/components/Flashcards/tabs/ReviewTab.tsx
@@ -1657,6 +1657,16 @@ export const ReviewTab: React.FC<ReviewTabProps> = ({
                             })}
                           </li>
                         </ol>
+                        <Text
+                          type="secondary"
+                          className="block text-xs"
+                          data-testid="flashcards-review-scheduler-preview"
+                        >
+                          {t("option:flashcards.onboardingSchedulerPreview", {
+                            defaultValue:
+                              "Scheduler defaults become available after you create a deck. Use Scheduler to tune daily limits and review algorithm settings before future sessions."
+                          })}
+                        </Text>
                         <a
                           href={FLASHCARDS_HELP_LINKS.ratings}
                           target="_blank"

--- a/apps/packages/ui/src/components/Flashcards/tabs/SchedulerTab.tsx
+++ b/apps/packages/ui/src/components/Flashcards/tabs/SchedulerTab.tsx
@@ -5,7 +5,8 @@ import { useTranslation } from "react-i18next"
 import {
   useDecksQuery,
   useDueCountsQuery,
-  useUpdateDeckMutation
+  useUpdateDeckMutation,
+  type UseFlashcardQueriesOptions
 } from "../hooks/useFlashcardQueries"
 import { DeckSchedulerSettingsEditor } from "../components/DeckSchedulerSettingsEditor"
 import { useDeckSchedulerDraft } from "../hooks/useDeckSchedulerDraft"
@@ -22,6 +23,7 @@ export interface SchedulerTabProps {
   isActive?: boolean
   initialDeckId?: number | null
   initialDeckHandoffKey?: string | null
+  deckVisibilityOptions?: UseFlashcardQueriesOptions
   onDirtyChange?: (dirty: boolean) => void
   discardSignal?: number
 }
@@ -50,11 +52,12 @@ export const SchedulerTab: React.FC<SchedulerTabProps> = ({
   isActive = false,
   initialDeckId = null,
   initialDeckHandoffKey = null,
+  deckVisibilityOptions,
   onDirtyChange,
   discardSignal = 0
 }) => {
   const { t } = useTranslation(["option", "common"])
-  const decksQuery = useDecksQuery()
+  const decksQuery = useDecksQuery(deckVisibilityOptions)
   const updateDeckMutation = useUpdateDeckMutation()
   const schedulerDraft = useDeckSchedulerDraft()
 
@@ -110,6 +113,7 @@ export const SchedulerTab: React.FC<SchedulerTabProps> = ({
     [allDecks, selectedDeckId]
   )
   const activeDeckCounts = useDueCountsQuery(activeDeck?.id, {
+    ...deckVisibilityOptions,
     enabled: isActive && !!activeDeck
   })
 

--- a/apps/packages/ui/src/components/Flashcards/tabs/__tests__/ManageTab.first-time.test.tsx
+++ b/apps/packages/ui/src/components/Flashcards/tabs/__tests__/ManageTab.first-time.test.tsx
@@ -1,0 +1,257 @@
+import { render, screen } from "@testing-library/react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { ManageTab } from "../ManageTab"
+import {
+  useCardsKeyboardNav,
+  useDecksQuery,
+  useDeleteFlashcardMutation,
+  useFlashcardDocumentQuery,
+  useManageQuery,
+  useResetFlashcardSchedulingMutation,
+  useTagSuggestionsQuery,
+  useUpdateDeckMutation,
+  useUpdateFlashcardsBulkMutation,
+  useUpdateFlashcardMutation
+} from "../../hooks"
+
+const { trackShortcutHintTelemetryMock } = vi.hoisted(() => ({
+  trackShortcutHintTelemetryMock: vi.fn().mockResolvedValue(undefined)
+}))
+const { trackErrorRecoveryTelemetryMock } = vi.hoisted(() => ({
+  trackErrorRecoveryTelemetryMock: vi.fn().mockResolvedValue(undefined)
+}))
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (
+      key: string,
+      defaultValueOrOptions?:
+        | string
+        | {
+            defaultValue?: string
+          }
+    ) => {
+      if (typeof defaultValueOrOptions === "string") return defaultValueOrOptions
+      if (defaultValueOrOptions?.defaultValue) return defaultValueOrOptions.defaultValue
+      return key
+    }
+  })
+}))
+
+vi.mock("@/utils/flashcards-shortcut-hint-telemetry", () => ({
+  trackFlashcardsShortcutHintTelemetry: trackShortcutHintTelemetryMock
+}))
+
+vi.mock("@/utils/chunk-processing", () => ({
+  processInChunks: vi.fn(async <T,>(items: T[], worker: (chunk: T[]) => Promise<void>) => {
+    await worker(items)
+  })
+}))
+
+vi.mock("@/utils/flashcards-error-recovery-telemetry", () => ({
+  trackFlashcardsErrorRecoveryTelemetry: trackErrorRecoveryTelemetryMock
+}))
+
+vi.mock("@tanstack/react-query", async () => {
+  const actual = await vi.importActual<typeof import("@tanstack/react-query")>("@tanstack/react-query")
+  return {
+    ...actual,
+    useQueryClient: () => ({
+      invalidateQueries: vi.fn()
+    })
+  }
+})
+
+vi.mock("@/hooks/useAntdMessage", () => ({
+  useAntdMessage: () => ({
+    success: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+    warning: vi.fn(),
+    loading: vi.fn(),
+    open: vi.fn(),
+    destroy: vi.fn()
+  })
+}))
+
+vi.mock("@/hooks/useUndoNotification", () => ({
+  useUndoNotification: () => ({
+    showUndoNotification: vi.fn()
+  })
+}))
+
+vi.mock("@/components/Common/confirm-danger", () => ({
+  useConfirmDanger: () => vi.fn().mockResolvedValue(true)
+}))
+
+vi.mock("../../hooks", () => ({
+  DOCUMENT_VIEW_SUPPORTED_SORTS: ["due", "created"],
+  getFlashcardDocumentQueryKey: vi.fn(() => ["flashcards:document", 1]),
+  useDecksQuery: vi.fn(),
+  useManageQuery: vi.fn(),
+  useFlashcardDocumentQuery: vi.fn(),
+  useTagSuggestionsQuery: vi.fn(),
+  useUpdateDeckMutation: vi.fn(),
+  useUpdateFlashcardMutation: vi.fn(),
+  useUpdateFlashcardsBulkMutation: vi.fn(),
+  useResetFlashcardSchedulingMutation: vi.fn(),
+  useDeleteFlashcardMutation: vi.fn(),
+  useCardsKeyboardNav: vi.fn(),
+  useDebouncedFormField: vi.fn(() => undefined),
+  getManageServerOrderBy: vi.fn(() => "due_at")
+}))
+
+vi.mock("../../components", () => ({
+  FlashcardMarkdownSnippet: ({ content }: { content: string }) => <div>{content}</div>,
+  MarkdownWithBoundary: ({ content }: { content: string }) => <div>{content}</div>,
+  FlashcardActionsMenu: () => null,
+  FlashcardEditDrawer: () => null,
+  FlashcardCreateDrawer: () => null
+}))
+
+vi.mock("@/services/flashcards", () => ({
+  getFlashcard: vi.fn(),
+  updateFlashcard: vi.fn(),
+  createFlashcard: vi.fn(),
+  deleteFlashcard: vi.fn(),
+  listFlashcards: vi.fn()
+}))
+
+vi.mock("../../utils/error-taxonomy", () => ({
+  formatFlashcardsUiErrorMessage: vi.fn(() => "Action failed"),
+  mapFlashcardsUiError: vi.fn(() => ({
+    code: "FLASHCARDS_UNKNOWN",
+    message: "Action failed",
+    actionLabel: "Retry",
+    rawMessage: "Action failed"
+  }))
+}))
+
+vi.mock("../../hooks/useFlashcardsShortcutHintDensity", () => ({
+  useFlashcardsShortcutHintDensity: () => ["expanded", vi.fn()]
+}))
+
+if (!(globalThis as any).ResizeObserver) {
+  ;(globalThis as any).ResizeObserver = class ResizeObserver {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  }
+}
+
+if (typeof window !== "undefined" && typeof window.matchMedia !== "function") {
+  Object.defineProperty(window, "matchMedia", {
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn()
+    }))
+  })
+}
+
+describe("ManageTab first-time state", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(useDecksQuery).mockReturnValue({
+      data: [
+        {
+          id: 1,
+          name: "Biology",
+          description: null,
+          deleted: false,
+          client_id: "test",
+          version: 1
+        }
+      ],
+      isLoading: false
+    } as any)
+    vi.mocked(useManageQuery).mockReturnValue({
+      data: {
+        items: [],
+        count: 0,
+        total: 0
+      },
+      isFetching: false
+    } as any)
+    vi.mocked(useFlashcardDocumentQuery).mockReturnValue({
+      items: [],
+      isFetching: false,
+      isLoading: false,
+      isTruncated: false,
+      hasNextPage: false,
+      isFetchingNextPage: false,
+      fetchNextPage: vi.fn(),
+      supportedSorts: ["due", "created"],
+      data: {
+        pages: []
+      }
+    } as any)
+    vi.mocked(useTagSuggestionsQuery).mockReturnValue({
+      data: [],
+      isLoading: false
+    } as any)
+    vi.mocked(useUpdateFlashcardMutation).mockReturnValue({
+      mutateAsync: vi.fn(),
+      isPending: false
+    } as any)
+    vi.mocked(useUpdateDeckMutation).mockReturnValue({
+      mutateAsync: vi.fn(),
+      isPending: false
+    } as any)
+    vi.mocked(useUpdateFlashcardsBulkMutation).mockReturnValue({
+      mutateAsync: vi.fn().mockResolvedValue({
+        results: []
+      }),
+      isPending: false
+    } as any)
+    vi.mocked(useResetFlashcardSchedulingMutation).mockReturnValue({
+      mutateAsync: vi.fn(),
+      isPending: false
+    } as any)
+    vi.mocked(useDeleteFlashcardMutation).mockReturnValue({
+      mutateAsync: vi.fn(),
+      isPending: false
+    } as any)
+    vi.mocked(useCardsKeyboardNav).mockImplementation(() => undefined)
+  })
+
+  it("suppresses expert manage chrome when there are no cards and no active filters", () => {
+    render(
+      <ManageTab
+        onNavigateToImport={() => {}}
+        onReviewCard={() => {}}
+        isActive
+      />
+    )
+
+    expect(screen.getByText("No flashcards yet")).toBeInTheDocument()
+    expect(screen.queryByTestId("flashcards-manage-shortcut-chips")).not.toBeInTheDocument()
+    expect(screen.queryByTestId("flashcards-manage-search")).not.toBeInTheDocument()
+    expect(screen.queryByTestId("flashcards-manage-sort-select")).not.toBeInTheDocument()
+    expect(screen.queryByTestId("flashcards-density-toggle")).not.toBeInTheDocument()
+    expect(screen.queryByTestId("flashcards-manage-selection-summary")).not.toBeInTheDocument()
+  })
+
+  it("keeps manage filters visible when an empty result comes from an active filter", () => {
+    render(
+      <ManageTab
+        onNavigateToImport={() => {}}
+        onReviewCard={() => {}}
+        isActive
+        initialDeckId={1}
+      />
+    )
+
+    expect(screen.getByText("No cards match your filters")).toBeInTheDocument()
+    expect(screen.getByTestId("flashcards-manage-search")).toBeInTheDocument()
+    expect(screen.getByTestId("flashcards-manage-sort-select")).toBeInTheDocument()
+    expect(screen.getByTestId("flashcards-density-toggle")).toBeInTheDocument()
+  })
+})

--- a/apps/packages/ui/src/components/Flashcards/tabs/__tests__/ReviewTab.create-cta.test.tsx
+++ b/apps/packages/ui/src/components/Flashcards/tabs/__tests__/ReviewTab.create-cta.test.tsx
@@ -310,6 +310,9 @@ describe("ReviewTab create CTA visibility", () => {
       "Alert"
     )
     expect(onboardingGuide).toHaveAttribute("aria-live", "off")
+    expect(screen.getByTestId("flashcards-review-scheduler-preview")).toHaveTextContent(
+      "Scheduler"
+    )
     expect(screen.getByTestId("flashcards-review-onboarding-doc-link")).toHaveAttribute(
       "href",
       FLASHCARDS_HELP_LINKS.ratings

--- a/apps/packages/ui/src/components/Flashcards/tabs/__tests__/SchedulerTab.editor.test.tsx
+++ b/apps/packages/ui/src/components/Flashcards/tabs/__tests__/SchedulerTab.editor.test.tsx
@@ -157,6 +157,30 @@ describe("SchedulerTab editor", () => {
     )
   })
 
+  it("uses the supplied deck visibility options for deck list and due counts", async () => {
+    render(
+      <SchedulerTab
+        isActive
+        deckVisibilityOptions={{ includeWorkspaceItems: true, workspaceId: "workspace-77" }}
+      />
+    )
+
+    expect(useDecksQuery).toHaveBeenCalledWith({
+      includeWorkspaceItems: true,
+      workspaceId: "workspace-77"
+    })
+    await waitFor(() => {
+      expect(useDueCountsQuery).toHaveBeenCalledWith(
+        1,
+        expect.objectContaining({
+          enabled: true,
+          includeWorkspaceItems: true,
+          workspaceId: "workspace-77"
+        })
+      )
+    })
+  })
+
   it("reapplies the same requested deck when a new scheduler handoff arrives", async () => {
     const { rerender } = render(
       <SchedulerTab isActive initialDeckId={2} initialDeckHandoffKey="handoff-1" />

--- a/apps/tldw-frontend/e2e/utils/page-objects/FlashcardsPage.ts
+++ b/apps/tldw-frontend/e2e/utils/page-objects/FlashcardsPage.ts
@@ -3,7 +3,7 @@
  *
  * The route renders FlashcardsWorkspace which shows either:
  * - A connection/offline banner when the server is unreachable
- * - FlashcardsManager with tabs for Study, Manage, Import / Export, Templates, and Scheduler
+ * - FlashcardsManager with tabs for Study, Manage, Transfer, Templates, and Scheduler
  *
  * API base paths:
  *   /api/v1/flashcards        (cards CRUD, review, generate, import, export)
@@ -87,7 +87,7 @@ export class FlashcardsPage extends BasePage {
   }
 
   get transferTab(): Locator {
-    return this.page.getByRole('tab', { name: /create\s*&\s*import|import\s*\/\s*export/i });
+    return this.page.getByRole('tab', { name: /transfer|create\s*&\s*import|import\s*\/\s*export/i });
   }
 
   // -- Locators: Tab bar extra content ---------------------------------------

--- a/apps/tldw-frontend/e2e/utils/page-objects/FlashcardsPage.ts
+++ b/apps/tldw-frontend/e2e/utils/page-objects/FlashcardsPage.ts
@@ -108,12 +108,32 @@ export class FlashcardsPage extends BasePage {
     return this.page.locator('[data-testid="flashcards-review-deck-select"]');
   }
 
+  get reviewTopbar(): Locator {
+    return this.page.locator('[data-testid="flashcards-review-topbar"]');
+  }
+
   get reviewModeToggle(): Locator {
     return this.page.locator('[data-testid="flashcards-review-mode-toggle"]');
   }
 
   get reviewModeCramOption(): Locator {
+    return this.reviewCramModeOption;
+  }
+
+  get reviewDueOnlyModeOption(): Locator {
+    return this.reviewModeToggle.getByText('Due only', { exact: true });
+  }
+
+  get reviewCramModeOption(): Locator {
     return this.reviewModeToggle.getByText('Cram', { exact: true });
+  }
+
+  get reviewCramTagInput(): Locator {
+    return this.page.locator('[data-testid="flashcards-review-cram-tag"]');
+  }
+
+  get reviewCramUpdateScheduleToggle(): Locator {
+    return this.page.locator('[data-testid="flashcards-review-cram-update-schedule"]');
   }
 
   get reviewPromptSideToggle(): Locator {
@@ -137,11 +157,51 @@ export class FlashcardsPage extends BasePage {
   }
 
   get reviewGoodButton(): Locator {
-    return this.page.locator('[data-testid="flashcards-review-rate-3"]');
+    return this.reviewRateGoodButton;
   }
 
   get reviewEasyButton(): Locator {
+    return this.reviewRateEasyButton;
+  }
+
+  get reviewRateAgainButton(): Locator {
+    return this.page.locator('[data-testid="flashcards-review-rate-1"]');
+  }
+
+  get reviewRateHardButton(): Locator {
+    return this.page.locator('[data-testid="flashcards-review-rate-2"]');
+  }
+
+  get reviewRateGoodButton(): Locator {
+    return this.page.locator('[data-testid="flashcards-review-rate-3"]');
+  }
+
+  get reviewRateEasyButton(): Locator {
     return this.page.locator('[data-testid="flashcards-review-rate-4"]');
+  }
+
+  get reviewRetryAlert(): Locator {
+    return this.page.locator('[data-testid="flashcards-review-retry-alert"]');
+  }
+
+  get reviewEndSessionButton(): Locator {
+    return this.page.locator('[data-testid="flashcards-review-end-session"]');
+  }
+
+  get reviewEndSessionEmptyButton(): Locator {
+    return this.page.locator('[data-testid="flashcards-review-end-session-empty"]');
+  }
+
+  get reviewShortcutQuestionChips(): Locator {
+    return this.page.locator('[data-testid="flashcards-review-shortcut-chips-question"]');
+  }
+
+  get reviewShortcutAnswerChips(): Locator {
+    return this.page.locator('[data-testid="flashcards-review-shortcut-chips-answer"]');
+  }
+
+  get reviewProgressStatus(): Locator {
+    return this.page.getByRole('status').filter({ hasText: /cards remaining|reviewed|min left/i });
   }
 
   get reviewEmptyCard(): Locator {
@@ -164,6 +224,10 @@ export class FlashcardsPage extends BasePage {
 
   get reviewImportCta(): Locator {
     return this.page.locator('[data-testid="flashcards-review-empty-import-cta"]');
+  }
+
+  get recentStudySessions(): Locator {
+    return this.page.getByText('Recent study sessions', { exact: true });
   }
 
   // -- Locators: Manage tab --------------------------------------------------
@@ -213,19 +277,19 @@ export class FlashcardsPage extends BasePage {
   }
 
   get createFrontTextarea(): Locator {
-    return this.createDrawer.getByPlaceholder('Question or prompt...');
+    return this.createDrawerFrontTextarea;
   }
 
   get createBackTextarea(): Locator {
-    return this.createDrawer.getByPlaceholder('Answer...');
+    return this.createDrawerBackTextarea;
   }
 
   get createSubmitButton(): Locator {
-    return this.createDrawer.getByRole('button', { name: 'Create', exact: true });
+    return this.createDrawerCreateButton;
   }
 
   get createAndAddAnotherButton(): Locator {
-    return this.createDrawer.getByRole('button', { name: 'Create & Add Another', exact: true });
+    return this.createDrawerCreateAndAddAnotherButton;
   }
 
   get createSuccessMessage(): Locator {
@@ -234,6 +298,22 @@ export class FlashcardsPage extends BasePage {
 
   get createErrorMessage(): Locator {
     return this.page.locator('.ant-message-notice-error');
+  }
+
+  get createDrawerFrontTextarea(): Locator {
+    return this.createDrawer.getByPlaceholder('Question or prompt...');
+  }
+
+  get createDrawerBackTextarea(): Locator {
+    return this.createDrawer.getByPlaceholder('Answer...');
+  }
+
+  get createDrawerCreateButton(): Locator {
+    return this.createDrawer.getByRole('button', { name: 'Create', exact: true });
+  }
+
+  get createDrawerCreateAndAddAnotherButton(): Locator {
+    return this.createDrawer.getByRole('button', { name: 'Create & Add Another' });
   }
 
   get editDrawer(): Locator {
@@ -270,8 +350,32 @@ export class FlashcardsPage extends BasePage {
     return this.page.locator('[data-testid="flashcards-import-textarea"]');
   }
 
+  get importDelimiterSelect(): Locator {
+    return this.page.locator('[data-testid="flashcards-import-delimiter"]');
+  }
+
+  get importPreflightWarning(): Locator {
+    return this.page.locator('[data-testid="flashcards-import-preflight-warning"]');
+  }
+
   get importButton(): Locator {
     return this.page.locator('[data-testid="flashcards-import-button"]');
+  }
+
+  get importResultAlert(): Locator {
+    return this.page.locator('[data-testid="flashcards-import-last-result"]');
+  }
+
+  get structuredImportPreviewButton(): Locator {
+    return this.page.locator('[data-testid="flashcards-structured-preview-button"]');
+  }
+
+  get structuredImportErrors(): Locator {
+    return this.page.locator('[data-testid="flashcards-structured-preview-errors"]');
+  }
+
+  get structuredImportSaveButton(): Locator {
+    return this.page.locator('[data-testid="flashcards-structured-save-button"]');
   }
 
   get exportDeckSelect(): Locator {
@@ -318,6 +422,13 @@ export class FlashcardsPage extends BasePage {
     await deckOption.click();
   }
 
+  async selectReviewDeckByName(deckName: string): Promise<void> {
+    await this.reviewDeckSelect.click({ force: true });
+    const deckOption = this.getActiveSelectOption(deckName);
+    await expect(deckOption).toBeVisible({ timeout: 10_000 });
+    await deckOption.click();
+  }
+
   async selectManageWorkspaceById(workspaceId: string): Promise<void> {
     await this.manageWorkspaceFilter.click({ force: true });
     const option = this.getActiveSelectOption(workspaceId, true);
@@ -336,6 +447,25 @@ export class FlashcardsPage extends BasePage {
     const deckOption = this.getActiveSelectOption(deckName);
     await expect(deckOption).toBeVisible({ timeout: 10_000 });
     await deckOption.click();
+  }
+
+  async selectImportFormat(formatLabel: string): Promise<void> {
+    await this.importFormatSelect.click({ force: true });
+    const option = this.getActiveSelectOption(formatLabel);
+    await expect(option).toBeVisible({ timeout: 10_000 });
+    await option.click();
+  }
+
+  async setReviewMode(mode: 'due' | 'cram'): Promise<void> {
+    if (mode === 'cram') {
+      await this.reviewCramModeOption.click({ force: true });
+    } else {
+      await this.reviewDueOnlyModeOption.click({ force: true });
+    }
+  }
+
+  getReviewRatingButton(key: '1' | '2' | '3' | '4'): Locator {
+    return this.page.locator(`[data-testid="flashcards-review-rate-${key}"]`);
   }
 
   async openManageFlashcardEdit(cardUuid: string): Promise<void> {

--- a/apps/tldw-frontend/e2e/utils/page-objects/FlashcardsPage.ts
+++ b/apps/tldw-frontend/e2e/utils/page-objects/FlashcardsPage.ts
@@ -346,8 +346,28 @@ export class FlashcardsPage extends BasePage {
     return this.page.locator('[data-testid="flashcards-import-format"]');
   }
 
+  get importTaskPanel(): Locator {
+    return this.page.locator('[data-testid="flashcards-import-task-panel"]');
+  }
+
+  get exportTaskPanel(): Locator {
+    return this.page.locator('[data-testid="flashcards-export-task-panel"]');
+  }
+
+  get transferTaskSwitcher(): Locator {
+    return this.page.locator('[data-testid="flashcards-transfer-task-switcher"]');
+  }
+
+  get transferImportTask(): Locator {
+    return this.transferTaskSwitcher.getByText('Import file', { exact: true });
+  }
+
+  get transferExportTask(): Locator {
+    return this.transferTaskSwitcher.getByText('Export backup', { exact: true });
+  }
+
   get importTextarea(): Locator {
-    return this.page.locator('[data-testid="flashcards-import-textarea"]');
+    return this.importTaskPanel.locator('[data-testid="flashcards-import-textarea"]');
   }
 
   get importDelimiterSelect(): Locator {
@@ -454,6 +474,17 @@ export class FlashcardsPage extends BasePage {
     const option = this.getActiveSelectOption(formatLabel);
     await expect(option).toBeVisible({ timeout: 10_000 });
     await option.click();
+  }
+
+  async openImportTask(): Promise<void> {
+    await this.transferImportTask.click({ force: true });
+    await expect(this.importTaskPanel).toBeVisible({ timeout: 10_000 });
+    await expect(this.importTextarea).toBeVisible({ timeout: 10_000 });
+  }
+
+  async openExportTask(): Promise<void> {
+    await this.transferExportTask.click({ force: true });
+    await expect(this.exportTaskPanel).toBeVisible({ timeout: 10_000 });
   }
 
   async setReviewMode(mode: 'due' | 'cram'): Promise<void> {

--- a/apps/tldw-frontend/e2e/workflows/tier-2-features/flashcards.spec.ts
+++ b/apps/tldw-frontend/e2e/workflows/tier-2-features/flashcards.spec.ts
@@ -17,11 +17,17 @@ import {
 } from '../../utils/fixtures';
 import { expectApiCall } from '../../utils/api-assertions';
 import { FlashcardsPage } from '../../utils/page-objects';
-import { seedAuth, fetchWithApiKey, TEST_CONFIG } from '../../utils/helpers';
+import {
+  dispatchKeyboardShortcut,
+  seedAuth,
+  fetchWithApiKey,
+  TEST_CONFIG,
+} from '../../utils/helpers';
 
 type SeededDeck = {
   id: number;
   name: string;
+  version?: number;
 };
 
 type SeededCard = {
@@ -88,6 +94,16 @@ async function createFlashcardCard(input: {
   const payload = (await response.json()) as SeededCard;
   expect(payload.uuid).toBeTruthy();
   return payload;
+}
+
+async function cleanupFlashcardDeck(deck: SeededDeck): Promise<void> {
+  await fetchWithApiKey(
+    `${TEST_CONFIG.serverUrl}/api/v1/flashcards/decks/${deck.id}?expected_version=${deck.version ?? 1}`,
+    TEST_CONFIG.apiKey,
+    {
+      method: 'DELETE',
+    }
+  ).catch(() => undefined);
 }
 
 test.describe('Flashcards', () => {
@@ -194,6 +210,72 @@ test.describe('Flashcards', () => {
       await assertNoCriticalErrors(diagnostics);
     });
 
+    test('flashcards Phase 0 evidence: reviews a seeded card with keyboard reveal and rating', async ({
+      authedPage,
+      serverInfo,
+      diagnostics,
+    }) => {
+      test.setTimeout(120_000);
+      skipIfServerUnavailable(serverInfo);
+
+      const runId = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+      const deck = await createFlashcardDeck(`E2E Phase0 Review ${runId}`);
+      const front = `Phase 0 front ${runId}`;
+      const back = `Phase 0 back ${runId}`;
+
+      await createFlashcardCard({
+        deckId: deck.id,
+        front,
+        back,
+      });
+
+      try {
+        flashcards = new FlashcardsPage(authedPage);
+        await flashcards.gotoPath(`/flashcards?tab=review&deck_id=${deck.id}`);
+        await flashcards.assertPageReady();
+
+        expect(await flashcards.isOnline()).toBe(true);
+        await expect(flashcards.reviewDeckSelect).toBeVisible({ timeout: 10_000 });
+        await expect(flashcards.reviewActiveCard).toBeVisible({ timeout: 20_000 });
+        await expect(flashcards.reviewActiveCard.getByText(front, { exact: true })).toBeVisible({
+          timeout: 10_000,
+        });
+        await expect(flashcards.reviewShortcutQuestionChips).toBeVisible({ timeout: 10_000 });
+
+        await dispatchKeyboardShortcut(authedPage, { key: ' ' });
+        await expect(flashcards.reviewActiveCard.getByText(back, { exact: true })).toBeVisible({
+          timeout: 10_000,
+        });
+        await expect(flashcards.reviewShortcutAnswerChips).toBeVisible({ timeout: 10_000 });
+        await expect(flashcards.reviewRateGoodButton).toBeVisible({ timeout: 10_000 });
+
+        const reviewResponsePromise = authedPage.waitForResponse((response) => {
+          return (
+            response.request().method() === 'POST' &&
+            /\/api\/v1\/flashcards\/review$/.test(response.url())
+          );
+        });
+
+        await dispatchKeyboardShortcut(authedPage, { key: '3' });
+
+        const reviewResponse = await reviewResponsePromise;
+        expect(reviewResponse.status()).toBeLessThan(400);
+
+        await expect(flashcards.reviewEmptyCard).toBeVisible({ timeout: 20_000 });
+        await expect(flashcards.reviewEmptyCard).toContainText(
+          /cards reviewed this session|all caught up|No cards are due/i
+        );
+
+        if (await flashcards.reviewProgressStatus.isVisible().catch(() => false)) {
+          await expect(flashcards.reviewProgressStatus).toContainText(/reviewed/i);
+        }
+
+        await assertNoCriticalErrors(diagnostics);
+      } finally {
+        await cleanupFlashcardDeck(deck);
+      }
+    });
+
     test('should flip the review prompt side for a selected deck', async ({
       authedPage,
       serverInfo,
@@ -298,6 +380,25 @@ test.describe('Flashcards', () => {
       expect(reviewResponse.status()).toBeLessThan(400);
 
       await expect(flashcards.reviewCompletionState).toBeVisible({ timeout: 20_000 });
+
+      await assertNoCriticalErrors(diagnostics);
+    });
+
+    test('flashcards Phase 0 evidence: Cram mode controls are reachable before review', async ({
+      authedPage,
+      diagnostics,
+    }) => {
+      flashcards = new FlashcardsPage(authedPage);
+      await flashcards.gotoPath('/flashcards?tab=review');
+      await flashcards.assertPageReady();
+
+      const online = await flashcards.isOnline();
+      if (!online) return;
+
+      await expect(flashcards.reviewTopbar).toBeVisible({ timeout: 10_000 });
+      await flashcards.setReviewMode('cram');
+      await expect(flashcards.reviewCramTagInput).toBeVisible({ timeout: 10_000 });
+      await expect(flashcards.reviewCramUpdateScheduleToggle).toBeVisible({ timeout: 10_000 });
 
       await assertNoCriticalErrors(diagnostics);
     });
@@ -667,6 +768,127 @@ test.describe('Flashcards', () => {
       await expect(flashcards.importButton).toBeVisible();
 
       await assertNoCriticalErrors(diagnostics);
+    });
+
+    test('flashcards Phase 0 evidence: invalid delimiter sample shows recovery preflight before import', async ({
+      authedPage,
+      diagnostics,
+    }) => {
+      flashcards = new FlashcardsPage(authedPage);
+      await flashcards.gotoPath('/flashcards?tab=importExport');
+      await flashcards.assertPageReady();
+
+      const online = await flashcards.isOnline();
+      if (!online) return;
+
+      await expect(flashcards.importTextarea).toBeVisible({ timeout: 10_000 });
+      await flashcards.importTextarea.fill('Deck,Front,Back\nBiology,Question,Answer');
+
+      await expect(flashcards.importPreflightWarning).toBeVisible({ timeout: 10_000 });
+      await expect(flashcards.importPreflightWarning).toContainText(
+        /Selected delimiter .* may be incorrect/i
+      );
+      await expect(flashcards.importButton).toBeEnabled();
+
+      await assertNoCriticalErrors(diagnostics);
+    });
+
+    test.fixme(
+      'flashcards Phase 0 RED evidence: invalid delimited import should not show zero-card success or get stuck (TASK-537)',
+      async ({ authedPage, serverInfo }) => {
+        skipIfServerUnavailable(serverInfo);
+
+        flashcards = new FlashcardsPage(authedPage);
+        await flashcards.gotoPath('/flashcards?tab=importExport');
+        await flashcards.assertPageReady();
+
+        await flashcards.importTextarea.fill('Deck\tFront\tBack\nBroken\t\t');
+        await flashcards.importButton.click();
+
+        await expect(flashcards.importResultAlert).toBeVisible({ timeout: 20_000 });
+        await expect(flashcards.importResultAlert).not.toContainText(/0 cards imported/i);
+        await expect(flashcards.importButton).toBeEnabled({ timeout: 20_000 });
+      }
+    );
+  });
+
+  // =========================================================================
+  // Responsive Smoke
+  // =========================================================================
+
+  test.describe('Responsive Smoke', () => {
+    test('flashcards Phase 0 evidence: records mobile study and transfer reachability', async ({
+      authedPage,
+      diagnostics,
+    }, testInfo) => {
+      await authedPage.setViewportSize({ width: 390, height: 844 });
+
+      flashcards = new FlashcardsPage(authedPage);
+      await flashcards.goto();
+      await flashcards.assertPageReady();
+
+      const online = await flashcards.isOnline();
+      if (!online) return;
+
+      await expect(flashcards.tabsContainer).toBeVisible({ timeout: 10_000 });
+      await flashcards.switchToTab('study');
+      const studyReachability = {
+        reviewTopbarVisible: await flashcards.reviewTopbar.isVisible().catch(() => false),
+        reviewDeckSelectVisible: await flashcards.reviewDeckSelect.isVisible().catch(() => false),
+      };
+      await testInfo.attach('flashcards-mobile-study-reachability.json', {
+        body: JSON.stringify(studyReachability, null, 2),
+        contentType: 'application/json',
+      });
+      await flashcards.testWithQuizButton.scrollIntoViewIfNeeded();
+      await expect(flashcards.testWithQuizButton).toBeVisible({ timeout: 10_000 });
+
+      await flashcards.switchToTab('transfer');
+      await expect(flashcards.importFormatSelect).toBeVisible({ timeout: 10_000 });
+      await expect(flashcards.importTextarea).toBeVisible({ timeout: 10_000 });
+      await expect(flashcards.importButton).toBeVisible({ timeout: 10_000 });
+
+      await assertNoCriticalErrors(diagnostics);
+    });
+  });
+
+  // =========================================================================
+  // Direct Handoffs
+  // =========================================================================
+
+  test.describe('Direct Handoffs', () => {
+    test('flashcards Phase 0 evidence: quiz handoff preserves selected review deck context', async ({
+      authedPage,
+      serverInfo,
+      diagnostics,
+    }) => {
+      test.setTimeout(90_000);
+      skipIfServerUnavailable(serverInfo);
+
+      const runId = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+      const deck = await createFlashcardDeck(`E2E Quiz Handoff ${runId}`);
+
+      try {
+        flashcards = new FlashcardsPage(authedPage);
+        await flashcards.gotoPath(`/flashcards?tab=review&deck_id=${deck.id}`);
+        await flashcards.assertPageReady();
+
+        expect(await flashcards.isOnline()).toBe(true);
+        await expect(flashcards.testWithQuizButton).toBeVisible({ timeout: 10_000 });
+
+        await flashcards.testWithQuizButton.click();
+        await authedPage.waitForURL(/\/quiz\?/, { timeout: 15_000 });
+
+        const url = new URL(authedPage.url());
+        expect(url.pathname).toBe('/quiz');
+        expect(url.searchParams.get('tab')).toBe('take');
+        expect(url.searchParams.get('source')).toBe('flashcards');
+        expect(url.searchParams.get('deck_id')).toBe(String(deck.id));
+
+        await assertNoCriticalErrors(diagnostics);
+      } finally {
+        await cleanupFlashcardDeck(deck);
+      }
     });
   });
 

--- a/apps/tldw-frontend/e2e/workflows/tier-2-features/flashcards.spec.ts
+++ b/apps/tldw-frontend/e2e/workflows/tier-2-features/flashcards.spec.ts
@@ -179,6 +179,76 @@ test.describe('Flashcards', () => {
 
       await assertNoCriticalErrors(diagnostics);
     });
+
+    test('flashcards Phase 1 evidence: empty first entry stays on Study with setup actions', async ({
+      authedPage,
+      serverInfo,
+      diagnostics,
+    }) => {
+      skipIfServerUnavailable(serverInfo);
+
+      await authedPage.route(/\/api\/v1\/flashcards\/decks(?:\?.*)?$/, async route => {
+        if (route.request().method() !== 'GET') return route.fallback();
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify([]),
+        });
+      });
+      await authedPage.route(/\/api\/v1\/flashcards\/review\/next(?:\?.*)?$/, async route => {
+        if (route.request().method() !== 'GET') return route.fallback();
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ card: null }),
+        });
+      });
+      await authedPage.route(/\/api\/v1\/flashcards\/review-sessions(?:\?.*)?$/, async route => {
+        if (route.request().method() !== 'GET') return route.fallback();
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify([]),
+        });
+      });
+      await authedPage.route(/\/api\/v1\/flashcards\/tags(?:\?.*)?$/, async route => {
+        if (route.request().method() !== 'GET') return route.fallback();
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ items: [] }),
+        });
+      });
+      await authedPage.route(/\/api\/v1\/flashcards(?:\?.*)?$/, async route => {
+        if (route.request().method() !== 'GET') return route.fallback();
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ items: [], count: 0, total: 0 }),
+        });
+      });
+
+      flashcards = new FlashcardsPage(authedPage);
+      await flashcards.gotoPath('/flashcards');
+      await flashcards.assertPageReady();
+
+      expect(await flashcards.isOnline()).toBe(true);
+      await expect(flashcards.studyTab).toHaveAttribute('aria-selected', 'true');
+      await expect(flashcards.transferTab).toBeVisible();
+      await expect(flashcards.schedulerTab).toHaveCount(0);
+      await expect(flashcards.tabsContainer.getByText('LLM', { exact: true })).toHaveCount(0);
+      await expect(authedPage.locator('[data-testid="flashcards-review-onboarding-guide"]')).toBeVisible({
+        timeout: 10_000,
+      });
+      await expect(authedPage.locator('[data-testid="flashcards-review-scheduler-preview"]')).toContainText(
+        'Scheduler'
+      );
+      await expect(authedPage.locator('[data-testid="flashcards-review-empty-create-cta"]')).toBeVisible();
+      await expect(authedPage.locator('[data-testid="flashcards-review-empty-import-cta"]')).toBeVisible();
+      await expect(authedPage.locator('[data-testid="flashcards-review-empty-generate-cta"]')).toBeVisible();
+
+      await assertNoCriticalErrors(diagnostics);
+    });
   });
 
   // =========================================================================

--- a/apps/tldw-frontend/e2e/workflows/tier-2-features/flashcards.spec.ts
+++ b/apps/tldw-frontend/e2e/workflows/tier-2-features/flashcards.spec.ts
@@ -97,13 +97,28 @@ async function createFlashcardCard(input: {
 }
 
 async function cleanupFlashcardDeck(deck: SeededDeck): Promise<void> {
-  await fetchWithApiKey(
-    `${TEST_CONFIG.serverUrl}/api/v1/flashcards/decks/${deck.id}?expected_version=${deck.version ?? 1}`,
-    TEST_CONFIG.apiKey,
-    {
-      method: 'DELETE',
-    }
-  ).catch(() => undefined);
+  const expectedVersion = deck.version ?? 1;
+
+  try {
+    const response = await fetchWithApiKey(
+      `${TEST_CONFIG.serverUrl}/api/v1/flashcards/decks/${deck.id}?expected_version=${expectedVersion}`,
+      TEST_CONFIG.apiKey,
+      {
+        method: 'DELETE',
+      }
+    );
+
+    expect(
+      response.ok,
+      `Failed to cleanup flashcard deck ${deck.id} at version ${expectedVersion}: ${response.status} ${response.statusText}`
+    ).toBeTruthy();
+  } catch (error) {
+    console.error(
+      `Failed to cleanup flashcard deck ${deck.id} at version ${expectedVersion} from ${TEST_CONFIG.serverUrl}`,
+      error
+    );
+    throw error;
+  }
 }
 
 test.describe('Flashcards', () => {
@@ -170,8 +185,7 @@ test.describe('Flashcards', () => {
         } else if (tab === 'scheduler') {
           await expect(authedPage.getByPlaceholder('Search decks')).toBeVisible({ timeout: 10_000 });
         } else if (tab === 'transfer') {
-          await expect(flashcards.importButton).toBeVisible({ timeout: 10_000 });
-          await expect(flashcards.exportButton).toBeVisible({ timeout: 10_000 });
+          await expect(flashcards.transferTaskSwitcher).toBeVisible({ timeout: 10_000 });
         } else {
           await expect(flashcards.reviewDeckSelect).toBeVisible({ timeout: 10_000 });
         }
@@ -783,7 +797,7 @@ test.describe('Flashcards', () => {
       if (!online) return;
 
       await flashcards.switchToTab('transfer');
-      await expect(flashcards.importButton).toBeVisible({ timeout: 10_000 });
+      await flashcards.openExportTask();
       await expect(flashcards.exportButton).toBeVisible({ timeout: 10_000 });
 
       const exportVisible = await flashcards.exportButton.isVisible().catch(() => false);
@@ -831,8 +845,8 @@ test.describe('Flashcards', () => {
       if (!online) return;
 
       await flashcards.switchToTab('transfer');
+      await flashcards.openImportTask();
       await expect(flashcards.importButton).toBeVisible({ timeout: 10_000 });
-      await expect(flashcards.exportButton).toBeVisible({ timeout: 10_000 });
 
       await expect(flashcards.importFormatSelect).toBeVisible({ timeout: 10_000 });
       await expect(flashcards.importButton).toBeVisible();
@@ -851,6 +865,7 @@ test.describe('Flashcards', () => {
       const online = await flashcards.isOnline();
       if (!online) return;
 
+      await flashcards.openImportTask();
       await expect(flashcards.importTextarea).toBeVisible({ timeout: 10_000 });
       await flashcards.importTextarea.fill('Deck,Front,Back\nBiology,Question,Answer');
 
@@ -863,8 +878,8 @@ test.describe('Flashcards', () => {
       await assertNoCriticalErrors(diagnostics);
     });
 
-    test.fixme(
-      'flashcards Phase 0 RED evidence: invalid delimited import should not show zero-card success or get stuck (TASK-537)',
+    test(
+      'flashcards Phase 0 evidence: invalid delimited import does not show zero-card success or get stuck (TASK-537)',
       async ({ authedPage, serverInfo }) => {
         skipIfServerUnavailable(serverInfo);
 
@@ -872,6 +887,7 @@ test.describe('Flashcards', () => {
         await flashcards.gotoPath('/flashcards?tab=importExport');
         await flashcards.assertPageReady();
 
+        await flashcards.openImportTask();
         await flashcards.importTextarea.fill('Deck\tFront\tBack\nBroken\t\t');
         await flashcards.importButton.click();
 
@@ -914,6 +930,7 @@ test.describe('Flashcards', () => {
       await expect(flashcards.testWithQuizButton).toBeVisible({ timeout: 10_000 });
 
       await flashcards.switchToTab('transfer');
+      await flashcards.openImportTask();
       await expect(flashcards.importFormatSelect).toBeVisible({ timeout: 10_000 });
       await expect(flashcards.importTextarea).toBeVisible({ timeout: 10_000 });
       await expect(flashcards.importButton).toBeVisible({ timeout: 10_000 });

--- a/backlog/completed/task-481 - Flashcards-UX-Phase-1-trust-empty-state-and-first-time-setup.md
+++ b/backlog/completed/task-481 - Flashcards-UX-Phase-1-trust-empty-state-and-first-time-setup.md
@@ -1,0 +1,69 @@
+---
+id: TASK-481
+title: Flashcards UX Phase 1 trust empty state and first-time setup
+status: Done
+labels:
+- ux
+- flashcards
+- frontend
+- tests
+modified_files:
+- apps/packages/ui/src/components/Flashcards/FlashcardsManager.tsx
+- apps/packages/ui/src/components/Flashcards/tabs/ReviewTab.tsx
+- apps/packages/ui/src/components/Flashcards/tabs/ManageTab.tsx
+- apps/packages/ui/src/components/Flashcards/components/StudyPackCreateDrawer.tsx
+- apps/packages/ui/src/components/Flashcards/__tests__/FlashcardsManager.consistency.test.tsx
+- apps/packages/ui/src/components/Flashcards/tabs/__tests__/ReviewTab.create-cta.test.tsx
+- apps/packages/ui/src/components/Flashcards/tabs/__tests__/ManageTab.first-time.test.tsx
+- apps/packages/ui/src/components/Flashcards/components/__tests__/StudyPackCreateDrawer.test.tsx
+- apps/tldw-frontend/e2e/workflows/tier-2-features/flashcards.spec.ts
+- apps/tldw-frontend/e2e/utils/page-objects/FlashcardsPage.ts
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement Phase 1 from Docs/superpowers/plans/2026-05-25-flashcards-ux-fixes-implementation-plan.md in the isolated flashcards worktree. Scope: make first entry to /flashcards understandable before dense transfer, management, or scheduler tooling. Keep changes scoped to /flashcards first-time setup, Manage no-card state, transfer labeling, scheduler discoverability, and Study Pack source-ID copy.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Empty accounts land on Study/home, not dense transfer tooling, while explicit generate/study-pack deep links still open transfer setup.
+- [ ] #2 First screen explains flashcards in this product and exposes clear actions to create manually, import a deck, generate from source, or choose an existing deck when present.
+- [ ] #3 Manage no-card state suppresses expert filters, sort, density, and shortcut chips until cards exist or filters are active.
+- [ ] #4 Scheduler is discoverable before a deck exists through disabled-tab copy or Study empty-state scheduling preview.
+- [ ] #5 Transfer/create/import label no longer implies normal import/export is LLM-only.
+- [ ] #6 Study Pack setup copy labels Source ID as an advanced/manual source reference and points users toward supported source types.
+- [ ] #7 Focused component/e2e verification is run or limitations are documented.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add RED component tests for Phase 1 first-entry tab behavior, first-time Study guidance/actions, Manage no-card chrome suppression, transfer label copy, scheduler discoverability, and Study Pack Source ID copy.
+2. Implement the smallest scoped UI changes in FlashcardsManager, ReviewTab, ManageTab, ImportExportTab/StudyPackPanel needed to satisfy the tests.
+3. Add or adjust Playwright coverage for first-time/empty/tab behavior using the Phase 0 harness selectors.
+4. Run focused Vitest and Playwright verification, record results, and complete the Backlog task.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Phase 1 complete. Empty /flashcards accounts now stay on Study with first-time setup actions and Scheduler preview copy; explicit generate and valid Study Pack deep links still open Transfer. Manage suppresses expert chrome for a no-card first-run state, Transfer no longer carries a visible LLM badge, and Study Pack Source ID copy is labeled as advanced/manual. Verification: Phase 1 RED tests observed failing before implementation; targeted affected component files passed; full Flashcards component suite passed (69 files, 333 tests); focused Phase 1 Playwright smoke passed after escalation for local Next port binding. Bandit skipped: TS/TSX/tests/backlog only.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched Python code or non-Python skip documented
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/completed/task-481 - Flashcards-UX-Phase-1-trust-empty-state-and-first-time-setup.md
+++ b/backlog/completed/task-481 - Flashcards-UX-Phase-1-trust-empty-state-and-first-time-setup.md
@@ -28,13 +28,13 @@ Implement Phase 1 from Docs/superpowers/plans/2026-05-25-flashcards-ux-fixes-imp
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Empty accounts land on Study/home, not dense transfer tooling, while explicit generate/study-pack deep links still open transfer setup.
-- [ ] #2 First screen explains flashcards in this product and exposes clear actions to create manually, import a deck, generate from source, or choose an existing deck when present.
-- [ ] #3 Manage no-card state suppresses expert filters, sort, density, and shortcut chips until cards exist or filters are active.
-- [ ] #4 Scheduler is discoverable before a deck exists through disabled-tab copy or Study empty-state scheduling preview.
-- [ ] #5 Transfer/create/import label no longer implies normal import/export is LLM-only.
-- [ ] #6 Study Pack setup copy labels Source ID as an advanced/manual source reference and points users toward supported source types.
-- [ ] #7 Focused component/e2e verification is run or limitations are documented.
+- [x] #1 Empty accounts land on Study/home, not dense transfer tooling, while explicit generate/study-pack deep links still open transfer setup.
+- [x] #2 First screen explains flashcards in this product and exposes clear actions to create manually, import a deck, generate from source, or choose an existing deck when present.
+- [x] #3 Manage no-card state suppresses expert filters, sort, density, and shortcut chips until cards exist or filters are active.
+- [x] #4 Scheduler is discoverable before a deck exists through disabled-tab copy or Study empty-state scheduling preview.
+- [x] #5 Transfer/create/import label no longer implies normal import/export is LLM-only.
+- [x] #6 Study Pack setup copy labels Source ID as an advanced/manual source reference and points users toward supported source types.
+- [x] #7 Focused component/e2e verification is run or limitations are documented.
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -60,10 +60,10 @@ Phase 1 complete. Empty /flashcards accounts now stay on Study with first-time s
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched Python code or non-Python skip documented
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched Python code or non-Python skip documented
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->

--- a/backlog/completed/task-526 - Flashcards-UX-PR-2087-follow-up-rebase-and-review-fixes.md
+++ b/backlog/completed/task-526 - Flashcards-UX-PR-2087-follow-up-rebase-and-review-fixes.md
@@ -1,0 +1,53 @@
+---
+id: TASK-526
+title: Flashcards UX PR 2087 follow-up rebase and review fixes
+status: Done
+labels:
+- flashcards
+- webui
+- pr-review
+priority: High
+references:
+- https://github.com/rmusser01/tldw_server/pull/2087
+modified_files:
+- apps/packages/ui/src/components/Flashcards
+- apps/tldw-frontend/e2e/workflows/tier-2-features/flashcards.spec.ts
+- apps/tldw-frontend/e2e/utils/page-objects/FlashcardsPage.ts
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Fetch latest origin/dev and rebase codex/flashcards-ux-phase1-pr
+- [x] #2 Inspect PR #2087 comments, review threads, and current check failures
+- [x] #3 Address validated review comments and PR issues in flashcards scope
+- [x] #4 Run focused verification for any changed files and push the branch
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+- Rebased the branch onto origin/dev at 84dac2f07.
+- Verified current PR review threads and addressed the active Qodo/CodeRabbit findings: removed the disabled Playwright fixme path by making it an active test, surfaced E2E cleanup failures, matched Scheduler deck queries to workspace visibility handoffs, cleared dirty Scheduler state on forced Scheduler hiding, aligned the workspace header Transfer label, and reconciled completed Backlog checklist state.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Follow-up complete for PR #2087. The branch is rebased on latest fetched origin/dev, actionable review findings are fixed, and verification passed: RED component checks failed for the intended missing behavior before implementation; focused component checks passed (3 files, 39 tests); full Flashcards component suite passed (72 files, 388 tests); targeted Playwright invalid-import test passed; neighboring Transfer Playwright checks passed (3 tests); `git diff --check` passed; no `test.fixme` remains in the touched flashcards scope. Bandit skipped: touched files are TS/TSX/E2E/backlog only.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/completed/task-526 - Flashcards-UX-Phase-1-PR-rebase-and-review-fixes.md
+++ b/backlog/completed/task-526 - Flashcards-UX-Phase-1-PR-rebase-and-review-fixes.md
@@ -1,0 +1,51 @@
+---
+id: TASK-526
+title: Flashcards UX Phase 1 PR rebase and review fixes
+status: Done
+labels:
+- flashcards
+- webui
+- pr-review
+priority: High
+references:
+- https://github.com/rmusser01/tldw_server/pull/2087
+modified_files:
+- apps/packages/ui/src/components/Flashcards/FlashcardsManager.tsx
+- backlog/tasks/task-526 - Flashcards-UX-Phase-1-PR-rebase-and-review-fixes.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Rebase codex/flashcards-ux-phase1-pr onto latest origin/dev
+- [ ] #2 Inspect PR #2087 review comments, review threads, and check results
+- [ ] #3 Address validated flashcards-scope review issues with focused code/test changes
+- [ ] #4 Run affected verification and push updated branch
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Rebased codex/flashcards-ux-phase1-pr onto the latest fetched origin/dev (already up to date), addressed the only actionable PR review thread by simplifying showSchedulerTab, and verified with focused manager tests, the full Flashcards component suite, Playwright Phase 1 smoke, and git diff --check. Bandit skipped because touched code is TS/TSX/backlog only.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/completed/task-526 - Flashcards-UX-Phase-1-PR-rebase-and-review-fixes.md
+++ b/backlog/completed/task-526 - Flashcards-UX-Phase-1-PR-rebase-and-review-fixes.md
@@ -22,10 +22,10 @@ modified_files:
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Rebase codex/flashcards-ux-phase1-pr onto latest origin/dev
-- [ ] #2 Inspect PR #2087 review comments, review threads, and check results
-- [ ] #3 Address validated flashcards-scope review issues with focused code/test changes
-- [ ] #4 Run affected verification and push updated branch
+- [x] #1 Rebase codex/flashcards-ux-phase1-pr onto latest origin/dev
+- [x] #2 Inspect PR #2087 review comments, review threads, and check results
+- [x] #3 Address validated flashcards-scope review issues with focused code/test changes
+- [x] #4 Run affected verification and push updated branch
 <!-- AC:END -->
 
 ## Implementation Notes
@@ -42,10 +42,10 @@ Rebased codex/flashcards-ux-phase1-pr onto the latest fetched origin/dev (alread
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->

--- a/backlog/completed/task-537 - Flashcards-UX-Phase-0-evidence-and-harness-refresh.md
+++ b/backlog/completed/task-537 - Flashcards-UX-Phase-0-evidence-and-harness-refresh.md
@@ -1,0 +1,57 @@
+---
+id: TASK-537
+title: Flashcards UX Phase 0 evidence and harness refresh
+status: Done
+assignee: []
+created_date: '2026-05-28 02:08'
+updated_date: '2026-05-28 02:31'
+labels:
+  - ux
+  - flashcards
+  - e2e
+  - tests
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement Phase 0 from Docs/superpowers/plans/2026-05-25-flashcards-ux-fixes-implementation-plan.md in the isolated flashcards worktree. Scope: refresh Flashcards e2e/page-object harness evidence for invalid import, manual create feedback, review completion, mobile/narrow smoke, and quiz handoff. Keep product changes out unless a blocker prevents harness verification.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Phase 0 selectors and tests cover or document first-run, import, create, review, mobile/narrow, and quiz-handoff evidence without landing unresolved failing tests.
+- [x] #2 RED evidence is recorded for new failing coverage before fixes or fixme markers are used where behavior is intentionally deferred.
+- [x] #3 Focused Flashcards component/e2e verification commands are run or limitations are documented.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Created isolated worktree branch codex/flashcards-ux-phase0. Stabilized focused component baseline by constraining the drawer deck-select helper to AntD option content and giving the slow jsdom drawer integration test the same 15s timeout pattern used by neighboring tests.
+
+Expanded FlashcardsPage selectors for review modes, ratings, progress/status, create drawer fields/actions, import result/recovery states, structured import controls, and quiz handoff usage.
+
+Added Phase 0 E2E evidence for seeded keyboard review completion, Cram controls, invalid delimiter preflight recovery, mobile reachability recording, and quiz handoff deck_id preservation. Added a fixme RED evidence test for invalid delimited import silently succeeding or getting stuck, deferred to Phase 2.
+
+Added component coverage that failed manual create feedback keeps the drawer open and preserves the draft. First-run onboarding/create/import/generate actions remain covered in ReviewTab.create-cta.test.tsx.
+
+Verification: bunx vitest run FlashcardCreateDrawer.deck-reference, ImportExportTab.import-results, ReviewTab.create-cta passed 40 tests. Playwright Phase 0 grep passed 5 tests with 1 expected fixme after rerun outside sandbox because sandbox could not bind the Next dev server port. Bandit not run because this slice touched TypeScript/test/backlog files only, no Python code.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Phase 0 harness refresh complete: page-object selectors, focused component recovery coverage, backend-backed/observable E2E evidence for review/import/mobile/quiz flows, and documented RED fixme coverage for the deferred invalid-import reliability issue.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## Summary
- Refreshes the Flashcards Phase 0/1 test harness and evidence coverage for first-time setup behavior.
- Keeps empty `/flashcards` accounts on Study, exposes first-time create/import/generate actions, and adds Scheduler preview copy before decks exist.
- Renames the top-level transfer surface to `Transfer`, removes the global LLM badge from normal import/export navigation, suppresses Manage expert chrome for no-card first-run states, and clarifies Study Pack Source ID as an advanced/manual reference.

## Test Plan
- [x] `bunx vitest run src/components/Flashcards`
- [x] `TLDW_SERVER_URL=http://127.0.0.1:8000 TLDW_API_KEY=THIS-IS-A-SECURE-KEY-123-FAKE-KEY npx playwright test e2e/workflows/tier-2-features/flashcards.spec.ts --project=tier-2 --grep "flashcards Phase 1" --reporter=line`
- [x] `git diff --check`
- [x] Bandit skipped: TS/TSX/tests/backlog only

## Change summary
AI-generated PR merge gate: the human requester must replace this section with a human-written summary explaining what changed and why these implementation choices were made before marking the PR ready to merge.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves the first-time Flashcards experience and refreshes Phase 0/1 tests. Empty accounts start on Study with clear setup actions; Scheduler is hidden until a deck exists with preview copy and safe discard; “Transfer” replaces “Create & Import” across the UI (TASK-481, TASK-526, TASK-537).

- **New Features**
  - Default empty accounts to Study; show create/import/generate CTAs; open Transfer first on explicit generate or study-pack deep links.
  - Hide the Scheduler tab until any deck exists; clamp scheduler deep-links to Study; auto-discard unsaved scheduler edits when Scheduler is hidden; pass workspace deck visibility to Scheduler.
  - Suppress Manage expert chrome on first run until cards exist or filters are active.
  - Rename “Create & Import” to “Transfer” everywhere; remove the “LLM” badge.
  - Label Study Pack Source ID as “advanced/manual” with supported-source guidance.
  - Refresh Phase 0/1 tests and e2e harness (keyboard review, cram controls, import preflight, mobile smoke, quiz handoff).

<sup>Written for commit ad31bce89eeaff41db3fb1cf9047ac967dc952a1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2087?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

