### PR TITLE
Close Quick Ingest result handoff task

### DIFF
--- a/backlog/tasks/task-394.3 - Improve-Quick-Ingest-result-handoff-and-recovery-actions.md
+++ b/backlog/tasks/task-394.3 - Improve-Quick-Ingest-result-handoff-and-recovery-actions.md
@@ -1,9 +1,10 @@
 ---
 id: TASK-394.3
 title: Improve Quick Ingest result handoff and recovery actions
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-05-16 00:43'
+updated_date: '2026-05-29 01:46'
 labels:
   - quick-ingest
   - ux
@@ -24,17 +25,25 @@ Execute implementation plan Task 3: improve success handoff, remove/retry behavi
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Successful ingests provide a primary route toward the created content or destination
-- [ ] #2 Remove/retry/recovery actions are functional or honestly constrained
-- [ ] #3 Partial success and failure outcomes are clear and recoverable
+- [x] #1 Successful ingests provide a primary route toward the created content or destination
+- [x] #2 Remove/retry/recovery actions are functional or honestly constrained
+- [x] #3 Partial success and failure outcomes are clear and recoverable
 <!-- AC:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Task 3 result handoff and recovery behavior is already present on latest origin/dev. Verified current code includes `result-actions.ts`, `WizardResultsStep` Open in Media handoff, QuickIngestWizardModal media navigation to `/media?id=...`, no Remove button without a real callback, duplicate skipped-copy distinctions for Already queued vs Already in library, and focused navigation/recovery tests.
+
+Verification rerun on latest origin/dev: `bunx vitest run src/components/Common/QuickIngest/__tests__/WizardResultsStep.navigation.test.tsx src/components/Common/QuickIngest/__tests__/QuickIngestWizardModal.session.test.tsx --maxWorkers=1 --no-file-parallelism` passed 35 tests; `git diff --check` passed. Planned Playwright real-backend smoke was not run because `curl -sf http://127.0.0.1:8000/api/v1/health` failed with connection refused. Bandit is not applicable for this closeout because the current branch only updates Backlog task metadata.
+<!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->


### PR DESCRIPTION
## Summary
- Closed `TASK-394.3` now that Quick Ingest result handoff/recovery behavior is present on `origin/dev`.
- Recorded current evidence for Open in Media, no-op Remove removal, skipped duplicate copy, and focused tests.
- Documented the skipped real-backend Playwright smoke because no local backend was listening.

## Verification
- `bunx vitest run src/components/Common/QuickIngest/__tests__/WizardResultsStep.navigation.test.tsx src/components/Common/QuickIngest/__tests__/QuickIngestWizardModal.session.test.tsx --maxWorkers=1 --no-file-parallelism` passed: 35 tests.
- `git diff --check` passed.
- `curl -sf http://127.0.0.1:8000/api/v1/health` failed with connection refused, so the planned Playwright real-backend smoke was not run.

## Notes
- Backlog-only closeout; Bandit is not applicable.
- Next sequential Quick Ingest task after this lands is `TASK-394.4`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Closed TASK-394.3 by marking the backlog task as Done and documenting that Quick Ingest result handoff/recovery is already present on `origin/dev`. Recorded verification (35 vitest passing), evidence for Open in Media navigation and recovery actions, and noted the Playwright smoke was skipped due to no local backend.

<sup>Written for commit 1b1cb56dba59353ba94b5ef0cb3b350d3b9fe0ea. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2106?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

