### PR TITLE
Stage 3B: clean up MCP protocol host dependencies

### DIFF
--- a/Docs/superpowers/plans/2026-05-29-mcp-unified-stage3b-protocol-host-deps-plan.md
+++ b/Docs/superpowers/plans/2026-05-29-mcp-unified-stage3b-protocol-host-deps-plan.md
@@ -1,0 +1,88 @@
+# MCP Unified Stage 3B Protocol Host Dependencies Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Remove the small remaining protocol-level host imports for telemetry, Redis factory defaults, and truthiness checks while preserving existing `tldw_server` behavior.
+
+**Architecture:** Keep `MCPProtocol` dependent on `MCPRuntimeDependencies` for host services. Move dynamic current-telemetry behavior into the default `tldw_server` adapter bundle, make idempotency's no-injection fallback runtime-neutral, and replace testing-helper truthiness imports with a local neutral helper.
+
+**Tech Stack:** Python 3.11, MCP Unified protocol/runtime dependency interfaces, pytest, Ruff, Bandit.
+
+**Status:** Complete
+
+---
+
+### Task 1: Add Stage 3B Protocol Boundary Tests
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/MCP_unified/tests/test_extraction_contracts.py`
+
+- [x] **Step 1: Add a failing import-boundary test for protocol host imports**
+
+Add an AST-based test that scans `tldw_Server_API/app/core/MCP_unified/protocol.py` and fails if it imports `tldw_Server_API.app.core.Infrastructure.redis_factory`, `tldw_Server_API.app.core.Metrics.telemetry`, or `tldw_Server_API.app.core.testing`.
+
+- [x] **Step 2: Add a failing dynamic telemetry adapter test**
+
+Update the existing telemetry test so `MCPProtocol()` gets current telemetry through the default dependency bundle, without monkeypatching `protocol.get_telemetry_manager`.
+
+- [x] **Step 3: Run RED tests**
+
+Run: `.venv/bin/python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_extraction_contracts.py -q`
+
+Expected: fail because `protocol.py` still imports the three host modules and default telemetry is still resolved directly in `MCPProtocol`.
+
+Observed: failed as expected with forbidden protocol imports and default telemetry resolving outside the runtime adapter.
+
+### Task 2: Implement Runtime-Neutral Protocol Helpers
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/MCP_unified/protocol.py`
+- Modify: `tldw_Server_API/app/core/MCP_unified/adapters/tldw_runtime.py`
+
+- [x] **Step 1: Remove protocol imports of host Redis, telemetry, and testing helpers**
+
+Delete the three direct imports from `protocol.py`.
+
+- [x] **Step 2: Add local truthiness helper**
+
+Add a small `_is_truthy()` helper in `protocol.py` and replace the three `is_truthy(...)` call sites.
+
+- [x] **Step 3: Make idempotency fallback runtime-neutral**
+
+Add an async no-op Redis factory in `protocol.py` that returns `None`, and use it only when `IdempotencyManager` is constructed without an injected factory.
+
+- [x] **Step 4: Move dynamic telemetry behavior to the tldw adapter bundle**
+
+Add a `TldwTelemetryProvider` proxy in `tldw_runtime.py` that calls `get_telemetry_manager()` on attribute access or `trace_context(...)`, and set `telemetry_provider=TldwTelemetryProvider()` in `build_default_runtime_dependencies()`.
+
+- [x] **Step 5: Simplify `MCPProtocol.telemetry`**
+
+Remove `_uses_default_telemetry_manager` and return `self.dependencies.telemetry_provider` from the telemetry property.
+
+### Task 3: Verify And Close Out
+
+**Files:**
+- Modify: `backlog/tasks/task-542 - Implement-MCP-Unified-Stage-3B-protocol-host-dependency-cleanup.md`
+- Modify: `Docs/superpowers/plans/2026-05-29-mcp-unified-stage3b-protocol-host-deps-plan.md`
+
+- [x] **Step 1: Run focused pytest**
+
+Run: `.venv/bin/python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_extraction_contracts.py tldw_Server_API/app/core/MCP_unified/tests/test_basic_functionality.py tldw_Server_API/app/core/MCP_unified/tests/test_protocol_allowed_tools.py tldw_Server_API/app/core/MCP_unified/tests/test_server_batch_and_formatting.py tldw_Server_API/app/core/MCP_unified/tests/test_stage2_context_session.py tldw_Server_API/app/core/MCP_unified/tests/test_scope_and_fallbacks.py -q`
+
+Result: 56 passed, 5 warnings.
+
+- [x] **Step 2: Run Ruff**
+
+Run: `.venv/bin/python -m ruff check tldw_Server_API/app/core/MCP_unified/protocol.py tldw_Server_API/app/core/MCP_unified/adapters/tldw_runtime.py tldw_Server_API/app/core/MCP_unified/tests/test_extraction_contracts.py mcp_unified/interfaces tldw_Server_API/app/core/MCP_unified/interfaces`
+
+Result: all checks passed.
+
+- [x] **Step 3: Run Bandit**
+
+Run: `.venv/bin/python -m bandit -r tldw_Server_API/app/core/MCP_unified/protocol.py tldw_Server_API/app/core/MCP_unified/adapters/tldw_runtime.py mcp_unified/interfaces tldw_Server_API/app/core/MCP_unified/interfaces -f json -o /tmp/bandit_mcp_stage3b_protocol_host_deps.json`
+
+Result: completed with `"results": []`.
+
+- [x] **Step 4: Update Backlog task and commit**
+
+Record verification results in TASK-542, mark acceptance criteria and DoD complete, then commit the Stage 3B slice.

