### PR TITLE
Add MCP Unified Stage 2F federation shell

### DIFF
--- a/Docs/superpowers/plans/2026-05-28-mcp-unified-stage2f-external-registry-shell-plan.md
+++ b/Docs/superpowers/plans/2026-05-28-mcp-unified-stage2f-external-registry-shell-plan.md
@@ -1,0 +1,23 @@
+## Stage 1: Package Federation Contracts
+**Goal**: Add standalone `mcp_unified.federation` contracts for virtual external tools, transport lifecycle, health state, and execution results without importing `tldw_Server_API`.
+**Success Criteria**: Public federation imports are package-local, carry namespaced `ext.<server_id>.<tool>` metadata, and represent lifecycle state without process spawning.
+**Tests**: Import-boundary tests and contract/model tests for virtual tool names, caller-owned metadata, and fake transport defaults.
+**Status**: Complete
+
+## Stage 2: Registry-Backed Non-Spawning Manager
+**Goal**: Implement a small manager that loads enabled `ExternalServerDefinition` rows from `ExternalRegistryStore`, starts/stops fake transports, refreshes virtual tools, reports health, and never launches stdio/websocket processes.
+**Success Criteria**: A registry-backed fake server can be started, listed, refreshed, stopped, and isolated per manager instance.
+**Tests**: Async tests with an in-memory registry store and fake transport factory.
+**Status**: Complete
+
+## Stage 3: Policy-Gated Execution And Audit
+**Goal**: Gate fake upstream tool calls on explicit effective-policy grants and emit structured audit events for allow/deny/lifecycle/discovery outcomes when an audit store is provided.
+**Success Criteria**: Discovered tools remain non-executable until profile/effective-policy grants allow the server/tool, denied calls carry machine-readable reason codes, and audit records avoid secret values.
+**Tests**: Async execution tests for denied server grant, denied tool allowlist, allowed execution, and audit event ordering.
+**Status**: Complete
+
+## Stage 4: Compatibility Verification
+**Goal**: Keep existing host MCP behavior intact while proving the new package shell stands alone.
+**Success Criteria**: Focused standalone tests, existing storage/runtime boundary tests, and Bandit on touched package code pass.
+**Tests**: `pytest` focused MCP package tests plus `bandit -r mcp_unified/federation`.
+**Status**: Complete

--- a/backlog/tasks/task-531 - Implement-MCP-Unified-Stage-2F-external-registry-shell.md
+++ b/backlog/tasks/task-531 - Implement-MCP-Unified-Stage-2F-external-registry-shell.md
@@ -1,0 +1,62 @@
+---
+id: TASK-531
+title: Implement MCP Unified Stage 2F external registry shell
+status: Done
+labels:
+- mcp-unified
+- standalone
+- stage2
+- federation
+references:
+- Docs/superpowers/specs/2026-05-26-mcp-unified-standalone-library-gateway-design.md
+modified_files:
+- Docs/superpowers/plans/2026-05-28-mcp-unified-stage2f-external-registry-shell-plan.md
+- mcp_unified/federation/__init__.py
+- mcp_unified/federation/manager.py
+- mcp_unified/federation/models.py
+- mcp_unified/federation/transports.py
+- tldw_Server_API/app/core/MCP_unified/tests/test_federation_shell_contracts.py
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Plan and implement the next reviewable MCP Unified standalone Stage 2F slice: package-local external-server registry models and a non-spawning fake transport lifecycle shell with health state, virtual-tool metadata, and policy-gated execution tests. Defer real stdio process spawning and host MCP Hub wiring.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 mcp_unified exposes package-local external registry/federation primitives with no tldw_Server_API imports.
+- [ ] #2 Fake/non-spawning transport lifecycle can register, start/stop, report health, and expose namespaced virtual-tool metadata without launching processes.
+- [ ] #3 Policy-gated execution denies or allows fake upstream tool calls based on injected profile/effective policy decisions and records audit events where available.
+- [ ] #4 Existing tldw_server MCP behavior and Stage 2A-2E tests remain compatible.
+- [ ] #5 Focused pytest and Bandit checks pass for the touched scope.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Docs/superpowers/plans/2026-05-28-mcp-unified-stage2f-external-registry-shell-plan.md
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+['Spec: Docs/superpowers/specs/2026-05-26-mcp-unified-standalone-library-gateway-design.md Stage 2F.']
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Stage 2F adds a standalone, non-spawning external federation shell under mcp_unified. It uses injected registry/transport/audit dependencies, exposes ext.<server>.<tool> virtual metadata, reports fake transport health, and gates execution on effective policy external-server, allowed-tool, denied-tool, and credential-slot grants. Real stdio/websocket process management remains deferred.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-531 - Implement-MCP-Unified-Stage-2F-external-registry-shell.md
+++ b/backlog/tasks/task-531 - Implement-MCP-Unified-Stage-2F-external-registry-shell.md
@@ -26,11 +26,11 @@ Plan and implement the next reviewable MCP Unified standalone Stage 2F slice: pa
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 mcp_unified exposes package-local external registry/federation primitives with no tldw_Server_API imports.
-- [ ] #2 Fake/non-spawning transport lifecycle can register, start/stop, report health, and expose namespaced virtual-tool metadata without launching processes.
-- [ ] #3 Policy-gated execution denies or allows fake upstream tool calls based on injected profile/effective policy decisions and records audit events where available.
-- [ ] #4 Existing tldw_server MCP behavior and Stage 2A-2E tests remain compatible.
-- [ ] #5 Focused pytest and Bandit checks pass for the touched scope.
+- [x] #1 mcp_unified exposes package-local external registry/federation primitives with no tldw_Server_API imports.
+- [x] #2 Fake/non-spawning transport lifecycle can register, start/stop, report health, and expose namespaced virtual-tool metadata without launching processes.
+- [x] #3 Policy-gated execution denies or allows fake upstream tool calls based on injected profile/effective policy decisions and records audit events where available.
+- [x] #4 Existing tldw_server MCP behavior and Stage 2A-2E tests remain compatible.
+- [x] #5 Focused pytest and Bandit checks pass for the touched scope.
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -42,7 +42,8 @@ Docs/superpowers/plans/2026-05-28-mcp-unified-stage2f-external-registry-shell-pl
 ## Implementation Notes
 
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
-['Spec: Docs/superpowers/specs/2026-05-26-mcp-unified-standalone-library-gateway-design.md Stage 2F.']
+- Spec: Docs/superpowers/specs/2026-05-26-mcp-unified-standalone-library-gateway-design.md Stage 2F.
+- PR #2094 review pass addressed lifecycle rollback, best-effort stop cleanup, refresh diagnostics, locked read snapshots, and helper docstrings.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary
@@ -53,10 +54,10 @@ Stage 2F adds a standalone, non-spawning external federation shell under mcp_uni
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->

--- a/mcp_unified/federation/__init__.py
+++ b/mcp_unified/federation/__init__.py
@@ -1,0 +1,22 @@
+"""Standalone non-spawning external federation shell."""
+
+from .manager import ExternalFederationManager
+from .models import (
+    ExternalToolCallResult,
+    ExternalToolDefinition,
+    FederatedToolResult,
+    FederationPolicyDenied,
+    VirtualExternalTool,
+)
+from .transports import ExternalFederationTransport, FakeExternalTransport
+
+__all__ = [
+    "ExternalFederationManager",
+    "ExternalFederationTransport",
+    "ExternalToolCallResult",
+    "ExternalToolDefinition",
+    "FakeExternalTransport",
+    "FederatedToolResult",
+    "FederationPolicyDenied",
+    "VirtualExternalTool",
+]

