### PR TITLE
Follow-up: route MCP catalog lookup through DB management

### DIFF
--- a/backlog/tasks/task-546 - Implement-MCP-Unified-Stage-3F-protocol-catalog-provider-seam.md
+++ b/backlog/tasks/task-546 - Implement-MCP-Unified-Stage-3F-protocol-catalog-provider-seam.md
@@ -7,6 +7,19 @@ labels:
 - mcp-unified
 - standalone
 - stage3
+modified_files:
+- mcp_unified/interfaces/__init__.py
+- mcp_unified/interfaces/runtime.py
+- tldw_Server_API/app/core/MCP_unified/adapters/tldw_runtime.py
+- tldw_Server_API/app/core/MCP_unified/interfaces/__init__.py
+- tldw_Server_API/app/core/MCP_unified/interfaces/runtime.py
+- tldw_Server_API/app/core/MCP_unified/protocol.py
+- tldw_Server_API/app/core/MCP_unified/tests/test_extraction_contracts.py
+- tldw_Server_API/app/core/MCP_unified/tests/test_protocol_catalog_filter.py
+- tldw_Server_API/app/core/DB_Management/Tool_Catalog_DB.py
+- tldw_Server_API/app/services/admin_tool_catalog_service.py
+- tldw_Server_API/tests/Services/test_admin_tool_catalog_service_backend_selection.py
+- backlog/tasks/task-546 - Implement-MCP-Unified-Stage-3F-protocol-catalog-provider-seam.md
 ---
 
 ## Description
@@ -46,20 +59,19 @@ Move protocol tool-catalog lookup behind a runtime dependency provider so MCPPro
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Stage 3F moved tool-catalog filtering out of `MCPProtocol` and into an injected runtime provider seam. Verification:
+Stage 3F moved tool-catalog filtering out of `MCPProtocol` and into an injected runtime provider seam. PR #2113 merged at `7afa5191a6` while this closeout was in progress, so the remaining DB_Management tightening was rebased onto the post-merge `origin/dev` and kept as a single follow-up commit on `codex/mcp-unified-stage3f-protocol-catalog-provider`.
 
-- RED: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_extraction_contracts.py::test_protocol_catalog_lookup_uses_runtime_dependencies tldw_Server_API/app/core/MCP_unified/tests/test_protocol_catalog_filter.py::test_protocol_catalog_resolution_uses_injected_provider -q` -> 2 failed for the intended direct import and missing provider delegation.
-- GREEN/focused pytest: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_extraction_contracts.py tldw_Server_API/app/core/MCP_unified/tests/test_protocol_catalog_filter.py tldw_Server_API/app/core/MCP_unified/tests/test_protocol_allowed_tools.py -q` -> 41 passed, 3 warnings
-- Ruff: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m ruff check mcp_unified/interfaces tldw_Server_API/app/core/MCP_unified/interfaces/__init__.py tldw_Server_API/app/core/MCP_unified/interfaces/runtime.py tldw_Server_API/app/core/MCP_unified/adapters/tldw_runtime.py tldw_Server_API/app/core/MCP_unified/protocol.py tldw_Server_API/app/core/MCP_unified/tests/test_extraction_contracts.py tldw_Server_API/app/core/MCP_unified/tests/test_protocol_catalog_filter.py` -> All checks passed
-- Bandit: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r mcp_unified/interfaces tldw_Server_API/app/core/MCP_unified/interfaces tldw_Server_API/app/core/MCP_unified/adapters/tldw_runtime.py tldw_Server_API/app/core/MCP_unified/protocol.py -f json -o /tmp/bandit_mcp_stage3f_protocol_catalog_provider.json` -> 0 results, 0 errors
-- `git diff --check` -> passed
+The final closeout moves catalog filter lookup SQL from `app/services` into `tldw_Server_API/app/core/DB_Management/Tool_Catalog_DB.py`; `admin_tool_catalog_service.resolve_tool_catalog_filter_names()` now delegates to that DB_Management helper while preserving the service API used by the MCP runtime adapter. The visible PR review threads were already resolved/outdated on GitHub, and this pass tightens the Qodo raw-SQL remediation rather than changing protocol behavior.
 
-Review-fix pass after rebase onto latest `origin/dev`:
+Verification:
 
