### PR TITLE
Improve /chat empty response recovery copy

### DIFF
--- a/apps/packages/ui/src/components/Option/Playground/Playground.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/Playground.tsx
@@ -64,7 +64,7 @@ import { ChevronDown, Keyboard, Search, X } from "lucide-react";
 import { CHAT_BACKGROUND_IMAGE_SETTING } from "@/services/settings/ui-settings";
 import { otherUnsupportedTypes } from "../Knowledge/utils/unsupported-types";
 import { useTranslation } from "react-i18next";
-import { useStoreMessageOption } from "@/store/option";
+import { useStoreMessageOption, type Message } from "@/store/option";
 import { useArtifactsStore } from "@/store/artifacts";
 import { DEGRADED_STATE_LABEL, READY_STATE_LABEL } from "@/design-system";
 import { useSetting } from "@/hooks/useSetting";
@@ -136,6 +136,21 @@ import type { Character } from "@/types/character";
 import { getAssistantSelectionMode } from "@/types/assistant-selection";
 
 type ChatModelCatalog = Awaited<ReturnType<typeof fetchChatModels>>;
+
+const getAssistantMessageRouteLabel = (
+  message: Message | null,
+): string | null => {
+  const routeCandidates = [message?.modelId, message?.modelName, message?.name];
+
+  for (const candidate of routeCandidates) {
+    const value = typeof candidate === "string" ? candidate.trim() : "";
+    if (value.includes(":")) {
+      return value;
+    }
+  }
+
+  return null;
+};
 
 const toText = (value: unknown): string =>
   typeof value === "string" ? value : String(value);
@@ -2079,6 +2094,10 @@ export const Playground = () => {
     if (!latestAssistantMessage || streaming || isProcessing) return false;
     return !hasVisibleAssistantResponse(latestAssistantMessage);
   }, [isProcessing, latestAssistantMessage, streaming]);
