### PR TITLE
Stage 3G: extract MCP catalog loader seam

### DIFF
--- a/Docs/superpowers/plans/2026-05-29-mcp-unified-stage3g-catalog-loader-package-plan.md
+++ b/Docs/superpowers/plans/2026-05-29-mcp-unified-stage3g-catalog-loader-package-plan.md
@@ -38,8 +38,9 @@
 ## Verification Log
 
 - RED: `python -m pytest ...::test_catalog_loader_delegates_to_standalone_package_loader ...::test_standalone_package_exports_catalog_loader_functions ...::test_host_and_standalone_loader_paths_share_cache -q` failed as expected before implementation because the standalone loader module did not exist and the host loader still owned YAML/Pydantic parsing.
-- GREEN: `.venv/bin/python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_extraction_contracts.py tldw_Server_API/tests/unit/test_mcp_catalog_loader.py tldw_Server_API/tests/unit/test_archetype_schemas.py tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py -q` -> 76 passed.
-- Ruff: `.venv/bin/python -m ruff check mcp_unified/federation/catalog_loader.py mcp_unified/federation/__init__.py tldw_Server_API/app/core/MCP_unified/catalog_loader.py tldw_Server_API/app/core/MCP_unified/tests/test_extraction_contracts.py tldw_Server_API/tests/unit/test_mcp_catalog_loader.py` -> all checks passed.
+- GREEN: `.venv/bin/python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_extraction_contracts.py tldw_Server_API/tests/unit/test_mcp_catalog_loader.py tldw_Server_API/tests/unit/test_mcp_catalog_endpoints.py tldw_Server_API/tests/integration/test_first_run_setup_flow.py tldw_Server_API/tests/unit/test_archetype_schemas.py tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py -q` -> 94 passed.
+- Ruff: `.venv/bin/python -m ruff check mcp_unified/federation/catalog_loader.py mcp_unified/federation/__init__.py tldw_Server_API/app/core/MCP_unified/catalog_loader.py tldw_Server_API/app/core/MCP_unified/tests/test_extraction_contracts.py tldw_Server_API/tests/unit/test_mcp_catalog_loader.py tldw_Server_API/tests/unit/test_mcp_catalog_endpoints.py tldw_Server_API/tests/integration/test_first_run_setup_flow.py` -> all checks passed.
 - Bandit: `.venv/bin/python -m bandit -r mcp_unified/federation/catalog_loader.py mcp_unified/federation/__init__.py tldw_Server_API/app/core/MCP_unified/catalog_loader.py -f json -o /tmp/bandit_mcp_stage3g_catalog_loader.json` -> 0 findings.
 - Whitespace: `git diff --check` -> clean.
 - PR: https://github.com/rmusser01/tldw_server/pull/2122
+- Qodo review pass: addressed Loguru logging, in-place cache reset fixtures, non-mapping YAML entry skipping, and slice-assignment cache replacement.

--- a/Docs/superpowers/plans/2026-05-29-mcp-unified-stage3g-catalog-loader-package-plan.md
+++ b/Docs/superpowers/plans/2026-05-29-mcp-unified-stage3g-catalog-loader-package-plan.md
@@ -1,0 +1,44 @@
+# MCP Unified Stage 3G Catalog Loader Package Seam Plan
+
+**Goal:** Move MCP catalog YAML loading into the standalone `mcp_unified` package while preserving existing `tldw_Server_API` imports.
+
+**Backlog:** TASK-547
+
+## Stage 1: RED Boundary And Compatibility Tests
+**Goal:** Capture the desired package boundary before implementation.
+**Success Criteria:** Tests fail because `mcp_unified.federation.catalog_loader` does not exist and the host loader still owns implementation state.
+**Tests:** Focused pytest for extraction contracts and catalog loader package compatibility.
+**Status:** Complete
+
+- [x] Add a boundary contract that requires the host catalog loader to delegate to `mcp_unified.federation.catalog_loader`.
+- [x] Add catalog loader tests proving standalone and host import paths expose the same functions/cache state.
+- [x] Run focused tests and confirm the expected RED failures.
+
+## Stage 2: Move Loader Ownership
+**Goal:** Put YAML loading/cache behavior in the standalone package and leave the host path as a compatibility wrapper.
+**Success Criteria:** Existing host imports keep working while package imports are usable by standalone consumers.
+**Tests:** RED tests turn green; existing catalog loader behavior remains unchanged.
+**Status:** Complete
+
+- [x] Add `mcp_unified.federation.catalog_loader`.
+- [x] Re-export loader functions from `mcp_unified.federation`.
+- [x] Replace host `catalog_loader.py` with a compatibility wrapper.
+- [x] Re-run focused tests.
+
+## Stage 3: Validation And Closeout
+**Goal:** Verify the slice and record the result.
+**Success Criteria:** Focused pytest, Ruff, Bandit, and diff whitespace checks pass or have documented non-slice blockers.
+**Tests:** Focused pytest, Ruff, Bandit, `git diff --check`.
+**Status:** In Progress
+
+- [x] Run focused pytest for extraction contracts, catalog loader, archetype schema, and package boundary tests.
+- [x] Run Ruff and Bandit on touched code.
+- [ ] Update TASK-547 with verification, summary, and PR link.
+
+## Verification Log
+
+- RED: `python -m pytest ...::test_catalog_loader_delegates_to_standalone_package_loader ...::test_standalone_package_exports_catalog_loader_functions ...::test_host_and_standalone_loader_paths_share_cache -q` failed as expected before implementation because the standalone loader module did not exist and the host loader still owned YAML/Pydantic parsing.
+- GREEN: `.venv/bin/python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_extraction_contracts.py tldw_Server_API/tests/unit/test_mcp_catalog_loader.py tldw_Server_API/tests/unit/test_archetype_schemas.py tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py -q` -> 76 passed.
+- Ruff: `.venv/bin/python -m ruff check mcp_unified/federation/catalog_loader.py mcp_unified/federation/__init__.py tldw_Server_API/app/core/MCP_unified/catalog_loader.py tldw_Server_API/app/core/MCP_unified/tests/test_extraction_contracts.py tldw_Server_API/tests/unit/test_mcp_catalog_loader.py` -> all checks passed.
+- Bandit: `.venv/bin/python -m bandit -r mcp_unified/federation/catalog_loader.py mcp_unified/federation/__init__.py tldw_Server_API/app/core/MCP_unified/catalog_loader.py -f json -o /tmp/bandit_mcp_stage3g_catalog_loader.json` -> 0 findings.
+- Whitespace: `git diff --check` -> clean.

