### PR TITLE
Add MCP SQLite storage contracts

### DIFF
--- a/Docs/superpowers/plans/2026-05-28-mcp-unified-stage2e-sqlite-stores-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-05-28-mcp-unified-stage2e-sqlite-stores-implementation-plan.md
@@ -1,0 +1,226 @@
+# MCP Unified Stage 2E SQLite Stores Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add package-local SQLite store primitives for MCP profile documents, profile assignments, approval policies, credential grants, external server definitions, and audit events.
+
+**Architecture:** This slice adds an optional standalone persistence backend under `mcp_unified.storage` that implements the split store protocols from Stage 2D with a schema-versioned SQLite database and JSON payload columns. It must stay package-local: no `tldw_Server_API` imports, no FastAPI routes, no runtime execution enforcement, no external process lifecycle, and no standalone gateway entrypoint.
+
+**Tech Stack:** Python 3.10+, stdlib `sqlite3`, Pydantic v2 models, pytest, Ruff, Mypy, Bandit, Backlog.md.
+
+---
+
+## Source Design
+
+- Spec: `Docs/superpowers/specs/2026-05-26-mcp-unified-standalone-library-gateway-design.md`
+- Prior slice: `Docs/superpowers/plans/2026-05-28-mcp-unified-stage2d-storage-contract-split-implementation-plan.md`
+- Backlog task: `TASK-528`
+
+## Scope
+
+In scope:
+- Add `SQLiteMCPStore` as a package-local implementation of the existing split store protocols.
+- Store complete Pydantic payloads as JSON while maintaining indexed columns needed for current protocol filters.
+- Add schema metadata with an explicit schema version and idempotent initialization.
+- Preserve caller-owned returned models with deep validation/copy boundaries.
+- Add focused tests for schema creation, CRUD/filter behavior, audit append/query behavior, and package-boundary isolation.
+
+Out of scope:
+- Runtime profile enforcement in `MCPProtocol` or `MCPServer`.
+- FastAPI routes, MCP Hub adapters, AuthNZ wiring, or gateway entrypoints.
+- External MCP process spawning or lifecycle management.
+- YAML import/export or migration CLI commands.
+- Cross-process locking beyond SQLite's normal transaction behavior.
+
+## Files
+
+- Create: `mcp_unified/storage/sqlite.py`
+- Modify: `mcp_unified/storage/__init__.py`
+- Create: `tldw_Server_API/app/core/MCP_unified/tests/test_sqlite_storage_contracts.py`
+- Modify: `Docs/superpowers/plans/2026-05-28-mcp-unified-stage2e-sqlite-stores-implementation-plan.md`
+- Modify: `backlog/tasks/task-528 - Implement-MCP-Unified-Stage-2E-SQLite-store-slice.md`
+
+## Task 1: RED Tests For SQLite Store Contracts
+
+**Files:**
+- Create: `tldw_Server_API/app/core/MCP_unified/tests/test_sqlite_storage_contracts.py`
+
+- [x] **Step 1: Write failing import and schema tests**
+
+Add tests that assert:
+- `mcp_unified.storage.sqlite` imports without any `tldw_Server_API` imports.
+- `SQLiteMCPStore(tmp_path / "mcp.sqlite")` creates schema metadata with `schema_version == "1"`.
+- Reopening the same database is idempotent and does not duplicate or corrupt metadata.
+
+- [x] **Step 2: Run RED test**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_sqlite_storage_contracts.py -v
+```
+
+Expected: FAIL because `mcp_unified.storage.sqlite` and `SQLiteMCPStore` do not exist yet.
+
+## Task 2: Implement Schema Initialization
+
+**Files:**
+- Create: `mcp_unified/storage/sqlite.py`
+- Modify: `mcp_unified/storage/__init__.py`
+
+- [x] **Step 1: Add SQLiteMCPStore constructor and schema**
+
+Implement:
+- `SQLiteMCPStore(path: str | Path)`
+- `SCHEMA_VERSION = 1`
+- idempotent schema creation for:
+  - `mcp_storage_meta`
+  - `mcp_profiles`
+  - `mcp_profile_assignments`
+  - `mcp_approval_policies`
+  - `mcp_credential_grants`
+  - `mcp_external_servers`
+  - `mcp_audit_events`
+- `close()` and `async aclose()` helpers.
+
+Use parameterized SQL only. Keep the module free of host imports.
+
+- [x] **Step 2: Export the store**
+
+Export `SQLiteMCPStore` from `mcp_unified.storage`.
+
+- [x] **Step 3: Run schema tests**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_sqlite_storage_contracts.py -v
+```
+
+Expected: schema/import tests pass; later CRUD tests will still fail until implemented.
+
+## Task 3: Implement Profile And Split Store CRUD
+
+**Files:**
+- Modify: `mcp_unified/storage/sqlite.py`
+- Modify: `tldw_Server_API/app/core/MCP_unified/tests/test_sqlite_storage_contracts.py`
+
+- [x] **Step 1: Write failing CRUD/filter tests**
+
+Add tests that assert:
+- `upsert_profile`, `get_profile`, `list_profiles`, and `delete_profile` round-trip `MCPProfile` with copy isolation.
+- `upsert_assignment`, `get_assignment`, `list_assignments`, and `delete_assignment` filter by `profile_id`, `principal_id`, and `workspace_id`.
+- `upsert_policy`, `get_policy`, `list_policies`, and `delete_policy` filter by `profile_id`.
+- `upsert_grant`, `get_grant`, `list_grants`, and `delete_grant` filter by `profile_id` and `external_server_id`.
+- `upsert_server`, `get_server`, `list_servers`, `list_server_definitions`, and `delete_server` filter enabled definitions separately from status-row compatibility.
+
+- [x] **Step 2: Run RED CRUD/filter tests**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_sqlite_storage_contracts.py -v
+```
+
+Expected: FAIL on missing CRUD/filter methods.
+
+- [x] **Step 3: Implement CRUD/filter methods**
+
+Implement protocol methods using model validation at both input and output boundaries. Store full model payloads as sorted JSON and keep filter columns in sync with the payload.
+
+- [x] **Step 4: Run GREEN CRUD/filter tests**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_sqlite_storage_contracts.py -v
+```
+
+Expected: PASS for schema and CRUD/filter tests.
+
+## Task 4: Implement Audit Append And Query
+
+**Files:**
+- Modify: `mcp_unified/storage/sqlite.py`
+- Modify: `tldw_Server_API/app/core/MCP_unified/tests/test_sqlite_storage_contracts.py`
+
+- [x] **Step 1: Write failing audit tests**
+
+Add tests that assert:
+- `append_event` persists `AuditEvent` payloads without sharing caller-owned dictionaries.
+- `query_events(actor_id=...)`, `query_events(profile_id=...)`, and `query_events(event_type=...)` filter correctly.
+- `query_events(limit=...)` returns deterministic newest-first results.
+
+- [x] **Step 2: Run RED audit tests**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_sqlite_storage_contracts.py -v
+```
+
+Expected: FAIL on missing audit behavior.
+
+- [x] **Step 3: Implement audit append/query**
+
+Implement append-only insert and parameterized filtered queries. Keep the method async to satisfy the package protocol, but use stdlib SQLite internally for this first package-local backend.
+
+- [x] **Step 4: Run GREEN audit tests**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_sqlite_storage_contracts.py -v
+```
+
+Expected: PASS.
+
+## Task 5: Focused Regression And Quality Gates
+
+**Files:**
+- Modify: `backlog/tasks/task-528 - Implement-MCP-Unified-Stage-2E-SQLite-store-slice.md`
+- Modify: `Docs/superpowers/plans/2026-05-28-mcp-unified-stage2e-sqlite-stores-implementation-plan.md`
+
+- [x] **Step 1: Run focused package regression**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m pytest \
+  tldw_Server_API/app/core/MCP_unified/tests/test_sqlite_storage_contracts.py \
+  tldw_Server_API/app/core/MCP_unified/tests/test_storage_contracts.py \
+  tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py \
+  tldw_Server_API/app/core/MCP_unified/tests/test_profile_registry_resolver.py \
+  tldw_Server_API/app/core/MCP_unified/tests/test_profile_structured_resolution.py \
+  -v
+```
+
+Expected: PASS.
+
+- [x] **Step 2: Run static and security checks**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m ruff check mcp_unified tldw_Server_API/app/core/MCP_unified/tests/test_sqlite_storage_contracts.py
+source .venv/bin/activate && python -m mypy mcp_unified tldw_Server_API/app/core/MCP_unified/tests/test_sqlite_storage_contracts.py
+source .venv/bin/activate && python -m bandit -r mcp_unified -f json -o /tmp/bandit_mcp_unified_stage2e_sqlite.json
+source .venv/bin/activate && python -c 'import json; data=json.load(open("/tmp/bandit_mcp_unified_stage2e_sqlite.json")); print(data["metrics"]["_totals"]); print("results", len(data["results"]))'
+git diff --check
+```
+
+Expected: Ruff passes, Mypy passes, Bandit reports 0 findings, and diff whitespace is clean.
+
+- [x] **Step 3: Update task and commit**
+
+Record implementation notes, verification, known skips, and final summary in `TASK-528`, then commit:
+
+```bash
+git add \
+  Docs/superpowers/plans/2026-05-28-mcp-unified-stage2e-sqlite-stores-implementation-plan.md \
+  mcp_unified/storage/__init__.py \
+  mcp_unified/storage/sqlite.py \
+  tldw_Server_API/app/core/MCP_unified/tests/test_sqlite_storage_contracts.py \
+  "backlog/tasks/task-528 - Implement-MCP-Unified-Stage-2E-SQLite-store-slice.md"
+git commit -m "feat: add mcp sqlite storage contracts"
+```

--- a/backlog/tasks/task-528 - Implement-MCP-Unified-Stage-2E-SQLite-store-slice.md
+++ b/backlog/tasks/task-528 - Implement-MCP-Unified-Stage-2E-SQLite-store-slice.md
@@ -1,0 +1,62 @@
+---
+id: TASK-528
+title: Implement MCP Unified Stage 2E SQLite store slice
+status: Done
+assignee: []
+created_date: ''
+updated_date: '2026-05-28 05:05'
+labels:
+  - mcp-unified
+  - standalone
+  - stage2
+  - sqlite
+dependencies: []
+references:
+  - >-
+    Docs/superpowers/specs/2026-05-26-mcp-unified-standalone-library-gateway-design.md
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Plan and implement the next reviewable MCP Unified standalone Stage 2E slice: gateway-local SQLite store and migration primitives for the split profile, assignment, approval policy, credential grant, external registry, and audit contracts. Keep the slice package-local and avoid runtime execution, FastAPI routes, external process lifecycle, or gateway entrypoints.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 SQLiteMCPStore initializes an idempotent schema with explicit schema version metadata.
+- [x] #2 Profiles, assignments, approval policies, credential grants, and external server definitions round-trip through SQLite with filtered listing and delete behavior.
+- [x] #3 Audit events append and query by actor, profile, event type, and newest-first limit semantics.
+- [x] #4 The standalone storage module remains free of tldw_Server_API imports and does not add FastAPI, runtime, gateway, or lifecycle wiring.
+- [x] #5 Focused regression, Ruff, Mypy, Bandit, and diff whitespace checks pass.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented a package-local SQLiteMCPStore in mcp_unified.storage using stdlib sqlite3 and JSON payload columns plus indexed filter columns. Added validation/copy boundaries through existing Pydantic models and allowlisted SQL identifier handling for filter queries while keeping SQL values parameterized. Exported the store from mcp_unified.storage and added contract tests for schema creation, future-schema rejection, CRUD/filter behavior, audit query semantics, copy isolation, and package-boundary isolation.
+
+Verification:
+- source .venv/bin/activate && python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_sqlite_storage_contracts.py tldw_Server_API/app/core/MCP_unified/tests/test_storage_contracts.py tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py tldw_Server_API/app/core/MCP_unified/tests/test_profile_registry_resolver.py tldw_Server_API/app/core/MCP_unified/tests/test_profile_structured_resolution.py -v -> 50 passed, 3 warnings
+- source .venv/bin/activate && python -m ruff check mcp_unified tldw_Server_API/app/core/MCP_unified/tests/test_sqlite_storage_contracts.py -> All checks passed
+- source .venv/bin/activate && python -m mypy mcp_unified tldw_Server_API/app/core/MCP_unified/tests/test_sqlite_storage_contracts.py -> Success, no issues in 15 source files
+- source .venv/bin/activate && python -m bandit -r mcp_unified -f json -o /tmp/bandit_mcp_unified_stage2e_sqlite.json -> 0 findings, 0 skipped tests
+- git diff --check -> clean
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Added the Stage 2E SQLite storage slice for MCP Unified standalone extraction. The new store covers schema-versioned SQLite persistence for profiles, profile assignments, approval policies, credential grants, external server definitions, and audit events without introducing host-package imports or runtime enforcement wiring. Known skips/blockers: none; gateway entrypoints, YAML import/export, runtime enforcement, and external MCP lifecycle remain out of scope for this slice.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-528 - Implement-MCP-Unified-Stage-2E-SQLite-store-slice.md
+++ b/backlog/tasks/task-528 - Implement-MCP-Unified-Stage-2E-SQLite-store-slice.md
@@ -4,7 +4,7 @@ title: Implement MCP Unified Stage 2E SQLite store slice
 status: Done
 assignee: []
 created_date: ''
-updated_date: '2026-05-28 05:05'
+updated_date: '2026-05-28 05:25'
 labels:
   - mcp-unified
   - standalone
@@ -43,12 +43,27 @@ Verification:
 - source .venv/bin/activate && python -m mypy mcp_unified tldw_Server_API/app/core/MCP_unified/tests/test_sqlite_storage_contracts.py -> Success, no issues in 15 source files
 - source .venv/bin/activate && python -m bandit -r mcp_unified -f json -o /tmp/bandit_mcp_unified_stage2e_sqlite.json -> 0 findings, 0 skipped tests
 - git diff --check -> clean
