### PR TITLE
Fix /chat local model readiness mismatch

### DIFF
--- a/apps/packages/ui/src/components/Option/Playground/__tests__/PlaygroundChat.server-load-state.test.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/__tests__/PlaygroundChat.server-load-state.test.tsx
@@ -234,6 +234,38 @@ describe("PlaygroundChat selected server chat load state", () => {
     expect(screen.getByTestId("playground-empty")).toBeInTheDocument()
   })
 
+  it("does not show the no-provider setup banner when the model catalog marks a local model usable", () => {
+    queryState.chatModels = [
+      {
+        api_name: "ollama",
+        model: "gemma3:1b",
+        provider: "ollama",
+        is_configured: true,
+        provider_is_configured: true
+      }
+    ]
+    queryState.providersStatus = {
+      any_configured: false,
+      providers: []
+    }
+    useMessageOptionState.value = {
+      ...useMessageOptionState.value,
+      serverChatLoadState: "idle",
+      serverChatLoadError: null
+    }
+
+    render(
+      <MemoryRouter>
+        <PlaygroundChat />
+      </MemoryRouter>
+    )
+
+    expect(
+      screen.queryByText("No LLM provider configured")
+    ).not.toBeInTheDocument()
+    expect(screen.getByTestId("playground-empty")).toBeInTheDocument()
+  })
+
   it("treats null chat model responses as empty instead of crashing readiness", () => {
     queryState.chatModels = null as any
     queryState.providersStatus = {

--- a/apps/packages/ui/src/utils/__tests__/chat-model-availability.test.ts
+++ b/apps/packages/ui/src/utils/__tests__/chat-model-availability.test.ts
@@ -161,6 +161,40 @@ describe("chat model availability utilities", () => {
     })
   })
 
+  it("preserves descriptor-level configured flags when aggregate provider status is stale", () => {
+    const models = mergeChatProviderStatusIntoModels(
+      [
+        {
+          id: "gemma3:1b",
+          model: "tldw:gemma3:1b",
+          provider: "ollama",
+          is_configured: true,
+          provider_is_configured: true
+        } as any
+      ],
+      {
+        any_configured: false,
+        providers: []
+      }
+    )
+
+    expect(models?.[0]).toMatchObject({
+      is_configured: true,
+      provider_is_configured: true
+    })
+    expect(
+      buildChatModelUsability({
+        selectedModel: "tldw:gemma3:1b",
+        availableModels: models as any[]
+      })
+    ).toMatchObject({
+      status: "ready",
+      canSend: true,
+      matchedModelId: "gemma3:1b",
+      matchedProvider: "ollama"
+    })
+  })
+
   it("ignores null provider status entries while enriching model readiness", () => {
     const models = mergeChatProviderStatusIntoModels(
       [

--- a/apps/packages/ui/src/utils/chat-model-availability.ts
+++ b/apps/packages/ui/src/utils/chat-model-availability.ts
@@ -428,8 +428,14 @@ export function mergeChatProviderStatusIntoModels<T extends ModelDescriptor>(
     const providerConfigured = providerKey
       ? providerConfiguredByKey.get(providerKey)
       : undefined
+    const descriptorConfigured = readConfiguredFlagFromRecords(
+      getChatModelDescriptorRecords(model)
+    )
     const effectiveConfigured =
-      providerConfigured ?? (noProviderConfigured ? false : undefined)
+      providerConfigured ??
+      (noProviderConfigured && descriptorConfigured !== true
+        ? false
+        : undefined)
 
     if (effectiveConfigured == null) return model
     changed = true

--- a/backlog/tasks/task-539 - Fix-chat-provider-model-readiness-mismatch-after-rails-rebaseline.md
+++ b/backlog/tasks/task-539 - Fix-chat-provider-model-readiness-mismatch-after-rails-rebaseline.md
@@ -1,0 +1,60 @@
+---
+id: TASK-539
+title: Fix /chat provider-model readiness mismatch after rails rebaseline
+status: Done
+labels:
+- chat
+- ux
+- webui
+- regression
+priority: High
+modified_files:
+- apps/packages/ui/src/utils/chat-model-availability.ts
+- apps/packages/ui/src/utils/__tests__/chat-model-availability.test.ts
+- apps/packages/ui/src/components/Option/Playground/__tests__/PlaygroundChat.server-load-state.test.tsx
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Investigate and fix the /chat readiness mismatch left after the rails UX rebaseline where global provider setup state can report no provider configured while the runtime/model rails still present a selected chat model as ready. Keep scope limited to /chat WebUI provider/model readiness, banners, send blocking, and focused regressions.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 /chat uses a consistent source of truth for no-provider banners, runtime readiness, and send blocking.
+- [x] #2 A usable local/provider-qualified chat model does not get blocked solely because the aggregate provider status reports any_configured=false.
+- [x] #3 The empty/unusable provider state still clearly blocks first send and shows setup guidance.
+- [x] #4 Focused regression tests cover the mismatch and the empty-provider case.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Root cause: mergeChatProviderStatusIntoModels treated aggregate any_configured:false as authoritative when provider status had no explicit configured provider rows, and downgraded model descriptors that already carried is_configured/provider_is_configured:true. That made /chat show the no-provider setup banner for callable local models.
+
+Implementation: preserve descriptor-level configured:true unless an explicit provider status row overrides it. Explicit provider false still blocks, empty/unusable catalogs still show setup guidance.
+
+Verification:
+- RED: bun run test src/utils/__tests__/chat-model-availability.test.ts src/components/Option/Playground/__tests__/PlaygroundChat.server-load-state.test.tsx failed on the new stale aggregate provider status regressions.
+- GREEN: same command passed 58/58 after the fix.
+- Rails guard: bun run test src/components/Option/Playground/__tests__/Playground.cockpit-controls.test.tsx passed 19/19.
+
+Bandit: not run; touched files are TypeScript UI/test files only.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Fixed the /chat provider/model readiness mismatch by preserving explicit callable model descriptors when provider aggregate status is stale. Added regressions for the stale any_configured:false + usable local model case at the shared readiness utility and PlaygroundChat banner level. Verified focused readiness tests and the cockpit rails controls tests pass. Bandit skipped because this is TypeScript UI/test-only work.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## Summary
- Preserves explicit callable local model descriptors when aggregate provider status is stale.
- Adds regressions for stale `any_configured:false` with a usable local model at the shared readiness utility and `/chat` banner level.
- Records TASK-539 with root cause, scope, verification, and Bandit skip rationale for TypeScript-only work.

## Test Plan
- [x] `bun run test src/utils/__tests__/chat-model-availability.test.ts src/components/Option/Playground/__tests__/PlaygroundChat.server-load-state.test.tsx`
- [x] `bun run test src/components/Option/Playground/__tests__/Playground.cockpit-controls.test.tsx`

## Change summary
Human-authored change summary required before marking this PR ready for merge per `Docs/superpowers/AI_GENERATED_PR_CHANGE_SUMMARY_POLICY_2026_04_17.md`.

## Notes
- Bandit not run because the touched implementation and regression files are TypeScript UI/test files only.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a readiness mismatch in `/chat` that showed the no-provider banner and blocked send even when a usable local model was available. Preserves descriptor-level configured flags so the UI reflects actual model usability and aligns with TASK-539.

- **Bug Fixes**
  - Preserve descriptor-level configured flags in `mergeChatProviderStatusIntoModels` when aggregate provider status is stale (`any_configured:false` with no explicit provider rows).
  - Stop showing the “No LLM provider configured” banner in `/chat` when a local model is usable; empty-provider cases still block as expected.
  - Added focused regressions in `apps/packages/ui/src/utils/__tests__/chat-model-availability.test.ts` and `apps/packages/ui/src/components/Option/Playground/__tests__/PlaygroundChat.server-load-state.test.tsx`.

<sup>Written for commit e02f400b75a323634a04997f9b7836d98602b2e7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2093?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

