### PR TITLE
chore: close quick ingest final verification

### DIFF
--- a/backlog/completed/task-394 - Implement-Quick-Ingest-UX-remediation.md
+++ b/backlog/completed/task-394 - Implement-Quick-Ingest-UX-remediation.md
@@ -4,7 +4,7 @@ title: Implement Quick Ingest UX remediation
 status: Done
 assignee: []
 created_date: '2026-05-16 00:41'
-updated_date: '2026-05-16 04:40'
+updated_date: '2026-05-29 04:11'
 labels:
   - quick-ingest
   - ux
@@ -36,15 +36,19 @@ Parent tracking task for executing the approved Quick Ingest UX remediation impl
 ## Implementation Notes
 
 <!-- SECTION:NOTES:BEGIN -->
+Canonical record: this `backlog/completed/` file is the authoritative parent closeout for TASK-394. The matching `backlog/tasks/` file is retained as a tracker mirror for PR visibility and points back here.
+
 Implementation complete across TASK-394.1 through TASK-394.7. Scope stayed within active Quick Ingest shared WebUI/extension modal/process surfaces, launch/close/cancel/recovery/result handoff, validation, and focused tests. Large-file strategy used the approved Truthful limit fix: current browser-buffered Quick Ingest upload limit is 50 MB, with the 500 MB transport redesign left as future work.
 
 Final verification evidence: shared Quick Ingest Vitest passed with 15 files / 178 tests; final WebUI Quick Ingest Playwright passed with 11 tests outside the macOS sandbox; git diff --check passed. No backend Python code was touched, so Bandit is not applicable. Residual risk: extension Playwright focused specs were migrated to active wizard selectors but could not be executed because extension globalSetup/build failed/hung before tests ran; exact command/failure recorded in TASK-394.6 and TASK-394.7. PR-ready notes are recorded in the implementation plan, preserving the human-owned Change summary placeholder.
+
+Current verification on latest dev after PR #2114: `bun run test src/components/Common/QuickIngest/__tests__ src/services/__tests__/quick-ingest-batch.test.ts src/services/__tests__/quick-ingest-session-reattach.test.ts --maxWorkers=1 --no-file-parallelism` passed with 17 files / 208 tests. `npx playwright test e2e/workflows/media-ingest.spec.ts --grep "Quick Ingest" --project=chromium --reporter=line` passed with 13 tests in 4.8m. `git diff --check` passed after this Backlog-only closeout edit. Bandit remains not applicable because no Python code was touched. PR #2114 also fixed the stale WebUI completed-results assertion helper, so the final browser sweep now covers the current shared wizard summary format.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Quick Ingest UX remediation is complete for the active shared wizard path: first-open clarity, result handoff, recovery/progress semantics, validation, and current-flow WebUI coverage are implemented and verified. Remaining caveat is extension Playwright execution, blocked by the existing extension build/globalSetup harness before specs start; the targeted extension specs themselves were updated away from stale legacy selectors.
+Quick Ingest UX remediation is complete for the active shared wizard path: first-open clarity, result handoff, recovery/progress semantics, validation, and current-flow WebUI coverage are implemented and verified against the current 208-test/13-scenario sweep. Remaining caveat is extension Playwright execution, blocked by the existing extension build/globalSetup harness before specs start; the targeted extension specs themselves were updated away from stale legacy selectors.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/completed/task-394.7 - Close-out-Quick-Ingest-UX-remediation-verification.md
+++ b/backlog/completed/task-394.7 - Close-out-Quick-Ingest-UX-remediation-verification.md
@@ -4,7 +4,7 @@ title: Close out Quick Ingest UX remediation verification
 status: Done
 assignee: []
 created_date: '2026-05-16 00:45'
-updated_date: '2026-05-16 04:39'
+updated_date: '2026-05-29 04:11'
 labels:
   - quick-ingest
   - verification
@@ -33,19 +33,23 @@ Execute implementation plan Task 7: run final verification, update the parent ta
 ## Implementation Notes
 
 <!-- SECTION:NOTES:BEGIN -->