--- a/backlog/tasks/task-542 - Implement-MCP-Unified-Stage-3B-protocol-host-dependency-cleanup.md
+++ b/backlog/tasks/task-542 - Implement-MCP-Unified-Stage-3B-protocol-host-dependency-cleanup.md
@@ -40,6 +40,7 @@ Docs/superpowers/plans/2026-05-29-mcp-unified-stage3b-protocol-host-deps-plan.md
 - Added a dynamic telemetry regression test that monkeypatches the tldw runtime adapter and verifies trace calls dispatch to the current telemetry manager through the default dependency bundle.
 - Removed direct protocol imports for telemetry, Redis factory fallback, and testing truthiness parsing; added local neutral helpers for truthy parsing and no-Redis fallback behavior.
 - Added `TldwTelemetryProvider` to the host adapter bundle so default in-repo runtime dependencies preserve current telemetry manager lookup without protocol-level host imports.
+- Review fix pass: rebased onto current `origin/dev`, moved the tldw runtime dependency builder import out of protocol module import time, annotated `MCPProtocol.telemetry`, added import-boundary coverage for relative imports, and logged the Redis factory-None fallback.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary
@@ -54,6 +55,13 @@ Verification:
 - Bandit: `.venv/bin/python -m bandit -r tldw_Server_API/app/core/MCP_unified/protocol.py tldw_Server_API/app/core/MCP_unified/adapters/tldw_runtime.py mcp_unified/interfaces tldw_Server_API/app/core/MCP_unified/interfaces -f json -o /tmp/bandit_mcp_stage3b_protocol_host_deps.json` -> `"results": []`.
 
 Known skips or blockers: none.