+
+Review-fix pass after rebasing on latest origin/dev:
+- Rebased PR #2089 branch onto origin/dev at 4a48a0f6.
+- Addressed async SQLite review feedback by routing async store methods through asyncio.to_thread, using a check_same_thread=False SQLite connection with timeout=30.0, and serializing connection access with a reentrant lock.
+- Addressed foreign-key feedback by adding profile_id foreign keys with ON DELETE CASCADE for assignments, approval policies, and credential grants, plus regression coverage for orphan rejection and cascade cleanup.
+- Addressed audit ordering feedback by normalizing persisted audit event timestamps to UTC and adding mixed-timezone ordering coverage.
+- Addressed the redundant limit branch feedback by combining query LIMIT handling into one conditional.
+- Evaluated the raw SQL / DB_Management comment and kept stdlib sqlite3 inside mcp_unified intentionally because this standalone storage package must not import host tldw_Server_API DB helpers; the package-boundary tests continue to enforce that.
+
+Review-fix verification:
+- source .venv/bin/activate && python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_sqlite_storage_contracts.py tldw_Server_API/app/core/MCP_unified/tests/test_storage_contracts.py tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py tldw_Server_API/app/core/MCP_unified/tests/test_profile_registry_resolver.py tldw_Server_API/app/core/MCP_unified/tests/test_profile_structured_resolution.py -v -> 54 passed, 3 warnings
+- source .venv/bin/activate && python -m ruff check mcp_unified tldw_Server_API/app/core/MCP_unified/tests/test_sqlite_storage_contracts.py -> All checks passed
+- source .venv/bin/activate && python -m mypy mcp_unified tldw_Server_API/app/core/MCP_unified/tests/test_sqlite_storage_contracts.py -> Success, no issues in 15 source files
+- source .venv/bin/activate && python -m bandit -r mcp_unified -f json -o /tmp/bandit_mcp_unified_stage2e_review.json -> 0 findings, 0 skipped tests
+- git diff --check -> clean
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Added the Stage 2E SQLite storage slice for MCP Unified standalone extraction. The new store covers schema-versioned SQLite persistence for profiles, profile assignments, approval policies, credential grants, external server definitions, and audit events without introducing host-package imports or runtime enforcement wiring. Known skips/blockers: none; gateway entrypoints, YAML import/export, runtime enforcement, and external MCP lifecycle remain out of scope for this slice.
+Added the Stage 2E SQLite storage slice and completed the PR #2089 review-fix pass after rebasing on latest dev. The store remains standalone/package-local while async methods now offload SQLite work, the connection is configured for thread offload with a lock timeout, dependent profile rows use foreign-key cascades, audit timestamps are normalized for correct newest-first ordering across timezone offsets, and review coverage was expanded. Known skips/blockers: none; host DB_Management wiring remains intentionally out of scope because it would violate the standalone package boundary.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-528 - Implement-MCP-Unified-Stage-2E-SQLite-store-slice.md
+++ b/backlog/tasks/task-528 - Implement-MCP-Unified-Stage-2E-SQLite-store-slice.md
@@ -4,7 +4,7 @@ title: Implement MCP Unified Stage 2E SQLite store slice
 status: Done
 assignee: []
 created_date: ''
-updated_date: '2026-05-28 05:25'
+updated_date: '2026-05-28 06:04'
 labels:
   - mcp-unified
   - standalone
@@ -58,12 +58,23 @@ Review-fix verification:
 - source .venv/bin/activate && python -m mypy mcp_unified tldw_Server_API/app/core/MCP_unified/tests/test_sqlite_storage_contracts.py -> Success, no issues in 15 source files
 - source .venv/bin/activate && python -m bandit -r mcp_unified -f json -o /tmp/bandit_mcp_unified_stage2e_review.json -> 0 findings, 0 skipped tests
 - git diff --check -> clean
+
+Additional review-fix pass completed after repeated raw SQL / async sqlite / audit ordering feedback. Replaced direct stdlib sqlite3 usage in mcp_unified/storage/sqlite.py with a SQLAlchemy Core-backed implementation while preserving the standalone package boundary and avoiding tldw_Server_API imports. Async store methods continue to offload DB work through asyncio.to_thread. SQLite engine creation now records timeout=30.0 and check_same_thread=False through connect_args, uses StaticPool for :memory: so thread offload shares the same in-memory schema, and enables FK enforcement on DBAPI connect. Audit events remain normalized to UTC before persistence, and existing FK cascade behavior is preserved. Added regression coverage for no direct sqlite3 import in the store module, SQLAlchemy connection args, :memory: thread-offload behavior, FK enforcement, and mixed-offset audit ordering.
+
+Verification for this pass:
+- source .venv/bin/activate && python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_sqlite_storage_contracts.py tldw_Server_API/app/core/MCP_unified/tests/test_storage_contracts.py tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py tldw_Server_API/app/core/MCP_unified/tests/test_profile_registry_resolver.py tldw_Server_API/app/core/MCP_unified/tests/test_profile_structured_resolution.py -v -> 56 passed, 3 warnings
+- source .venv/bin/activate && python -m ruff check mcp_unified tldw_Server_API/app/core/MCP_unified/tests/test_sqlite_storage_contracts.py -> All checks passed
+- source .venv/bin/activate && python -m mypy mcp_unified tldw_Server_API/app/core/MCP_unified/tests/test_sqlite_storage_contracts.py -> Success, no issues in 15 source files
+- source .venv/bin/activate && python -m bandit -r mcp_unified -> No issues identified
+- git diff --check -> clean
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
 Added the Stage 2E SQLite storage slice and completed the PR #2089 review-fix pass after rebasing on latest dev. The store remains standalone/package-local while async methods now offload SQLite work, the connection is configured for thread offload with a lock timeout, dependent profile rows use foreign-key cascades, audit timestamps are normalized for correct newest-first ordering across timezone offsets, and review coverage was expanded. Known skips/blockers: none; host DB_Management wiring remains intentionally out of scope because it would violate the standalone package boundary.
+
+Additional review-fix pass replaced direct sqlite3/raw SQL handling in the standalone store with SQLAlchemy Core while keeping async thread offload, UTC audit normalization, FK cascades, and standalone package-boundary tests intact.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/mcp_unified/storage/__init__.py
+++ b/mcp_unified/storage/__init__.py
@@ -7,6 +7,7 @@ from .models import (
     ExternalServerDefinition,
     ProfileAssignment,
 )