+Canonical record: this `backlog/completed/` file is the authoritative final closeout for TASK-394.7. The matching `backlog/tasks/` file is retained as a tracker mirror for PR visibility and points back here.
+
 Started Task 7 after closing TASK-394.6. Scope: final commit/scope review, focused verification recap, parent/child Backlog closeout, Bandit applicability, extension harness gap documentation, and PR-ready summary with human-owned Change summary placeholder.
 
 Final scope review: git diff --stat dev...HEAD is limited to Quick Ingest shared UI/components/tests, WebUI/extension Quick Ingest e2e helpers/specs, planning docs, and Backlog task records. No backend Python files were touched.
 
 Final verification: ./node_modules/.bin/vitest run src/components/Common/QuickIngest/__tests__ src/services/__tests__/quick-ingest-batch.test.ts src/services/__tests__/quick-ingest-session-reattach.test.ts --maxWorkers=1 --no-file-parallelism passed with 15 files / 178 tests. Final WebUI Playwright passed outside the macOS sandbox: TLDW_WEB_AUTOSTART=false TLDW_WEB_URL=http://127.0.0.1:18001 NEXT_PUBLIC_API_URL=http://127.0.0.1:8000 TLDW_E2E_SERVER_URL=http://127.0.0.1:8000 TLDW_E2E_API_KEY=THIS-IS-A-SECURE-KEY-123-FAKE-KEY bunx playwright test e2e/workflows/media-ingest.spec.ts --grep "Quick Ingest" --project=chromium --reporter=line; 11 tests passed. git diff --check passed. Bandit not applicable because touched files are frontend TypeScript/TSX/JSON/docs/Backlog only.
 
-Residual risk: focused extension Playwright still did not reach test execution because extension globalSetup/build failed/hung before specs ran, as documented in TASK-394.6. PR notes prepared with human-owned Change summary placeholder.
+Current verification on latest dev after PR #2114: `bun run test src/components/Common/QuickIngest/__tests__ src/services/__tests__/quick-ingest-batch.test.ts src/services/__tests__/quick-ingest-session-reattach.test.ts --maxWorkers=1 --no-file-parallelism` passed with 17 files / 208 tests. `npx playwright test e2e/workflows/media-ingest.spec.ts --grep "Quick Ingest" --project=chromium --reporter=line` passed with 13 tests in 4.8m. `git diff --check` passed after this Backlog-only closeout edit. Bandit remains not applicable because no Python code was touched.
+
+Residual risk: focused extension Playwright still did not reach test execution because extension globalSetup/build failed/hung before specs ran, as documented in TASK-394.6. Current WebUI browser coverage includes the extension playlist handoff scenario, and PR #2114 fixed the stale completed-results assertion helper so the 13-scenario sweep now reflects the shared wizard summary format.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Task 7 complete: branch scope reviewed, final focused shared/WebUI verification passed, Bandit was documented as not applicable, extension harness blocker remains explicitly recorded, and PR-ready summary notes are prepared with the required human-owned Change summary placeholder.
+Task 7 complete: branch scope reviewed, current focused shared/WebUI verification passed with 208 Vitest checks and 13 browser scenarios, Bandit was documented as not applicable, extension harness execution remains explicitly recorded as the only known residual blocker, and the completed record is now the unambiguous authoritative closeout.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-394 - Implement-Quick-Ingest-UX-remediation.md
+++ b/backlog/tasks/task-394 - Implement-Quick-Ingest-UX-remediation.md
@@ -1,9 +1,10 @@
 ---
 id: TASK-394
 title: Implement Quick Ingest UX remediation
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-05-16 00:41'
+updated_date: '2026-05-29 04:11'
 labels:
   - quick-ingest
   - ux
@@ -26,18 +27,34 @@ Parent tracking task for executing the approved Quick Ingest UX remediation impl
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Approved implementation plan tasks are executed in order with review checkpoints
-- [ ] #2 Quick Ingest changes remain scoped to active shared WebUI/extension surfaces
-- [ ] #3 Verification evidence is recorded for completed slices
-- [ ] #4 Final summary identifies changed files, tests, and residual risks
+- [x] #1 Approved implementation plan tasks are executed in order with review checkpoints
+- [x] #2 Quick Ingest changes remain scoped to active shared WebUI/extension surfaces
+- [x] #3 Verification evidence is recorded for completed slices
+- [x] #4 Final summary identifies changed files, tests, and residual risks
 <!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Tracker mirror retained for PR visibility. The authoritative parent closeout record is `backlog/completed/task-394 - Implement-Quick-Ingest-UX-remediation.md`.
