### PR TITLE
chore: close quick ingest recovery task

### DIFF
--- a/backlog/completed/task-394.4 - Correct-Quick-Ingest-offline-cancel-and-progress-states.md
+++ b/backlog/completed/task-394.4 - Correct-Quick-Ingest-offline-cancel-and-progress-states.md
@@ -4,7 +4,7 @@ title: Correct Quick Ingest offline cancel and progress states
 status: Done
 assignee: []
 created_date: '2026-05-16 00:43'
-updated_date: '2026-05-16 03:18'
+updated_date: '2026-05-29 01:59'
 labels:
   - quick-ingest
   - ux
@@ -33,15 +33,23 @@ Execute implementation plan Task 4: align offline checks, cancel/close behavior,
 ## Implementation Notes
 
 <!-- SECTION:NOTES:BEGIN -->
+Canonical record: this `backlog/completed/` file is the authoritative final closeout for TASK-394.4. The active-tracker mirror at `backlog/tasks/task-394.4 - Correct-Quick-Ingest-offline-cancel-and-progress-states.md` points here and should not be treated as a separate task.
+
 Started Task 4 in quick-ingest UX remediation branch. Scope: offline/disconnected processing guard, cancel/close distinction, neutral progress copy, and minimized widget terminal-state accuracy.
 
 Implemented offline processing guards in Add and Review steps using the shared connection store, added retry recovery affordances, neutralized global processing copy, and split minimized widget terminal states into Done, Failed, Cancelled, and Interrupted. Functional commit: 9958abdc8.
+
+Closeout verification on latest origin/dev confirmed the Task 4 behavior is still present: Add step disables quick processing while disconnected, shows server-offline recovery copy with retry, still allows Configure for queued items, and guards handleQuickProcess while offline/checking. ProcessingStep uses neutral global copy (`Processing and indexing content`) and FloatingProgressWidget splits Done, Failed, Cancelled, and Interrupted minimized terminal states.
+
+Latest verification: `bun run test src/components/Common/QuickIngest/__tests__/QuickIngestWizardModal.integration.test.tsx src/components/Common/QuickIngest/__tests__/QuickIngestWizardModal.session.test.tsx src/components/Common/QuickIngest/__tests__/FloatingProgressWidget.test.tsx --maxWorkers=1 --no-file-parallelism` passed 61 tests after `bun install` under `apps/` repaired copied worktree package links. `npx playwright test e2e/workflows/media-ingest.spec.ts --grep "quick ingest can be dismissed during processing" --project=chromium --reporter=line` passed 1 test in 57.1s. Bandit is not applicable to the closeout PR because it only updates Backlog task metadata.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Task 4 complete. Offline/disconnected users can still add and configure items, but processing actions are blocked with explicit recovery copy and Retry connection. Review prevents final processing while disconnected. Progress copy now uses neutral processing/indexing language. Minimized progress widget distinguishes completed, failed, cancelled, and interrupted sessions with non-success terminal states. Verification: focused Vitest suite passed (48 tests), focused Playwright dismiss/resume flow passed (1 test, 46.2s), and git diff --check passed. Bandit skipped because this task touched frontend TypeScript/TSX only and no Python code.
+Task 4 complete. This `backlog/completed/` file is the authoritative closeout. Offline/disconnected users can still add and configure items, but processing actions are blocked with explicit recovery copy and Retry connection. Review prevents final processing while disconnected. Progress copy uses neutral processing/indexing language. Minimized progress widget distinguishes completed, failed, cancelled, and interrupted sessions with non-success terminal states.
+
+Latest verification on origin/dev: focused Quick Ingest Vitest coverage passed 61 tests, focused Playwright dismiss/resume coverage passed 1 test in 57.1s, and `git diff --check` passed. Bandit was skipped for the metadata-only closeout PR.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-394.4 - Correct-Quick-Ingest-offline-cancel-and-progress-states.md
+++ b/backlog/tasks/task-394.4 - Correct-Quick-Ingest-offline-cancel-and-progress-states.md
@@ -33,6 +33,8 @@ Execute implementation plan Task 4: align offline checks, cancel/close behavior,
 ## Implementation Notes
 
 <!-- SECTION:NOTES:BEGIN -->