--- a/mcp_unified/federation/manager.py
+++ b/mcp_unified/federation/manager.py
@@ -37,6 +37,7 @@ class ExternalFederationManager:
         self._transports: dict[str, ExternalFederationTransport] = {}
         self._virtual_tools: dict[str, VirtualExternalTool] = {}
         self._last_errors: dict[str, str | None] = {}
+        self._last_lifecycle_errors: list[dict[str, Any]] = []
         self._started = False
         self._lock = asyncio.Lock()
 
@@ -45,30 +46,55 @@ class ExternalFederationManager:
         """Return whether the manager has an active logical lifecycle."""
         return self._started
 
+    @property
+    def last_lifecycle_errors(self) -> list[dict[str, Any]]:
+        """Return cleanup or lifecycle errors captured during best-effort operations."""
+        return deepcopy(self._last_lifecycle_errors)
+
     async def start(self) -> None:
         """Load enabled registry definitions and connect fake transports."""
         async with self._lock:
             await self._stop_unlocked()
             servers = await self._load_enabled_servers()
-            for server in servers:
-                transport = self._transport_factory(server)
-                self._servers[server.id] = server
-                self._transports[server.id] = transport
-                self._last_errors[server.id] = None
-                await transport.connect()
-                await self._audit(
-                    "external_server.lifecycle",
-                    payload={
-                        "reason_code": "started",
-                        "server_id": server.id,
-                        "transport": server.transport,
-                        "spawns_process": False,
-                    },
-                    target_type="external_server",
-                    target_id=server.id,
-                )
-                await self._refresh_server_tools_unlocked(server.id)
-            self._started = True
+            current_server: ExternalServerDefinition | None = None
+            try:
+                for server in servers:
+                    current_server = server
+                    transport = self._transport_factory(server)
+                    self._servers[server.id] = server
+                    self._transports[server.id] = transport
+                    self._last_errors[server.id] = None
+                    await transport.connect()
+                    await self._audit(
+                        "external_server.lifecycle",
+                        payload={
+                            "reason_code": "started",
+                            "server_id": server.id,
+                            "transport": server.transport,
+                            "spawns_process": False,
+                        },
+                        target_type="external_server",
+                        target_id=server.id,
+                    )
+                    await self._refresh_server_tools_unlocked(server.id)
+            except Exception as exc:  # noqa: BLE001 - adapters may raise arbitrary lifecycle errors.
+                if current_server is not None:
+                    self._last_errors[current_server.id] = self._exception_summary(exc)
+                    await self._audit_best_effort(
+                        "external_server.lifecycle",
+                        payload={
+                            "reason_code": "start_failed",
+                            "server_id": current_server.id,
+                            "error_type": type(exc).__name__,
+                            "error_message": str(exc),
+                        },
+                        target_type="external_server",
+                        target_id=current_server.id,
+                    )
+                await self._stop_unlocked()
+                raise
+            else:
+                self._started = True
 
     async def stop(self) -> None:
         """Close active fake transports and clear runtime state."""
@@ -88,10 +114,23 @@ class ExternalFederationManager:
                 try:
                     await self._refresh_server_tools_unlocked(target_id)
                     refreshed += 1
-                except (OSError, RuntimeError, TimeoutError, ValueError, TypeError):
+                except Exception as exc:  # noqa: BLE001 - adapters may raise arbitrary discovery errors.
                     errors[target_id] = "external_server_discovery_failed"
-                    self._last_errors[target_id] = "external_server_discovery_failed"
+                    self._last_errors[target_id] = self._exception_summary(exc)
                     self._clear_server_tools(target_id)
