### PR TITLE
chore: finalize llama.cpp admin rollout

### DIFF
--- a/Docs/superpowers/plans/2026-05-15-llamacpp-server-management-webui-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-05-15-llamacpp-server-management-webui-implementation-plan.md
@@ -916,7 +916,7 @@ git commit -m "feat: guide llama.cpp server management in admin UI"
 - Modify: `apps/tldw-frontend/e2e/workflows/tier-4-admin/admin-llamacpp.spec.ts`
 - Modify: `backlog/tasks/<implementation-task>.md` through Backlog MCP during execution.
 
-- [ ] **Step 1: Update llama.cpp integration docs**
+- [x] **Step 1: Update llama.cpp integration docs**
 
 Document:
 
@@ -926,7 +926,7 @@ Document:
 - warnings-first hardware guidance;
 - explicit `Use this in Chat`.
 
-- [ ] **Step 2: Update E2E smoke test**
+- [x] **Step 2: Update E2E smoke test**
 
 Mock backend responses for:
 
@@ -944,7 +944,7 @@ Assert the normal flow:
 4. provider wiring prompt appears;
 5. user confirms `Use this in Chat`.
 
-- [ ] **Step 3: Run backend focused suite**
+- [x] **Step 3: Run backend focused suite**
 
 Run:
 
@@ -963,7 +963,7 @@ python -m pytest \
 
 Expected: PASS.
 
-- [ ] **Step 4: Run frontend focused suite**
+- [x] **Step 4: Run frontend focused suite**
 
 Run:
 
@@ -975,7 +975,7 @@ bunx vitest run \
 
 Expected: PASS.
 
-- [ ] **Step 5: Run E2E smoke if server harness is available**
+- [x] **Step 5: Run E2E smoke if server harness is available**
 
 Run the existing project command for the tier-4 admin llama.cpp spec. If the repo requires a running dev server, start it with the established `bun run dev` workflow and record the URL/port used.
 
@@ -987,7 +987,7 @@ bunx playwright test apps/tldw-frontend/e2e/workflows/tier-4-admin/admin-llamacp
 
 Expected: PASS, or document the environment blocker.
 
-- [ ] **Step 6: Run Bandit on touched backend scope**
+- [x] **Step 6: Run Bandit on touched backend scope**
 
 Run:
 
@@ -1007,7 +1007,7 @@ python -m bandit \
 
 Expected: no new high/medium findings in touched code. Fix new findings before finalizing.
 
-- [ ] **Step 7: Run whitespace check**
+- [x] **Step 7: Run whitespace check**
 
 Run:
 
@@ -1017,7 +1017,7 @@ git diff --check
 
 Expected: no whitespace errors.
 
