### PR TITLE
Stage 3C: extract MCP server host dependency seams

### DIFF
--- a/Docs/superpowers/plans/2026-05-29-mcp-unified-stage3c-server-host-deps-plan.md
+++ b/Docs/superpowers/plans/2026-05-29-mcp-unified-stage3c-server-host-deps-plan.md
@@ -1,0 +1,21 @@
+# MCP Unified Stage 3C Server Host Dependency Cleanup Plan
+
+Backlog: TASK-543
+
+## Stage 1: Contract Tests
+**Goal**: Capture the remaining `server.py` host dependency leaks before implementation.
+**Success Criteria**: Focused extraction tests fail for import-boundary, missing runtime exports, WebSocket stream factory injection, and AuthNZ websocket fail-closed behavior.
+**Tests**: `python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_extraction_contracts.py -q`
+**Status**: Complete
+
+## Stage 2: Runtime Adapter Seams
+**Goal**: Move env/test helper access and WebSocket stream construction behind runtime dependency protocols.
+**Success Criteria**: `server.py` no longer imports host testing helpers or `WebSocketStream`; default tldw runtime dependencies preserve current behavior.
+**Tests**: Focused MCP Unified extraction and server tests.
+**Status**: Complete
+
+## Stage 3: Verification And PR
+**Goal**: Verify the slice, update task records, and publish a reviewable PR.
+**Success Criteria**: Focused pytest, Ruff, and Bandit pass; Backlog task includes verification evidence; branch is committed, pushed, and PR opened.
+**Tests**: Focused pytest set, `ruff check`, and scoped Bandit.
+**Status**: Complete