+  const emptyAssistantResponseRouteLabel = React.useMemo(() => {
+    if (!emptyAssistantResponse) return null;
+    return getAssistantMessageRouteLabel(latestAssistantMessage);
+  }, [emptyAssistantResponse, latestAssistantMessage]);
   const runtimeStatusDetail =
     serverReadinessState === "blocked"
       ? toText(
@@ -2919,6 +2938,7 @@ export const Playground = () => {
       canRegenerate={canRegenerateLastResponse}
       onRegenerate={() => regenerateLastMessage()}
       emptyAssistantResponse={emptyAssistantResponse}
+      emptyAssistantResponseRouteLabel={emptyAssistantResponseRouteLabel}
       settingSummaries={runtimeSettingSummaries}
       toolChoice={toolChoice as RuntimeToolChoice}
       onToolChoiceChange={(nextChoice) => setToolChoice(nextChoice)}

--- a/apps/packages/ui/src/components/Option/Playground/PlaygroundRuntimeInspector.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/PlaygroundRuntimeInspector.tsx
@@ -82,6 +82,7 @@ export type PlaygroundRuntimeInspectorProps = {
   canRegenerate?: boolean;
   onRegenerate?: () => void;
   emptyAssistantResponse?: boolean;
+  emptyAssistantResponseRouteLabel?: string | null;
   settingSummaries?: RuntimeSettingSummary[];
   toolSummary?: RuntimeToolSummary | null;
   setupRecoveryMode?: boolean;
@@ -121,6 +122,7 @@ export const PlaygroundRuntimeInspector = ({
   canRegenerate = false,
   onRegenerate,
   emptyAssistantResponse = false,
+  emptyAssistantResponseRouteLabel = null,
   settingSummaries = [],
   toolSummary = null,
   setupRecoveryMode = false,
@@ -150,10 +152,17 @@ export const PlaygroundRuntimeInspector = ({
       : displayProvider && displayModel
         ? `${displayProvider}:${displayModel}`
         : selectedModel || null);
-  const emptyAssistantResponseSummary = routeLabel
+  const emptyAssistantRouteLabel =
+    typeof emptyAssistantResponseRouteLabel === "string"
+      ? emptyAssistantResponseRouteLabel.trim() || null
+      : null;
+  const emptyAssistantResponseSummary = emptyAssistantRouteLabel
     ? t(
         "cockpit.emptyAssistantResponseSummaryWithRoute",
-        `${routeLabel} returned no response text.`,
+        {
+          defaultValue: "{{route}} returned no response text.",
+          route: emptyAssistantRouteLabel,
+        },
       )
     : t(
         "cockpit.emptyAssistantResponseSummary",

--- a/apps/packages/ui/src/components/Option/Playground/PlaygroundRuntimeInspector.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/PlaygroundRuntimeInspector.tsx
@@ -150,6 +150,19 @@ export const PlaygroundRuntimeInspector = ({
       : displayProvider && displayModel
         ? `${displayProvider}:${displayModel}`
         : selectedModel || null);
+  const emptyAssistantResponseSummary = routeLabel
+    ? t(
+        "cockpit.emptyAssistantResponseSummaryWithRoute",
+        `${routeLabel} returned no response text.`,
+      )
+    : t(
+        "cockpit.emptyAssistantResponseSummary",
+        "No response text returned.",
+      );
+  const emptyAssistantResponseDetail = t(
+    "cockpit.emptyAssistantResponseDetail",
+    "Regenerate this turn, or choose a different model if this provider keeps returning empty output.",
+  );
   const modelUsabilityBlocks =
     Boolean(modelUsabilityStatus) &&
     modelUsabilityStatus !== "ready" &&
@@ -569,16 +582,10 @@ export const PlaygroundRuntimeInspector = ({
             className="mt-2 rounded-md border border-warn/30 bg-warn/10 px-2.5 py-2 text-xs text-warn"
           >
             <p className="font-medium">
-              {t(
-                "cockpit.emptyAssistantResponseSummary",
-                "No response text returned.",
-              )}
+              {emptyAssistantResponseSummary}
             </p>
             <p className="mt-1 opacity-90">
-              {t(
-                "cockpit.emptyAssistantResponseDetail",
-                "Regenerate this turn or switch model settings before trying again.",
-              )}
+              {emptyAssistantResponseDetail}
             </p>
           </div>
         ) : null}

--- a/apps/packages/ui/src/components/Option/Playground/__tests__/Playground.cockpit-shell.test.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/__tests__/Playground.cockpit-shell.test.tsx
@@ -1283,7 +1283,9 @@ describe("Playground cockpit shell", () => {
       within(runControls).getByRole("status", {
         name: "Empty assistant response",
       }),
-    ).toHaveTextContent("No response text returned.");
+    ).toHaveTextContent(
+      "openai:gpt-4.1-mini returned no response text.",
+    );
 
     fireEvent.click(
       within(runControls).getByRole("button", {

--- a/apps/packages/ui/src/components/Option/Playground/__tests__/Playground.cockpit-shell.test.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/__tests__/Playground.cockpit-shell.test.tsx
@@ -1255,6 +1255,21 @@ describe("Playground cockpit shell", () => {
   });
 
   it("surfaces empty assistant response recovery in the runtime sidechannel", async () => {
+    messageOptionState.value.selectedModel = "anthropic:claude-3-haiku";
+    tldwServerState.fetchChatModels.mockResolvedValue([
+      {
+        model: "openai:gpt-4.1-mini",
+        provider: "openai",
+        is_configured: true,
+        provider_is_configured: true,
+      },
+      {
+        model: "anthropic:claude-3-haiku",
+        provider: "anthropic",
+        is_configured: true,
+        provider_is_configured: true,
+      },
+    ]);
     messageOptionState.value.messages = [
       {
         id: "user-1",

--- a/apps/packages/ui/src/components/Option/Playground/__tests__/PlaygroundRuntimeInspector.first-slice.test.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/__tests__/PlaygroundRuntimeInspector.first-slice.test.tsx
@@ -526,9 +526,11 @@ describe("PlaygroundRuntimeInspector first-slice controls", () => {
     const status = within(runControls).getByRole("status", {
       name: "Empty assistant response",
     });
-    expect(status).toHaveTextContent("No response text returned.");
     expect(status).toHaveTextContent(
-      "Regenerate this turn or switch model settings before trying again.",
+      "openai:gpt-4.1-mini returned no response text.",
+    );
+    expect(status).toHaveTextContent(
+      "Regenerate this turn, or choose a different model if this provider keeps returning empty output.",
     );
 
     fireEvent.click(

--- a/apps/packages/ui/src/components/Option/Playground/__tests__/PlaygroundRuntimeInspector.first-slice.test.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/__tests__/PlaygroundRuntimeInspector.first-slice.test.tsx
@@ -7,7 +7,19 @@ import { PlaygroundRuntimeInspector } from "../PlaygroundRuntimeInspector";
 
 vi.mock("react-i18next", () => ({
   useTranslation: () => ({
-    t: (_key: string, fallback?: string) => fallback,
+    t: (
+      key: string,
+      fallbackOrOptions?:
+        | string
+        | { defaultValue?: string; [key: string]: unknown },
+    ) => {
+      if (typeof fallbackOrOptions === "string") return fallbackOrOptions;
+      const template = fallbackOrOptions?.defaultValue || key;
+      return template.replace(/\{\{(\w+)\}\}/g, (_, token: string) => {
+        const value = fallbackOrOptions?.[token];
+        return value == null ? `{{${token}}}` : String(value);
+      });
+    },
   }),
 }));
 
@@ -515,11 +527,15 @@ describe("PlaygroundRuntimeInspector first-slice controls", () => {
 
   it("surfaces empty assistant responses beside the regenerate control", () => {
     const props = renderInspector({
+      selectedProvider: "anthropic",
+      selectedModel: "claude-3-haiku",
+      providerRouteLabel: "anthropic:claude-3-haiku",
       streaming: false,
       runtimeStatus: "ready",
       canStopStreaming: false,
       canRegenerate: true,
       emptyAssistantResponse: true,
+      emptyAssistantResponseRouteLabel: "openai:gpt-4.1-mini",
     });
 
     const runControls = screen.getByRole("region", { name: "Run controls" });

--- a/backlog/tasks/task-540 - Improve-chat-provider-no-response-failure-copy.md
+++ b/backlog/tasks/task-540 - Improve-chat-provider-no-response-failure-copy.md
@@ -1,0 +1,62 @@
+---
+id: TASK-540
+title: Improve /chat provider no-response failure copy
+status: Done
+labels:
+- chat
+- ux
+- webui
+- regression
+priority: Medium
+modified_files:
+- apps/packages/ui/src/components/Option/Playground/PlaygroundRuntimeInspector.tsx
+- apps/packages/ui/src/components/Option/Playground/__tests__/PlaygroundRuntimeInspector.first-slice.test.tsx
+- apps/packages/ui/src/components/Option/Playground/__tests__/Playground.cockpit-shell.test.tsx
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement the remaining /chat UX follow-up for richer response failure copy when a provider returns an empty or no-response result. Scope is limited to /chat WebUI runtime/composer failure messaging and focused regressions; do not broaden into sidebar/history architecture or extension draft transfer.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Empty or no-response assistant results in /chat surface provider/actionable recovery copy instead of a generic silent/ambiguous state.
+- [x] #2 The runtime rail still exposes regenerate/retry affordance context for empty responses.
+- [x] #3 Existing provider error and visible assistant response behavior is preserved.
+- [x] #4 Focused regression tests cover the new copy path and the unchanged non-empty path.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Root cause: the runtime rail empty-assistant-response status used generic copy ('No response text returned') even when /chat knew the active provider/model route. That made provider no-response cases less actionable than other model/provider readiness states.
+
+Implementation: PlaygroundRuntimeInspector now derives empty-response summary from the existing provider/model route label when available, e.g. 'openai:gpt-4.1-mini returned no response text.', and keeps a generic fallback when no route is known. The detail copy now recommends regenerating or choosing a different model if the provider keeps returning empty output. Regenerate wiring is unchanged.
+
+Verification:
+- RED: bun run test src/components/Option/Playground/__tests__/PlaygroundRuntimeInspector.first-slice.test.tsx src/components/Option/Playground/__tests__/Playground.cockpit-shell.test.tsx failed on the new provider-route-specific empty-response expectations.
+- GREEN: same command passed 55/55 after the fix.
+- git diff --check passed.
+
+Known baseline noise: Playground.cockpit-shell.test.tsx logs provider-status mock warnings because the test's mocked tldwClient does not implement getProvidersStatus; this warning existed in the focused run and did not fail the suite.
+
+Bandit: not run; touched files are TypeScript UI/test files only.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Improved /chat empty/no-response recovery copy in the runtime rail by naming the active provider/model route when available and preserving regenerate recovery. Added focused regressions in PlaygroundRuntimeInspector and Playground cockpit shell coverage. Verified red-green focused tests and git diff --check. Bandit skipped because this is TypeScript UI/test-only work.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-540 - Improve-chat-provider-no-response-failure-copy.md
+++ b/backlog/tasks/task-540 - Improve-chat-provider-no-response-failure-copy.md
@@ -2,16 +2,16 @@
 id: TASK-540
 title: Improve /chat provider no-response failure copy
 status: Done
+assignee: []
+created_date: ''
+updated_date: '2026-05-28 19:53'
 labels:
-- chat
-- ux
-- webui
-- regression
-priority: Medium
-modified_files:
-- apps/packages/ui/src/components/Option/Playground/PlaygroundRuntimeInspector.tsx
-- apps/packages/ui/src/components/Option/Playground/__tests__/PlaygroundRuntimeInspector.first-slice.test.tsx
-- apps/packages/ui/src/components/Option/Playground/__tests__/Playground.cockpit-shell.test.tsx
+  - chat
+  - ux
+  - webui
+  - regression
+dependencies: []
+priority: medium
 ---
 
 ## Description
@@ -30,6 +30,7 @@ Implement the remaining /chat UX follow-up for richer response failure copy when
 
 ## Implementation Notes
 
+<!-- SECTION:NOTES:BEGIN -->
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
 Root cause: the runtime rail empty-assistant-response status used generic copy ('No response text returned') even when /chat knew the active provider/model route. That made provider no-response cases less actionable than other model/provider readiness states.
 
@@ -43,12 +44,23 @@ Verification:
 Known baseline noise: Playground.cockpit-shell.test.tsx logs provider-status mock warnings because the test's mocked tldwClient does not implement getProvidersStatus; this warning existed in the focused run and did not fail the suite.
 
 Bandit: not run; touched files are TypeScript UI/test files only.
+Review fix pass (PR #2095): review feedback was valid. The PR version used current providerRouteLabel/selectedModel for empty-response copy while the empty-response state was triggered by latestAssistantMessage. That could misattribute the failure after model switching. Playground now derives emptyAssistantResponseRouteLabel from latest assistant message metadata (modelId/modelName/name when provider-qualified), passes it separately to PlaygroundRuntimeInspector, and keeps the normal current-route display unchanged. PlaygroundRuntimeInspector now uses i18next interpolation with defaultValue '{{route}} returned no response text.' for localization-compatible copy.
+
+Review-fix verification:
+- RED: bun run test src/components/Option/Playground/__tests__/Playground.cockpit-shell.test.tsx src/components/Option/Playground/__tests__/PlaygroundRuntimeInspector.first-slice.test.tsx failed when an empty OpenAI assistant message remained after the current model switched to Anthropic; banner incorrectly named the Anthropic route.
+- GREEN: same command passed 55/55 after the fix.
+- git diff --check passed.
+
+PR check review: Full Suite failures inspected from run 26583264296 are backend/Python failures outside this TypeScript UI PR surface. Ubuntu 3.11 reported failing modules Audio and Audit, including Audit test_audit_db_deps.py::test_schedule_service_stop_clears_flag_on_failure; the job log also showed unrelated PostgreSQL COALESCE(boolean, integer) AuthNZ query errors. Frontend lint/build/playground checks had passed on the PR run.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
+<!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
 Improved /chat empty/no-response recovery copy in the runtime rail by naming the active provider/model route when available and preserving regenerate recovery. Added focused regressions in PlaygroundRuntimeInspector and Playground cockpit shell coverage. Verified red-green focused tests and git diff --check. Bandit skipped because this is TypeScript UI/test-only work.
+
+Review-fix pass for PR #2095 addressed all unresolved inline comments: empty-response route labels now come from the assistant message that triggered the banner instead of the current selection, and the route-bearing copy now uses i18next interpolation. Re-ran focused Playground tests (55/55) and git diff --check. Inspected failing Full Suite checks and found backend/Python failures outside this TypeScript UI PR surface.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done


### PR DESCRIPTION
## Summary
- Names the active provider/model route when `/chat` receives an empty assistant response.
- Keeps regenerate recovery available while making the empty-output guidance more actionable.
- Records TASK-540 with root cause, red/green verification, baseline warning, and Bandit skip rationale for TypeScript-only work.

## Test Plan
- [x] `bun run test src/components/Option/Playground/__tests__/PlaygroundRuntimeInspector.first-slice.test.tsx src/components/Option/Playground/__tests__/Playground.cockpit-shell.test.tsx`
- [x] `git diff --check`

## Change summary
Human-authored change summary required before marking this PR ready for merge per `Docs/superpowers/AI_GENERATED_PR_CHANGE_SUMMARY_POLICY_2026_04_17.md`.

## Notes
- `Playground.cockpit-shell.test.tsx` logs existing provider-status mock warnings because that test mock does not implement `getProvidersStatus`; the suite still passes.
- Bandit not run because the touched implementation and regression files are TypeScript UI/test files only.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies empty assistant responses in `/chat` by showing the provider/model from the message that returned no text and tightening the recovery guidance. Keeps regenerate available; updates tests; addresses `TASK-540`.

- **Bug Fixes**
  - Derive the route label from the latest assistant message (`modelId`/`modelName`/`name`) to avoid mislabeling after model switches; fall back to generic copy when unknown.
  - Update recovery text to suggest regenerating or choosing a different model if the provider keeps returning empty output.
  - Extend focused tests to assert route-specific copy and preserve behavior for non-empty responses.

<sup>Written for commit e29a3392b9307ebcc5b6f457d4c461ca6d2de940. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2095?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