+Canonical completed record: `backlog/completed/task-394.4 - Correct-Quick-Ingest-offline-cancel-and-progress-states.md`. This `backlog/tasks/` file is a tracker mirror retained for PR visibility and should not be treated as a separate closeout record.
+
 Latest origin/dev already contains the Task 4 Quick Ingest recovery behavior. Verified Add step disables quick processing while disconnected, shows server-offline recovery copy with retry, still allows Configure for queued items, and guards handleQuickProcess while offline/checking. Verified ProcessingStep uses neutral global copy (`Processing and indexing content`) and FloatingProgressWidget splits Done, Failed, Cancelled, and Interrupted minimized terminal states.
 
 Verification: `bun run test src/components/Common/QuickIngest/__tests__/QuickIngestWizardModal.integration.test.tsx src/components/Common/QuickIngest/__tests__/QuickIngestWizardModal.session.test.tsx src/components/Common/QuickIngest/__tests__/FloatingProgressWidget.test.tsx --maxWorkers=1 --no-file-parallelism` passed 61 tests after `bun install` under `apps/` repaired copied worktree package links. Verification: `npx playwright test e2e/workflows/media-ingest.spec.ts --grep "quick ingest can be dismissed during processing" --project=chromium --reporter=line` passed 1 test in 57.1s. Bandit is not applicable because this closeout branch only updates Backlog task metadata.