+
+Implementation is complete across TASK-394.1 through TASK-394.7. Current final verification on latest dev after PR #2114: `bun run test src/components/Common/QuickIngest/__tests__ src/services/__tests__/quick-ingest-batch.test.ts src/services/__tests__/quick-ingest-session-reattach.test.ts --maxWorkers=1 --no-file-parallelism` passed with 17 files / 208 tests. `npx playwright test e2e/workflows/media-ingest.spec.ts --grep "Quick Ingest" --project=chromium --reporter=line` passed with 13 tests in 4.8m. `git diff --check` passed after this Backlog-only closeout edit.
+
+Bandit remains not applicable for this closeout because no Python code was touched. Known residual risk: focused extension Playwright execution is still blocked by the extension globalSetup/build harness before specs start, as documented in TASK-394.6; the shared WebUI sweep includes the extension playlist handoff scenario.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Quick Ingest UX remediation is closed for the active shared wizard path. The current dev baseline has passing focused shared Quick Ingest coverage and WebUI browser coverage, stale tracker duplicates now point to the completed canonical records, and the only documented residual risk is the separate extension harness execution blocker.
+<!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->

--- a/backlog/tasks/task-394.7 - Close-out-Quick-Ingest-UX-remediation-verification.md
+++ b/backlog/tasks/task-394.7 - Close-out-Quick-Ingest-UX-remediation-verification.md
@@ -1,9 +1,10 @@
 ---
 id: TASK-394.7
 title: Close out Quick Ingest UX remediation verification
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-05-16 00:45'
+updated_date: '2026-05-29 04:11'
 labels:
   - quick-ingest
   - verification
@@ -24,17 +25,33 @@ Execute implementation plan Task 7: run final verification, update the parent ta
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Final verification covers lint/test/build/browser evidence appropriate to touched files
-- [ ] #2 Backlog parent and child tasks are updated with completion evidence and residual risks
-- [ ] #3 PR-ready summary lists changes, tests, and scope boundaries
+- [x] #1 Final verification covers lint/test/build/browser evidence appropriate to touched files
+- [x] #2 Backlog parent and child tasks are updated with completion evidence and residual risks
+- [x] #3 PR-ready summary lists changes, tests, and scope boundaries
 <!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Tracker mirror retained for PR visibility. The authoritative final closeout record is `backlog/completed/task-394.7 - Close-out-Quick-Ingest-UX-remediation-verification.md`.
+
+Current verification on latest dev after PR #2114: `bun run test src/components/Common/QuickIngest/__tests__ src/services/__tests__/quick-ingest-batch.test.ts src/services/__tests__/quick-ingest-session-reattach.test.ts --maxWorkers=1 --no-file-parallelism` passed with 17 files / 208 tests. `npx playwright test e2e/workflows/media-ingest.spec.ts --grep "Quick Ingest" --project=chromium --reporter=line` passed with 13 tests in 4.8m. `git diff --check` passed after the Backlog-only closeout edits. Bandit remains not applicable for this tracker-only slice because no Python code was touched.
+
+Residual risk remains the extension Playwright globalSetup/build harness blocker documented in TASK-394.6; current WebUI shared-wizard coverage includes the extension playlist handoff scenario, and PR #2114 already fixed the stale completed-results assertion helper.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Task 7 is closed against current dev evidence: shared Quick Ingest unit/integration coverage and WebUI browser coverage both pass on the updated 208-test/13-scenario sweep, parent and child Backlog records have current closeout notes, and the only known residual risk remains the separate extension harness execution blocker.
+<!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->


### PR DESCRIPTION
## Change summary (maintainer-owned)

- Close TASK-394.7 and refresh the TASK-394 parent closeout records against current dev verification.
- Mark the active backlog task copies as tracker mirrors and make the completed records the authoritative closeouts, avoiding the ambiguous active/completed duplicate state.
- Preserve the documented extension Playwright harness blocker while recording the current passing shared/WebUI Quick Ingest evidence.

## Verification

- bun run test src/components/Common/QuickIngest/__tests__ src/services/__tests__/quick-ingest-batch.test.ts src/services/__tests__/quick-ingest-session-reattach.test.ts --maxWorkers=1 --no-file-parallelism (17 files / 208 tests passed)
- npx playwright test e2e/workflows/media-ingest.spec.ts --grep "Quick Ingest" --project=chromium --reporter=line (13 passed in 4.8m)
- git diff --check
- git show --check --stat --oneline HEAD

## Scope

Backlog-only closeout update. No runtime UI, extension, backend, or test code changed in this PR.

## Residual risk

Focused extension Playwright execution remains blocked by the extension globalSetup/build harness before specs start, as already documented in TASK-394.6. The WebUI sweep includes the extension playlist handoff scenario.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Finalizes Quick Ingest UX remediation by making the completed backlog records the canonical closeouts and marking TASK-394 and TASK-394.7 as Done. Records current verification evidence (208 Vitest tests, 13 Playwright scenarios) and documents the remaining extension Playwright harness blocker; no runtime or test code changed.

<sup>Written for commit 64ef6138ed32a07a9b7473f1422eba2b79321baa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2116?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