+
+Review fix verification after rebasing on current `origin/dev`:
+- RED: `.venv/bin/python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_extraction_contracts.py tldw_Server_API/app/core/MCP_unified/tests/test_idempotency_and_category.py::test_idempotency_warns_when_redis_factory_returns_none -q` failed as expected on the top-level adapter import and missing Redis factory-None warning.
+- GREEN: `.venv/bin/python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_extraction_contracts.py tldw_Server_API/app/core/MCP_unified/tests/test_idempotency_and_category.py tldw_Server_API/app/core/MCP_unified/tests/test_basic_functionality.py tldw_Server_API/app/core/MCP_unified/tests/test_protocol_allowed_tools.py tldw_Server_API/app/core/MCP_unified/tests/test_server_batch_and_formatting.py tldw_Server_API/app/core/MCP_unified/tests/test_stage2_context_session.py tldw_Server_API/app/core/MCP_unified/tests/test_scope_and_fallbacks.py -q` -> 68 passed, 5 warnings.
+- Ruff: `.venv/bin/python -m ruff check tldw_Server_API/app/core/MCP_unified/protocol.py tldw_Server_API/app/core/MCP_unified/adapters/tldw_runtime.py tldw_Server_API/app/core/MCP_unified/tests/test_extraction_contracts.py tldw_Server_API/app/core/MCP_unified/tests/test_idempotency_and_category.py mcp_unified/interfaces tldw_Server_API/app/core/MCP_unified/interfaces` -> all checks passed.
+- Bandit runtime scope: `.venv/bin/python -m bandit -r tldw_Server_API/app/core/MCP_unified/protocol.py tldw_Server_API/app/core/MCP_unified/adapters/tldw_runtime.py mcp_unified/interfaces tldw_Server_API/app/core/MCP_unified/interfaces -f json -o /tmp/bandit_mcp_stage3b_review_fixes_runtime.json` -> `"results": []`.
+- Note: a test-inclusive Bandit run was also attempted and only surfaced the repo's existing pytest assert/temp-path baseline noise in MCP test modules.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-542 - Implement-MCP-Unified-Stage-3B-protocol-host-dependency-cleanup.md
+++ b/backlog/tasks/task-542 - Implement-MCP-Unified-Stage-3B-protocol-host-dependency-cleanup.md
@@ -1,0 +1,67 @@
+---
+id: TASK-542
+title: Implement MCP Unified Stage 3B protocol host-dependency cleanup
+status: Done
+labels:
+- mcp
+- mcp-unified
+- standalone
+- stage3
+priority: medium
+documentation:
+- Docs/superpowers/specs/2026-05-26-mcp-unified-standalone-library-gateway-design.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Continue MCP Unified standalone extraction after Stage 3A merged by removing small remaining protocol-level host dependencies for telemetry, Redis factory defaults, and truthiness helpers. Keep tldw_server compatibility behavior intact and do not start standalone gateway work.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 MCPProtocol uses injected runtime dependencies for telemetry and Redis idempotency defaults without importing tldw_server telemetry or redis factory directly.
+- [x] #2 Protocol truthiness checks use a runtime-neutral local helper instead of importing tldw_server testing helpers.
+- [x] #3 Default tldw_server runtime dependencies preserve dynamic current telemetry manager behavior through a host adapter/proxy.
+- [x] #4 Focused tests cover the protocol import cleanup and compatibility behavior.
+- [x] #5 Focused pytest, Ruff, and Bandit verification are recorded.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Docs/superpowers/plans/2026-05-29-mcp-unified-stage3b-protocol-host-deps-plan.md
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+- Added an AST contract test that fails if `protocol.py` imports the tldw Redis factory, telemetry manager, or testing truthiness helper directly.
+- Added a dynamic telemetry regression test that monkeypatches the tldw runtime adapter and verifies trace calls dispatch to the current telemetry manager through the default dependency bundle.
+- Removed direct protocol imports for telemetry, Redis factory fallback, and testing truthiness parsing; added local neutral helpers for truthy parsing and no-Redis fallback behavior.
+- Added `TldwTelemetryProvider` to the host adapter bundle so default in-repo runtime dependencies preserve current telemetry manager lookup without protocol-level host imports.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Implemented Stage 3B protocol host-dependency cleanup. `MCPProtocol` now depends on injected runtime dependencies for telemetry and Redis idempotency defaults, local protocol truthiness parsing no longer imports `tldw_Server_API.app.core.testing`, and the tldw adapter supplies a dynamic telemetry proxy for default server compatibility.
+
+Verification:
+- RED: `.venv/bin/python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_extraction_contracts.py -q` failed as expected on forbidden protocol imports and telemetry compatibility.
+- GREEN: `.venv/bin/python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_extraction_contracts.py tldw_Server_API/app/core/MCP_unified/tests/test_basic_functionality.py tldw_Server_API/app/core/MCP_unified/tests/test_protocol_allowed_tools.py tldw_Server_API/app/core/MCP_unified/tests/test_server_batch_and_formatting.py tldw_Server_API/app/core/MCP_unified/tests/test_stage2_context_session.py tldw_Server_API/app/core/MCP_unified/tests/test_scope_and_fallbacks.py -q` -> 56 passed, 5 warnings.
+- Ruff: `.venv/bin/python -m ruff check tldw_Server_API/app/core/MCP_unified/protocol.py tldw_Server_API/app/core/MCP_unified/adapters/tldw_runtime.py tldw_Server_API/app/core/MCP_unified/tests/test_extraction_contracts.py mcp_unified/interfaces tldw_Server_API/app/core/MCP_unified/interfaces` -> all checks passed.
+- Bandit: `.venv/bin/python -m bandit -r tldw_Server_API/app/core/MCP_unified/protocol.py tldw_Server_API/app/core/MCP_unified/adapters/tldw_runtime.py mcp_unified/interfaces tldw_Server_API/app/core/MCP_unified/interfaces -f json -o /tmp/bandit_mcp_stage3b_protocol_host_deps.json` -> `"results": []`.
+
+Known skips or blockers: none.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/tldw_Server_API/app/core/MCP_unified/adapters/tldw_runtime.py
+++ b/tldw_Server_API/app/core/MCP_unified/adapters/tldw_runtime.py
@@ -48,6 +48,27 @@ _TLDW_RUNTIME_ADAPTER_EXCEPTIONS = (
 )
 
 
+class TldwTelemetryProvider:
+    """Proxy the current tldw_server telemetry manager for MCP protocol spans."""
+
+    @staticmethod
+    def _current() -> Any:
+        """Return the current host telemetry manager."""
+        return get_telemetry_manager()
+
+    def trace_context(
+        self,
+        operation_name: str,
+        attributes: dict[str, Any] | None = None,
+    ) -> Any:
+        """Open a trace context through the current host telemetry manager."""
+        return self._current().trace_context(operation_name, attributes)
+
+    def __getattr__(self, name: str) -> Any:
+        """Forward compatibility methods to the current host telemetry manager."""
+        return getattr(self._current(), name)
+
+
 class TldwDatabasePathResolver:
     """Resolve per-user database paths through the tldw_server DB path helper."""
 
@@ -327,7 +348,7 @@ def build_default_runtime_dependencies() -> MCPRuntimeDependencies:
         rbac_policy=get_rbac_policy(),
         rate_limiter=get_rate_limiter(),
         metrics_collector=get_metrics_collector(),
-        telemetry_provider=get_telemetry_manager(),
+        telemetry_provider=TldwTelemetryProvider(),
         database_path_resolver=TldwDatabasePathResolver(),
         api_key_scope_normalizer=TldwApiKeyScopeNormalizer(),
         effective_policy_resolver=TldwEffectivePolicyResolver(),

--- a/tldw_Server_API/app/core/MCP_unified/protocol.py
+++ b/tldw_Server_API/app/core/MCP_unified/protocol.py
@@ -34,11 +34,10 @@ except ImportError:  # Fallback for v1
 
 from loguru import logger
 
-from .adapters.tldw_runtime import build_default_runtime_dependencies
 from .auth.authnz_rbac import Action, Resource
 from .auth.rate_limiter import RateLimitExceeded
 from .config import get_config
