### PR TITLE
Polish MCP Hub setup diagnostics

### DIFF
--- a/Docs/superpowers/plans/2026-05-28-mcp-hub-setup-polish-diagnostics-plan.md
+++ b/Docs/superpowers/plans/2026-05-28-mcp-hub-setup-polish-diagnostics-plan.md
@@ -1,0 +1,205 @@
+# MCP Hub Setup Polish Diagnostics Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Complete `TASK-223.2` by closing the remaining MCP Hub setup diagnostics gap: deployment diagnostics must expose the WebUI readiness health URL, last health status, and last HTTP status code, while preserving the already-landed no-auth, catalog recovery, setup isolation, and toy MCP smoke behavior.
+
+**Architecture:** Keep MCP Hub as the owner of setup diagnostics. Extend the existing `tldw:server-readiness-state` event emitted by `ServerReadinessGate` with bounded health-check details and cache the latest detail on `window` so diagnostics panels mounted after app readiness can still read it. Consume that snapshot in `DeploymentDiagnosticsPanel` without introducing a backend endpoint.
+
+**Tech Stack:** React, TypeScript, Vitest/jsdom, Playwright E2E, Backlog.md.
+
+---
+
+### Task 1: Extend Server Readiness Diagnostics
+
+**Files:**
+- Modify: `apps/tldw-frontend/components/networking/ServerReadinessGate.tsx`
+- Test: `apps/tldw-frontend/components/networking/__tests__/ServerReadinessGate.test.tsx`
+
+- [x] **Step 1: Write the failing readiness diagnostics test**
+
+Add a test that stubs advanced mode health to return HTTP `206` with `{ status: "degraded" }`, listens for `tldw:server-readiness-state`, and asserts the event detail includes:
+
+```ts
+{
+  state: "degraded",
+  healthUrl: "http://127.0.0.1:8000/api/v1/health",
+  httpStatus: 206,
+  healthStatus: "degraded"
+}
+```
+
+Also assert `(window as any).__tldwServerReadinessState` receives the same bounded detail.
+
+- [x] **Step 2: Run the focused test and verify RED**
+
+Run:
+
+```bash
+cd apps/tldw-frontend
+bunx vitest run components/networking/__tests__/ServerReadinessGate.test.tsx
+```
+
+Expected: FAIL because the event/global snapshot does not yet expose `healthUrl`, `httpStatus`, or `healthStatus`.
+
+- [x] **Step 3: Implement minimal readiness diagnostics**
+
+In `ServerReadinessGate.tsx`, extend the health result type with:
+
+```ts
+healthUrl: string
+httpStatus?: number
+healthStatus?: string
+errorMessage?: string
+checkedAt: string
+```
+
+Populate those fields inside `checkHealth()`. For response bodies, parse `status` when JSON is available; for fetch/parse failures, return a blocked result with `errorMessage` and no `httpStatus`. Update `emitServerReadinessState()` to include the diagnostic fields and assign the same object to:
+
+```ts
+(window as any).__tldwServerReadinessState = detail
+```
+
+before dispatching the event.
+
+- [x] **Step 4: Run the focused test and verify GREEN**
+
+Run:
+
+```bash
+cd apps/tldw-frontend
+bunx vitest run components/networking/__tests__/ServerReadinessGate.test.tsx
+```
+
+Expected: PASS.
+
+### Task 2: Surface Last Readiness Result In MCP Hub Diagnostics
+
+**Files:**
+- Modify: `apps/packages/ui/src/components/Option/MCPHub/DeploymentDiagnosticsPanel.tsx`
+- Test: `apps/packages/ui/src/components/Option/MCPHub/__tests__/DeploymentDiagnosticsPanel.test.tsx`
+
+- [x] **Step 1: Write the failing deployment panel test**
+
+Set `(window as any).__tldwServerReadinessState` before render and assert the panel shows:
+
+- `Last health status`
+- `degraded`
+- `Last status code`
+- `206`
+- `Health URL`
+- the cached readiness health URL
+
+- [x] **Step 2: Run the focused test and verify RED**
+
+Run:
+
+```bash
+cd apps/packages/ui
+bun run test src/components/Option/MCPHub/__tests__/DeploymentDiagnosticsPanel.test.tsx
+```
+
+Expected: FAIL because the panel currently shows computed Health URL and MCP health only, not the readiness snapshot fields.
+
+- [x] **Step 3: Implement minimal panel state**
+
+In `DeploymentDiagnosticsPanel.tsx`, read the cached value from `(window as any).__tldwServerReadinessState` on mount and subscribe to `tldw:server-readiness-state`. Render compact description rows:
+
+- `Last health status`: `healthStatus ?? state ?? "unknown"`
+- `Last status code`: `String(httpStatus)`, or `not recorded`
+- `Last checked`: `checkedAt`, or `not recorded`
+
+Keep the existing deployment mode, request mode, API origin, computed Health URL, and MCP health rows.
+
+- [x] **Step 4: Run the focused test and verify GREEN**
+
+Run:
+
+```bash
+cd apps/packages/ui
+bun run test src/components/Option/MCPHub/__tests__/DeploymentDiagnosticsPanel.test.tsx
+```
+
+Expected: PASS.
+
+### Task 3: Re-run Existing Setup Polish Coverage
+
+**Files:**
+- Test only:
+  - `apps/packages/ui/src/components/Option/MCPHub/__tests__/ExternalServersTab.test.tsx`
+  - `apps/packages/ui/src/components/Option/MCPHub/__tests__/ToolCatalogsTab.test.tsx`
+  - `apps/packages/ui/src/components/Option/MCPHub/__tests__/McpHubPage.test.tsx`
+  - `apps/tldw-frontend/e2e/workflows/tier-2-features/mcp-hub.spec.ts`
+  - `Docs/MCP/mcp_hub_management.md`
+
+- [x] **Step 1: Verify already-landed PR 2 UI states**
+
+Run:
+
+```bash
+cd apps/packages/ui
+bun run test src/components/Option/MCPHub/__tests__/ExternalServersTab.test.tsx src/components/Option/MCPHub/__tests__/ToolCatalogsTab.test.tsx src/components/Option/MCPHub/__tests__/McpHubPage.test.tsx
+```
+
+Expected: PASS. These tests cover no-auth stdio state, legacy fallback gating, catalog empty/stale guidance, and MCP Hub placement of deployment diagnostics.
+
+- [x] **Step 2: Verify setup isolation documentation exists**
+
+Check `Docs/MCP/mcp_hub_management.md` includes the disposable-path recipe for `USER_DB_BASE_DIR`, `DATABASE_URL`, and `MCP_DATABASE_URL`, and that the toy E2E uses a temporary stdio server path.
+
+- [ ] **Step 3: Run the toy MCP E2E smoke when feasible**
+
+Not run in this turn because no local backend was listening on `127.0.0.1:8000`; existing Playwright coverage and disposable-path documentation were verified by inspection.
+
+Run:
+
+```bash
+cd apps/tldw-frontend
+npx playwright test e2e/workflows/tier-2-features/mcp-hub.spec.ts --grep "Toy MCP walkthrough smoke" --reporter=line
+```
+
+Expected: PASS against a live backend that supports MCP Hub mutations, or SKIP with the existing guarded reason when the live API cannot mutate external servers or the temp stdio runtime is not executable from the API process.
+
+### Task 4: Final Verification And Backlog Closeout
+
+**Files:**
+- Modify: `backlog/tasks/task-223.2 - PR-2-MCP-Hub-setup-polish-and-diagnostics.md`
+
+- [x] **Step 1: Run final focused verification**
+
+Run:
+
+```bash
+cd apps/packages/ui
+bun run test src/components/Option/MCPHub/__tests__/DeploymentDiagnosticsPanel.test.tsx src/components/Option/MCPHub/__tests__/ExternalServersTab.test.tsx src/components/Option/MCPHub/__tests__/ToolCatalogsTab.test.tsx src/components/Option/MCPHub/__tests__/McpHubPage.test.tsx
+```
+
+Run:
+
+```bash
+cd apps/tldw-frontend
+bunx vitest run components/networking/__tests__/ServerReadinessGate.test.tsx
+```
+
+- [x] **Step 2: Run security/static hygiene checks**
+
+Run:
+
+```bash
+git diff --check
+```
+
+Bandit is not required for this slice unless Python files are touched.
+
+- [x] **Step 3: Update Backlog**
+
+Mark `TASK-223.2` acceptance criteria and DoD complete, record the focused verification commands, and summarize that PR 2 now has no-auth setup, catalog recovery, deployment diagnostics with last readiness health status/code, setup isolation docs, and toy MCP smoke coverage.
+
+- [ ] **Step 4: Commit**
+
+Run:
+
+```bash
+git add apps/tldw-frontend/components/networking/ServerReadinessGate.tsx apps/tldw-frontend/components/networking/__tests__/ServerReadinessGate.test.tsx apps/packages/ui/src/components/Option/MCPHub/DeploymentDiagnosticsPanel.tsx apps/packages/ui/src/components/Option/MCPHub/__tests__/DeploymentDiagnosticsPanel.test.tsx docs/superpowers/plans/2026-05-28-mcp-hub-setup-polish-diagnostics-plan.md "backlog/tasks/task-223.1 - PR-1-MCP-Hub-live-discovery-and-chat-payload-correctness.md" "backlog/tasks/task-223.2 - PR-2-MCP-Hub-setup-polish-and-diagnostics.md"
+git commit -m "feat: complete MCP Hub setup diagnostics"
+```

