### PR TITLE
Decouple MCP module breaker fallback

### DIFF
--- a/Docs/superpowers/plans/2026-05-29-mcp-unified-stage3i-module-breaker-seam-plan.md
+++ b/Docs/superpowers/plans/2026-05-29-mcp-unified-stage3i-module-breaker-seam-plan.md
@@ -1,0 +1,57 @@
+# MCP Unified Stage 3I Module Circuit-Breaker Seam Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Remove the remaining direct host circuit-breaker dependency from MCP module base behavior while preserving tldw_server module runtime compatibility.
+
+**Architecture:** Keep `BaseModule` and `ModuleConfig` import-compatible at the host path for this slice, but make the base module depend on a neutral circuit-breaker contract instead of importing `tldw_Server_API.app.core.Infrastructure.circuit_breaker`. Wire the tldw host circuit breaker through the existing runtime dependency bundle when modules are registered by `MCPServer`, and use a small host-neutral fallback breaker for direct module construction in tests or embedded package use.
+
+**Tech Stack:** Python, asyncio, pytest, Ruff, Bandit.
+
+**Backlog:** TASK-549
+**PR:** https://github.com/rmusser01/tldw_server/pull/2128
+
+---
+
+### Task 1: RED Boundary And Injection Tests
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/MCP_unified/tests/test_extraction_contracts.py`
+- Modify: `tldw_Server_API/app/core/MCP_unified/tests/test_basic_functionality.py`
+
+- [x] Add a boundary contract proving `modules/base.py` does not import `tldw_Server_API.app.core.Infrastructure.circuit_breaker`.
+- [x] Add a server registration regression proving `MCPServer` passes `dependencies.circuit_breaker_factory` into `ModuleConfig`.
+- [x] Run the focused tests and confirm the expected RED failures.
+
+### Task 2: Host-Neutral Base Fallback And Host Injection
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/MCP_unified/modules/base.py`
+- Modify: `tldw_Server_API/app/core/MCP_unified/server.py`
+
+- [x] Replace the direct host circuit-breaker factory fallback with a local neutral async breaker contract that supports `can_attempt()`, `record_failure()`, `record_success()`, and `call_async()`.
+- [x] Replace direct catching of host `CircuitBreakerOpenError` with a local neutral open exception that is also used by the fallback breaker.
+- [x] Inject `self.dependencies.circuit_breaker_factory` into every `ModuleConfig` created by `MCPServer._register_default_modules()`.
+- [x] Re-run RED tests and confirm they pass.
+
+### Task 3: Compatibility Verification And Closeout
+
+**Files:**
+- Modify: `backlog/tasks/task-549 - Implement-MCP-Unified-Stage-3I-module-circuit-breaker-seam.md`
+- Modify: `Docs/superpowers/plans/2026-05-29-mcp-unified-stage3i-module-breaker-seam-plan.md`
+
+- [x] Run focused MCP module/server tests covering extraction contracts, basic module behavior, concurrency/breaker behavior, and server registration.
+- [x] Run Ruff on touched Python files.
+- [x] Run Bandit on touched implementation files.
+- [x] Run `git diff --check`.
+- [x] Update TASK-549 and this plan with verification results and final status.
+
+## Verification
+
+- Rebased cleanly onto `origin/dev` at `02a017e655` before final verification.
+- RED focused tests: `.venv/bin/python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_extraction_contracts.py::test_base_module_does_not_import_host_circuit_breaker tldw_Server_API/app/core/MCP_unified/tests/test_extraction_contracts.py::test_mcp_server_default_module_configs_use_injected_circuit_breaker_factory -q` -> failed as expected on the existing host import and missing factory injection.
+- Focused pytest after rebase: `.venv/bin/python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_extraction_contracts.py tldw_Server_API/app/core/MCP_unified/tests/test_basic_functionality.py::TestBaseModule tldw_Server_API/app/core/MCP_unified/tests/test_concurrency_and_breaker.py -q` -> 38 passed, 3 warnings.
+- Ruff after rebase: `.venv/bin/python -m ruff check tldw_Server_API/app/core/MCP_unified/modules/base.py tldw_Server_API/app/core/MCP_unified/server.py tldw_Server_API/app/core/MCP_unified/tests/test_extraction_contracts.py` -> All checks passed.
+- Bandit after rebase: `.venv/bin/python -m bandit -r tldw_Server_API/app/core/MCP_unified/modules/base.py tldw_Server_API/app/core/MCP_unified/server.py -f json -o /tmp/bandit_mcp_stage3i_module_breaker_after_rebase.json` -> 0 findings.
+- Whitespace after rebase: `git diff --check` -> passed.
+- Known skips/blockers: none.

