### PR TITLE
Migrate Flashcards ManageTab alert to design system

### DIFF
--- a/apps/packages/ui/scripts/design-system-product-state-baseline.json
+++ b/apps/packages/ui/scripts/design-system-product-state-baseline.json
@@ -88,17 +88,6 @@
     "migrationQueue": "shared-product-state"
   },
   {
-    "id": "antd-product-state-import:src/components/Flashcards/tabs/ManageTab.tsx:Alert",
-    "path": "src/components/Flashcards/tabs/ManageTab.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/Flashcards/tabs/ManageTab.tsx before the guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
     "id": "antd-product-state-import:src/components/Option/Admin/ApiKeyManagementPage.tsx:Alert#antd-alert-apikeymanagementpage-type-error-access-denied-1uep3es",
     "path": "src/components/Option/Admin/ApiKeyManagementPage.tsx",
     "rule": "antd-product-state-import",

--- a/apps/packages/ui/src/components/Flashcards/tabs/ManageTab.tsx
+++ b/apps/packages/ui/src/components/Flashcards/tabs/ManageTab.tsx
@@ -1,7 +1,6 @@
 import React from "react"
 import { useQueryClient } from "@tanstack/react-query"
 import {
-  Alert,
   Badge,
   Button,
   Checkbox,
@@ -27,6 +26,7 @@ import { useTranslation } from "react-i18next"
 import { useConfirmDanger } from "@/components/Common/confirm-danger"
 import { useAntdMessage } from "@/hooks/useAntdMessage"
 import { useUndoNotification } from "@/hooks/useUndoNotification"
+import { Alert as DsAlert } from "@/components/ui/primitives"
 import { trackFlashcardsShortcutHintTelemetry } from "@/utils/flashcards-shortcut-hint-telemetry"
 import { processInChunks } from "@/utils/chunk-processing"
 import {
@@ -2696,9 +2696,8 @@ export const ManageTab: React.FC<ManageTabProps> = ({
         centered
       >
         <div className="space-y-4">
-          <Alert
-            type="warning"
-            showIcon
+          <DsAlert
+            variant="warning"
             title={t("option:flashcards.bulkDeleteLargeWarning", {
               defaultValue: "These cards will move to Trash for {{seconds}} seconds.",
               seconds: DELETE_UNDO_SECONDS

--- a/apps/packages/ui/src/components/Flashcards/tabs/__tests__/ManageTab.undo-stage3.test.tsx
+++ b/apps/packages/ui/src/components/Flashcards/tabs/__tests__/ManageTab.undo-stage3.test.tsx
@@ -21,7 +21,7 @@ import {
 } from "../../hooks"
 import { FLASHCARDS_DRAWER_WIDTH_PX } from "../../constants"
 import { FLASHCARDS_LAYOUT_GUARDRAILS } from "../../constants/layout-guardrails"
-import { getFlashcard, updateFlashcard } from "@/services/flashcards"
+import { getFlashcard, listFlashcards, updateFlashcard } from "@/services/flashcards"
 
 const showUndoNotificationMock = vi.fn()
 const updateMutationMock = vi.fn()
@@ -187,12 +187,21 @@ const sampleCard: Flashcard = {
   reverse: false
 }
 
+const buildSampleCards = (count: number): Flashcard[] =>
+  Array.from({ length: count }, (_item, index) => ({
+    ...sampleCard,
+    uuid: `card-undo-${index + 1}`,
+    front: `Front prompt ${index + 1}`,
+    back: `Back answer ${index + 1}`
+  }))
+
 describe("ManageTab stage3 undo controls", () => {
   beforeEach(async () => {
     vi.clearAllMocks()
     trackErrorRecoveryTelemetryMock.mockClear()
     updateMutationMock.mockReset()
     vi.mocked(getFlashcard).mockReset()
+    vi.mocked(listFlashcards).mockReset()
     vi.mocked(updateFlashcard).mockReset()
     Object.values(messageSpies).forEach((spy) => spy.mockReset())
     await clearSetting(FLASHCARDS_SHORTCUT_HINT_DENSITY_SETTING)
@@ -495,5 +504,43 @@ describe("ManageTab stage3 undo controls", () => {
       tags: ["biology"],
       expected_version: 14
     })
+  }, 15000)
+
+  it("renders large bulk delete warning with the design-system Alert", async () => {
+    const cards = buildSampleCards(101)
+    vi.mocked(listFlashcards).mockResolvedValue({
+      items: cards,
+      total: cards.length,
+      page: 1,
+      page_size: cards.length
+    } as any)
+    vi.mocked(useManageQuery).mockReturnValue({
+      data: {
+        items: [sampleCard],
+        count: cards.length,
+        total: cards.length
+      },
+      isFetching: false
+    } as any)
+
+    render(
+      <ManageTab
+        onNavigateToImport={() => {}}
+        onReviewCard={() => {}}
+        isActive={false}
+      />
+    )
+
+    fireEvent.click(
+      screen.getByLabelText("Select all cards on this page")
+    )
+    fireEvent.click(screen.getByTestId("flashcards-select-all-across"))
+    fireEvent.click(screen.getByRole("button", { name: "Delete" }))
+
+    const warning = await screen.findByText(
+      "These cards will move to Trash for 30 seconds."
+    )
+    expect(listFlashcards).toHaveBeenCalled()
+    expect(warning.closest('[data-ds-component="Alert"]')).toBeInTheDocument()
   }, 15000)
 })

--- a/backlog/tasks/task-540 - Migrate-Flashcards-ManageTab-bulk-delete-warning-to-design-system-Alert.md
+++ b/backlog/tasks/task-540 - Migrate-Flashcards-ManageTab-bulk-delete-warning-to-design-system-Alert.md
@@ -1,0 +1,56 @@
+---
+id: TASK-540
+title: Migrate Flashcards ManageTab bulk delete warning to design-system Alert
+status: Done
+labels:
+- flashcards
+- design-system
+- webui
+priority: medium
+modified_files:
+- apps/packages/ui/src/components/Flashcards/tabs/ManageTab.tsx
+- apps/packages/ui/src/components/Flashcards/tabs/__tests__/ManageTab.undo-stage3.test.tsx
+- apps/packages/ui/scripts/design-system-product-state-baseline.json
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Replace the remaining AntD Alert in the Flashcards ManageTab large bulk-delete confirmation workflow with the shared design-system Alert primitive, preserving copy and destructive-action behavior while removing the migrated product-state baseline exception.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Focused ManageTab test proves the large bulk-delete warning renders through data-ds-component="Alert".
+- [x] #2 ManageTab bulk-delete warning copy, icon semantics, and confirmation flow remain unchanged for users.
+- [x] #3 The ManageTab Alert baseline exception is removed and the design-system product-state verifier reports no stale ManageTab Alert exception.
+- [x] #4 Focused Flashcards ManageTab verification and git diff hygiene are recorded.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Inspect current ManageTab bulk-delete warning and nearby ManageTab tests on fresh origin/dev. 2. Add a focused failing assertion for the large bulk-delete warning design-system Alert marker. 3. Replace the AntD Alert callout with the design-system Alert primitive without changing visible copy or modal flow. 4. Remove the ManageTab Alert baseline exception. 5. Run focused tests, product-state verification, and diff checks; document results.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+TDD red/green completed. Added focused coverage for the large bulk-delete path that selects all matching cards through the ManageTab select-all-across affordance, opens the type-to-confirm delete modal, and asserts the warning copy has a `data-ds-component="Alert"` ancestor. The RED run failed because the AntD Alert had no design-system marker. Replaced only that warning callout with the shared design-system Alert primitive using `variant="warning"`, preserving the translated title copy and modal flow. Removed the Flashcards ManageTab Alert baseline exception. Verification: focused ManageTab undo-stage3 Vitest passes 8/8; `git diff --check` passes; exact baseline grep shows no Flashcards ManageTab Alert exception remains. `bun run verify:design-system-state` still exits 1 on unrelated Integrations/Writing/Notes/Research product-state findings and stale Integrations baseline entries, with no Flashcards ManageTab finding. Bandit skipped because this slice only touches frontend TypeScript/TSX, baseline JSON, and Backlog markdown.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Migrated the Flashcards ManageTab large bulk-delete warning from AntD Alert to the shared design-system Alert primitive. Focused TDD coverage now verifies the >100-card bulk-delete modal warning renders with `data-ds-component="Alert"` through the select-all-across flow. Removed the Flashcards ManageTab Alert baseline exception. Verification: focused ManageTab undo-stage3 Vitest passes 8/8; `git diff --check` passes; product-state verifier still fails on unrelated Integrations/Writing/Notes/Research baseline findings, with no Flashcards ManageTab finding. Bandit skipped because no Python files changed.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## Summary
- Replace the Flashcards ManageTab large bulk-delete AntD Alert with the shared design-system Alert primitive.
- Add focused coverage for the >100-card select-all-across bulk delete warning and its design-system marker.
- Remove the migrated Flashcards ManageTab Alert product-state baseline exception and close Backlog TASK-540.

## Test Plan
- [x] bunx vitest run src/components/Flashcards/tabs/__tests__/ManageTab.undo-stage3.test.tsx
- [x] git diff --cached --check
- [x] rg -n "Flashcards/tabs/ManageTab\.tsx:Alert|Flashcards/tabs/ManageTab\.tsx.*Alert" apps/packages/ui/scripts/design-system-product-state-baseline.json (no matches)
- [x] rg -n "\bAlert\b|DsAlert|data-ds-component" apps/packages/ui/src/components/Flashcards/tabs/ManageTab.tsx
- [ ] bun run verify:design-system-state (currently exits 1 on unrelated Integrations/Writing/Notes/Research baseline findings; no Flashcards ManageTab finding remains)

## Change summary
This narrows the Flashcards ManageTab bulk-delete warning onto the same product-state primitive used by the rest of the design-system migration work, while preserving the existing destructive-action copy and modal behavior. The regression test drives the actual select-all-across path so the migrated state component is covered where users encounter it.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrated the Flashcards ManageTab bulk-delete warning from AntD to the design-system `Alert`, keeping the copy and modal flow unchanged. Added focused coverage for the >100-card select-all-across delete path and removed the product-state baseline exception; completes TASK-540.

- **Refactors**
  - Replaced AntD `Alert` with design-system `Alert` in the bulk-delete modal.
  - Added a focused test asserting the DS `Alert` renders in the select-all-across flow and removed the ManageTab Alert baseline exception.

<sup>Written for commit 2711272466da29f493df636e1a38ef1e5f20ea2d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2097?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