+                    audit_error = await self._audit_best_effort(
+                        "external_server.discovery",
+                        payload={
+                            "reason_code": "external_server_discovery_failed",
+                            "server_id": target_id,
+                            "error_type": type(exc).__name__,
+                            "error_message": str(exc),
+                        },
+                        target_type="external_server",
+                        target_id=target_id,
+                    )
+                    if audit_error is not None:
+                        self._last_lifecycle_errors.append(audit_error)
             return {
                 "refreshed_servers": refreshed,
                 "total_servers": len(target_ids),
@@ -101,34 +140,45 @@ class ExternalFederationManager:
 
     async def list_servers(self) -> list[dict[str, Any]]:
         """Return summarized health for loaded external server definitions."""
+        async with self._lock:
+            snapshots = [
+                (
+                    server_id,
+                    server.model_copy(deep=True),
+                    self._transports.get(server_id),
+                    self._last_errors.get(server_id),
+                    self._count_tools_for_server(server_id),
+                )
+                for server_id, server in sorted(self._servers.items())
+            ]
+
         rows: list[dict[str, Any]] = []
-        for server_id in sorted(self._servers):
-            server = self._servers[server_id]
-            transport = self._transports.get(server_id)
+        for _server_id, server, transport, last_error, tool_count in snapshots:
             checks = {"configured": True, "connected": False, "spawns_process": False}
             if transport is not None:
                 checks = await transport.health_check()
             connected = bool(checks.get("connected"))
-            status = self._server_status(server_id=server_id, connected=connected)
+            status = self._server_status(connected=connected, last_error=last_error)
             rows.append(
                 {
                     "id": server.id,
                     "name": server.name,
                     "transport": server.transport,
-                    "tool_count": self._count_tools_for_server(server.id),
+                    "tool_count": tool_count,
                     "status": status,
                     "checks": dict(checks),
-                    "last_error": self._last_errors.get(server.id),
+                    "last_error": last_error,
                 }
             )
         return rows
 
-    def list_virtual_tools(self) -> list[VirtualExternalTool]:
+    async def list_virtual_tools(self) -> list[VirtualExternalTool]:
         """Return discovered virtual tools sorted by namespaced tool name."""
-        return [
-            self._virtual_tools[name]
-            for name in sorted(self._virtual_tools)
-        ]
+        async with self._lock:
+            return [
+                deepcopy(self._virtual_tools[name])
+                for name in sorted(self._virtual_tools)
+            ]
 
     async def execute_virtual_tool(
         self,
@@ -145,7 +195,9 @@ class ExternalFederationManager:
             if virtual_tool is None:
                 raise ValueError(f"Unknown external virtual tool '{virtual_tool_name}'")
 
-            server = self._servers[virtual_tool.server_id]
+            server = self._servers.get(virtual_tool.server_id)
+            if server is None:
+                raise ValueError(f"External server '{virtual_tool.server_id}' is unavailable")
             profile_id = self._policy_profile_id(effective_policy)
             deny_reason = self._deny_reason(
                 server=server,
@@ -170,7 +222,9 @@ class ExternalFederationManager:
                     },
                 )
 
-            transport = self._transports[virtual_tool.server_id]
+            transport = self._transports.get(virtual_tool.server_id)
+            if transport is None:
+                raise ValueError(f"External server '{virtual_tool.server_id}' is unavailable")
             result = await transport.call_tool(
                 virtual_tool.upstream_tool_name,
                 deepcopy(arguments or {}),
@@ -206,23 +260,53 @@ class ExternalFederationManager:
         raise TypeError("external registry rows must be ExternalServerDefinition or dict")
 
     async def _stop_unlocked(self) -> None:
-        for server_id, transport in list(self._transports.items()):
-            await transport.close()
-            await self._audit(
-                "external_server.lifecycle",
-                payload={
+        errors: list[dict[str, Any]] = []
+        try:
+            for server_id, transport in list(self._transports.items()):
+                close_error: dict[str, Any] | None = None
+                try:
+                    await transport.close()
+                except Exception as exc:  # noqa: BLE001 - shutdown must continue across adapter failures.
+                    close_error = self._lifecycle_error(
+                        server_id=server_id,
+                        operation="close",
+                        exc=exc,
+                    )
+                    errors.append(close_error)
+
+                payload: dict[str, Any] = {
                     "reason_code": "stopped",
                     "server_id": server_id,
                     "spawns_process": False,
+                }
+                if close_error is not None:
+                    payload["close_error"] = close_error
+                audit_error = await self._audit_best_effort(
+                    "external_server.lifecycle",
+                    payload=payload,
+                    target_type="external_server",
+                    target_id=server_id,
+                )
+                if audit_error is not None:
+                    errors.append(audit_error)
+        finally:
+            self._servers = {}
+            self._transports = {}
+            self._virtual_tools = {}
+            self._last_errors = {}
+            self._started = False
+            self._last_lifecycle_errors = errors
+
+        if errors:
+            audit_error = await self._audit_best_effort(
+                "external_server.lifecycle_error",
+                payload={
+                    "reason_code": "stop_errors",
+                    "errors": deepcopy(errors),
                 },
-                target_type="external_server",
-                target_id=server_id,
             )
-        self._servers = {}
-        self._transports = {}
-        self._virtual_tools = {}
-        self._last_errors = {}
-        self._started = False
+            if audit_error is not None:
+                self._last_lifecycle_errors.append(audit_error)
 
     async def _refresh_server_tools_unlocked(self, server_id: str) -> None:
         transport = self._transports[server_id]
@@ -455,12 +539,60 @@ class ExternalFederationManager:
         )
         await self._audit_store.append_event(event)
 
-    def _server_status(self, *, server_id: str, connected: bool) -> str:
-        if connected and self._last_errors.get(server_id) is None:
+    async def _audit_best_effort(
+        self,
+        event_type: str,
+        *,
+        payload: dict[str, Any],
+        actor_id: str | None = None,
+        profile_id: str | None = None,
+        target_type: str | None = None,
+        target_id: str | None = None,
+    ) -> dict[str, Any] | None:
+        try:
+            await self._audit(
+                event_type,
+                payload=payload,
+                actor_id=actor_id,
+                profile_id=profile_id,
+                target_type=target_type,
+                target_id=target_id,
+            )
+        except Exception as exc:  # noqa: BLE001 - audit failures must not block cleanup.
+            return self._lifecycle_error(
+                server_id=target_id,
+                operation="audit",
+                exc=exc,
+            )
+        return None
+
+    @staticmethod
+    def _server_status(*, connected: bool, last_error: str | None) -> str:
+        if connected and last_error is None:
             return "healthy"
-        if connected or self._last_errors.get(server_id) is None:
+        if connected or last_error is None:
             return "degraded"
         return "unhealthy"
+
+    @staticmethod
+    def _exception_summary(exc: BaseException) -> str:
+        message = str(exc).strip()
+        error_type = type(exc).__name__
+        return f"{error_type}: {message}" if message else error_type
+
+    @staticmethod
+    def _lifecycle_error(
+        *,
+        server_id: str | None,
+        operation: str,
+        exc: BaseException,
+    ) -> dict[str, Any]:
+        return {
+            "server_id": server_id,
+            "operation": operation,
+            "error_type": type(exc).__name__,
+            "error_message": str(exc),
+        }
 
     @staticmethod
     def _virtual_tool_name(server_id: str, tool_name: str) -> str:

--- a/mcp_unified/federation/manager.py
+++ b/mcp_unified/federation/manager.py
@@ -1,0 +1,506 @@
+"""Registry-backed non-spawning external federation manager."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Callable, Iterable
+from copy import deepcopy
+from datetime import datetime, timezone
+from typing import Any
+from uuid import uuid4
+
+from mcp_unified.storage import AuditEvent, ExternalServerDefinition
+
+from .models import (
+    ExternalToolCallResult,
+    FederatedToolResult,
+    FederationPolicyDenied,
+    VirtualExternalTool,
+)
+from .transports import ExternalFederationTransport
+
+
+class ExternalFederationManager:
+    """Standalone external federation shell with no process-spawning transports."""
+
+    def __init__(
+        self,
+        *,
+        registry_store: Any,
+        transport_factory: Callable[[ExternalServerDefinition], ExternalFederationTransport],
+        audit_store: Any | None = None,
+    ) -> None:
+        self._registry_store = registry_store
+        self._transport_factory = transport_factory
+        self._audit_store = audit_store
+        self._servers: dict[str, ExternalServerDefinition] = {}
+        self._transports: dict[str, ExternalFederationTransport] = {}
+        self._virtual_tools: dict[str, VirtualExternalTool] = {}
+        self._last_errors: dict[str, str | None] = {}
+        self._started = False
+        self._lock = asyncio.Lock()
+
+    @property
+    def started(self) -> bool:
+        """Return whether the manager has an active logical lifecycle."""
+        return self._started
+
+    async def start(self) -> None:
+        """Load enabled registry definitions and connect fake transports."""
+        async with self._lock:
+            await self._stop_unlocked()
+            servers = await self._load_enabled_servers()
+            for server in servers:
+                transport = self._transport_factory(server)
+                self._servers[server.id] = server
+                self._transports[server.id] = transport
+                self._last_errors[server.id] = None
+                await transport.connect()
+                await self._audit(
+                    "external_server.lifecycle",
+                    payload={
+                        "reason_code": "started",
+                        "server_id": server.id,
+                        "transport": server.transport,
+                        "spawns_process": False,
+                    },
+                    target_type="external_server",
+                    target_id=server.id,
+                )
+                await self._refresh_server_tools_unlocked(server.id)
+            self._started = True
+
+    async def stop(self) -> None:
+        """Close active fake transports and clear runtime state."""
+        async with self._lock:
+            await self._stop_unlocked()
+
+    async def refresh(self, server_id: str | None = None) -> dict[str, Any]:
+        """Refresh virtual tool metadata for one server or all loaded servers."""
+        async with self._lock:
+            target_ids = [server_id] if server_id else sorted(self._servers)
+            refreshed = 0
+            errors: dict[str, str] = {}
+            for target_id in target_ids:
+                if target_id not in self._servers:
+                    errors[target_id] = "unknown_server"
+                    continue
+                try:
+                    await self._refresh_server_tools_unlocked(target_id)
+                    refreshed += 1
+                except (OSError, RuntimeError, TimeoutError, ValueError, TypeError):
+                    errors[target_id] = "external_server_discovery_failed"
+                    self._last_errors[target_id] = "external_server_discovery_failed"
+                    self._clear_server_tools(target_id)
+            return {
+                "refreshed_servers": refreshed,
+                "total_servers": len(target_ids),
+                "virtual_tools": len(self._virtual_tools),
+                "errors": errors,
+            }
+
+    async def list_servers(self) -> list[dict[str, Any]]:
+        """Return summarized health for loaded external server definitions."""
+        rows: list[dict[str, Any]] = []
+        for server_id in sorted(self._servers):
+            server = self._servers[server_id]
+            transport = self._transports.get(server_id)
+            checks = {"configured": True, "connected": False, "spawns_process": False}
+            if transport is not None:
+                checks = await transport.health_check()
+            connected = bool(checks.get("connected"))
+            status = self._server_status(server_id=server_id, connected=connected)
+            rows.append(
+                {
+                    "id": server.id,
+                    "name": server.name,
+                    "transport": server.transport,
+                    "tool_count": self._count_tools_for_server(server.id),
+                    "status": status,
+                    "checks": dict(checks),
+                    "last_error": self._last_errors.get(server.id),
+                }
+            )
+        return rows
+
+    def list_virtual_tools(self) -> list[VirtualExternalTool]:
+        """Return discovered virtual tools sorted by namespaced tool name."""
+        return [
+            self._virtual_tools[name]
+            for name in sorted(self._virtual_tools)
+        ]
+
+    async def execute_virtual_tool(
+        self,
+        virtual_tool_name: str,
+        arguments: dict[str, Any] | None,
+        *,
+        effective_policy: Any,
+        actor_id: str | None = None,
+        context: Any = None,
+    ) -> FederatedToolResult:
+        """Execute a virtual external tool after effective-policy checks pass."""
+        async with self._lock:
+            virtual_tool = self._virtual_tools.get(virtual_tool_name)
+            if virtual_tool is None:
+                raise ValueError(f"Unknown external virtual tool '{virtual_tool_name}'")
+
+            server = self._servers[virtual_tool.server_id]
+            profile_id = self._policy_profile_id(effective_policy)
+            deny_reason = self._deny_reason(
+                server=server,
+                virtual_tool=virtual_tool,
+                effective_policy=effective_policy,
+            )
+            if deny_reason is not None:
+                await self._audit_execution(
+                    event_type="external_tool.denied",
+                    reason_code=deny_reason,
+                    virtual_tool=virtual_tool,
+                    actor_id=actor_id,
+                    profile_id=profile_id,
+                )
+                raise FederationPolicyDenied(
+                    deny_reason,
+                    f"External tool '{virtual_tool_name}' denied: {deny_reason}",
+                    payload={
+                        "reason_code": deny_reason,
+                        "server_id": virtual_tool.server_id,
+                        "virtual_tool_name": virtual_tool_name,
+                    },
+                )
+
+            transport = self._transports[virtual_tool.server_id]
+            result = await transport.call_tool(
+                virtual_tool.upstream_tool_name,
+                deepcopy(arguments or {}),
+                context=context,
+            )
+            await self._audit_execution(
+                event_type="external_tool.allowed",
+                reason_code="allowed",
+                virtual_tool=virtual_tool,
+                actor_id=actor_id,
+                profile_id=profile_id,
+            )
+            return self._federated_result(virtual_tool, result)
+
+    async def _load_enabled_servers(self) -> list[ExternalServerDefinition]:
+        if hasattr(self._registry_store, "list_server_definitions"):
+            rows = await self._registry_store.list_server_definitions(enabled=True)
+        else:
+            rows = await self._registry_store.list_servers()
+        servers: list[ExternalServerDefinition] = []
+        for row in rows:
+            server = self._coerce_server_definition(row)
+            if server.enabled:
+                servers.append(server)
+        return servers
+
+    @staticmethod
+    def _coerce_server_definition(row: Any) -> ExternalServerDefinition:
+        if isinstance(row, ExternalServerDefinition):
+            return row.model_copy(deep=True)
+        if isinstance(row, dict):
+            return ExternalServerDefinition(**deepcopy(row))
+        raise TypeError("external registry rows must be ExternalServerDefinition or dict")
+
+    async def _stop_unlocked(self) -> None:
+        for server_id, transport in list(self._transports.items()):
+            await transport.close()
+            await self._audit(
+                "external_server.lifecycle",
+                payload={
+                    "reason_code": "stopped",
+                    "server_id": server_id,
+                    "spawns_process": False,
+                },
+                target_type="external_server",
+                target_id=server_id,
+            )
+        self._servers = {}
+        self._transports = {}
+        self._virtual_tools = {}
+        self._last_errors = {}
+        self._started = False
+
+    async def _refresh_server_tools_unlocked(self, server_id: str) -> None:
+        transport = self._transports[server_id]
+        tools = await transport.list_tools()
+        self._clear_server_tools(server_id)
+        for tool in tools:
+            virtual_name = self._virtual_tool_name(server_id, tool.name)
+            metadata = deepcopy(tool.metadata or {})
+            metadata.setdefault("external_server_id", server_id)
+            metadata.setdefault("upstream_tool_name", tool.name)
+            self._virtual_tools[virtual_name] = VirtualExternalTool(
+                virtual_name=virtual_name,
+                server_id=server_id,
+                upstream_tool_name=tool.name,
+                description=tool.description,
+                input_schema=deepcopy(tool.input_schema),
+                metadata=metadata,
+                is_write=self._is_write_tool(tool.name, metadata),
+            )
+        self._last_errors[server_id] = None
+        await self._audit(
+            "external_server.discovery",
+            payload={
+                "reason_code": "discovered",
+                "server_id": server_id,
+                "tool_count": len(tools),
+            },
+            target_type="external_server",
+            target_id=server_id,
+        )
+
+    def _deny_reason(
+        self,
+        *,
+        server: ExternalServerDefinition,
+        virtual_tool: VirtualExternalTool,
+        effective_policy: Any,
+    ) -> str | None:
+        if self._tool_matches_any(
+            virtual_tool,
+            self._policy_list(effective_policy, "denied_tools"),
+        ):
+            return "tool_denied"
+        if not self._has_server_grant(effective_policy, virtual_tool):
+            return "external_server_not_granted"
+        allowed_tools = self._policy_list(effective_policy, "allowed_tools")
+        if allowed_tools and not self._tool_matches_any(virtual_tool, allowed_tools):
+            return "tool_not_allowed"
+        if self._missing_credential_slots(server, effective_policy):
+            return "required_credential_grant_missing"
+        return None
+
+    def _has_server_grant(
+        self,
+        effective_policy: Any,
+        virtual_tool: VirtualExternalTool,
+    ) -> bool:
+        for grant in self._policy_dicts(effective_policy, "external_server_grants"):
+            if not self._grant_matches_server(grant, virtual_tool.server_id):
+                continue
+            tool_patterns = self._grant_tool_patterns(grant)
+            if tool_patterns and not self._tool_matches_any(virtual_tool, tool_patterns):
+                continue
+            return True
+        return False
+
+    def _missing_credential_slots(
+        self,
+        server: ExternalServerDefinition,
+        effective_policy: Any,
+    ) -> list[str]:
+        required_slots = {
+            str(slot).strip()
+            for slot in server.credential_slots
+            if str(slot).strip()
+        }
+        if not required_slots:
+            return []
+        granted_slots: set[str] = set()
+        for grant in self._policy_dicts(effective_policy, "credential_grants"):
+            if not self._grant_matches_server(grant, server.id):
+                continue
+            granted_slots.update(self._credential_slots_for_grant(grant))
+        return sorted(required_slots - granted_slots)
+
+    @staticmethod
+    def _credential_slots_for_grant(grant: dict[str, Any]) -> set[str]:
+        slots: set[str] = set()
+        for key in ("credential_slot", "slot"):
+            value = str(grant.get(key) or "").strip()
+            if value:
+                slots.add(value)
+        for key in ("credential_slots", "slots"):
+            raw = grant.get(key)
+            if isinstance(raw, str):
+                values: Iterable[Any] = [raw]
+            elif isinstance(raw, Iterable) and not isinstance(raw, (bytes, dict)):
+                values = raw
+            else:
+                values = []
+            slots.update(str(value).strip() for value in values if str(value).strip())
+        return slots
+
+    @staticmethod
+    def _grant_matches_server(grant: dict[str, Any], server_id: str) -> bool:
+        if grant.get("enabled") is False:
+            return False
+        raw_server_id = (
+            grant.get("server_id")
+            or grant.get("external_server_id")
+            or grant.get("id")
+        )
+        return str(raw_server_id or "").strip() == server_id
+
+    @staticmethod
+    def _grant_tool_patterns(grant: dict[str, Any]) -> list[str]:
+        patterns: list[str] = []
+        for key in ("tools", "tool_names", "allowed_tools"):
+            raw = grant.get(key)
+            if isinstance(raw, str):
+                patterns.append(raw)
+            elif isinstance(raw, Iterable) and not isinstance(raw, (bytes, dict)):
+                patterns.extend(str(item) for item in raw)
+        return [pattern for pattern in patterns if pattern.strip()]
+
+    @classmethod
+    def _tool_matches_any(
+        cls,
+        virtual_tool: VirtualExternalTool,
+        patterns: list[str],
+    ) -> bool:
+        return any(cls._tool_matches_pattern(virtual_tool, pattern) for pattern in patterns)
+
+    @staticmethod
+    def _tool_matches_pattern(
+        virtual_tool: VirtualExternalTool,
+        pattern: str,
+    ) -> bool:
+        candidate = str(pattern or "").strip()
+        if candidate in {"*", "ext.*"}:
+            return True
+        if candidate.endswith("*"):
+            prefix = candidate[:-1]
+            return (
+                virtual_tool.virtual_name.startswith(prefix)
+                or virtual_tool.upstream_tool_name.startswith(prefix)
+            )
+        return candidate in {
+            virtual_tool.virtual_name,
+            virtual_tool.upstream_tool_name,
+        }
+
+    @staticmethod
+    def _policy_list(effective_policy: Any, field_name: str) -> list[str]:
+        values = ExternalFederationManager._policy_value(effective_policy, field_name, [])
+        if isinstance(values, str):
+            return [values]
+        if isinstance(values, Iterable) and not isinstance(values, (bytes, dict)):
+            return [str(value) for value in values if str(value).strip()]
+        return []
+
+    @staticmethod
+    def _policy_dicts(effective_policy: Any, field_name: str) -> list[dict[str, Any]]:
+        values = ExternalFederationManager._policy_value(effective_policy, field_name, [])
+        if isinstance(values, dict):
+            return [deepcopy(values)]
+        if not isinstance(values, Iterable) or isinstance(values, (str, bytes)):
+            return []
+        return [
+            deepcopy(value)
+            for value in values
+            if isinstance(value, dict)
+        ]
+
+    @staticmethod
+    def _policy_profile_id(effective_policy: Any) -> str | None:
+        value = ExternalFederationManager._policy_value(effective_policy, "profile_id", None)
+        return str(value) if value is not None else None
+
+    @staticmethod
+    def _policy_value(effective_policy: Any, field_name: str, default: Any) -> Any:
+        if isinstance(effective_policy, dict):
+            return effective_policy.get(field_name, default)
+        return getattr(effective_policy, field_name, default)
+
+    async def _audit_execution(
+        self,
+        *,
+        event_type: str,
+        reason_code: str,
+        virtual_tool: VirtualExternalTool,
+        actor_id: str | None,
+        profile_id: str | None,
+    ) -> None:
+        await self._audit(
+            event_type,
+            actor_id=actor_id,
+            profile_id=profile_id,
+            target_type="external_tool",
+            target_id=virtual_tool.virtual_name,
+            payload={
+                "reason_code": reason_code,
+                "server_id": virtual_tool.server_id,
+                "virtual_tool_name": virtual_tool.virtual_name,
+                "upstream_tool_name": virtual_tool.upstream_tool_name,
+            },
+        )
+
+    async def _audit(
+        self,
+        event_type: str,
+        *,
+        payload: dict[str, Any],
+        actor_id: str | None = None,
+        profile_id: str | None = None,
+        target_type: str | None = None,
+        target_id: str | None = None,
+    ) -> None:
+        if self._audit_store is None:
+            return
+        event = AuditEvent(
+            id=f"mcp-fed-{uuid4().hex}",
+            event_type=event_type,
+            actor_id=actor_id,
+            profile_id=profile_id,
+            target_type=target_type,
+            target_id=target_id,
+            payload=deepcopy(payload),
+            created_at=datetime.now(timezone.utc),
+        )
+        await self._audit_store.append_event(event)
+
+    def _server_status(self, *, server_id: str, connected: bool) -> str:
+        if connected and self._last_errors.get(server_id) is None:
+            return "healthy"
+        if connected or self._last_errors.get(server_id) is None:
+            return "degraded"
+        return "unhealthy"
+
+    @staticmethod
+    def _virtual_tool_name(server_id: str, tool_name: str) -> str:
+        return f"ext.{server_id}.{tool_name}"
+
+    def _clear_server_tools(self, server_id: str) -> None:
+        self._virtual_tools = {
+            name: tool
+            for name, tool in self._virtual_tools.items()
+            if tool.server_id != server_id
+        }
+
+    def _count_tools_for_server(self, server_id: str) -> int:
+        return sum(1 for tool in self._virtual_tools.values() if tool.server_id == server_id)
+
+    @staticmethod
+    def _federated_result(
+        virtual_tool: VirtualExternalTool,
+        result: ExternalToolCallResult,
+    ) -> FederatedToolResult:
+        return FederatedToolResult(
+            content=deepcopy(result.content),
+            is_error=result.is_error,
+            metadata=deepcopy(result.metadata),
+            server_id=virtual_tool.server_id,
+            upstream_tool_name=virtual_tool.upstream_tool_name,
+            virtual_tool_name=virtual_tool.virtual_name,
+        )
+
+    @staticmethod
+    def _is_write_tool(tool_name: str, metadata: dict[str, Any]) -> bool:
+        annotations = metadata.get("annotations")
+        if isinstance(annotations, dict) and isinstance(annotations.get("readOnlyHint"), bool):
+            return not annotations["readOnlyHint"]
+        for key in ("read_only", "readOnly", "is_read_only"):
+            value = metadata.get(key)
+            if isinstance(value, bool):
+                return not value
+        lowered = tool_name.lower()
+        return any(
+            token in lowered
+            for token in ("create", "update", "delete", "write", "patch", "import")
+        )

--- a/mcp_unified/federation/models.py
+++ b/mcp_unified/federation/models.py
@@ -1,0 +1,88 @@
+"""Standalone external federation data contracts."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from dataclasses import dataclass, field
+from typing import Any
+
+
+def _copy_mapping(value: dict[str, Any] | None) -> dict[str, Any]:
+    """Return caller-owned mapping data for public result objects."""
+    return deepcopy(value or {})
+
+
+@dataclass(slots=True)
+class ExternalToolDefinition:
+    """Normalized external tool metadata discovered from a transport."""
+
+    name: str
+    description: str = ""
+    input_schema: dict[str, Any] = field(default_factory=lambda: {"type": "object"})
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def copy(self) -> ExternalToolDefinition:
+        """Return a caller-owned copy of this tool definition."""
+        return ExternalToolDefinition(
+            name=self.name,
+            description=self.description,
+            input_schema=_copy_mapping(self.input_schema),
+            metadata=_copy_mapping(self.metadata),
+        )
+
+
+@dataclass(slots=True)
+class ExternalToolCallResult:
+    """Normalized external transport call result."""
+
+    content: Any
+    is_error: bool = False
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def copy(self) -> ExternalToolCallResult:
+        """Return a caller-owned copy of this transport result."""
+        return ExternalToolCallResult(
+            content=deepcopy(self.content),
+            is_error=self.is_error,
+            metadata=_copy_mapping(self.metadata),
+        )
+
+
+@dataclass(slots=True)
+class VirtualExternalTool:
+    """External tool exposed through a namespaced virtual tool name."""
+
+    virtual_name: str
+    server_id: str
+    upstream_tool_name: str
+    description: str = ""
+    input_schema: dict[str, Any] = field(default_factory=lambda: {"type": "object"})
+    metadata: dict[str, Any] = field(default_factory=dict)
+    is_write: bool = False
+
+
+@dataclass(slots=True)
+class FederatedToolResult:
+    """Result returned by the standalone federation manager."""
+
+    content: Any
+    server_id: str
+    upstream_tool_name: str
+    virtual_tool_name: str
+    is_error: bool = False
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+class FederationPolicyDenied(PermissionError):
+    """Raised when effective policy blocks an external tool execution."""
+
+    def __init__(
+        self,
+        reason_code: str,
+        message: str,
+        *,
+        payload: dict[str, Any] | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.reason_code = reason_code
+        self.payload = _copy_mapping(payload)

--- a/mcp_unified/federation/transports.py
+++ b/mcp_unified/federation/transports.py
@@ -1,0 +1,113 @@
+"""Non-spawning transport contracts for standalone external federation."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Any, Protocol
+
+from .models import ExternalToolCallResult, ExternalToolDefinition
+
+
+class ExternalFederationTransport(Protocol):
+    """Minimal external transport lifecycle used by the standalone shell."""
+
+    server_id: str
+
+    @property
+    def transport_name(self) -> str:
+        """Return a human-readable transport name."""
+        ...
+
+    async def connect(self) -> None:
+        """Start the logical transport lifecycle without launching processes."""
+        ...
+
+    async def close(self) -> None:
+        """Stop the logical transport lifecycle."""
+        ...
+
+    async def health_check(self) -> dict[str, bool]:
+        """Return quick health indicators for this transport."""
+        ...
+
+    async def list_tools(self) -> list[ExternalToolDefinition]:
+        """Return discovered external tool definitions."""
+        ...
+
+    async def call_tool(
+        self,
+        tool_name: str,
+        arguments: dict[str, Any],
+        context: Any = None,
+    ) -> ExternalToolCallResult:
+        """Execute a logical external tool call."""
+        ...
+
+
+class FakeExternalTransport:
+    """In-memory non-spawning transport for registry and policy tests."""
+
+    transport_name = "fake"
+
+    def __init__(
+        self,
+        *,
+        server_id: str,
+        tools: list[ExternalToolDefinition] | None = None,
+        results: dict[str, ExternalToolCallResult] | None = None,
+        health: dict[str, bool] | None = None,
+    ) -> None:
+        self.server_id = server_id
+        self.connected = False
+        self.connect_count = 0
+        self.close_count = 0
+        self.spawn_count = 0
+        self.calls: list[tuple[str, dict[str, Any]]] = []
+        self._tools = [tool.copy() for tool in tools or []]
+        self._results = {
+            name: result.copy()
+            for name, result in (results or {}).items()
+        }
+        self._health = dict(health or {})
+
+    async def connect(self) -> None:
+        """Mark the fake transport connected without spawning a process."""
+        self.connect_count += 1
+        self.connected = True
+
+    async def close(self) -> None:
+        """Mark the fake transport closed."""
+        self.close_count += 1
+        self.connected = False
+
+    async def health_check(self) -> dict[str, bool]:
+        """Return deterministic fake transport health."""
+        return {
+            "configured": True,
+            "connected": self.connected,
+            "spawns_process": False,
+            **self._health,
+        }
+
+    async def list_tools(self) -> list[ExternalToolDefinition]:
+        """Return caller-owned fake tool definitions."""
+        return [tool.copy() for tool in self._tools]
+
+    async def call_tool(
+        self,
+        tool_name: str,
+        arguments: dict[str, Any],
+        context: Any = None,
+    ) -> ExternalToolCallResult:
+        """Return a configured fake result for the requested tool."""
+        del context
+        call_args = deepcopy(arguments or {})
+        self.calls.append((tool_name, call_args))
+        result = self._results.get(tool_name)
+        if result is None:
+            return ExternalToolCallResult(
+                content={"error": f"Unknown fake external tool '{tool_name}'"},
+                is_error=True,
+                metadata={"reason_code": "unknown_fake_external_tool"},
+            )
+        return result.copy()

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_federation_shell_contracts.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_federation_shell_contracts.py
@@ -1,0 +1,310 @@
+"""Tests for the standalone MCP external federation shell contracts."""
+
+from __future__ import annotations
+
+import ast
+import importlib
+from pathlib import Path
+from typing import Any
+
+import pytest
+from mcp_unified.profiles.resolution import EffectivePolicy
+from mcp_unified.storage import AuditEvent, ExternalServerDefinition
+
+
+def _tldw_imports_for(path: Path) -> list[str]:
+    """Return imports from a Python file that cross into the host package."""
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    imports: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imports.extend(
+                alias.name
+                for alias in node.names
+                if alias.name == "tldw_Server_API"
+                or alias.name.startswith("tldw_Server_API.")
+            )
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            if node.module == "tldw_Server_API" or node.module.startswith("tldw_Server_API."):
+                imports.append(node.module)
+    return imports
+
+
+class _MemoryExternalRegistryStore:
+    def __init__(self, servers: list[ExternalServerDefinition]) -> None:
+        self._servers = {server.id: server for server in servers}
+
+    async def get_server(self, server_id: str) -> ExternalServerDefinition | None:
+        return self._servers.get(server_id)
+
+    async def list_servers(self) -> list[ExternalServerDefinition]:
+        return list(self._servers.values())
+
+    async def list_server_definitions(
+        self,
+        *,
+        enabled: bool | None = None,
+    ) -> list[ExternalServerDefinition]:
+        rows = list(self._servers.values())
+        if enabled is None:
+            return rows
+        return [server for server in rows if server.enabled is enabled]
+
+    async def upsert_server(
+        self,
+        server: ExternalServerDefinition,
+    ) -> ExternalServerDefinition:
+        self._servers[server.id] = server
+        return server
+
+    async def delete_server(self, server_id: str) -> bool:
+        return self._servers.pop(server_id, None) is not None
+
+
+class _MemoryAuditStore:
+    def __init__(self) -> None:
+        self.events: list[AuditEvent] = []
+
+    async def append_event(self, event: AuditEvent) -> AuditEvent:
+        self.events.append(event)
+        return event
+
+    async def query_events(
+        self,
+        *,
+        actor_id: str | None = None,
+        profile_id: str | None = None,
+        event_type: str | None = None,
+        limit: int | None = None,
+    ) -> list[AuditEvent]:
+        rows = [
+            event
+            for event in self.events
+            if (actor_id is None or event.actor_id == actor_id)
+            and (profile_id is None or event.profile_id == profile_id)
+            and (event_type is None or event.event_type == event_type)
+        ]
+        return rows[:limit] if limit is not None else rows
+
+
+def _research_server(**overrides: Any) -> ExternalServerDefinition:
+    values: dict[str, Any] = {
+        "id": "research",
+        "name": "Research",
+        "transport": "stdio",
+        "command": ["fake-mcp-research"],
+    }
+    values.update(overrides)
+    return ExternalServerDefinition(**values)
+
+
+def test_federation_package_has_no_tldw_server_imports() -> None:
+    federation = importlib.import_module("mcp_unified.federation")
+
+    assert federation.__file__ is not None
+    federation_root = Path(federation.__file__).resolve().parent
+    offenders: dict[str, list[str]] = {}
+    for path in federation_root.rglob("*.py"):
+        imports = _tldw_imports_for(path)
+        if imports:
+            offenders[str(path)] = imports
+    assert offenders == {}
+
+
+@pytest.mark.asyncio
+async def test_non_spawning_manager_loads_registry_and_virtual_tools() -> None:
+    from mcp_unified.federation import (
+        ExternalFederationManager,
+        ExternalToolCallResult,
+        ExternalToolDefinition,
+        FakeExternalTransport,
+    )
+
+    store = _MemoryExternalRegistryStore([_research_server()])
+    transports: dict[str, FakeExternalTransport] = {}
+
+    def _transport_factory(server: ExternalServerDefinition) -> FakeExternalTransport:
+        transport = FakeExternalTransport(
+            server_id=server.id,
+            tools=[
+                ExternalToolDefinition(
+                    name="search",
+                    description="Search research indexes",
+                    input_schema={"type": "object", "properties": {"query": {"type": "string"}}},
+                    metadata={"category": "search"},
+                )
+            ],
+            results={
+                "search": ExternalToolCallResult(content={"matches": ["paper-1"]}),
+            },
+        )
+        transports[server.id] = transport
+        return transport
+
+    manager = ExternalFederationManager(
+        registry_store=store,
+        transport_factory=_transport_factory,
+    )
+
+    await manager.start()
+
+    server_rows = await manager.list_servers()
+    virtual_tools = manager.list_virtual_tools()
+
+    assert server_rows == [
+        {
+            "id": "research",
+            "name": "Research",
+            "transport": "stdio",
+            "tool_count": 1,
+            "status": "healthy",
+            "checks": {"configured": True, "connected": True, "spawns_process": False},
+            "last_error": None,
+        }
+    ]
+    assert [tool.virtual_name for tool in virtual_tools] == ["ext.research.search"]
+    assert virtual_tools[0].server_id == "research"
+    assert virtual_tools[0].upstream_tool_name == "search"
+    assert virtual_tools[0].metadata["category"] == "search"
+    assert transports["research"].connect_count == 1
+    assert transports["research"].spawn_count == 0
+
+
+@pytest.mark.asyncio
+async def test_external_execution_requires_profile_server_grant_and_audits_denial() -> None:
+    from mcp_unified.federation import (
+        ExternalFederationManager,
+        ExternalToolCallResult,
+        ExternalToolDefinition,
+        FakeExternalTransport,
+        FederationPolicyDenied,
+    )
+
+    audit = _MemoryAuditStore()
+    transport = FakeExternalTransport(
+        server_id="research",
+        tools=[ExternalToolDefinition(name="search")],
+        results={"search": ExternalToolCallResult(content={"matches": []})},
+    )
+    manager = ExternalFederationManager(
+        registry_store=_MemoryExternalRegistryStore([_research_server()]),
+        transport_factory=lambda _server: transport,
+        audit_store=audit,
+    )
+    await manager.start()
+
+    with pytest.raises(FederationPolicyDenied) as exc_info:
+        await manager.execute_virtual_tool(
+            "ext.research.search",
+            {"query": "MCP"},
+            effective_policy=EffectivePolicy(profile_id="project-researcher"),
+            actor_id="user-1",
+        )
+
+    assert exc_info.value.reason_code == "external_server_not_granted"
+    assert transport.calls == []
+    assert [event.event_type for event in audit.events] == [
+        "external_server.lifecycle",
+        "external_server.discovery",
+        "external_tool.denied",
+    ]
+    deny_event = audit.events[-1]
+    assert deny_event.actor_id == "user-1"
+    assert deny_event.profile_id == "project-researcher"
+    assert deny_event.payload["reason_code"] == "external_server_not_granted"
+    assert deny_event.payload["virtual_tool_name"] == "ext.research.search"
+
+
+@pytest.mark.asyncio
+async def test_external_execution_allows_granted_tool_and_audits_success() -> None:
+    from mcp_unified.federation import (
+        ExternalFederationManager,
+        ExternalToolCallResult,
+        ExternalToolDefinition,
+        FakeExternalTransport,
+    )
+
+    audit = _MemoryAuditStore()
+    transport = FakeExternalTransport(
+        server_id="research",
+        tools=[ExternalToolDefinition(name="search")],
+        results={"search": ExternalToolCallResult(content={"matches": ["paper-1"]})},
+    )
+    manager = ExternalFederationManager(
+        registry_store=_MemoryExternalRegistryStore([_research_server()]),
+        transport_factory=lambda _server: transport,
+        audit_store=audit,
+    )
+    await manager.start()
+
+    result = await manager.execute_virtual_tool(
+        "ext.research.search",
+        {"query": "MCP"},
+        effective_policy=EffectivePolicy(
+            profile_id="deep-researcher",
+            allowed_tools=["ext.research.search"],
+            external_server_grants=[{"server_id": "research"}],
+        ),
+        actor_id="user-1",
+    )
+
+    assert result.content == {"matches": ["paper-1"]}
+    assert result.server_id == "research"
+    assert result.upstream_tool_name == "search"
+    assert transport.calls == [("search", {"query": "MCP"})]
+    assert audit.events[-1].event_type == "external_tool.allowed"
+    assert audit.events[-1].payload["reason_code"] == "allowed"
+
+
+@pytest.mark.asyncio
+async def test_external_execution_requires_credential_grants_for_required_slots() -> None:
+    from mcp_unified.federation import (
+        ExternalFederationManager,
+        ExternalToolCallResult,
+        ExternalToolDefinition,
+        FakeExternalTransport,
+        FederationPolicyDenied,
+    )
+
+    transport = FakeExternalTransport(
+        server_id="research",
+        tools=[ExternalToolDefinition(name="search")],
+        results={"search": ExternalToolCallResult(content={"matches": ["paper-1"]})},
+    )
+    manager = ExternalFederationManager(
+        registry_store=_MemoryExternalRegistryStore(
+            [_research_server(credential_slots=["research_api"])]
+        ),
+        transport_factory=lambda _server: transport,
+    )
+    await manager.start()
+
+    with pytest.raises(FederationPolicyDenied) as exc_info:
+        await manager.execute_virtual_tool(
+            "ext.research.search",
+            {"query": "MCP"},
+            effective_policy=EffectivePolicy(
+                profile_id="deep-researcher",
+                external_server_grants=[{"server_id": "research"}],
+            ),
+        )
+
+    assert exc_info.value.reason_code == "required_credential_grant_missing"
+    assert transport.calls == []
+
+    result = await manager.execute_virtual_tool(
+        "ext.research.search",
+        {"query": "MCP"},
+        effective_policy=EffectivePolicy(
+            profile_id="deep-researcher",
+            external_server_grants=[{"server_id": "research"}],
+            credential_grants=[
+                {
+                    "external_server_id": "research",
+                    "credential_slot": "research_api",
+                }
+            ],
+        ),
+    )
+
+    assert result.content == {"matches": ["paper-1"]}

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_federation_shell_contracts.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_federation_shell_contracts.py
@@ -31,6 +31,8 @@ def _tldw_imports_for(path: Path) -> list[str]:
 
 
 class _MemoryExternalRegistryStore:
+    """In-memory external registry test double for package contract tests."""
+
     def __init__(self, servers: list[ExternalServerDefinition]) -> None:
         self._servers = {server.id: server for server in servers}
 
@@ -62,6 +64,8 @@ class _MemoryExternalRegistryStore:
 
 
 class _MemoryAuditStore:
+    """In-memory audit sink that preserves appended events for assertions."""
+
     def __init__(self) -> None:
         self.events: list[AuditEvent] = []
 
@@ -149,7 +153,7 @@ async def test_non_spawning_manager_loads_registry_and_virtual_tools() -> None:
     await manager.start()
 
     server_rows = await manager.list_servers()
-    virtual_tools = manager.list_virtual_tools()
+    virtual_tools = await manager.list_virtual_tools()
 
     assert server_rows == [
         {
@@ -254,6 +258,138 @@ async def test_external_execution_allows_granted_tool_and_audits_success() -> No
     assert transport.calls == [("search", {"query": "MCP"})]
     assert audit.events[-1].event_type == "external_tool.allowed"
     assert audit.events[-1].payload["reason_code"] == "allowed"
+
+
+@pytest.mark.asyncio
+async def test_start_rolls_back_connected_transports_on_discovery_failure() -> None:
+    from mcp_unified.federation import (
+        ExternalFederationManager,
+        ExternalToolDefinition,
+        FakeExternalTransport,
+    )
+
+    class _FailingDiscoveryTransport(FakeExternalTransport):
+        """Fake transport that connects but fails during tool discovery."""
+
+        async def list_tools(self) -> list[ExternalToolDefinition]:
+            raise RuntimeError("discovery failed")
+
+    research_transport = FakeExternalTransport(
+        server_id="research",
+        tools=[ExternalToolDefinition(name="search")],
+    )
+    broken_transport = _FailingDiscoveryTransport(server_id="broken")
+    transports = {
+        "research": research_transport,
+        "broken": broken_transport,
+    }
+    manager = ExternalFederationManager(
+        registry_store=_MemoryExternalRegistryStore(
+            [
+                _research_server(),
+                _research_server(id="broken", name="Broken"),
+            ]
+        ),
+        transport_factory=lambda server: transports[server.id],
+    )
+
+    with pytest.raises(RuntimeError, match="discovery failed"):
+        await manager.start()
+
+    assert manager.started is False
+    assert research_transport.connected is False
+    assert broken_transport.connected is False
+    assert research_transport.close_count == 1
+    assert broken_transport.close_count == 1
+    assert await manager.list_servers() == []
+
+
+@pytest.mark.asyncio
+async def test_stop_clears_state_when_close_and_audit_failures_occur() -> None:
+    from mcp_unified.federation import (
+        ExternalFederationManager,
+        ExternalToolDefinition,
+        FakeExternalTransport,
+    )
+
+    class _FailingCloseTransport(FakeExternalTransport):
+        """Fake transport that fails during close after marking itself closed."""
+
+        async def close(self) -> None:
+            await super().close()
+            raise RuntimeError("close failed")
+
+    class _FailingStopAuditStore(_MemoryAuditStore):
+        """Audit sink that fails only for stop lifecycle events."""
+
+        async def append_event(self, event: AuditEvent) -> AuditEvent:
+            if (
+                event.event_type == "external_server.lifecycle"
+                and event.payload.get("reason_code") == "stopped"
+            ):
+                raise RuntimeError("audit failed")
+            return await super().append_event(event)
+
+    transport = _FailingCloseTransport(
+        server_id="research",
+        tools=[ExternalToolDefinition(name="search")],
+    )
+    manager = ExternalFederationManager(
+        registry_store=_MemoryExternalRegistryStore([_research_server()]),
+        transport_factory=lambda _server: transport,
+        audit_store=_FailingStopAuditStore(),
+    )
+    await manager.start()
+
+    await manager.stop()
+
+    assert manager.started is False
+    assert transport.connected is False
+    assert await manager.list_servers() == []
+    assert [error["operation"] for error in manager.last_lifecycle_errors] == [
+        "close",
+        "audit",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_refresh_audits_discovery_error_details() -> None:
+    from mcp_unified.federation import (
+        ExternalFederationManager,
+        ExternalToolDefinition,
+        FakeExternalTransport,
+    )
+
+    class _ToggleDiscoveryTransport(FakeExternalTransport):
+        """Fake transport that can fail discovery after initial startup."""
+
+        fail_discovery = False
+
+        async def list_tools(self) -> list[ExternalToolDefinition]:
+            if self.fail_discovery:
+                raise RuntimeError("refresh failed")
+            return await super().list_tools()
+
+    audit = _MemoryAuditStore()
+    transport = _ToggleDiscoveryTransport(
+        server_id="research",
+        tools=[ExternalToolDefinition(name="search")],
+    )
+    manager = ExternalFederationManager(
+        registry_store=_MemoryExternalRegistryStore([_research_server()]),
+        transport_factory=lambda _server: transport,
+        audit_store=audit,
+    )
+    await manager.start()
+    transport.fail_discovery = True
+
+    result = await manager.refresh()
+
+    assert result["errors"] == {"research": "external_server_discovery_failed"}
+    assert audit.events[-1].event_type == "external_server.discovery"
+    assert audit.events[-1].payload["reason_code"] == "external_server_discovery_failed"
+    assert audit.events[-1].payload["error_type"] == "RuntimeError"
+    assert audit.events[-1].payload["error_message"] == "refresh failed"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Adds `mcp_unified.federation` as a standalone, package-local, non-spawning federation shell.
- Loads enabled external server registry definitions, exposes `ext.<server>.<tool>` virtual metadata, reports fake transport health, and emits optional audit events.
- Gates fake upstream execution on effective policy server grants, denied/allowed tool lists, and required credential-slot grants; real stdio/websocket process spawning remains deferred.

## Test Plan
- [x] `source .venv/bin/activate && python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_federation_shell_contracts.py tldw_Server_API/app/core/MCP_unified/tests/test_storage_contracts.py tldw_Server_API/app/core/MCP_unified/tests/test_sqlite_storage_contracts.py tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py -q`
- [x] `source .venv/bin/activate && python -m ruff check mcp_unified/federation tldw_Server_API/app/core/MCP_unified/tests/test_federation_shell_contracts.py`
- [x] `source .venv/bin/activate && python -m bandit -r mcp_unified/federation -f json -o /tmp/bandit_mcp_stage2f_pr.json`

## Merge Gate
- This PR was authored by Codex. Per the repository AI-generated PR policy, a human maintainer must add or own the final Change summary before merge.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a standalone, non-spawning federation shell under `mcp_unified.federation` that discovers registry-backed servers, exposes `ext.<server>.<tool>` virtual tools, gates execution by effective policy and credential grants, and audits lifecycle, discovery, and allow/deny outcomes. Implements failure-atomic startup, best-effort shutdown, and clearer refresh/health reporting for Stage 2F (TASK-531).

- **New Features**
  - `ExternalFederationManager` loads enabled `ExternalServerDefinition`s, connects non-spawning transports, refreshes tools, lists servers with health, and exposes namespaced virtual tools with read/write hints.
  - Execution is policy-gated via `external_server_grants`, `allowed_tools`, `denied_tools`, and required `credential_slots`; denials raise `FederationPolicyDenied` with reason codes.
  - Optional auditing emits `AuditEvent`s for lifecycle, discovery success/failure, and allowed/denied executions.
  - Transport layer defined by `ExternalFederationTransport` and `FakeExternalTransport`; real stdio/websocket spawning is deferred.

- **Bug Fixes**
  - Startup is failure-atomic and rolls back already-connected transports on discovery errors.
  - Stop is best-effort; close/audit failures are captured in `last_lifecycle_errors`.
  - `refresh()` returns counts and per-server errors and audits failure details.
  - Health/list operations snapshot state under a lock to avoid races.

<sup>Written for commit 53011424a42c54d35f4f8dffe695a281239d0d55. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2094?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