-- Focused pytest: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_extraction_contracts.py tldw_Server_API/app/core/MCP_unified/tests/test_protocol_catalog_filter.py tldw_Server_API/app/core/MCP_unified/tests/test_protocol_allowed_tools.py tldw_Server_API/tests/Services/test_admin_tool_catalog_service_backend_selection.py -q` -> 56 passed, 5 warnings
-- Ruff: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m ruff check mcp_unified/interfaces tldw_Server_API/app/core/MCP_unified/interfaces/__init__.py tldw_Server_API/app/core/MCP_unified/interfaces/runtime.py tldw_Server_API/app/core/MCP_unified/adapters/tldw_runtime.py tldw_Server_API/app/core/MCP_unified/protocol.py tldw_Server_API/app/core/MCP_unified/tests/test_extraction_contracts.py tldw_Server_API/app/core/MCP_unified/tests/test_protocol_catalog_filter.py tldw_Server_API/app/core/MCP_unified/tests/test_protocol_allowed_tools.py tldw_Server_API/app/services/admin_tool_catalog_service.py tldw_Server_API/tests/Services/test_admin_tool_catalog_service_backend_selection.py` -> All checks passed
-- Bandit: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r mcp_unified/interfaces tldw_Server_API/app/core/MCP_unified/interfaces tldw_Server_API/app/core/MCP_unified/adapters/tldw_runtime.py tldw_Server_API/app/core/MCP_unified/protocol.py tldw_Server_API/app/services/admin_tool_catalog_service.py -f json -o /tmp/bandit_mcp_stage3f_protocol_catalog_provider_review.json` -> 0 results, 0 errors
-- `git diff --check` -> passed
+- Rebase: `git rebase origin/dev` -> successfully rebased one follow-up commit onto `origin/dev` after PR #2113 merged.
+- RED: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_admin_tool_catalog_service_backend_selection.py::test_resolve_tool_catalog_filter_names_delegates_to_db_management -q` -> failed with `ImportError: cannot import name 'Tool_Catalog_DB'`, proving the missing DB_Management seam.
+- GREEN/focused regression: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_admin_tool_catalog_service_backend_selection.py::test_resolve_tool_catalog_filter_names_delegates_to_db_management tldw_Server_API/tests/Services/test_admin_tool_catalog_service_backend_selection.py::test_resolve_tool_catalog_filter_names_handles_tuple_rows -q` -> 2 passed, 5 warnings.
+- Post-rebase focused pytest: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_extraction_contracts.py tldw_Server_API/app/core/MCP_unified/tests/test_protocol_catalog_filter.py tldw_Server_API/app/core/MCP_unified/tests/test_protocol_allowed_tools.py tldw_Server_API/tests/Services/test_admin_tool_catalog_service_backend_selection.py -q` -> 57 passed, 5 warnings.
+- Post-rebase Ruff: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m ruff check mcp_unified/interfaces tldw_Server_API/app/core/MCP_unified/interfaces/__init__.py tldw_Server_API/app/core/MCP_unified/interfaces/runtime.py tldw_Server_API/app/core/MCP_unified/adapters/tldw_runtime.py tldw_Server_API/app/core/MCP_unified/protocol.py tldw_Server_API/app/core/DB_Management/Tool_Catalog_DB.py tldw_Server_API/app/services/admin_tool_catalog_service.py tldw_Server_API/app/core/MCP_unified/tests/test_extraction_contracts.py tldw_Server_API/app/core/MCP_unified/tests/test_protocol_catalog_filter.py tldw_Server_API/app/core/MCP_unified/tests/test_protocol_allowed_tools.py tldw_Server_API/tests/Services/test_admin_tool_catalog_service_backend_selection.py` -> All checks passed.
+- Post-rebase Bandit: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/core/DB_Management/Tool_Catalog_DB.py tldw_Server_API/app/services/admin_tool_catalog_service.py -f json -o /tmp/bandit_mcp_stage3f_protocol_catalog_provider_followup_rebased.json` -> 0 results, 0 errors.
+- `git diff --check origin/dev...HEAD` -> passed.
 
 No known blockers or verification skips.
 <!-- SECTION:FINAL_SUMMARY:END -->

--- a/backlog/tasks/task-546 - Implement-MCP-Unified-Stage-3F-protocol-catalog-provider-seam.md
+++ b/backlog/tasks/task-546 - Implement-MCP-Unified-Stage-3F-protocol-catalog-provider-seam.md
@@ -19,6 +19,7 @@ modified_files:
 - tldw_Server_API/app/core/DB_Management/Tool_Catalog_DB.py
 - tldw_Server_API/app/services/admin_tool_catalog_service.py
 - tldw_Server_API/tests/Services/test_admin_tool_catalog_service_backend_selection.py
+- tldw_Server_API/tests/DB_Management/unit/test_tool_catalog_db.py
 - backlog/tasks/task-546 - Implement-MCP-Unified-Stage-3F-protocol-catalog-provider-seam.md
 ---
 
@@ -59,19 +60,19 @@ Move protocol tool-catalog lookup behind a runtime dependency provider so MCPPro
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Stage 3F moved tool-catalog filtering out of `MCPProtocol` and into an injected runtime provider seam. PR #2113 merged at `7afa5191a6` while this closeout was in progress, so the remaining DB_Management tightening was rebased onto the post-merge `origin/dev` and kept as a single follow-up commit on `codex/mcp-unified-stage3f-protocol-catalog-provider`.
+Stage 3F moved tool-catalog filtering out of `MCPProtocol` and into an injected runtime provider seam. PR #2113 merged at `7afa5191a6`; this follow-up PR #2118 remains rebased on latest `origin/dev` and keeps the DB_Management ownership cleanup as the active change.
 