-from .interfaces.runtime import MCPRuntimeDependencies
+from .interfaces.runtime import MCPRuntimeDependencies, TelemetryProvider
 from .modules.base import BaseModule
 
 try:  # pragma: no cover - optional dependency
@@ -280,6 +279,11 @@ class IdempotencyManager:
                     redis_kwargs=params,
                 )
                 if self._redis_client is None:
+                    logger.warning(
+                        "MCP idempotency Redis unavailable; falling back to local locks. "
+                        "Error: Redis client factory returned None for context=mcp_idempotency",
+                    )
+                    self._redis_client = None
                     self._redis_ready = False
                     return False
                 self._redis_ready = True
@@ -540,7 +544,11 @@ class MCPProtocol:
     """
 
     def __init__(self, dependencies: MCPRuntimeDependencies | None = None):
-        self.dependencies = dependencies or build_default_runtime_dependencies()
+        if dependencies is None:
+            from .adapters.tldw_runtime import build_default_runtime_dependencies
+
+            dependencies = build_default_runtime_dependencies()
+        self.dependencies = dependencies
         self.module_registry = self.dependencies.module_registry
         self.rbac_policy = self.dependencies.rbac_policy
         self.rate_limiter = self.dependencies.rate_limiter
@@ -577,7 +585,7 @@ class MCPProtocol:
         logger.info("MCP Protocol handler initialized")
 
     @property
-    def telemetry(self):
+    def telemetry(self) -> TelemetryProvider:
         """Return the injected telemetry provider."""
         return self.dependencies.telemetry_provider
 

--- a/tldw_Server_API/app/core/MCP_unified/protocol.py
+++ b/tldw_Server_API/app/core/MCP_unified/protocol.py
@@ -5,11 +5,16 @@ Implements JSON-RPC 2.0 with enhanced error handling and request routing.
 """
 
 import asyncio
+import contextlib
 import hashlib
 import hmac
+import inspect
 import json
+import re
 import secrets
+import time
 import uuid
+from collections import OrderedDict
 from dataclasses import asdict, dataclass, is_dataclass
 from datetime import datetime, timezone
 from enum import IntEnum
@@ -26,21 +31,12 @@ except ImportError:  # Fallback for v1
         from pydantic import root_validator as model_validator  # type: ignore
     except ImportError:
         model_validator = None  # type: ignore
-import contextlib
-import inspect
-import re
-import time
-from collections import OrderedDict
 
 from loguru import logger
 
-from tldw_Server_API.app.core.Infrastructure.redis_factory import create_async_redis_client
-from tldw_Server_API.app.core.Metrics.telemetry import get_telemetry_manager
-from tldw_Server_API.app.core.testing import is_truthy
-
+from .adapters.tldw_runtime import build_default_runtime_dependencies
 from .auth.authnz_rbac import Action, Resource
 from .auth.rate_limiter import RateLimitExceeded
-from .adapters.tldw_runtime import build_default_runtime_dependencies
 from .config import get_config
 from .interfaces.runtime import MCPRuntimeDependencies
 from .modules.base import BaseModule
@@ -121,6 +117,20 @@ _MCP_PROTOCOL_NONCRITICAL_EXCEPTIONS = (
 )
 
 _MCP_TOOL_EXECUTION_ERROR = "tool_execution_error"
+_TRUTHY_VALUES = {"1", "true", "yes", "y", "on"}
+
+
+def _is_truthy(value: Any) -> bool:
+    """Parse host-neutral truthy flags without importing tldw_server helpers."""
+    try:
+        return str(value or "").strip().lower() in _TRUTHY_VALUES
+    except _MCP_PROTOCOL_NONCRITICAL_EXCEPTIONS:
+        return False
+
+
+async def _no_redis_client_factory(**_kwargs: Any) -> None:
+    """Fallback Redis factory used when embedders do not provide Redis support."""
+    return None
 
 
 class MCPRequest(BaseModel):
@@ -234,7 +244,7 @@ class IdempotencyManager:
         self._redis_ready = False
         self._redis_attempted = False
         self._redis_guard = asyncio.Lock()
-        self._redis_client_factory = redis_client_factory or create_async_redis_client
+        self._redis_client_factory = redis_client_factory or _no_redis_client_factory
 
     def _prune_local_locks(self) -> None:
         """Drop stale local locks once their cache/binding entries are gone."""
@@ -269,6 +279,9 @@ class IdempotencyManager:
                     context="mcp_idempotency",
                     redis_kwargs=params,
                 )