--- a/backlog/tasks/task-549 - Implement-MCP-Unified-Stage-3I-module-circuit-breaker-seam.md
+++ b/backlog/tasks/task-549 - Implement-MCP-Unified-Stage-3I-module-circuit-breaker-seam.md
@@ -1,0 +1,61 @@
+---
+id: TASK-549
+title: Implement MCP Unified Stage 3I module circuit-breaker seam
+status: Done
+assignee: []
+created_date: ''
+updated_date: '2026-05-29 19:36'
+labels:
+  - mcp
+  - mcp-unified
+  - standalone
+  - stage3
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/pull/2128'
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Remove the remaining direct host circuit-breaker dependency from MCP module base behavior while preserving tldw_server compatibility through the injected runtime circuit-breaker factory.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 MCP module base no longer imports tldw_Server_API circuit breaker internals directly.
+- [x] #2 tldw_server module registration injects the host circuit-breaker factory through runtime dependencies for compatibility.
+- [x] #3 Regression tests cover the boundary rule and factory injection behavior.
+- [x] #4 Focused pytest, Ruff, Bandit, and diff whitespace verification are recorded before PR closeout.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+- Rebased cleanly onto origin/dev at 02a017e655 before final verification.
+- Added RED coverage for the modules/base.py circuit-breaker host import and for MCPServer default-module ModuleConfig breaker factory injection.
+- Replaced the modules/base.py fallback host circuit-breaker import with a small host-neutral async breaker supporting can_attempt(), record_failure(), record_success(), and call_async().
+- Preserved tldw_server compatibility by injecting self.dependencies.circuit_breaker_factory when MCPServer._register_default_modules() builds ModuleConfig instances.
+- RED focused tests failed as expected before implementation: direct host import and missing injection.
+- Focused pytest after rebase: .venv/bin/python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_extraction_contracts.py tldw_Server_API/app/core/MCP_unified/tests/test_basic_functionality.py::TestBaseModule tldw_Server_API/app/core/MCP_unified/tests/test_concurrency_and_breaker.py -q -> 38 passed, 3 warnings.
+- Ruff touched scope after rebase: All checks passed.
+- Bandit touched implementation scope after rebase: 0 findings in /tmp/bandit_mcp_stage3i_module_breaker_after_rebase.json.
+- Whitespace after rebase: git diff --check -> passed.
+- Known skips/blockers: none.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Removed the remaining direct tldw_server circuit-breaker dependency from MCP module base behavior and routed host module registrations through the injected runtime breaker factory. Direct module construction now has a host-neutral fallback breaker for standalone-safe behavior while the tldw server path continues to use the existing host breaker adapter.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-550 - Address-PR-2128-MCP-module-breaker-review-comments.md
+++ b/backlog/tasks/task-550 - Address-PR-2128-MCP-module-breaker-review-comments.md
@@ -1,0 +1,64 @@
+---
+id: TASK-550
+title: Address PR 2128 MCP module breaker review comments
+status: Done
+assignee: []
+created_date: ''
+updated_date: '2026-05-29 20:38'
+labels:
+  - mcp
+  - mcp-unified
+  - review-fix
+  - stage3
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/pull/2128'
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Address validated Qodo, CodeRabbit, and Gemini review feedback on PR 2128 after rebasing onto latest dev.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 PR branch is rebased onto latest origin/dev.
+- [x] #2 Validated review findings for the fallback module circuit breaker are addressed with minimal scoped changes.
+- [x] #3 Regression tests cover recovery_at wall-clock compatibility and half-open probe-slot limits.
+- [x] #4 Focused pytest, Ruff, Bandit, and diff whitespace verification are recorded before push.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+- Rebase check completed: branch is up to date with origin/dev at 02a017e655.
+- Validated review findings: Qodo call_async typing, recovery_at epoch compatibility, helper docstring, and half-open probe limit are applicable. Gemini and CodeRabbit overlap on the half-open probe-limit finding.
+- Added regression coverage for fallback recovery_at using epoch time and half-open probe-slot rejection. The new tests failed before implementation as expected: recovery_at used monotonic time, and the second half-open probe was admitted until module timeout.
+- Fixed fallback breaker behavior by using epoch time for _opened_at/recovery_at compatibility and tracking _half_open_in_flight against half_open_max_calls.
+- Added call_async type hints and documented _is_circuit_breaker_open_error compatibility behavior.
+- Cleaned touched test-file typing/broad-exception issues reported by Ruff.
+- Focused pytest: .venv/bin/python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_extraction_contracts.py tldw_Server_API/app/core/MCP_unified/tests/test_basic_functionality.py::TestBaseModule tldw_Server_API/app/core/MCP_unified/tests/test_concurrency_and_breaker.py -q -> 40 passed, 3 warnings.
+- Ruff touched scope: All checks passed.
+- Bandit touched implementation scope: 0 findings in /tmp/bandit_mcp_stage3i_review_fixes.json.
+- Whitespace: git diff --check -> passed.
+- Known skips/blockers: none.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Addressed the PR 2128 fallback circuit-breaker review findings: typed call_async, epoch-compatible recovery_at, documented open-error compatibility detection, and enforced half-open probe concurrency limits with regression coverage.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/tldw_Server_API/app/core/MCP_unified/modules/base.py
+++ b/tldw_Server_API/app/core/MCP_unified/modules/base.py
@@ -117,24 +117,112 @@ def _build_module_circuit_breaker_config(config: ModuleConfig) -> ModuleCircuitB
     )
 
 