--- a/apps/packages/ui/src/components/Option/MCPHub/DeploymentDiagnosticsPanel.tsx
+++ b/apps/packages/ui/src/components/Option/MCPHub/DeploymentDiagnosticsPanel.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from "react"
 import { Card, Descriptions, Tag } from "antd"
 
 import {
@@ -16,6 +17,18 @@ type DeploymentDiagnosticsPanelProps = {
   env?: DeploymentDiagnosticsEnv
   pageOrigin?: string
 }
+
+type ServerReadinessSnapshot = {
+  state?: string
+  degradedChecks?: string[]
+  healthUrl?: string
+  httpStatus?: number
+  healthStatus?: string
+  errorMessage?: string
+  checkedAt?: string
+}
+
+const SERVER_READINESS_STATE_EVENT = "tldw:server-readiness-state"
 
 const trimTrailingSlash = (value: string): string => value.replace(/\/+$/, "")
 
@@ -37,10 +50,45 @@ const getPageOrigin = (pageOrigin?: string): string => {
 const buildHealthUrl = (apiOrigin: string): string =>
   apiOrigin ? `${trimTrailingSlash(apiOrigin)}/api/v1/health` : "/api/v1/health"
 
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value)
+
+const normalizeReadinessSnapshot = (value: unknown): ServerReadinessSnapshot | null => {
+  if (!isRecord(value)) return null
+  return {
+    state: typeof value.state === "string" ? value.state : undefined,
+    degradedChecks: Array.isArray(value.degradedChecks)
+      ? value.degradedChecks.filter((item): item is string => typeof item === "string")
+      : undefined,
+    healthUrl: typeof value.healthUrl === "string" ? value.healthUrl : undefined,
+    httpStatus: typeof value.httpStatus === "number" ? value.httpStatus : undefined,
+    healthStatus: typeof value.healthStatus === "string" ? value.healthStatus : undefined,
+    errorMessage: typeof value.errorMessage === "string" ? value.errorMessage : undefined,
+    checkedAt: typeof value.checkedAt === "string" ? value.checkedAt : undefined
+  }
+}
+
+const readReadinessSnapshot = (): ServerReadinessSnapshot | null => {
+  if (typeof window === "undefined") return null
+  return normalizeReadinessSnapshot(
+    (window as typeof window & { __tldwServerReadinessState?: unknown })
+      .__tldwServerReadinessState
+  )
+}
+
+const getHealthTagColor = (state: string): string => {
+  if (state === "healthy" || state === "ok" || state === "ready") return "green"
+  if (state === "unhealthy" || state === "blocked") return "red"
+  if (state === "degraded" || state === "unavailable") return "orange"
+  return "default"
+}
+
 export const DeploymentDiagnosticsPanel = ({
   env,
   pageOrigin
 }: DeploymentDiagnosticsPanelProps) => {
+  const [readinessSnapshot, setReadinessSnapshot] =
+    useState<ServerReadinessSnapshot | null>(() => readReadinessSnapshot())
   const healthState = useMcpToolsStore((state) => state.healthState)
   const deploymentEnv = env ?? readDeploymentEnv()
   const resolvedPageOrigin = getPageOrigin(pageOrigin)
@@ -67,6 +115,28 @@ export const DeploymentDiagnosticsPanel = ({
     healthUrl = "not available"
     configIssue = err instanceof Error ? err.message : "Invalid deployment networking config."
   }
+
+  useEffect(() => {
+    setReadinessSnapshot(readReadinessSnapshot())
+    const handleReadinessState = (event: Event) => {
+      setReadinessSnapshot(
+        normalizeReadinessSnapshot(
+          (event as CustomEvent<ServerReadinessSnapshot>).detail
+        )
+      )
+    }
+    window.addEventListener(SERVER_READINESS_STATE_EVENT, handleReadinessState)
+    return () => {
+      window.removeEventListener(SERVER_READINESS_STATE_EVENT, handleReadinessState)
+    }
+  }, [])
+
+  const lastHealthStatus =
+    readinessSnapshot?.healthStatus || readinessSnapshot?.state || "unknown"
+  const lastStatusCode =
+    typeof readinessSnapshot?.httpStatus === "number"
+      ? String(readinessSnapshot.httpStatus)
+      : "not recorded"
 
   return (
     <Card size="small" title="Deployment Diagnostics">
@@ -101,6 +171,27 @@ export const DeploymentDiagnosticsPanel = ({
             {healthState}
           </Tag>
         </Descriptions.Item>
+        <Descriptions.Item label="Last health status">
+          <Tag color={getHealthTagColor(lastHealthStatus)}>
+            {lastHealthStatus}
+          </Tag>
+        </Descriptions.Item>
+        <Descriptions.Item label="Last status code">
+          {lastStatusCode}
+        </Descriptions.Item>
+        <Descriptions.Item label="Last checked">
+          {readinessSnapshot?.checkedAt || "not recorded"}
+        </Descriptions.Item>
+        {readinessSnapshot?.healthUrl ? (
+          <Descriptions.Item label="Readiness health URL" span={3}>
+            {readinessSnapshot.healthUrl}
+          </Descriptions.Item>
+        ) : null}
+        {readinessSnapshot?.errorMessage ? (
+          <Descriptions.Item label="Last health error" span={3}>
+            {readinessSnapshot.errorMessage}
+          </Descriptions.Item>
+        ) : null}
         {configIssue ? (
           <Descriptions.Item label="Config issue" span={3}>
             {configIssue}

--- a/apps/packages/ui/src/components/Option/MCPHub/__tests__/DeploymentDiagnosticsPanel.test.tsx
+++ b/apps/packages/ui/src/components/Option/MCPHub/__tests__/DeploymentDiagnosticsPanel.test.tsx
@@ -8,6 +8,8 @@ import { DeploymentDiagnosticsPanel } from "../DeploymentDiagnosticsPanel"
 describe("DeploymentDiagnosticsPanel", () => {
   afterEach(() => {
     useMcpToolsStore.setState({ healthState: "unknown" })
+    delete (window as unknown as { __tldwServerReadinessState?: unknown })
+      .__tldwServerReadinessState
   })
 
   it("summarizes quickstart same-origin diagnostics", () => {
@@ -48,5 +50,33 @@ describe("DeploymentDiagnosticsPanel", () => {
     expect(screen.getByText("http://127.0.0.1:8000")).toBeTruthy()
     expect(screen.getByText("http://127.0.0.1:8000/api/v1/health")).toBeTruthy()
     expect(screen.getByText("unhealthy")).toBeTruthy()
+  })
+
+  it("shows the last WebUI readiness health result when available", () => {
+    ;(window as unknown as { __tldwServerReadinessState?: unknown })
+      .__tldwServerReadinessState = {
+      state: "degraded",
+      degradedChecks: ["mcp"],
+      healthUrl: "http://127.0.0.1:8000/api/v1/health",
+      httpStatus: 206,
+      healthStatus: "degraded",
+      checkedAt: "2026-05-28T20:00:00.000Z"
+    }
+    useMcpToolsStore.setState({ healthState: "healthy" })
+
+    render(
+      <DeploymentDiagnosticsPanel
+        env={{ NEXT_PUBLIC_TLDW_DEPLOYMENT_MODE: "quickstart" }}
+        pageOrigin="http://localhost:3000"
+      />
+    )
+
+    expect(screen.getByText("Last health status")).toBeTruthy()
+    expect(screen.getByText("degraded")).toBeTruthy()
+    expect(screen.getByText("Last status code")).toBeTruthy()
+    expect(screen.getByText("206")).toBeTruthy()
+    expect(screen.getByText("Last checked")).toBeTruthy()
+    expect(screen.getByText("2026-05-28T20:00:00.000Z")).toBeTruthy()
+    expect(screen.getByText("http://127.0.0.1:8000/api/v1/health")).toBeTruthy()
   })
 })

--- a/apps/tldw-frontend/__tests__/components/networking/ServerReadinessGate.degraded.test.tsx
+++ b/apps/tldw-frontend/__tests__/components/networking/ServerReadinessGate.degraded.test.tsx
@@ -90,10 +90,10 @@ describe("ServerReadinessGate degraded health", () => {
       )
       expect(readinessListener).toHaveBeenCalledWith(
         expect.objectContaining({
-          detail: {
+          detail: expect.objectContaining({
             state: "degraded",
             degradedChecks: ["chacha_notes"]
-          }
+          })
         })
       )
     } finally {
@@ -124,10 +124,12 @@ describe("ServerReadinessGate degraded health", () => {
 
     expect(await screen.findByTestId("readiness-event-child")).toBeInTheDocument()
     await waitFor(() => {
-      expect(childReadinessListener).toHaveBeenCalledWith({
-        state: "degraded",
-        degradedChecks: ["chacha_notes"]
-      })
+      expect(childReadinessListener).toHaveBeenCalledWith(
+        expect.objectContaining({
+          state: "degraded",
+          degradedChecks: ["chacha_notes"]
+        })
+      )
     })
   })
 

--- a/apps/tldw-frontend/components/networking/ServerReadinessGate.tsx
+++ b/apps/tldw-frontend/components/networking/ServerReadinessGate.tsx
@@ -20,10 +20,25 @@ const RETRY_INTERVAL_MS = 2_000
 const OFFLINE_BYPASS_KEYS = ["__tldw_allow_offline", "__tldw_test_bypass"] as const
 
 type GateState = "checking" | "ready" | "waiting" | "timeout" | "degraded"
+type ServerReadinessPublishedState = {
+  state: "ready" | "degraded" | "blocked"
+  degradedChecks: string[]
+  healthUrl: string
+  httpStatus?: number
+  healthStatus?: string
+  errorMessage?: string
+  checkedAt: string
+}
 type ReadinessResult =
-  | { state: "ready" }
-  | { state: "degraded"; degradedChecks: string[] }
-  | { state: "blocked" }
+  | { state: "ready"; diagnostics: ServerReadinessPublishedState }
+  | { state: "degraded"; degradedChecks: string[]; diagnostics: ServerReadinessPublishedState }
+  | { state: "blocked"; diagnostics: ServerReadinessPublishedState }
+
+declare global {
+  interface Window {
+    __tldwServerReadinessState?: ServerReadinessPublishedState
+  }
+}
 
 const ENTERABLE_HTTP_STATUSES = new Set([200, 206])
 const READY_HEALTH_STATUSES = new Set(["healthy", "ok"])
@@ -58,41 +73,116 @@ function extractDegradedChecks(body: unknown): string[] {
     .map(([name]) => name)
 }
 
+function extractHealthStatus(body: unknown): string | undefined {
+  if (!body || typeof body !== "object") return undefined
+  const status = (body as { status?: unknown }).status
+  return typeof status === "string" ? status.toLowerCase() : undefined
+}
+
+function buildReadinessDiagnostics({
+  state,
+  degradedChecks = [],
+  httpStatus,
+  healthStatus,
+  errorMessage
+}: {
+  state: "ready" | "degraded" | "blocked"
+  degradedChecks?: string[]
+  httpStatus?: number
+  healthStatus?: string
+  errorMessage?: string
+}): ServerReadinessPublishedState {
+  return {
+    state,
+    degradedChecks,
+    healthUrl: HEALTH_URL,
+    httpStatus,
+    healthStatus,
+    errorMessage,
+    checkedAt: new Date().toISOString()
+  }
+}
+
 async function checkHealth(): Promise<ReadinessResult> {
   try {
     const res = await fetch(HEALTH_URL, {
       method: "GET",
       signal: AbortSignal.timeout(3000)
     })
-    if (!ENTERABLE_HTTP_STATUSES.has(res.status)) {
-      return { state: "blocked" }
-    }
-    const body = await res.json()
-    const status =
-      typeof body?.status === "string" ? body.status.toLowerCase() : ""
-    if (READY_HEALTH_STATUSES.has(status)) {
-      return { state: "ready" }
-    }
-    if (status === "degraded") {
+    let body: unknown
+    let healthStatus: string | undefined
+    try {
+      body = await res.json()
+      healthStatus = extractHealthStatus(body)
+    } catch (err) {
       return {
-        state: "degraded",
-        degradedChecks: extractDegradedChecks(body)
+        state: "blocked",
+        diagnostics: buildReadinessDiagnostics({
+          state: "blocked",
+          httpStatus: res.status,
+          errorMessage: err instanceof Error ? err.message : "Could not parse health response."
+        })
       }
     }
-    return { state: "blocked" }
-  } catch {
-    return { state: "blocked" }
+    if (!ENTERABLE_HTTP_STATUSES.has(res.status)) {
+      return {
+        state: "blocked",
+        diagnostics: buildReadinessDiagnostics({
+          state: "blocked",
+          httpStatus: res.status,
+          healthStatus
+        })
+      }
+    }
+    const status = healthStatus ?? ""
+    if (READY_HEALTH_STATUSES.has(status)) {
+      return {
+        state: "ready",
+        diagnostics: buildReadinessDiagnostics({
+          state: "ready",
+          httpStatus: res.status,
+          healthStatus: status
+        })
+      }
+    }
+    if (status === "degraded") {
+      const degradedChecks = extractDegradedChecks(body)
+      return {
+        state: "degraded",
+        degradedChecks,
+        diagnostics: buildReadinessDiagnostics({
+          state: "degraded",
+          degradedChecks,
+          httpStatus: res.status,
+          healthStatus: status
+        })
+      }
+    }
+    return {
+      state: "blocked",
+      diagnostics: buildReadinessDiagnostics({
+        state: "blocked",
+        httpStatus: res.status,
+        healthStatus: status || undefined
+      })
+    }
+  } catch (err) {
+    return {
+      state: "blocked",
+      diagnostics: buildReadinessDiagnostics({
+        state: "blocked",
+        errorMessage: err instanceof Error ? err.message : "Health request failed."
+      })
+    }
   }
 }
 
-function emitServerReadinessState(
-  state: "ready" | "degraded" | "blocked",
-  degradedChecks: string[] = []
-) {
+function emitServerReadinessState(detail: ServerReadinessPublishedState) {
   if (typeof window === "undefined") return
+  window.__tldwServerReadinessState = detail
   window.dispatchEvent(
     new CustomEvent(SERVER_READINESS_STATE_EVENT, {
-      detail: { state, degradedChecks }
+      detail
     })
   )
 }
@@ -106,6 +196,8 @@ export const ServerReadinessGate: React.FC<{
     shouldBypassReadinessForOffline() ? "ready" : "checking"
   )
   const [degradedChecks, setDegradedChecks] = React.useState<string[]>([])
+  const [lastReadinessState, setLastReadinessState] =
+    React.useState<ServerReadinessPublishedState | null>(null)
 
   React.useEffect(() => {
     if (typeof window === "undefined") return
@@ -120,6 +212,7 @@ export const ServerReadinessGate: React.FC<{
 
     setGate((current) => (current === "ready" ? current : "checking"))
     setDegradedChecks([])
+    setLastReadinessState(null)
 
     let cancelled = false
     let retryTimer: number | undefined
@@ -128,6 +221,7 @@ export const ServerReadinessGate: React.FC<{
     const attempt = async () => {
       const result = await checkHealth()
       if (cancelled) return
+      setLastReadinessState(result.diagnostics)
 
       if (result.state === "ready") {
         setGate("ready")
@@ -172,16 +266,21 @@ export const ServerReadinessGate: React.FC<{
     if (!state) return
 
     const emitTimer = window.setTimeout(() => {
-      emitServerReadinessState(
+      emitServerReadinessState({
+        ...(lastReadinessState ??
+          buildReadinessDiagnostics({
+            state,
+            degradedChecks: state === "degraded" ? degradedChecks : []
+          })),
         state,
-        state === "degraded" ? degradedChecks : []
-      )
+        degradedChecks: state === "degraded" ? degradedChecks : []
+      })
     }, 0)
 
     return () => {
       window.clearTimeout(emitTimer)
     }
-  }, [bypass, degradedChecks, gate])
+  }, [bypass, degradedChecks, gate, lastReadinessState])
 
   if (bypass || gate === "ready" || gate === "timeout") {
     return <>{children}</>

--- a/apps/tldw-frontend/components/networking/ServerReadinessGate.tsx
+++ b/apps/tldw-frontend/components/networking/ServerReadinessGate.tsx
@@ -109,22 +109,25 @@ async function checkHealth(): Promise<ReadinessResult> {
       method: "GET",
       signal: AbortSignal.timeout(3000)
     })
+    const isEnterable = ENTERABLE_HTTP_STATUSES.has(res.status)
     let body: unknown
     let healthStatus: string | undefined
     try {
       body = await res.json()
       healthStatus = extractHealthStatus(body)
     } catch (err) {
-      return {
-        state: "blocked",
-        diagnostics: buildReadinessDiagnostics({
+      if (isEnterable) {
+        return {
           state: "blocked",
-          httpStatus: res.status,
-          errorMessage: err instanceof Error ? err.message : "Could not parse health response."
-        })
+          diagnostics: buildReadinessDiagnostics({
+            state: "blocked",
+            httpStatus: res.status,
+            errorMessage: err instanceof Error ? err.message : "Could not parse health response."
+          })
+        }
       }
     }
-    if (!ENTERABLE_HTTP_STATUSES.has(res.status)) {
+    if (!isEnterable) {
       return {
         state: "blocked",
         diagnostics: buildReadinessDiagnostics({
@@ -163,7 +166,8 @@ async function checkHealth(): Promise<ReadinessResult> {
       diagnostics: buildReadinessDiagnostics({
         state: "blocked",
         httpStatus: res.status,
-        healthStatus: status || undefined
+        // Empty status means the health JSON did not include a usable status field.
+        healthStatus: status !== "" ? status : undefined
       })
     }
   } catch (err) {
@@ -266,14 +270,20 @@ export const ServerReadinessGate: React.FC<{
     if (!state) return
 
     const emitTimer = window.setTimeout(() => {
+      const emittedDegradedChecks =
+        state === "degraded"
+          ? degradedChecks
+          : state === "blocked"
+            ? (lastReadinessState?.degradedChecks ?? [])
+            : []
       emitServerReadinessState({
         ...(lastReadinessState ??
           buildReadinessDiagnostics({
             state,
-            degradedChecks: state === "degraded" ? degradedChecks : []
+            degradedChecks: emittedDegradedChecks
           })),
         state,
-        degradedChecks: state === "degraded" ? degradedChecks : []
+        degradedChecks: emittedDegradedChecks
       })
     }, 0)
 

--- a/apps/tldw-frontend/components/networking/__tests__/ServerReadinessGate.test.tsx
+++ b/apps/tldw-frontend/components/networking/__tests__/ServerReadinessGate.test.tsx
@@ -15,6 +15,8 @@ describe("ServerReadinessGate", () => {
     } catch {
       // ignore test storage availability
     }
+    delete (window as unknown as { __tldwServerReadinessState?: unknown })
+      .__tldwServerReadinessState
     vi.restoreAllMocks()
     vi.useRealTimers()
     vi.unstubAllEnvs()
@@ -67,6 +69,65 @@ describe("ServerReadinessGate", () => {
     })
 
     expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it("publishes bounded readiness diagnostics for degraded health", async () => {
+    vi.stubEnv("NEXT_PUBLIC_TLDW_DEPLOYMENT_MODE", "advanced")
+    vi.stubEnv("NEXT_PUBLIC_API_URL", "http://127.0.0.1:8000")
+    vi.spyOn(globalThis, "fetch").mockResolvedValue({
+      ok: true,
+      status: 206,
+      json: async () => ({
+        status: "degraded",
+        checks: { mcp: { status: "degraded" } }
+      })
+    } as Response)
+
+    const readinessEvents: Array<Record<string, unknown>> = []
+    const handleReadinessState = (event: Event) => {
+      readinessEvents.push(
+        (event as CustomEvent<Record<string, unknown>>).detail
+      )
+    }
+    window.addEventListener(
+      "tldw:server-readiness-state",
+      handleReadinessState
+    )
+
+    try {
+      const { ServerReadinessGate } = await import("../ServerReadinessGate")
+
+      render(
+        <ServerReadinessGate allowDegraded>
+          <div>App ready</div>
+        </ServerReadinessGate>
+      )
+
+      await waitFor(() => {
+        expect(screen.getByText("App ready")).toBeInTheDocument()
+      })
+
+      await waitFor(() => {
+        expect(readinessEvents.at(-1)).toEqual(
+          expect.objectContaining({
+            state: "degraded",
+            healthUrl: "http://127.0.0.1:8000/api/v1/health",
+            httpStatus: 206,
+            healthStatus: "degraded",
+            degradedChecks: ["mcp"]
+          })
+        )
+      })
+      expect(
+        (window as unknown as { __tldwServerReadinessState?: unknown })
+          .__tldwServerReadinessState
+      ).toEqual(readinessEvents.at(-1))
+    } finally {
+      window.removeEventListener(
+        "tldw:server-readiness-state",
+        handleReadinessState
+      )
+    }
   })
 
   it("accepts ok and allowed degraded status envelopes from normal successful responses", async () => {

--- a/apps/tldw-frontend/components/networking/__tests__/ServerReadinessGate.test.tsx
+++ b/apps/tldw-frontend/components/networking/__tests__/ServerReadinessGate.test.tsx
@@ -225,6 +225,92 @@ describe("ServerReadinessGate", () => {
     expect(screen.queryByText("App ready")).toBeNull()
   })
 
+  it("reports non-enterable non-json health responses by status", async () => {
+    vi.useFakeTimers()
+    vi.stubEnv("NEXT_PUBLIC_TLDW_DEPLOYMENT_MODE", "advanced")
+    vi.stubEnv("NEXT_PUBLIC_API_URL", "http://127.0.0.1:8000")
+    vi.spyOn(globalThis, "fetch").mockResolvedValue({
+      ok: false,
+      status: 503,
+      json: async () => {
+        throw new Error("Unexpected token <")
+      }
+    } as Response)
+    const { ServerReadinessGate } = await import("../ServerReadinessGate")
+
+    render(
+      <ServerReadinessGate>
+        <div>App ready</div>
+      </ServerReadinessGate>
+    )
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(16_000)
+    })
+
+    expect(screen.getByText("App ready")).toBeInTheDocument()
+    await act(async () => {
+      await vi.runOnlyPendingTimersAsync()
+    })
+    expect(
+      (window as unknown as { __tldwServerReadinessState?: unknown })
+        .__tldwServerReadinessState
+    ).toEqual(
+      expect.objectContaining({
+        state: "blocked",
+        httpStatus: 503
+      })
+    )
+    expect(
+      (
+        window as unknown as {
+          __tldwServerReadinessState?: { errorMessage?: string }
+        }
+      )
+        .__tldwServerReadinessState?.errorMessage
+    ).toBeUndefined()
+  })
+
+  it("preserves degraded checks when timeout blocks an unaccepted degraded response", async () => {
+    vi.useFakeTimers()
+    vi.stubEnv("NEXT_PUBLIC_TLDW_DEPLOYMENT_MODE", "advanced")
+    vi.stubEnv("NEXT_PUBLIC_API_URL", "http://127.0.0.1:8000")
+    vi.spyOn(globalThis, "fetch").mockResolvedValue({
+      ok: true,
+      status: 206,
+      json: async () => ({
+        status: "degraded",
+        checks: { mcp: { status: "degraded" } }
+      })
+    } as Response)
+    const { ServerReadinessGate } = await import("../ServerReadinessGate")
+
+    render(
+      <ServerReadinessGate>
+        <div>App ready</div>
+      </ServerReadinessGate>
+    )
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(16_000)
+    })
+
+    expect(screen.getByText("App ready")).toBeInTheDocument()
+    await act(async () => {
+      await vi.runOnlyPendingTimersAsync()
+    })
+    expect(
+      (window as unknown as { __tldwServerReadinessState?: unknown })
+        .__tldwServerReadinessState
+    ).toEqual(
+      expect.objectContaining({
+        state: "blocked",
+        healthStatus: "degraded",
+        degradedChecks: ["mcp"]
+      })
+    )
+  })
+
   it("restarts readiness checks when leaving a bypass route after timing out", async () => {
     vi.useFakeTimers()
     vi.stubEnv("NEXT_PUBLIC_TLDW_DEPLOYMENT_MODE", "advanced")

--- a/backlog/tasks/task-223 - MCP-Hub-walkthrough-remediation-plan.md
+++ b/backlog/tasks/task-223 - MCP-Hub-walkthrough-remediation-plan.md
@@ -1,18 +1,18 @@
 ---
 id: TASK-223
 title: MCP Hub walkthrough remediation plan
-status: In Progress
+status: Done
 assignee: []
-created_date: '2026-05-10 06:13'
-updated_date: '2026-05-10 06:26'
+created_date: 2026-05-10 06:13
+updated_date: 2026-05-10 06:26
 labels:
-  - mcp
-  - webui
-  - ux
-  - planning
+- mcp
+- webui
+- ux
+- planning
 dependencies: []
 documentation:
-  - Docs/superpowers/specs/2026-05-10-mcp-hub-walkthrough-remediation-design.md
+- Docs/superpowers/specs/2026-05-10-mcp-hub-walkthrough-remediation-design.md
 priority: high
 ---
 

--- a/backlog/tasks/task-223.1 - PR-1-MCP-Hub-live-discovery-and-chat-payload-correctness.md
+++ b/backlog/tasks/task-223.1 - PR-1-MCP-Hub-live-discovery-and-chat-payload-correctness.md
@@ -14,7 +14,7 @@ labels:
 dependencies: []
 documentation:
   - Docs/superpowers/specs/2026-05-10-mcp-hub-walkthrough-remediation-design.md
-  - docs/superpowers/plans/2026-05-10-mcp-hub-live-discovery-chat-plan.md
+  - Docs/superpowers/plans/2026-05-10-mcp-hub-live-discovery-chat-plan.md
 parent_task_id: TASK-223
 priority: high
 ---
@@ -38,7 +38,7 @@ Implement the first PR-sized remediation slice from the MCP Hub walkthrough. Thi
 ## Implementation Plan
 
 <!-- SECTION:PLAN:BEGIN -->
-PR 1 implementation plan drafted at docs/superpowers/plans/2026-05-10-mcp-hub-live-discovery-chat-plan.md.
+PR 1 implementation plan drafted at Docs/superpowers/plans/2026-05-10-mcp-hub-live-discovery-chat-plan.md.
 
 Stages:
 1. Backend runtime refresh/reconcile endpoint at POST /api/v1/mcp/hub/external-servers/refresh-discovery, live MCP singleton resolution, manager reconciliation, module registry remapping, external federation validator coverage.

--- a/backlog/tasks/task-223.1 - PR-1-MCP-Hub-live-discovery-and-chat-payload-correctness.md
+++ b/backlog/tasks/task-223.1 - PR-1-MCP-Hub-live-discovery-and-chat-payload-correctness.md
@@ -1,11 +1,11 @@
 ---
 id: TASK-223.1
 title: 'PR 1: MCP Hub live discovery and chat payload correctness'
-status: In Progress
+status: Done
 assignee:
   - Codex
 created_date: '2026-05-10 06:13'
-updated_date: '2026-05-10 06:37'
+updated_date: '2026-05-28 20:16'
 labels:
   - mcp
   - webui
@@ -27,12 +27,12 @@ Implement the first PR-sized remediation slice from the MCP Hub walkthrough. Thi
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Managed external server create, update, and import can trigger live external tool discovery refresh without backend restart.
-- [ ] #2 The existing external.tools.refresh MCP tool validates arguments and no longer fails the write-tool pre-exec validator for valid calls.
-- [ ] #3 MCP Hub setup and catalog surfaces report refresh success, refresh failure, and runtime unavailable states clearly.
-- [ ] #4 Chat request construction and raw request preview use the same effective MCP tool decision and expose the reason when tools are omitted.
-- [ ] #5 The readiness gate allows degraded but usable health into the app while preserving blocking behavior for unreachable or unhealthy API states.
-- [ ] #6 Focused backend, frontend, and readiness tests cover the changed behavior.
+- [x] #1 Managed external server create, update, and import can trigger live external tool discovery refresh without backend restart.
+- [x] #2 The existing external.tools.refresh MCP tool validates arguments and no longer fails the write-tool pre-exec validator for valid calls.
+- [x] #3 MCP Hub setup and catalog surfaces report refresh success, refresh failure, and runtime unavailable states clearly.
+- [x] #4 Chat request construction and raw request preview use the same effective MCP tool decision and expose the reason when tools are omitted.
+- [x] #5 The readiness gate allows degraded but usable health into the app while preserving blocking behavior for unreachable or unhealthy API states.
+- [x] #6 Focused backend, frontend, and readiness tests cover the changed behavior.
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -56,12 +56,18 @@ Started implementation planning for PR 1 only. No code changes yet. Plan will re
 Plan self-review tightened Stage 1 and Stage 2 details: the refresh endpoint remains POST /api/v1/mcp/hub/external-servers/refresh-discovery but should be placed before nearby parameterized routes; ExternalFederationModule.validate_tool_arguments must validate external.tools.refresh server_id and __confirm_write booleans; frontend invalidation should include the exact ["mcp-health"] query family.
 <!-- SECTION:NOTES:END -->
 
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Verified on origin/dev after PR merge that the PR 1 MCP Hub live discovery and chat payload correctness work is already implemented. Evidence: `python -m pytest tldw_Server_API/tests/MCP_unified/test_mcp_hub_management_api.py tldw_Server_API/tests/MCP_unified/test_mcp_protocol_external_federation.py -q` passed 48 tests; `bun run test src/services/tldw/__tests__/mcp-hub.test.ts src/components/Option/MCPHub/__tests__/ExternalServersTab.test.tsx src/components/Option/MCPHub/__tests__/ToolCatalogsTab.test.tsx src/utils/__tests__/chat-tools.test.ts src/models/__tests__/pageAssistModel.mcp-tools.test.ts src/components/Option/Playground/__tests__/usePlaygroundRawPreview.mcp-tools.test.tsx` passed 59 tests.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->

--- a/backlog/tasks/task-223.2 - PR-2-MCP-Hub-setup-polish-and-diagnostics.md
+++ b/backlog/tasks/task-223.2 - PR-2-MCP-Hub-setup-polish-and-diagnostics.md
@@ -1,9 +1,11 @@
 ---
 id: TASK-223.2
 title: 'PR 2: MCP Hub setup polish and diagnostics'
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - Codex
 created_date: '2026-05-10 06:13'
+updated_date: '2026-05-28 20:17'
 labels:
   - mcp
   - webui
@@ -11,6 +13,9 @@ labels:
   - diagnostics
 dependencies:
   - TASK-223.1
+documentation:
+  - Docs/superpowers/specs/2026-05-10-mcp-hub-walkthrough-remediation-design.md
+  - Docs/superpowers/plans/2026-05-28-mcp-hub-setup-polish-diagnostics-plan.md
 parent_task_id: TASK-223
 priority: medium
 ---
@@ -23,20 +28,36 @@ Implement the second PR-sized remediation slice from the MCP Hub walkthrough. Th
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 No-auth local stdio servers render a neutral or healthy no-credentials-required state instead of missing-auth warnings.
-- [ ] #2 Legacy Secret Fallback appears only when the selected managed server actually uses the transitional server-level secret flow.
-- [ ] #3 Tool Catalog empty and stale states offer clear Add server and Refresh discovery actions with setup, runtime, and permissions distinctions.
-- [ ] #4 MCP Hub or shared diagnostics expose effective deployment mode, API origin, and health endpoint enough to diagnose quickstart versus advanced split-brain configuration.
-- [ ] #5 Setup isolation expectations for local walkthrough or E2E runs are documented or verified where practical.
-- [ ] #6 Focused UI tests and a toy MCP E2E smoke cover the polished setup path.
+- [x] #1 No-auth local stdio servers render a neutral or healthy no-credentials-required state instead of missing-auth warnings.
+- [x] #2 Legacy Secret Fallback appears only when the selected managed server actually uses the transitional server-level secret flow.
+- [x] #3 Tool Catalog empty and stale states offer clear Add server and Refresh discovery actions with setup, runtime, and permissions distinctions.
+- [x] #4 MCP Hub or shared diagnostics expose effective deployment mode, API origin, and health endpoint enough to diagnose quickstart versus advanced split-brain configuration.
+- [x] #5 Setup isolation expectations for local walkthrough or E2E runs are documented or verified where practical.
+- [x] #6 Focused UI tests and a toy MCP E2E smoke cover the polished setup path.
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Implementation plan written at Docs/superpowers/plans/2026-05-28-mcp-hub-setup-polish-diagnostics-plan.md. Executed Tasks 1-2 with TDD for readiness diagnostics and deployment-panel display, then reran the existing no-auth/categorical setup polish tests.
+<!-- SECTION:PLAN:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Completed MCP Hub setup diagnostics closeout for PR 2. ServerReadinessGate now publishes a bounded readiness snapshot containing state, degraded checks, health URL, last HTTP status code, health status, error message, and checked timestamp, and stores it on window for panels mounted after readiness. DeploymentDiagnosticsPanel now reads that snapshot and updates from tldw:server-readiness-state events, exposing Last health status, Last status code, Last checked, and Readiness health URL alongside deployment mode, request mode, API origin, computed Health URL, and MCP health. Existing no-auth stdio, legacy secret fallback gating, Tool Catalog empty/stale guidance, setup isolation docs, and toy MCP E2E coverage were verified present. Verification: ServerReadinessGate Vitest 9 passed; DeploymentDiagnosticsPanel Vitest 3 passed; MCP Hub setup polish Vitest 34 passed; git diff --check passed. Live Playwright toy smoke was not run because no local backend was listening on 127.0.0.1:8000 in this turn.
+
+Bandit was not run because this slice touched TypeScript/TSX, docs, and Backlog metadata only; no Python source changed.
+
+Additional typecheck attempts: `bunx tsc -p tsconfig.json --noEmit --pretty false` in apps/tldw-frontend failed on existing unrelated E2E type debt outside this slice; the same command in apps/packages/ui terminated with Node heap OOM before reporting diagnostics.
+<!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->


### PR DESCRIPTION
## Summary
- Added bounded server-readiness diagnostics from the WebUI readiness gate so MCP Hub can show the last health URL, status, status code, checked time, and health error without adding another API request.
- Surfaced those diagnostics in the MCP Hub deployment diagnostics panel alongside the existing setup guidance.
- Closed the MCP Hub walkthrough remediation tracker now that both PR-sized child tasks are complete.

## Verification
- `bunx vitest run components/networking/__tests__/ServerReadinessGate.test.tsx` from `apps/tldw-frontend` passed: 9 tests.
- `bun run test src/components/Option/MCPHub/__tests__/DeploymentDiagnosticsPanel.test.tsx src/components/Option/MCPHub/__tests__/ExternalServersTab.test.tsx src/components/Option/MCPHub/__tests__/ToolCatalogsTab.test.tsx src/components/Option/MCPHub/__tests__/McpHubPage.test.tsx` from `apps/packages/ui` passed: 34 tests.
- `git diff --check` passed.

## Known Skips / Baseline Issues
- Live Playwright toy MCP smoke was not run because no local backend was listening at `127.0.0.1:8000`.
- Full frontend typecheck was not clean before this slice: `apps/tldw-frontend` still hits unrelated E2E type debt, and `apps/packages/ui` typecheck terminates with Node heap OOM.
- Bandit was not run because this PR only changes TS/TSX, docs, and Backlog tracking.

## Change summary
This PR keeps MCP Hub setup diagnostics within existing ownership boundaries: the global readiness gate already probes backend health, so it now publishes a small browser-local diagnostic snapshot instead of making MCP Hub duplicate health checks. MCP Hub consumes that snapshot to explain setup/readiness failures in context while preserving the existing backend API and MCP Hub service contracts.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Polished MCP Hub setup diagnostics by publishing a bounded WebUI readiness snapshot and showing it in the MCP Hub diagnostics panel. Users can see the last health URL, status, HTTP code, checked time, and any error without extra API calls.

- **New Features**
  - `ServerReadinessGate` now emits and caches a readiness snapshot on `window.__tldwServerReadinessState` and via `tldw:server-readiness-state`.
  - Snapshot includes: `state`, `degradedChecks`, `healthUrl`, `httpStatus`, `healthStatus`, `errorMessage`, `checkedAt`.
  - `DeploymentDiagnosticsPanel` reads the snapshot, subscribes to updates, and displays Last health status, Last status code, Last checked, Readiness health URL, and last error when available; no backend changes.

- **Bug Fixes**
  - Preserve `degradedChecks` when a degraded response is later blocked by timeout.
  - Report non-enterable non-JSON health responses by HTTP status; surface parse/request errors in `errorMessage` when applicable.
  - Standardized event detail shape so listeners receive the same snapshot payload.

<sup>Written for commit f353f01aba3c48b6facfa6638133fc9b50745e9a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2100?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

