### PR TITLE
Migrate Flashcards document row states to design system

### DIFF
--- a/apps/packages/ui/scripts/design-system-product-state-baseline.json
+++ b/apps/packages/ui/scripts/design-system-product-state-baseline.json
@@ -1,49 +1,5 @@
 [
   {
-    "id": "antd-product-state-import:src/components/Flashcards/components/FlashcardDocumentRow.tsx:Alert#antd-alert-flashcarddocumentrow-type-error-line-414-o4coyq",
-    "path": "src/components/Flashcards/components/FlashcardDocumentRow.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/Flashcards/components/FlashcardDocumentRow.tsx before the stable duplicate-id guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
-    "id": "antd-product-state-import:src/components/Flashcards/components/FlashcardDocumentRow.tsx:Alert#antd-alert-flashcarddocumentrow-type-error-line-455-1nwiluh",
-    "path": "src/components/Flashcards/components/FlashcardDocumentRow.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/Flashcards/components/FlashcardDocumentRow.tsx before the stable duplicate-id guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
-    "id": "antd-product-state-import:src/components/Flashcards/components/FlashcardDocumentRow.tsx:Alert#antd-alert-flashcarddocumentrow-type-warning-reload-row-1h0zxtk",
-    "path": "src/components/Flashcards/components/FlashcardDocumentRow.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/Flashcards/components/FlashcardDocumentRow.tsx before the stable duplicate-id guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
-    "id": "antd-product-state-import:src/components/Flashcards/components/FlashcardDocumentRow.tsx:Tag",
-    "path": "src/components/Flashcards/components/FlashcardDocumentRow.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Tag",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Tag product-state UI in src/components/Flashcards/components/FlashcardDocumentRow.tsx before the guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
     "id": "antd-product-state-import:src/components/Option/Admin/ApiKeyManagementPage.tsx:Alert#antd-alert-apikeymanagementpage-type-error-access-denied-1uep3es",
     "path": "src/components/Option/Admin/ApiKeyManagementPage.tsx",
     "rule": "antd-product-state-import",

--- a/apps/packages/ui/src/components/Flashcards/components/FlashcardDocumentRow.tsx
+++ b/apps/packages/ui/src/components/Flashcards/components/FlashcardDocumentRow.tsx
@@ -443,7 +443,7 @@ export const FlashcardDocumentRow: React.FC<FlashcardDocumentRowProps> = ({
             title={errorMessage || "This row changed elsewhere."}
             data-testid={`flashcards-document-row-conflict-${savedCard.uuid}`}
           >
-            <div className="flex gap-2">
+            <div className="mt-2 flex gap-2">
               <Button
                 size="small"
                 onClick={(event) => {

--- a/apps/packages/ui/src/components/Flashcards/components/FlashcardDocumentRow.tsx
+++ b/apps/packages/ui/src/components/Flashcards/components/FlashcardDocumentRow.tsx
@@ -1,7 +1,8 @@
 import React from "react"
-import { Alert, Button, Checkbox, Input, Select, Tag, Typography, type InputRef } from "antd"
+import { Button, Checkbox, Input, Select, Typography, type InputRef } from "antd"
 import type { TextAreaRef } from "antd/es/input/TextArea"
 
+import { Alert, Badge } from "@/components/ui/primitives"
 import type { Deck, Flashcard, FlashcardBulkUpdateItem, FlashcardBulkUpdateResponse } from "@/services/flashcards"
 import { getFlashcardSourceMeta } from "../utils/source-reference"
 import { FlashcardQueueStateBadge } from "../utils/queue-state-badges"
@@ -87,6 +88,12 @@ export const FlashcardDocumentRow: React.FC<FlashcardDocumentRowProps> = ({
           `Deck ${savedCard.deck_id}`
         )
       : "No deck"
+  const modelBadgeLabel =
+    savedCard.model_type === "cloze"
+      ? "Fill-in-blank"
+      : savedCard.reverse
+        ? "Reversible"
+        : "Standard"
   const sourceMeta = getFlashcardSourceMeta(savedCard)
 
   const getFieldElement = React.useCallback(
@@ -198,7 +205,11 @@ export const FlashcardDocumentRow: React.FC<FlashcardDocumentRowProps> = ({
                 onError={(error) => setUploadError(error.message)}
               />
             )}
-            {status === "saving" && <Tag color="processing">Saving</Tag>}
+            {status === "saving" && (
+              <Badge variant="info" size="sm" dot>
+                Saving
+              </Badge>
+            )}
             {status === "saved" && undoSnapshot && (
               <Button
                 size="small"
@@ -246,19 +257,27 @@ export const FlashcardDocumentRow: React.FC<FlashcardDocumentRowProps> = ({
           </div>
         )}
         <div className="flex flex-wrap gap-1.5">
-          <Tag>{savedCard.model_type === "cloze" ? "Fill-in-blank" : savedCard.reverse ? "Reversible" : "Standard"}</Tag>
+          <Badge variant="secondary" size="sm">{modelBadgeLabel}</Badge>
           <FlashcardQueueStateBadge
             card={savedCard}
             testId={`flashcards-document-row-queue-state-${savedCard.uuid}`}
           />
-          <Tag color="blue">{deckLabel}</Tag>
+          <Badge variant="info" size="sm" outline>
+            {deckLabel}
+          </Badge>
           {(savedCard.tags || []).map((tag) => (
-            <Tag key={`${savedCard.uuid}-${tag}`}>{tag}</Tag>
+            <Badge key={`${savedCard.uuid}-${tag}`} variant="secondary" size="sm" outline>
+              {tag}
+            </Badge>
           ))}
           {sourceMeta && (
-            <Tag color={sourceMeta.unavailable ? "default" : "green"}>
+            <Badge
+              variant={sourceMeta.unavailable ? "secondary" : "success"}
+              size="sm"
+              outline={sourceMeta.unavailable}
+            >
               {sourceMeta.label}
-            </Tag>
+            </Badge>
           )}
         </div>
       </div>
@@ -412,8 +431,7 @@ export const FlashcardDocumentRow: React.FC<FlashcardDocumentRowProps> = ({
 
         {uploadError && (
           <Alert
-            type="error"
-            showIcon
+            variant="error"
             title={uploadError}
             data-testid={`flashcards-document-row-upload-error-${savedCard.uuid}`}
           />
@@ -421,46 +439,42 @@ export const FlashcardDocumentRow: React.FC<FlashcardDocumentRowProps> = ({
 
         {status === "conflict" && (
           <Alert
-            type="warning"
-            showIcon
+            variant="warning"
             title={errorMessage || "This row changed elsewhere."}
-            action={
-              <div className="flex gap-2">
-                <Button
-                  size="small"
-                  onClick={(event) => {
-                    event.stopPropagation()
-                    void reloadRow()
-                  }}
-                >
-                  Reload row
-                </Button>
-                <Button
-                  size="small"
-                  type="primary"
-                  onClick={(event) => {
-                    event.stopPropagation()
-                    void reapplyConflict()
-                  }}
-                >
-                  Reapply my edit
-                </Button>
-              </div>
-            }
             data-testid={`flashcards-document-row-conflict-${savedCard.uuid}`}
-          />
+          >
+            <div className="flex gap-2">
+              <Button
+                size="small"
+                onClick={(event) => {
+                  event.stopPropagation()
+                  void reloadRow()
+                }}
+              >
+                Reload row
+              </Button>
+              <Button
+                size="small"
+                type="primary"
+                onClick={(event) => {
+                  event.stopPropagation()
+                  void reapplyConflict()
+                }}
+              >
+                Reapply my edit
+              </Button>
+            </div>
+          </Alert>
         )}
 
         {(status === "validation_error" || status === "not_found") && (
           <Alert
-            type="error"
-            showIcon
+            variant="error"
             title={errorMessage || "This row could not be saved."}
-            description={
-              validationFields.length > 0 ? `Check: ${validationFields.join(", ")}` : undefined
-            }
             data-testid={`flashcards-document-row-error-${savedCard.uuid}`}
-          />
+          >
+            {validationFields.length > 0 ? `Check: ${validationFields.join(", ")}` : null}
+          </Alert>
         )}
       </div>
     </div>

--- a/apps/packages/ui/src/components/Flashcards/components/__tests__/FlashcardDocumentRow.image-insert.test.tsx
+++ b/apps/packages/ui/src/components/Flashcards/components/__tests__/FlashcardDocumentRow.image-insert.test.tsx
@@ -122,4 +122,40 @@ describe("FlashcardDocumentRow image insertion", () => {
       )
     })
   })
+
+  it("renders upload failures with a design-system alert", async () => {
+    uploadFlashcardAsset.mockRejectedValue(new Error("Upload unavailable"))
+
+    render(
+      <FlashcardDocumentRow
+        card={makeFlashcard()}
+        decks={decks}
+        selected={false}
+        selectAllAcross={false}
+        filterContext={{
+          deckId: 1,
+          tags: ["bio"],
+          sortBy: "due",
+          dueStatus: "all"
+        }}
+        queryKey={["flashcards:document", 1]}
+        onToggleSelect={() => {}}
+        bulkUpdate={vi.fn()}
+      />
+    )
+
+    fireEvent.click(screen.getByTestId("flashcards-document-row-front-display-row-1"))
+    await screen.findByTestId("flashcards-document-row-front-input-row-1")
+
+    const uploadInput = screen.getByLabelText("Upload image for Question row-1")
+    fireEvent.change(uploadInput, {
+      target: {
+        files: [new File(["binary"], "scan.png", { type: "image/png" })]
+      }
+    })
+
+    const alert = await screen.findByTestId("flashcards-document-row-upload-error-row-1")
+    expect(alert).toHaveAttribute("data-ds-component", "Alert")
+    expect(alert).toHaveTextContent("Upload unavailable")
+  })
 })

--- a/apps/packages/ui/src/components/Flashcards/components/__tests__/FlashcardDocumentRow.test.tsx
+++ b/apps/packages/ui/src/components/Flashcards/components/__tests__/FlashcardDocumentRow.test.tsx
@@ -62,6 +62,54 @@ describe("FlashcardDocumentRow", () => {
     vi.clearAllMocks()
   })
 
+  it("renders row metadata chips with design-system badges", () => {
+    render(
+      <FlashcardDocumentRow
+        card={makeFlashcard({
+          reverse: true,
+          tags: ["bio", "exam"],
+          source_ref_type: "media",
+          source_ref_id: "42"
+        })}
+        decks={decks}
+        selected={false}
+        selectAllAcross={false}
+        filterContext={{
+          deckId: 1,
+          tags: ["bio"],
+          sortBy: "due",
+          dueStatus: "all"
+        }}
+        queryKey={["flashcards:document", 1]}
+        onToggleSelect={() => {}}
+        bulkUpdate={vi.fn()}
+      />
+    )
+
+    expect(
+      screen.getByText("Reversible").closest('[data-ds-component="Badge"]')
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText("New").closest('[data-ds-component="Badge"]')
+    ).toBeInTheDocument()
+    expect(
+      screen
+        .getAllByText("Biology")
+        .some((node) => node.closest('[data-ds-component="Badge"]'))
+    ).toBe(true)
+    expect(
+      screen
+        .getAllByText("bio")
+        .some((node) => node.closest('[data-ds-component="Badge"]'))
+    ).toBe(true)
+    expect(
+      screen.getByText("exam").closest('[data-ds-component="Badge"]')
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText("Media #42").closest('[data-ds-component="Badge"]')
+    ).toBeInTheDocument()
+  })
+
   it("queues overlapping row edits and sends the second patch after the first succeeds", async () => {
     let resolveFirst: ((value: FlashcardBulkUpdateResponse) => void) | null = null
     const firstPromise = new Promise<FlashcardBulkUpdateResponse>((resolve) => {
@@ -210,7 +258,8 @@ describe("FlashcardDocumentRow", () => {
     fireEvent.change(notesInput, { target: { value: "" } })
     fireEvent.blur(notesInput)
 
-    await screen.findByTestId("flashcards-document-row-conflict-row-1")
+    const conflictAlert = await screen.findByTestId("flashcards-document-row-conflict-row-1")
+    expect(conflictAlert).toHaveAttribute("data-ds-component", "Alert")
     fireEvent.click(screen.getByRole("button", { name: /reapply my edit/i }))
 
     await waitFor(() => {
@@ -273,7 +322,8 @@ describe("FlashcardDocumentRow", () => {
     fireEvent.change(frontInput, { target: { value: "Edited front" } })
     fireEvent.blur(frontInput)
 
-    await screen.findByTestId("flashcards-document-row-conflict-row-1")
+    const conflictAlert = await screen.findByTestId("flashcards-document-row-conflict-row-1")
+    expect(conflictAlert).toHaveAttribute("data-ds-component", "Alert")
     fireEvent.click(screen.getByRole("button", { name: /reload row/i }))
 
     await waitFor(() => {

--- a/apps/packages/ui/src/components/Flashcards/utils/queue-state-badges.tsx
+++ b/apps/packages/ui/src/components/Flashcards/utils/queue-state-badges.tsx
@@ -1,34 +1,34 @@
 import React from "react"
-import { Tag } from "antd"
 
+import { Badge, type BadgeVariant } from "@/components/ui/primitives"
 import type { Flashcard } from "@/services/flashcards"
 
 const QUEUE_STATE_META: Record<
   Flashcard["queue_state"],
   {
     label: string
-    color: string
+    variant: BadgeVariant
   }
 > = {
   new: {
     label: "New",
-    color: "blue"
+    variant: "info"
   },
   learning: {
     label: "Learning",
-    color: "gold"
+    variant: "warning"
   },
   review: {
     label: "Review",
-    color: "green"
+    variant: "success"
   },
   relearning: {
     label: "Relearning",
-    color: "orange"
+    variant: "warning"
   },
   suspended: {
     label: "Suspended",
-    color: "red"
+    variant: "danger"
   }
 }
 
@@ -74,9 +74,14 @@ export const FlashcardQueueStateBadge: React.FC<FlashcardQueueStateBadgeProps> =
   const normalizedQueueState = coerceQueueState(card.queue_state)
 
   return (
-    <Tag color={QUEUE_STATE_META[normalizedQueueState].color} data-testid={testId}>
+    <Badge
+      variant={QUEUE_STATE_META[normalizedQueueState].variant}
+      size="sm"
+      dot
+      data-testid={testId}
+    >
       {formatFlashcardQueueStateLabel(normalizedQueueState, card.suspended_reason)}
-    </Tag>
+    </Badge>
   )
 }
 

--- a/backlog/tasks/task-545 - Migrate-Flashcards-document-row-product-states-to-design-system.md
+++ b/backlog/tasks/task-545 - Migrate-Flashcards-document-row-product-states-to-design-system.md
@@ -1,0 +1,71 @@
+---
+id: TASK-545
+title: Migrate Flashcards document row product states to design system
+status: Done
+assignee: []
+created_date: ''
+updated_date: '2026-05-29 03:46'
+labels:
+  - flashcards
+  - webui
+  - design-system
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Migrate the remaining Flashcards document row Alert and Tag product-state affordances from Ant Design primitives to shared design-system primitives without broadening beyond the /flashcards document row workflow.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 FlashcardDocumentRow no longer imports or renders Ant Design Alert or Tag for product-state row affordances.
+- [x] #2 Upload errors, conflict recovery, validation/not-found errors, saving status, card-type chips, deck chips, tag chips, and source chips preserve visible copy, actions, and test ids where present.
+- [x] #3 Focused Flashcards document-row tests cover the design-system Alert and chip rendering paths.
+- [x] #4 The design-system product-state baseline no longer lists FlashcardDocumentRow Alert or Tag findings.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Inspect existing FlashcardDocumentRow tests and local design-system primitives used for chips/badges.
+2. Add focused failing regression coverage for row alert and chip product-state rendering.
+3. Replace Ant Design Alert/Tag usages in FlashcardDocumentRow with shared design-system primitives while preserving behavior.
+4. Remove resolved FlashcardDocumentRow entries from the product-state baseline and run focused verification.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+- Replaced FlashcardDocumentRow Ant Design Alert usage with shared design-system Alert for upload errors, conflict recovery, and validation/not-found errors.
+- Replaced FlashcardDocumentRow direct Ant Design Tag usage with shared design-system Badge for saving status, card type, deck, user tags, and source chips.
+- Migrated FlashcardQueueStateBadge from Ant Design Tag to shared design-system Badge so row queue-state metadata uses the same design-system chip contract.
+- Added focused row tests for design-system metadata badges, conflict alerts, and upload-error alerts.
+- Removed the resolved FlashcardDocumentRow Alert/Tag exceptions from the design-system product-state baseline.
+
+Verification:
+- RED: bun run test src/components/Flashcards/components/__tests__/FlashcardDocumentRow.test.tsx src/components/Flashcards/components/__tests__/FlashcardDocumentRow.image-insert.test.tsx --maxWorkers=1 --no-file-parallelism failed on the new design-system Alert/Badge assertions.
+- GREEN: bun run test src/components/Flashcards/components/__tests__/FlashcardDocumentRow.test.tsx src/components/Flashcards/components/__tests__/FlashcardDocumentRow.image-insert.test.tsx src/components/Flashcards/tabs/__tests__/ManageTab.document-mode.test.tsx src/components/Flashcards/tabs/__tests__/ReviewTab.queue-state.test.tsx --maxWorkers=1 --no-file-parallelism passed 15 tests across 4 files.
+- git diff --check passed.
+- rg confirmed no FlashcardDocumentRow entries remain in design-system-product-state-baseline.json.
+- Bandit skipped: no Python files touched.
+- bun run verify:design-system-state still exits 1 on unrelated existing non-Flashcards blocked/stale findings; Flashcards exceptions dropped from 28 to 24.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Flashcards document row product-state alerts and chips now render through shared design-system Alert/Badge primitives, including queue-state badges. Focused row, document-mode, and review queue-state tests cover the migrated paths. The FlashcardDocumentRow Alert/Tag baseline exceptions were removed; repo-wide design-system verification still reports unrelated existing non-Flashcards blocked/stale findings.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## Summary
- Migrate `FlashcardDocumentRow` upload/conflict/validation alerts from Ant Design `Alert` to the shared design-system `Alert`.
- Replace document-row metadata chips and `FlashcardQueueStateBadge` with the shared design-system `Badge`.
- Remove the resolved `FlashcardDocumentRow` Alert/Tag entries from the product-state baseline and add focused regression coverage.

## Change summary (maintainer-owned)
Pending maintainer update before merge: this PR is AI-generated and needs a human-owned explanation of what changed and why these implementation choices were made.

## UX Audit Checklist
- [x] Scope is limited to the `/flashcards` document-row workflow and direct product-state cleanup.
- [x] Existing row copy, actions, test ids, and conflict recovery behavior are preserved.
- [x] Status, deck, tag, source, and queue-state chips now use the shared design-system badge marker.
- [x] No unrelated Study, Quiz, Watchlists, backend, or broad app redesign surfaces were changed.

## Watchlists Checklist
- [x] No Watchlists surfaces or workflows changed.

## Test Plan
- [x] `bun run test src/components/Flashcards/components/__tests__/FlashcardDocumentRow.test.tsx src/components/Flashcards/components/__tests__/FlashcardDocumentRow.image-insert.test.tsx src/components/Flashcards/tabs/__tests__/ManageTab.document-mode.test.tsx src/components/Flashcards/tabs/__tests__/ReviewTab.queue-state.test.tsx --maxWorkers=1 --no-file-parallelism`
- [x] `git diff --check origin/dev..HEAD`
- [x] `rg -n "src/components/Flashcards/components/FlashcardDocumentRow.tsx|FlashcardDocumentRow.tsx:(Alert|Tag)|antd-alert-flashcarddocumentrow" apps/packages/ui/scripts/design-system-product-state-baseline.json` returns no matches
- [x] `bun run verify:design-system-state` was run and still exits 1 on unrelated existing non-Flashcards blocked/stale findings
- [x] Bandit skipped: no Python files touched

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrates Flashcards document-row alerts and chips from Ant Design to the design-system `Alert` and `Badge` to unify UI and remove legacy exceptions. Satisfies TASK-545 while preserving copy, actions, and test ids.

- **Refactors**
  - Replaced AntD `Alert`/`Tag` in `FlashcardDocumentRow` with design-system `Alert`/`Badge` from `@/components/ui/primitives` for upload errors, conflicts, validation/not-found, and saving; model, deck, tag, and source chips now use variant/outline badges.
  - Moved `FlashcardQueueStateBadge` to design-system `Badge` with variant mapping and small/dot styles.
  - Updated tests to assert `data-ds-component` on Alerts/Badges (including upload-failure and conflict cases) and removed related findings from `design-system-product-state-baseline.json`.

<sup>Written for commit 996b5be9bcbcbf170dbdb883606464b682fc3608. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2112?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