-- [ ] **Step 8: Commit Task 6**
+- [x] **Step 8: Commit Task 6**
 
 ```bash
 git add \
@@ -1031,21 +1031,21 @@ git commit -m "docs: document llama.cpp admin management flow"
 
 ## Final Acceptance Checklist
 
-- [ ] `/admin/llamacpp` renders a guided readiness, inventory, and launch workflow.
-- [ ] Config facade reports saved config, active config, env overrides, and restart-required reasons.
-- [ ] Config updates use `setup_manager.update_config()` and refresh config caches.
-- [ ] Inventory supports bounded recursive GGUF scan and registered local paths.
-- [ ] `model_id` start path works without passing arbitrary absolute paths from the UI.
-- [ ] Existing `/llamacpp/start_server` filename flow still works.
-- [ ] Hardware snapshot warnings never hard-block launch.
-- [ ] `Use this in Chat` updates only `Local-API.llama_api_IP` after explicit confirmation.
-- [ ] Log tail endpoint is bounded and cannot read arbitrary paths.
-- [ ] New endpoints are admin-only and rate-limited consistently with existing lifecycle endpoints.
-- [ ] Focused backend tests pass.
-- [ ] Focused frontend tests pass.
-- [ ] E2E smoke either passes or has a documented environment blocker.
-- [ ] Bandit has no new actionable findings in touched backend code.
-- [ ] `git diff --check` passes.
+- [x] `/admin/llamacpp` renders a guided readiness, inventory, and launch workflow.
+- [x] Config facade reports saved config, active config, env overrides, and restart-required reasons.
+- [x] Config updates use `setup_manager.update_config()` and refresh config caches.
+- [x] Inventory supports bounded recursive GGUF scan and registered local paths.
+- [x] `model_id` start path works without passing arbitrary absolute paths from the UI.
+- [x] Existing `/llamacpp/start_server` filename flow still works.
+- [x] Hardware snapshot warnings never hard-block launch.
+- [x] `Use this in Chat` updates only `Local-API.llama_api_IP` after explicit confirmation.
+- [x] Log tail endpoint is bounded and cannot read arbitrary paths.
+- [x] New endpoints are admin-only and rate-limited consistently with existing lifecycle endpoints.
+- [x] Focused backend tests pass.
+- [x] Focused frontend tests pass.
+- [x] E2E smoke either passes or has a documented environment blocker.
+- [x] Bandit has no new actionable findings in touched backend code.
+- [x] `git diff --check` passes.
 
 ## Implementation Notes
 
@@ -1055,3 +1055,4 @@ git commit -m "docs: document llama.cpp admin management flow"
 - If `setup_manager.update_config()` rejects a new config key, add the key to `Config_Files/config.txt` before attempting to persist it.
 - If both `TldwApiClient.ts` and `domains/models-audio.ts` need methods, update both in the same commit to avoid client drift.
 - Do not resolve unrelated dirty files in the main worktree. Stage only files touched for this feature.
+- Final closeout verification on the post-merge `origin/dev` baseline passed: backend focused llama.cpp suite `180 passed`; package-local frontend llama.cpp/admin suite `58 passed`; tier-4 Playwright admin llama.cpp smoke `6 passed`; Bandit on touched backend scope reported zero findings; `git diff --check` passed.

--- a/backlog/tasks/task-368 - Implement-llama.cpp-server-management-WebUI-improvements.md
+++ b/backlog/tasks/task-368 - Implement-llama.cpp-server-management-WebUI-improvements.md
@@ -1,20 +1,20 @@
 ---
 id: TASK-368
 title: Implement llama.cpp server management WebUI improvements
-status: In Progress
+status: Done
 assignee: []
-created_date: '2026-05-15 03:41'
+created_date: 2026-05-15 03:41
+updated_date: 2026-05-29 05:23
 labels:
-  - implementation
-  - llamacpp
-  - webui
-  - self-hosted
+- implementation
+- llamacpp
+- webui
+- self-hosted
 dependencies:
-  - TASK-365
+- TASK-365
 documentation:
-  - Docs/superpowers/specs/2026-05-15-llamacpp-server-management-webui-design.md
-  - >-
-    Docs/superpowers/plans/2026-05-15-llamacpp-server-management-webui-implementation-plan.md
+- Docs/superpowers/specs/2026-05-15-llamacpp-server-management-webui-design.md
+- Docs/superpowers/plans/2026-05-15-llamacpp-server-management-webui-implementation-plan.md
 priority: medium
 ---
 
@@ -26,18 +26,30 @@ Implement the approved single-server llama.cpp server management WebUI flow from
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 All implementation-plan task slices are completed or explicitly documented as blocked.
-- [ ] #2 The final feature preserves V1 constraints: one managed server, no downloads/uploads, explicit provider wiring, warnings not hard blocking, and backend-owned safety.
-- [ ] #3 Focused backend and frontend tests pass, with any environment-limited E2E checks documented.
-- [ ] #4 Bandit is run on touched backend scope and new actionable findings are fixed or documented.
+- [x] #1 All implementation-plan task slices are completed or explicitly documented as blocked.
+- [x] #2 The final feature preserves V1 constraints: one managed server, no downloads/uploads, explicit provider wiring, warnings not hard blocking, and backend-owned safety.
+- [x] #3 Focused backend and frontend tests pass, with any environment-limited E2E checks documented.
+- [x] #4 Bandit is run on touched backend scope and new actionable findings are fixed or documented.
 <!-- AC:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Parent rollout closeout completed after the final TASK-368.6 validation slice. Implementation-plan slices TASK-368.1 through TASK-368.7 are completed or already documented as completed review-fix work. Final verification on the post-merge origin/dev baseline passed: backend focused llama.cpp suite 180 passed; frontend focused llama.cpp/admin suite 58 passed; tier-4 admin llama.cpp Playwright smoke 6 passed; Bandit on touched backend scope reported zero findings; git diff --check passed. V1 boundaries remain explicit: one managed server, backend-owned path/config safety, hardware warnings are advisory, and provider wiring is user-confirmed through Use this in Chat rather than automatic route rewrites.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+The llama.cpp server management WebUI rollout is complete. The feature now has backend config/inventory/provider/log/runtime foundations, a guided Admin UI for readiness, inventory, launch, assets, profiles, and runtime state, explicit user-confirmed Chat provider wiring, review-fix hardening for path/config/event-loop/log-tail concerns, docs, and tier-4 smoke coverage. Focused backend/frontend/E2E/security/whitespace verification passed on the post-merge baseline; no rollout blockers remain.
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/backlog/tasks/task-368.6 - Finalize-llama.cpp-admin-rollout.md
+++ b/backlog/tasks/task-368.6 - Finalize-llama.cpp-admin-rollout.md
@@ -1,20 +1,19 @@
 ---
 id: TASK-368.6
 title: Finalize llama.cpp admin rollout
-status: To Do
+status: Done
 assignee: []
-created_date: '2026-05-15 03:46'
-updated_date: '2026-05-15 03:46'
+created_date: 2026-05-15 03:46
+updated_date: 2026-05-29 05:23
 labels:
-  - implementation
-  - docs
-  - llamacpp
+- implementation
+- docs
+- llamacpp
 dependencies:
-  - TASK-368.5
+- TASK-368.5
 documentation:
-  - Docs/superpowers/specs/2026-05-15-llamacpp-server-management-webui-design.md
-  - >-
-    Docs/superpowers/plans/2026-05-15-llamacpp-server-management-webui-implementation-plan.md
+- Docs/superpowers/specs/2026-05-15-llamacpp-server-management-webui-design.md
+- Docs/superpowers/plans/2026-05-15-llamacpp-server-management-webui-implementation-plan.md
 parent_task_id: TASK-368
 priority: medium
 ---
@@ -27,19 +26,31 @@ Complete the docs E2E verification and final validation slice from the implement
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 llama.cpp integration docs describe the new managed admin flow and explicit provider wiring boundary.
-- [ ] #2 The tier 4 admin llama.cpp E2E smoke covers readiness inventory start and chat wiring with mocked backend responses.
-- [ ] #3 Focused backend and frontend tests are run and results are recorded.
-- [ ] #4 Bandit is run on touched backend scope and git diff --check passes.
-- [ ] #5 Parent implementation task is updated with final summary and known skips or blockers.
+- [x] #1 llama.cpp integration docs describe the new managed admin flow and explicit provider wiring boundary.
+- [x] #2 The tier 4 admin llama.cpp E2E smoke covers readiness inventory start and chat wiring with mocked backend responses.
+- [x] #3 Focused backend and frontend tests are run and results are recorded.
+- [x] #4 Bandit is run on touched backend scope and git diff --check passes.
+- [x] #5 Parent implementation task is updated with final summary and known skips or blockers.
 <!-- AC:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Closeout completed on the post-merge origin/dev baseline. Verification: backend focused llama.cpp suite passed (180 passed, 6 warnings; existing post-success Loguru closed-stream cleanup noise observed after pytest exit); frontend package-local llama.cpp/admin suite passed (10 files, 58 tests); tier-4 admin llama.cpp Playwright smoke passed (6 tests); Bandit on touched backend scope wrote /tmp/bandit_llamacpp_admin.json with zero findings; git diff --check passed. Docs and E2E coverage already describe and exercise the managed admin flow, readiness/inventory/start path, explicit Use this in Chat provider wiring boundary, assets/import/download refresh mocks, and no automatic provider rewrites.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Final rollout validation is complete. The llama.cpp integration docs and tier-4 admin smoke cover the managed admin flow, provider-plane boundary, readiness/inventory/start path, and explicit chat wiring. Focused backend, frontend, Playwright, Bandit, and whitespace checks all passed on the post-merge baseline. No functional blockers remain; the only noted noise is the existing pytest post-exit Loguru closed-stream cleanup output after a passing backend run.
+<!-- SECTION:FINAL_SUMMARY:END -->


### PR DESCRIPTION
Change summary (maintainer-owned)

- Closes TASK-368.6 and the parent TASK-368 now that the llama.cpp Admin rollout has landed across the backend, frontend, docs, and smoke coverage.
- Updates the implementation plan final checklist with post-merge verification evidence.
- Keeps this PR tracking-only: no runtime, API, or UI behavior changes.

Verification

- Backend focused llama.cpp suite: 180 passed, 6 warnings. Pytest exited 0; existing post-success Loguru closed-stream cleanup noise appeared after completion.
- Frontend package-local llama.cpp/admin suite: 10 files passed, 58 tests passed.
- Tier-4 admin llama.cpp Playwright smoke: 6 passed.
- Bandit on touched backend llama.cpp scope: zero findings in /tmp/bandit_llamacpp_admin.json.
- git diff --check
- git show --stat --oneline HEAD

Notes

- The branch was rebased onto the latest origin/dev after another merge landed.
- Git reported pre-existing repository GC housekeeping noise about unreachable loose objects during fetch/commit; this PR does not change repository maintenance state.

UX Audit Checklist

- [x] No user-facing UI or copy changes in this PR.
- [x] The closeout records preserve the explicit managed-plane/provider-plane boundary and user-confirmed Use this in Chat behavior.

Watchlists

- [x] llama.cpp Admin rollout tracking matches merged implementation state.
- [x] No runtime behavior changed by this PR.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Finalize the llama.cpp Admin rollout by updating docs and tasks with the completed checklist and post-merge verification. Closes TASK-368 and TASK-368.6; backend (180), frontend (58), and Playwright (6) tests passed; Bandit and whitespace checks clean; no runtime, API, or UI changes.

<sup>Written for commit d2680250f5f29312f79aa2ec56ec7487db0ba021. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2124?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