--- a/backlog/tasks/task-543 - Implement-MCP-Unified-Stage-3C-server-host-dependency-cleanup.md
+++ b/backlog/tasks/task-543 - Implement-MCP-Unified-Stage-3C-server-host-dependency-cleanup.md
@@ -1,0 +1,67 @@
+---
+id: TASK-543
+title: Implement MCP Unified Stage 3C server host-dependency cleanup
+status: Done
+assignee: []
+created_date: ''
+updated_date: '2026-05-29 01:47'
+labels:
+  - mcp
+  - mcp-unified
+  - standalone
+  - stage3
+dependencies: []
+documentation:
+  - >-
+    Docs/superpowers/specs/2026-05-26-mcp-unified-standalone-library-gateway-design.md
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Continue MCP Unified standalone extraction after Stage 3B merged by removing server.py import-time host dependencies for testing helpers, AuthNZ exceptions, and WebSocket stream construction. Preserve existing tldw_server WebSocket/auth/test behavior through runtime adapters and focused compatibility tests.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 MCP server.py no longer imports tldw_server testing helpers, AuthNZ exception classes, or WebSocketStream at module import time.
+- [x] #2 Runtime dependencies expose host-neutral environment flag and WebSocket stream construction seams, with tldw_runtime preserving current behavior.
+- [x] #3 AuthNZ websocket token failures are handled inside the tldw auth adapter so server.py does not need AuthNZ exception classes in its noncritical exception tuple.
+- [x] #4 Focused tests cover server import-boundary cleanup, runtime dependency exports, WebSocket stream factory injection, and AuthNZ adapter fail-closed behavior.
+- [x] #5 Focused pytest, Ruff, and Bandit verification are recorded.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Docs/superpowers/plans/2026-05-29-mcp-unified-stage3c-server-host-deps-plan.md
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Verification: RED extraction contracts failed for the expected missing seams; focused pytest passed with 71 tests; Ruff passed on touched files; Bandit scoped scan wrote /tmp/bandit_mcp_stage3c_server_host_deps.json with empty results.
+
+Test hygiene: switched touched WebSocket security tests to monkeypatch.setenv so MCP_WS_* values do not leak into later WebSocket workspace tests.
+
+Review fix pass after PR #2105 comments: added _handle_websocket_messages -> None annotation, restored AuthNZ-token MCP-JWT fallback gate when the adapter returns None, and added a host-neutral WebSocketStream protocol for the stream factory contract.
+
+Review verification: focused pytest passed with 74 tests; Ruff passed on touched files; Bandit scoped scan wrote /tmp/bandit_mcp_stage3c_server_host_deps_review.json with empty results.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Implemented MCP Unified Stage 3C server host-dependency cleanup and addressed PR #2105 review feedback. server.py no longer imports tldw_server testing helpers, AuthNZ exception classes, or WebSocketStream at module import time. Runtime dependencies now expose host-neutral environment flag and WebSocket stream contracts, the tldw runtime adapter preserves current behavior, AuthNZ websocket verification failures fail closed without allowing MCP-JWT fallback for AuthNZ tokens, and focused tests cover the boundary, contract, fallback, and WebSocket test-hygiene paths.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/mcp_unified/interfaces/__init__.py
+++ b/mcp_unified/interfaces/__init__.py
@@ -11,6 +11,7 @@ from .runtime import (
     AuthenticatedIdentity,
     CircuitBreakerFactory,
     DatabasePathResolver,
+    EnvironmentFlagsProvider,
     LifecycleGuard,
     MCPRuntimeDependencies,
     MetricsCollector,
@@ -23,6 +24,9 @@ from .runtime import (
     RedisClientFactory,
     ServerAuthProvider,
     TelemetryProvider,
+    WebSocketCloseTarget,
+    WebSocketStream,
+    WebSocketStreamFactory,
 )
 from .storage import (
     ApprovalPolicyStore,
@@ -43,6 +47,7 @@ __all__ = [
     "CredentialGrantStore",
     "DatabasePathResolver",
     "EffectivePolicyResolver",
+    "EnvironmentFlagsProvider",
     "ExternalAccessEvaluator",
     "ExternalRegistryStore",
     "LifecycleGuard",
@@ -60,4 +65,7 @@ __all__ = [
     "RedisClientFactory",
     "ServerAuthProvider",
     "TelemetryProvider",
+    "WebSocketCloseTarget",
+    "WebSocketStream",
+    "WebSocketStreamFactory",
 ]

--- a/mcp_unified/interfaces/runtime.py
+++ b/mcp_unified/interfaces/runtime.py
@@ -221,6 +221,52 @@ class PolicyContextProvider(Protocol):
     def is_policy_context_enabled(self) -> bool: ...
 
 
+class EnvironmentFlagsProvider(Protocol):
+    """Host environment/test-mode helper facade used by MCPServer."""
+
+    def env_flag_enabled(self, name: str) -> bool: ...
+
+    def is_test_mode(self) -> bool: ...
+
+    def is_explicit_pytest_runtime(self) -> bool: ...
+
+    def is_truthy(self, value: Any) -> bool: ...
+
+
+class WebSocketCloseTarget(Protocol):
+    """Minimal websocket close capability exposed through stream wrappers."""
+
+    async def close(self, code: int = 1000, reason: str = "") -> Any: ...
+
+
+class WebSocketStream(Protocol):
+    """Host-neutral websocket stream operations used by MCPServer."""
+
+    ws: WebSocketCloseTarget
+
+    async def start(self) -> None: ...
+
+    async def stop(self) -> None: ...
+
+    def mark_activity(self) -> None: ...
+
+    async def send_json(self, payload: dict[str, Any]) -> None: ...
+
+
+class WebSocketStreamFactory(Protocol):
+    """Factory for host websocket stream lifecycle wrappers."""
+
+    def __call__(
+        self,
+        websocket: Any,
+        *,
+        heartbeat_interval_s: float | None,
+        idle_timeout_s: float | None,
+        close_on_done: bool,
+        labels: dict[str, str],
+    ) -> WebSocketStream: ...
+
+
 @dataclass(slots=True)
 class MCPRuntimeDependencies:
     """Concrete dependency bundle passed into MCP runtime components."""
@@ -243,3 +289,5 @@ class MCPRuntimeDependencies:
     permission_seeder: PermissionSeeder
     module_config_provider: ModuleConfigProvider
     policy_context_provider: PolicyContextProvider
+    environment_flags_provider: EnvironmentFlagsProvider
+    websocket_stream_factory: WebSocketStreamFactory

--- a/tldw_Server_API/app/core/MCP_unified/adapters/tldw_runtime.py
+++ b/tldw_Server_API/app/core/MCP_unified/adapters/tldw_runtime.py
@@ -24,6 +24,7 @@ from tldw_Server_API.app.core.MCP_unified.auth.rate_limiter import get_rate_limi
 from tldw_Server_API.app.core.MCP_unified.interfaces.runtime import (
     AuthenticatedIdentity,
     MCPRuntimeDependencies,
+    WebSocketStream,
 )
 from tldw_Server_API.app.core.MCP_unified.modules.registry import get_module_registry
 from tldw_Server_API.app.core.MCP_unified.monitoring.metrics import get_metrics_collector
@@ -182,11 +183,22 @@ class TldwServerAuthProvider:
         websocket: Any,
     ) -> AuthenticatedIdentity | None:
         """Authenticate an AuthNZ websocket bearer token and project identity data."""
-        from starlette.requests import Request
+        try:
+            from starlette.requests import Request
 
-        from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import (
-            verify_jwt_and_fetch_user,
-        )
+            from tldw_Server_API.app.core.AuthNZ.exceptions import (
+                InvalidTokenError,
+                TokenExpiredError,
+            )
+            from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import (
+                verify_jwt_and_fetch_user,
+            )
+        except _TLDW_RUNTIME_ADAPTER_EXCEPTIONS as exc:
+            logger.debug(
+                "MCP AuthNZ websocket dependencies unavailable: {}",
+                exc.__class__.__name__,
+            )
+            return None
 
         try:
             scope = {
@@ -210,7 +222,20 @@ class TldwServerAuthProvider:
             )
             return None
 
-        user = await verify_jwt_and_fetch_user(Request(scope), token)
+        try:
+            user = await verify_jwt_and_fetch_user(Request(scope), token)
+        except (InvalidTokenError, TokenExpiredError) as exc:
+            logger.debug(
+                "MCP AuthNZ websocket token authentication failed closed: {}",
+                exc.__class__.__name__,
+            )
+            return None
+        except _TLDW_RUNTIME_ADAPTER_EXCEPTIONS as exc:
+            logger.debug(
+                "MCP AuthNZ websocket user lookup failed closed: {}",
+                exc.__class__.__name__,
+            )
+            return None
         user_id = str(getattr(user, "id", None) or "")
         if not user_id:
             return None
@@ -313,6 +338,58 @@ class TldwPolicyContextProvider:
         return is_mcp_hub_policy_enforcement_enabled()
 
 
+class TldwEnvironmentFlagsProvider:
+    """Expose tldw_server environment and test-mode helpers to MCPServer."""
+
+    def env_flag_enabled(self, name: str) -> bool:
+        """Return whether a named environment flag is enabled by host rules."""
+        from tldw_Server_API.app.core.testing import env_flag_enabled
+
+        return env_flag_enabled(name)
+
+    def is_test_mode(self) -> bool:
+        """Return whether the host process is running in test mode."""
+        from tldw_Server_API.app.core.testing import is_test_mode
+
+        return is_test_mode()
+
+    def is_explicit_pytest_runtime(self) -> bool:
+        """Return whether the host process is an explicit pytest runtime."""
+        from tldw_Server_API.app.core.testing import is_explicit_pytest_runtime
+
+        return is_explicit_pytest_runtime()
+
+    def is_truthy(self, value: Any) -> bool:
+        """Normalize host truthy environment-style values."""
+        from tldw_Server_API.app.core.testing import is_truthy
+
+        return is_truthy(value)
+
+
+class TldwWebSocketStreamFactory:
+    """Create tldw_server WebSocketStream wrappers for MCP websocket sessions."""
+
+    def __call__(
+        self,
+        websocket: Any,
+        *,
+        heartbeat_interval_s: float | None,
+        idle_timeout_s: float | None,
+        close_on_done: bool,
+        labels: dict[str, str],
+    ) -> WebSocketStream:
+        """Return a host WebSocketStream configured for MCP transport lifecycle."""
+        from tldw_Server_API.app.core.Streaming.streams import WebSocketStream
+
+        return WebSocketStream(
+            websocket,
+            heartbeat_interval_s=heartbeat_interval_s,
+            idle_timeout_s=idle_timeout_s,
+            close_on_done=close_on_done,
+            labels=labels,
+        )
+
+
 def _to_tldw_circuit_breaker_config(config: Any) -> CircuitBreakerConfig:
     """Convert a host-neutral circuit-breaker config to tldw_server config."""
     if isinstance(config, CircuitBreakerConfig):
@@ -362,4 +439,6 @@ def build_default_runtime_dependencies() -> MCPRuntimeDependencies:
         permission_seeder=TldwPermissionSeeder(),
         module_config_provider=TldwModuleConfigProvider(),
         policy_context_provider=TldwPolicyContextProvider(),
+        environment_flags_provider=TldwEnvironmentFlagsProvider(),
+        websocket_stream_factory=TldwWebSocketStreamFactory(),
     )

--- a/tldw_Server_API/app/core/MCP_unified/interfaces/__init__.py
+++ b/tldw_Server_API/app/core/MCP_unified/interfaces/__init__.py
@@ -10,6 +10,7 @@ from mcp_unified.interfaces import (
     CredentialGrantStore,
     DatabasePathResolver,
     EffectivePolicyResolver,
+    EnvironmentFlagsProvider,
     ExternalAccessEvaluator,
     ExternalRegistryStore,
     LifecycleGuard,
@@ -27,6 +28,9 @@ from mcp_unified.interfaces import (
     RedisClientFactory,
     ServerAuthProvider,
     TelemetryProvider,
+    WebSocketCloseTarget,
+    WebSocketStream,
+    WebSocketStreamFactory,
 )
 
 __all__ = [
@@ -39,6 +43,7 @@ __all__ = [
     "CredentialGrantStore",
     "DatabasePathResolver",
     "EffectivePolicyResolver",
+    "EnvironmentFlagsProvider",
     "ExternalAccessEvaluator",
     "ExternalRegistryStore",
     "LifecycleGuard",
@@ -56,4 +61,7 @@ __all__ = [
     "RedisClientFactory",
     "ServerAuthProvider",
     "TelemetryProvider",
+    "WebSocketCloseTarget",
+    "WebSocketStream",
+    "WebSocketStreamFactory",
 ]

--- a/tldw_Server_API/app/core/MCP_unified/interfaces/runtime.py
+++ b/tldw_Server_API/app/core/MCP_unified/interfaces/runtime.py
@@ -5,6 +5,7 @@ from mcp_unified.interfaces.runtime import (
     AuthenticatedIdentity,
     CircuitBreakerFactory,
     DatabasePathResolver,
+    EnvironmentFlagsProvider,
     LifecycleGuard,
     MCPRuntimeDependencies,
     MetricsCollector,
@@ -17,6 +18,9 @@ from mcp_unified.interfaces.runtime import (
     RedisClientFactory,
     ServerAuthProvider,
     TelemetryProvider,
+    WebSocketCloseTarget,
+    WebSocketStream,
+    WebSocketStreamFactory,
 )
 
 __all__ = [
@@ -24,6 +28,7 @@ __all__ = [
     "ApiKeyScopeNormalizer",
     "CircuitBreakerFactory",
     "DatabasePathResolver",
+    "EnvironmentFlagsProvider",
     "LifecycleGuard",
     "MCPRuntimeDependencies",
     "MetricsCollector",
@@ -36,4 +41,7 @@ __all__ = [
     "RedisClientFactory",
     "ServerAuthProvider",
     "TelemetryProvider",
+    "WebSocketCloseTarget",
+    "WebSocketStream",
+    "WebSocketStreamFactory",
 ]

--- a/tldw_Server_API/app/core/MCP_unified/server.py
+++ b/tldw_Server_API/app/core/MCP_unified/server.py
@@ -18,24 +18,9 @@ from typing import Any, Optional
 from fastapi import HTTPException, WebSocket, WebSocketDisconnect
 from loguru import logger
 
-from tldw_Server_API.app.core.AuthNZ.exceptions import InvalidTokenError, TokenExpiredError
-from tldw_Server_API.app.core.Streaming.streams import WebSocketStream
-from tldw_Server_API.app.core.testing import (
-    env_flag_enabled as _env_flag_enabled,
-)
-from tldw_Server_API.app.core.testing import (
-    is_explicit_pytest_runtime as _is_explicit_pytest_runtime,
-)
-from tldw_Server_API.app.core.testing import (
-    is_test_mode as _is_test_mode,
-)
-from tldw_Server_API.app.core.testing import (
-    is_truthy as _is_truthy,
-)
-
 from .auth.rate_limiter import RateLimitExceeded
 from .config import get_config, validate_config
-from .interfaces.runtime import MCPRuntimeDependencies
+from .interfaces.runtime import MCPRuntimeDependencies, WebSocketStream
 from .protocol import MCPProtocol, MCPRequest, MCPResponse, RequestContext
 from .security.ip_filter import get_ip_access_controller
 from .security.request_guards import enforce_client_certificate_headers
@@ -61,8 +46,6 @@ _MCP_SERVER_NONCRITICAL_EXCEPTIONS = (
     json.JSONDecodeError,
     HTTPException,
     WebSocketDisconnect,
-    InvalidTokenError,
-    TokenExpiredError,
     RateLimitExceeded,
 )
 
@@ -225,6 +208,8 @@ class MCPServer:
         self.permission_seeder = self.dependencies.permission_seeder
         self.module_config_provider = self.dependencies.module_config_provider
         self.policy_context_provider = self.dependencies.policy_context_provider
+        self.environment_flags_provider = self.dependencies.environment_flags_provider
+        self.websocket_stream_factory = self.dependencies.websocket_stream_factory
         self.jwt_manager = _JWTManagerProxy(self.auth_provider.get_mcp_jwt_manager())
         self.rbac_policy = self.dependencies.rbac_policy
         self.rate_limiter = self.dependencies.rate_limiter
@@ -284,6 +269,64 @@ class MCPServer:
             )
             return False
 
+    def _env_flag_enabled(self, name: str) -> bool:
+        """Return host-normalized boolean state for an environment flag."""
+        try:
+            return bool(self.environment_flags_provider.env_flag_enabled(name))
+        except _MCP_SERVER_NONCRITICAL_EXCEPTIONS as exc:
+            logger.warning(
+                "MCP environment flag resolution failed for {}: {}",
+                name,
+                self._mask_secrets(str(exc)),
+            )
+            return False
+
+    def _is_test_mode(self) -> bool:
+        """Return whether the host reports test mode for MCP behavior gates."""
+        try:
+            return bool(self.environment_flags_provider.is_test_mode())
+        except _MCP_SERVER_NONCRITICAL_EXCEPTIONS:
+            return False
+
+    def _is_explicit_pytest_runtime(self) -> bool:
+        """Return whether the host reports an explicit pytest runtime."""
+        try:
+            return bool(self.environment_flags_provider.is_explicit_pytest_runtime())
+        except _MCP_SERVER_NONCRITICAL_EXCEPTIONS:
+            return False
+
+    def _is_truthy(self, value: Any) -> bool:
+        """Return host-normalized truthiness, with a neutral local fallback."""
+        try:
+            return bool(self.environment_flags_provider.is_truthy(value))
+        except _MCP_SERVER_NONCRITICAL_EXCEPTIONS:
+            return self._fallback_truthy(value)
+
+    def _is_authnz_access_token(self, token: str) -> bool:
+        """Return whether the injected auth provider recognizes an AuthNZ token."""
+        try:
+            return bool(self.auth_provider.is_authnz_access_token(token))
+        except _MCP_SERVER_NONCRITICAL_EXCEPTIONS as exc:
+            logger.debug(
+                "MCP AuthNZ token detection failed closed: {}",
+                self._mask_secrets(str(exc)),
+            )
+            return False
+
+    @staticmethod
+    def _fallback_truthy(value: Any) -> bool:
+        """Parse common boolean environment values without host imports."""
+        if isinstance(value, bool):
+            return value
+        if value is None:
+            return False
+        return str(value).strip().lower() in {"1", "true", "t", "yes", "y", "on"}
+
+    @staticmethod
+    def _env_flag_explicitly_disabled(name: str) -> bool:
+        """Return True when an env flag is set to a common disabled value."""
+        return os.getenv(name, "").strip().lower() in {"0", "false", "off", "no", "n"}
+
     def _default_media_db_path(self) -> str:
         """Return the host-provided default media DB path for module config."""
         try:
@@ -294,6 +337,24 @@ class MCPServer:
                 self._mask_secrets(str(exc)),
             )
             return ""
+
+    def _create_websocket_stream(self, websocket: WebSocket) -> WebSocketStream:
+        """Create the host websocket stream wrapper for an accepted MCP session."""
+        return self.websocket_stream_factory(
+            websocket,
+            heartbeat_interval_s=(
+                float(self.config.ws_ping_interval)
+                if self.config.ws_ping_interval
+                else None
+            ),
+            idle_timeout_s=(
+                float(self.config.ws_idle_timeout_seconds)
+                if self.config.ws_idle_timeout_seconds
+                else None
+            ),
+            close_on_done=True,
+            labels={"component": "mcp", "endpoint": "mcp_ws"},
+        )
 
     def get_active_connection_count(self) -> int:
         return len(self.connections)
@@ -345,14 +406,14 @@ class MCPServer:
 
             try:
                 # Fail fast on insecure production configurations
-                _test_mode = _is_test_mode() or _is_explicit_pytest_runtime()
+                _test_mode = self._is_test_mode() or self._is_explicit_pytest_runtime()
                 if not self.config.debug_mode and not _test_mode:
                     ok = validate_config()
                     if not ok:
                         raise RuntimeError("MCP configuration validation failed; refusing to start in production")
                 # Warn if demo auth is enabled in a non-debug environment
                 try:
-                    if _env_flag_enabled("MCP_ENABLE_DEMO_AUTH") and not self.config.debug_mode:
+                    if self._env_flag_enabled("MCP_ENABLE_DEMO_AUTH") and not self.config.debug_mode:
                         logger.warning("MCP_ENABLE_DEMO_AUTH is enabled - for development only; DO NOT USE IN PRODUCTION")
                 except _MCP_SERVER_NONCRITICAL_EXCEPTIONS:
                     pass
@@ -462,8 +523,8 @@ class MCPServer:
                         logger.warning(f"Invalid MCP_MODULES item format: '{item}'")
 
             # 3) Optional default: enable media module if flag is set and nothing else specified
-            enable_media_flag = _env_flag_enabled("MCP_ENABLE_MEDIA_MODULE")
-            test_mode = _is_test_mode()
+            enable_media_flag = self._env_flag_enabled("MCP_ENABLE_MEDIA_MODULE")
+            test_mode = self._is_test_mode()
             if enable_media_flag and not modules_to_load:
                 default_media_path = self._default_media_db_path()
                 modules_to_load.append({
@@ -482,7 +543,7 @@ class MCPServer:
 
             # 4) Test convenience: default-enable media module when TEST_MODE unless explicitly disabled
             if test_mode and not any(m.get("id") == "media" for m in modules_to_load):
-                if os.getenv("MCP_ENABLE_MEDIA_MODULE", "").strip().lower() not in {"0", "false", "off", "no", "n"}:
+                if not self._env_flag_explicitly_disabled("MCP_ENABLE_MEDIA_MODULE"):
                     default_media_path = self._default_media_db_path()
                     modules_to_load.append({
                         "id": "media",
@@ -513,7 +574,7 @@ class MCPServer:
                     logger.info("MCP filesystem module enabled by default; queuing FilesystemModule for registration")
 
             # 6) Optional: Sandbox module (code interpreter) - disabled by default
-            if _env_flag_enabled("MCP_ENABLE_SANDBOX_MODULE"):
+            if self._env_flag_enabled("MCP_ENABLE_SANDBOX_MODULE"):
                 modules_to_load.append({
                     "id": "sandbox",
                     "class": "tldw_Server_API.app.core.MCP_unified.modules.implementations.sandbox_module:SandboxModule",
@@ -767,7 +828,9 @@ class MCPServer:
         resolved_ip = controller.resolve_client_ip(raw_remote_ip, forwarded_for, real_ip)
         # Test harness mapping and bypass: allow WS in pytest/TEST_MODE and map 'testclient' to loopback
         try:
-            _is_test_env = bool(_is_explicit_pytest_runtime() or _is_test_mode())
+            _is_test_env = bool(
+                self._is_explicit_pytest_runtime() or self._is_test_mode()
+            )
         except _MCP_SERVER_NONCRITICAL_EXCEPTIONS:
             _is_test_env = False
         if resolved_ip == "testclient" or resolved_ip is None and _is_test_env:
@@ -859,9 +922,14 @@ class MCPServer:
                         metadata["roles"] = list(identity.roles)
                     if identity.permissions:
                         metadata["permissions"] = list(identity.permissions)
+                elif self._is_authnz_access_token(auth_token):
+                    authnz_token_failed = True
+                    if not api_key:
+                        await websocket.close(code=1008, reason="Authentication failed")
+                        return
             except _MCP_SERVER_NONCRITICAL_EXCEPTIONS as e:
                 logger.debug(f"AuthNZ JWT auth failed: {self._mask_secrets(str(e))}")
-                if self.auth_provider.is_authnz_access_token(auth_token):
+                if self._is_authnz_access_token(auth_token):
                     authnz_token_failed = True
                     if not api_key:
                         await websocket.close(code=1008, reason="Authentication failed")
@@ -929,7 +997,7 @@ class MCPServer:
                 import os as _os
                 override = _os.getenv("MCP_WS_AUTH_REQUIRED")
                 if override is not None:
-                    override_val = _is_truthy(override)
+                    override_val = self._is_truthy(override)
                     if self.config.ws_auth_required == self._ws_auth_required_initial:
                         ws_auth_required = override_val
         except _MCP_SERVER_NONCRITICAL_EXCEPTIONS:
@@ -1005,14 +1073,9 @@ class MCPServer:
         )
 
         # Initialize unified WS lifecycle (ping/idle/error) and accept the socket
-        stream: Optional[WebSocketStream] = WebSocketStream(
-            websocket,
-            heartbeat_interval_s=float(self.config.ws_ping_interval) if self.config.ws_ping_interval else None,
-            idle_timeout_s=float(self.config.ws_idle_timeout_seconds) if self.config.ws_idle_timeout_seconds else None,
-            close_on_done=True,
-            labels={"component": "mcp", "endpoint": "mcp_ws"},
-        )
+        stream: Optional[WebSocketStream] = None
         try:
+            stream = self._create_websocket_stream(websocket)
             await stream.start()
             # Handle messages (domain JSON-RPC payloads go through send_json; no event-wrapping)
             await self._handle_websocket_messages(connection, stream)
@@ -1050,7 +1113,11 @@ class MCPServer:
             with suppress(_MCP_SERVER_NONCRITICAL_EXCEPTIONS):
                 self.metrics_collector.update_connection_count("websocket", len(self.connections))
 
-    async def _handle_websocket_messages(self, connection: WebSocketConnection, stream: WebSocketStream):
+    async def _handle_websocket_messages(
+        self,
+        connection: WebSocketConnection,
+        stream: WebSocketStream,
+    ) -> None:
         """Handle incoming WebSocket messages"""
         while True:
             sess: Optional[SessionData] = None

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_extraction_contracts.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_extraction_contracts.py
@@ -6,7 +6,7 @@ import inspect
 from collections.abc import Callable
 from pathlib import Path
 from types import SimpleNamespace
-from typing import Any
+from typing import Any, get_type_hints
 
 import pytest
 
@@ -36,6 +36,8 @@ def _fake_runtime_dependencies() -> SimpleNamespace:
         permission_seeder=object(),
         module_config_provider=object(),
         policy_context_provider=object(),
+        environment_flags_provider=_FakeEnvironmentFlagsProvider(),
+        websocket_stream_factory=_RecordingWebSocketStreamFactory(),
     )
 
 
@@ -112,6 +114,90 @@ class _FakePolicyContextProvider:
 
     def is_policy_context_enabled(self) -> bool:
         return self.enabled
+
+
+class _FakeEnvironmentFlagsProvider:
+    """Environment flag provider double with caller-controlled results."""
+
+    def __init__(
+        self,
+        *,
+        flags: dict[str, bool] | None = None,
+        test_mode: bool = False,
+        explicit_pytest_runtime: bool = False,
+        truthy_values: dict[Any, bool] | None = None,
+    ) -> None:
+        self.flags = flags or {}
+        self.test_mode = test_mode
+        self.explicit_pytest_runtime = explicit_pytest_runtime
+        self.truthy_values = truthy_values or {}
+        self.flag_calls: list[str] = []
+        self.truthy_calls: list[Any] = []
+
+    def env_flag_enabled(self, name: str) -> bool:
+        self.flag_calls.append(name)
+        return self.flags.get(name, False)
+
+    def is_test_mode(self) -> bool:
+        return self.test_mode
+
+    def is_explicit_pytest_runtime(self) -> bool:
+        return self.explicit_pytest_runtime
+
+    def is_truthy(self, value: Any) -> bool:
+        self.truthy_calls.append(value)
+        return self.truthy_values.get(value, False)
+
+
+class _FakeWebSocketStream:
+    """Sentinel stream object returned by the injected WebSocket stream factory."""
+
+    def __init__(self) -> None:
+        self.ws = SimpleNamespace(close=lambda *args, **kwargs: None)
+        self.sent: list[dict[str, Any]] = []
+        self.started = False
+        self.stopped = False
+        self.activity_marks = 0
+
+    async def start(self) -> None:
+        self.started = True
+
+    async def stop(self) -> None:
+        self.stopped = True
+
+    def mark_activity(self) -> None:
+        self.activity_marks += 1
+
+    async def send_json(self, payload: dict[str, Any]) -> None:
+        self.sent.append(payload)
+
+
+class _RecordingWebSocketStreamFactory:
+    """WebSocket stream factory double that records construction calls."""
+
+    def __init__(self) -> None:
+        self.stream = _FakeWebSocketStream()
+        self.calls: list[dict[str, Any]] = []
+
+    def __call__(
+        self,
+        websocket: Any,
+        *,
+        heartbeat_interval_s: float | None,
+        idle_timeout_s: float | None,
+        close_on_done: bool,
+        labels: dict[str, str],
+    ) -> _FakeWebSocketStream:
+        self.calls.append(
+            {
+                "websocket": websocket,
+                "heartbeat_interval_s": heartbeat_interval_s,
+                "idle_timeout_s": idle_timeout_s,
+                "close_on_done": close_on_done,
+                "labels": labels,
+            }
+        )
+        return self.stream
 
 
 class _FakeAuthProvider:
@@ -264,6 +350,24 @@ def test_protocol_uses_runtime_dependencies_for_stage3b_host_services() -> None:
     assert offenders == []
 
 
+def test_server_uses_runtime_dependencies_for_stage3c_host_services() -> None:
+    forbidden_imports = {
+        "tldw_Server_API.app.core.AuthNZ.exceptions",
+        "tldw_Server_API.app.core.Streaming.streams",
+        "tldw_Server_API.app.core.testing",
+    }
+
+    imports = _resolved_import_sources_for(MCP_ROOT / "server.py", MCP_PACKAGE)
+    offenders = sorted(
+        source
+        for source in imports
+        if source in forbidden_imports
+        or any(source.startswith(f"{forbidden}.") for forbidden in forbidden_imports)
+    )
+
+    assert offenders == []
+
+
 def test_protocol_boundary_scan_resolves_relative_imports(tmp_path: Path) -> None:
     sample = tmp_path / "sample.py"
     sample.write_text(
@@ -332,6 +436,34 @@ async def test_tldw_auth_provider_fails_closed_for_unencodable_ws_headers(
     assert verify_calls == 0
 
 
+@pytest.mark.asyncio
+async def test_tldw_auth_provider_fails_closed_when_authnz_ws_verify_rejects(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from tldw_Server_API.app.core.AuthNZ.exceptions import InvalidTokenError
+    from tldw_Server_API.app.core.MCP_unified.adapters import tldw_runtime
+
+    async def _reject_token(*_args: Any, **_kwargs: Any) -> None:
+        raise InvalidTokenError("bad token")
+
+    monkeypatch.setattr(tldw_runtime, "get_jwt_manager", lambda: object())
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.AuthNZ.User_DB_Handling.verify_jwt_and_fetch_user",
+        _reject_token,
+    )
+
+    provider = tldw_runtime.TldwServerAuthProvider()
+    websocket = SimpleNamespace(headers={}, client=None)
+
+    assert (
+        await provider.authenticate_authnz_websocket_token(
+            "token",
+            websocket=websocket,
+        )
+        is None
+    )
+
+
 def test_stage3_runtime_contracts_are_exported_by_interface_packages() -> None:
     import mcp_unified.interfaces as standalone_interfaces
 
@@ -344,6 +476,9 @@ def test_stage3_runtime_contracts_are_exported_by_interface_packages() -> None:
         "PermissionSeeder",
         "PolicyContextProvider",
         "ServerAuthProvider",
+        "EnvironmentFlagsProvider",
+        "WebSocketStream",
+        "WebSocketStreamFactory",
     ]
 
     for name in names:
@@ -374,6 +509,8 @@ def test_mcp_server_accepts_runtime_dependencies() -> None:
     assert server.permission_seeder is deps.permission_seeder
     assert server.module_config_provider is deps.module_config_provider
     assert server.policy_context_provider is deps.policy_context_provider
+    assert server.environment_flags_provider is deps.environment_flags_provider
+    assert server.websocket_stream_factory is deps.websocket_stream_factory
 
 
 def test_mcp_server_registers_shutdown_family_through_injected_lifecycle_guard() -> None:
@@ -420,6 +557,9 @@ async def test_mcp_server_default_media_module_path_uses_injected_module_config_
     monkeypatch.setenv("MCP_ENABLE_FILESYSTEM_MODULE", "0")
     monkeypatch.setenv("MCP_MODULES_CONFIG", "/tmp/mcp-stage3-no-modules.yaml")
     deps = _server_runtime_dependencies()
+    deps.environment_flags_provider = _FakeEnvironmentFlagsProvider(
+        flags={"MCP_ENABLE_MEDIA_MODULE": True}
+    )
     server = MCPServer(dependencies=deps)
 
     await server._register_default_modules()  # noqa: SLF001
@@ -440,6 +580,73 @@ def test_mcp_server_uses_injected_auth_and_policy_context_helpers() -> None:
 
     assert server._extract_api_key_permissions({"scopes": "ignored"}) == ["fake.scope"]  # noqa: SLF001
     assert server._policy_context_enabled() is False  # noqa: SLF001
+
+
+def test_websocket_stream_factory_declares_returned_stream_contract() -> None:
+    from mcp_unified.interfaces import runtime as standalone_runtime
+
+    hints = get_type_hints(standalone_runtime.WebSocketStreamFactory.__call__)
+
+    assert hints["return"] is standalone_runtime.WebSocketStream
+    assert hasattr(standalone_runtime.WebSocketStream, "start")
+    assert hasattr(standalone_runtime.WebSocketStream, "stop")
+    assert hasattr(standalone_runtime.WebSocketStream, "mark_activity")
+    assert hasattr(standalone_runtime.WebSocketStream, "send_json")
+
+
+def test_mcp_server_websocket_stream_annotations_use_runtime_contract() -> None:
+    from tldw_Server_API.app.core.MCP_unified.interfaces import WebSocketStream
+    from tldw_Server_API.app.core.MCP_unified.server import MCPServer
+
+    create_hints = get_type_hints(MCPServer._create_websocket_stream)
+    handle_hints = get_type_hints(MCPServer._handle_websocket_messages)
+
+    assert create_hints["return"] is WebSocketStream
+    assert handle_hints["stream"] is WebSocketStream
+    assert handle_hints["return"] is type(None)
+
+
+def test_mcp_server_uses_injected_environment_flags_provider() -> None:
+    from tldw_Server_API.app.core.MCP_unified.server import MCPServer
+
+    deps = _server_runtime_dependencies()
+    deps.environment_flags_provider = _FakeEnvironmentFlagsProvider(
+        flags={"MCP_ENABLE_DEMO_AUTH": True},
+        test_mode=True,
+        explicit_pytest_runtime=True,
+        truthy_values={"yes": True},
+    )
+    server = MCPServer(dependencies=deps)
+
+    assert server._env_flag_enabled("MCP_ENABLE_DEMO_AUTH") is True  # noqa: SLF001
+    assert server._is_test_mode() is True  # noqa: SLF001
+    assert server._is_explicit_pytest_runtime() is True  # noqa: SLF001
+    assert server._is_truthy("yes") is True  # noqa: SLF001
+
+
+def test_mcp_server_uses_injected_websocket_stream_factory() -> None:
+    from tldw_Server_API.app.core.MCP_unified.server import MCPServer
+
+    deps = _server_runtime_dependencies()
+    factory = _RecordingWebSocketStreamFactory()
+    deps.websocket_stream_factory = factory
+    server = MCPServer(dependencies=deps)
+    server.config.ws_ping_interval = 7
+    server.config.ws_idle_timeout_seconds = 11
+    websocket = object()
+
+    stream = server._create_websocket_stream(websocket)  # noqa: SLF001
+
+    assert stream is factory.stream
+    assert factory.calls == [
+        {
+            "websocket": websocket,
+            "heartbeat_interval_s": 7.0,
+            "idle_timeout_s": 11.0,
+            "close_on_done": True,
+            "labels": {"component": "mcp", "endpoint": "mcp_ws"},
+        }
+    ]
 
 
 def test_mcp_server_logs_host_adapter_fallbacks(

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_security_hardening.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_security_hardening.py
@@ -1,14 +1,13 @@
-import os
-import pytest
-
 from types import SimpleNamespace
 
-from tldw_Server_API.app.core.MCP_unified.server import MCPServer
-from tldw_Server_API.app.core.MCP_unified.config import get_config
-from tldw_Server_API.app.core.MCP_unified.auth.jwt_manager import get_jwt_manager
-from tldw_Server_API.app.core.MCP_unified.auth.authnz_rbac import AuthNZRBAC, Resource, Action
+import pytest
 from fastapi import WebSocketDisconnect
+
 from tldw_Server_API.app.core.AuthNZ.exceptions import InvalidTokenError
+from tldw_Server_API.app.core.MCP_unified.auth.authnz_rbac import Action, AuthNZRBAC, Resource
+from tldw_Server_API.app.core.MCP_unified.auth.jwt_manager import get_jwt_manager
+from tldw_Server_API.app.core.MCP_unified.config import get_config
+from tldw_Server_API.app.core.MCP_unified.server import MCPServer
 
 
 class FakeWebSocket:
@@ -38,7 +37,7 @@ class FakeWebSocket:
 @pytest.mark.asyncio
 async def test_ws_origin_denied(monkeypatch):
     # Configure allowed origins to a different host than provided header
-    os.environ["MCP_WS_ALLOWED_ORIGINS"] = "https://allowed.com"
+    monkeypatch.setenv("MCP_WS_ALLOWED_ORIGINS", "https://allowed.com")
     # Reset config cache
     try:
         get_config.cache_clear()  # type: ignore[attr-defined]
@@ -60,9 +59,9 @@ async def test_ws_origin_denied(monkeypatch):
 @pytest.mark.asyncio
 async def test_ws_query_auth_disabled_requires_auth(monkeypatch):
     # Allow any origin for this test and require auth
-    os.environ["MCP_WS_ALLOWED_ORIGINS"] = "*"
-    os.environ["MCP_WS_AUTH_REQUIRED"] = "1"
-    os.environ["MCP_WS_ALLOW_QUERY_AUTH"] = "0"  # default, explicit here
+    monkeypatch.setenv("MCP_WS_ALLOWED_ORIGINS", "*")
+    monkeypatch.setenv("MCP_WS_AUTH_REQUIRED", "1")
+    monkeypatch.setenv("MCP_WS_ALLOW_QUERY_AUTH", "0")  # default, explicit here
     try:
         get_config.cache_clear()  # type: ignore[attr-defined]
     except Exception:
@@ -85,10 +84,10 @@ async def test_ws_query_auth_disabled_requires_auth(monkeypatch):
 @pytest.mark.asyncio
 async def test_ws_header_bearer_auth_accepts(monkeypatch):
     # Allow any origin and allow auth via header
-    os.environ["MCP_WS_ALLOWED_ORIGINS"] = "*"
-    os.environ["MCP_WS_AUTH_REQUIRED"] = "1"
-    os.environ["MCP_WS_ALLOW_QUERY_AUTH"] = "0"
-    os.environ["MCP_JWT_SECRET"] = "x" * 64  # strong secret
+    monkeypatch.setenv("MCP_WS_ALLOWED_ORIGINS", "*")
+    monkeypatch.setenv("MCP_WS_AUTH_REQUIRED", "1")
+    monkeypatch.setenv("MCP_WS_ALLOW_QUERY_AUTH", "0")
+    monkeypatch.setenv("MCP_JWT_SECRET", "x" * 64)  # strong secret
     try:
         get_config.cache_clear()  # type: ignore[attr-defined]
     except Exception:
@@ -118,9 +117,9 @@ async def test_ws_header_bearer_auth_accepts(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_ws_invalid_authnz_token_allows_api_key(monkeypatch):
-    os.environ["MCP_WS_ALLOWED_ORIGINS"] = "*"
-    os.environ["MCP_WS_AUTH_REQUIRED"] = "1"
-    os.environ["MCP_WS_ALLOW_QUERY_AUTH"] = "0"
+    monkeypatch.setenv("MCP_WS_ALLOWED_ORIGINS", "*")
+    monkeypatch.setenv("MCP_WS_AUTH_REQUIRED", "1")
+    monkeypatch.setenv("MCP_WS_ALLOW_QUERY_AUTH", "0")
     try:
         get_config.cache_clear()  # type: ignore[attr-defined]
     except Exception:
@@ -159,6 +158,55 @@ async def test_ws_invalid_authnz_token_allows_api_key(monkeypatch):
     assert ws.accepted is True
     if ws.closed:
         assert "Authentication failed" not in (ws.close_args[1] or "")
+
+
+@pytest.mark.asyncio
+async def test_ws_failed_authnz_token_does_not_fall_back_to_mcp_jwt():
+    server = MCPServer()
+    server.config.ws_allowed_origins = ["*"]
+    server.config.ws_auth_required = True
+
+    class _FailingAuthNZProvider:
+        def get_mcp_jwt_manager(self):
+            return object()
+
+        def is_authnz_access_token(self, _token: str) -> bool:
+            return True
+
+        async def authenticate_authnz_websocket_token(self, _token: str, *, websocket):
+            del websocket
+            return None
+
+        async def validate_api_key(self, _api_key: str, *, ip_address: str | None = None):
+            del ip_address
+            return None
+
+        def normalize_api_key_permissions(self, info: dict | None) -> list[str]:
+            return []
+
+    class _JwtVerifier:
+        def __init__(self) -> None:
+            self.calls = 0
+
+        def verify_token(self, _token: str):
+            self.calls += 1
+            raise AssertionError("MCP JWT verifier should not receive AuthNZ access tokens")
+
+    jwt_verifier = _JwtVerifier()
+    server.auth_provider = _FailingAuthNZProvider()
+    server.jwt_manager = jwt_verifier  # type: ignore[assignment]
+    ws = FakeWebSocket(
+        headers={
+            "origin": "https://any.com",
+            "Authorization": "Bearer expired-authnz-token",
+        }
+    )
+
+    await server.handle_websocket(ws, client_id="c-authnz-failed")
+
+    assert jwt_verifier.calls == 0
+    assert ws.closed is True
+    assert ws.close_args == (1008, "Authentication failed")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Change summary (maintainer-owned)

Maintainer: replace this section with your own summary before merge, per `Docs/superpowers/AI_GENERATED_PR_CHANGE_SUMMARY_POLICY_2026_04_17.md`.

## AI-authored implementation notes

- Added host-neutral `EnvironmentFlagsProvider` and `WebSocketStreamFactory` runtime contracts and re-exported them through standalone and compatibility interface packages.
- Moved MCP server env/test helper usage and WebSocket stream construction behind injected runtime dependencies, preserving tldw_server behavior through `tldw_runtime` adapters.
- Made AuthNZ websocket verification failures fail closed inside the tldw auth adapter so `server.py` no longer needs AuthNZ exception classes in its noncritical exception tuple.
- Added extraction/injection regression tests for the server boundary, runtime exports, stream factory injection, and AuthNZ fail-closed behavior.
- Cleaned up touched WebSocket security tests to use `monkeypatch.setenv`, preventing `MCP_WS_*` env leakage into later WebSocket workspace tests.

## Verification

- RED: `.venv/bin/python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_extraction_contracts.py -q` failed for the expected missing Stage 3C seams before implementation.
- GREEN: `.venv/bin/python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_extraction_contracts.py tldw_Server_API/app/core/MCP_unified/tests/test_server_batch_and_formatting.py tldw_Server_API/app/core/MCP_unified/tests/test_scope_and_fallbacks.py tldw_Server_API/app/core/MCP_unified/tests/test_basic_functionality.py tldw_Server_API/app/core/MCP_unified/tests/test_security_hardening.py tldw_Server_API/app/core/MCP_unified/tests/test_log_redaction.py tldw_Server_API/tests/MCP_unified/test_mcp_ws_workspace_context.py -q` -> 71 passed, 4 warnings.
- `.venv/bin/python -m ruff check tldw_Server_API/app/core/MCP_unified/server.py tldw_Server_API/app/core/MCP_unified/adapters/tldw_runtime.py tldw_Server_API/app/core/MCP_unified/interfaces/runtime.py tldw_Server_API/app/core/MCP_unified/interfaces/__init__.py mcp_unified/interfaces/runtime.py mcp_unified/interfaces/__init__.py tldw_Server_API/app/core/MCP_unified/tests/test_extraction_contracts.py tldw_Server_API/app/core/MCP_unified/tests/test_security_hardening.py` -> All checks passed.
- `.venv/bin/python -m bandit -r tldw_Server_API/app/core/MCP_unified/server.py tldw_Server_API/app/core/MCP_unified/adapters/tldw_runtime.py mcp_unified/interfaces tldw_Server_API/app/core/MCP_unified/interfaces -f json -o /tmp/bandit_mcp_stage3c_server_host_deps.json` -> empty `results`.

## Watchlists

- [ ] Confirm no frontend/backend entrypoint depends on importing host testing helpers through `server.py`.
- [ ] Confirm WebSocket auth behavior remains acceptable when an AuthNZ token fails validation and an API key is also present.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Decoupled the MCP server from host-only code by adding runtime seams for env flags and WebSocket streams, and routing AuthNZ handling through adapters. Preserves `tldw_server` behavior, prevents MCP-JWT fallback for failed AuthNZ tokens, and completes TASK-543.

- **Refactors**
  - Added `EnvironmentFlagsProvider`, `WebSocketStreamFactory`, and the `WebSocketStream`/`WebSocketCloseTarget` protocols; exported via `mcp_unified/interfaces`.
  - Updated `server.py` to use injected env flags and stream factory; removed direct imports of host testing helpers, AuthNZ exceptions, and `WebSocketStream`.
  - Implemented `TldwEnvironmentFlagsProvider` and `TldwWebSocketStreamFactory` in `tldw_runtime`; wired into default `MCPRuntimeDependencies`.
  - Added regression tests for import boundary, runtime exports, stream factory injection, and policy/env flag gating.

- **Bug Fixes**
  - WebSocket AuthNZ token verification now fails closed inside the adapter; no MCP-JWT fallback when an AuthNZ access token fails, while API key fallback remains unchanged.
  - Eliminated `MCP_WS_*` env leakage across tests by using `monkeypatch.setenv`.

<sup>Written for commit 44bea35a5e8ba3c828ebf1436816a28d18870fb6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2105?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

