### PR TITLE
Clarify Quick Ingest review estimates

### DIFF
--- a/apps/packages/ui/src/assets/locale/en/option.json
+++ b/apps/packages/ui/src/assets/locale/en/option.json
@@ -652,6 +652,8 @@
     "reviewWarningConfirm": "Enable review",
     "reviewWarningCancel": "Cancel",
     "reviewRunLabel": "Review",
+    "review.warnLongTime": "Processing may take a while ({{time}})",
+    "review.summary": "{{count}} items | {{preset}} preset | {{time}} estimated",
     "reviewDraftsCreated": "Drafts ready for review.",
     "reviewDraftsFailedTitle": "Review drafts couldn't be created.",
     "reviewDraftsFailedFallback": "Failed to create review drafts.",

--- a/apps/packages/ui/src/components/Common/QuickIngest/ReviewStep.tsx
+++ b/apps/packages/ui/src/components/Common/QuickIngest/ReviewStep.tsx
@@ -166,7 +166,7 @@ export const ReviewStep: React.FC<ReviewStepProps> = ({
     // Long estimated time
     if (totalEstimatedSeconds > LONG_TIME_THRESHOLD) {
       result.push(
-        qi("review.warnLongTime", "Processing may take a while (~{{time}})", {
+        qi("review.warnLongTime", "Processing may take a while ({{time}})", {
           time: estimatedTimeLabel,
         })
       )
@@ -206,7 +206,7 @@ export const ReviewStep: React.FC<ReviewStepProps> = ({
           {qi("review.title", "Ready to Process")}
         </h2>
         <p className="mt-1 text-sm text-text-muted">
-          {qi("review.summary", "{{count}} items | {{preset}} preset | ~{{time}} estimated", {
+          {qi("review.summary", "{{count}} items | {{preset}} preset | {{time}} estimated", {
             count: selectedQueueItems.length,
             preset: presetLabel,
             time: estimatedTimeLabel,

--- a/apps/packages/ui/src/components/Common/QuickIngest/__tests__/QuickIngestWizardModal.integration.test.tsx
+++ b/apps/packages/ui/src/components/Common/QuickIngest/__tests__/QuickIngestWizardModal.integration.test.tsx
@@ -829,6 +829,38 @@ describe("QuickIngestWizardModal — full wizard flow integration", () => {
     expect(startButton).toBeTruthy()
   })
 
+  it("Step 3 — renders estimate copy without duplicate approximation markers", () => {
+    render(
+      <WizardTestHarness
+        onClose={onClose}
+        initialState={{
+          currentStep: 3,
+          highestStep: 3,
+          queueItems: [
+            {
+              id: "large-video",
+              kind: "file",
+              fileName: "large-video.mp4",
+              detectedType: "video",
+              icon: "Film",
+              fileSize: 400 * 1024 * 1024,
+              mimeType: "video/mp4",
+              validation: { valid: true },
+            },
+          ],
+        }}
+      />
+    )
+
+    const summary = screen.getByText(/1 items \| Standard preset/i)
+    expect(summary).toHaveTextContent(/~\d+ (sec|min|hr) estimated/)
+    expect(summary).not.toHaveTextContent("~~")
+
+    const longTimeWarning = screen.getByText(/Processing may take a while/i)
+    expect(longTimeWarning).toHaveTextContent(/~\d+ (sec|min|hr)/)
+    expect(longTimeWarning).not.toHaveTextContent("~~")
+  })
+
   it("Step 3 — blocks final processing while disconnected and allows going back", async () => {
     const user = userEvent.setup()
     const retryConnection = vi.fn()

--- a/apps/packages/ui/src/public/_locales/en/messages.json
+++ b/apps/packages/ui/src/public/_locales/en/messages.json
@@ -1376,6 +1376,12 @@
   "quickIngest_reviewRunLabel": {
     "message": "Review"
   },
+  "quickIngest_review.warnLongTime": {
+    "message": "Processing may take a while ({{time}})"
+  },
+  "quickIngest_review.summary": {
+    "message": "{{count}} items | {{preset}} preset | {{time}} estimated"
+  },
   "quickIngest_reviewDraftsCreated": {
     "message": "Drafts ready for review."
   },

--- a/apps/packages/ui/src/public/_locales/en/option.json
+++ b/apps/packages/ui/src/public/_locales/en/option.json
@@ -602,6 +602,12 @@
   "quickIngest_reviewRunLabel": {
     "message": "Review"
   },
+  "quickIngest_review.warnLongTime": {
+    "message": "Processing may take a while ({{time}})"
+  },
+  "quickIngest_review.summary": {
+    "message": "{{count}} items | {{preset}} preset | {{time}} estimated"
+  },
   "quickIngest_reviewDraftsCreated": {
     "message": "Drafts ready for review."
   },

--- a/backlog/tasks/task-394.2 - Clarify-Quick-Ingest-entry-and-destination-copy.md
+++ b/backlog/tasks/task-394.2 - Clarify-Quick-Ingest-entry-and-destination-copy.md
@@ -1,9 +1,10 @@
 ---
 id: TASK-394.2
 title: Clarify Quick Ingest entry and destination copy
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-05-16 00:42'
+updated_date: '2026-05-28 06:06'
 labels:
   - quick-ingest
   - ux
@@ -24,17 +25,41 @@ Execute implementation plan Task 2: improve first-time clarity, destination expe
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Entry labels and wizard copy clarify Quick Ingest purpose and where items go
-- [ ] #2 First-time and returning-user flows keep the same quick path with better recognition over recall
-- [ ] #3 Accessible labels and keyboard/focus behavior are preserved or improved
+- [x] #1 Entry labels and wizard copy clarify Quick Ingest purpose and where items go
+- [x] #2 First-time and returning-user flows keep the same quick path with better recognition over recall
+- [x] #3 Accessible labels and keyboard/focus behavior are preserved or improved
 <!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+- Started from merged dev 66c8bec4d in isolated worktree .worktrees/notes-post-merge-next. Scope: execute plan Task 2 only, focused Quick Ingest launcher/Add step copy and tests.
+
+- Merged dev already included the first-open Add step purpose/destination copy and the Quick Ingest launcher wording/aria-label baseline.
+- Added a regression test for Review step estimate copy to prevent duplicate approximation markers (for example, `~~21 min estimated`).
+- Patched Review step summary and long-duration warning templates so `formatEstimate()` owns the `~` marker.
+- Verification: local UI dependencies were repaired with `bun install` under `apps/` because copied worktree symlinks pointed at a missing node_modules store.
+- Verification: `./node_modules/.bin/vitest run src/components/Common/QuickIngest/__tests__/QuickIngestWizardModal.integration.test.tsx --maxWorkers=1 --no-file-parallelism` passed after the red failure was observed.
+- Verification: `./node_modules/.bin/vitest run src/components/Layouts/__tests__/QuickIngestButton.resume.test.tsx --maxWorkers=1 --no-file-parallelism` passed.
+- Verification: `git diff --check` passed.
+- Browser smoke: Next dev server started at http://127.0.0.1:18082 with local test API-key env; `/media` rendered the Quick Ingest launcher, but an unrelated dev runtime overlay from `GET /api/v1/media?page=1&results_per_page=20&include_keywords=true` blocked modal interaction. Dev server was stopped.
+- Bandit: skipped because this slice only changes frontend TS/TSX and Backlog task metadata.
+- PR review follow-up after rebasing on origin/dev: added explicit Quick Ingest review estimate locale entries without a leading approximation marker in the i18next and extension locale bundles, and loosened the duplicate-marker regression to accept every unit emitted by `formatEstimate()`.
+- Review-fix verification: `./node_modules/.bin/vitest run src/components/Common/QuickIngest/__tests__/QuickIngestWizardModal.integration.test.tsx --maxWorkers=1 --no-file-parallelism`, `./node_modules/.bin/vitest run src/components/Layouts/__tests__/QuickIngestButton.resume.test.tsx --maxWorkers=1 --no-file-parallelism`, locale JSON/static no-`~{{time}}` check, and `git diff --check` passed.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Completed Task 2 focused slice. The merged baseline already had the first-open Add step destination copy and launcher terminology, so this slice fixed the remaining Review step estimate-copy defect and added regression coverage. Quick Ingest review now renders a single approximation marker from the formatter, avoiding strings like `~~21 min estimated` in both the summary and long-duration warning.
+<!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->


### PR DESCRIPTION
## Summary
- Fix Quick Ingest Review copy so estimate approximation markers are rendered once by `formatEstimate()`.
- Add a regression test covering duplicate markers in the review summary and long-duration warning.
- Close `TASK-394.2` with verification notes.

## Test Plan
- [x] `./node_modules/.bin/vitest run src/components/Common/QuickIngest/__tests__/QuickIngestWizardModal.integration.test.tsx --maxWorkers=1 --no-file-parallelism`
- [x] `./node_modules/.bin/vitest run src/components/Layouts/__tests__/QuickIngestButton.resume.test.tsx --maxWorkers=1 --no-file-parallelism`
- [x] `git diff --check`

## Browser Smoke
- [x] Started Next dev server at `http://127.0.0.1:18082` with local test API-key env and verified `/media` renders the Quick Ingest launcher.
- [ ] Modal interaction was not completed because an unrelated dev runtime overlay from `GET /api/v1/media?page=1&results_per_page=20&include_keywords=true` blocked the page.

## Change Summary
TODO: Human requester must replace this with a human-written summary before merge per `Docs/superpowers/AI_GENERATED_PR_CHANGE_SUMMARY_POLICY_2026_04_17.md`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarified Quick Ingest review estimates. Centralized the "~" in `formatEstimate()` and updated i18next and extension locales so the summary and long-time warning show a single marker.

- **Bug Fixes**
  - Removed "~" from review templates and added `review.summary` and `review.warnLongTime` locale entries without it across both locale bundles.
  - Strengthened the integration test to cover all time units and catch duplicate markers.
  - Satisfies TASK-394.2 copy clarity for the Review step.

<sup>Written for commit ad968ab88833dde3402189679447a3cfab37d628. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2092?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

