### PR TITLE
Migrate Flashcards image occlusion alerts

### DIFF
--- a/apps/packages/ui/scripts/design-system-product-state-baseline.json
+++ b/apps/packages/ui/scripts/design-system-product-state-baseline.json
@@ -44,28 +44,6 @@
     "migrationQueue": "shared-product-state"
   },
   {
-    "id": "antd-product-state-import:src/components/Flashcards/tabs/ImageOcclusionPanel.tsx:Alert#antd-alert-imageocclusionpanel-type-info-line-230-fgog2f",
-    "path": "src/components/Flashcards/tabs/ImageOcclusionPanel.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/Flashcards/tabs/ImageOcclusionPanel.tsx before the stable duplicate-id guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
-    "id": "antd-product-state-import:src/components/Flashcards/tabs/ImageOcclusionPanel.tsx:Alert#antd-alert-imageocclusionpanel-type-info-line-317-9ku49j",
-    "path": "src/components/Flashcards/tabs/ImageOcclusionPanel.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/Flashcards/tabs/ImageOcclusionPanel.tsx before the stable duplicate-id guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
     "id": "antd-product-state-import:src/components/Flashcards/tabs/ImportExport/ImportPanel.tsx:Alert#antd-alert-importpanel-type-warning-line-1099-o87fjq",
     "path": "src/components/Flashcards/tabs/ImportExport/ImportPanel.tsx",
     "rule": "antd-product-state-import",

--- a/apps/packages/ui/src/components/Flashcards/tabs/ImageOcclusionPanel.tsx
+++ b/apps/packages/ui/src/components/Flashcards/tabs/ImageOcclusionPanel.tsx
@@ -1,6 +1,7 @@
-import { Alert, Button, Card, Input, Typography } from "antd"
+import { Button, Card, Input, Typography } from "antd"
 import React from "react"
 import { useTranslation } from "react-i18next"
+import { Alert } from "@/components/ui/primitives"
 
 import {
   finalizeNormalizedOcclusionRect,
@@ -228,8 +229,7 @@ export const ImageOcclusionPanel: React.FC<ImageOcclusionPanelProps> = ({ onChan
 
       {!sourceUrl ? (
         <Alert
-          type="info"
-          showIcon
+          variant="info"
           title={t("option:flashcards.occlusionAwaitingImage", {
             defaultValue: "Choose an image to begin authoring occlusions."
           })}
@@ -315,8 +315,7 @@ export const ImageOcclusionPanel: React.FC<ImageOcclusionPanelProps> = ({ onChan
 
               {regions.length === 0 ? (
                 <Alert
-                  type="info"
-                  showIcon
+                  variant="info"
                   title={t("option:flashcards.occlusionNoRegions", {
                     defaultValue: "No regions yet. Draw on the image to add one."
                   })}

--- a/apps/packages/ui/src/components/Flashcards/tabs/__tests__/ImageOcclusionPanel.test.tsx
+++ b/apps/packages/ui/src/components/Flashcards/tabs/__tests__/ImageOcclusionPanel.test.tsx
@@ -96,4 +96,25 @@ describe("ImageOcclusionPanel", () => {
     })
     expect(screen.getByTestId("image-occlusion-selected-region")).toHaveTextContent("Region 1")
   })
+
+  it("renders empty authoring notices with the design-system Alert", async () => {
+    render(<ImageOcclusionPanel />)
+
+    const awaitingImageNotice = screen.getByText(
+      "Choose an image to begin authoring occlusions."
+    )
+    expect(awaitingImageNotice.closest('[data-ds-component="Alert"]')).toBeInTheDocument()
+
+    fireEvent.change(screen.getByLabelText("Upload image occlusion source"), {
+      target: {
+        files: [new File(["binary"], "diagram.png", { type: "image/png" })]
+      }
+    })
+
+    expect(await screen.findByAltText("Image occlusion source preview")).toBeInTheDocument()
+    const noRegionsNotice = screen.getByText(
+      "No regions yet. Draw on the image to add one."
+    )
+    expect(noRegionsNotice.closest('[data-ds-component="Alert"]')).toBeInTheDocument()
+  })
 })

--- a/backlog/tasks/task-543 - Migrate-Flashcards-ImageOcclusionPanel-alerts-to-design-system-Alert.md
+++ b/backlog/tasks/task-543 - Migrate-Flashcards-ImageOcclusionPanel-alerts-to-design-system-Alert.md
@@ -1,0 +1,56 @@
+---
+id: TASK-543
+title: Migrate Flashcards ImageOcclusionPanel alerts to design-system Alert
+status: Done
+labels:
+- flashcards
+- design-system
+- webui
+priority: medium
+modified_files:
+- apps/packages/ui/src/components/Flashcards/tabs/ImageOcclusionPanel.tsx
+- apps/packages/ui/src/components/Flashcards/tabs/__tests__/ImageOcclusionPanel.test.tsx
+- apps/packages/ui/scripts/design-system-product-state-baseline.json
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Replace the remaining AntD informational Alert notices in the Flashcards ImageOcclusionPanel authoring workflow with the shared design-system Alert primitive, preserving the upload/region authoring behavior and removing the migrated baseline exceptions.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Focused ImageOcclusionPanel test proves the empty image and empty regions notices render through data-ds-component="Alert".
+- [x] #2 Existing image upload, region drawing, label editing, and selection behavior remains covered.
+- [x] #3 ImageOcclusionPanel Alert baseline exceptions are removed.
+- [x] #4 Focused Flashcards ImageOcclusionPanel verification and known product-state verifier caveats are recorded.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Verify the existing ImageOcclusionPanel test baseline on current dev. 2. Add focused failing assertions that both empty image/empty region notices render with data-ds-component="Alert". 3. Replace the AntD informational alerts with the shared design-system Alert primitive while preserving translated copy and panel behavior. 4. Remove the two migrated ImageOcclusionPanel baseline exceptions. 5. Run focused tests, product-state checks, and diff hygiene.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+TDD red/green completed. Added focused coverage for the two empty authoring notices: the initial "Choose an image" state and the uploaded-image/no-regions state. The RED run failed because the existing AntD Alert did not expose `data-ds-component="Alert"`. Replaced only those two informational notices with the shared design-system Alert primitive using `variant="info"`, preserving translated title copy and authoring flow. Removed the two Flashcards ImageOcclusionPanel Alert baseline exceptions. PR review follow-up: switched the design-system Alert import/usages from the temporary `DsAlert` alias to direct `Alert` now that AntD Alert is no longer imported in this file. Verification: baseline ImageOcclusionPanel Vitest passed before implementation; focused RED failed for the missing design-system marker; focused GREEN passed; full ImageOcclusionPanel Vitest passes 2/2; exact baseline grep shows no ImageOcclusionPanel Alert exception remains. `bun run verify:design-system-state` still exits 1 on unrelated Integrations/Writing/Notes/Research product-state findings and stale Integrations baseline entries, while Flashcards exceptions dropped from 32 to 30 and ImageOcclusionPanel no longer appears. Bandit skipped because this slice only touches frontend TSX, baseline JSON, and Backlog markdown.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Migrated the Flashcards ImageOcclusionPanel empty-state informational notices from AntD Alert to the shared design-system Alert primitive using the direct `Alert` import requested in PR review. Added focused test coverage for both notices and removed the migrated ImageOcclusionPanel Alert product-state baseline exceptions. Verification: ImageOcclusionPanel Vitest passes 2/2; exact baseline grep has no ImageOcclusionPanel Alert match; broader product-state verifier still fails on unrelated baseline findings outside this Flashcards slice. Bandit skipped because no Python files changed.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## Summary
- Replace the Flashcards ImageOcclusionPanel empty-state AntD Alerts with the shared design-system Alert primitive.
- Add focused coverage for the initial no-image notice and uploaded-image/no-regions notice using the design-system marker.
- Remove the migrated ImageOcclusionPanel Alert product-state baseline exceptions and close Backlog TASK-543.

## Test Plan
- [x] bunx vitest run src/components/Flashcards/tabs/__tests__/ImageOcclusionPanel.test.tsx
- [x] git diff --check
- [x] git diff --cached --check
- [x] rg -n "ImageOcclusionPanel\.tsx:Alert|ImageOcclusionPanel\.tsx.*Alert" apps/packages/ui/scripts/design-system-product-state-baseline.json (no matches)
- [ ] bun run verify:design-system-state (currently exits 1 on unrelated Integrations/Writing/Notes/Research baseline findings; ImageOcclusionPanel no longer appears and Flashcards exceptions dropped from 32 to 30)

## Change summary
This keeps the image occlusion authoring workflow behavior unchanged while moving its two empty-state notices onto the shared product-state primitive. The test covers the states users hit before and immediately after uploading an image, which are the two migrated callouts represented in the baseline cleanup.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrated the Flashcards ImageOcclusionPanel empty-state notices from `antd` `Alert` to the shared design-system `Alert`, with no behavior changes. Closes TASK-543.

- **Refactors**
  - Added tests that assert the `data-ds-component="Alert"` marker for both notices.
  - Removed the two `ImageOcclusionPanel` `Alert` entries from the product-state baseline.

<sup>Written for commit b64e5ca10bec99fcbc1f856084a626cb3a79351e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2104?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