-The final closeout moves catalog filter lookup SQL from `app/services` into `tldw_Server_API/app/core/DB_Management/Tool_Catalog_DB.py`; `admin_tool_catalog_service.resolve_tool_catalog_filter_names()` now delegates to that DB_Management helper while preserving the service API used by the MCP runtime adapter. The visible PR review threads were already resolved/outdated on GitHub, and this pass tightens the Qodo raw-SQL remediation rather than changing protocol behavior.
+The PR #2118 Qodo review follow-up adds sanitized contextual debug logging for DB_Management catalog lookup failures. `Tool_Catalog_DB` now logs exception class plus safe request context (`catalog_name`, `catalog_id`, `team_id`, `org_id`, `strict`) for both catalog-name lookup failures and catalog-entry lookup failures, without logging raw exception messages, traces, database paths, or SQL fragments.
 
 Verification:
 
-- Rebase: `git rebase origin/dev` -> successfully rebased one follow-up commit onto `origin/dev` after PR #2113 merged.
-- RED: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_admin_tool_catalog_service_backend_selection.py::test_resolve_tool_catalog_filter_names_delegates_to_db_management -q` -> failed with `ImportError: cannot import name 'Tool_Catalog_DB'`, proving the missing DB_Management seam.
-- GREEN/focused regression: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_admin_tool_catalog_service_backend_selection.py::test_resolve_tool_catalog_filter_names_delegates_to_db_management tldw_Server_API/tests/Services/test_admin_tool_catalog_service_backend_selection.py::test_resolve_tool_catalog_filter_names_handles_tuple_rows -q` -> 2 passed, 5 warnings.
-- Post-rebase focused pytest: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_extraction_contracts.py tldw_Server_API/app/core/MCP_unified/tests/test_protocol_catalog_filter.py tldw_Server_API/app/core/MCP_unified/tests/test_protocol_allowed_tools.py tldw_Server_API/tests/Services/test_admin_tool_catalog_service_backend_selection.py -q` -> 57 passed, 5 warnings.
-- Post-rebase Ruff: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m ruff check mcp_unified/interfaces tldw_Server_API/app/core/MCP_unified/interfaces/__init__.py tldw_Server_API/app/core/MCP_unified/interfaces/runtime.py tldw_Server_API/app/core/MCP_unified/adapters/tldw_runtime.py tldw_Server_API/app/core/MCP_unified/protocol.py tldw_Server_API/app/core/DB_Management/Tool_Catalog_DB.py tldw_Server_API/app/services/admin_tool_catalog_service.py tldw_Server_API/app/core/MCP_unified/tests/test_extraction_contracts.py tldw_Server_API/app/core/MCP_unified/tests/test_protocol_catalog_filter.py tldw_Server_API/app/core/MCP_unified/tests/test_protocol_allowed_tools.py tldw_Server_API/tests/Services/test_admin_tool_catalog_service_backend_selection.py` -> All checks passed.
-- Post-rebase Bandit: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/core/DB_Management/Tool_Catalog_DB.py tldw_Server_API/app/services/admin_tool_catalog_service.py -f json -o /tmp/bandit_mcp_stage3f_protocol_catalog_provider_followup_rebased.json` -> 0 results, 0 errors.
-- `git diff --check origin/dev...HEAD` -> passed.
+- Rebase: `git rebase origin/dev` -> successfully rebased one follow-up commit onto latest `origin/dev`.
+- RED: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/DB_Management/unit/test_tool_catalog_db.py -q` -> 2 failed because logs only contained `MCP catalog lookup failed: RuntimeError` / `MCP catalog entries lookup failed: RuntimeError`, proving missing context.
+- GREEN/focused regression: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/DB_Management/unit/test_tool_catalog_db.py -q` -> 2 passed, 5 warnings.
+- Focused pytest: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_extraction_contracts.py tldw_Server_API/app/core/MCP_unified/tests/test_protocol_catalog_filter.py tldw_Server_API/app/core/MCP_unified/tests/test_protocol_allowed_tools.py tldw_Server_API/tests/Services/test_admin_tool_catalog_service_backend_selection.py tldw_Server_API/tests/DB_Management/unit/test_tool_catalog_db.py -q` -> 59 passed, 5 warnings.
+- Ruff: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m ruff check mcp_unified/interfaces tldw_Server_API/app/core/MCP_unified/interfaces/__init__.py tldw_Server_API/app/core/MCP_unified/interfaces/runtime.py tldw_Server_API/app/core/MCP_unified/adapters/tldw_runtime.py tldw_Server_API/app/core/MCP_unified/protocol.py tldw_Server_API/app/core/DB_Management/Tool_Catalog_DB.py tldw_Server_API/app/services/admin_tool_catalog_service.py tldw_Server_API/app/core/MCP_unified/tests/test_extraction_contracts.py tldw_Server_API/app/core/MCP_unified/tests/test_protocol_catalog_filter.py tldw_Server_API/app/core/MCP_unified/tests/test_protocol_allowed_tools.py tldw_Server_API/tests/Services/test_admin_tool_catalog_service_backend_selection.py tldw_Server_API/tests/DB_Management/unit/test_tool_catalog_db.py` -> All checks passed.
+- Bandit: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/core/DB_Management/Tool_Catalog_DB.py tldw_Server_API/app/services/admin_tool_catalog_service.py -f json -o /tmp/bandit_mcp_stage3f_protocol_catalog_provider_qodo_context_final.json` -> 0 results, 0 errors.
+- `git diff --check` -> passed.
 
 No known blockers or verification skips.
 <!-- SECTION:FINAL_SUMMARY:END -->