--- a/Docs/superpowers/plans/2026-05-29-mcp-unified-stage3g-catalog-loader-package-plan.md
+++ b/Docs/superpowers/plans/2026-05-29-mcp-unified-stage3g-catalog-loader-package-plan.md
@@ -29,11 +29,11 @@
 **Goal:** Verify the slice and record the result.
 **Success Criteria:** Focused pytest, Ruff, Bandit, and diff whitespace checks pass or have documented non-slice blockers.
 **Tests:** Focused pytest, Ruff, Bandit, `git diff --check`.
-**Status:** In Progress
+**Status:** Complete
 
 - [x] Run focused pytest for extraction contracts, catalog loader, archetype schema, and package boundary tests.
 - [x] Run Ruff and Bandit on touched code.
-- [ ] Update TASK-547 with verification, summary, and PR link.
+- [x] Update TASK-547 with verification, summary, and PR link.
 
 ## Verification Log
 
@@ -42,3 +42,4 @@
 - Ruff: `.venv/bin/python -m ruff check mcp_unified/federation/catalog_loader.py mcp_unified/federation/__init__.py tldw_Server_API/app/core/MCP_unified/catalog_loader.py tldw_Server_API/app/core/MCP_unified/tests/test_extraction_contracts.py tldw_Server_API/tests/unit/test_mcp_catalog_loader.py` -> all checks passed.
 - Bandit: `.venv/bin/python -m bandit -r mcp_unified/federation/catalog_loader.py mcp_unified/federation/__init__.py tldw_Server_API/app/core/MCP_unified/catalog_loader.py -f json -o /tmp/bandit_mcp_stage3g_catalog_loader.json` -> 0 findings.
 - Whitespace: `git diff --check` -> clean.
+- PR: https://github.com/rmusser01/tldw_server/pull/2122

--- a/backlog/tasks/task-547 - Implement-MCP-Unified-Stage-3G-catalog-loader-package-seam.md
+++ b/backlog/tasks/task-547 - Implement-MCP-Unified-Stage-3G-catalog-loader-package-seam.md
@@ -13,6 +13,8 @@ modified_files:
 - mcp_unified/federation/__init__.py
 - tldw_Server_API/app/core/MCP_unified/catalog_loader.py
 - tldw_Server_API/app/core/MCP_unified/tests/test_extraction_contracts.py
+- tldw_Server_API/tests/integration/test_first_run_setup_flow.py
+- tldw_Server_API/tests/unit/test_mcp_catalog_endpoints.py
 - tldw_Server_API/tests/unit/test_mcp_catalog_loader.py
 ---
 
@@ -37,14 +39,15 @@ Move MCP catalog YAML loader behavior into the standalone mcp_unified package wh
 - Re-exported catalog loader functions from `mcp_unified.federation` so standalone consumers can import load/list/get behavior without the host API package.
 - Replaced `tldw_Server_API.app.core.MCP_unified.catalog_loader` with a compatibility wrapper that imports the standalone implementation and shares the same cache object.
 - Added regression coverage for the host-wrapper package boundary, standalone exports, and shared host/package cache behavior.
-- Verification: RED boundary tests failed before implementation; focused pytest later reported 76 passed; Ruff passed; Bandit reported 0 findings; `git diff --check` was clean.
+- Addressed Qodo review findings by switching the standalone loader to Loguru, using slice assignment for cache replacement, skipping non-mapping YAML entries, and updating remaining cache-reset fixtures to mutate in place.
+- Verification: RED boundary tests failed before implementation; focused pytest later reported 94 passed; Ruff passed; Bandit reported 0 findings; `git diff --check` was clean.
 - PR: https://github.com/rmusser01/tldw_server/pull/2122
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Implemented the Stage 3G catalog loader package seam. The standalone `mcp_unified` package now owns catalog load/list/get behavior, while the existing host import path remains compatible through a thin wrapper. PR: https://github.com/rmusser01/tldw_server/pull/2122
+Implemented the Stage 3G catalog loader package seam and addressed Qodo's review findings. The standalone `mcp_unified` package now owns catalog load/list/get behavior, while the existing host import path remains compatible through a thin wrapper. PR: https://github.com/rmusser01/tldw_server/pull/2122
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-547 - Implement-MCP-Unified-Stage-3G-catalog-loader-package-seam.md
+++ b/backlog/tasks/task-547 - Implement-MCP-Unified-Stage-3G-catalog-loader-package-seam.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-547
 title: Implement MCP Unified Stage 3G catalog loader package seam