+from .sqlite import SQLiteMCPStore
 
 __all__ = [
     "ApprovalPolicyDocument",
@@ -14,4 +15,5 @@ __all__ = [
     "CredentialGrant",
     "ExternalServerDefinition",
     "ProfileAssignment",
+    "SQLiteMCPStore",
 ]

--- a/mcp_unified/storage/sqlite.py
+++ b/mcp_unified/storage/sqlite.py
@@ -1,12 +1,19 @@
-"""SQLite-backed standalone MCP storage primitives."""
+"""SQLite-backed standalone MCP storage primitives.
+
+This backend intentionally stays in ``mcp_unified`` and uses stdlib SQLite so
+the standalone package does not import host ``tldw_Server_API`` DB helpers.
+"""
 
 from __future__ import annotations
 
+import asyncio
 import json
 import sqlite3
-from collections.abc import Mapping
+import threading
+from collections.abc import Callable, Mapping
+from datetime import timezone
 from pathlib import Path
-from typing import Any, ClassVar, TypeVar
+from typing import Any, ClassVar, ParamSpec, TypeVar
 
 from pydantic import BaseModel
 
@@ -20,6 +27,8 @@ from mcp_unified.storage.models import (
 )
 
 ModelT = TypeVar("ModelT", bound=BaseModel)
+ReturnT = TypeVar("ReturnT")
+ParamsT = ParamSpec("ParamsT")
 
 
 class SQLiteMCPStore:
@@ -80,38 +89,198 @@ class SQLiteMCPStore:
             db_path = Path(path).expanduser()
             db_path.parent.mkdir(parents=True, exist_ok=True)
             self.path = str(db_path)
-        self._conn = sqlite3.connect(self.path)
+        self._lock = threading.RLock()
+        self._conn = sqlite3.connect(
+            self.path,
+            timeout=30.0,
+            check_same_thread=False,
+        )
         self._conn.row_factory = sqlite3.Row
         self._conn.execute("PRAGMA foreign_keys = ON")
         self._initialize_schema()
 
     def close(self) -> None:
         """Close the underlying SQLite connection."""
-        self._conn.close()
+        self._close_sync()
 
     async def aclose(self) -> None:
         """Async-friendly close helper for callers managing stores generically."""
-        self.close()
+        await self._run_db(self._close_sync)
 
     async def get_profile(self, profile_id: str) -> MCPProfile | None:
         """Return a copy-isolated profile by id."""
-        return self._get_model("mcp_profiles", profile_id, MCPProfile)
+        return await self._run_db(self._get_profile_sync, profile_id)
 
     async def list_profiles(self) -> list[MCPProfile]:
         """Return all profiles sorted by id."""
-        rows = self._conn.execute(
-            "SELECT payload FROM mcp_profiles ORDER BY id",
-        ).fetchall()
-        return [self._load_model(row["payload"], MCPProfile) for row in rows]
+        return await self._run_db(self._list_profiles_sync)
 
     async def upsert_profile(
         self,
         profile: MCPProfile | Mapping[str, Any],
     ) -> MCPProfile:
         """Store a profile document and return the persisted model."""
+        return await self._run_db(self._upsert_profile_sync, profile)
+
+    async def delete_profile(self, profile_id: str) -> bool:
+        """Delete a profile by id and return whether it existed."""
+        return await self._run_db(self._delete_profile_sync, profile_id)
+
+    async def get_assignment(self, assignment_id: str) -> ProfileAssignment | None:
+        """Return a profile assignment by id."""
+        return await self._run_db(self._get_assignment_sync, assignment_id)
+
+    async def list_assignments(
+        self,
+        *,
+        profile_id: str | None = None,
+        principal_id: str | None = None,
+        workspace_id: str | None = None,
+    ) -> list[ProfileAssignment]:
+        """Return profile assignments matching optional filters."""
+        return await self._run_db(
+            self._list_assignments_sync,
+            profile_id=profile_id,
+            principal_id=principal_id,
+            workspace_id=workspace_id,
+        )
+
+    async def upsert_assignment(
+        self,
+        assignment: ProfileAssignment,
+    ) -> ProfileAssignment:
+        """Store a profile assignment and return the persisted model."""
+        return await self._run_db(self._upsert_assignment_sync, assignment)
+
+    async def delete_assignment(self, assignment_id: str) -> bool:
+        """Delete a profile assignment by id and return whether it existed."""
+        return await self._run_db(self._delete_assignment_sync, assignment_id)
+
+    async def get_policy(self, policy_id: str) -> ApprovalPolicyDocument | None:
+        """Return an approval policy by id."""
+        return await self._run_db(self._get_policy_sync, policy_id)
+
+    async def list_policies(
+        self,
+        *,
+        profile_id: str | None = None,
+    ) -> list[ApprovalPolicyDocument]:
+        """Return approval policies matching optional filters."""
+        return await self._run_db(self._list_policies_sync, profile_id=profile_id)
+
+    async def upsert_policy(
+        self,
+        policy: ApprovalPolicyDocument,
+    ) -> ApprovalPolicyDocument:
+        """Store an approval policy and return the persisted model."""
+        return await self._run_db(self._upsert_policy_sync, policy)
+
+    async def delete_policy(self, policy_id: str) -> bool:
+        """Delete an approval policy by id and return whether it existed."""
+        return await self._run_db(self._delete_policy_sync, policy_id)
+
+    async def get_grant(self, grant_id: str) -> CredentialGrant | None:
+        """Return a credential grant by id."""
+        return await self._run_db(self._get_grant_sync, grant_id)
+
+    async def list_grants(
+        self,
+        *,
+        profile_id: str | None = None,
+        external_server_id: str | None = None,
+    ) -> list[CredentialGrant]:
+        """Return credential grants matching optional filters."""
+        return await self._run_db(
+            self._list_grants_sync,
+            profile_id=profile_id,
+            external_server_id=external_server_id,
+        )
+
+    async def upsert_grant(self, grant: CredentialGrant) -> CredentialGrant:
+        """Store a credential grant and return the persisted model."""
+        return await self._run_db(self._upsert_grant_sync, grant)
+
+    async def delete_grant(self, grant_id: str) -> bool:
+        """Delete a credential grant by id and return whether it existed."""
+        return await self._run_db(self._delete_grant_sync, grant_id)
+
+    async def get_server(self, server_id: str) -> ExternalServerDefinition | None:
+        """Return an external server definition by id."""
+        return await self._run_db(self._get_server_sync, server_id)
+
+    async def list_servers(self) -> list[ExternalServerDefinition]:
+        """Return all external server definitions sorted by id."""
+        return await self.list_server_definitions()
+
+    async def list_server_definitions(
+        self,
+        *,
+        enabled: bool | None = None,
+    ) -> list[ExternalServerDefinition]:
+        """Return external server definitions matching optional enabled state."""
+        return await self._run_db(self._list_server_definitions_sync, enabled=enabled)
+
+    async def upsert_server(
+        self,
+        server: ExternalServerDefinition,
+    ) -> ExternalServerDefinition:
+        """Store an external server definition and return the persisted model."""
+        return await self._run_db(self._upsert_server_sync, server)
+
+    async def delete_server(self, server_id: str) -> bool:
+        """Delete an external server definition by id and return whether it existed."""
+        return await self._run_db(self._delete_server_sync, server_id)
+
+    async def append_event(self, event: AuditEvent) -> AuditEvent:
+        """Append an audit event and return the persisted event."""
+        return await self._run_db(self._append_event_sync, event)
+
+    async def query_events(
+        self,
+        *,
+        actor_id: str | None = None,
+        profile_id: str | None = None,
+        event_type: str | None = None,
+        limit: int | None = None,
+    ) -> list[AuditEvent]:
+        """Return audit events matching optional filters, newest first."""
+        return await self._run_db(
+            self._query_events_sync,
+            actor_id=actor_id,
+            profile_id=profile_id,
+            event_type=event_type,
+            limit=limit,
+        )
+
+    async def _run_db(
+        self,
+        operation: Callable[ParamsT, ReturnT],
+        *args: ParamsT.args,
+        **kwargs: ParamsT.kwargs,
+    ) -> ReturnT:
+        return await asyncio.to_thread(operation, *args, **kwargs)
+
+    def _close_sync(self) -> None:
+        with self._lock:
+            self._conn.close()
+
+    def _get_profile_sync(self, profile_id: str) -> MCPProfile | None:
+        return self._get_model("mcp_profiles", profile_id, MCPProfile)
+
+    def _list_profiles_sync(self) -> list[MCPProfile]:
+        with self._lock:
+            rows = self._conn.execute(
+                "SELECT payload FROM mcp_profiles ORDER BY id",
+            ).fetchall()
+        return [self._load_model(row["payload"], MCPProfile) for row in rows]
+
+    def _upsert_profile_sync(
+        self,
+        profile: MCPProfile | Mapping[str, Any],
+    ) -> MCPProfile:
         validated = self._validate_profile(profile)
         payload = self._dump_model(validated)
-        with self._conn:
+        with self._lock, self._conn:
             self._conn.execute(
                 """
                 INSERT INTO mcp_profiles(id, enabled, updated_at, payload)
@@ -130,26 +299,23 @@ class SQLiteMCPStore:
             )
         return self._load_model(payload, MCPProfile)
 
-    async def delete_profile(self, profile_id: str) -> bool:
-        """Delete a profile by id and return whether it existed."""
+    def _delete_profile_sync(self, profile_id: str) -> bool:
         return self._delete_by_id("mcp_profiles", profile_id)
 
-    async def get_assignment(self, assignment_id: str) -> ProfileAssignment | None:
-        """Return a profile assignment by id."""
+    def _get_assignment_sync(self, assignment_id: str) -> ProfileAssignment | None:
         return self._get_model(
             "mcp_profile_assignments",
             assignment_id,
             ProfileAssignment,
         )
 
-    async def list_assignments(
+    def _list_assignments_sync(
         self,
         *,
         profile_id: str | None = None,
         principal_id: str | None = None,
         workspace_id: str | None = None,
     ) -> list[ProfileAssignment]:
-        """Return profile assignments matching optional filters."""
         rows = self._select_filtered_payloads(
             "mcp_profile_assignments",
             {
@@ -160,13 +326,12 @@ class SQLiteMCPStore:
         )
         return [self._load_model(row["payload"], ProfileAssignment) for row in rows]
 
-    async def upsert_assignment(
+    def _upsert_assignment_sync(
         self,
         assignment: ProfileAssignment,
     ) -> ProfileAssignment:
-        """Store a profile assignment and return the persisted model."""
         payload = self._dump_model(assignment)
-        with self._conn:
+        with self._lock, self._conn:
             self._conn.execute(
                 """
                 INSERT INTO mcp_profile_assignments(
@@ -196,33 +361,29 @@ class SQLiteMCPStore:
             )
         return self._load_model(payload, ProfileAssignment)
 
-    async def delete_assignment(self, assignment_id: str) -> bool:
-        """Delete a profile assignment by id and return whether it existed."""
+    def _delete_assignment_sync(self, assignment_id: str) -> bool:
         return self._delete_by_id("mcp_profile_assignments", assignment_id)
 
-    async def get_policy(self, policy_id: str) -> ApprovalPolicyDocument | None:
-        """Return an approval policy by id."""
+    def _get_policy_sync(self, policy_id: str) -> ApprovalPolicyDocument | None:
         return self._get_model("mcp_approval_policies", policy_id, ApprovalPolicyDocument)
 
-    async def list_policies(
+    def _list_policies_sync(
         self,
         *,
         profile_id: str | None = None,
     ) -> list[ApprovalPolicyDocument]:
-        """Return approval policies matching optional filters."""
         rows = self._select_filtered_payloads(
             "mcp_approval_policies",
             {"profile_id": profile_id},
         )
         return [self._load_model(row["payload"], ApprovalPolicyDocument) for row in rows]
 
-    async def upsert_policy(
+    def _upsert_policy_sync(
         self,
         policy: ApprovalPolicyDocument,
     ) -> ApprovalPolicyDocument:
-        """Store an approval policy and return the persisted model."""
         payload = self._dump_model(policy)
-        with self._conn:
+        with self._lock, self._conn:
             self._conn.execute(
                 """
                 INSERT INTO mcp_approval_policies(
@@ -245,21 +406,18 @@ class SQLiteMCPStore:
             )
         return self._load_model(payload, ApprovalPolicyDocument)
 
-    async def delete_policy(self, policy_id: str) -> bool:
-        """Delete an approval policy by id and return whether it existed."""
+    def _delete_policy_sync(self, policy_id: str) -> bool:
         return self._delete_by_id("mcp_approval_policies", policy_id)
 
-    async def get_grant(self, grant_id: str) -> CredentialGrant | None:
-        """Return a credential grant by id."""
+    def _get_grant_sync(self, grant_id: str) -> CredentialGrant | None:
         return self._get_model("mcp_credential_grants", grant_id, CredentialGrant)
 
-    async def list_grants(
+    def _list_grants_sync(
         self,
         *,
         profile_id: str | None = None,
         external_server_id: str | None = None,
     ) -> list[CredentialGrant]:
-        """Return credential grants matching optional filters."""
         rows = self._select_filtered_payloads(
             "mcp_credential_grants",
             {
@@ -269,10 +427,9 @@ class SQLiteMCPStore:
         )
         return [self._load_model(row["payload"], CredentialGrant) for row in rows]
 
-    async def upsert_grant(self, grant: CredentialGrant) -> CredentialGrant:
-        """Store a credential grant and return the persisted model."""
+    def _upsert_grant_sync(self, grant: CredentialGrant) -> CredentialGrant:
         payload = self._dump_model(grant)
-        with self._conn:
+        with self._lock, self._conn:
             self._conn.execute(
                 """
                 INSERT INTO mcp_credential_grants(
@@ -297,37 +454,29 @@ class SQLiteMCPStore:
             )
         return self._load_model(payload, CredentialGrant)
 
-    async def delete_grant(self, grant_id: str) -> bool:
-        """Delete a credential grant by id and return whether it existed."""
+    def _delete_grant_sync(self, grant_id: str) -> bool:
         return self._delete_by_id("mcp_credential_grants", grant_id)
 
-    async def get_server(self, server_id: str) -> ExternalServerDefinition | None:
-        """Return an external server definition by id."""
+    def _get_server_sync(self, server_id: str) -> ExternalServerDefinition | None:
         return self._get_model("mcp_external_servers", server_id, ExternalServerDefinition)
 
-    async def list_servers(self) -> list[ExternalServerDefinition]:
-        """Return all external server definitions sorted by id."""
-        return await self.list_server_definitions()
-
-    async def list_server_definitions(
+    def _list_server_definitions_sync(
         self,
         *,
         enabled: bool | None = None,
     ) -> list[ExternalServerDefinition]:
-        """Return external server definitions matching optional enabled state."""
         rows = self._select_filtered_payloads(
             "mcp_external_servers",
             {"enabled": None if enabled is None else int(enabled)},
         )
         return [self._load_model(row["payload"], ExternalServerDefinition) for row in rows]
 
-    async def upsert_server(
+    def _upsert_server_sync(
         self,
         server: ExternalServerDefinition,
     ) -> ExternalServerDefinition:
-        """Store an external server definition and return the persisted model."""
         payload = self._dump_model(server)
-        with self._conn:
+        with self._lock, self._conn:
             self._conn.execute(
                 """
                 INSERT INTO mcp_external_servers(
@@ -350,14 +499,13 @@ class SQLiteMCPStore:
             )
         return self._load_model(payload, ExternalServerDefinition)
 
-    async def delete_server(self, server_id: str) -> bool:
-        """Delete an external server definition by id and return whether it existed."""
+    def _delete_server_sync(self, server_id: str) -> bool:
         return self._delete_by_id("mcp_external_servers", server_id)
 
-    async def append_event(self, event: AuditEvent) -> AuditEvent:
-        """Append an audit event and return the persisted event."""
-        payload = self._dump_model(event)
-        with self._conn:
+    def _append_event_sync(self, event: AuditEvent) -> AuditEvent:
+        normalized = self._normalize_audit_event(event)
+        payload = self._dump_model(normalized)
+        with self._lock, self._conn:
             self._conn.execute(
                 """
                 INSERT INTO mcp_audit_events(
@@ -366,17 +514,17 @@ class SQLiteMCPStore:
                 VALUES (?, ?, ?, ?, ?, ?)
                 """,
                 (
-                    event.id,
-                    event.actor_id,
-                    event.profile_id,
-                    event.event_type,
-                    event.created_at.isoformat(),
+                    normalized.id,
+                    normalized.actor_id,
+                    normalized.profile_id,
+                    normalized.event_type,
+                    normalized.created_at.isoformat(),
                     payload,
                 ),
             )
         return self._load_model(payload, AuditEvent)
 
-    async def query_events(
+    def _query_events_sync(
         self,
         *,
         actor_id: str | None = None,
@@ -384,7 +532,6 @@ class SQLiteMCPStore:
         event_type: str | None = None,
         limit: int | None = None,
     ) -> list[AuditEvent]:
-        """Return audit events matching optional filters, newest first."""
         if limit is not None and limit < 0:
             raise ValueError("limit must be non-negative")
         rows = self._select_filtered_payloads(
@@ -400,7 +547,7 @@ class SQLiteMCPStore:
         return [self._load_model(row["payload"], AuditEvent) for row in rows]
 
     def _initialize_schema(self) -> None:
-        with self._conn:
+        with self._lock, self._conn:
             self._conn.execute(
                 """
                 CREATE TABLE IF NOT EXISTS mcp_storage_meta (
@@ -430,7 +577,10 @@ class SQLiteMCPStore:
                     is_default INTEGER NOT NULL,
                     enabled INTEGER NOT NULL,
                     updated_at TEXT NOT NULL,
-                    payload TEXT NOT NULL
+                    payload TEXT NOT NULL,
+                    FOREIGN KEY(profile_id)
+                        REFERENCES mcp_profiles(id)
+                        ON DELETE CASCADE
                 )
                 """
             )
@@ -441,7 +591,10 @@ class SQLiteMCPStore:
                     profile_id TEXT,
                     enabled INTEGER NOT NULL,
                     updated_at TEXT NOT NULL,
-                    payload TEXT NOT NULL
+                    payload TEXT NOT NULL,
+                    FOREIGN KEY(profile_id)
+                        REFERENCES mcp_profiles(id)
+                        ON DELETE CASCADE
                 )
                 """
             )
@@ -453,7 +606,10 @@ class SQLiteMCPStore:
                     external_server_id TEXT,
                     enabled INTEGER NOT NULL,
                     updated_at TEXT NOT NULL,
-                    payload TEXT NOT NULL
+                    payload TEXT NOT NULL,
+                    FOREIGN KEY(profile_id)
+                        REFERENCES mcp_profiles(id)
+                        ON DELETE CASCADE
                 )
                 """
             )
@@ -534,7 +690,7 @@ class SQLiteMCPStore:
         )
 
     def _delete_by_id(self, table: str, item_id: str) -> bool:
-        with self._conn:
+        with self._lock, self._conn:
             cursor = self._conn.execute(
                 self._DELETE_BY_ID_SQL[table],
                 (item_id,),
@@ -547,10 +703,11 @@ class SQLiteMCPStore:
         item_id: str,
         model_cls: type[ModelT],
     ) -> ModelT | None:
-        row = self._conn.execute(
-            self._SELECT_BY_ID_SQL[table],
-            (item_id,),
-        ).fetchone()
+        with self._lock:
+            row = self._conn.execute(
+                self._SELECT_BY_ID_SQL[table],
+                (item_id,),
+            ).fetchone()
         if row is None:
             return None
         return self._load_model(row["payload"], model_cls)
@@ -578,9 +735,9 @@ class SQLiteMCPStore:
         query_parts.extend(["ORDER BY", self._ORDER_BY_SQL[order_by]])
         if limit is not None:
             query_parts.append("LIMIT ?")
-        if limit is not None:
             values.append(limit)
-        return self._conn.execute(" ".join(query_parts), values).fetchall()
+        with self._lock:
+            return self._conn.execute(" ".join(query_parts), values).fetchall()
 
     def _validate_filter_request(
         self,
@@ -610,6 +767,13 @@ class SQLiteMCPStore:
     @staticmethod
     def _load_model(payload: str, model_cls: type[ModelT]) -> ModelT:
         return model_cls.model_validate_json(payload)
+
+    @staticmethod
+    def _normalize_audit_event(event: AuditEvent) -> AuditEvent:
+        return event.model_copy(
+            update={"created_at": event.created_at.astimezone(timezone.utc)},
+            deep=True,
+        )
 
     @staticmethod
     def _validate_profile(profile: MCPProfile | Mapping[str, Any]) -> MCPProfile:

--- a/mcp_unified/storage/sqlite.py
+++ b/mcp_unified/storage/sqlite.py
@@ -1,21 +1,37 @@
 """SQLite-backed standalone MCP storage primitives.
 
-This backend intentionally stays in ``mcp_unified`` and uses stdlib SQLite so
-the standalone package does not import host ``tldw_Server_API`` DB helpers.
+The store uses SQLAlchemy Core as its database boundary so this standalone
+package does not issue raw sqlite3 calls or import host DB_Management helpers.
 """
 
 from __future__ import annotations
 
 import asyncio
 import json
-import sqlite3
-import threading
 from collections.abc import Callable, Mapping
 from datetime import timezone
 from pathlib import Path
-from typing import Any, ClassVar, ParamSpec, TypeVar
+from typing import Any, ClassVar, ParamSpec, TypeVar, cast
 
 from pydantic import BaseModel
+from sqlalchemy import (
+    URL,
+    Column,
+    Engine,
+    ForeignKey,
+    Index,
+    Integer,
+    MetaData,
+    String,
+    Table,
+    Text,
+    create_engine,
+    delete,
+    event,
+    select,
+)
+from sqlalchemy.dialects.sqlite import insert as sqlite_insert
+from sqlalchemy.pool import StaticPool
 
 from mcp_unified.profiles.models import MCPProfile
 from mcp_unified.storage.models import (
@@ -32,40 +48,9 @@ ParamsT = ParamSpec("ParamsT")
 
 
 class SQLiteMCPStore:
-    """Package-local SQLite implementation for MCP standalone stores."""
+    """SQLAlchemy-backed SQLite implementation for MCP standalone stores."""
 
     SCHEMA_VERSION = 1
-    _DELETE_BY_ID_SQL: ClassVar[dict[str, str]] = {
-        "mcp_profiles": "DELETE FROM mcp_profiles WHERE id = ?",
-        "mcp_profile_assignments": (
-            "DELETE FROM mcp_profile_assignments WHERE id = ?"
-        ),
-        "mcp_approval_policies": "DELETE FROM mcp_approval_policies WHERE id = ?",
-        "mcp_credential_grants": "DELETE FROM mcp_credential_grants WHERE id = ?",
-        "mcp_external_servers": "DELETE FROM mcp_external_servers WHERE id = ?",
-    }
-    _SELECT_BY_ID_SQL: ClassVar[dict[str, str]] = {
-        "mcp_profiles": "SELECT payload FROM mcp_profiles WHERE id = ?",
-        "mcp_profile_assignments": (
-            "SELECT payload FROM mcp_profile_assignments WHERE id = ?"
-        ),
-        "mcp_approval_policies": (
-            "SELECT payload FROM mcp_approval_policies WHERE id = ?"
-        ),
-        "mcp_credential_grants": (
-            "SELECT payload FROM mcp_credential_grants WHERE id = ?"
-        ),
-        "mcp_external_servers": (
-            "SELECT payload FROM mcp_external_servers WHERE id = ?"
-        ),
-    }
-    _SELECT_PAYLOAD_SQL: ClassVar[dict[str, str]] = {
-        "mcp_profile_assignments": "SELECT payload FROM mcp_profile_assignments",
-        "mcp_approval_policies": "SELECT payload FROM mcp_approval_policies",
-        "mcp_credential_grants": "SELECT payload FROM mcp_credential_grants",
-        "mcp_external_servers": "SELECT payload FROM mcp_external_servers",
-        "mcp_audit_events": "SELECT payload FROM mcp_audit_events",
-    }
     _FILTERABLE_COLUMNS: ClassVar[dict[str, frozenset[str]]] = {
         "mcp_profile_assignments": frozenset(
             {"profile_id", "principal_id", "workspace_id"}
@@ -77,10 +62,9 @@ class SQLiteMCPStore:
         "mcp_external_servers": frozenset({"enabled"}),
         "mcp_audit_events": frozenset({"actor_id", "profile_id", "event_type"}),
     }
-    _ORDER_BY_SQL: ClassVar[dict[str, str]] = {
-        "id ASC": "id ASC",
-        "created_at DESC, id DESC": "created_at DESC, id DESC",
-    }
+    _ORDER_BY_KEYS: ClassVar[frozenset[str]] = frozenset(
+        {"id ASC", "created_at DESC, id DESC"}
+    )
 
     def __init__(self, path: str | Path) -> None:
         if str(path) == ":memory:":
@@ -89,18 +73,15 @@ class SQLiteMCPStore:
             db_path = Path(path).expanduser()
             db_path.parent.mkdir(parents=True, exist_ok=True)
             self.path = str(db_path)
-        self._lock = threading.RLock()
-        self._conn = sqlite3.connect(
-            self.path,
-            timeout=30.0,
-            check_same_thread=False,
-        )
-        self._conn.row_factory = sqlite3.Row
-        self._conn.execute("PRAGMA foreign_keys = ON")
+
+        self._metadata = MetaData()
+        self._tables = self._build_tables(self._metadata)
+        self._engine = self._create_engine()
+        event.listen(self._engine, "connect", self._enable_foreign_keys)
         self._initialize_schema()
 
     def close(self) -> None:
-        """Close the underlying SQLite connection."""
+        """Dispose the underlying database engine."""
         self._close_sync()
 
     async def aclose(self) -> None:
@@ -261,17 +242,13 @@ class SQLiteMCPStore:
         return await asyncio.to_thread(operation, *args, **kwargs)
 
     def _close_sync(self) -> None:
-        with self._lock:
-            self._conn.close()
+        self._engine.dispose()
 
     def _get_profile_sync(self, profile_id: str) -> MCPProfile | None:
         return self._get_model("mcp_profiles", profile_id, MCPProfile)
 
     def _list_profiles_sync(self) -> list[MCPProfile]:
-        with self._lock:
-            rows = self._conn.execute(
-                "SELECT payload FROM mcp_profiles ORDER BY id",
-            ).fetchall()
+        rows = self._select_payloads("mcp_profiles", order_by="id ASC")
         return [self._load_model(row["payload"], MCPProfile) for row in rows]
 
     def _upsert_profile_sync(
@@ -280,23 +257,16 @@ class SQLiteMCPStore:
     ) -> MCPProfile:
         validated = self._validate_profile(profile)
         payload = self._dump_model(validated)
-        with self._lock, self._conn:
-            self._conn.execute(
-                """
-                INSERT INTO mcp_profiles(id, enabled, updated_at, payload)
-                VALUES (?, ?, ?, ?)
-                ON CONFLICT(id) DO UPDATE SET
-                    enabled = excluded.enabled,
-                    updated_at = excluded.updated_at,
-                    payload = excluded.payload
-                """,
-                (
-                    validated.id,
-                    int(validated.enabled),
-                    validated.updated_at.isoformat(),
-                    payload,
-                ),
-            )
+        self._upsert_row(
+            "mcp_profiles",
+            {
+                "id": validated.id,
+                "enabled": int(validated.enabled),
+                "updated_at": validated.updated_at.isoformat(),
+                "payload": payload,
+            },
+            update_columns=("enabled", "updated_at", "payload"),
+        )
         return self._load_model(payload, MCPProfile)
 
     def _delete_profile_sync(self, profile_id: str) -> bool:
@@ -316,9 +286,9 @@ class SQLiteMCPStore:
         principal_id: str | None = None,
         workspace_id: str | None = None,
     ) -> list[ProfileAssignment]:
-        rows = self._select_filtered_payloads(
+        rows = self._select_payloads(
             "mcp_profile_assignments",
-            {
+            filters={
                 "profile_id": profile_id,
                 "principal_id": principal_id,
                 "workspace_id": workspace_id,
@@ -331,34 +301,28 @@ class SQLiteMCPStore:
         assignment: ProfileAssignment,
     ) -> ProfileAssignment:
         payload = self._dump_model(assignment)
-        with self._lock, self._conn:
-            self._conn.execute(
-                """
-                INSERT INTO mcp_profile_assignments(
-                    id, profile_id, principal_id, workspace_id, is_default,
-                    enabled, updated_at, payload
-                )
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?)
-                ON CONFLICT(id) DO UPDATE SET
-                    profile_id = excluded.profile_id,
-                    principal_id = excluded.principal_id,
-                    workspace_id = excluded.workspace_id,
-                    is_default = excluded.is_default,
-                    enabled = excluded.enabled,
-                    updated_at = excluded.updated_at,
-                    payload = excluded.payload
-                """,
-                (
-                    assignment.id,
-                    assignment.profile_id,
-                    assignment.principal_id,
-                    assignment.workspace_id,
-                    int(assignment.is_default),
-                    int(assignment.enabled),
-                    assignment.updated_at.isoformat(),
-                    payload,
-                ),
-            )
+        self._upsert_row(
+            "mcp_profile_assignments",
+            {
+                "id": assignment.id,
+                "profile_id": assignment.profile_id,
+                "principal_id": assignment.principal_id,
+                "workspace_id": assignment.workspace_id,
+                "is_default": int(assignment.is_default),
+                "enabled": int(assignment.enabled),
+                "updated_at": assignment.updated_at.isoformat(),
+                "payload": payload,
+            },
+            update_columns=(
+                "profile_id",
+                "principal_id",
+                "workspace_id",
+                "is_default",
+                "enabled",
+                "updated_at",
+                "payload",
+            ),
+        )
         return self._load_model(payload, ProfileAssignment)
 
     def _delete_assignment_sync(self, assignment_id: str) -> bool:
@@ -372,9 +336,9 @@ class SQLiteMCPStore:
         *,
         profile_id: str | None = None,
     ) -> list[ApprovalPolicyDocument]:
-        rows = self._select_filtered_payloads(
+        rows = self._select_payloads(
             "mcp_approval_policies",
-            {"profile_id": profile_id},
+            filters={"profile_id": profile_id},
         )
         return [self._load_model(row["payload"], ApprovalPolicyDocument) for row in rows]
 
@@ -383,27 +347,17 @@ class SQLiteMCPStore:
         policy: ApprovalPolicyDocument,
     ) -> ApprovalPolicyDocument:
         payload = self._dump_model(policy)
-        with self._lock, self._conn:
-            self._conn.execute(
-                """
-                INSERT INTO mcp_approval_policies(
-                    id, profile_id, enabled, updated_at, payload
-                )
-                VALUES (?, ?, ?, ?, ?)
-                ON CONFLICT(id) DO UPDATE SET
-                    profile_id = excluded.profile_id,
-                    enabled = excluded.enabled,
-                    updated_at = excluded.updated_at,
-                    payload = excluded.payload
-                """,
-                (
-                    policy.id,
-                    policy.profile_id,
-                    int(policy.enabled),
-                    policy.updated_at.isoformat(),
-                    payload,
-                ),
-            )
+        self._upsert_row(
+            "mcp_approval_policies",
+            {
+                "id": policy.id,
+                "profile_id": policy.profile_id,
+                "enabled": int(policy.enabled),
+                "updated_at": policy.updated_at.isoformat(),
+                "payload": payload,
+            },
+            update_columns=("profile_id", "enabled", "updated_at", "payload"),
+        )
         return self._load_model(payload, ApprovalPolicyDocument)
 
     def _delete_policy_sync(self, policy_id: str) -> bool:
@@ -418,9 +372,9 @@ class SQLiteMCPStore:
         profile_id: str | None = None,
         external_server_id: str | None = None,
     ) -> list[CredentialGrant]:
-        rows = self._select_filtered_payloads(
+        rows = self._select_payloads(
             "mcp_credential_grants",
-            {
+            filters={
                 "profile_id": profile_id,
                 "external_server_id": external_server_id,
             },
@@ -429,29 +383,24 @@ class SQLiteMCPStore:
 
     def _upsert_grant_sync(self, grant: CredentialGrant) -> CredentialGrant:
         payload = self._dump_model(grant)
-        with self._lock, self._conn:
-            self._conn.execute(
-                """
-                INSERT INTO mcp_credential_grants(
-                    id, profile_id, external_server_id, enabled, updated_at, payload
-                )
-                VALUES (?, ?, ?, ?, ?, ?)
-                ON CONFLICT(id) DO UPDATE SET
-                    profile_id = excluded.profile_id,
-                    external_server_id = excluded.external_server_id,
-                    enabled = excluded.enabled,
-                    updated_at = excluded.updated_at,
-                    payload = excluded.payload
-                """,
-                (
-                    grant.id,
-                    grant.profile_id,
-                    grant.external_server_id,
-                    int(grant.enabled),
-                    grant.updated_at.isoformat(),
-                    payload,
-                ),
-            )
+        self._upsert_row(
+            "mcp_credential_grants",
+            {
+                "id": grant.id,
+                "profile_id": grant.profile_id,
+                "external_server_id": grant.external_server_id,
+                "enabled": int(grant.enabled),
+                "updated_at": grant.updated_at.isoformat(),
+                "payload": payload,
+            },
+            update_columns=(
+                "profile_id",
+                "external_server_id",
+                "enabled",
+                "updated_at",
+                "payload",
+            ),
+        )
         return self._load_model(payload, CredentialGrant)
 
     def _delete_grant_sync(self, grant_id: str) -> bool:
@@ -465,9 +414,9 @@ class SQLiteMCPStore:
         *,
         enabled: bool | None = None,
     ) -> list[ExternalServerDefinition]:
-        rows = self._select_filtered_payloads(
+        rows = self._select_payloads(
             "mcp_external_servers",
-            {"enabled": None if enabled is None else int(enabled)},
+            filters={"enabled": None if enabled is None else int(enabled)},
         )
         return [self._load_model(row["payload"], ExternalServerDefinition) for row in rows]
 
@@ -476,27 +425,17 @@ class SQLiteMCPStore:
         server: ExternalServerDefinition,
     ) -> ExternalServerDefinition:
         payload = self._dump_model(server)
-        with self._lock, self._conn:
-            self._conn.execute(
-                """
-                INSERT INTO mcp_external_servers(
-                    id, enabled, transport, updated_at, payload
-                )
-                VALUES (?, ?, ?, ?, ?)
-                ON CONFLICT(id) DO UPDATE SET
-                    enabled = excluded.enabled,
-                    transport = excluded.transport,
-                    updated_at = excluded.updated_at,
-                    payload = excluded.payload
-                """,
-                (
-                    server.id,
-                    int(server.enabled),
-                    server.transport,
-                    server.updated_at.isoformat(),
-                    payload,
-                ),
-            )
+        self._upsert_row(
+            "mcp_external_servers",
+            {
+                "id": server.id,
+                "enabled": int(server.enabled),
+                "transport": server.transport,
+                "updated_at": server.updated_at.isoformat(),
+                "payload": payload,
+            },
+            update_columns=("enabled", "transport", "updated_at", "payload"),
+        )
         return self._load_model(payload, ExternalServerDefinition)
 
     def _delete_server_sync(self, server_id: str) -> bool:
@@ -505,23 +444,17 @@ class SQLiteMCPStore:
     def _append_event_sync(self, event: AuditEvent) -> AuditEvent:
         normalized = self._normalize_audit_event(event)
         payload = self._dump_model(normalized)
-        with self._lock, self._conn:
-            self._conn.execute(
-                """
-                INSERT INTO mcp_audit_events(
-                    id, actor_id, profile_id, event_type, created_at, payload
-                )
-                VALUES (?, ?, ?, ?, ?, ?)
-                """,
-                (
-                    normalized.id,
-                    normalized.actor_id,
-                    normalized.profile_id,
-                    normalized.event_type,
-                    normalized.created_at.isoformat(),
-                    payload,
-                ),
-            )
+        self._insert_row(
+            "mcp_audit_events",
+            {
+                "id": normalized.id,
+                "actor_id": normalized.actor_id,
+                "profile_id": normalized.profile_id,
+                "event_type": normalized.event_type,
+                "created_at": normalized.created_at.isoformat(),
+                "payload": payload,
+            },
+        )
         return self._load_model(payload, AuditEvent)
 
     def _query_events_sync(
@@ -534,9 +467,9 @@ class SQLiteMCPStore:
     ) -> list[AuditEvent]:
         if limit is not None and limit < 0:
             raise ValueError("limit must be non-negative")
-        rows = self._select_filtered_payloads(
+        rows = self._select_payloads(
             "mcp_audit_events",
-            {
+            filters={
                 "actor_id": actor_id,
                 "profile_id": profile_id,
                 "event_type": event_type,
@@ -546,215 +479,285 @@ class SQLiteMCPStore:
         )
         return [self._load_model(row["payload"], AuditEvent) for row in rows]
 
-    def _initialize_schema(self) -> None:
-        with self._lock, self._conn:
-            self._conn.execute(
-                """
-                CREATE TABLE IF NOT EXISTS mcp_storage_meta (
-                    key TEXT PRIMARY KEY,
-                    value TEXT NOT NULL
-                )
-                """
-            )
-            self._ensure_compatible_schema_version()
-            self._conn.execute(
-                """
-                CREATE TABLE IF NOT EXISTS mcp_profiles (
-                    id TEXT PRIMARY KEY,
-                    enabled INTEGER NOT NULL,
-                    updated_at TEXT NOT NULL,
-                    payload TEXT NOT NULL
-                )
-                """
-            )
-            self._conn.execute(
-                """
-                CREATE TABLE IF NOT EXISTS mcp_profile_assignments (
-                    id TEXT PRIMARY KEY,
-                    profile_id TEXT NOT NULL,
-                    principal_id TEXT,
-                    workspace_id TEXT,
-                    is_default INTEGER NOT NULL,
-                    enabled INTEGER NOT NULL,
-                    updated_at TEXT NOT NULL,
-                    payload TEXT NOT NULL,
-                    FOREIGN KEY(profile_id)
-                        REFERENCES mcp_profiles(id)
-                        ON DELETE CASCADE
-                )
-                """
-            )
-            self._conn.execute(
-                """
-                CREATE TABLE IF NOT EXISTS mcp_approval_policies (
-                    id TEXT PRIMARY KEY,
-                    profile_id TEXT,
-                    enabled INTEGER NOT NULL,
-                    updated_at TEXT NOT NULL,
-                    payload TEXT NOT NULL,
-                    FOREIGN KEY(profile_id)
-                        REFERENCES mcp_profiles(id)
-                        ON DELETE CASCADE
-                )
-                """
-            )
-            self._conn.execute(
-                """
-                CREATE TABLE IF NOT EXISTS mcp_credential_grants (
-                    id TEXT PRIMARY KEY,
-                    profile_id TEXT NOT NULL,
-                    external_server_id TEXT,
-                    enabled INTEGER NOT NULL,
-                    updated_at TEXT NOT NULL,
-                    payload TEXT NOT NULL,
-                    FOREIGN KEY(profile_id)
-                        REFERENCES mcp_profiles(id)
-                        ON DELETE CASCADE
-                )
-                """
-            )
-            self._conn.execute(
-                """
-                CREATE TABLE IF NOT EXISTS mcp_external_servers (
-                    id TEXT PRIMARY KEY,
-                    enabled INTEGER NOT NULL,
-                    transport TEXT NOT NULL,
-                    updated_at TEXT NOT NULL,
-                    payload TEXT NOT NULL
-                )
-                """
-            )
-            self._conn.execute(
-                """
-                CREATE TABLE IF NOT EXISTS mcp_audit_events (
-                    id TEXT PRIMARY KEY,
-                    actor_id TEXT,
-                    profile_id TEXT,
-                    event_type TEXT NOT NULL,
-                    created_at TEXT NOT NULL,
-                    payload TEXT NOT NULL
-                )
-                """
-            )
-            self._conn.execute(
-                "CREATE INDEX IF NOT EXISTS idx_mcp_assignments_profile ON mcp_profile_assignments(profile_id)"
-            )
-            self._conn.execute(
-                "CREATE INDEX IF NOT EXISTS idx_mcp_assignments_principal ON mcp_profile_assignments(principal_id)"
-            )
-            self._conn.execute(
-                "CREATE INDEX IF NOT EXISTS idx_mcp_assignments_workspace ON mcp_profile_assignments(workspace_id)"
-            )
-            self._conn.execute(
-                "CREATE INDEX IF NOT EXISTS idx_mcp_policies_profile ON mcp_approval_policies(profile_id)"
-            )
-            self._conn.execute(
-                "CREATE INDEX IF NOT EXISTS idx_mcp_grants_profile ON mcp_credential_grants(profile_id)"
-            )
-            self._conn.execute(
-                "CREATE INDEX IF NOT EXISTS idx_mcp_grants_external_server ON mcp_credential_grants(external_server_id)"
-            )
-            self._conn.execute(
-                "CREATE INDEX IF NOT EXISTS idx_mcp_external_enabled ON mcp_external_servers(enabled)"
-            )
-            self._conn.execute(
-                "CREATE INDEX IF NOT EXISTS idx_mcp_audit_actor ON mcp_audit_events(actor_id)"
-            )
-            self._conn.execute(
-                "CREATE INDEX IF NOT EXISTS idx_mcp_audit_profile ON mcp_audit_events(profile_id)"
-            )
-            self._conn.execute(
-                "CREATE INDEX IF NOT EXISTS idx_mcp_audit_event_type ON mcp_audit_events(event_type)"
-            )
-            self._conn.execute(
-                "CREATE INDEX IF NOT EXISTS idx_mcp_audit_created_at ON mcp_audit_events(created_at)"
-            )
+    def _create_engine(self) -> Engine:
+        engine_kwargs: dict[str, Any] = {
+            "connect_args": {
+                "timeout": 30.0,
+                "check_same_thread": False,
+            },
+            "future": True,
+        }
+        if self.path == ":memory:":
+            engine_kwargs["poolclass"] = StaticPool
+        return create_engine(self._database_url(), **engine_kwargs)
 
-    def _ensure_compatible_schema_version(self) -> None:
-        current = self._conn.execute(
-            "SELECT value FROM mcp_storage_meta WHERE key = ?",
-            ("schema_version",),
-        ).fetchone()
+    def _database_url(self) -> URL:
+        return URL.create("sqlite", database=self.path)
+
+    def _initialize_schema(self) -> None:
+        meta_table = self._tables["mcp_storage_meta"]
+        with self._engine.begin() as connection:
+            meta_table.create(connection, checkfirst=True)
+            self._ensure_compatible_schema_version(connection)
+        self._metadata.create_all(self._engine)
+
+    def _ensure_compatible_schema_version(self, connection: Any) -> None:
+        meta_table = self._tables["mcp_storage_meta"]
+        current = connection.execute(
+            select(meta_table.c.value).where(meta_table.c.key == "schema_version")
+        ).mappings().first()
         if current is not None and int(current["value"]) > self.SCHEMA_VERSION:
             raise RuntimeError(
                 f"SQLite MCP store schema {current['value']} is newer than supported "
                 f"schema {self.SCHEMA_VERSION}"
             )
-        self._conn.execute(
-            """
-            INSERT INTO mcp_storage_meta(key, value)
-            VALUES (?, ?)
-            ON CONFLICT(key) DO UPDATE SET value = excluded.value
-            """,
-            ("schema_version", str(self.SCHEMA_VERSION)),
+        statement = sqlite_insert(meta_table).values(
+            key="schema_version",
+            value=str(self.SCHEMA_VERSION),
+        )
+        connection.execute(
+            statement.on_conflict_do_update(
+                index_elements=[meta_table.c.key],
+                set_={"value": statement.excluded.value},
+            )
         )
 
-    def _delete_by_id(self, table: str, item_id: str) -> bool:
-        with self._lock, self._conn:
-            cursor = self._conn.execute(
-                self._DELETE_BY_ID_SQL[table],
-                (item_id,),
+    def _upsert_row(
+        self,
+        table_name: str,
+        values: Mapping[str, Any],
+        *,
+        update_columns: tuple[str, ...],
+    ) -> None:
+        table = self._table(table_name)
+        statement = sqlite_insert(table).values(**values)
+        connection_values = {
+            column: getattr(statement.excluded, column)
+            for column in update_columns
+        }
+        with self._engine.begin() as connection:
+            connection.execute(
+                statement.on_conflict_do_update(
+                    index_elements=[table.c.id],
+                    set_=connection_values,
+                )
             )
-        return cursor.rowcount > 0
+
+    def _insert_row(self, table_name: str, values: Mapping[str, Any]) -> None:
+        table = self._table(table_name)
+        with self._engine.begin() as connection:
+            connection.execute(table.insert().values(**values))
+
+    def _delete_by_id(self, table_name: str, item_id: str) -> bool:
+        table = self._table(table_name)
+        with self._engine.begin() as connection:
+            result = connection.execute(delete(table).where(table.c.id == item_id))
+        return bool(result.rowcount and result.rowcount > 0)
 
     def _get_model(
         self,
-        table: str,
+        table_name: str,
         item_id: str,
         model_cls: type[ModelT],
     ) -> ModelT | None:
-        with self._lock:
-            row = self._conn.execute(
-                self._SELECT_BY_ID_SQL[table],
-                (item_id,),
-            ).fetchone()
+        table = self._table(table_name)
+        with self._engine.connect() as connection:
+            row = connection.execute(
+                select(table.c.payload).where(table.c.id == item_id)
+            ).mappings().first()
         if row is None:
             return None
         return self._load_model(row["payload"], model_cls)
 
-    def _select_filtered_payloads(
+    def _select_payloads(
         self,
-        table: str,
-        filters: dict[str, Any],
+        table_name: str,
+        filters: Mapping[str, Any] | None = None,
         *,
         limit: int | None = None,
         order_by: str = "id ASC",
-    ) -> list[sqlite3.Row]:
-        self._validate_filter_request(table, filters, order_by)
-        clauses: list[str] = []
-        values: list[Any] = []
+    ) -> list[Mapping[str, Any]]:
+        filters = filters or {}
+        self._validate_filter_request(table_name, filters, order_by)
+        table = self._table(table_name)
+        statement = select(table.c.payload)
         for column, value in filters.items():
             if value is None:
                 continue
-            clauses.append(f"{column} = ?")
-            values.append(value)
-        where = f"WHERE {' AND '.join(clauses)}" if clauses else ""
-        query_parts = [self._SELECT_PAYLOAD_SQL[table]]
-        if where:
-            query_parts.append(where)
-        query_parts.extend(["ORDER BY", self._ORDER_BY_SQL[order_by]])
+            statement = statement.where(table.c[column] == value)
+        for column in self._order_by_columns(table, order_by):
+            statement = statement.order_by(column)
         if limit is not None:
-            query_parts.append("LIMIT ?")
-            values.append(limit)
-        with self._lock:
-            return self._conn.execute(" ".join(query_parts), values).fetchall()
+            statement = statement.limit(limit)
+        with self._engine.connect() as connection:
+            return [
+                dict(row)
+                for row in connection.execute(statement).mappings().all()
+            ]
 
     def _validate_filter_request(
         self,
-        table: str,
-        filters: dict[str, Any],
+        table_name: str,
+        filters: Mapping[str, Any],
         order_by: str,
     ) -> None:
-        allowed_columns = self._FILTERABLE_COLUMNS.get(table)
-        if allowed_columns is None:
-            raise ValueError(f"Unsupported filter table: {table}")
-        unknown_columns = set(filters) - allowed_columns
+        allowed_columns = self._FILTERABLE_COLUMNS.get(table_name)
+        if allowed_columns is None and filters:
+            raise ValueError(f"Unsupported filter table: {table_name}")
+        unknown_columns = set(filters) - (allowed_columns or frozenset())
         if unknown_columns:
             raise ValueError(
-                f"Unsupported filter columns for {table}: {sorted(unknown_columns)}"
+                f"Unsupported filter columns for {table_name}: {sorted(unknown_columns)}"
             )
-        if order_by not in self._ORDER_BY_SQL:
+        if order_by not in self._ORDER_BY_KEYS:
             raise ValueError(f"Unsupported order by clause: {order_by}")
+
+    def _table(self, table_name: str) -> Table:
+        try:
+            return self._tables[table_name]
+        except KeyError as exc:
+            raise ValueError(f"Unsupported table: {table_name}") from exc
+
+    @staticmethod
+    def _order_by_columns(table: Table, order_by: str) -> list[Any]:
+        if order_by == "id ASC":
+            return [table.c.id.asc()]
+        if order_by == "created_at DESC, id DESC":
+            return [table.c.created_at.desc(), table.c.id.desc()]
+        raise ValueError(f"Unsupported order by clause: {order_by}")
+
+    @staticmethod
+    def _enable_foreign_keys(dbapi_connection: Any, _connection_record: Any) -> None:
+        cursor = dbapi_connection.cursor()
+        try:
+            cursor.execute("PRAGMA foreign_keys = ON")
+        finally:
+            cursor.close()
+
+    @classmethod
+    def _build_tables(cls, metadata: MetaData) -> dict[str, Table]:
+        tables: dict[str, Table] = {}
+        tables["mcp_storage_meta"] = Table(
+            "mcp_storage_meta",
+            metadata,
+            Column("key", String, primary_key=True),
+            Column("value", String, nullable=False),
+        )
+        tables["mcp_profiles"] = Table(
+            "mcp_profiles",
+            metadata,
+            Column("id", String, primary_key=True),
+            Column("enabled", Integer, nullable=False),
+            Column("updated_at", String, nullable=False),
+            Column("payload", Text, nullable=False),
+        )
+        tables["mcp_profile_assignments"] = Table(
+            "mcp_profile_assignments",
+            metadata,
+            Column("id", String, primary_key=True),
+            Column(
+                "profile_id",
+                String,
+                ForeignKey("mcp_profiles.id", ondelete="CASCADE"),
+                nullable=False,
+            ),
+            Column("principal_id", String),
+            Column("workspace_id", String),
+            Column("is_default", Integer, nullable=False),
+            Column("enabled", Integer, nullable=False),
+            Column("updated_at", String, nullable=False),
+            Column("payload", Text, nullable=False),
+        )
+        tables["mcp_approval_policies"] = Table(
+            "mcp_approval_policies",
+            metadata,
+            Column("id", String, primary_key=True),
+            Column(
+                "profile_id",
+                String,
+                ForeignKey("mcp_profiles.id", ondelete="CASCADE"),
+            ),
+            Column("enabled", Integer, nullable=False),
+            Column("updated_at", String, nullable=False),
+            Column("payload", Text, nullable=False),
+        )
+        tables["mcp_credential_grants"] = Table(
+            "mcp_credential_grants",
+            metadata,
+            Column("id", String, primary_key=True),
+            Column(
+                "profile_id",
+                String,
+                ForeignKey("mcp_profiles.id", ondelete="CASCADE"),
+                nullable=False,
+            ),
+            Column("external_server_id", String),
+            Column("enabled", Integer, nullable=False),
+            Column("updated_at", String, nullable=False),
+            Column("payload", Text, nullable=False),
+        )
+        tables["mcp_external_servers"] = Table(
+            "mcp_external_servers",
+            metadata,
+            Column("id", String, primary_key=True),
+            Column("enabled", Integer, nullable=False),
+            Column("transport", String, nullable=False),
+            Column("updated_at", String, nullable=False),
+            Column("payload", Text, nullable=False),
+        )
+        tables["mcp_audit_events"] = Table(
+            "mcp_audit_events",
+            metadata,
+            Column("id", String, primary_key=True),
+            Column("actor_id", String),
+            Column("profile_id", String),
+            Column("event_type", String, nullable=False),
+            Column("created_at", String, nullable=False),
+            Column("payload", Text, nullable=False),
+        )
+        cls._add_indexes(tables)
+        return tables
+
+    @staticmethod
+    def _add_indexes(tables: Mapping[str, Table]) -> None:
+        Index(
+            "idx_mcp_assignments_profile",
+            tables["mcp_profile_assignments"].c.profile_id,
+        )
+        Index(
+            "idx_mcp_assignments_principal",
+            tables["mcp_profile_assignments"].c.principal_id,
+        )
+        Index(
+            "idx_mcp_assignments_workspace",
+            tables["mcp_profile_assignments"].c.workspace_id,
+        )
+        Index(
+            "idx_mcp_policies_profile",
+            tables["mcp_approval_policies"].c.profile_id,
+        )
+        Index(
+            "idx_mcp_grants_profile",
+            tables["mcp_credential_grants"].c.profile_id,
+        )
+        Index(
+            "idx_mcp_grants_external_server",
+            tables["mcp_credential_grants"].c.external_server_id,
+        )
+        Index(
+            "idx_mcp_external_enabled",
+            tables["mcp_external_servers"].c.enabled,
+        )
+        Index("idx_mcp_audit_actor", tables["mcp_audit_events"].c.actor_id)
+        Index("idx_mcp_audit_profile", tables["mcp_audit_events"].c.profile_id)
+        Index(
+            "idx_mcp_audit_event_type",
+            tables["mcp_audit_events"].c.event_type,
+        )
+        Index(
+            "idx_mcp_audit_created_at",
+            tables["mcp_audit_events"].c.created_at,
+        )
 
     @staticmethod
     def _dump_model(model: BaseModel) -> str:
@@ -765,8 +768,8 @@ class SQLiteMCPStore:
         )
 
     @staticmethod
-    def _load_model(payload: str, model_cls: type[ModelT]) -> ModelT:
-        return model_cls.model_validate_json(payload)
+    def _load_model(payload: Any, model_cls: type[ModelT]) -> ModelT:
+        return model_cls.model_validate_json(cast(str, payload))
 
     @staticmethod
     def _normalize_audit_event(event: AuditEvent) -> AuditEvent:

--- a/mcp_unified/storage/sqlite.py
+++ b/mcp_unified/storage/sqlite.py
@@ -1,0 +1,621 @@
+"""SQLite-backed standalone MCP storage primitives."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any, ClassVar, TypeVar
+
+from pydantic import BaseModel
+
+from mcp_unified.profiles.models import MCPProfile
+from mcp_unified.storage.models import (
+    ApprovalPolicyDocument,
+    AuditEvent,
+    CredentialGrant,
+    ExternalServerDefinition,
+    ProfileAssignment,
+)
+
+ModelT = TypeVar("ModelT", bound=BaseModel)
+
+
+class SQLiteMCPStore:
+    """Package-local SQLite implementation for MCP standalone stores."""
+
+    SCHEMA_VERSION = 1
+    _DELETE_BY_ID_SQL: ClassVar[dict[str, str]] = {
+        "mcp_profiles": "DELETE FROM mcp_profiles WHERE id = ?",
+        "mcp_profile_assignments": (
+            "DELETE FROM mcp_profile_assignments WHERE id = ?"
+        ),
+        "mcp_approval_policies": "DELETE FROM mcp_approval_policies WHERE id = ?",
+        "mcp_credential_grants": "DELETE FROM mcp_credential_grants WHERE id = ?",
+        "mcp_external_servers": "DELETE FROM mcp_external_servers WHERE id = ?",
+    }
+    _SELECT_BY_ID_SQL: ClassVar[dict[str, str]] = {
+        "mcp_profiles": "SELECT payload FROM mcp_profiles WHERE id = ?",
+        "mcp_profile_assignments": (
+            "SELECT payload FROM mcp_profile_assignments WHERE id = ?"
+        ),
+        "mcp_approval_policies": (
+            "SELECT payload FROM mcp_approval_policies WHERE id = ?"
+        ),
+        "mcp_credential_grants": (
+            "SELECT payload FROM mcp_credential_grants WHERE id = ?"
+        ),
+        "mcp_external_servers": (
+            "SELECT payload FROM mcp_external_servers WHERE id = ?"
+        ),
+    }
+    _SELECT_PAYLOAD_SQL: ClassVar[dict[str, str]] = {
+        "mcp_profile_assignments": "SELECT payload FROM mcp_profile_assignments",
+        "mcp_approval_policies": "SELECT payload FROM mcp_approval_policies",
+        "mcp_credential_grants": "SELECT payload FROM mcp_credential_grants",
+        "mcp_external_servers": "SELECT payload FROM mcp_external_servers",
+        "mcp_audit_events": "SELECT payload FROM mcp_audit_events",
+    }
+    _FILTERABLE_COLUMNS: ClassVar[dict[str, frozenset[str]]] = {
+        "mcp_profile_assignments": frozenset(
+            {"profile_id", "principal_id", "workspace_id"}
+        ),
+        "mcp_approval_policies": frozenset({"profile_id"}),
+        "mcp_credential_grants": frozenset(
+            {"profile_id", "external_server_id"}
+        ),
+        "mcp_external_servers": frozenset({"enabled"}),
+        "mcp_audit_events": frozenset({"actor_id", "profile_id", "event_type"}),
+    }
+    _ORDER_BY_SQL: ClassVar[dict[str, str]] = {
+        "id ASC": "id ASC",
+        "created_at DESC, id DESC": "created_at DESC, id DESC",
+    }
+
+    def __init__(self, path: str | Path) -> None:
+        if str(path) == ":memory:":
+            self.path = ":memory:"
+        else:
+            db_path = Path(path).expanduser()
+            db_path.parent.mkdir(parents=True, exist_ok=True)
+            self.path = str(db_path)
+        self._conn = sqlite3.connect(self.path)
+        self._conn.row_factory = sqlite3.Row
+        self._conn.execute("PRAGMA foreign_keys = ON")
+        self._initialize_schema()
+
+    def close(self) -> None:
+        """Close the underlying SQLite connection."""
+        self._conn.close()
+
+    async def aclose(self) -> None:
+        """Async-friendly close helper for callers managing stores generically."""
+        self.close()
+
+    async def get_profile(self, profile_id: str) -> MCPProfile | None:
+        """Return a copy-isolated profile by id."""
+        return self._get_model("mcp_profiles", profile_id, MCPProfile)
+
+    async def list_profiles(self) -> list[MCPProfile]:
+        """Return all profiles sorted by id."""
+        rows = self._conn.execute(
+            "SELECT payload FROM mcp_profiles ORDER BY id",
+        ).fetchall()
+        return [self._load_model(row["payload"], MCPProfile) for row in rows]
+
+    async def upsert_profile(
+        self,
+        profile: MCPProfile | Mapping[str, Any],
+    ) -> MCPProfile:
+        """Store a profile document and return the persisted model."""
+        validated = self._validate_profile(profile)
+        payload = self._dump_model(validated)
+        with self._conn:
+            self._conn.execute(
+                """
+                INSERT INTO mcp_profiles(id, enabled, updated_at, payload)
+                VALUES (?, ?, ?, ?)
+                ON CONFLICT(id) DO UPDATE SET
+                    enabled = excluded.enabled,
+                    updated_at = excluded.updated_at,
+                    payload = excluded.payload
+                """,
+                (
+                    validated.id,
+                    int(validated.enabled),
+                    validated.updated_at.isoformat(),
+                    payload,
+                ),
+            )
+        return self._load_model(payload, MCPProfile)
+
+    async def delete_profile(self, profile_id: str) -> bool:
+        """Delete a profile by id and return whether it existed."""
+        return self._delete_by_id("mcp_profiles", profile_id)
+
+    async def get_assignment(self, assignment_id: str) -> ProfileAssignment | None:
+        """Return a profile assignment by id."""
+        return self._get_model(
+            "mcp_profile_assignments",
+            assignment_id,
+            ProfileAssignment,
+        )
+
+    async def list_assignments(
+        self,
+        *,
+        profile_id: str | None = None,
+        principal_id: str | None = None,
+        workspace_id: str | None = None,
+    ) -> list[ProfileAssignment]:
+        """Return profile assignments matching optional filters."""
+        rows = self._select_filtered_payloads(
+            "mcp_profile_assignments",
+            {
+                "profile_id": profile_id,
+                "principal_id": principal_id,
+                "workspace_id": workspace_id,
+            },
+        )
+        return [self._load_model(row["payload"], ProfileAssignment) for row in rows]
+
+    async def upsert_assignment(
+        self,
+        assignment: ProfileAssignment,
+    ) -> ProfileAssignment:
+        """Store a profile assignment and return the persisted model."""
+        payload = self._dump_model(assignment)
+        with self._conn:
+            self._conn.execute(
+                """
+                INSERT INTO mcp_profile_assignments(
+                    id, profile_id, principal_id, workspace_id, is_default,
+                    enabled, updated_at, payload
+                )
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT(id) DO UPDATE SET
+                    profile_id = excluded.profile_id,
+                    principal_id = excluded.principal_id,
+                    workspace_id = excluded.workspace_id,
+                    is_default = excluded.is_default,
+                    enabled = excluded.enabled,
+                    updated_at = excluded.updated_at,
+                    payload = excluded.payload
+                """,
+                (
+                    assignment.id,
+                    assignment.profile_id,
+                    assignment.principal_id,
+                    assignment.workspace_id,
+                    int(assignment.is_default),
+                    int(assignment.enabled),
+                    assignment.updated_at.isoformat(),
+                    payload,
+                ),
+            )
+        return self._load_model(payload, ProfileAssignment)
+
+    async def delete_assignment(self, assignment_id: str) -> bool:
+        """Delete a profile assignment by id and return whether it existed."""
+        return self._delete_by_id("mcp_profile_assignments", assignment_id)
+
+    async def get_policy(self, policy_id: str) -> ApprovalPolicyDocument | None:
+        """Return an approval policy by id."""
+        return self._get_model("mcp_approval_policies", policy_id, ApprovalPolicyDocument)
+
+    async def list_policies(
+        self,
+        *,
+        profile_id: str | None = None,
+    ) -> list[ApprovalPolicyDocument]:
+        """Return approval policies matching optional filters."""
+        rows = self._select_filtered_payloads(
+            "mcp_approval_policies",
+            {"profile_id": profile_id},
+        )
+        return [self._load_model(row["payload"], ApprovalPolicyDocument) for row in rows]
+
+    async def upsert_policy(
+        self,
+        policy: ApprovalPolicyDocument,
+    ) -> ApprovalPolicyDocument:
+        """Store an approval policy and return the persisted model."""
+        payload = self._dump_model(policy)
+        with self._conn:
+            self._conn.execute(
+                """
+                INSERT INTO mcp_approval_policies(
+                    id, profile_id, enabled, updated_at, payload
+                )
+                VALUES (?, ?, ?, ?, ?)
+                ON CONFLICT(id) DO UPDATE SET
+                    profile_id = excluded.profile_id,
+                    enabled = excluded.enabled,
+                    updated_at = excluded.updated_at,
+                    payload = excluded.payload
+                """,
+                (
+                    policy.id,
+                    policy.profile_id,
+                    int(policy.enabled),
+                    policy.updated_at.isoformat(),
+                    payload,
+                ),
+            )
+        return self._load_model(payload, ApprovalPolicyDocument)
+
+    async def delete_policy(self, policy_id: str) -> bool:
+        """Delete an approval policy by id and return whether it existed."""
+        return self._delete_by_id("mcp_approval_policies", policy_id)
+
+    async def get_grant(self, grant_id: str) -> CredentialGrant | None:
+        """Return a credential grant by id."""
+        return self._get_model("mcp_credential_grants", grant_id, CredentialGrant)
+
+    async def list_grants(
+        self,
+        *,
+        profile_id: str | None = None,
+        external_server_id: str | None = None,
+    ) -> list[CredentialGrant]:
+        """Return credential grants matching optional filters."""
+        rows = self._select_filtered_payloads(
+            "mcp_credential_grants",
+            {
+                "profile_id": profile_id,
+                "external_server_id": external_server_id,
+            },
+        )
+        return [self._load_model(row["payload"], CredentialGrant) for row in rows]
+
+    async def upsert_grant(self, grant: CredentialGrant) -> CredentialGrant:
+        """Store a credential grant and return the persisted model."""
+        payload = self._dump_model(grant)
+        with self._conn:
+            self._conn.execute(
+                """
+                INSERT INTO mcp_credential_grants(
+                    id, profile_id, external_server_id, enabled, updated_at, payload
+                )
+                VALUES (?, ?, ?, ?, ?, ?)
+                ON CONFLICT(id) DO UPDATE SET
+                    profile_id = excluded.profile_id,
+                    external_server_id = excluded.external_server_id,
+                    enabled = excluded.enabled,
+                    updated_at = excluded.updated_at,
+                    payload = excluded.payload
+                """,
+                (
+                    grant.id,
+                    grant.profile_id,
+                    grant.external_server_id,
+                    int(grant.enabled),
+                    grant.updated_at.isoformat(),
+                    payload,
+                ),
+            )
+        return self._load_model(payload, CredentialGrant)
+
+    async def delete_grant(self, grant_id: str) -> bool:
+        """Delete a credential grant by id and return whether it existed."""
+        return self._delete_by_id("mcp_credential_grants", grant_id)
+
+    async def get_server(self, server_id: str) -> ExternalServerDefinition | None:
+        """Return an external server definition by id."""
+        return self._get_model("mcp_external_servers", server_id, ExternalServerDefinition)
+
+    async def list_servers(self) -> list[ExternalServerDefinition]:
+        """Return all external server definitions sorted by id."""
+        return await self.list_server_definitions()
+
+    async def list_server_definitions(
+        self,
+        *,
+        enabled: bool | None = None,
+    ) -> list[ExternalServerDefinition]:
+        """Return external server definitions matching optional enabled state."""
+        rows = self._select_filtered_payloads(
+            "mcp_external_servers",
+            {"enabled": None if enabled is None else int(enabled)},
+        )
+        return [self._load_model(row["payload"], ExternalServerDefinition) for row in rows]
+
+    async def upsert_server(
+        self,
+        server: ExternalServerDefinition,
+    ) -> ExternalServerDefinition:
+        """Store an external server definition and return the persisted model."""
+        payload = self._dump_model(server)
+        with self._conn:
+            self._conn.execute(
+                """
+                INSERT INTO mcp_external_servers(
+                    id, enabled, transport, updated_at, payload
+                )
+                VALUES (?, ?, ?, ?, ?)
+                ON CONFLICT(id) DO UPDATE SET
+                    enabled = excluded.enabled,
+                    transport = excluded.transport,
+                    updated_at = excluded.updated_at,
+                    payload = excluded.payload
+                """,
+                (
+                    server.id,
+                    int(server.enabled),
+                    server.transport,
+                    server.updated_at.isoformat(),
+                    payload,
+                ),
+            )
+        return self._load_model(payload, ExternalServerDefinition)
+
+    async def delete_server(self, server_id: str) -> bool:
+        """Delete an external server definition by id and return whether it existed."""
+        return self._delete_by_id("mcp_external_servers", server_id)
+
+    async def append_event(self, event: AuditEvent) -> AuditEvent:
+        """Append an audit event and return the persisted event."""
+        payload = self._dump_model(event)
+        with self._conn:
+            self._conn.execute(
+                """
+                INSERT INTO mcp_audit_events(
+                    id, actor_id, profile_id, event_type, created_at, payload
+                )
+                VALUES (?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    event.id,
+                    event.actor_id,
+                    event.profile_id,
+                    event.event_type,
+                    event.created_at.isoformat(),
+                    payload,
+                ),
+            )
+        return self._load_model(payload, AuditEvent)
+
+    async def query_events(
+        self,
+        *,
+        actor_id: str | None = None,
+        profile_id: str | None = None,
+        event_type: str | None = None,
+        limit: int | None = None,
+    ) -> list[AuditEvent]:
+        """Return audit events matching optional filters, newest first."""
+        if limit is not None and limit < 0:
+            raise ValueError("limit must be non-negative")
+        rows = self._select_filtered_payloads(
+            "mcp_audit_events",
+            {
+                "actor_id": actor_id,
+                "profile_id": profile_id,
+                "event_type": event_type,
+            },
+            limit=limit,
+            order_by="created_at DESC, id DESC",
+        )
+        return [self._load_model(row["payload"], AuditEvent) for row in rows]
+
+    def _initialize_schema(self) -> None:
+        with self._conn:
+            self._conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS mcp_storage_meta (
+                    key TEXT PRIMARY KEY,
+                    value TEXT NOT NULL
+                )
+                """
+            )
+            self._ensure_compatible_schema_version()
+            self._conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS mcp_profiles (
+                    id TEXT PRIMARY KEY,
+                    enabled INTEGER NOT NULL,
+                    updated_at TEXT NOT NULL,
+                    payload TEXT NOT NULL
+                )
+                """
+            )
+            self._conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS mcp_profile_assignments (
+                    id TEXT PRIMARY KEY,
+                    profile_id TEXT NOT NULL,
+                    principal_id TEXT,
+                    workspace_id TEXT,
+                    is_default INTEGER NOT NULL,
+                    enabled INTEGER NOT NULL,
+                    updated_at TEXT NOT NULL,
+                    payload TEXT NOT NULL
+                )
+                """
+            )
+            self._conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS mcp_approval_policies (
+                    id TEXT PRIMARY KEY,
+                    profile_id TEXT,
+                    enabled INTEGER NOT NULL,
+                    updated_at TEXT NOT NULL,
+                    payload TEXT NOT NULL
+                )
+                """
+            )
+            self._conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS mcp_credential_grants (
+                    id TEXT PRIMARY KEY,
+                    profile_id TEXT NOT NULL,
+                    external_server_id TEXT,
+                    enabled INTEGER NOT NULL,
+                    updated_at TEXT NOT NULL,
+                    payload TEXT NOT NULL
+                )
+                """
+            )
+            self._conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS mcp_external_servers (
+                    id TEXT PRIMARY KEY,
+                    enabled INTEGER NOT NULL,
+                    transport TEXT NOT NULL,
+                    updated_at TEXT NOT NULL,
+                    payload TEXT NOT NULL
+                )
+                """
+            )
+            self._conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS mcp_audit_events (
+                    id TEXT PRIMARY KEY,
+                    actor_id TEXT,
+                    profile_id TEXT,
+                    event_type TEXT NOT NULL,
+                    created_at TEXT NOT NULL,
+                    payload TEXT NOT NULL
+                )
+                """
+            )
+            self._conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_mcp_assignments_profile ON mcp_profile_assignments(profile_id)"
+            )
+            self._conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_mcp_assignments_principal ON mcp_profile_assignments(principal_id)"
+            )
+            self._conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_mcp_assignments_workspace ON mcp_profile_assignments(workspace_id)"
+            )
+            self._conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_mcp_policies_profile ON mcp_approval_policies(profile_id)"
+            )
+            self._conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_mcp_grants_profile ON mcp_credential_grants(profile_id)"
+            )
+            self._conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_mcp_grants_external_server ON mcp_credential_grants(external_server_id)"
+            )
+            self._conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_mcp_external_enabled ON mcp_external_servers(enabled)"
+            )
+            self._conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_mcp_audit_actor ON mcp_audit_events(actor_id)"
+            )
+            self._conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_mcp_audit_profile ON mcp_audit_events(profile_id)"
+            )
+            self._conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_mcp_audit_event_type ON mcp_audit_events(event_type)"
+            )
+            self._conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_mcp_audit_created_at ON mcp_audit_events(created_at)"
+            )
+
+    def _ensure_compatible_schema_version(self) -> None:
+        current = self._conn.execute(
+            "SELECT value FROM mcp_storage_meta WHERE key = ?",
+            ("schema_version",),
+        ).fetchone()
+        if current is not None and int(current["value"]) > self.SCHEMA_VERSION:
+            raise RuntimeError(
+                f"SQLite MCP store schema {current['value']} is newer than supported "
+                f"schema {self.SCHEMA_VERSION}"
+            )
+        self._conn.execute(
+            """
+            INSERT INTO mcp_storage_meta(key, value)
+            VALUES (?, ?)
+            ON CONFLICT(key) DO UPDATE SET value = excluded.value
+            """,
+            ("schema_version", str(self.SCHEMA_VERSION)),
+        )
+
+    def _delete_by_id(self, table: str, item_id: str) -> bool:
+        with self._conn:
+            cursor = self._conn.execute(
+                self._DELETE_BY_ID_SQL[table],
+                (item_id,),
+            )
+        return cursor.rowcount > 0
+
+    def _get_model(
+        self,
+        table: str,
+        item_id: str,
+        model_cls: type[ModelT],
+    ) -> ModelT | None:
+        row = self._conn.execute(
+            self._SELECT_BY_ID_SQL[table],
+            (item_id,),
+        ).fetchone()
+        if row is None:
+            return None
+        return self._load_model(row["payload"], model_cls)
+
+    def _select_filtered_payloads(
+        self,
+        table: str,
+        filters: dict[str, Any],
+        *,
+        limit: int | None = None,
+        order_by: str = "id ASC",
+    ) -> list[sqlite3.Row]:
+        self._validate_filter_request(table, filters, order_by)
+        clauses: list[str] = []
+        values: list[Any] = []
+        for column, value in filters.items():
+            if value is None:
+                continue
+            clauses.append(f"{column} = ?")
+            values.append(value)
+        where = f"WHERE {' AND '.join(clauses)}" if clauses else ""
+        query_parts = [self._SELECT_PAYLOAD_SQL[table]]
+        if where:
+            query_parts.append(where)
+        query_parts.extend(["ORDER BY", self._ORDER_BY_SQL[order_by]])
+        if limit is not None:
+            query_parts.append("LIMIT ?")
+        if limit is not None:
+            values.append(limit)
+        return self._conn.execute(" ".join(query_parts), values).fetchall()
+
+    def _validate_filter_request(
+        self,
+        table: str,
+        filters: dict[str, Any],
+        order_by: str,
+    ) -> None:
+        allowed_columns = self._FILTERABLE_COLUMNS.get(table)
+        if allowed_columns is None:
+            raise ValueError(f"Unsupported filter table: {table}")
+        unknown_columns = set(filters) - allowed_columns
+        if unknown_columns:
+            raise ValueError(
+                f"Unsupported filter columns for {table}: {sorted(unknown_columns)}"
+            )
+        if order_by not in self._ORDER_BY_SQL:
+            raise ValueError(f"Unsupported order by clause: {order_by}")
+
+    @staticmethod
+    def _dump_model(model: BaseModel) -> str:
+        return json.dumps(
+            model.model_dump(mode="json"),
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+
+    @staticmethod
+    def _load_model(payload: str, model_cls: type[ModelT]) -> ModelT:
+        return model_cls.model_validate_json(payload)
+
+    @staticmethod
+    def _validate_profile(profile: MCPProfile | Mapping[str, Any]) -> MCPProfile:
+        if isinstance(profile, MCPProfile):
+            return profile.model_copy(deep=True)
+        return MCPProfile.model_validate(profile)
+
+
+__all__ = ["SQLiteMCPStore"]

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_sqlite_storage_contracts.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_sqlite_storage_contracts.py
@@ -4,10 +4,9 @@ from __future__ import annotations
 
 import ast
 import sqlite3
-from collections.abc import Callable
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from typing import Any, cast
+from typing import Any
 
 import pytest
 
@@ -30,6 +29,18 @@ def _tldw_imports_for(path: Path) -> list[str]:
     return imports
 
 
+def _direct_imports_for(path: Path) -> list[str]:
+    """Return direct module imports used by a Python source file."""
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    imports: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imports.extend(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            imports.append(node.module)
+    return imports
+
+
 def test_sqlite_storage_module_has_no_tldw_server_imports() -> None:
     import mcp_unified.storage.sqlite as sqlite_storage
 
@@ -37,6 +48,17 @@ def test_sqlite_storage_module_has_no_tldw_server_imports() -> None:
     sqlite_path = Path(sqlite_storage.__file__).resolve()
 
     assert _tldw_imports_for(sqlite_path) == []
+
+
+def test_sqlite_storage_module_uses_db_abstraction_not_direct_sqlite3() -> None:
+    import mcp_unified.storage.sqlite as sqlite_storage
+
+    assert sqlite_storage.__file__ is not None
+    sqlite_path = Path(sqlite_storage.__file__).resolve()
+    direct_imports = _direct_imports_for(sqlite_path)
+
+    assert "sqlite3" not in direct_imports
+    assert not any(import_name.startswith("sqlite3.") for import_name in direct_imports)
 
 
 def test_sqlite_store_initializes_schema_version_idempotently(tmp_path: Path) -> None:
@@ -102,26 +124,23 @@ def test_sqlite_store_uses_thread_safe_timeout_connection(
     import mcp_unified.storage.sqlite as sqlite_storage
     from mcp_unified.storage import SQLiteMCPStore
 
-    original_connect = cast(
-        Callable[..., sqlite3.Connection],
-        sqlite_storage.sqlite3.connect,
-    )
-    connect_kwargs: dict[str, Any] = {}
+    original_create_engine = sqlite_storage.create_engine
+    engine_kwargs: dict[str, Any] = {}
 
-    def recording_connect(
+    def recording_create_engine(
         *args: Any,
         **kwargs: Any,
-    ) -> sqlite3.Connection:
-        connect_kwargs.update(kwargs)
-        return original_connect(*args, **kwargs)
+    ) -> Any:
+        engine_kwargs.update(kwargs)
+        return original_create_engine(*args, **kwargs)
 
-    monkeypatch.setattr(sqlite_storage.sqlite3, "connect", recording_connect)
+    monkeypatch.setattr(sqlite_storage, "create_engine", recording_create_engine)
 
     store = SQLiteMCPStore(tmp_path / "mcp.sqlite")
     store.close()
 
-    assert connect_kwargs["timeout"] == 30.0
-    assert connect_kwargs["check_same_thread"] is False
+    assert engine_kwargs["connect_args"]["timeout"] == 30.0
+    assert engine_kwargs["connect_args"]["check_same_thread"] is False
 
 
 @pytest.mark.asyncio
@@ -153,6 +172,21 @@ async def test_sqlite_store_async_methods_offload_database_work(
     assert "_append_event_sync" in calls
     assert "_query_events_sync" in calls
     assert "_close_sync" in calls
+
+
+@pytest.mark.asyncio
+async def test_sqlite_store_memory_database_survives_thread_offload() -> None:
+    from mcp_unified.profiles import MCPProfile
+    from mcp_unified.storage import SQLiteMCPStore
+
+    store = SQLiteMCPStore(":memory:")
+
+    await store.upsert_profile(MCPProfile(id="qa", name="QA Engineer"))
+    profiles = await store.list_profiles()
+
+    assert [profile.id for profile in profiles] == ["qa"]
+
+    await store.aclose()
 
 
 @pytest.mark.asyncio
@@ -293,10 +327,11 @@ async def test_sqlite_store_enforces_profile_foreign_keys_and_cascades(
         ProfileAssignment,
         SQLiteMCPStore,
     )
+    from sqlalchemy.exc import IntegrityError
 
     store = SQLiteMCPStore(tmp_path / "mcp.sqlite")
 
-    with pytest.raises(sqlite3.IntegrityError):
+    with pytest.raises(IntegrityError):
         await store.upsert_assignment(
             ProfileAssignment(
                 id="orphan-assignment",

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_sqlite_storage_contracts.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_sqlite_storage_contracts.py
@@ -1,0 +1,321 @@
+"""Tests for standalone MCP SQLite storage contracts."""
+
+from __future__ import annotations
+
+import ast
+import sqlite3
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+
+def _tldw_imports_for(path: Path) -> list[str]:
+    """Return imports from a Python file that cross into the host package."""
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    imports: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imports.extend(
+                alias.name
+                for alias in node.names
+                if alias.name == "tldw_Server_API"
+                or alias.name.startswith("tldw_Server_API.")
+            )
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            if node.module == "tldw_Server_API" or node.module.startswith("tldw_Server_API."):
+                imports.append(node.module)
+    return imports
+
+
+def test_sqlite_storage_module_has_no_tldw_server_imports() -> None:
+    import mcp_unified.storage.sqlite as sqlite_storage
+
+    assert sqlite_storage.__file__ is not None
+    sqlite_path = Path(sqlite_storage.__file__).resolve()
+
+    assert _tldw_imports_for(sqlite_path) == []
+
+
+def test_sqlite_store_initializes_schema_version_idempotently(tmp_path: Path) -> None:
+    from mcp_unified.storage import SQLiteMCPStore
+
+    db_path = tmp_path / "mcp.sqlite"
+    store = SQLiteMCPStore(db_path)
+    store.close()
+
+    reopened = SQLiteMCPStore(db_path)
+    reopened.close()
+
+    with sqlite3.connect(db_path) as conn:
+        version = conn.execute(
+            "SELECT value FROM mcp_storage_meta WHERE key = ?",
+            ("schema_version",),
+        ).fetchone()
+        tables = {
+            row[0]
+            for row in conn.execute(
+                "SELECT name FROM sqlite_master WHERE type = 'table'",
+            )
+        }
+
+    assert version == ("1",)
+    assert {
+        "mcp_storage_meta",
+        "mcp_profiles",
+        "mcp_profile_assignments",
+        "mcp_approval_policies",
+        "mcp_credential_grants",
+        "mcp_external_servers",
+        "mcp_audit_events",
+    }.issubset(tables)
+
+
+def test_sqlite_store_rejects_future_schema_version(tmp_path: Path) -> None:
+    from mcp_unified.storage import SQLiteMCPStore
+
+    db_path = tmp_path / "mcp.sqlite"
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            """
+            CREATE TABLE mcp_storage_meta (
+                key TEXT PRIMARY KEY,
+                value TEXT NOT NULL
+            )
+            """
+        )
+        conn.execute(
+            "INSERT INTO mcp_storage_meta(key, value) VALUES (?, ?)",
+            ("schema_version", "999"),
+        )
+
+    with pytest.raises(RuntimeError, match="newer than supported"):
+        SQLiteMCPStore(db_path)
+
+
+@pytest.mark.asyncio
+async def test_sqlite_store_round_trips_profiles_with_copy_isolation(tmp_path: Path) -> None:
+    from mcp_unified.profiles import MCPProfile
+    from mcp_unified.storage import SQLiteMCPStore
+
+    store = SQLiteMCPStore(tmp_path / "mcp.sqlite")
+    profile = MCPProfile(
+        id="orchestrator",
+        name="Orchestrator",
+        metadata={"nested": {"value": "original"}},
+    )
+
+    stored = await store.upsert_profile(profile)
+    profile.metadata["nested"]["value"] = "mutated"
+    stored.metadata["nested"]["value"] = "mutated-again"
+
+    fetched = await store.get_profile("orchestrator")
+    listed = await store.list_profiles()
+    deleted = await store.delete_profile("orchestrator")
+    missing_delete = await store.delete_profile("orchestrator")
+
+    assert fetched is not None
+    assert fetched.metadata["nested"]["value"] == "original"
+    assert [profile.id for profile in listed] == ["orchestrator"]
+    assert deleted is True
+    assert missing_delete is False
+    assert await store.get_profile("orchestrator") is None
+
+    await store.aclose()
+
+
+@pytest.mark.asyncio
+async def test_sqlite_store_filters_assignment_policy_and_grant_rows(
+    tmp_path: Path,
+) -> None:
+    from mcp_unified.storage import (
+        ApprovalPolicyDocument,
+        CredentialGrant,
+        ProfileAssignment,
+        SQLiteMCPStore,
+    )
+
+    store = SQLiteMCPStore(tmp_path / "mcp.sqlite")
+    await store.upsert_assignment(
+        ProfileAssignment(
+            id="assignment-user",
+            profile_id="backend",
+            principal_id="user-1",
+        )
+    )
+    await store.upsert_assignment(
+        ProfileAssignment(
+            id="assignment-workspace",
+            profile_id="backend",
+            workspace_id="workspace-1",
+        )
+    )
+    await store.upsert_assignment(
+        ProfileAssignment(
+            id="assignment-default",
+            profile_id="frontend",
+            is_default=True,
+        )
+    )
+    await store.upsert_policy(
+        ApprovalPolicyDocument(
+            id="policy-backend",
+            name="Backend writes",
+            profile_id="backend",
+            required_for=["filesystem.write"],
+        )
+    )
+    await store.upsert_policy(
+        ApprovalPolicyDocument(
+            id="policy-frontend",
+            name="Frontend writes",
+            profile_id="frontend",
+        )
+    )
+    await store.upsert_grant(
+        CredentialGrant(
+            id="grant-search",
+            profile_id="backend",
+            broker_id="local",
+            credential_slot="search",
+            external_server_id="search-server",
+        )
+    )
+    await store.upsert_grant(
+        CredentialGrant(
+            id="grant-docs",
+            profile_id="frontend",
+            broker_id="local",
+            credential_slot="docs",
+            external_server_id="docs-server",
+        )
+    )
+
+    backend_assignments = await store.list_assignments(profile_id="backend")
+    principal_assignments = await store.list_assignments(principal_id="user-1")
+    workspace_assignments = await store.list_assignments(workspace_id="workspace-1")
+    backend_policies = await store.list_policies(profile_id="backend")
+    backend_grants = await store.list_grants(profile_id="backend")
+    search_grants = await store.list_grants(external_server_id="search-server")
+
+    assert [assignment.id for assignment in backend_assignments] == [
+        "assignment-user",
+        "assignment-workspace",
+    ]
+    assert [assignment.id for assignment in principal_assignments] == ["assignment-user"]
+    assert [assignment.id for assignment in workspace_assignments] == [
+        "assignment-workspace"
+    ]
+    assert [policy.id for policy in backend_policies] == ["policy-backend"]
+    assert [grant.id for grant in backend_grants] == ["grant-search"]
+    assert [grant.id for grant in search_grants] == ["grant-search"]
+    assert await store.delete_assignment("assignment-user") is True
+    assert await store.get_assignment("assignment-user") is None
+    assert await store.delete_policy("missing-policy") is False
+    assert await store.delete_grant("missing-grant") is False
+
+    await store.aclose()
+
+
+@pytest.mark.asyncio
+async def test_sqlite_store_lists_external_server_definitions(tmp_path: Path) -> None:
+    from mcp_unified.storage import ExternalServerDefinition, SQLiteMCPStore
+
+    store = SQLiteMCPStore(tmp_path / "mcp.sqlite")
+    await store.upsert_server(
+        ExternalServerDefinition(
+            id="filesystem",
+            name="Filesystem",
+            transport="stdio",
+            command=["/usr/local/bin/mcp-filesystem"],
+        )
+    )
+    await store.upsert_server(
+        ExternalServerDefinition(
+            id="search",
+            name="Search",
+            transport="websocket",
+            url="wss://example.test/mcp",
+        )
+    )
+    await store.upsert_server(
+        ExternalServerDefinition(
+            id="draft",
+            name="Draft",
+            transport="stdio",
+            enabled=False,
+        )
+    )
+
+    all_servers = await store.list_servers()
+    enabled_servers = await store.list_server_definitions(enabled=True)
+    disabled_servers = await store.list_server_definitions(enabled=False)
+
+    assert [server.id for server in all_servers] == ["draft", "filesystem", "search"]
+    assert [server.id for server in enabled_servers] == ["filesystem", "search"]
+    assert [server.id for server in disabled_servers] == ["draft"]
+    assert await store.get_server("filesystem") is not None
+    assert await store.delete_server("filesystem") is True
+    assert await store.get_server("filesystem") is None
+
+    await store.aclose()
+
+
+@pytest.mark.asyncio
+async def test_sqlite_store_appends_and_queries_audit_events(tmp_path: Path) -> None:
+    from mcp_unified.storage import AuditEvent, SQLiteMCPStore
+
+    store = SQLiteMCPStore(tmp_path / "mcp.sqlite")
+    base_time = datetime(2026, 5, 28, 12, 0, tzinfo=timezone.utc)
+    payload: dict[str, Any] = {
+        "tool": "filesystem.write",
+        "args": {"path": "/repo/README.md"},
+    }
+
+    await store.append_event(
+        AuditEvent(
+            id="old",
+            event_type="tool.allowed",
+            actor_id="user-1",
+            profile_id="backend",
+            payload=payload,
+            created_at=base_time,
+        )
+    )
+    await store.append_event(
+        AuditEvent(
+            id="middle",
+            event_type="tool.denied",
+            actor_id="user-2",
+            profile_id="frontend",
+            created_at=base_time + timedelta(minutes=1),
+        )
+    )
+    await store.append_event(
+        AuditEvent(
+            id="new",
+            event_type="tool.allowed",
+            actor_id="user-1",
+            profile_id="backend",
+            created_at=base_time + timedelta(minutes=2),
+        )
+    )
+    payload["args"]["path"] = "/repo/CHANGED.md"
+
+    newest_two = await store.query_events(limit=2)
+    user_events = await store.query_events(actor_id="user-1")
+    backend_events = await store.query_events(profile_id="backend")
+    denied_events = await store.query_events(event_type="tool.denied")
+    old_event = [event for event in user_events if event.id == "old"][0]
+
+    assert [event.id for event in newest_two] == ["new", "middle"]
+    assert await store.query_events(limit=0) == []
+    with pytest.raises(ValueError, match="limit must be non-negative"):
+        await store.query_events(limit=-1)
+    assert [event.id for event in user_events] == ["new", "old"]
+    assert [event.id for event in backend_events] == ["new", "old"]
+    assert [event.id for event in denied_events] == ["middle"]
+    assert old_event.payload["args"]["path"] == "/repo/README.md"
+
+    await store.aclose()

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_sqlite_storage_contracts.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_sqlite_storage_contracts.py
@@ -4,9 +4,10 @@ from __future__ import annotations
 
 import ast
 import sqlite3
+from collections.abc import Callable
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 import pytest
 
@@ -94,6 +95,66 @@ def test_sqlite_store_rejects_future_schema_version(tmp_path: Path) -> None:
         SQLiteMCPStore(db_path)
 
 
+def test_sqlite_store_uses_thread_safe_timeout_connection(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    import mcp_unified.storage.sqlite as sqlite_storage
+    from mcp_unified.storage import SQLiteMCPStore
+
+    original_connect = cast(
+        Callable[..., sqlite3.Connection],
+        sqlite_storage.sqlite3.connect,
+    )
+    connect_kwargs: dict[str, Any] = {}
+
+    def recording_connect(
+        *args: Any,
+        **kwargs: Any,
+    ) -> sqlite3.Connection:
+        connect_kwargs.update(kwargs)
+        return original_connect(*args, **kwargs)
+
+    monkeypatch.setattr(sqlite_storage.sqlite3, "connect", recording_connect)
+
+    store = SQLiteMCPStore(tmp_path / "mcp.sqlite")
+    store.close()
+
+    assert connect_kwargs["timeout"] == 30.0
+    assert connect_kwargs["check_same_thread"] is False
+
+
+@pytest.mark.asyncio
+async def test_sqlite_store_async_methods_offload_database_work(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    import mcp_unified.storage.sqlite as sqlite_storage
+    from mcp_unified.profiles import MCPProfile
+    from mcp_unified.storage import AuditEvent, SQLiteMCPStore
+
+    store = SQLiteMCPStore(tmp_path / "mcp.sqlite")
+    calls: list[str] = []
+
+    async def recording_to_thread(function: Any, /, *args: Any, **kwargs: Any) -> Any:
+        calls.append(function.__name__)
+        return function(*args, **kwargs)
+
+    monkeypatch.setattr(sqlite_storage.asyncio, "to_thread", recording_to_thread)
+
+    await store.upsert_profile(MCPProfile(id="backend", name="Backend"))
+    await store.list_profiles()
+    await store.append_event(AuditEvent(id="event-1", event_type="tool.allowed"))
+    await store.query_events()
+    await store.aclose()
+
+    assert "_upsert_profile_sync" in calls
+    assert "_list_profiles_sync" in calls
+    assert "_append_event_sync" in calls
+    assert "_query_events_sync" in calls
+    assert "_close_sync" in calls
+
+
 @pytest.mark.asyncio
 async def test_sqlite_store_round_trips_profiles_with_copy_isolation(tmp_path: Path) -> None:
     from mcp_unified.profiles import MCPProfile
@@ -129,6 +190,7 @@ async def test_sqlite_store_round_trips_profiles_with_copy_isolation(tmp_path: P
 async def test_sqlite_store_filters_assignment_policy_and_grant_rows(
     tmp_path: Path,
 ) -> None:
+    from mcp_unified.profiles import MCPProfile
     from mcp_unified.storage import (
         ApprovalPolicyDocument,
         CredentialGrant,
@@ -137,6 +199,8 @@ async def test_sqlite_store_filters_assignment_policy_and_grant_rows(
     )
 
     store = SQLiteMCPStore(tmp_path / "mcp.sqlite")
+    await store.upsert_profile(MCPProfile(id="backend", name="Backend"))
+    await store.upsert_profile(MCPProfile(id="frontend", name="Frontend"))
     await store.upsert_assignment(
         ProfileAssignment(
             id="assignment-user",
@@ -214,6 +278,61 @@ async def test_sqlite_store_filters_assignment_policy_and_grant_rows(
     assert await store.get_assignment("assignment-user") is None
     assert await store.delete_policy("missing-policy") is False
     assert await store.delete_grant("missing-grant") is False
+
+    await store.aclose()
+
+
+@pytest.mark.asyncio
+async def test_sqlite_store_enforces_profile_foreign_keys_and_cascades(
+    tmp_path: Path,
+) -> None:
+    from mcp_unified.profiles import MCPProfile
+    from mcp_unified.storage import (
+        ApprovalPolicyDocument,
+        CredentialGrant,
+        ProfileAssignment,
+        SQLiteMCPStore,
+    )
+
+    store = SQLiteMCPStore(tmp_path / "mcp.sqlite")
+
+    with pytest.raises(sqlite3.IntegrityError):
+        await store.upsert_assignment(
+            ProfileAssignment(
+                id="orphan-assignment",
+                profile_id="missing-profile",
+                principal_id="user-1",
+            )
+        )
+
+    await store.upsert_profile(MCPProfile(id="backend", name="Backend"))
+    await store.upsert_assignment(
+        ProfileAssignment(
+            id="assignment-user",
+            profile_id="backend",
+            principal_id="user-1",
+        )
+    )
+    await store.upsert_policy(
+        ApprovalPolicyDocument(
+            id="policy-backend",
+            name="Backend writes",
+            profile_id="backend",
+        )
+    )
+    await store.upsert_grant(
+        CredentialGrant(
+            id="grant-search",
+            profile_id="backend",
+            broker_id="local",
+            credential_slot="search",
+        )
+    )
+
+    assert await store.delete_profile("backend") is True
+    assert await store.list_assignments(profile_id="backend") == []
+    assert await store.list_policies(profile_id="backend") == []
+    assert await store.list_grants(profile_id="backend") == []
 
     await store.aclose()
 
@@ -317,5 +436,45 @@ async def test_sqlite_store_appends_and_queries_audit_events(tmp_path: Path) -> 
     assert [event.id for event in backend_events] == ["new", "old"]
     assert [event.id for event in denied_events] == ["middle"]
     assert old_event.payload["args"]["path"] == "/repo/README.md"
+
+    await store.aclose()
+
+
+@pytest.mark.asyncio
+async def test_sqlite_store_orders_audit_events_by_utc_instant(
+    tmp_path: Path,
+) -> None:
+    from mcp_unified.storage import AuditEvent, SQLiteMCPStore
+
+    store = SQLiteMCPStore(tmp_path / "mcp.sqlite")
+    older = datetime(
+        2026,
+        5,
+        29,
+        0,
+        15,
+        tzinfo=timezone(timedelta(hours=2)),
+    )
+    newer = datetime(
+        2026,
+        5,
+        28,
+        23,
+        30,
+        tzinfo=timezone(timedelta(hours=-2)),
+    )
+
+    await store.append_event(
+        AuditEvent(id="older-offset", event_type="tool.allowed", created_at=older)
+    )
+    await store.append_event(
+        AuditEvent(id="newer-offset", event_type="tool.allowed", created_at=newer)
+    )
+
+    events = await store.query_events()
+
+    assert [event.id for event in events] == ["newer-offset", "older-offset"]
+    assert events[0].created_at.utcoffset() == timedelta(0)
+    assert events[0].created_at.isoformat() == "2026-05-29T01:30:00+00:00"
 
     await store.aclose()


### PR DESCRIPTION
## Summary
- Adds `SQLiteMCPStore` as a package-local SQLite backend for MCP standalone profile, assignment, approval policy, credential grant, external server, and audit stores.
- Stores complete Pydantic payload JSON with indexed filter columns, schema metadata, future-schema rejection, and copy-isolated round trips.
- Adds focused contract coverage for schema initialization, CRUD/filter behavior, audit queries, limit validation, and host-package boundary isolation.

## Test Plan
- [x] `source .venv/bin/activate && python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_sqlite_storage_contracts.py tldw_Server_API/app/core/MCP_unified/tests/test_storage_contracts.py tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py tldw_Server_API/app/core/MCP_unified/tests/test_profile_registry_resolver.py tldw_Server_API/app/core/MCP_unified/tests/test_profile_structured_resolution.py -v` -> 50 passed, 3 warnings
- [x] `source .venv/bin/activate && python -m ruff check mcp_unified tldw_Server_API/app/core/MCP_unified/tests/test_sqlite_storage_contracts.py`
- [x] `source .venv/bin/activate && python -m mypy mcp_unified tldw_Server_API/app/core/MCP_unified/tests/test_sqlite_storage_contracts.py`
- [x] `source .venv/bin/activate && python -m bandit -r mcp_unified -f json -o /tmp/bandit_mcp_unified_stage2e_sqlite.json` -> 0 findings, 0 skipped tests
- [x] `git diff --check`

## Merge Gate
- [ ] Human requester adds the required Change summary explaining what changed and why these implementation choices were made.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `SQLiteMCPStore`, a package-local SQLite backend for MCP Unified standalone storage. It stores full JSON payloads with filtered CRUD and audit, and now uses SQLAlchemy Core instead of raw `sqlite3`.

- **New Features**
  - Idempotent schema init with `schema_version=1` and future-version rejection.
  - Store full Pydantic JSON with indexed filter columns; copy-safe round trips.
  - CRUD for profiles, assignments (profile/principal/workspace), policies (profile), grants (profile/external_server), and external servers (enabled).
  - Audit append and query with filters, newest-first ordering, and limit validation.
  - Package-local only (no `tldw_Server_API` imports); export `SQLiteMCPStore` from `mcp_unified.storage`.

- **Refactors**
  - Moved off raw `sqlite3` to SQLAlchemy Core; no direct `sqlite3` imports.
  - Engine config: `check_same_thread=False`, 30s timeout, `StaticPool` for `:memory:`, and PRAGMA foreign keys ON via connect hook.
  - Async store methods offload DB work via `asyncio.to_thread`.
  - Kept FK cascades for profile-linked rows and normalized audit timestamps to UTC.

<sup>Written for commit c277b645a624c8ce2579008a9509e2419b350003. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2089?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