@@ -85,8 +86,10 @@ No known blockers or verification skips.
 - `tldw_Server_API/app/core/MCP_unified/protocol.py`
 - `tldw_Server_API/app/core/MCP_unified/tests/test_extraction_contracts.py`
 - `tldw_Server_API/app/core/MCP_unified/tests/test_protocol_catalog_filter.py`
+- `tldw_Server_API/app/core/DB_Management/Tool_Catalog_DB.py`
 - `tldw_Server_API/app/services/admin_tool_catalog_service.py`
 - `tldw_Server_API/tests/Services/test_admin_tool_catalog_service_backend_selection.py`
+- `tldw_Server_API/tests/DB_Management/unit/test_tool_catalog_db.py`
 - `backlog/tasks/task-546 - Implement-MCP-Unified-Stage-3F-protocol-catalog-provider-seam.md`
 
 ## Definition of Done

--- a/tldw_Server_API/app/core/DB_Management/Tool_Catalog_DB.py
+++ b/tldw_Server_API/app/core/DB_Management/Tool_Catalog_DB.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+from loguru import logger
+
+_TOOL_CATALOG_LOOKUP_EXCEPTIONS = (
+    AttributeError,
+    ConnectionError,
+    IndexError,
+    KeyError,
+    LookupError,
+    OSError,
+    RuntimeError,
+    TimeoutError,
+    TypeError,
+    ValueError,
+)
+
+
+def _coerce_catalog_id(catalog_id: Any) -> int | None:
+    """Return a numeric catalog id when the request supplied one."""
+    if catalog_id is None:
+        return None
+    try:
+        return int(catalog_id)
+    except (TypeError, ValueError):
+        return None
+
+
+def _row_value(row: Any, key: str, index: int) -> Any:
+    """Read a value from dict-like, record-like, or tuple-like DB rows."""
+    if row is None:
+        return None
+    if isinstance(row, Mapping):
+        return row.get(key)
+
+    keys = getattr(row, "keys", None)
+    if callable(keys):
+        try:
+            return row[key]
+        except (IndexError, KeyError, TypeError):
+            pass
+
+    if isinstance(row, Sequence) and not isinstance(row, (str, bytes, bytearray)):
+        return row[index] if len(row) > index else None
+
+    try:
+        return row[index]
+    except (IndexError, KeyError, TypeError):
+        return None
+
+
+async def _resolve_tool_catalog_name(
+    db: Any,
+    *,
+    name: str,
+    metadata: Mapping[str, Any],
+) -> int | None:
+    """Resolve a catalog name using team, org, then global precedence."""
+    team_id = metadata.get("team_id")
+    org_id = metadata.get("org_id")
+    row = None
+    try:
+        if team_id is not None:
+            row = await db.fetchone(
+                "SELECT id FROM tool_catalogs WHERE name = ? AND team_id = ?",
+                name,
+                team_id,
+            )
+        if row is None and org_id is not None:
+            row = await db.fetchone(
+                "SELECT id FROM tool_catalogs WHERE name = ? AND org_id = ? AND team_id IS NULL",
+                name,
+                org_id,
+            )
+        if row is None:
+            row = await db.fetchone(
+                "SELECT id FROM tool_catalogs WHERE name = ? AND org_id IS NULL AND team_id IS NULL",
+                name,
+            )
+        value = _row_value(row, "id", 0)
+        return int(value) if value is not None else None
+    except _TOOL_CATALOG_LOOKUP_EXCEPTIONS as exc:
+        logger.debug("MCP catalog lookup failed: {}", exc.__class__.__name__)
+        return None
+
+
+async def _resolve_tool_catalog_entries(
+    db: Any,
+    *,
+    catalog_id: int,
+    strict: bool,
+) -> set[str] | None:
+    """Return tool names for a resolved catalog id."""
+    try:
+        rows = await db.fetchall(
+            "SELECT tool_name FROM tool_catalog_entries WHERE catalog_id = ?",
+            catalog_id,
+        )
+    except _TOOL_CATALOG_LOOKUP_EXCEPTIONS as exc:
+        logger.debug("MCP catalog entries lookup failed: {}", exc.__class__.__name__)
+        return set() if strict else None
+
+    names: set[str] = set()
+    for row in rows or []:
+        value = _row_value(row, "tool_name", 0)
+        if isinstance(value, str):
+            names.add(value)
+    if names:
+        return names
+    return set() if strict else None
+
+
+async def resolve_tool_catalog_filter_names(
+    db: Any,
+    *,
+    catalog_name: str | None,
+    catalog_id: Any,
+    metadata: Mapping[str, Any] | None,
+    strict: bool,
+) -> set[str] | None:
+    """Resolve MCP catalog request parameters into a tool-name filter.
+
+    The AuthNZ database pool normalizes SQLite and PostgreSQL placeholder
+    styles behind ``fetchone``/``fetchall``. Keeping this SQL in DB_Management
+    preserves the repository database boundary while allowing the MCP runtime
+    adapter and admin service to remain host-service bridges instead of query
+    owners.
+    """
+    resolved_id = _coerce_catalog_id(catalog_id)
+    if resolved_id is None and isinstance(catalog_name, str) and catalog_name.strip():
+        resolved_id = await _resolve_tool_catalog_name(
+            db,
+            name=catalog_name.strip(),
+            metadata=metadata or {},
+        )
+
+    if resolved_id is None:
+        return set() if strict else None
+
+    return await _resolve_tool_catalog_entries(
+        db,
+        catalog_id=resolved_id,
+        strict=strict,
+    )