-status: In Progress
+status: Done
 labels:
 - mcp
 - mcp-unified
@@ -38,12 +38,13 @@ Move MCP catalog YAML loader behavior into the standalone mcp_unified package wh
 - Replaced `tldw_Server_API.app.core.MCP_unified.catalog_loader` with a compatibility wrapper that imports the standalone implementation and shares the same cache object.
 - Added regression coverage for the host-wrapper package boundary, standalone exports, and shared host/package cache behavior.
 - Verification: RED boundary tests failed before implementation; focused pytest later reported 76 passed; Ruff passed; Bandit reported 0 findings; `git diff --check` was clean.
+- PR: https://github.com/rmusser01/tldw_server/pull/2122
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Implemented the Stage 3G catalog loader package seam. The standalone `mcp_unified` package now owns catalog load/list/get behavior, while the existing host import path remains compatible through a thin wrapper. PR link pending.
+Implemented the Stage 3G catalog loader package seam. The standalone `mcp_unified` package now owns catalog load/list/get behavior, while the existing host import path remains compatible through a thin wrapper. PR: https://github.com/rmusser01/tldw_server/pull/2122
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-547 - Implement-MCP-Unified-Stage-3G-catalog-loader-package-seam.md
+++ b/backlog/tasks/task-547 - Implement-MCP-Unified-Stage-3G-catalog-loader-package-seam.md
@@ -1,0 +1,57 @@
+---
+id: TASK-547
+title: Implement MCP Unified Stage 3G catalog loader package seam
+status: In Progress
+labels:
+- mcp
+- mcp-unified
+- standalone
+- stage3
+modified_files:
+- Docs/superpowers/plans/2026-05-29-mcp-unified-stage3g-catalog-loader-package-plan.md
+- mcp_unified/federation/catalog_loader.py
+- mcp_unified/federation/__init__.py
+- tldw_Server_API/app/core/MCP_unified/catalog_loader.py
+- tldw_Server_API/app/core/MCP_unified/tests/test_extraction_contracts.py
+- tldw_Server_API/tests/unit/test_mcp_catalog_loader.py
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Move MCP catalog YAML loader behavior into the standalone mcp_unified package while preserving the existing tldw_Server_API catalog_loader import path as a compatibility wrapper. Keep the slice scoped to catalog loading and cache behavior.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Standalone mcp_unified package exposes catalog loader functions for load/list/get behavior.
+- [x] #2 Existing tldw_Server_API.app.core.MCP_unified.catalog_loader imports remain compatible and share the standalone cache behavior.
+- [x] #3 Regression tests cover package ownership, host-wrapper compatibility, and existing catalog loader behavior.
+- [x] #4 Focused pytest, Ruff, Bandit, and diff whitespace verification are recorded before PR closeout.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+- Added `mcp_unified.federation.catalog_loader` as the standalone owner of YAML catalog parsing, Pydantic validation, and in-memory catalog cache behavior.
+- Re-exported catalog loader functions from `mcp_unified.federation` so standalone consumers can import load/list/get behavior without the host API package.
+- Replaced `tldw_Server_API.app.core.MCP_unified.catalog_loader` with a compatibility wrapper that imports the standalone implementation and shares the same cache object.
+- Added regression coverage for the host-wrapper package boundary, standalone exports, and shared host/package cache behavior.
+- Verification: RED boundary tests failed before implementation; focused pytest later reported 76 passed; Ruff passed; Bandit reported 0 findings; `git diff --check` was clean.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Implemented the Stage 3G catalog loader package seam. The standalone `mcp_unified` package now owns catalog load/list/get behavior, while the existing host import path remains compatible through a thin wrapper. PR link pending.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/mcp_unified/federation/__init__.py
+++ b/mcp_unified/federation/__init__.py
@@ -1,11 +1,15 @@
 """Standalone non-spawning external federation shell."""
 
+from . import catalog_loader
+from .catalog_loader import get_catalog_entry, list_catalog_entries, load_mcp_catalog
 from .manager import ExternalFederationManager
 from .models import (
     ExternalToolCallResult,
     ExternalToolDefinition,
     FederatedToolResult,
     FederationPolicyDenied,
+    MCPAuthType,
+    MCPCatalogEntry,
     VirtualExternalTool,
 )
 from .transports import ExternalFederationTransport, FakeExternalTransport
@@ -18,5 +22,11 @@ __all__ = [
     "FakeExternalTransport",
     "FederatedToolResult",
     "FederationPolicyDenied",
+    "MCPAuthType",
+    "MCPCatalogEntry",
     "VirtualExternalTool",
+    "catalog_loader",
+    "get_catalog_entry",
+    "list_catalog_entries",
+    "load_mcp_catalog",
 ]

--- a/mcp_unified/federation/catalog_loader.py
+++ b/mcp_unified/federation/catalog_loader.py
@@ -7,15 +7,14 @@ by front-end setup flows and standalone MCP server hosts.
 """
 from __future__ import annotations
 
-import logging
+from collections.abc import Mapping
 from pathlib import Path
 
 import yaml
+from loguru import logger
 from pydantic import ValidationError
 
 from .models import MCPCatalogEntry
-
-logger = logging.getLogger(__name__)
 
 # Module-level cache
 _CATALOG_CACHE: list[MCPCatalogEntry] = []
@@ -23,8 +22,7 @@ _CATALOG_CACHE: list[MCPCatalogEntry] = []
 
 def _replace_cache(entries: list[MCPCatalogEntry]) -> list[MCPCatalogEntry]:
     """Replace the catalog cache in place and return a caller-owned list."""
-    _CATALOG_CACHE.clear()
-    _CATALOG_CACHE.extend(entries)
+    _CATALOG_CACHE[:] = entries
     return list(_CATALOG_CACHE)
 
 
@@ -42,44 +40,46 @@ def load_mcp_catalog(path: str | Path) -> list[MCPCatalogEntry]:
     """
     file_path = Path(path)
     if not file_path.is_file():