-def _default_circuit_breaker_factory(*, name: str, config: Any) -> Any:
-    from tldw_Server_API.app.core.Infrastructure.circuit_breaker import (
-        CircuitBreaker,
-        CircuitBreakerConfig,
-    )
+class ModuleCircuitBreakerOpenError(Exception):
+    """Raised when the module fallback circuit breaker rejects a call."""
 
-    return CircuitBreaker(
-        name=name,
-        config=CircuitBreakerConfig(
-            failure_threshold=config.failure_threshold,
-            recovery_timeout=config.recovery_timeout,
-            backoff_factor=config.backoff_factor,
-            max_recovery_timeout=config.max_recovery_timeout,
-            half_open_max_calls=config.half_open_max_calls,
-            success_threshold=config.success_threshold,
-            category=config.category,
-            service=config.service,
-        ),
+    def __init__(
+        self,
+        message: str,
+        *,
+        breaker_name: str = "",
+        recovery_timeout: float = 0.0,
+        failure_count: int = 0,
+        recovery_at: float | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.breaker_name = breaker_name
+        self.recovery_timeout = recovery_timeout
+        self.failure_count = failure_count
+        self.recovery_at = recovery_at
+
+
+class _DefaultModuleCircuitBreaker:
+    """Small host-neutral async circuit breaker used when no host factory is injected."""
+
+    def __init__(self, *, name: str, config: ModuleCircuitBreakerConfig) -> None:
+        self.name = name
+        self.config = config
+        self.failure_count = 0
+        self.success_count = 0
+        self._state = "closed"
+        self._opened_at: float | None = None
+        self._current_recovery_timeout = config.recovery_timeout
+
+    def can_attempt(self) -> bool:
+        if self._state != "open":
+            return True
+        if self._opened_at is None:
+            return False
+        if time.monotonic() - self._opened_at >= self._current_recovery_timeout:
+            self._state = "half_open"
+            self.success_count = 0
+            return True
+        return False
+
+    def record_failure(self) -> None:
+        self.failure_count += 1
+        self.success_count = 0
+        if self._state == "half_open":
+            self._open(with_backoff=True)
+            return
+        if self.failure_count >= self.config.failure_threshold:
+            self._open(with_backoff=False)
+
+    def record_success(self) -> None:
+        if self._state == "half_open":
+            self.success_count += 1
+            if self.success_count >= self.config.success_threshold:
+                self._close()
+            return
+        self.failure_count = 0
+
+    async def call_async(self, operation):
+        if not self.can_attempt():
+            raise ModuleCircuitBreakerOpenError(
+                f"Circuit breaker '{self.name}' is open",
+                breaker_name=self.name,
+                recovery_timeout=self._current_recovery_timeout,
+                failure_count=self.failure_count,
+                recovery_at=(
+                    self._opened_at + self._current_recovery_timeout
+                    if self._opened_at is not None
+                    else None
+                ),
+            )
+        try:
+            result = await operation()
+        except Exception:
+            self.record_failure()
+            raise
+        self.record_success()
+        return result
+
+    def _open(self, *, with_backoff: bool) -> None:
+        if with_backoff:
+            self._current_recovery_timeout = min(
+                self._current_recovery_timeout * self.config.backoff_factor,
+                self.config.max_recovery_timeout,
+            )
+        self._state = "open"
+        self._opened_at = time.monotonic()
+
+    def _close(self) -> None:
+        self._state = "closed"
+        self._opened_at = None
+        self.failure_count = 0
+        self.success_count = 0
+        self._current_recovery_timeout = self.config.recovery_timeout
+
+
+def _default_circuit_breaker_factory(*, name: str, config: Any) -> Any:
+    return _DefaultModuleCircuitBreaker(name=name, config=config)
+
+
+def _is_circuit_breaker_open_error(exc: BaseException) -> bool:
+    return isinstance(exc, ModuleCircuitBreakerOpenError) or (
+        type(exc).__name__ == "CircuitBreakerOpenError"
+        and hasattr(exc, "breaker_name")
+        and hasattr(exc, "recovery_timeout")
     )
 
 
@@ -332,9 +420,6 @@ class BaseModule(ABC):
         The semaphore concurrency guard and timeout wrapping are applied
         as an inner wrapper around the operation.
         """
-        from tldw_Server_API.app.core.Infrastructure.circuit_breaker import (
-            CircuitBreakerOpenError,
-        )
         start_time = time.time()
 
         async def _guarded_operation():
@@ -361,10 +446,9 @@ class BaseModule(ABC):
             self._metrics.record_request(True, latency_ms)
             return result
 
-        except CircuitBreakerOpenError:
-            raise
-
         except Exception as e:
+            if _is_circuit_breaker_open_error(e):
+                raise
             latency_ms = (time.time() - start_time) * 1000
             self._metrics.record_request(False, latency_ms)
             logger.error(f"Operation failed in module {self.name}: {str(e)}")

--- a/tldw_Server_API/app/core/MCP_unified/modules/base.py
+++ b/tldw_Server_API/app/core/MCP_unified/modules/base.py
@@ -8,12 +8,15 @@ import asyncio
 import contextlib
 import time
 from abc import ABC, abstractmethod
+from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta
 from enum import Enum
-from typing import Any, Optional
+from typing import Any, Optional, TypeVar
 
 from loguru import logger
+
+T = TypeVar("T")
 
 
 class HealthStatus(str, Enum):
@@ -146,16 +149,20 @@ class _DefaultModuleCircuitBreaker:
         self.success_count = 0
         self._state = "closed"
         self._opened_at: float | None = None
+        self._half_open_in_flight = 0
         self._current_recovery_timeout = config.recovery_timeout
 
     def can_attempt(self) -> bool:
+        if self._state == "half_open":
+            return self._half_open_in_flight < self.config.half_open_max_calls
         if self._state != "open":
             return True
         if self._opened_at is None:
             return False
-        if time.monotonic() - self._opened_at >= self._current_recovery_timeout:
+        if time.time() - self._opened_at >= self._current_recovery_timeout:
             self._state = "half_open"
             self.success_count = 0
+            self._half_open_in_flight = 0
             return True
         return False
 
@@ -176,7 +183,8 @@ class _DefaultModuleCircuitBreaker:
             return
         self.failure_count = 0
 
-    async def call_async(self, operation):
+    async def call_async(self, operation: Callable[[], Awaitable[T]]) -> T:
+        """Execute operation if the fallback breaker state allows an attempt."""
         if not self.can_attempt():
             raise ModuleCircuitBreakerOpenError(
                 f"Circuit breaker '{self.name}' is open",
@@ -189,11 +197,17 @@ class _DefaultModuleCircuitBreaker:
                     else None
                 ),
             )
+        half_open_probe = self._state == "half_open"
+        if half_open_probe:
+            self._half_open_in_flight += 1
         try:
             result = await operation()
         except Exception:
             self.record_failure()
             raise
+        finally:
+            if half_open_probe:
+                self._half_open_in_flight = max(0, self._half_open_in_flight - 1)
         self.record_success()
         return result
 
@@ -204,11 +218,13 @@ class _DefaultModuleCircuitBreaker:
                 self.config.max_recovery_timeout,
             )
         self._state = "open"
-        self._opened_at = time.monotonic()
+        self._opened_at = time.time()
+        self._half_open_in_flight = 0
 
     def _close(self) -> None:
         self._state = "closed"
         self._opened_at = None
+        self._half_open_in_flight = 0
         self.failure_count = 0
         self.success_count = 0
         self._current_recovery_timeout = self.config.recovery_timeout
@@ -219,6 +235,7 @@ def _default_circuit_breaker_factory(*, name: str, config: Any) -> Any:
 
 
 def _is_circuit_breaker_open_error(exc: BaseException) -> bool:
+    """Return whether an exception is a local or host circuit-open rejection."""
     return isinstance(exc, ModuleCircuitBreakerOpenError) or (
         type(exc).__name__ == "CircuitBreakerOpenError"
         and hasattr(exc, "breaker_name")

--- a/tldw_Server_API/app/core/MCP_unified/server.py
+++ b/tldw_Server_API/app/core/MCP_unified/server.py
@@ -623,6 +623,7 @@ class MCPServer:
                         circuit_breaker_backoff_factor=m.get("circuit_breaker_backoff_factor", 2.0),
                         circuit_breaker_max_timeout=m.get("circuit_breaker_max_timeout", 300),
                         settings=_resolve_env_placeholders(m.get("settings", {})),
+                        circuit_breaker_factory=self.dependencies.circuit_breaker_factory,
                     )
                     await self.module_registry.register_module(module_id, cls, mc)
                     logger.info(f"Registered MCP module: {module_id} ({class_ref})")

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_concurrency_and_breaker.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_concurrency_and_breaker.py
@@ -1,8 +1,14 @@
 import asyncio
-import pytest
-from typing import Dict, Any
+import time
+from typing import Any
 
-from tldw_Server_API.app.core.MCP_unified.modules.base import BaseModule, ModuleConfig
+import pytest
+
+from tldw_Server_API.app.core.MCP_unified.modules.base import (
+    BaseModule,
+    ModuleCircuitBreakerOpenError,
+    ModuleConfig,
+)
 
 
 class SlowModule(BaseModule):
@@ -17,13 +23,13 @@ class SlowModule(BaseModule):
     async def on_shutdown(self) -> None:
         return None
 
-    async def check_health(self) -> Dict[str, bool]:
+    async def check_health(self) -> dict[str, bool]:
         return {"ok": True}
 
     async def get_tools(self) -> list[dict]:
         return []
 
-    async def execute_tool(self, tool_name: str, arguments: Dict[str, Any], context=None):
+    async def execute_tool(self, tool_name: str, arguments: dict[str, Any], context=None):
         return None
 
     async def _work(self, delay: float):
@@ -63,13 +69,13 @@ class FlappyModule(BaseModule):
     async def on_shutdown(self) -> None:
         return None
 
-    async def check_health(self) -> Dict[str, bool]:
+    async def check_health(self) -> dict[str, bool]:
         return {"ok": True}
 
     async def get_tools(self) -> list[dict]:
         return []
 
-    async def execute_tool(self, tool_name: str, arguments: Dict[str, Any], context=None):
+    async def execute_tool(self, tool_name: str, arguments: dict[str, Any], context=None):
         return None
 
     async def _always_fail(self):
@@ -89,7 +95,7 @@ async def test_circuit_breaker_half_open_with_backoff_behaves():
     ))
 
     # First failure -> open
-    with pytest.raises(Exception):
+    with pytest.raises(RuntimeError):
         await mod.execute_with_circuit_breaker(mod._always_fail)
 
     # Wait for the short initial recovery timeout to expire
@@ -98,10 +104,68 @@ async def test_circuit_breaker_half_open_with_backoff_behaves():
     assert mod.is_circuit_breaker_open() is False
 
     # Fail again in half-open -> re-open with backoff (longer timeout now)
-    with pytest.raises(Exception):
+    with pytest.raises(RuntimeError):
         await mod.execute_with_circuit_breaker(mod._always_fail)
 
-    from tldw_Server_API.app.core.Infrastructure.circuit_breaker import CircuitState
     # Backoff should have increased recovery timeout, so breaker stays OPEN
     assert mod._circuit_breaker._current_recovery_timeout > 0.01
     assert mod.is_circuit_breaker_open() is True
+
+
+@pytest.mark.asyncio
+async def test_fallback_circuit_breaker_recovery_at_uses_epoch_time():
+    mod = FlappyModule(ModuleConfig(
+        name="fallback_recovery_at",
+        circuit_breaker_threshold=1,
+        circuit_breaker_timeout=2,
+        circuit_breaker_factory=None,
+    ))
+
+    with pytest.raises(RuntimeError):
+        await mod.execute_with_circuit_breaker(mod._always_fail)
+
+    before_rejection = time.time()
+    with pytest.raises(ModuleCircuitBreakerOpenError) as exc_info:
+        await mod.execute_with_circuit_breaker(mod._always_fail)
+    after_rejection = time.time()
+
+    assert exc_info.value.recovery_at is not None
+    assert before_rejection < exc_info.value.recovery_at <= after_rejection + 2
+
+
+@pytest.mark.asyncio
+async def test_fallback_circuit_breaker_limits_half_open_probe_concurrency():
+    started = asyncio.Event()
+    release = asyncio.Event()
+    active_probes = 0
+
+    async def _slow_success() -> str:
+        nonlocal active_probes
+        active_probes += 1
+        started.set()
+        try:
+            await release.wait()
+        finally:
+            active_probes -= 1
+        return "ok"
+
+    mod = FlappyModule(ModuleConfig(
+        name="fallback_half_open_limit",
+        circuit_breaker_threshold=1,
+        circuit_breaker_timeout=0.01,
+        circuit_breaker_factory=None,
+    ))
+
+    with pytest.raises(RuntimeError):
+        await mod.execute_with_circuit_breaker(mod._always_fail)
+    await asyncio.sleep(0.02)
+
+    first_probe = asyncio.create_task(mod.execute_with_circuit_breaker(_slow_success))
+    await started.wait()
+    assert active_probes == 1
+
+    with pytest.raises(ModuleCircuitBreakerOpenError):
+        await mod.execute_with_circuit_breaker(_slow_success)
+
+    release.set()
+    assert await first_probe == "ok"

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_extraction_contracts.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_extraction_contracts.py
@@ -440,6 +440,21 @@ def test_mcp_discovery_module_uses_package_local_environment_helpers() -> None:
     assert offenders == []
 
 
+def test_base_module_does_not_import_host_circuit_breaker() -> None:
+    forbidden_import = "tldw_Server_API.app.core.Infrastructure.circuit_breaker"
+    imports = _resolved_import_sources_for(
+        MCP_ROOT / "modules" / "base.py",
+        f"{MCP_PACKAGE}.modules",
+    )
+    offenders = sorted(
+        source
+        for source in imports
+        if source == forbidden_import or source.startswith(f"{forbidden_import}.")
+    )
+
+    assert offenders == []
+
+
 def test_catalog_loader_uses_standalone_catalog_schema() -> None:
     """Catalog loading must depend on standalone MCP package schemas."""
     forbidden_import = "tldw_Server_API.app.api.v1.schemas.archetype_schemas"
@@ -706,6 +721,28 @@ async def test_mcp_server_default_media_module_path_uses_injected_module_config_
     assert media_registration["config"].settings["db_path"] == (
         deps.module_config_provider.media_db_path
     )
+
+
+@pytest.mark.asyncio
+async def test_mcp_server_default_module_configs_use_injected_circuit_breaker_factory(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from tldw_Server_API.app.core.MCP_unified.server import MCPServer
+
+    monkeypatch.setenv("MCP_ENABLE_MEDIA_MODULE", "1")
+    monkeypatch.setenv("MCP_ENABLE_FILESYSTEM_MODULE", "0")
+    monkeypatch.setenv("MCP_MODULES_CONFIG", "/tmp/mcp-stage3-no-modules.yaml")
+    deps = _server_runtime_dependencies()
+    deps.environment_flags_provider = _FakeEnvironmentFlagsProvider(
+        flags={"MCP_ENABLE_MEDIA_MODULE": True}
+    )
+    server = MCPServer(dependencies=deps)
+
+    await server._register_default_modules()  # noqa: SLF001
+
+    assert deps.module_registry.registrations
+    for registration in deps.module_registry.registrations:
+        assert registration["config"].circuit_breaker_factory is deps.circuit_breaker_factory
 
 
 def test_mcp_server_uses_injected_auth_and_policy_context_helpers() -> None:


### PR DESCRIPTION
## Change summary (maintainer-owned)

Maintainer: please replace this section before merge with your own summary of what changed and why these implementation choices were made.

## What changed

- Removed the direct `tldw_Server_API.app.core.Infrastructure.circuit_breaker` import from `MCP_unified/modules/base.py`.
- Added a small host-neutral async fallback breaker for direct module construction when no host breaker factory is injected.
- Kept host behavior on the tldw_server path by wiring `self.dependencies.circuit_breaker_factory` into default module `ModuleConfig` construction.
- Added extraction-boundary and server-registration regression coverage for the circuit-breaker seam.
- Added TASK-549 and the Stage 3I plan/verification record.

## Verification

- Rebased cleanly onto `origin/dev` at `02a017e655` before final verification.
- RED focused tests failed as expected before implementation on the host import and missing factory injection.
- `.venv/bin/python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_extraction_contracts.py tldw_Server_API/app/core/MCP_unified/tests/test_basic_functionality.py::TestBaseModule tldw_Server_API/app/core/MCP_unified/tests/test_concurrency_and_breaker.py -q` -> 38 passed, 3 warnings.
- `.venv/bin/python -m ruff check tldw_Server_API/app/core/MCP_unified/modules/base.py tldw_Server_API/app/core/MCP_unified/server.py tldw_Server_API/app/core/MCP_unified/tests/test_extraction_contracts.py` -> All checks passed.
- `.venv/bin/python -m bandit -r tldw_Server_API/app/core/MCP_unified/modules/base.py tldw_Server_API/app/core/MCP_unified/server.py -f json -o /tmp/bandit_mcp_stage3i_module_breaker_after_rebase.json` -> 0 findings.
- `git diff --check` -> passed.

## Known skips/blockers

- None.

## Backlog

- TASK-549

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Decouples the MCP module base from the host circuit breaker by replacing direct imports with a small host‑neutral async fallback and consistent open‑error handling. Keeps `tldw_server` behavior via injected factories; aligns with TASK‑549 and addresses TASK‑550.

- **Refactors**
  - Replaced host fallback with `_DefaultModuleCircuitBreaker` and `ModuleCircuitBreakerOpenError`; default factory now returns the local breaker.
  - Added `_is_circuit_breaker_open_error` and updated `execute_with_circuit_breaker` to handle host and fallback open errors without importing host types.
  - Injected `dependencies.circuit_breaker_factory` into default `ModuleConfig` from `MCPServer._register_default_modules()`.

- **Bug Fixes**
  - Made `recovery_at` epoch‑based for compatibility and enforced half‑open probe concurrency limits; added regression tests.
  - Tightened typing on `call_async` and improved docs for open‑error compatibility.

<sup>Written for commit 2745501fee90dd4c1b1084d14214ee0fb589dd86. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2128?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

