### PR TITLE
Stage 3D: extract MCP security test-mode seams

### DIFF
--- a/Docs/superpowers/plans/2026-05-29-mcp-unified-stage3d-security-test-seams-plan.md
+++ b/Docs/superpowers/plans/2026-05-29-mcp-unified-stage3d-security-test-seams-plan.md
@@ -1,0 +1,85 @@
+# MCP Unified Stage 3D Security Test Seams Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Remove direct host testing-helper imports from MCP Unified security/config code while preserving test-mode guard behavior.
+
+**Architecture:** Add a package-local environment helper owned by MCP Unified and make `config.py`, `security/ip_filter.py`, and `security/request_guards.py` depend on it instead of `tldw_Server_API.app.core.testing`. Keep the helper dependency-free so it can move with the standalone package later, while matching the existing test-mode/env-flag semantics used by current guard paths.
+
+**Tech Stack:** Python, FastAPI/Starlette requests, pytest, Ruff, Bandit.
+
+**Backlog:** TASK-482
+
+---
+
+### Task 1: Boundary And Behavior Tests
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/MCP_unified/tests/test_extraction_contracts.py`
+- Modify: `tldw_Server_API/app/core/MCP_unified/tests/test_http_security_guards.py`
+
+- [x] **Step 1: Write failing import-boundary test**
+
+Add a contract test that scans `config.py`, `security/ip_filter.py`, and `security/request_guards.py` and fails if any import source resolves to `tldw_Server_API.app.core.testing`.
+
+- [x] **Step 2: Write failing guard behavior tests**
+
+Add tests that force MCP test mode via environment variables and verify:
+- IP allowlist normalizes missing synthetic client IP to loopback.
+- Client-certificate guard accepts `testclient` only in test mode while still requiring the configured certificate header/value.
+
+- [x] **Step 3: Verify RED**
+
+Run:
+```bash
+source .venv/bin/activate
+python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_extraction_contracts.py::test_security_and_config_use_package_local_environment_helpers tldw_Server_API/app/core/MCP_unified/tests/test_http_security_guards.py::test_ip_allowlist_normalizes_missing_client_ip_in_test_mode tldw_Server_API/app/core/MCP_unified/tests/test_http_security_guards.py::test_client_certificate_guard_allows_testclient_only_in_test_mode -q
+```
+
+Expected: import-boundary test fails before implementation; behavior tests may already pass through the old host helper.
+
+### Task 2: Package-Local Environment Helper
+
+**Files:**
+- Create: `tldw_Server_API/app/core/MCP_unified/environment.py`
+- Modify: `tldw_Server_API/app/core/MCP_unified/config.py`
+- Modify: `tldw_Server_API/app/core/MCP_unified/security/ip_filter.py`
+- Modify: `tldw_Server_API/app/core/MCP_unified/security/request_guards.py`
+
+- [x] **Step 1: Add helper**
+
+Implement `env_flag_enabled(name: str) -> bool`, `is_truthy(value: object) -> bool`, `is_explicit_pytest_runtime() -> bool`, and `is_test_mode() -> bool` using only `os.environ`/`PYTEST_CURRENT_TEST` and safe truthy-string handling.
+
+- [x] **Step 2: Replace imports**
+
+Update config/security modules to import from `..environment` or `.environment` as appropriate.
+
+- [x] **Step 3: Verify GREEN**
+
+Run the Task 1 pytest command again. Expected: all selected tests pass.
+
+### Task 3: Focused Validation And Closeout
+
+**Files:**
+- Modify: `backlog/tasks/task-482 - Implement-MCP-Unified-Stage-3D-security-test-mode-seam-cleanup.md`
+
+- [x] **Step 1: Run focused regression suite**
+
+Run:
+```bash
+source .venv/bin/activate
+python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_extraction_contracts.py tldw_Server_API/app/core/MCP_unified/tests/test_http_security_guards.py tldw_Server_API/app/core/MCP_unified/tests/test_config_safe_defaults.py -q
+```
+
+- [x] **Step 2: Run lint/security checks**
+
+Run:
+```bash
+source .venv/bin/activate
+python -m ruff check tldw_Server_API/app/core/MCP_unified/environment.py tldw_Server_API/app/core/MCP_unified/config.py tldw_Server_API/app/core/MCP_unified/security/ip_filter.py tldw_Server_API/app/core/MCP_unified/security/request_guards.py tldw_Server_API/app/core/MCP_unified/tests/test_extraction_contracts.py tldw_Server_API/app/core/MCP_unified/tests/test_http_security_guards.py
+python -m bandit -r tldw_Server_API/app/core/MCP_unified/environment.py tldw_Server_API/app/core/MCP_unified/config.py tldw_Server_API/app/core/MCP_unified/security/ip_filter.py tldw_Server_API/app/core/MCP_unified/security/request_guards.py -f json -o /tmp/bandit_mcp_stage3d_security_test_seams.json
+```
+
+- [x] **Step 3: Update Backlog and commit**
+
+Record touched files, verification output, known skips, and final summary on TASK-482. Commit the focused slice and open the PR.

--- a/backlog/tasks/task-482 - Implement-MCP-Unified-Stage-3D-security-test-mode-seam-cleanup.md
+++ b/backlog/tasks/task-482 - Implement-MCP-Unified-Stage-3D-security-test-mode-seam-cleanup.md
@@ -55,6 +55,8 @@ Verification:
 - `python -m ruff check ...` on the touched MCP files passed.
 - `python -m bandit -r ... -f json -o /tmp/bandit_mcp_stage3d_security_test_seams.json` completed with zero findings and zero errors.
 - `git diff --check` passed.
+Review-fix pass after rebase onto origin/dev 4be634b5f3. Confirmed open PR threads: guard test type hints, broad exception swallowing in new tests, and production spoof risk for unconditional testclient loopback normalization.
+Review fixes implemented after rebase: gated `testclient` IP normalization behind explicit test runtime, added a spoofed forwarded-header regression, annotated new test functions with `MonkeyPatch`/`-> None`, and replaced broad cache-clear exception swallowing in the new tests with a direct helper. Verification: focused pytest passed with 44 passed; Ruff passed on touched MCP files; Bandit returned zero findings; git diff --check passed.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary
@@ -62,6 +64,7 @@ Verification:
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
 MCP Unified config and security guard test-mode helpers now live inside the MCP package boundary instead of importing host-level testing helpers. Focused import-boundary and guard behavior coverage protects the seam and existing loopback/client-certificate test-mode behavior.
 PR: https://github.com/rmusser01/tldw_server/pull/2108
+Review-fix pass rebased on origin/dev 4be634b5f3: addressed Gemini spoofing concern and both Qodo findings.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-482 - Implement-MCP-Unified-Stage-3D-security-test-mode-seam-cleanup.md
+++ b/backlog/tasks/task-482 - Implement-MCP-Unified-Stage-3D-security-test-mode-seam-cleanup.md
@@ -16,6 +16,8 @@ modified_files:
 - tldw_Server_API/app/core/MCP_unified/security/ip_filter.py
 - tldw_Server_API/app/core/MCP_unified/security/request_guards.py
 - backlog/tasks/task-482 - Implement-MCP-Unified-Stage-3D-security-test-mode-seam-cleanup.md
+references:
+- https://github.com/rmusser01/tldw_server/pull/2108
 ---
 
 ## Description
@@ -59,6 +61,7 @@ Verification:
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
 MCP Unified config and security guard test-mode helpers now live inside the MCP package boundary instead of importing host-level testing helpers. Focused import-boundary and guard behavior coverage protects the seam and existing loopback/client-certificate test-mode behavior.
+PR: https://github.com/rmusser01/tldw_server/pull/2108
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-482 - Implement-MCP-Unified-Stage-3D-security-test-mode-seam-cleanup.md
+++ b/backlog/tasks/task-482 - Implement-MCP-Unified-Stage-3D-security-test-mode-seam-cleanup.md
@@ -1,0 +1,72 @@
+---
+id: TASK-482
+title: Implement MCP Unified Stage 3D security test-mode seam cleanup
+status: Done
+labels:
+- mcp
+- mcp-unified
+- standalone
+- stage3
+modified_files:
+- Docs/superpowers/plans/2026-05-29-mcp-unified-stage3d-security-test-seams-plan.md
+- tldw_Server_API/app/core/MCP_unified/tests/test_extraction_contracts.py
+- tldw_Server_API/app/core/MCP_unified/tests/test_http_security_guards.py
+- tldw_Server_API/app/core/MCP_unified/environment.py
+- tldw_Server_API/app/core/MCP_unified/config.py
+- tldw_Server_API/app/core/MCP_unified/security/ip_filter.py
+- tldw_Server_API/app/core/MCP_unified/security/request_guards.py
+- backlog/tasks/task-482 - Implement-MCP-Unified-Stage-3D-security-test-mode-seam-cleanup.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Remove direct host testing-helper imports from MCP Unified security/config code while preserving test-mode behavior for IP and request guards. Keep the slice limited to standalone-extraction seams and focused regression coverage.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 security/ip_filter.py and security/request_guards.py no longer import tldw_Server_API.app.core.testing directly.
+- [x] #2 config.py no longer imports host testing helpers directly; test-mode/env flag behavior is provided through a host-neutral helper or runtime seam.
+- [x] #3 Regression tests cover the import boundary and existing test-mode loopback/client-certificate guard behavior.
+- [x] #4 Focused pytest, Ruff, and Bandit verification are recorded before PR closeout.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Docs/superpowers/plans/2026-05-29-mcp-unified-stage3d-security-test-seams-plan.md
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Implemented the Stage 3D security/config test-mode seam cleanup on branch `codex/mcp-unified-stage3d-security-test-seams`.
+
+RED verification: the import-boundary test failed because `config.py`, `security/ip_filter.py`, and `security/request_guards.py` imported `tldw_Server_API.app.core.testing`; the two behavior tests passed through the old host helper path.
+
+GREEN implementation: added `tldw_Server_API/app/core/MCP_unified/environment.py` with dependency-free `env_flag_enabled`, `is_truthy`, `is_test_mode`, and `is_explicit_pytest_runtime` helpers. Updated MCP config and security guard modules to use the package-local helper while preserving existing test-mode behavior.
+
+Verification:
+- `python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_extraction_contracts.py::test_security_and_config_use_package_local_environment_helpers tldw_Server_API/app/core/MCP_unified/tests/test_http_security_guards.py::test_ip_allowlist_normalizes_missing_client_ip_in_test_mode tldw_Server_API/app/core/MCP_unified/tests/test_http_security_guards.py::test_client_certificate_guard_allows_testclient_only_in_test_mode -q` passed with 3 passed.
+- `python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_extraction_contracts.py tldw_Server_API/app/core/MCP_unified/tests/test_http_security_guards.py tldw_Server_API/app/core/MCP_unified/tests/test_config_safe_defaults.py -q` passed with 43 passed.
+- `python -m ruff check ...` on the touched MCP files passed.
+- `python -m bandit -r ... -f json -o /tmp/bandit_mcp_stage3d_security_test_seams.json` completed with zero findings and zero errors.
+- `git diff --check` passed.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+MCP Unified config and security guard test-mode helpers now live inside the MCP package boundary instead of importing host-level testing helpers. Focused import-boundary and guard behavior coverage protects the seam and existing loopback/client-certificate test-mode behavior.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/tldw_Server_API/app/core/MCP_unified/config.py
+++ b/tldw_Server_API/app/core/MCP_unified/config.py
@@ -22,7 +22,7 @@ except (ImportError, AttributeError):  # v1 fallback
 from loguru import logger
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
-from tldw_Server_API.app.core.testing import env_flag_enabled, is_test_mode
+from .environment import env_flag_enabled, is_explicit_pytest_runtime, is_test_mode
 
 _MCP_CONFIG_NONCRITICAL_EXCEPTIONS: tuple[type[BaseException], ...] = (
     AttributeError,
@@ -424,7 +424,6 @@ class MCPConfig(BaseSettings):
         """
         try:
             # Optional opt-out to inherit global logger configuration
-            import os as _os
             if env_flag_enabled("MCP_INHERIT_GLOBAL_LOGGER"):
                 return
         except _MCP_CONFIG_NONCRITICAL_EXCEPTIONS:
@@ -514,7 +513,7 @@ def validate_config() -> bool:
         try:
             test_mode = (
                 is_test_mode()
-                or bool(os.getenv("PYTEST_CURRENT_TEST"))
+                or is_explicit_pytest_runtime()
             )
         except _MCP_CONFIG_NONCRITICAL_EXCEPTIONS:
             test_mode = False

--- a/tldw_Server_API/app/core/MCP_unified/environment.py
+++ b/tldw_Server_API/app/core/MCP_unified/environment.py
@@ -1,0 +1,51 @@
+"""Dependency-free environment helpers for MCP Unified.
+
+These helpers mirror the small truthy/test-mode surface MCP needs without
+depending on host-level testing modules, so the code can move with the
+standalone package boundary.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+_TRUTHY = {"1", "true", "yes", "y", "on"}
+_ENV_HELPER_NONCRITICAL_EXCEPTIONS = (AttributeError, OSError, TypeError, ValueError)
+
+
+def is_truthy(value: Any) -> bool:
+    """Return True when a value uses one of the accepted truthy spellings."""
+    try:
+        return str(value or "").strip().lower() in _TRUTHY
+    except _ENV_HELPER_NONCRITICAL_EXCEPTIONS:
+        return False
+
+
+def env_flag_enabled(name: str) -> bool:
+    """Return True when the named environment variable is explicitly truthy."""
+    try:
+        return is_truthy(os.getenv(name))
+    except _ENV_HELPER_NONCRITICAL_EXCEPTIONS:
+        return False
+
+
+def is_test_mode() -> bool:
+    """Return True when MCP test mode is explicitly enabled by environment."""
+    return env_flag_enabled("TEST_MODE") or env_flag_enabled("TLDW_TEST_MODE")
+
+
+def is_explicit_pytest_runtime() -> bool:
+    """Return True while pytest exposes its active test runtime signal."""
+    try:
+        return bool(str(os.getenv("PYTEST_CURRENT_TEST") or "").strip())
+    except _ENV_HELPER_NONCRITICAL_EXCEPTIONS:
+        return False
+
+
+__all__ = [
+    "env_flag_enabled",
+    "is_explicit_pytest_runtime",
+    "is_test_mode",
+    "is_truthy",
+]

--- a/tldw_Server_API/app/core/MCP_unified/security/ip_filter.py
+++ b/tldw_Server_API/app/core/MCP_unified/security/ip_filter.py
@@ -13,8 +13,8 @@ from functools import lru_cache
 from fastapi import HTTPException, Request
 from loguru import logger
 
-from tldw_Server_API.app.core.testing import is_test_mode
 from ..config import get_config
+from ..environment import is_explicit_pytest_runtime, is_test_mode
 
 
 class IPAccessController:
@@ -153,9 +153,8 @@ async def enforce_ip_allowlist(request: Request) -> None:
         resolved_ip = "127.0.0.1"
     else:
         try:
-            import os as _os
             if (resolved_ip is None and (
-                _os.getenv("PYTEST_CURRENT_TEST") or
+                is_explicit_pytest_runtime() or
                 is_test_mode()
             )):
                 resolved_ip = "127.0.0.1"

--- a/tldw_Server_API/app/core/MCP_unified/security/ip_filter.py
+++ b/tldw_Server_API/app/core/MCP_unified/security/ip_filter.py
@@ -149,17 +149,9 @@ async def enforce_ip_allowlist(request: Request) -> None:
     # name "testclient" which is not a valid IP address. Treat it as loopback so
     # that unit tests are not blocked by the allowlist when TEST_MODE/pytest
     # execution is detected.
-    if resolved_ip == "testclient":
+    test_runtime = is_explicit_pytest_runtime() or is_test_mode()
+    if test_runtime and (resolved_ip == "testclient" or resolved_ip is None):
         resolved_ip = "127.0.0.1"
-    else:
-        try:
-            if (resolved_ip is None and (
-                is_explicit_pytest_runtime() or
-                is_test_mode()
-            )):
-                resolved_ip = "127.0.0.1"
-        except Exception as loopback_error:
-            logger.debug("MCP IP filter loopback normalization failed", exc_info=loopback_error)
 
     if not controller.is_allowed(resolved_ip):
         logger.warning(

--- a/tldw_Server_API/app/core/MCP_unified/security/request_guards.py
+++ b/tldw_Server_API/app/core/MCP_unified/security/request_guards.py
@@ -10,8 +10,8 @@ from fastapi import HTTPException, Request
 from loguru import logger
 from starlette.requests import ClientDisconnect
 
-from tldw_Server_API.app.core.testing import is_test_mode
 from ..config import get_config
+from ..environment import is_test_mode
 from .ip_filter import enforce_ip_allowlist as _enforce_ip_allowlist
 from .ip_filter import get_ip_access_controller
 

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_extraction_contracts.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_extraction_contracts.py
@@ -368,6 +368,28 @@ def test_server_uses_runtime_dependencies_for_stage3c_host_services() -> None:
     assert offenders == []
 
 
+def test_security_and_config_use_package_local_environment_helpers() -> None:
+    forbidden_import = "tldw_Server_API.app.core.testing"
+    targets = {
+        MCP_ROOT / "config.py": MCP_PACKAGE,
+        MCP_ROOT / "security" / "ip_filter.py": f"{MCP_PACKAGE}.security",
+        MCP_ROOT / "security" / "request_guards.py": f"{MCP_PACKAGE}.security",
+    }
+
+    offenders: dict[str, list[str]] = {}
+    for path, package in targets.items():
+        imports = _resolved_import_sources_for(path, package)
+        blocked = sorted(
+            source
+            for source in imports
+            if source == forbidden_import or source.startswith(f"{forbidden_import}.")
+        )
+        if blocked:
+            offenders[str(path.relative_to(MCP_ROOT))] = blocked
+
+    assert offenders == {}
+
+
 def test_protocol_boundary_scan_resolves_relative_imports(tmp_path: Path) -> None:
     sample = tmp_path / "sample.py"
     sample.write_text(

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_http_security_guards.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_http_security_guards.py
@@ -3,6 +3,7 @@
 import pytest
 from fastapi import Depends, FastAPI, HTTPException
 from fastapi.testclient import TestClient
+from pytest import MonkeyPatch
 from starlette.requests import Request
 
 from tldw_Server_API.app.core.MCP_unified.security import ip_filter
@@ -29,6 +30,10 @@ def _build_guarded_app() -> FastAPI:
         return {"status": "ok"}
 
     return app
+
+
+def _clear_ip_access_controller_cache() -> None:
+    ip_filter.get_ip_access_controller.cache_clear()  # type: ignore[attr-defined]
 
 
 def test_enforce_http_security_rejects_large_payload(monkeypatch):
@@ -158,7 +163,9 @@ async def test_enforce_request_body_limit_handles_client_disconnect(monkeypatch)
 
 
 @pytest.mark.asyncio
-async def test_ip_allowlist_normalizes_missing_client_ip_in_test_mode(monkeypatch):
+async def test_ip_allowlist_normalizes_missing_client_ip_in_test_mode(
+    monkeypatch: MonkeyPatch,
+) -> None:
     from types import SimpleNamespace
 
     cfg = SimpleNamespace(
@@ -177,10 +184,7 @@ async def test_ip_allowlist_normalizes_missing_client_ip_in_test_mode(monkeypatc
         "tldw_Server_API.app.core.MCP_unified.security.ip_filter.get_config",
         lambda: cfg,
     )
-    try:
-        ip_filter.get_ip_access_controller.cache_clear()  # type: ignore[attr-defined]
-    except Exception:
-        _ = None
+    _clear_ip_access_controller_cache()
 
     scope = {
         "type": "http",
@@ -196,7 +200,7 @@ async def test_ip_allowlist_normalizes_missing_client_ip_in_test_mode(monkeypatc
         "server": ("testserver", 80),
     }
 
-    async def _receive_empty():
+    async def _receive_empty() -> dict[str, object]:
         return {"type": "http.request", "body": b""}
 
     request = Request(scope, _receive_empty)
@@ -204,7 +208,61 @@ async def test_ip_allowlist_normalizes_missing_client_ip_in_test_mode(monkeypatc
     await ip_filter.enforce_ip_allowlist(request)
 
 
-def test_client_certificate_guard_allows_testclient_only_in_test_mode(monkeypatch):
+@pytest.mark.asyncio
+async def test_ip_allowlist_rejects_spoofed_testclient_forwarded_header_outside_test_mode(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    from types import SimpleNamespace
+
+    cfg = SimpleNamespace(
+        allowed_client_ips=["127.0.0.1"],
+        blocked_client_ips=[],
+        trust_x_forwarded_for=True,
+        trusted_proxy_depth=0,
+        trusted_proxy_ips=["127.0.0.1/32"],
+        http_max_body_bytes=524288,
+        client_cert_required=False,
+        client_cert_header=None,
+        client_cert_header_value=None,
+    )
+    monkeypatch.delenv("TEST_MODE", raising=False)
+    monkeypatch.delenv("TLDW_TEST_MODE", raising=False)
+    monkeypatch.setattr(ip_filter, "is_explicit_pytest_runtime", lambda: False)
+    monkeypatch.setattr(ip_filter, "is_test_mode", lambda: False)
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.MCP_unified.security.ip_filter.get_config",
+        lambda: cfg,
+    )
+    _clear_ip_access_controller_cache()
+
+    scope = {
+        "type": "http",
+        "asgi": {"version": "3.0", "spec_version": "2.3"},
+        "http_version": "1.1",
+        "method": "POST",
+        "scheme": "http",
+        "path": "/api/v1/mcp/health",
+        "raw_path": b"/api/v1/mcp/health",
+        "query_string": b"",
+        "headers": [(b"x-forwarded-for", b"testclient")],
+        "client": ("127.0.0.1", 12345),
+        "server": ("testserver", 80),
+    }
+
+    async def _receive_empty() -> dict[str, object]:
+        return {"type": "http.request", "body": b""}
+
+    request = Request(scope, _receive_empty)
+
+    with pytest.raises(HTTPException) as rejected:
+        await ip_filter.enforce_ip_allowlist(request)
+
+    assert rejected.value.status_code == 403
+
+
+def test_client_certificate_guard_allows_testclient_only_in_test_mode(
+    monkeypatch: MonkeyPatch,
+) -> None:
     from types import SimpleNamespace
 
     cfg = SimpleNamespace(
@@ -228,10 +286,7 @@ def test_client_certificate_guard_allows_testclient_only_in_test_mode(monkeypatc
         "tldw_Server_API.app.core.MCP_unified.security.ip_filter.get_config",
         lambda: cfg,
     )
-    try:
-        ip_filter.get_ip_access_controller.cache_clear()  # type: ignore[attr-defined]
-    except Exception:
-        _ = None
+    _clear_ip_access_controller_cache()
 
     with pytest.raises(HTTPException) as rejected:
         enforce_client_certificate_headers(

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_http_security_guards.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_http_security_guards.py
@@ -1,12 +1,13 @@
 """Regression tests for HTTP-layer security guards."""
 
 import pytest
-from fastapi import Depends, FastAPI
+from fastapi import Depends, FastAPI, HTTPException
 from fastapi.testclient import TestClient
 from starlette.requests import Request
 
 from tldw_Server_API.app.core.MCP_unified.security import ip_filter
 from tldw_Server_API.app.core.MCP_unified.security.request_guards import (
+    enforce_client_certificate_headers,
     enforce_http_security,
     enforce_request_body_limit,
 )
@@ -154,6 +155,104 @@ async def test_enforce_request_body_limit_handles_client_disconnect(monkeypatch)
 
     # Should not propagate starlette.requests.ClientDisconnect
     await enforce_request_body_limit(request)
+
+
+@pytest.mark.asyncio
+async def test_ip_allowlist_normalizes_missing_client_ip_in_test_mode(monkeypatch):
+    from types import SimpleNamespace
+
+    cfg = SimpleNamespace(
+        allowed_client_ips=["127.0.0.1"],
+        blocked_client_ips=[],
+        trust_x_forwarded_for=False,
+        trusted_proxy_depth=0,
+        trusted_proxy_ips=[],
+        http_max_body_bytes=524288,
+        client_cert_required=False,
+        client_cert_header=None,
+        client_cert_header_value=None,
+    )
+    monkeypatch.setenv("TLDW_TEST_MODE", "1")
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.MCP_unified.security.ip_filter.get_config",
+        lambda: cfg,
+    )
+    try:
+        ip_filter.get_ip_access_controller.cache_clear()  # type: ignore[attr-defined]
+    except Exception:
+        _ = None
+
+    scope = {
+        "type": "http",
+        "asgi": {"version": "3.0", "spec_version": "2.3"},
+        "http_version": "1.1",
+        "method": "POST",
+        "scheme": "http",
+        "path": "/api/v1/mcp/health",
+        "raw_path": b"/api/v1/mcp/health",
+        "query_string": b"",
+        "headers": [],
+        "client": None,
+        "server": ("testserver", 80),
+    }
+
+    async def _receive_empty():
+        return {"type": "http.request", "body": b""}
+
+    request = Request(scope, _receive_empty)
+
+    await ip_filter.enforce_ip_allowlist(request)
+
+
+def test_client_certificate_guard_allows_testclient_only_in_test_mode(monkeypatch):
+    from types import SimpleNamespace
+
+    cfg = SimpleNamespace(
+        allowed_client_ips=[],
+        blocked_client_ips=[],
+        trust_x_forwarded_for=False,
+        trusted_proxy_depth=0,
+        trusted_proxy_ips=[],
+        http_max_body_bytes=524288,
+        client_cert_required=True,
+        client_cert_header="x-client-cert",
+        client_cert_header_value="verified",
+    )
+    monkeypatch.delenv("TEST_MODE", raising=False)
+    monkeypatch.delenv("TLDW_TEST_MODE", raising=False)
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.MCP_unified.security.request_guards.get_config",
+        lambda: cfg,
+    )
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.MCP_unified.security.ip_filter.get_config",
+        lambda: cfg,
+    )
+    try:
+        ip_filter.get_ip_access_controller.cache_clear()  # type: ignore[attr-defined]
+    except Exception:
+        _ = None
+
+    with pytest.raises(HTTPException) as rejected:
+        enforce_client_certificate_headers(
+            {"x-client-cert": "verified"},
+            remote_addr="testclient",
+        )
+    assert rejected.value.status_code == 403
+
+    monkeypatch.setenv("TLDW_TEST_MODE", "1")
+
+    enforce_client_certificate_headers(
+        {"x-client-cert": "verified"},
+        remote_addr="testclient",
+    )
+
+    with pytest.raises(HTTPException) as bad_cert:
+        enforce_client_certificate_headers(
+            {"x-client-cert": "denied"},
+            remote_addr="testclient",
+        )
+    assert bad_cert.value.status_code == 403
 
 
 def test_enforce_http_security_requires_client_certificate(monkeypatch):


### PR DESCRIPTION
## Change summary (maintainer-owned)

Maintainer: replace this section with your own summary before merge, per `Docs/superpowers/AI_GENERATED_PR_CHANGE_SUMMARY_POLICY_2026_04_17.md`.

## AI-authored implementation notes

- Added dependency-free MCP Unified environment helpers for truthy env flags, explicit MCP test mode, and active pytest runtime detection.
- Updated MCP config and security guard code to use the package-local helper instead of importing `tldw_Server_API.app.core.testing`.
- Added an extraction contract test that blocks `config.py`, `security/ip_filter.py`, and `security/request_guards.py` from regressing to the host testing helper import.
- Added guard behavior coverage for missing-client-IP loopback normalization in test mode and `testclient` client-certificate handling.
- Closed TASK-482 with verification notes.

## Verification

- RED: `.venv/bin/python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_extraction_contracts.py::test_security_and_config_use_package_local_environment_helpers tldw_Server_API/app/core/MCP_unified/tests/test_http_security_guards.py::test_ip_allowlist_normalizes_missing_client_ip_in_test_mode tldw_Server_API/app/core/MCP_unified/tests/test_http_security_guards.py::test_client_certificate_guard_allows_testclient_only_in_test_mode -q` failed as expected on the new import-boundary test before implementation.
- GREEN: `.venv/bin/python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_extraction_contracts.py::test_security_and_config_use_package_local_environment_helpers tldw_Server_API/app/core/MCP_unified/tests/test_http_security_guards.py::test_ip_allowlist_normalizes_missing_client_ip_in_test_mode tldw_Server_API/app/core/MCP_unified/tests/test_http_security_guards.py::test_client_certificate_guard_allows_testclient_only_in_test_mode -q` -> 3 passed.
- `.venv/bin/python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_extraction_contracts.py tldw_Server_API/app/core/MCP_unified/tests/test_http_security_guards.py tldw_Server_API/app/core/MCP_unified/tests/test_config_safe_defaults.py -q` -> 43 passed, 3 warnings.
- `.venv/bin/python -m ruff check tldw_Server_API/app/core/MCP_unified/environment.py tldw_Server_API/app/core/MCP_unified/config.py tldw_Server_API/app/core/MCP_unified/security/ip_filter.py tldw_Server_API/app/core/MCP_unified/security/request_guards.py tldw_Server_API/app/core/MCP_unified/tests/test_extraction_contracts.py tldw_Server_API/app/core/MCP_unified/tests/test_http_security_guards.py` -> All checks passed.
- `.venv/bin/python -m bandit -r tldw_Server_API/app/core/MCP_unified/environment.py tldw_Server_API/app/core/MCP_unified/config.py tldw_Server_API/app/core/MCP_unified/security/ip_filter.py tldw_Server_API/app/core/MCP_unified/security/request_guards.py -f json -o /tmp/bandit_mcp_stage3d_security_test_seams.json` -> empty `results`.
- `git diff --check` -> passed.

## Watchlists

- [ ] Confirm no standalone-package packaging step needs `environment.py` mirrored into `mcp_unified/` before config/security are moved.
- [ ] Confirm test-mode behavior remains intentionally limited to `TEST_MODE`/`TLDW_TEST_MODE`, with pytest runtime detection only used where the prior code already used `PYTEST_CURRENT_TEST`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracted a dependency-free test-mode environment seam for MCP Unified and moved config/security to it, removing `tldw_Server_API.app.core.testing` imports. Tightened test handling by gating loopback normalization to explicit pytest or test mode and adding a spoofed `X-Forwarded-For` regression; aligns with TASK-482.

- **Refactors**
  - Added `environment.py` with `is_test_mode`, `env_flag_enabled`, `is_explicit_pytest_runtime`, and `is_truthy`.
  - Updated `config.py`, `security/ip_filter.py`, and `security/request_guards.py` to use the local helper; replaced `PYTEST_CURRENT_TEST` checks with `is_explicit_pytest_runtime`.
  - IP allowlist now normalizes `testclient` or missing client IP to loopback only in pytest/test mode; rejects spoofed `X-Forwarded-For: testclient` outside test mode; client-cert guard still allows `testclient` only in test mode and rejects bad certs.
  - Added import-boundary and guard behavior tests; documented plan and closed TASK-482.

<sup>Written for commit 5e9bdc468a767453ee046ac548d6a2f8b0c9f911. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2108?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