+                if self._redis_client is None:
+                    self._redis_ready = False
+                    return False
                 self._redis_ready = True
             except _MCP_PROTOCOL_NONCRITICAL_EXCEPTIONS as exc:
                 logger.warning(
@@ -527,7 +540,6 @@ class MCPProtocol:
     """
 
     def __init__(self, dependencies: MCPRuntimeDependencies | None = None):
-        self._uses_default_telemetry_manager = dependencies is None
         self.dependencies = dependencies or build_default_runtime_dependencies()
         self.module_registry = self.dependencies.module_registry
         self.rbac_policy = self.dependencies.rbac_policy
@@ -566,9 +578,7 @@ class MCPProtocol:
 
     @property
     def telemetry(self):
-        """Return current global telemetry by default, or the injected provider."""
-        if self._uses_default_telemetry_manager:
-            return get_telemetry_manager()
+        """Return the injected telemetry provider."""
         return self.dependencies.telemetry_provider
 
     async def _rbac_check(self, user_id: Optional[str], resource: Resource, action: Action, resource_id: Optional[str] = None) -> bool:
@@ -993,7 +1003,7 @@ class MCPProtocol:
         if isinstance(raw, (int, float)):
             return bool(raw)
         if isinstance(raw, str):
-            return is_truthy(raw)
+            return _is_truthy(raw)
         return False
 
     @staticmethod
@@ -1425,7 +1435,7 @@ class MCPProtocol:
             masked = self._mask_secrets(str(e))
             secret_redacted = bool(getattr(e, "_mcp_masked_secret", False)) or masked != str(e)
             if secret_redacted:
-                log.error(
+                log.error(  # noqa: TRY400 - avoid logging sanitized exception traceback.
                     f"MCP request failed: method={request.method}, error={masked}",
                     extra={"audit": True},
                 )
@@ -1459,7 +1469,7 @@ class MCPProtocol:
             masked = self._mask_secrets(str(e))
             secret_redacted = bool(getattr(e, "_mcp_masked_secret", False)) or masked != str(e)
             if secret_redacted:
-                log.error(
+                log.error(  # noqa: TRY400 - avoid logging sanitized exception traceback.
                     f"MCP request failed: method={request.method}, error={masked}",
                     extra={"audit": True},
                 )
@@ -1506,14 +1516,14 @@ class MCPProtocol:
         masked = self._mask_secrets(original)
         if masked == original:
             with contextlib.suppress(Exception):
-                setattr(exc, "_mcp_masked_secret", False)
+                exc._mcp_masked_secret = False
             return exc
         try:
             sanitized = exc.__class__(masked)
         except Exception:
             sanitized = RuntimeError(masked)
         with contextlib.suppress(Exception):
-            setattr(sanitized, "_mcp_masked_secret", True)
+            sanitized._mcp_masked_secret = True
         if hasattr(sanitized, "__dict__") and hasattr(exc, "__dict__"):
             with contextlib.suppress(Exception):
                 for attr in ("errno", "code", "name", "lineno"):
@@ -1522,7 +1532,7 @@ class MCPProtocol:
         with contextlib.suppress(Exception):
             sanitized.args = (masked,)
         with contextlib.suppress(Exception):
-            setattr(sanitized, "_mcp_masked_secret", True)
+            sanitized._mcp_masked_secret = True
         return sanitized
 
     @staticmethod
@@ -1533,7 +1543,7 @@ class MCPProtocol:
         except Exception:
             sanitized = RuntimeError(message)
         with contextlib.suppress(Exception):
-            setattr(sanitized, "_mcp_sanitized_error", True)
+            sanitized._mcp_sanitized_error = True
         return sanitized
 
     def _error_response(
@@ -1735,7 +1745,7 @@ class MCPProtocol:
             elif isinstance(raw_strict, (int, float)):
                 strict = bool(raw_strict)
             elif isinstance(raw_strict, str):
-                strict = is_truthy(raw_strict)
+                strict = _is_truthy(raw_strict)
         catalog_name = None
         catalog_id = None
         if isinstance(params, dict):
@@ -1948,7 +1958,7 @@ class MCPProtocol:
         metadata = getattr(context, "metadata", None)
         if not isinstance(metadata, dict):
             return None
-        if not is_truthy(metadata.get("mcp_policy_context_enabled")):
+        if not _is_truthy(metadata.get("mcp_policy_context_enabled")):
             return None
         cached = metadata.get("_mcp_effective_tool_policy")
         if isinstance(cached, dict):
@@ -2615,7 +2625,10 @@ class MCPProtocol:
                 return response_payload
 
             except _MCP_PROTOCOL_NONCRITICAL_EXCEPTIONS as e:
-                context.logger.error("Tool execution failed", error_type=e.__class__.__name__)
+                context.logger.error(  # noqa: TRY400 - structured audit log records sanitized type only.
+                    "Tool execution failed",
+                    error_type=e.__class__.__name__,
+                )
                 try:
                     duration = max(0.0, time.time() - t0)
                     self.metrics.record_module_operation(module=getattr(module, "name", "unknown"), operation="tools_call", duration=duration, success=False)

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_extraction_contracts.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_extraction_contracts.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import ast
+import contextlib
 import inspect
 from collections.abc import Callable
 from pathlib import Path
@@ -143,6 +144,22 @@ class _FakeAuthProvider:
         return ["fake.scope"] if info else []
 
 
+class _TelemetryManagerDouble:
+    """Telemetry manager double that exposes trace_context calls."""
+
+    def __init__(self, label: str) -> None:
+        self.label = label
+        self.trace_calls: list[tuple[str, dict[str, Any] | None]] = []
+
+    def trace_context(
+        self,
+        operation_name: str,
+        attributes: dict[str, Any] | None = None,
+    ) -> Any:
+        self.trace_calls.append((operation_name, attributes))
+        return contextlib.nullcontext(self.label)
+
+
 def _server_runtime_dependencies() -> SimpleNamespace:
     deps = _fake_runtime_dependencies()
     deps.module_registry = _RecordingModuleRegistry()
@@ -185,6 +202,17 @@ def _interface_boundary_violations_for(path: Path, interface_dir: Path) -> list[
     return violations
 
 
+def _absolute_import_sources_for(path: Path) -> list[str]:
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    imports: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imports.extend(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module and node.level == 0:
+            imports.append(node.module)
+    return imports
+
+
 def test_new_interface_modules_do_not_import_tldw_server_api() -> None:
     interface_dir = MCP_ROOT / "interfaces"
     assert interface_dir.exists()
@@ -196,6 +224,24 @@ def test_new_interface_modules_do_not_import_tldw_server_api() -> None:
         if violations:
             offenders[str(path)] = violations
     assert offenders == {}
+
+
+def test_protocol_uses_runtime_dependencies_for_stage3b_host_services() -> None:
+    forbidden_imports = {
+        "tldw_Server_API.app.core.Infrastructure.redis_factory",
+        "tldw_Server_API.app.core.Metrics.telemetry",
+        "tldw_Server_API.app.core.testing",
+    }
+
+    imports = _absolute_import_sources_for(MCP_ROOT / "protocol.py")
+    offenders = sorted(
+        source
+        for source in imports
+        if source in forbidden_imports
+        or any(source.startswith(f"{forbidden}.") for forbidden in forbidden_imports)
+    )
+
+    assert offenders == []
 
 
 def test_default_runtime_dependency_builder_exposes_core_dependencies() -> None:
@@ -459,24 +505,24 @@ def test_authnz_access_token_helper_documents_boolean_semantics() -> None:
 def test_default_server_protocol_uses_current_telemetry_manager(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    from tldw_Server_API.app.core.MCP_unified import protocol as protocol_mod
+    from tldw_Server_API.app.core.MCP_unified.adapters import tldw_runtime
     from tldw_Server_API.app.core.MCP_unified.server import MCPServer
 
-    first_manager = object()
-    second_manager = object()
-    deps = _fake_runtime_dependencies()
-    deps.telemetry_provider = first_manager
+    first_manager = _TelemetryManagerDouble("first")
+    second_manager = _TelemetryManagerDouble("second")
     current = {"manager": first_manager}
 
-    monkeypatch.setattr(protocol_mod, "build_default_runtime_dependencies", lambda: deps)
-    monkeypatch.setattr(protocol_mod, "get_telemetry_manager", lambda: current["manager"])
+    monkeypatch.setattr(tldw_runtime, "get_telemetry_manager", lambda: current["manager"])
 
     server = MCPServer()
 
-    assert server.dependencies is deps
-    assert server.protocol.telemetry is first_manager
+    with server.protocol.telemetry.trace_context("first-op", {"generation": 1}) as span:
+        assert span == "first"
     current["manager"] = second_manager
-    assert server.protocol.telemetry is second_manager
+    with server.protocol.telemetry.trace_context("second-op", {"generation": 2}) as span:
+        assert span == "second"
+    assert first_manager.trace_calls == [("first-op", {"generation": 1})]
+    assert second_manager.trace_calls == [("second-op", {"generation": 2})]
 
 
 def test_protocol_instances_do_not_share_prepared_call_secrets() -> None:

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_extraction_contracts.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_extraction_contracts.py
@@ -11,6 +11,7 @@ from typing import Any
 import pytest
 
 MCP_ROOT = Path(__file__).resolve().parents[1]
+MCP_PACKAGE = "tldw_Server_API.app.core.MCP_unified"
 EXPECTED_INTERFACE_FILES = {"runtime.py", "policy.py", "storage.py"}
 
 
@@ -202,14 +203,33 @@ def _interface_boundary_violations_for(path: Path, interface_dir: Path) -> list[
     return violations
 
 
-def _absolute_import_sources_for(path: Path) -> list[str]:
+def _resolve_import_from_source(package: str, module: str | None, level: int) -> str:
+    """Return an absolute module path for an ``ast.ImportFrom`` source."""
+    if level == 0:
+        return module or ""
+
+    package_parts = package.split(".")
+    base_parts = package_parts[: len(package_parts) - level + 1]
+    if module:
+        base_parts.extend(module.split("."))
+    return ".".join(base_parts)
+
+
+def _resolved_import_sources_for(
+    path: Path,
+    package: str,
+    *,
+    top_level_only: bool = False,
+) -> list[str]:
+    """Return import module sources from Python AST, resolving relative imports."""
     tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    nodes = tree.body if top_level_only else ast.walk(tree)
     imports: list[str] = []
-    for node in ast.walk(tree):
+    for node in nodes:
         if isinstance(node, ast.Import):
             imports.extend(alias.name for alias in node.names)
-        elif isinstance(node, ast.ImportFrom) and node.module and node.level == 0:
-            imports.append(node.module)
+        elif isinstance(node, ast.ImportFrom):
+            imports.append(_resolve_import_from_source(package, node.module, node.level))
     return imports
 
 
@@ -233,7 +253,7 @@ def test_protocol_uses_runtime_dependencies_for_stage3b_host_services() -> None:
         "tldw_Server_API.app.core.testing",
     }
 
-    imports = _absolute_import_sources_for(MCP_ROOT / "protocol.py")
+    imports = _resolved_import_sources_for(MCP_ROOT / "protocol.py", MCP_PACKAGE)
     offenders = sorted(
         source
         for source in imports
@@ -242,6 +262,32 @@ def test_protocol_uses_runtime_dependencies_for_stage3b_host_services() -> None:
     )
 
     assert offenders == []
+
+
+def test_protocol_boundary_scan_resolves_relative_imports(tmp_path: Path) -> None:
+    sample = tmp_path / "sample.py"
+    sample.write_text(
+        "from ..testing import is_truthy\n"
+        "from .adapters.tldw_runtime import build_default_runtime_dependencies\n",
+        encoding="utf-8",
+    )
+
+    imports = _resolved_import_sources_for(sample, MCP_PACKAGE)
+
+    assert imports == [
+        "tldw_Server_API.app.core.testing",
+        "tldw_Server_API.app.core.MCP_unified.adapters.tldw_runtime",
+    ]
+
+
+def test_protocol_import_time_boundary_does_not_load_tldw_runtime_adapter() -> None:
+    imports = _resolved_import_sources_for(
+        MCP_ROOT / "protocol.py",
+        MCP_PACKAGE,
+        top_level_only=True,
+    )
+
+    assert "tldw_Server_API.app.core.MCP_unified.adapters.tldw_runtime" not in imports
 
 
 def test_default_runtime_dependency_builder_exposes_core_dependencies() -> None:

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_idempotency_and_category.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_idempotency_and_category.py
@@ -1,18 +1,18 @@
+from typing import Any
+
 import pytest
 
-from typing import Dict, Any
-
-from tldw_Server_API.app.core.MCP_unified.config import get_config
 from tldw_Server_API.app.core.MCP_unified.command_runtime.adapters import (
     derive_step_idempotency_key,
 )
+from tldw_Server_API.app.core.MCP_unified.config import get_config
+from tldw_Server_API.app.core.MCP_unified.modules.base import BaseModule, ModuleConfig, create_tool_definition
 from tldw_Server_API.app.core.MCP_unified.modules.implementations.run_command_module import (
     RunCommandModule,
 )
-from tldw_Server_API.app.core.MCP_unified.protocol import IdempotencyManager, MCPProtocol, MCPRequest, RequestContext
-from tldw_Server_API.app.core.MCP_unified.modules.base import BaseModule, ModuleConfig, create_tool_definition
 from tldw_Server_API.app.core.MCP_unified.modules.registry import get_module_registry
 from tldw_Server_API.app.core.MCP_unified.monitoring.metrics import get_metrics_collector
+from tldw_Server_API.app.core.MCP_unified.protocol import IdempotencyManager, MCPProtocol, MCPRequest, RequestContext
 
 
 class AllowAllRBAC:
@@ -31,10 +31,10 @@ class _CountingWriteModule(BaseModule):
     async def on_shutdown(self) -> None:
         return None
 
-    async def check_health(self) -> Dict[str, bool]:
+    async def check_health(self) -> dict[str, bool]:
         return {"ok": True}
 
-    async def get_tools(self) -> list[Dict[str, Any]]:
+    async def get_tools(self) -> list[dict[str, Any]]:
         return [
             create_tool_definition(
                 name="write_count",
@@ -44,11 +44,11 @@ class _CountingWriteModule(BaseModule):
             )
         ]
 
-    def validate_tool_arguments(self, tool_name: str, arguments: Dict[str, Any]):
+    def validate_tool_arguments(self, tool_name: str, arguments: dict[str, Any]):
         if tool_name == "write_count" and (not isinstance(arguments, dict) or "x" not in arguments):
             raise ValueError("x required")
 
-    async def execute_tool(self, tool_name: str, arguments: Dict[str, Any], context=None):
+    async def execute_tool(self, tool_name: str, arguments: dict[str, Any], context=None):
         # Side effect: increment counter when actually executed
         self.counter += 1
         return f"count:{self.counter}:{arguments.get('x')}"
@@ -174,10 +174,10 @@ class _CategoryModule(BaseModule):
     async def on_shutdown(self) -> None:
         return None
 
-    async def check_health(self) -> Dict[str, bool]:
+    async def check_health(self) -> dict[str, bool]:
         return {"ok": True}
 
-    async def get_tools(self) -> list[Dict[str, Any]]:
+    async def get_tools(self) -> list[dict[str, Any]]:
         # Explicit metadata category must be preferred by protocol
         return [create_tool_definition(
             name="echo_meta_ingestion",
@@ -186,11 +186,11 @@ class _CategoryModule(BaseModule):
             metadata={"category": "ingestion"},
         )]
 
-    def validate_tool_arguments(self, tool_name: str, arguments: Dict[str, Any]):
+    def validate_tool_arguments(self, tool_name: str, arguments: dict[str, Any]):
         if "m" not in arguments:
             raise ValueError("m required")
 
-    async def execute_tool(self, tool_name: str, arguments: Dict[str, Any], context=None):
+    async def execute_tool(self, tool_name: str, arguments: dict[str, Any], context=None):
         return arguments.get("m")
 
 
@@ -234,6 +234,37 @@ async def test_idempotency_local_lock_map_prunes_with_cache_bounds():
     # Local cache is size-bounded, and lock bookkeeping should track cache lifetime.
     assert len(manager._local_cache) <= 3
     assert len(manager._local_locks) <= 3
+
+
+@pytest.mark.asyncio
+async def test_idempotency_warns_when_redis_factory_returns_none(monkeypatch):
+    from tldw_Server_API.app.core.MCP_unified import protocol as protocol_mod
+
+    class _Config:
+        """Config double that advertises Redis connection settings."""
+
+        def get_redis_connection_params(self) -> dict[str, str]:
+            """Return non-empty Redis params so the factory path is exercised."""
+            return {"url": "redis://localhost:6379/0"}
+
+    async def _none_factory(**_kwargs: Any) -> None:
+        """Return None to simulate a misconfigured Redis factory."""
+        return None
+
+    warnings: list[tuple[str, tuple[Any, ...], dict[str, Any]]] = []
+
+    def _record_warning(message: str, *args: Any, **kwargs: Any) -> None:
+        """Record warnings emitted by the protocol logger."""
+        warnings.append((message, args, kwargs))
+
+    monkeypatch.setattr(protocol_mod, "get_config", lambda: _Config())
+    monkeypatch.setattr(protocol_mod.logger, "warning", _record_warning)
+
+    manager = IdempotencyManager(redis_client_factory=_none_factory)
+
+    assert await manager._ensure_redis() is False
+    assert manager._redis_client is None
+    assert any("returned None" in message for message, _args, _kwargs in warnings)
 
 
 def test_nested_step_idempotency_is_stable_and_content_derived():


### PR DESCRIPTION
## Summary
- Removed direct `protocol.py` imports of the tldw Redis factory, telemetry manager, and testing truthiness helper.
- Added a host-adapter telemetry proxy so default in-repo MCP runtime dependencies still resolve the current telemetry manager dynamically.
- Added extraction contract coverage plus TASK-542 and the Stage 3B implementation plan.

## Change summary
This narrows the next Stage 3 extraction seam without starting the standalone gateway work. The protocol now stays on the runtime dependency boundary for telemetry and Redis idempotency defaults, while the tldw adapter owns the host-specific Redis factory and dynamic telemetry lookup. I kept the protocol truthiness helper local because it is a tiny dependency-free parsing rule and importing the broader testing helper would keep an avoidable host edge in the protocol layer.

## Verification
- `.venv/bin/python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_extraction_contracts.py -q`
  - RED run failed as expected on the forbidden imports and dynamic telemetry compatibility.
- `.venv/bin/python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_extraction_contracts.py tldw_Server_API/app/core/MCP_unified/tests/test_basic_functionality.py tldw_Server_API/app/core/MCP_unified/tests/test_protocol_allowed_tools.py tldw_Server_API/app/core/MCP_unified/tests/test_server_batch_and_formatting.py tldw_Server_API/app/core/MCP_unified/tests/test_stage2_context_session.py tldw_Server_API/app/core/MCP_unified/tests/test_scope_and_fallbacks.py -q`
  - 56 passed, 5 warnings.
- `.venv/bin/python -m ruff check tldw_Server_API/app/core/MCP_unified/protocol.py tldw_Server_API/app/core/MCP_unified/adapters/tldw_runtime.py tldw_Server_API/app/core/MCP_unified/tests/test_extraction_contracts.py mcp_unified/interfaces tldw_Server_API/app/core/MCP_unified/interfaces`
  - All checks passed.
- `.venv/bin/python -m bandit -r tldw_Server_API/app/core/MCP_unified/protocol.py tldw_Server_API/app/core/MCP_unified/adapters/tldw_runtime.py mcp_unified/interfaces tldw_Server_API/app/core/MCP_unified/interfaces -f json -o /tmp/bandit_mcp_stage3b_protocol_host_deps.json`
  - `"results": []`.

## Backlog
- TASK-542

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stage 3B removes the last host-specific imports from the MCP protocol and preserves dynamic telemetry via a host adapter proxy. This completes TASK-542 and keeps `tldw_server` behavior unchanged.

- **Refactors**
  - Removed direct `tldw_server` imports from `protocol.py` (Redis factory, telemetry, and testing truthiness).
  - Added `_is_truthy` and a runtime-neutral `_no_redis_client_factory`; idempotency now falls back to local locks and warns when the Redis factory returns `None`.
  - Introduced `TldwTelemetryProvider` in `tldw_runtime.py` and wired it into `build_default_runtime_dependencies()`; `MCPProtocol.telemetry` now always returns the injected provider.
  - Lazy-loaded `build_default_runtime_dependencies()` inside `MCPProtocol.__init__` to avoid adapter imports at protocol import time.
  - Expanded contract tests to resolve relative imports, guard protocol import-time boundaries, and verify the telemetry proxy’s `trace_context` dispatch.

<sup>Written for commit 439fb7fd0b9b63a062388f1a6f4f979863dce5b6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2102?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