-        logger.warning("MCP catalog file does not exist: %s", file_path)
+        logger.warning("MCP catalog file does not exist: {}", file_path)
         return _replace_cache([])
 
     try:
         raw = file_path.read_text(encoding="utf-8")
         data = yaml.safe_load(raw)
     except (FileNotFoundError, OSError, yaml.YAMLError, TypeError, ValueError):
-        logger.warning(
-            "Failed to read/parse MCP catalog file: %s",
-            file_path,
-            exc_info=True,
+        logger.opt(exception=True).warning(
+            "Failed to read/parse MCP catalog file: {}", file_path
         )
         return _replace_cache([])
 
     if not isinstance(data, dict) or "catalog" not in data:
-        logger.warning("Skipping %s: missing top-level 'catalog' key", file_path.name)
+        logger.warning("Skipping {}: missing top-level 'catalog' key", file_path.name)
         return _replace_cache([])
 
     entries = data["catalog"]
     if not isinstance(entries, list):
-        logger.warning("Skipping %s: 'catalog' value is not a list", file_path.name)
+        logger.warning("Skipping {}: 'catalog' value is not a list", file_path.name)
         return _replace_cache([])
 
     new_cache: list[MCPCatalogEntry] = []
     for idx, entry_data in enumerate(entries):
+        if not isinstance(entry_data, Mapping):
+            logger.warning("Skipping malformed MCP catalog entry at index {}", idx)
+            continue
+
         try:
-            entry = MCPCatalogEntry(**entry_data)
+            entry = MCPCatalogEntry(**dict(entry_data))
             new_cache.append(entry)
-            logger.debug("Loaded MCP catalog entry '%s'", entry.key)
+            logger.debug("Loaded MCP catalog entry '{}'", entry.key)
         except ValidationError:
-            logger.warning(
-                "Skipping malformed MCP catalog entry at index %s",
-                idx,
-                exc_info=True,
+            logger.opt(exception=True).warning(
+                "Skipping malformed MCP catalog entry at index {}", idx
             )
 
     _replace_cache(new_cache)
-    logger.info("Loaded %s MCP catalog entry/entries from %s", len(_CATALOG_CACHE), file_path)
+    logger.info(
+        "Loaded {} MCP catalog entry/entries from {}", len(_CATALOG_CACHE), file_path
+    )
     return list(_CATALOG_CACHE)
 
 

--- a/mcp_unified/federation/catalog_loader.py
+++ b/mcp_unified/federation/catalog_loader.py
@@ -1,0 +1,100 @@
+"""
+MCP server catalog loader.
+
+Loads curated external MCP server catalog entries from a YAML file,
+validates them with Pydantic, and caches them in memory for fast access
+by front-end setup flows and standalone MCP server hosts.
+"""
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import yaml
+from pydantic import ValidationError
+
+from .models import MCPCatalogEntry
+
+logger = logging.getLogger(__name__)
+
+# Module-level cache
+_CATALOG_CACHE: list[MCPCatalogEntry] = []
+
+
+def _replace_cache(entries: list[MCPCatalogEntry]) -> list[MCPCatalogEntry]:
+    """Replace the catalog cache in place and return a caller-owned list."""
+    _CATALOG_CACHE.clear()
+    _CATALOG_CACHE.extend(entries)
+    return list(_CATALOG_CACHE)
+
+
+def load_mcp_catalog(path: str | Path) -> list[MCPCatalogEntry]:
+    """Load catalog entries from a YAML file, validate via Pydantic, and cache.
+
+    The YAML file must contain a top-level ``catalog`` key whose value is
+    a list of mapping objects. Each mapping is validated as an
+    :class:`MCPCatalogEntry`. Malformed entries are logged and skipped so
+    that one bad entry does not prevent the rest from loading.
+
+    The cache is replaced in place so host compatibility wrappers keep a
+    shared cache object. This function is intended to be called once at
+    startup; it is not designed for concurrent hot-reload.
+    """
+    file_path = Path(path)
+    if not file_path.is_file():
+        logger.warning("MCP catalog file does not exist: %s", file_path)
+        return _replace_cache([])
+
+    try:
+        raw = file_path.read_text(encoding="utf-8")
+        data = yaml.safe_load(raw)
+    except (FileNotFoundError, OSError, yaml.YAMLError, TypeError, ValueError):
+        logger.warning(
+            "Failed to read/parse MCP catalog file: %s",
+            file_path,
+            exc_info=True,
+        )
+        return _replace_cache([])
+
+    if not isinstance(data, dict) or "catalog" not in data:
+        logger.warning("Skipping %s: missing top-level 'catalog' key", file_path.name)
+        return _replace_cache([])
+
+    entries = data["catalog"]
+    if not isinstance(entries, list):
+        logger.warning("Skipping %s: 'catalog' value is not a list", file_path.name)
+        return _replace_cache([])
+
+    new_cache: list[MCPCatalogEntry] = []
+    for idx, entry_data in enumerate(entries):
+        try:
+            entry = MCPCatalogEntry(**entry_data)
+            new_cache.append(entry)
+            logger.debug("Loaded MCP catalog entry '%s'", entry.key)
+        except ValidationError:
+            logger.warning(
+                "Skipping malformed MCP catalog entry at index %s",
+                idx,
+                exc_info=True,
+            )
+
+    _replace_cache(new_cache)
+    logger.info("Loaded %s MCP catalog entry/entries from %s", len(_CATALOG_CACHE), file_path)
+    return list(_CATALOG_CACHE)
+
+
+def list_catalog_entries(
+    archetype_key: str | None = None,
+) -> list[MCPCatalogEntry]:
+    """Return cached catalog entries, optionally filtered by archetype key."""
+    if archetype_key is None:
+        return list(_CATALOG_CACHE)
+    return [e for e in _CATALOG_CACHE if archetype_key in e.suggested_for]
+
+
+def get_catalog_entry(key: str) -> MCPCatalogEntry | None:
+    """Return the cached catalog entry identified by *key*, or ``None``."""
+    for entry in _CATALOG_CACHE:
+        if entry.key == key:
+            return entry
+    return None

--- a/tldw_Server_API/app/core/MCP_unified/catalog_loader.py
+++ b/tldw_Server_API/app/core/MCP_unified/catalog_loader.py
@@ -1,121 +1,22 @@
 """
-MCP Server Catalog Loader.
+Compatibility wrapper for the standalone MCP catalog loader.
 
-Loads curated external MCP server catalog entries from a YAML file,
-validates them with Pydantic, and caches them in memory for fast access
-by API endpoints and the setup wizard.
+The implementation lives in :mod:`mcp_unified.federation.catalog_loader` so
+standalone MCP hosts can use the same YAML catalog loading behavior without
+importing the tldw_server API package.
 """
 from __future__ import annotations
 
-from pathlib import Path
+from mcp_unified.federation.catalog_loader import (
+    _CATALOG_CACHE,
+    get_catalog_entry,
+    list_catalog_entries,
+    load_mcp_catalog,
+)
 
-import yaml
-from loguru import logger
-from mcp_unified.federation.models import MCPCatalogEntry
-from pydantic import ValidationError
-
-# Module-level cache
-_CATALOG_CACHE: list[MCPCatalogEntry] = []
-
-
-def load_mcp_catalog(path: str | Path) -> list[MCPCatalogEntry]:
-    """Load catalog entries from a YAML file, validate via Pydantic, and cache.
-
-    The YAML file must contain a top-level ``catalog`` key whose value is
-    a list of mapping objects.  Each mapping is validated as an
-    :class:`MCPCatalogEntry`.  Malformed entries are logged with loguru
-    and skipped so that one bad entry does not prevent the rest from
-    loading.
-
-    The cache is replaced atomically so that concurrent readers never see
-    a partially-populated state.  This function is intended to be called
-    once at startup; it is **not** designed for concurrent hot-reload.
-
-    Parameters
-    ----------
-    path:
-        Path to the YAML catalog file.
-
-    Returns
-    -------
-    list[MCPCatalogEntry]
-        The validated (and now cached) catalog entries.
-    """
-    global _CATALOG_CACHE
-
-    file_path = Path(path)
-    if not file_path.is_file():
-        logger.warning("MCP catalog file does not exist: {}", file_path)
-        _CATALOG_CACHE = []
-        return []
-
-    try:
-        raw = file_path.read_text(encoding="utf-8")
-        data = yaml.safe_load(raw)
-    except (FileNotFoundError, OSError, yaml.YAMLError, TypeError, ValueError):
-        logger.opt(exception=True).warning(
-            "Failed to read/parse MCP catalog file: {}", file_path
-        )
-        _CATALOG_CACHE = []
-        return []
-
-    if not isinstance(data, dict) or "catalog" not in data:
-        logger.warning(
-            "Skipping {}: missing top-level 'catalog' key", file_path.name
-        )
-        _CATALOG_CACHE = []
-        return _CATALOG_CACHE
-
-    entries = data["catalog"]
-    if not isinstance(entries, list):
-        logger.warning(
-            "Skipping {}: 'catalog' value is not a list", file_path.name
-        )
-        _CATALOG_CACHE = []
-        return _CATALOG_CACHE
-
-    new_cache: list[MCPCatalogEntry] = []
-    for idx, entry_data in enumerate(entries):
-        try:
-            entry = MCPCatalogEntry(**entry_data)
-            new_cache.append(entry)
-            logger.debug("Loaded MCP catalog entry '{}'", entry.key)
-        except ValidationError:
-            logger.opt(exception=True).warning(
-                "Skipping malformed MCP catalog entry at index {}", idx
-            )
-
-    # Atomic replacement — readers never see a half-populated cache.
-    _CATALOG_CACHE = new_cache
-    logger.info(
-        "Loaded {} MCP catalog entry/entries from {}", len(_CATALOG_CACHE), file_path
-    )
-    return list(_CATALOG_CACHE)
-
-
-def list_catalog_entries(
-    archetype_key: str | None = None,
-) -> list[MCPCatalogEntry]:
-    """Return cached catalog entries, optionally filtered by archetype key.
-
-    Parameters
-    ----------
-    archetype_key:
-        If provided, only entries whose ``suggested_for`` list contains
-        this value are returned.  If ``None``, all entries are returned.
-
-    Returns
-    -------
-    list[MCPCatalogEntry]
-    """
-    if archetype_key is None:
-        return list(_CATALOG_CACHE)
-    return [e for e in _CATALOG_CACHE if archetype_key in e.suggested_for]
-
-
-def get_catalog_entry(key: str) -> MCPCatalogEntry | None:
-    """Return the cached catalog entry identified by *key*, or ``None``."""
-    for entry in _CATALOG_CACHE:
-        if entry.key == key:
-            return entry
-    return None
+__all__ = [
+    "_CATALOG_CACHE",
+    "get_catalog_entry",
+    "list_catalog_entries",
+    "load_mcp_catalog",
+]

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_extraction_contracts.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_extraction_contracts.py
@@ -11,6 +11,8 @@ from typing import Any, get_type_hints
 import pytest
 
 MCP_ROOT = Path(__file__).resolve().parents[1]
+REPO_ROOT = Path(__file__).resolve().parents[5]
+STANDALONE_MCP_ROOT = REPO_ROOT / "mcp_unified"
 MCP_PACKAGE = "tldw_Server_API.app.core.MCP_unified"
 EXPECTED_INTERFACE_FILES = {"runtime.py", "policy.py", "storage.py"}
 
@@ -468,6 +470,18 @@ def test_catalog_loader_delegates_to_standalone_package_loader() -> None:
 
     assert "mcp_unified.federation.catalog_loader" in imports
     assert offenders == []
+
+
+def test_standalone_catalog_loader_uses_loguru_not_stdlib_logging() -> None:
+    """Package catalog loader should use the project-standard Loguru logger."""
+    imports = _resolved_import_sources_for(
+        STANDALONE_MCP_ROOT / "federation" / "catalog_loader.py",
+        "mcp_unified.federation",
+        top_level_only=True,
+    )
+
+    assert "loguru" in imports
+    assert "logging" not in imports
 
 
 def test_protocol_boundary_scan_resolves_relative_imports(tmp_path: Path) -> None:

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_extraction_contracts.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_extraction_contracts.py
@@ -451,6 +451,25 @@ def test_catalog_loader_uses_standalone_catalog_schema() -> None:
     assert offenders == []
 
 
+def test_catalog_loader_delegates_to_standalone_package_loader() -> None:
+    """Host catalog loader should be a thin wrapper around package loader code."""
+    imports = _resolved_import_sources_for(
+        MCP_ROOT / "catalog_loader.py",
+        MCP_PACKAGE,
+        top_level_only=True,
+    )
+    forbidden_sources = {"yaml", "loguru", "pydantic"}
+    offenders = sorted(
+        source
+        for source in imports
+        if source in forbidden_sources
+        or any(source.startswith(f"{forbidden}.") for forbidden in forbidden_sources)
+    )
+
+    assert "mcp_unified.federation.catalog_loader" in imports
+    assert offenders == []
+
+
 def test_protocol_boundary_scan_resolves_relative_imports(tmp_path: Path) -> None:
     sample = tmp_path / "sample.py"
     sample.write_text(

--- a/tldw_Server_API/tests/integration/test_first_run_setup_flow.py
+++ b/tldw_Server_API/tests/integration/test_first_run_setup_flow.py
@@ -5,25 +5,22 @@ import pathlib
 
 import pytest
 
-import tldw_Server_API.app.core.Persona.archetype_loader as _loader_mod
 import tldw_Server_API.app.core.MCP_unified.catalog_loader as _catalog_mod
-from tldw_Server_API.app.core.Persona.archetype_loader import (
-    load_archetypes_from_directory,
-    get_archetype,
+import tldw_Server_API.app.core.Persona.archetype_loader as _loader_mod
+from tldw_Server_API.app.api.v1.endpoints.archetype_endpoints import (
+    get_archetype_preview,
+    get_persona_archetype,
+    list_persona_archetypes,
 )
+from tldw_Server_API.app.api.v1.endpoints.mcp_unified_endpoint import list_mcp_catalog
+from tldw_Server_API.app.api.v1.schemas.persona import PersonaSetupEventCreate
 from tldw_Server_API.app.core.MCP_unified.catalog_loader import (
     load_mcp_catalog,
-    list_catalog_entries,
 )
-from tldw_Server_API.app.api.v1.endpoints.archetype_endpoints import (
-    list_persona_archetypes,
-    get_persona_archetype,
-    get_archetype_preview,
+from tldw_Server_API.app.core.Persona.archetype_loader import (
+    get_archetype,
+    load_archetypes_from_directory,
 )
-from tldw_Server_API.app.api.v1.endpoints.mcp_unified_endpoint import (
-    list_mcp_catalog,
-)
-from tldw_Server_API.app.api.v1.schemas.persona import PersonaSetupEventCreate
 
 ARCHETYPES_DIR = pathlib.Path("tldw_Server_API/Config_Files/persona_archetypes")
 CATALOG_PATH = pathlib.Path("tldw_Server_API/Config_Files/mcp_server_catalog.yaml")
@@ -34,12 +31,12 @@ pytestmark = pytest.mark.integration
 @pytest.fixture(autouse=True)
 def _load_data():
     _loader_mod._CACHE = {}
-    _catalog_mod._CATALOG_CACHE = []
+    _catalog_mod._CATALOG_CACHE.clear()
     load_archetypes_from_directory(ARCHETYPES_DIR)
     load_mcp_catalog(CATALOG_PATH)
     yield
     _loader_mod._CACHE = {}
-    _catalog_mod._CATALOG_CACHE = []
+    _catalog_mod._CATALOG_CACHE.clear()
 
 
 @pytest.mark.asyncio
@@ -68,10 +65,10 @@ async def test_get_archetype_detail():
 @pytest.mark.asyncio
 async def test_get_archetype_preview_shape():
     result = await get_archetype_preview("research_assistant")
-    assert result["name"] == "Research Assistant"
-    assert result["archetype_key"] == "research_assistant"
-    assert "voice_defaults" in result
-    assert result["setup"]["current_step"] == "archetype"
+    assert result.name == "Research Assistant"
+    assert result.archetype_key == "research_assistant"
+    assert isinstance(result.voice_defaults, dict)
+    assert result.setup.current_step == "archetype"
 
 
 @pytest.mark.asyncio

--- a/tldw_Server_API/tests/unit/test_mcp_catalog_endpoints.py
+++ b/tldw_Server_API/tests/unit/test_mcp_catalog_endpoints.py
@@ -7,12 +7,12 @@ import pytest
 from fastapi import HTTPException
 
 import tldw_Server_API.app.api.v1.endpoints.mcp_unified_endpoint as mcp_endpoint
+import tldw_Server_API.app.core.MCP_unified.catalog_loader as _catalog_mod
 from tldw_Server_API.app.api.v1.endpoints.mcp_unified_endpoint import (
     MCPConnectionTestRequest,
-    list_mcp_catalog,
     check_mcp_connection,
+    list_mcp_catalog,
 )
-import tldw_Server_API.app.core.MCP_unified.catalog_loader as _catalog_mod
 from tldw_Server_API.app.core.MCP_unified.catalog_loader import load_mcp_catalog
 
 pytestmark = pytest.mark.unit
@@ -28,10 +28,15 @@ _CATALOG_YAML = (
 @pytest.fixture(autouse=True)
 def _load_real_catalog():
     """Load the real catalog YAML before each test and clear after."""
-    _catalog_mod._CATALOG_CACHE = []
+    _catalog_mod._CATALOG_CACHE.clear()
     load_mcp_catalog(_CATALOG_YAML)
     yield
-    _catalog_mod._CATALOG_CACHE = []
+    _catalog_mod._CATALOG_CACHE.clear()
+
+
+def _allow_catalog_probe_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Bypass DNS-backed URL safety checks in tests covering probe behavior."""
+    monkeypatch.setattr(mcp_endpoint, "assert_url_safe", lambda _url: None)
 
 
 # -- list_mcp_catalog --------------------------------------------------------
@@ -80,6 +85,7 @@ async def test_list_catalog_unknown_archetype_returns_empty():
 @pytest.mark.asyncio
 async def test_connection_unreachable(monkeypatch: pytest.MonkeyPatch):
     """Catalog connection failures should return a safe unreachable response."""
+    _allow_catalog_probe_url(monkeypatch)
     req = MCPConnectionTestRequest(url="https://api.github.com")
 
     async def _failing_probe(_url: str, _headers: dict[str, str]) -> None:
@@ -120,6 +126,7 @@ async def test_connection_failure_logs_canonical_url_without_request_secrets(
         probed_urls.append(url)
         raise OSError("network down")
 
+    _allow_catalog_probe_url(monkeypatch)
     monkeypatch.setattr(mcp_endpoint, "logger", _FakeLogger())
     monkeypatch.setattr(mcp_endpoint, "_is_private_ip", lambda _host: False)
     monkeypatch.setattr(mcp_endpoint, "_probe_mcp_connection", _failing_probe)
@@ -146,6 +153,7 @@ async def test_connection_uses_api_key_header(monkeypatch: pytest.MonkeyPatch):
         captured_headers.update(headers)
         return None
 
+    _allow_catalog_probe_url(monkeypatch)
     monkeypatch.setattr(
         "tldw_Server_API.app.api.v1.endpoints.mcp_unified_endpoint._is_private_ip",
         lambda _host: False,

--- a/tldw_Server_API/tests/unit/test_mcp_catalog_loader.py
+++ b/tldw_Server_API/tests/unit/test_mcp_catalog_loader.py
@@ -56,6 +56,25 @@ _ONE_GOOD_ONE_BAD_YAML = textwrap.dedent("""\
         name: 12345
 """)
 
+_NON_MAPPING_ENTRIES_YAML = textwrap.dedent("""\
+    catalog:
+      - key: github
+        name: GitHub
+        description: Repositories, issues, PRs, and code search
+        url_template: https://api.github.com
+        auth_type: bearer
+        category: development
+      - null
+      - just-a-string
+      - []
+      - key: arxiv
+        name: arXiv
+        description: Academic paper search and retrieval
+        url_template: https://export.arxiv.org/api
+        auth_type: none
+        category: research
+""")
+
 
 # -- Fixtures ----------------------------------------------------------------
 
@@ -232,6 +251,15 @@ class TestMalformedEntries:
 
         assert len(result) == 1
         assert result[0].key == "github"
+
+    def test_non_mapping_entries_are_skipped(self, tmp_path: Path):
+        """Non-mapping YAML entries are malformed entries, not fatal errors."""
+        p = tmp_path / "catalog.yaml"
+        p.write_text(_NON_MAPPING_ENTRIES_YAML, encoding="utf-8")
+
+        result = load_mcp_catalog(p)
+
+        assert [entry.key for entry in result] == ["github", "arxiv"]
 
     def test_missing_file(self, tmp_path: Path):
         result = load_mcp_catalog(tmp_path / "does_not_exist.yaml")

--- a/tldw_Server_API/tests/unit/test_mcp_catalog_loader.py
+++ b/tldw_Server_API/tests/unit/test_mcp_catalog_loader.py
@@ -63,9 +63,9 @@ _ONE_GOOD_ONE_BAD_YAML = textwrap.dedent("""\
 @pytest.fixture(autouse=True)
 def _clear_cache():
     """Ensure the module-level cache is empty before and after each test."""
-    _catalog_mod._CATALOG_CACHE = []
+    _catalog_mod._CATALOG_CACHE.clear()
     yield
-    _catalog_mod._CATALOG_CACHE = []
+    _catalog_mod._CATALOG_CACHE.clear()
 
 
 @pytest.fixture()
@@ -102,6 +102,42 @@ class TestLoadMcpCatalog:
 
         assert ApiMCPCatalogEntry is StandaloneMCPCatalogEntry
         assert all(isinstance(e, StandaloneMCPCatalogEntry) for e in result)
+
+    def test_standalone_package_exports_catalog_loader_functions(
+        self,
+        catalog_file: Path,
+    ):
+        """Standalone package exports the same catalog loader functions."""
+        from mcp_unified.federation import load_mcp_catalog as package_load_mcp_catalog
+        from mcp_unified.federation.catalog_loader import (
+            get_catalog_entry as package_get_catalog_entry,
+        )
+
+        assert package_load_mcp_catalog is load_mcp_catalog
+
+        package_load_mcp_catalog(catalog_file)
+
+        assert package_get_catalog_entry("github") is not None
+        assert [entry.key for entry in list_catalog_entries()] == ["github", "arxiv"]
+
+    def test_host_and_standalone_loader_paths_share_cache(
+        self,
+        catalog_file: Path,
+        tmp_path: Path,
+    ):
+        """Host compatibility wrapper and standalone loader share cache state."""
+        from mcp_unified.federation import catalog_loader as package_catalog_mod
+
+        package_catalog_mod.load_mcp_catalog(catalog_file)
+
+        assert [entry.key for entry in _catalog_mod.list_catalog_entries()] == [
+            "github",
+            "arxiv",
+        ]
+
+        _catalog_mod.load_mcp_catalog(tmp_path / "missing.yaml")
+
+        assert package_catalog_mod.list_catalog_entries() == []
 
     def test_cache_is_populated(self, catalog_file: Path):
         load_mcp_catalog(catalog_file)
@@ -214,7 +250,9 @@ class TestMalformedEntries:
         def boom(_raw: str):
             raise RuntimeError("unexpected parser failure")
 
-        monkeypatch.setattr(_catalog_mod.yaml, "safe_load", boom)
+        from mcp_unified.federation import catalog_loader as package_catalog_mod
+
+        monkeypatch.setattr(package_catalog_mod.yaml, "safe_load", boom)
 
         with pytest.raises(RuntimeError, match="unexpected parser failure"):
             load_mcp_catalog(catalog_file)


### PR DESCRIPTION
## Change summary (maintainer-owned)

Maintainer: please replace this section before merge with a human-authored summary of what changed and why these implementation choices were made.

## AI-authored implementation notes

- Moves MCP catalog YAML load/list/get behavior into `mcp_unified.federation.catalog_loader`.
- Leaves `tldw_Server_API.app.core.MCP_unified.catalog_loader` as a compatibility wrapper over the standalone implementation.
- Re-exports the loader functions from `mcp_unified.federation` for standalone consumers.
- Adds regression coverage for package ownership, host-wrapper compatibility, shared cache state, and existing catalog-loader behavior.
- Addresses Qodo review findings for Loguru logging, cache reset semantics, non-mapping YAML entries, and cache replacement.

## Risk and rollback

- Risk is limited to MCP catalog loading/import paths.
- The wrapper preserves the existing host import path and shares the same cache object by replacing the standalone cache contents in place.
- Rollback is reverting the PR; no migrations or persistent data changes.

## Verification

- RED: focused package-boundary tests failed before implementation because `mcp_unified.federation.catalog_loader` did not exist and the host loader still owned parsing.
- RED: Qodo follow-up regressions failed before fixes for stdlib logging and non-mapping YAML entries.
- `.venv/bin/python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_extraction_contracts.py tldw_Server_API/tests/unit/test_mcp_catalog_loader.py tldw_Server_API/tests/unit/test_mcp_catalog_endpoints.py tldw_Server_API/tests/integration/test_first_run_setup_flow.py tldw_Server_API/tests/unit/test_archetype_schemas.py tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py -q` -> 94 passed, 5 warnings.
- `.venv/bin/python -m ruff check mcp_unified/federation/catalog_loader.py mcp_unified/federation/__init__.py tldw_Server_API/app/core/MCP_unified/catalog_loader.py tldw_Server_API/app/core/MCP_unified/tests/test_extraction_contracts.py tldw_Server_API/tests/unit/test_mcp_catalog_loader.py tldw_Server_API/tests/unit/test_mcp_catalog_endpoints.py tldw_Server_API/tests/integration/test_first_run_setup_flow.py` -> all checks passed.
- `.venv/bin/python -m bandit -r mcp_unified/federation/catalog_loader.py mcp_unified/federation/__init__.py tldw_Server_API/app/core/MCP_unified/catalog_loader.py -f json -o /tmp/bandit_mcp_stage3g_catalog_loader.json` -> 0 findings.
- `git diff --check` and `git diff --cached --check` -> clean.

## Watchlists

- MCP Unified standalone extraction
- Catalog loader import compatibility
- Package-boundary regression tests
