### PR TITLE
Migrate Flashcards import alerts to design-system Alert

### DIFF
--- a/apps/packages/ui/scripts/design-system-product-state-baseline.json
+++ b/apps/packages/ui/scripts/design-system-product-state-baseline.json
@@ -44,28 +44,6 @@
     "migrationQueue": "shared-product-state"
   },
   {
-    "id": "antd-product-state-import:src/components/Flashcards/tabs/ImportExport/ImportPanel.tsx:Alert#antd-alert-importpanel-type-warning-line-1099-o87fjq",
-    "path": "src/components/Flashcards/tabs/ImportExport/ImportPanel.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/Flashcards/tabs/ImportExport/ImportPanel.tsx before the stable duplicate-id guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
-    "id": "antd-product-state-import:src/components/Flashcards/tabs/ImportExport/ImportPanel.tsx:Alert#antd-alert-importpanel-type-warning-line-1210-clqg8f",
-    "path": "src/components/Flashcards/tabs/ImportExport/ImportPanel.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/Flashcards/tabs/ImportExport/ImportPanel.tsx before the stable duplicate-id guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
     "id": "antd-product-state-import:src/components/Option/Admin/ApiKeyManagementPage.tsx:Alert#antd-alert-apikeymanagementpage-type-error-access-denied-1uep3es",
     "path": "src/components/Option/Admin/ApiKeyManagementPage.tsx",
     "rule": "antd-product-state-import",

--- a/apps/packages/ui/src/components/Flashcards/tabs/ImportExport/ImportPanel.tsx
+++ b/apps/packages/ui/src/components/Flashcards/tabs/ImportExport/ImportPanel.tsx
@@ -1,7 +1,6 @@
 import React from "react"
 import { useQueryClient } from "@tanstack/react-query"
 import {
-  Alert,
   Button,
   Card,
   Collapse,
@@ -16,6 +15,7 @@ import {
 } from "antd"
 import { useTranslation } from "react-i18next"
 
+import { Alert } from "@/components/ui/primitives"
 import { useAntdMessage } from "@/hooks/useAntdMessage"
 import { useUndoNotification } from "@/hooks/useUndoNotification"
 import { processInChunks } from "@/utils/chunk-processing"
@@ -1097,14 +1097,14 @@ export const ImportPanel: React.FC<TransferActionReporterProps> = ({ onTransferA
       )}
       {importPreflightWarning && (
         <Alert
-          type="warning"
-          showIcon
+          variant="warning"
           data-testid="flashcards-import-preflight-warning"
           title={t("option:flashcards.importPreflightTitle", {
             defaultValue: "Check import format before continuing"
           })}
-          description={importPreflightWarning}
-        />
+        >
+          {importPreflightWarning}
+        </Alert>
       )}
       {importMode !== "structured" && (
         <>
@@ -1208,32 +1208,30 @@ export const ImportPanel: React.FC<TransferActionReporterProps> = ({ onTransferA
 
       {importMode === "structured" && structuredPreviewErrors.length > 0 && (
         <Alert
-          type="warning"
-          showIcon
+          variant="warning"
           data-testid="flashcards-structured-preview-errors"
           title={t("option:flashcards.structuredPreviewErrorsTitle", {
             defaultValue: "Preview warnings"
           })}
-          description={
-            <div className="space-y-1 text-xs">
-              {structuredPreviewErrors.map((error, index) => (
-                <div key={`${error.line ?? "line"}-${index}`}>
-                  <Text code>
-                    {typeof error.line === "number"
-                      ? t("option:flashcards.importErrorLine", {
-                          defaultValue: "Line {{line}}",
-                          line: error.line
-                        })
-                      : t("option:flashcards.importErrorRowUnknown", {
-                          defaultValue: "Unknown row"
-                        })}
-                  </Text>
-                  <Text className="ml-2">{error.error}</Text>
-                </div>
-              ))}
-            </div>
-          }
-        />
+        >
+          <div className="space-y-1 text-xs">
+            {structuredPreviewErrors.map((error, index) => (
+              <div key={`${error.line ?? "line"}-${index}`}>
+                <Text code>
+                  {typeof error.line === "number"
+                    ? t("option:flashcards.importErrorLine", {
+                        defaultValue: "Line {{line}}",
+                        line: error.line
+                      })
+                    : t("option:flashcards.importErrorRowUnknown", {
+                        defaultValue: "Unknown row"
+                      })}
+                </Text>
+                <Text className="ml-2">{error.error}</Text>
+              </div>
+            ))}
+          </div>
+        </Alert>
       )}
 
       {importMode === "structured" && structuredDrafts.length > 0 && (
@@ -1316,8 +1314,7 @@ export const ImportPanel: React.FC<TransferActionReporterProps> = ({ onTransferA
       {lastResult && (
         <Alert
           data-testid="flashcards-import-last-result"
-          showIcon
-          type={lastResult.errors.length > 0 ? "warning" : "success"}
+          variant={lastResult.errors.length > 0 ? "warning" : "success"}
           title={
             lastResult.errors.length > 0
               ? t("option:flashcards.lastImportPartial", {
@@ -1330,66 +1327,65 @@ export const ImportPanel: React.FC<TransferActionReporterProps> = ({ onTransferA
                   imported: lastResult.imported
                 })
           }
-          description={
-            lastResult.errors.length > 0 && (
-              <div className="mt-1 space-y-1 text-xs">
-                {lastResult.errors.slice(0, 6).map((err, idx) => {
-                  const location =
-                    typeof err.line === "number"
-                      ? t("option:flashcards.importErrorLine", {
-                          defaultValue: "Line {{line}}",
-                          line: err.line
+        >
+          {lastResult.errors.length > 0 && (
+            <div className="mt-1 space-y-1 text-xs">
+              {lastResult.errors.slice(0, 6).map((err, idx) => {
+                const location =
+                  typeof err.line === "number"
+                    ? t("option:flashcards.importErrorLine", {
+                        defaultValue: "Line {{line}}",
+                        line: err.line
+                      })
+                    : typeof err.index === "number"
+                      ? t("option:flashcards.importErrorItem", {
+                          defaultValue: "Item {{index}}",
+                          index: err.index
                         })
-                      : typeof err.index === "number"
-                        ? t("option:flashcards.importErrorItem", {
-                            defaultValue: "Item {{index}}",
-                            index: err.index
-                          })
-                        : t("option:flashcards.importErrorRowUnknown", {
-                            defaultValue: "Unknown row"
-                          })
-                  const guidance = getImportErrorGuidance(err.error, t)
-                  return (
-                    <div key={`${location}-${idx}`} className="space-y-1">
-                      <div>
-                        <Text code>{location}</Text>
-                        <Text className="ml-2">{err.error}</Text>
-                      </div>
-                      {guidance && (
-                        <div className="flex flex-wrap items-center gap-2 pl-1">
-                          <Text type="secondary" className="block">
-                            {guidance.copy}
-                          </Text>
-                          {guidance.helpAnchorId && (
-                            <Button
-                              type="link"
-                              size="small"
-                              className="!h-auto !p-0 text-xs"
-                              onClick={() => scrollToImportHelp(guidance.helpAnchorId)}
-                              data-testid={`flashcards-import-error-help-${idx}`}
-                            >
-                              {t("option:flashcards.importErrorHelpLink", {
-                                defaultValue: "View format help"
-                              })}
-                            </Button>
-                          )}
-                        </div>
-                      )}
+                      : t("option:flashcards.importErrorRowUnknown", {
+                          defaultValue: "Unknown row"
+                        })
+                const guidance = getImportErrorGuidance(err.error, t)
+                return (
+                  <div key={`${location}-${idx}`} className="space-y-1">
+                    <div>
+                      <Text code>{location}</Text>
+                      <Text className="ml-2">{err.error}</Text>
                     </div>
-                  )
-                })}
-                {lastResult.errors.length > 6 && (
-                  <Text type="secondary">
-                    {t("option:flashcards.importErrorsMore", {
-                      defaultValue: "+{{count}} more errors",
-                      count: lastResult.errors.length - 6
-                    })}
-                  </Text>
-                )}
-              </div>
-            )
-          }
-        />
+                    {guidance && (
+                      <div className="flex flex-wrap items-center gap-2 pl-1">
+                        <Text type="secondary" className="block">
+                          {guidance.copy}
+                        </Text>
+                        {guidance.helpAnchorId && (
+                          <Button
+                            type="link"
+                            size="small"
+                            className="!h-auto !p-0 text-xs"
+                            onClick={() => scrollToImportHelp(guidance.helpAnchorId)}
+                            data-testid={`flashcards-import-error-help-${idx}`}
+                          >
+                            {t("option:flashcards.importErrorHelpLink", {
+                              defaultValue: "View format help"
+                            })}
+                          </Button>
+                        )}
+                      </div>
+                    )}
+                  </div>
+                )
+              })}
+              {lastResult.errors.length > 6 && (
+                <Text type="secondary">
+                  {t("option:flashcards.importErrorsMore", {
+                    defaultValue: "+{{count}} more errors",
+                    count: lastResult.errors.length - 6
+                  })}
+                </Text>
+              )}
+            </div>
+          )}
+        </Alert>
       )}
     </div>
   )

--- a/apps/packages/ui/src/components/Flashcards/tabs/__tests__/ImportExportTab.import-results.test.tsx
+++ b/apps/packages/ui/src/components/Flashcards/tabs/__tests__/ImportExportTab.import-results.test.tsx
@@ -323,7 +323,9 @@ describe("ImportExportTab import result details", () => {
     })
     fireEvent.click(screen.getByTestId("flashcards-import-button"))
 
-    expect(await screen.findByText("Last import: 2 imported, 1 skipped")).toBeInTheDocument()
+    const lastResultAlert = await screen.findByTestId("flashcards-import-last-result")
+    expect(lastResultAlert).toHaveAttribute("data-ds-component", "Alert")
+    expect(screen.getByText("Last import: 2 imported, 1 skipped")).toBeInTheDocument()
     expect(screen.getByText("Line 15")).toBeInTheDocument()
     expect(screen.getByText("Missing required field: Front")).toBeInTheDocument()
     expect(
@@ -383,7 +385,9 @@ describe("ImportExportTab import result details", () => {
       }
     })
 
-    expect(screen.getByTestId("flashcards-import-preflight-warning")).toBeInTheDocument()
+    const preflightWarning = screen.getByTestId("flashcards-import-preflight-warning")
+    expect(preflightWarning).toBeInTheDocument()
+    expect(preflightWarning).toHaveAttribute("data-ds-component", "Alert")
     expect(
       screen.getByText(
         "Selected delimiter (Tab) may be incorrect. This sample looks Comma-delimited."
@@ -595,6 +599,49 @@ describe("ImportExportTab import result details", () => {
         reverse: false
       })
     ])
+  })
+
+  it("renders structured preview warnings with design-system alerts", async () => {
+    const previewMutateAsync = vi.fn().mockResolvedValue({
+      detected_format: "qa_labels",
+      skipped_blocks: 1,
+      errors: [{ line: 3, error: "Skipped unlabeled block" }],
+      drafts: [
+        {
+          front: "What is ATP?",
+          back: "Primary energy currency.",
+          line_start: 1,
+          line_end: 2,
+          tags: []
+        }
+      ]
+    })
+    vi.mocked(usePreviewStructuredQaImportMutation).mockReturnValue({
+      mutateAsync: previewMutateAsync,
+      isPending: false
+    } as any)
+
+    render(<ImportExportTab />)
+    await openImportTask()
+
+    const formatSelect = screen.getByTestId("flashcards-import-format")
+    fireEvent.mouseDown(
+      formatSelect.querySelector(".ant-select-selector") ?? formatSelect
+    )
+    fireEvent.click(screen.getByText("Structured Q&A"))
+
+    fireEvent.change(screen.getByTestId("flashcards-import-textarea"), {
+      target: { value: "Q: What is ATP?\nA: Primary energy currency.\nNotes only." }
+    })
+    fireEvent.click(screen.getByTestId("flashcards-structured-preview-button"))
+
+    const previewWarning = await screen.findByTestId(
+      "flashcards-structured-preview-errors"
+    )
+    expect(previewWarning).toHaveAttribute("data-ds-component", "Alert")
+    expect(previewWarning).toHaveTextContent("Preview warnings")
+    expect(previewWarning).toHaveTextContent("Line 3")
+    expect(previewWarning).toHaveTextContent("Skipped unlabeled block")
   })
 
   it("keeps selected invalid structured drafts in the editor when saving", async () => {

--- a/apps/packages/ui/src/components/Flashcards/tabs/__tests__/__snapshots__/ImportExportTab.import-results.test.tsx.snap
+++ b/apps/packages/ui/src/components/Flashcards/tabs/__tests__/__snapshots__/ImportExportTab.import-results.test.tsx.snap
@@ -2,44 +2,49 @@
 
 exports[`ImportExportTab import result details > matches baseline snapshot for import result state 1`] = `
 <div
-  class="ant-alert ant-alert-warning ant-alert-with-description css-var-root css-dev-only-do-not-override-3uaqrl"
-  data-show="true"
+  class="flex items-start gap-3 rounded-lg border p-3 border-warn/30 bg-warn/10"
+  data-ds-component="Alert"
   data-testid="flashcards-import-last-result"
   role="alert"
 >
   <span
-    class="ant-alert-icon"
+    aria-hidden="true"
+    class="mt-0.5 flex-shrink-0 text-warn"
   >
-    <span
-      aria-label="exclamation-circle"
-      class="anticon anticon-exclamation-circle"
-      role="img"
+    <svg
+      aria-hidden="true"
+      class="lucide lucide-triangle-alert size-4"
+      fill="none"
+      height="24"
+      stroke="currentColor"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      stroke-width="2"
+      viewBox="0 0 24 24"
+      width="24"
+      xmlns="http://www.w3.org/2000/svg"
     >
-      <svg
-        aria-hidden="true"
-        data-icon="exclamation-circle"
-        fill="currentColor"
-        focusable="false"
-        height="1em"
-        viewBox="64 64 896 896"
-        width="1em"
-      >
-        <path
-          d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm-32 232c0-4.4 3.6-8 8-8h48c4.4 0 8 3.6 8 8v272c0 4.4-3.6 8-8 8h-48c-4.4 0-8-3.6-8-8V296zm32 440a48.01 48.01 0 010-96 48.01 48.01 0 010 96z"
-        />
-      </svg>
-    </span>
+      <path
+        d="m21.73 18-8-14a2 2 0 0 0-3.48 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.73-3"
+      />
+      <path
+        d="M12 9v4"
+      />
+      <path
+        d="M12 17h.01"
+      />
+    </svg>
   </span>
   <div
-    class="ant-alert-section"
+    class="min-w-0 flex-1"
   >
-    <div
-      class="ant-alert-title"
+    <p
+      class="text-sm font-medium text-warn"
     >
       Last import: 2 imported, 1 skipped
-    </div>
+    </p>
     <div
-      class="ant-alert-description"
+      class="text-sm text-warn mt-1"
     >
       <div
         class="mt-1 space-y-1 text-xs"

--- a/backlog/tasks/task-544 - Migrate-Flashcards-ImportPanel-alerts-to-design-system-Alert.md
+++ b/backlog/tasks/task-544 - Migrate-Flashcards-ImportPanel-alerts-to-design-system-Alert.md
@@ -1,0 +1,70 @@
+---
+id: TASK-544
+title: Migrate Flashcards ImportPanel alerts to design-system Alert
+status: Done
+assignee: []
+created_date: ''
+updated_date: '2026-05-29 01:58'
+labels:
+  - flashcards
+  - webui
+  - design-system
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Migrate the direct Flashcards import workflow alert states in ImportPanel from Ant Design Alert to the shared design-system Alert primitive without broadening beyond /flashcards.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 ImportPanel no longer imports or renders Ant Design Alert for flashcards import status states.
+- [x] #2 Preflight, structured preview error, and last-result alert states preserve user-facing copy and test ids while rendering the shared design-system Alert marker.
+- [x] #3 Focused Flashcards ImportPanel tests cover the design-system alert rendering path.
+- [x] #4 The design-system product-state baseline no longer lists ImportPanel Alert findings.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Inspect existing ImportPanel tests and current alert render paths.
+2. Add focused failing regression coverage that verifies ImportPanel alert states render as design-system alerts.
+3. Replace the ImportPanel Ant Design Alert usages with the shared Alert primitive, preserving copy/test ids.
+4. Remove resolved ImportPanel Alert entries from the product-state baseline and run focused verification.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+- Replaced ImportPanel direct Ant Design Alert usage with the shared design-system Alert primitive for preflight warnings, structured preview warnings, and last import results.
+- Preserved existing copy, conditional warning/success semantics, help-link behavior, and test ids.
+- Added focused import workflow assertions that the preflight warning, structured preview warning, and last-result states render with data-ds-component="Alert".
+- Removed the resolved Flashcards ImportPanel Alert exceptions from the design-system product-state baseline.
+
+Verification:
+- RED: bun run test src/components/Flashcards/tabs/__tests__/ImportExportTab.import-results.test.tsx --maxWorkers=1 --no-file-parallelism failed on the three new data-ds-component assertions.
+- GREEN: bun run test src/components/Flashcards/tabs/__tests__/ImportExportTab.import-results.test.tsx --maxWorkers=1 --no-file-parallelism passed 28 tests.
+- git diff --check passed.
+- rg confirmed no Flashcards ImportPanel entries remain in design-system-product-state-baseline.json.
+- Bandit skipped: no Python files touched.
+- bun run verify:design-system-state still exits 1 on unrelated existing non-Flashcards blocked/stale findings.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Flashcards ImportPanel import status alerts now render through the shared design-system Alert primitive, with focused regression coverage and updated snapshots. The ImportPanel Alert baseline exceptions were removed; repo-wide design-system verification still reports unrelated existing non-Flashcards blocked/stale entries.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## Summary
- Migrate Flashcards `ImportPanel` preflight, structured-preview, and last-import result alerts from Ant Design `Alert` to the shared design-system `Alert`.
- Add focused import workflow regression coverage for the design-system alert marker and update the affected snapshot.
- Remove the resolved Flashcards `ImportPanel` Alert exceptions from the design-system product-state baseline.

## Change summary (maintainer-owned)
Pending maintainer update before merge: this PR is AI-generated and needs a human-owned explanation of what changed and why these implementation choices were made.

## UX Audit Checklist
- [x] Scope is limited to the `/flashcards` import workflow and direct product-state cleanup.
- [x] Existing import warning/result copy and test ids are preserved.
- [x] Warning and success status semantics are preserved through design-system alert variants.
- [x] No unrelated Study, Quiz, Watchlists, or backend flows were changed.

## Watchlists Checklist
- [x] No Watchlists surfaces or workflows changed.

## Test Plan
- [x] `bun run test src/components/Flashcards/tabs/__tests__/ImportExportTab.import-results.test.tsx --maxWorkers=1 --no-file-parallelism`
- [x] `git diff --check origin/dev..HEAD`
- [x] `rg -n "src/components/Flashcards/tabs/ImportExport/ImportPanel.tsx" apps/packages/ui/scripts/design-system-product-state-baseline.json` returns no matches
- [x] `bun run verify:design-system-state` was run and still exits 1 on unrelated existing non-Flashcards blocked/stale findings
- [x] Bandit skipped: no Python files touched


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrates Flashcards ImportPanel alerts from `antd` `Alert` to the shared design-system `Alert` to standardize the import UI and remove legacy exceptions. Aligns with TASK-544; no copy or behavior changes.

- **Refactors**
  - Replace `antd` `Alert` with design-system `Alert` for preflight warning, structured preview warnings, and last import result; use `variant` and child content.
  - Preserve titles, body copy, test ids, and warning/success semantics.
  - Add focused tests asserting `data-ds-component="Alert"` and update snapshot.
  - Remove ImportPanel `Alert` exceptions from `design-system-product-state-baseline.json`.

<sup>Written for commit b4440190137964c22729981f28fca5b75cd371aa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2109?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