--- a/tldw_Server_API/app/core/DB_Management/Tool_Catalog_DB.py
+++ b/tldw_Server_API/app/core/DB_Management/Tool_Catalog_DB.py
@@ -56,7 +56,9 @@ async def _resolve_tool_catalog_name(
     db: Any,
     *,
     name: str,
+    catalog_id: Any,
     metadata: Mapping[str, Any],
+    strict: bool,
 ) -> int | None:
     """Resolve a catalog name using team, org, then global precedence."""
     team_id = metadata.get("team_id")
@@ -83,7 +85,15 @@ async def _resolve_tool_catalog_name(
         value = _row_value(row, "id", 0)
         return int(value) if value is not None else None
     except _TOOL_CATALOG_LOOKUP_EXCEPTIONS as exc:
-        logger.debug("MCP catalog lookup failed: {}", exc.__class__.__name__)
+        logger.debug(
+            "MCP catalog lookup failed: error_type={} catalog_name={} catalog_id={} team_id={} org_id={} strict={}",
+            exc.__class__.__name__,
+            name,
+            catalog_id,
+            team_id,
+            org_id,
+            strict,
+        )
         return None
 
 
@@ -91,6 +101,8 @@ async def _resolve_tool_catalog_entries(
     db: Any,
     *,
     catalog_id: int,
+    catalog_name: str | None,
+    metadata: Mapping[str, Any],
     strict: bool,
 ) -> set[str] | None:
     """Return tool names for a resolved catalog id."""
@@ -100,7 +112,15 @@ async def _resolve_tool_catalog_entries(
             catalog_id,
         )
     except _TOOL_CATALOG_LOOKUP_EXCEPTIONS as exc:
-        logger.debug("MCP catalog entries lookup failed: {}", exc.__class__.__name__)
+        logger.debug(
+            "MCP catalog entries lookup failed: error_type={} catalog_name={} catalog_id={} team_id={} org_id={} strict={}",
+            exc.__class__.__name__,
+            catalog_name,
+            catalog_id,
+            metadata.get("team_id"),
+            metadata.get("org_id"),
+            strict,
+        )
         return set() if strict else None
 
     names: set[str] = set()
@@ -131,10 +151,13 @@ async def resolve_tool_catalog_filter_names(
     """
     resolved_id = _coerce_catalog_id(catalog_id)
     if resolved_id is None and isinstance(catalog_name, str) and catalog_name.strip():
+        lookup_metadata = metadata or {}
         resolved_id = await _resolve_tool_catalog_name(
             db,
             name=catalog_name.strip(),
-            metadata=metadata or {},
+            catalog_id=catalog_id,
+            metadata=lookup_metadata,
+            strict=strict,
         )
 
     if resolved_id is None:
@@ -143,5 +166,7 @@ async def resolve_tool_catalog_filter_names(
     return await _resolve_tool_catalog_entries(
         db,
         catalog_id=resolved_id,
+        catalog_name=catalog_name.strip() if isinstance(catalog_name, str) else None,
+        metadata=metadata or {},
         strict=strict,
     )

--- a/tldw_Server_API/app/services/admin_tool_catalog_service.py
+++ b/tldw_Server_API/app/services/admin_tool_catalog_service.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import Mapping, Sequence
+from collections.abc import Mapping
 from typing import Any
 
 from loguru import logger
@@ -9,6 +9,7 @@ from tldw_Server_API.app.core.AuthNZ.database import (
     build_postgres_in_clause,
     build_sqlite_in_clause,
 )
+from tldw_Server_API.app.core.DB_Management import Tool_Catalog_DB as tool_catalog_db
 from tldw_Server_API.app.core.exceptions import ToolCatalogConflictError
 
 
@@ -30,114 +31,6 @@ def _is_postgres_connection(db: Any) -> bool:
     return callable(getattr(db, "fetchrow", None))
 
 
-_TOOL_CATALOG_LOOKUP_EXCEPTIONS = (
-    AttributeError,
-    ConnectionError,
-    IndexError,
-    KeyError,
-    LookupError,
-    OSError,
-    RuntimeError,
-    TimeoutError,
-    TypeError,
-    ValueError,
-)
-
-
-def _coerce_catalog_id(catalog_id: Any) -> int | None:
-    """Return a numeric catalog id when the request supplied one."""
-    if catalog_id is None:
-        return None
-    try:
-        return int(catalog_id)
-    except (TypeError, ValueError):
-        return None
-
-
-def _row_value(row: Any, key: str, index: int) -> Any:
-    """Read a value from dict-like, record-like, or tuple-like DB rows."""
-    if row is None:
-        return None
-    if isinstance(row, Mapping):
-        return row.get(key)
-
-    keys = getattr(row, "keys", None)
-    if callable(keys):
-        try:
-            return row[key]
-        except (IndexError, KeyError, TypeError):
-            pass
-
-    if isinstance(row, Sequence) and not isinstance(row, (str, bytes, bytearray)):
-        return row[index] if len(row) > index else None
-
-    try:
-        return row[index]
-    except (IndexError, KeyError, TypeError):
-        return None
-
-
-async def _resolve_tool_catalog_name(
-    db: Any,
-    *,
-    name: str,
-    metadata: Mapping[str, Any],
-) -> int | None:
-    """Resolve a catalog name using team, org, then global precedence."""
-    team_id = metadata.get("team_id")
-    org_id = metadata.get("org_id")
-    row = None
-    try:
-        if team_id is not None:
-            row = await db.fetchone(
-                "SELECT id FROM tool_catalogs WHERE name = ? AND team_id = ?",
-                name,
-                team_id,
-            )
-        if row is None and org_id is not None:
-            row = await db.fetchone(
-                "SELECT id FROM tool_catalogs WHERE name = ? AND org_id = ? AND team_id IS NULL",
-                name,
-                org_id,
-            )
-        if row is None:
-            row = await db.fetchone(
-                "SELECT id FROM tool_catalogs WHERE name = ? AND org_id IS NULL AND team_id IS NULL",
-                name,
-            )
-        value = _row_value(row, "id", 0)
-        return int(value) if value is not None else None
-    except _TOOL_CATALOG_LOOKUP_EXCEPTIONS as exc:
-        logger.debug("MCP catalog lookup failed: {}", exc.__class__.__name__)
-        return None
-
-
-async def _resolve_tool_catalog_entries(
-    db: Any,
-    *,
-    catalog_id: int,
-    strict: bool,
-) -> set[str] | None:
-    """Return tool names for a resolved catalog id."""
-    try:
-        rows = await db.fetchall(
-            "SELECT tool_name FROM tool_catalog_entries WHERE catalog_id = ?",
-            catalog_id,
-        )
-    except _TOOL_CATALOG_LOOKUP_EXCEPTIONS as exc:
-        logger.debug("MCP catalog entries lookup failed: {}", exc.__class__.__name__)
-        return set() if strict else None
-
-    names: set[str] = set()
-    for row in rows or []:
-        value = _row_value(row, "tool_name", 0)
-        if isinstance(value, str):
-            names.add(value)
-    if names:
-        return names
-    return set() if strict else None
-
-
 async def resolve_tool_catalog_filter_names(
     db: Any,
     *,
@@ -146,27 +39,12 @@ async def resolve_tool_catalog_filter_names(
     metadata: Mapping[str, Any] | None,
     strict: bool,
 ) -> set[str] | None:
-    """Resolve MCP catalog request parameters into a tool-name filter.
-
-    The AuthNZ database pool normalizes SQLite and PostgreSQL placeholder
-    styles behind ``fetchone``/``fetchall``. Keeping this SQL here preserves
-    the service boundary while allowing the MCP runtime adapter to remain a
-    host-service bridge instead of a query owner.
-    """
-    resolved_id = _coerce_catalog_id(catalog_id)
-    if resolved_id is None and isinstance(catalog_name, str) and catalog_name.strip():
-        resolved_id = await _resolve_tool_catalog_name(
-            db,
-            name=catalog_name.strip(),
-            metadata=metadata or {},
-        )
-
-    if resolved_id is None:
-        return set() if strict else None
-
-    return await _resolve_tool_catalog_entries(
+    """Resolve MCP catalog request parameters through the DB_Management layer."""
+    return await tool_catalog_db.resolve_tool_catalog_filter_names(
         db,
-        catalog_id=resolved_id,
+        catalog_name=catalog_name,
+        catalog_id=catalog_id,
+        metadata=metadata,
         strict=strict,
     )
 

--- a/tldw_Server_API/tests/DB_Management/unit/test_tool_catalog_db.py
+++ b/tldw_Server_API/tests/DB_Management/unit/test_tool_catalog_db.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from tldw_Server_API.app.core.DB_Management import Tool_Catalog_DB as tool_catalog_db
+
+
+class _CatalogNameFailureDb:
+    async def fetchone(self, *_args: Any, **_kwargs: Any) -> Any:
+        raise RuntimeError("catalog lookup failed at /private/authnz.db")
+
+    async def fetchall(self, *_args: Any, **_kwargs: Any) -> Any:  # pragma: no cover - trap
+        raise AssertionError("entry lookup should not run after catalog name failure")
+
+
+class _CatalogEntriesFailureDb:
+    async def fetchall(self, *_args: Any, **_kwargs: Any) -> Any:
+        raise RuntimeError("catalog entries failed at /private/authnz.db")
+
+
+def _capture_debug_logs(monkeypatch: pytest.MonkeyPatch) -> list[str]:
+    records: list[str] = []
+
+    def _debug(message: str, *args: Any, **_kwargs: Any) -> None:
+        records.append(message.format(*args))
+
+    monkeypatch.setattr(tool_catalog_db, "logger", SimpleNamespace(debug=_debug))
+    return records
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_catalog_name_lookup_failure_logs_safe_request_context(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    records = _capture_debug_logs(monkeypatch)
+
+    resolved = await tool_catalog_db.resolve_tool_catalog_filter_names(
+        _CatalogNameFailureDb(),
+        catalog_name="Team Research",
+        catalog_id=None,
+        metadata={"team_id": 7, "org_id": 5},
+        strict=False,
+    )
+
+    joined = "\n".join(records)
+    assert resolved is None
+    assert "RuntimeError" in joined
+    assert "catalog_name=Team Research" in joined
+    assert "team_id=7" in joined
+    assert "org_id=5" in joined
+    assert "strict=False" in joined
+    assert "/private/" not in joined
+    assert "authnz.db" not in joined
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_catalog_entries_lookup_failure_logs_safe_request_context(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    records = _capture_debug_logs(monkeypatch)
+
+    resolved = await tool_catalog_db.resolve_tool_catalog_filter_names(
+        _CatalogEntriesFailureDb(),
+        catalog_name=None,
+        catalog_id=42,
+        metadata={"team_id": 7, "org_id": 5},
+        strict=True,
+    )
+
+    joined = "\n".join(records)
+    assert resolved == set()
+    assert "RuntimeError" in joined
+    assert "catalog_id=42" in joined
+    assert "team_id=7" in joined
+    assert "org_id=5" in joined
+    assert "strict=True" in joined
+    assert "/private/" not in joined
+    assert "authnz.db" not in joined

--- a/tldw_Server_API/tests/Services/test_admin_tool_catalog_service_backend_selection.py
+++ b/tldw_Server_API/tests/Services/test_admin_tool_catalog_service_backend_selection.py
@@ -155,6 +155,59 @@ async def test_resolve_tool_catalog_filter_names_handles_tuple_rows() -> None:
 
 @pytest.mark.asyncio
 @pytest.mark.unit
+async def test_resolve_tool_catalog_filter_names_delegates_to_db_management(monkeypatch) -> None:
+    from tldw_Server_API.app.core.DB_Management import Tool_Catalog_DB as tool_catalog_db
+
+    calls: list[dict[str, Any]] = []
+
+    async def _resolve_from_db_management(
+        db: Any,
+        *,
+        catalog_name: str | None,
+        catalog_id: Any,
+        metadata: Any,
+        strict: bool,
+    ) -> set[str]:
+        calls.append(
+            {
+                "db": db,
+                "catalog_name": catalog_name,
+                "catalog_id": catalog_id,
+                "metadata": metadata,
+                "strict": strict,
+            }
+        )
+        return {"media.search"}
+
+    monkeypatch.setattr(
+        tool_catalog_db,
+        "resolve_tool_catalog_filter_names",
+        _resolve_from_db_management,
+    )
+    db = object()
+
+    resolved = await svc.resolve_tool_catalog_filter_names(
+        db,
+        catalog_name="A",
+        catalog_id="12",
+        metadata={"team_id": 7},
+        strict=True,
+    )
+
+    assert resolved == {"media.search"}
+    assert calls == [
+        {
+            "db": db,
+            "catalog_name": "A",
+            "catalog_id": "12",
+            "metadata": {"team_id": 7},
+            "strict": True,
+        }
+    ]
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
 @pytest.mark.parametrize(
     ("call_factory", "expected_log", "raw_marker"),
     [


### PR DESCRIPTION
## Change Summary (Maintainer-Owned)

Maintainer to confirm before merge: PR #2113 merged while final review closeout was in progress. This follow-up keeps the MCP protocol catalog provider behavior from #2113, then tightens the Qodo raw-SQL remediation by moving the catalog filter lookup SQL from `app/services` into `tldw_Server_API/app/core/DB_Management/Tool_Catalog_DB.py`.

## AI-Generated Implementation Notes

- Added `Tool_Catalog_DB.resolve_tool_catalog_filter_names()` as the DB_Management owner for MCP catalog name/id lookup and entry resolution.
- Kept `admin_tool_catalog_service.resolve_tool_catalog_filter_names()` as a thin delegate so existing MCP runtime adapter call sites do not change.
- Added a regression test proving the service delegates to DB_Management, while retaining tuple/dict row coverage.
- Updated TASK-546 with the post-merge rebase and verification record.

## Verification

- Rebase: `git rebase origin/dev` -> successfully rebased one follow-up commit onto `origin/dev` after PR #2113 merged.
- RED: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_admin_tool_catalog_service_backend_selection.py::test_resolve_tool_catalog_filter_names_delegates_to_db_management -q` -> failed with `ImportError: cannot import name 'Tool_Catalog_DB'`.
- GREEN/focused regression: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_admin_tool_catalog_service_backend_selection.py::test_resolve_tool_catalog_filter_names_delegates_to_db_management tldw_Server_API/tests/Services/test_admin_tool_catalog_service_backend_selection.py::test_resolve_tool_catalog_filter_names_handles_tuple_rows -q` -> 2 passed, 5 warnings.
- Post-rebase focused pytest: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_extraction_contracts.py tldw_Server_API/app/core/MCP_unified/tests/test_protocol_catalog_filter.py tldw_Server_API/app/core/MCP_unified/tests/test_protocol_allowed_tools.py tldw_Server_API/tests/Services/test_admin_tool_catalog_service_backend_selection.py -q` -> 57 passed, 5 warnings.
- Post-rebase Ruff: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m ruff check mcp_unified/interfaces tldw_Server_API/app/core/MCP_unified/interfaces/__init__.py tldw_Server_API/app/core/MCP_unified/interfaces/runtime.py tldw_Server_API/app/core/MCP_unified/adapters/tldw_runtime.py tldw_Server_API/app/core/MCP_unified/protocol.py tldw_Server_API/app/core/DB_Management/Tool_Catalog_DB.py tldw_Server_API/app/services/admin_tool_catalog_service.py tldw_Server_API/app/core/MCP_unified/tests/test_extraction_contracts.py tldw_Server_API/app/core/MCP_unified/tests/test_protocol_catalog_filter.py tldw_Server_API/app/core/MCP_unified/tests/test_protocol_allowed_tools.py tldw_Server_API/tests/Services/test_admin_tool_catalog_service_backend_selection.py` -> All checks passed.
- Post-rebase Bandit: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/core/DB_Management/Tool_Catalog_DB.py tldw_Server_API/app/services/admin_tool_catalog_service.py -f json -o /tmp/bandit_mcp_stage3f_protocol_catalog_provider_followup_rebased.json` -> 0 results, 0 errors.
- `git diff --check origin/dev...HEAD` -> passed.

## Watchlist

- PR #2113 is already merged, so this is intentionally a follow-up PR rather than a mutation of #2113.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Routes MCP tool-catalog filtering through DB_Management and adds safe, contextual debug logs for lookup failures. Aligns with TASK-546 by keeping the runtime adapter API unchanged and moving catalog SQL and row handling into the DB layer.

- **Refactors**
  - Introduced `Tool_Catalog_DB.resolve_tool_catalog_filter_names()`; `admin_tool_catalog_service` now delegates.
  - Centralized row handling and name-resolution precedence (team → org → global) in DB_Management.

- **Bug Fixes**
  - Sanitized debug logs for catalog-name and catalog-entry errors include only `error_type` and request context (`catalog_name`/`catalog_id`, `team_id`, `org_id`, `strict`).
  - Added unit tests for delegation and safe logging; strict mode returns `set()` on entry errors without leaking file paths or SQL.

<sup>Written for commit 945e7877f88cf057d77a20b134e066db5b2de81a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2118?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

