### PR TITLE
Migrate Admin StatusBanner feedback states

### DIFF
--- a/apps/packages/ui/scripts/design-system-product-state-baseline.json
+++ b/apps/packages/ui/scripts/design-system-product-state-baseline.json
@@ -385,28 +385,6 @@
     "migrationQueue": "shared-product-state"
   },
   {
-    "id": "antd-product-state-import:src/components/Option/Admin/StatusBanner.tsx:Alert",
-    "path": "src/components/Option/Admin/StatusBanner.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/Option/Admin/StatusBanner.tsx before the guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
-    "id": "antd-product-state-import:src/components/Option/Admin/StatusBanner.tsx:Spin",
-    "path": "src/components/Option/Admin/StatusBanner.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Spin",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Spin product-state UI in src/components/Option/Admin/StatusBanner.tsx before the guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
     "id": "antd-product-state-import:src/components/Option/Admin/UsageAnalyticsPage.tsx:Alert#antd-alert-usageanalyticspage-type-error-access-denied-y-14wdvha",
     "path": "src/components/Option/Admin/UsageAnalyticsPage.tsx",
     "rule": "antd-product-state-import",

--- a/apps/packages/ui/src/components/Option/Admin/StatusBanner.tsx
+++ b/apps/packages/ui/src/components/Option/Admin/StatusBanner.tsx
@@ -70,12 +70,9 @@ export const StatusBanner: React.FC<StatusBannerProps> = ({
 
   if (loading) {
     return (
-      <LoadingState
-        mode="inline"
-        size="sm"
-        label="Loading status..."
-        className={`rounded-lg border border-border bg-bg p-3 ${className || ""}`}
-      />
+      <div className={`flex items-center gap-2 rounded-lg border border-border bg-bg p-3 ${className || ""}`}>
+        <LoadingState mode="inline" size="sm" label="Loading status..." />
+      </div>
     )
   }
 

--- a/apps/packages/ui/src/components/Option/Admin/StatusBanner.tsx
+++ b/apps/packages/ui/src/components/Option/Admin/StatusBanner.tsx
@@ -1,6 +1,8 @@
 import React from "react"
-import { Tag, Button, Space, Spin, Alert } from "antd"
+import { Tag, Button, Space } from "antd"
 import { RefreshCw, Square } from "lucide-react"
+import { LoadingState } from "@/components/ui/feedback/LoadingState"
+import { Alert } from "@/components/ui/primitives/Alert"
 import { sanitizeAdminErrorMessage } from "./admin-error-utils"
 
 type StatusState = "running" | "online" | "stopped" | "offline" | "loading" | "active" | "inactive" | "unknown"
@@ -68,10 +70,12 @@ export const StatusBanner: React.FC<StatusBannerProps> = ({
 
   if (loading) {
     return (
-      <div className={`flex items-center gap-2 rounded-lg border border-border bg-bg p-3 ${className || ""}`}>
-        <Spin size="small" />
-        <span className="text-sm text-text-muted">Loading status...</span>
-      </div>
+      <LoadingState
+        mode="inline"
+        size="sm"
+        label="Loading status..."
+        className={`rounded-lg border border-border bg-bg p-3 ${className || ""}`}
+      />
     )
   }
 
@@ -82,19 +86,13 @@ export const StatusBanner: React.FC<StatusBannerProps> = ({
     )
     return (
       <Alert
-        type="error"
+        variant="error"
         title="Status Error"
-        description={safeError}
-        showIcon
         className={className}
-        action={
-          onRefresh && (
-            <Button size="small" onClick={onRefresh} icon={<RefreshCw size={14} />}>
-              Retry
-            </Button>
-          )
-        }
-      />
+        action={onRefresh ? { label: "Retry", onClick: onRefresh } : undefined}
+      >
+        {safeError}
+      </Alert>
     )
   }
 

--- a/apps/packages/ui/src/components/Option/Admin/__tests__/StatusBanner.test.tsx
+++ b/apps/packages/ui/src/components/Option/Admin/__tests__/StatusBanner.test.tsx
@@ -9,8 +9,11 @@ describe("StatusBanner", () => {
     render(<StatusBanner state="loading" loading />)
 
     const loadingText = screen.getByText("Loading status...")
+    const loadingState = loadingText.closest('[data-ds-component="LoadingState"]')
 
-    expect(loadingText.closest('[data-ds-component="LoadingState"]')).toBeTruthy()
+    expect(loadingState).toBeTruthy()
+    expect(loadingState?.parentElement?.className).toContain("flex")
+    expect(loadingState?.parentElement?.className).toContain("border-border")
   })
 
   it("sanitizes user-facing admin error details", () => {

--- a/apps/packages/ui/src/components/Option/Admin/__tests__/StatusBanner.test.tsx
+++ b/apps/packages/ui/src/components/Option/Admin/__tests__/StatusBanner.test.tsx
@@ -1,9 +1,18 @@
 import React from "react"
-import { describe, expect, it } from "vitest"
+import { describe, expect, it, vi } from "vitest"
 import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
 import { StatusBanner } from "../StatusBanner"
 
 describe("StatusBanner", () => {
+  it("renders loading status through the design-system LoadingState primitive", () => {
+    render(<StatusBanner state="loading" loading />)
+
+    const loadingText = screen.getByText("Loading status...")
+
+    expect(loadingText.closest('[data-ds-component="LoadingState"]')).toBeTruthy()
+  })
+
   it("sanitizes user-facing admin error details", () => {
     render(
       <StatusBanner
@@ -18,5 +27,27 @@ describe("StatusBanner", () => {
     expect(fullText).toContain("[redacted-path]")
     expect(fullText).not.toContain("/api/v1/admin/mlx/status")
     expect(fullText).not.toContain("/Users/dev/.config/tldw/config.txt")
+  })
+
+  it("renders errors through the design-system Alert primitive and preserves retry", async () => {
+    const user = userEvent.setup()
+    const onRefresh = vi.fn()
+
+    render(
+      <StatusBanner
+        state="inactive"
+        error="Failed to load status"
+        onRefresh={onRefresh}
+      />
+    )
+
+    const title = screen.getByText("Status Error")
+    const alert = title.closest('[data-ds-component="Alert"]')
+
+    expect(alert).toBeTruthy()
+
+    await user.click(screen.getByRole("button", { name: "Retry" }))
+
+    expect(onRefresh).toHaveBeenCalledTimes(1)
   })
 })

--- a/backlog/tasks/task-45.44.11.5 - Migrate-Admin-StatusBanner-feedback-states-to-design-system-primitives.md
+++ b/backlog/tasks/task-45.44.11.5 - Migrate-Admin-StatusBanner-feedback-states-to-design-system-primitives.md
@@ -1,0 +1,69 @@
+---
+id: TASK-45.44.11.5
+title: Migrate Admin StatusBanner feedback states to design-system primitives
+status: Done
+assignee: []
+created_date: '2026-05-29'
+updated_date: '2026-05-29 17:32'
+labels:
+  - design-system
+  - webui
+  - admin
+  - product-state
+dependencies: []
+references:
+  - apps/packages/ui/src/components/Option/Admin/StatusBanner.tsx
+  - apps/packages/ui/scripts/design-system-product-state-baseline.json
+parent_task_id: TASK-45.44.11
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Migrate Admin StatusBanner's product-state AntD Alert and Spin usages to canonical design-system feedback primitives while preserving status, retry, and quick-action behavior.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 StatusBanner loading state renders through the design-system LoadingState primitive without changing the visible loading copy.
+- [x] #2 StatusBanner error state renders through the design-system Alert primitive and preserves sanitized error copy and retry behavior.
+- [x] #3 Focused regression coverage proves the migrated loading and error states use design-system primitives.
+- [x] #4 The StatusBanner Alert and Spin product-state baseline exceptions are removed, focused guard coverage passes, and the full guard log has no StatusBanner findings.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+TDD red: StatusBanner focused Vitest failed because the loading branch lacked a data-ds-component="LoadingState" ancestor and the error branch lacked a data-ds-component="Alert" ancestor.
+
+Green: replaced the AntD Spin loading branch with the design-system LoadingState primitive and replaced the AntD Alert error branch with the design-system Alert primitive while preserving sanitized error text and Retry callback behavior. Removed the two matching StatusBanner product-state baseline exceptions.
+
+Verification:
+- bunx vitest run src/components/Option/Admin/__tests__/StatusBanner.test.tsx => 3 tests passed. Bun emitted its existing localStorage warning.
+- bunx vitest run src/design-system/__tests__/product-state-guard.test.ts --reporter=dot => 54 tests passed. Bun emitted its existing localStorage warning.
+- rg -n "StatusBanner" /tmp/design-system-status-banner.log => no output after running the full guard, confirming the remaining full-guard failures are not from StatusBanner.
+- rg -n "antd-product-state-import:src/components/Option/Admin/StatusBanner" apps/packages/ui/scripts/design-system-product-state-baseline.json => no output.
+- NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit --pretty false with touched-path filter for StatusBanner/baseline/task => exit 0 with no touched-path output. The default-heap broad tsc attempt OOMed before diagnostics.
+- git diff --check => exit 0.
+
+Known blocker: bun run verify:design-system-state currently exits 1 on unrelated current-dev product-state drift in IntegrationPolicyPanel, WritingActionBar, Notes, and ResearchWorkspace plus stale IntegrationPolicyPanel baseline entries. This slice keeps that broader cleanup out of scope.
+
+Bandit: skipped because this slice only changes frontend TypeScript/TSX, JSON baseline data, and Backlog markdown; no Python runtime code was touched.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Migrated Admin StatusBanner loading and error feedback states from AntD Spin/Alert to the canonical design-system LoadingState and Alert primitives. Added focused regression coverage for both migrated branches, preserved sanitized error and Retry behavior, and removed the two obsolete StatusBanner product-state baseline exceptions.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-45.44.11.5 - Migrate-Admin-StatusBanner-feedback-states-to-design-system-primitives.md
+++ b/backlog/tasks/task-45.44.11.5 - Migrate-Admin-StatusBanner-feedback-states-to-design-system-primitives.md
@@ -4,7 +4,7 @@ title: Migrate Admin StatusBanner feedback states to design-system primitives
 status: Done
 assignee: []
 created_date: '2026-05-29'
-updated_date: '2026-05-29 17:32'
+updated_date: '2026-05-29 20:36'
 labels:
   - design-system
   - webui
@@ -50,6 +50,18 @@ Verification:
 Known blocker: bun run verify:design-system-state currently exits 1 on unrelated current-dev product-state drift in IntegrationPolicyPanel, WritingActionBar, Notes, and ResearchWorkspace plus stale IntegrationPolicyPanel baseline entries. This slice keeps that broader cleanup out of scope.
 
 Bandit: skipped because this slice only changes frontend TypeScript/TSX, JSON baseline data, and Backlog markdown; no Python runtime code was touched.
+
+PR review follow-up after rebase:
+- Rebased codex/design-system-admin-status-banner onto latest origin/dev.
+- Added a regression assertion that the loading branch keeps a block-level flex/bordered banner wrapper around the canonical LoadingState primitive.
+- Wrapped LoadingState in the original banner container to avoid inline-flex shrink-wrap layout shifts while keeping the design-system primitive inside.
+
+Review-fix verification:
+- bunx vitest run src/components/Option/Admin/__tests__/StatusBanner.test.tsx => 3 tests passed.
+- bunx vitest run src/design-system/__tests__/product-state-guard.test.ts --reporter=dot => 54 tests passed.
+- bun run verify:design-system-state still exits 1 on unrelated current-dev IntegrationPolicyPanel/WritingActionBar/Notes/ResearchWorkspace drift; rg -n "StatusBanner" /tmp/design-system-status-banner-rebased.log returned no output.
+- NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit --pretty false with touched-path filter for StatusBanner/baseline/task => exit 0 with no touched-path output.
+- git diff --check => exit 0.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary


### PR DESCRIPTION
## Summary
- Migrates Admin StatusBanner loading feedback from AntD Spin to the design-system LoadingState primitive.
- Migrates StatusBanner error feedback from AntD Alert to the design-system Alert primitive while preserving sanitized error text and Retry behavior.
- Removes the two obsolete StatusBanner product-state baseline exceptions and closes TASK-45.44.11.5.

## Verification
- [x] bunx vitest run src/components/Option/Admin/__tests__/StatusBanner.test.tsx
- [x] bunx vitest run src/design-system/__tests__/product-state-guard.test.ts --reporter=dot
- [x] rg -n "StatusBanner" /tmp/design-system-status-banner.log returned no output after the full guard run
- [x] rg -n "antd-product-state-import:src/components/Option/Admin/StatusBanner" apps/packages/ui/scripts/design-system-product-state-baseline.json returned no output
- [x] NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit --pretty false with touched-path filter for StatusBanner/baseline/task returned exit 0 with no touched-path output
- [x] git diff --check

## Known current-dev guard drift
- `bun run verify:design-system-state` currently exits 1 on unrelated IntegrationPolicyPanel, WritingActionBar, Notes, and ResearchWorkspace findings plus stale IntegrationPolicyPanel baseline entries. This PR leaves that broader cleanup out of scope; the full guard log has no StatusBanner findings.

## Change summary
Human-written change summary required before merge per Docs/superpowers/AI_GENERATED_PR_CHANGE_SUMMARY_POLICY_2026_04_17.md.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced Admin StatusBanner loading and error feedback with design-system primitives to standardize UI and remove `antd`, completing TASK-45.44.11.5. Addressed review feedback to keep the banner layout around `LoadingState` and added focused tests.

- **Refactors**
  - Swapped `antd` Spin/Alert for design-system `LoadingState` (inline, sm) and `Alert`; preserved loading copy, sanitized error text, and Retry.
  - Kept the flex/bordered banner wrapper to avoid layout shifts; tests assert wrapper classes, DS primitive usage, and Retry callback.
  - Removed two StatusBanner product-state baseline exceptions.

<sup>Written for commit 933913d19635e30d75d04cd2fae7b1bd2c399c46. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2127?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