@@ -41,6 +43,8 @@ Verification: `bun run test src/components/Common/QuickIngest/__tests__/QuickIng
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Tracker mirror for the authoritative completed record at `backlog/completed/task-394.4 - Correct-Quick-Ingest-offline-cancel-and-progress-states.md`.
+
 Closed Task 4 on latest origin/dev after verifying the offline, cancel, progress, and minimized background states are already implemented. Add step processing is blocked while disconnected with visible retry/recovery copy, configuration remains available, QuickIngestWizardModal guards quick processing while offline/checking, ProcessingStep uses neutral global progress copy, and FloatingProgressWidget distinguishes Done, Failed, Cancelled, and Interrupted terminal states.
 
 Verification: `bun run test src/components/Common/QuickIngest/__tests__/QuickIngestWizardModal.integration.test.tsx src/components/Common/QuickIngest/__tests__/QuickIngestWizardModal.session.test.tsx src/components/Common/QuickIngest/__tests__/FloatingProgressWidget.test.tsx --maxWorkers=1 --no-file-parallelism` passed 61 tests. `npx playwright test e2e/workflows/media-ingest.spec.ts --grep "quick ingest can be dismissed during processing" --project=chromium --reporter=line` passed 1 test in 57.1s. Bandit is not applicable because this closeout branch only changes Backlog task metadata.

--- a/backlog/tasks/task-394.4 - Correct-Quick-Ingest-offline-cancel-and-progress-states.md
+++ b/backlog/tasks/task-394.4 - Correct-Quick-Ingest-offline-cancel-and-progress-states.md
@@ -1,9 +1,10 @@
 ---
 id: TASK-394.4
 title: Correct Quick Ingest offline cancel and progress states
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-05-16 00:43'
+updated_date: '2026-05-29 01:59'
 labels:
   - quick-ingest
   - ux
@@ -24,17 +25,33 @@ Execute implementation plan Task 4: align offline checks, cancel/close behavior,
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Offline and network failure states surface before or during submit with actionable recovery
-- [ ] #2 Cancel/close behavior distinguishes draft dismissal from in-flight processing
-- [ ] #3 Progress/background status copy does not imply unsupported background jobs or hidden completion tracking
+- [x] #1 Offline and network failure states surface before or during submit with actionable recovery
+- [x] #2 Cancel/close behavior distinguishes draft dismissal from in-flight processing
+- [x] #3 Progress/background status copy does not imply unsupported background jobs or hidden completion tracking
 <!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Latest origin/dev already contains the Task 4 Quick Ingest recovery behavior. Verified Add step disables quick processing while disconnected, shows server-offline recovery copy with retry, still allows Configure for queued items, and guards handleQuickProcess while offline/checking. Verified ProcessingStep uses neutral global copy (`Processing and indexing content`) and FloatingProgressWidget splits Done, Failed, Cancelled, and Interrupted minimized terminal states.
+
+Verification: `bun run test src/components/Common/QuickIngest/__tests__/QuickIngestWizardModal.integration.test.tsx src/components/Common/QuickIngest/__tests__/QuickIngestWizardModal.session.test.tsx src/components/Common/QuickIngest/__tests__/FloatingProgressWidget.test.tsx --maxWorkers=1 --no-file-parallelism` passed 61 tests after `bun install` under `apps/` repaired copied worktree package links. Verification: `npx playwright test e2e/workflows/media-ingest.spec.ts --grep "quick ingest can be dismissed during processing" --project=chromium --reporter=line` passed 1 test in 57.1s. Bandit is not applicable because this closeout branch only updates Backlog task metadata.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Closed Task 4 on latest origin/dev after verifying the offline, cancel, progress, and minimized background states are already implemented. Add step processing is blocked while disconnected with visible retry/recovery copy, configuration remains available, QuickIngestWizardModal guards quick processing while offline/checking, ProcessingStep uses neutral global progress copy, and FloatingProgressWidget distinguishes Done, Failed, Cancelled, and Interrupted terminal states.
+
+Verification: `bun run test src/components/Common/QuickIngest/__tests__/QuickIngestWizardModal.integration.test.tsx src/components/Common/QuickIngest/__tests__/QuickIngestWizardModal.session.test.tsx src/components/Common/QuickIngest/__tests__/FloatingProgressWidget.test.tsx --maxWorkers=1 --no-file-parallelism` passed 61 tests. `npx playwright test e2e/workflows/media-ingest.spec.ts --grep "quick ingest can be dismissed during processing" --project=chromium --reporter=line` passed 1 test in 57.1s. Bandit is not applicable because this closeout branch only changes Backlog task metadata.
+<!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->


### PR DESCRIPTION
## Summary

- What changed: closed Backlog `TASK-394.4` with checked acceptance criteria, Definition of Done, implementation notes, and final summary.
- Why: latest `origin/dev` already contains the Quick Ingest Task 4 implementation; this PR records verification and closes the tracking task without changing runtime code.

## Validation

- [ ] Tests added/updated for behavior changes: not applicable, metadata-only closeout.
- [x] Relevant unit/integration tests pass locally.
- [x] Docs updated: Backlog task status, AC/DoD, notes, and final summary updated.

Focused validation run locally:

- `cd apps/packages/ui && bun run test src/components/Common/QuickIngest/__tests__/QuickIngestWizardModal.integration.test.tsx src/components/Common/QuickIngest/__tests__/QuickIngestWizardModal.session.test.tsx src/components/Common/QuickIngest/__tests__/FloatingProgressWidget.test.tsx --maxWorkers=1 --no-file-parallelism` passed 61 tests.
- `cd apps/tldw-frontend && npx playwright test e2e/workflows/media-ingest.spec.ts --grep "quick ingest can be dismissed during processing" --project=chromium --reporter=line` passed 1 test in 57.1s.
- `git diff --check` passed.
- Bandit not applicable because this branch only updates Backlog metadata.

## UX Audit Checklist (v2 Stage 5)

- [ ] `npm run e2e:smoke:stage5` passes: not run, metadata-only closeout.
- [ ] `npx playwright test e2e/smoke/all-pages.spec.ts --reporter=line` passes: not run, metadata-only closeout.
- [x] No listed AntD deprecations in console output: not applicable, no runtime UI changes.
- [x] No `Maximum update depth exceeded` warnings on audited routes: focused Quick Ingest Playwright scenario passed.
- [x] No unresolved `{{...}}` placeholders on audited routes: focused Quick Ingest Playwright scenario passed.
- [ ] WebUI/extension parity validated for shared UI fixes: not applicable, no shared UI code changes.

## Watchlists Accessibility Checklist (Group 09 Stage 5)

- [x] Not applicable: no Watchlists UI behavior changed.

## Watchlists Scale Checklist (Group 10 Stage 5)

- [x] Not applicable: no Watchlists polling, notifications, or scale behavior changed.

## Risk & Rollback

- Risk level: Low.
- Rollback plan: revert the single Backlog task metadata commit if the task should remain open.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Marks TASK-394.4 (Quick Ingest offline cancel and progress states) as Done with checked AC/DoD and verification, and sets `backlog/completed/` as the canonical closeout with a mirror in `backlog/tasks/`. Confirms dev already has offline guards, cancel vs close, neutral progress copy, and minimized widget terminal states; no runtime code changes.

<sup>Written for commit 9d4f091e0c774a36f927b21e90d2a1bf1b611cbc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2107?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

