### PR TITLE
docs: close folder-to-notes Sources design task

### DIFF
--- a/Docs/superpowers/specs/2026-05-17-folder-notes-sources-ui-exposure-design.md
+++ b/Docs/superpowers/specs/2026-05-17-folder-notes-sources-ui-exposure-design.md
@@ -1,7 +1,7 @@
 # Folder-To-Notes Sources UI Exposure Design
 
 Date: 2026-05-17
-Status: Critique pass applied, pending user review
+Status: Approved for implementation planning
 Owner: Codex brainstorming session
 Backlog: TASK-400
 

--- a/backlog/completed/task-400 - Design-WebUI-and-extension-exposure-for-folder-to-notes-Sources-sync.md
+++ b/backlog/completed/task-400 - Design-WebUI-and-extension-exposure-for-folder-to-notes-Sources-sync.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-400
 title: Design WebUI and extension exposure for folder-to-notes Sources sync
-status: In Progress
+status: Done
 labels:
 - design
 - webui
@@ -34,21 +34,21 @@ Spec phase only. Critique pass applied after user review. The direct Notes folde
 ## Implementation Notes
 
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
-
+Closed the design tracker after PR #2099 merged. The spec is approved for implementation planning, and the downstream implementation plan already exists in Docs/superpowers/plans/2026-05-17-folder-notes-sources-ui-exposure-implementation-plan.md under completed TASK-403. Verification for this closeout: inspected the spec, downstream plan, active backlog inventory, and current origin/dev merge state; no product code changed. Bandit is not applicable for this docs/backlog-only closeout.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-
+Design tracker complete. The folder-to-notes Sources UI exposure spec now reflects approved-for-implementation-planning status, with the implementation plan already created and completed under TASK-403. This closeout changes only spec/backlog metadata and leaves implementation work to the existing plan stages.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->


### PR DESCRIPTION
## Summary
- Marked the folder-to-notes Sources UI exposure spec as approved for implementation planning.
- Closed and archived `TASK-400` now that the downstream implementation plan exists under completed `TASK-403`.
- No product code changed.

## Tests
- `git diff --check`
- `git diff --cached --check`
- Inspected the spec, completed implementation plan, active backlog inventory, and current `origin/dev` merge state.
- Bandit not applicable: docs/backlog-only closeout.

## Change summary
Human requester to write: what changed and why this design-tracker closeout was the right implementation choice.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Marked the folder-to-notes Sources UI exposure spec as Approved for implementation planning and closed the design tracker. Moved `TASK-400` to Done and linked to the completed implementation plan under `TASK-403`; docs-only, no product code changes.

<sup>Written for commit 41eb3f8e359ea0cc2c0e4e80c9b8804923863eb2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2101?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

