### PR TITLE
Stage 3F: extract MCP catalog schema seam

### DIFF
--- a/Docs/superpowers/plans/2026-05-29-mcp-unified-stage3f-catalog-schema-seam-plan.md
+++ b/Docs/superpowers/plans/2026-05-29-mcp-unified-stage3f-catalog-schema-seam-plan.md
@@ -1,0 +1,44 @@
+# MCP Unified Stage 3F Catalog Schema Seam Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Move MCP external catalog entry schemas into the standalone `mcp_unified` package while preserving tldw_server API schema compatibility.
+
+**Architecture:** Define the catalog schema in `mcp_unified.federation.models`, update the MCP catalog loader to import from that package boundary, and re-export the same model/type from `archetype_schemas.py` so existing API imports remain stable.
+
+**Tech Stack:** Python, Pydantic, pytest, Ruff, Bandit.
+
+**Backlog:** TASK-546
+
+---
+
+### Task 1: RED Boundary And Compatibility Tests
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/MCP_unified/tests/test_extraction_contracts.py`
+- Modify: `tldw_Server_API/tests/unit/test_mcp_catalog_loader.py`
+
+- [x] Add a contract test that fails while `catalog_loader.py` imports `MCPCatalogEntry` from `tldw_Server_API.app.api.v1.schemas.archetype_schemas`.
+- [x] Add/adjust catalog behavior coverage proving `catalog_loader.py` returns the same `MCPCatalogEntry` class exported by `mcp_unified.federation.models` and by `archetype_schemas.py`.
+- [x] Run the focused tests and confirm the boundary test fails before implementation.
+
+### Task 2: Move Catalog Schema Ownership
+
+**Files:**
+- Modify: `mcp_unified/federation/models.py`
+- Modify: `tldw_Server_API/app/api/v1/schemas/archetype_schemas.py`
+- Modify: `tldw_Server_API/app/core/MCP_unified/catalog_loader.py`
+
+- [x] Add `MCPAuthType` and `MCPCatalogEntry` to `mcp_unified.federation.models`.
+- [x] Re-export those names from `archetype_schemas.py`.
+- [x] Update `catalog_loader.py` to import from `mcp_unified.federation.models`.
+- [x] Re-run the focused tests and confirm they pass.
+
+### Task 3: Validation And Closeout
+
+**Files:**
+- Modify: `backlog/tasks/task-546 - Implement-MCP-Unified-Stage-3F-catalog-schema-seam-cleanup.md`
+
+- [x] Run focused pytest for extraction contracts, catalog loader, archetype schema tests, and standalone package boundary tests.
+- [x] Run Ruff and Bandit on touched files.
+- [ ] Update TASK-546 with verification, final summary, and PR link.

--- a/Docs/superpowers/plans/2026-05-29-mcp-unified-stage3f-catalog-schema-seam-plan.md
+++ b/Docs/superpowers/plans/2026-05-29-mcp-unified-stage3f-catalog-schema-seam-plan.md
@@ -41,4 +41,4 @@
 
 - [x] Run focused pytest for extraction contracts, catalog loader, archetype schema tests, and standalone package boundary tests.
 - [x] Run Ruff and Bandit on touched files.
-- [ ] Update TASK-546 with verification, final summary, and PR link.
+- [x] Update TASK-546 with verification, final summary, and PR link.

--- a/backlog/tasks/task-546 - Implement-MCP-Unified-Stage-3F-catalog-schema-seam-cleanup.md
+++ b/backlog/tasks/task-546 - Implement-MCP-Unified-Stage-3F-catalog-schema-seam-cleanup.md
@@ -59,6 +59,11 @@ Verification:
 - `git diff --check` -> clean.
 
 PR: https://github.com/rmusser01/tldw_server/pull/2115
+
+Rebase/review follow-up:
+- Rebasing onto origin/dev 7afa5191a6 completed without conflicts.
+- CodeRabbit pre-merge summary warned about docstring coverage and PR body template content. The broader docstring percentage includes existing test-file baseline, but the new regression tests now include explicit docstrings. PR body template content was updated with a Risk & Rollback section; the maintainer-owned summary placeholder remains because project policy requires the human maintainer to write it.
+- Follow-up verification: focused pytest -> 73 passed, 5 warnings; Ruff -> all checks passed; Bandit -> 0 findings; `git diff --check` -> clean.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-546 - Implement-MCP-Unified-Stage-3F-catalog-schema-seam-cleanup.md
+++ b/backlog/tasks/task-546 - Implement-MCP-Unified-Stage-3F-catalog-schema-seam-cleanup.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-546
 title: Implement MCP Unified Stage 3F catalog schema seam cleanup
-status: In Progress
+status: Done
 labels:
 - mcp
 - mcp-unified
@@ -57,6 +57,8 @@ Verification:
 - `.venv/bin/python -m ruff check mcp_unified/federation/models.py tldw_Server_API/app/api/v1/schemas/archetype_schemas.py tldw_Server_API/app/core/MCP_unified/catalog_loader.py tldw_Server_API/app/core/MCP_unified/tests/test_extraction_contracts.py tldw_Server_API/tests/unit/test_mcp_catalog_loader.py` -> all checks passed.
 - `.venv/bin/python -m bandit -r mcp_unified/federation/models.py tldw_Server_API/app/api/v1/schemas/archetype_schemas.py tldw_Server_API/app/core/MCP_unified/catalog_loader.py -f json -o /tmp/bandit_mcp_stage3f_catalog_schema.json` -> 0 findings.
 - `git diff --check` -> clean.
+
+PR: https://github.com/rmusser01/tldw_server/pull/2115
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-546 - Implement-MCP-Unified-Stage-3F-catalog-schema-seam-cleanup.md
+++ b/backlog/tasks/task-546 - Implement-MCP-Unified-Stage-3F-catalog-schema-seam-cleanup.md
@@ -1,0 +1,78 @@
+---
+id: TASK-546
+title: Implement MCP Unified Stage 3F catalog schema seam cleanup
+status: In Progress
+labels:
+- mcp
+- mcp-unified
+- standalone
+- stage3
+modified_files:
+- Docs/superpowers/plans/2026-05-29-mcp-unified-stage3f-catalog-schema-seam-plan.md
+- mcp_unified/federation/models.py
+- tldw_Server_API/app/api/v1/schemas/archetype_schemas.py
+- tldw_Server_API/app/core/MCP_unified/catalog_loader.py
+- tldw_Server_API/app/core/MCP_unified/tests/test_extraction_contracts.py
+- tldw_Server_API/tests/unit/test_mcp_catalog_loader.py
+- backlog/tasks/task-546 - Implement-MCP-Unified-Stage-3F-catalog-schema-seam-cleanup.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Move the MCP external server catalog entry schema to the standalone MCP package boundary and keep tldw_server API schema imports working through compatibility re-exports. Keep the slice scoped to catalog schema ownership and import-boundary coverage.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 catalog_loader.py no longer imports MCPCatalogEntry from tldw_Server_API API schemas.
+- [x] #2 MCPCatalogEntry and MCPAuthType are owned by the standalone mcp_unified package and are re-exported by archetype_schemas for compatibility.
+- [x] #3 Regression tests cover the import boundary and existing catalog loader/API schema behavior.
+- [x] #4 Focused pytest, Ruff, and Bandit verification are recorded before PR closeout.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Docs/superpowers/plans/2026-05-29-mcp-unified-stage3f-catalog-schema-seam-plan.md
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Started Stage 3F from origin/dev d8f092e553. Scope is limited to MCP catalog schema ownership and compatibility re-exports.
+
+RED verification:
+- `.venv/bin/python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_extraction_contracts.py::test_catalog_loader_uses_standalone_catalog_schema tldw_Server_API/tests/unit/test_mcp_catalog_loader.py::TestLoadMcpCatalog::test_catalog_entry_schema_is_standalone_package_model -q`
+- Expected result: 2 failures while `catalog_loader.py` imported the API schema and `mcp_unified.federation.models` did not export `MCPCatalogEntry`.
+
+Implementation:
+- Added standalone `MCPAuthType` and `MCPCatalogEntry` to `mcp_unified.federation.models`.
+- Re-exported the standalone names from `archetype_schemas.py` so existing API imports keep working.
+- Updated `catalog_loader.py` to depend on `mcp_unified.federation.models`.
+- Added extraction-boundary and loader compatibility regression coverage.
+
+Verification:
+- `.venv/bin/python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_extraction_contracts.py tldw_Server_API/tests/unit/test_mcp_catalog_loader.py tldw_Server_API/tests/unit/test_archetype_schemas.py tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py -q` -> 71 passed, 5 warnings.
+- `.venv/bin/python -m ruff check mcp_unified/federation/models.py tldw_Server_API/app/api/v1/schemas/archetype_schemas.py tldw_Server_API/app/core/MCP_unified/catalog_loader.py tldw_Server_API/app/core/MCP_unified/tests/test_extraction_contracts.py tldw_Server_API/tests/unit/test_mcp_catalog_loader.py` -> all checks passed.
+- `.venv/bin/python -m bandit -r mcp_unified/federation/models.py tldw_Server_API/app/api/v1/schemas/archetype_schemas.py tldw_Server_API/app/core/MCP_unified/catalog_loader.py -f json -o /tmp/bandit_mcp_stage3f_catalog_schema.json` -> 0 findings.
+- `git diff --check` -> clean.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Moved the MCP catalog entry contract to the standalone package boundary while keeping `archetype_schemas.py` as a compatibility export for API callers. The MCP catalog loader now imports `MCPCatalogEntry` from `mcp_unified.federation.models`, and regression tests cover both the package boundary and API re-export identity.
+
+Known skips or blockers: none.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/mcp_unified/federation/models.py
+++ b/mcp_unified/federation/models.py
@@ -4,7 +4,24 @@ from __future__ import annotations
 
 from copy import deepcopy
 from dataclasses import dataclass, field
-from typing import Any
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field
+
+MCPAuthType = Literal["none", "bearer", "api_key"]
+
+
+class MCPCatalogEntry(BaseModel):
+    """One entry in the external MCP server catalog shown during setup."""
+
+    key: str
+    name: str
+    description: str
+    url_template: str
+    auth_type: MCPAuthType = "none"
+    category: str
+    logo_key: str | None = None
+    suggested_for: list[str] = Field(default_factory=list)
 
 
 def _copy_mapping(value: dict[str, Any] | None) -> dict[str, Any]:

--- a/tldw_Server_API/app/api/v1/schemas/archetype_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/archetype_schemas.py
@@ -9,11 +9,10 @@ from __future__ import annotations
 
 from typing import Any, Literal
 
+from mcp_unified.federation.models import MCPAuthType, MCPCatalogEntry
 from pydantic import BaseModel, Field, model_validator
 
 from tldw_Server_API.app.api.v1.schemas.persona import PersonaConfirmationMode
-
-MCPAuthType = Literal["none", "bearer", "api_key"]
 
 
 class ArchetypePersonaDefaults(BaseModel):
@@ -108,19 +107,6 @@ class ArchetypePreviewResponse(BaseModel):
     archetype_key: str
     voice_defaults: dict[str, Any] = Field(default_factory=dict)
     setup: ArchetypePreviewSetupState = Field(default_factory=ArchetypePreviewSetupState)
-
-
-class MCPCatalogEntry(BaseModel):
-    """One entry in the external MCP server catalog shown during setup."""
-
-    key: str
-    name: str
-    description: str
-    url_template: str
-    auth_type: MCPAuthType = "none"
-    category: str
-    logo_key: str | None = None
-    suggested_for: list[str] = Field(default_factory=list)
 
 
 __all__ = [

--- a/tldw_Server_API/app/core/MCP_unified/catalog_loader.py
+++ b/tldw_Server_API/app/core/MCP_unified/catalog_loader.py
@@ -11,9 +11,8 @@ from pathlib import Path
 
 import yaml
 from loguru import logger
+from mcp_unified.federation.models import MCPCatalogEntry
 from pydantic import ValidationError
-
-from tldw_Server_API.app.api.v1.schemas.archetype_schemas import MCPCatalogEntry
 
 # Module-level cache
 _CATALOG_CACHE: list[MCPCatalogEntry] = []

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_extraction_contracts.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_extraction_contracts.py
@@ -438,6 +438,18 @@ def test_mcp_discovery_module_uses_package_local_environment_helpers() -> None:
     assert offenders == []
 
 
+def test_catalog_loader_uses_standalone_catalog_schema() -> None:
+    forbidden_import = "tldw_Server_API.app.api.v1.schemas.archetype_schemas"
+    imports = _resolved_import_sources_for(MCP_ROOT / "catalog_loader.py", MCP_PACKAGE)
+    offenders = sorted(
+        source
+        for source in imports
+        if source == forbidden_import or source.startswith(f"{forbidden_import}.")
+    )
+
+    assert offenders == []
+
+
 def test_protocol_boundary_scan_resolves_relative_imports(tmp_path: Path) -> None:
     sample = tmp_path / "sample.py"
     sample.write_text(

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_extraction_contracts.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_extraction_contracts.py
@@ -439,6 +439,7 @@ def test_mcp_discovery_module_uses_package_local_environment_helpers() -> None:
 
 
 def test_catalog_loader_uses_standalone_catalog_schema() -> None:
+    """Catalog loading must depend on standalone MCP package schemas."""
     forbidden_import = "tldw_Server_API.app.api.v1.schemas.archetype_schemas"
     imports = _resolved_import_sources_for(MCP_ROOT / "catalog_loader.py", MCP_PACKAGE)
     offenders = sorted(

--- a/tldw_Server_API/tests/unit/test_mcp_catalog_loader.py
+++ b/tldw_Server_API/tests/unit/test_mcp_catalog_loader.py
@@ -89,6 +89,7 @@ class TestLoadMcpCatalog:
         assert keys == {"github", "arxiv"}
 
     def test_catalog_entry_schema_is_standalone_package_model(self, catalog_file: Path):
+        """Catalog loader entries use the standalone model re-exported by the API."""
         from mcp_unified.federation.models import (
             MCPCatalogEntry as StandaloneMCPCatalogEntry,
         )

--- a/tldw_Server_API/tests/unit/test_mcp_catalog_loader.py
+++ b/tldw_Server_API/tests/unit/test_mcp_catalog_loader.py
@@ -6,8 +6,8 @@ from pathlib import Path
 
 import pytest
 
-from tldw_Server_API.app.api.v1.schemas.archetype_schemas import MCPCatalogEntry
 import tldw_Server_API.app.core.MCP_unified.catalog_loader as _catalog_mod
+from tldw_Server_API.app.api.v1.schemas.archetype_schemas import MCPCatalogEntry
 from tldw_Server_API.app.core.MCP_unified.catalog_loader import (
     get_catalog_entry,
     list_catalog_entries,
@@ -87,6 +87,20 @@ class TestLoadMcpCatalog:
         assert all(isinstance(e, MCPCatalogEntry) for e in result)
         keys = {e.key for e in result}
         assert keys == {"github", "arxiv"}
+
+    def test_catalog_entry_schema_is_standalone_package_model(self, catalog_file: Path):
+        from mcp_unified.federation.models import (
+            MCPCatalogEntry as StandaloneMCPCatalogEntry,
+        )
+
+        from tldw_Server_API.app.api.v1.schemas.archetype_schemas import (
+            MCPCatalogEntry as ApiMCPCatalogEntry,
+        )
+
+        result = load_mcp_catalog(catalog_file)
+
+        assert ApiMCPCatalogEntry is StandaloneMCPCatalogEntry
+        assert all(isinstance(e, StandaloneMCPCatalogEntry) for e in result)
 
     def test_cache_is_populated(self, catalog_file: Path):
         load_mcp_catalog(catalog_file)


### PR DESCRIPTION
## Change summary (maintainer-owned)

Maintainer TODO: replace this section with a human-written summary explaining what changed and why these implementation choices were made before merge.

## AI-authored implementation notes

- Moved MCP catalog `MCPAuthType` and `MCPCatalogEntry` ownership into `mcp_unified.federation.models`.
- Re-exported those names from `archetype_schemas.py` so existing API callers keep the same import path.
- Updated `catalog_loader.py` to import the catalog entry contract from the standalone package boundary.
- Added regression coverage for the import boundary and API re-export identity.
- Rebased onto latest `origin/dev` (`7afa5191a6`) and added docstrings to the new regression tests after CodeRabbit's docstring-coverage warning.

## Risk & Rollback

Risk level: Low. The behavioral surface is limited to schema ownership and import routing for MCP catalog entries; the API schema module still re-exports the same names for compatibility.

Rollback plan: Revert this PR to restore the previous API-owned catalog schema definition and catalog-loader import path.

## Verification

- RED: `.venv/bin/python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_extraction_contracts.py::test_catalog_loader_uses_standalone_catalog_schema tldw_Server_API/tests/unit/test_mcp_catalog_loader.py::TestLoadMcpCatalog::test_catalog_entry_schema_is_standalone_package_model -q` failed as expected before implementation.
- Rebased GREEN: `.venv/bin/python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_extraction_contracts.py tldw_Server_API/tests/unit/test_mcp_catalog_loader.py tldw_Server_API/tests/unit/test_archetype_schemas.py tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py -q` -> 73 passed, 5 warnings.
- Ruff: `.venv/bin/python -m ruff check mcp_unified/federation/models.py tldw_Server_API/app/api/v1/schemas/archetype_schemas.py tldw_Server_API/app/core/MCP_unified/catalog_loader.py tldw_Server_API/app/core/MCP_unified/tests/test_extraction_contracts.py tldw_Server_API/tests/unit/test_mcp_catalog_loader.py` -> all checks passed.
- Bandit: `.venv/bin/python -m bandit -r mcp_unified/federation/models.py tldw_Server_API/app/api/v1/schemas/archetype_schemas.py tldw_Server_API/app/core/MCP_unified/catalog_loader.py -f json -o /tmp/bandit_mcp_stage3f_catalog_schema_rebased.json` -> 0 findings.
- `git diff --check origin/dev...HEAD` -> clean.

## Watchlists

- [x] Scope limited to catalog schema ownership and compatibility re-export.
- [x] No raw SQL or DB behavior touched.
- [x] No runtime transport behavior touched.
- [x] Backlog task: TASK-546.
