### PR TITLE
Stage 3E: isolate MCP discovery environment helper

### DIFF
--- a/backlog/tasks/task-545 - Implement-MCP-Unified-Stage-3E-discovery-environment-seam-cleanup.md
+++ b/backlog/tasks/task-545 - Implement-MCP-Unified-Stage-3E-discovery-environment-seam-cleanup.md
@@ -1,0 +1,65 @@
+---
+id: TASK-545
+title: Implement MCP Unified Stage 3E discovery environment seam cleanup
+status: Done
+labels:
+- mcp
+- mcp-unified
+- standalone
+- stage3
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Remove the remaining direct host testing-helper import from MCP discovery module by using the package-local MCP Unified environment helper for catalog_strict truthy parsing. Keep host-adapter imports unchanged and add focused import-boundary/behavior coverage.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] MCP discovery no longer imports `tldw_Server_API.app.core.testing` directly.
+- [x] `catalog_strict` string truthy parsing still reaches the protocol as a boolean value.
+- [x] Focused import-boundary and discovery behavior tests cover the seam.
+- [x] Verification includes focused pytest, Ruff, Bandit, and whitespace diff checks.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+- Switched `mcp_discovery_module.py` from the host-level testing helper to `MCP_unified.environment.is_truthy`.
+- Added an extraction contract test that forbids the discovery implementation from importing `tldw_Server_API.app.core.testing`.
+- Added behavior coverage proving string `catalog_strict` values such as `"yes"` are normalized before dispatch to `MCPProtocol._handle_tools_list`.
+- Cleaned touched test typing annotations to satisfy the repo Ruff rules.
+- Addressed PR review feedback by typing the new async test's `monkeypatch` fixture and return value, and by replacing unused-argument `del` statements in the fake handler with underscore-prefixed parameter names.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Stage 3E removed the remaining non-adapter MCP discovery import of the host testing helper while preserving the catalog strictness parsing behavior. Verification:
+
+- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_extraction_contracts.py tldw_Server_API/app/core/MCP_unified/tests/test_mcp_discovery_module.py tldw_Server_API/tests/MCP_unified/test_mcp_discovery_sanitization.py -q` -> 31 passed, 5 warnings
+- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m ruff check tldw_Server_API/app/core/MCP_unified/modules/implementations/mcp_discovery_module.py tldw_Server_API/app/core/MCP_unified/tests/test_extraction_contracts.py tldw_Server_API/app/core/MCP_unified/tests/test_mcp_discovery_module.py` -> All checks passed
+- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/core/MCP_unified/modules/implementations/mcp_discovery_module.py -f json -o /tmp/bandit_mcp_stage3e_discovery_env.json` -> 0 results, 0 errors
+- `git diff --check` -> passed
+
+PR review pass: after rebasing on `origin/dev` at `a01c7b7f50`, Qodo and Gemini feedback requested explicit type hints on the new test and idiomatic unused parameters in the fake protocol handler. Both were addressed before force-pushing the rebased branch.
+
+No known blockers or verification skips.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Modified Files
+- `tldw_Server_API/app/core/MCP_unified/modules/implementations/mcp_discovery_module.py`
+- `tldw_Server_API/app/core/MCP_unified/tests/test_extraction_contracts.py`
+- `tldw_Server_API/app/core/MCP_unified/tests/test_mcp_discovery_module.py`
+- `backlog/tasks/task-545 - Implement-MCP-Unified-Stage-3E-discovery-environment-seam-cleanup.md`
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/tldw_Server_API/app/core/MCP_unified/modules/implementations/mcp_discovery_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/modules/implementations/mcp_discovery_module.py
@@ -14,8 +14,8 @@ from loguru import logger
 
 from tldw_Server_API.app.core.AuthNZ.database import build_sqlite_in_clause, get_db_pool
 from tldw_Server_API.app.core.AuthNZ.orgs_teams import list_org_memberships_for_user
+from tldw_Server_API.app.core.MCP_unified.environment import is_truthy
 from tldw_Server_API.app.core.MCP_unified.protocol import MCPProtocol, RequestContext
-from tldw_Server_API.app.core.testing import is_truthy
 
 from ..base import BaseModule, create_tool_definition
 

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_extraction_contracts.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_extraction_contracts.py
@@ -390,6 +390,23 @@ def test_security_and_config_use_package_local_environment_helpers() -> None:
     assert offenders == {}
 
 
+def test_mcp_discovery_module_uses_package_local_environment_helpers() -> None:
+    forbidden_import = "tldw_Server_API.app.core.testing"
+    discovery_module = MCP_ROOT / "modules" / "implementations" / "mcp_discovery_module.py"
+
+    imports = _resolved_import_sources_for(
+        discovery_module,
+        f"{MCP_PACKAGE}.modules.implementations",
+    )
+    offenders = sorted(
+        source
+        for source in imports
+        if source == forbidden_import or source.startswith(f"{forbidden_import}.")
+    )
+
+    assert offenders == []
+
+
 def test_protocol_boundary_scan_resolves_relative_imports(tmp_path: Path) -> None:
     sample = tmp_path / "sample.py"
     sample.write_text(

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_mcp_discovery_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_mcp_discovery_module.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, Dict
+from typing import Any
 
 import pytest
 
@@ -17,10 +17,10 @@ class DummyModule(BaseModule):
     async def on_shutdown(self) -> None:
         return None
 
-    async def check_health(self) -> Dict[str, bool]:
+    async def check_health(self) -> dict[str, bool]:
         return {"ok": True}
 
-    async def get_tools(self) -> list[Dict[str, Any]]:
+    async def get_tools(self) -> list[dict[str, Any]]:
         return [
             create_tool_definition(
                 name="dummy.echo",
@@ -29,7 +29,7 @@ class DummyModule(BaseModule):
             )
         ]
 
-    async def execute_tool(self, tool_name: str, arguments: Dict[str, Any], context: Any | None = None) -> Any:
+    async def execute_tool(self, tool_name: str, arguments: dict[str, Any], context: Any | None = None) -> Any:
         return {"ok": True, "tool": tool_name, "args": arguments}
 
 
@@ -52,6 +52,28 @@ async def test_discovery_lists_modules_and_tools(monkeypatch):
 
     tools_res = await mod.execute_tool("mcp.tools.list", {"modules": ["dummy"]}, context=ctx)
     assert any(t.get("name") == "dummy.echo" for t in tools_res.get("tools", []))
+
+
+@pytest.mark.asyncio
+async def test_discovery_tools_list_parses_catalog_strict_string(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, Any] = {}
+
+    async def _handle_tools_list(
+        _self: MCPProtocol,
+        params: dict[str, Any],
+        _context: RequestContext,
+    ) -> dict[str, Any]:
+        captured.update(params)
+        return {"tools": []}
+
+    monkeypatch.setattr(MCPProtocol, "_handle_tools_list", _handle_tools_list)
+
+    mod = MCPDiscoveryModule(ModuleConfig(name="mcp_discovery"))
+    ctx = RequestContext(request_id="mcp-discovery-strict", user_id="1", metadata={})
+
+    await mod.execute_tool("mcp.tools.list", {"catalog_strict": "yes"}, context=ctx)
+
+    assert captured["catalog_strict"] is True
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Change Summary (Maintainer-Owned)

Maintainer to confirm before merge: this PR completes the next MCP Unified standalone extraction cleanup slice by moving MCP discovery's truthy parsing dependency onto the MCP package-local environment helper. The behavior stays the same while reducing host-core coupling outside the explicit runtime adapter boundary.

## AI-Generated Implementation Notes

- Replaced `tldw_Server_API.app.core.testing.is_truthy` with `tldw_Server_API.app.core.MCP_unified.environment.is_truthy` in `mcp_discovery_module.py`.
- Added an extraction contract test to prevent `mcp_discovery_module.py` from reintroducing direct `tldw_Server_API.app.core.testing` imports.
- Added behavior coverage for `catalog_strict` string parsing through `mcp.tools.list`.
- Recorded TASK-545 with acceptance criteria, touched files, verification, Bandit result, and final summary.

## Verification

- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_extraction_contracts.py tldw_Server_API/app/core/MCP_unified/tests/test_mcp_discovery_module.py tldw_Server_API/tests/MCP_unified/test_mcp_discovery_sanitization.py -q` -> 31 passed, 5 warnings
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m ruff check tldw_Server_API/app/core/MCP_unified/modules/implementations/mcp_discovery_module.py tldw_Server_API/app/core/MCP_unified/tests/test_extraction_contracts.py tldw_Server_API/app/core/MCP_unified/tests/test_mcp_discovery_module.py` -> All checks passed
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/core/MCP_unified/modules/implementations/mcp_discovery_module.py -f json -o /tmp/bandit_mcp_stage3e_discovery_env.json` -> 0 results, 0 errors
- `git diff --check` -> passed

## Watchlist

- Host adapter imports of `tldw_Server_API.app.core.testing` are intentionally unchanged in this slice because the adapter is the allowed host integration boundary.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Isolated MCP discovery from the host testing helper by using the package-local environment helper for truthy parsing. Behavior is unchanged and the adapter boundary is cleaner. Addresses TASK-545.

- **Refactors**
  - Replaced `tldw_Server_API.app.core.testing.is_truthy` with `tldw_Server_API.app.core.MCP_unified.environment.is_truthy`.
  - Added an extraction contract test to forbid `tldw_Server_API.app.core.testing` imports in the discovery module.
  - Added behavior coverage to ensure `catalog_strict` string values normalize to booleans for `mcp.tools.list`.

<sup>Written for commit dea22aca000820e681fbae3b091a336b1021a1fb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2111?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

