### PR TITLE
Restore sidepanel chat handoff into WebUI

### DIFF
--- a/Docs/superpowers/plans/2026-05-29-sidepanel-chat-webui-handoff-implementation.md
+++ b/Docs/superpowers/plans/2026-05-29-sidepanel-chat-webui-handoff-implementation.md
@@ -199,7 +199,7 @@ bun run test src/services/__tests__/sidepanel-chat-handoff.test.ts
 
 Expected: pass.
 
-- [ ] **Step 7: Commit**
+- [x] **Step 7: Commit**
 
 ```bash
 git add apps/packages/ui/src/services/sidepanel-chat-handoff.ts apps/packages/ui/src/services/__tests__/sidepanel-chat-handoff.test.ts
@@ -485,7 +485,7 @@ git commit -m "feat: import sidepanel chat handoff in webui"
 - Possibly modify: `apps/packages/ui/src/components/Option/Playground/__tests__/Playground.cockpit-shell.test.tsx` only if route cleanup needs an existing integration assertion.
 - Possibly modify: `tests/e2e/...` only if there is already a sidepanel packaged smoke test harness for chat handoff.
 
-- [ ] **Step 1: Run focused unit regression set**
+- [x] **Step 1: Run focused unit regression set**
 
 Run from `apps/packages/ui`:
 
@@ -495,7 +495,9 @@ bun run test src/services/__tests__/sidepanel-chat-handoff.test.ts src/component
 
 Expected: pass.
 
-- [ ] **Step 2: Run existing relevant playground/sidepanel tests**
+Result: Passed with `--maxWorkers=1 --no-file-parallelism` (5 files, 36 tests). Only the known Node localStorage ExperimentalWarning was emitted.
+
+- [x] **Step 2: Run existing relevant playground/sidepanel tests**
 
 Run from `apps/packages/ui`:
 
@@ -505,11 +507,15 @@ bun run test src/utils/__tests__/sidepanel-full-app-route.test.ts src/utils/__te
 
 Expected: pass, or document unrelated baseline failures with exact failing tests.
 
-- [ ] **Step 3: Type/build sanity**
+Result: Passed with `--maxWorkers=1 --no-file-parallelism` (4 files, 46 tests). Existing provider-status mock warnings were emitted but no tests failed.
+
+- [x] **Step 3: Type/build sanity**
 
 Run the narrowest repo-supported compile check available for `apps/packages/ui`. If no focused typecheck script exists, run the existing focused Vitest suite and document that full package typecheck is not available in `package.json`.
 
-- [ ] **Step 4: Packaged extension smoke**
+Result: `NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit --pretty false` passed from `apps/packages/ui`.
+
+- [x] **Step 4: Packaged extension smoke**
 
 If the local packaged extension harness used by `TASK-534` is available, verify:
 
@@ -523,7 +529,9 @@ If the local packaged extension harness used by `TASK-534` is available, verify:
 
 Record screenshot or terminal evidence in the implementation task.
 
-- [ ] **Step 5: Bandit**
+Result: Existing smoke harness was found and `.output/chrome-mv3` built successfully, but packaged browser assertions could not run on this host. Full smoke command skipped all 3 tests because extension launch was unavailable; JSON follow-up reported `browserType.launchPersistentContext: Timeout 30000ms exceeded`. Longer headful launch timed out before route assertions; CI-style headless launch skipped with `Could not determine extension id from [no extension targets]`.
+
+- [x] **Step 5: Bandit**
 
 No Python is expected. Record Bandit skipped for UI-only TypeScript changes. If the implementation unexpectedly touches Python, run Bandit on the touched Python paths from the repo root:
 
@@ -531,7 +539,9 @@ No Python is expected. Record Bandit skipped for UI-only TypeScript changes. If 
 source .venv/bin/activate && python -m bandit -r <touched_python_paths> -f json -o /tmp/bandit_sidepanel_chat_handoff.json
 ```
 
-- [ ] **Step 6: Final implementation task update**
+Result: Skipped because the verification/implementation scope touched TypeScript, TSX, and markdown only; no Python paths were changed.
+
+- [x] **Step 6: Final implementation task update**
 
 Update the implementation Backlog task with:
 

--- a/Docs/superpowers/plans/2026-05-29-sidepanel-chat-webui-handoff-implementation.md
+++ b/Docs/superpowers/plans/2026-05-29-sidepanel-chat-webui-handoff-implementation.md
@@ -329,7 +329,7 @@ git commit -m "feat: add sidepanel continue in webui action"
 - Modify: `apps/packages/ui/src/components/Option/Playground/PlaygroundForm.tsx`
 - Modify: `apps/packages/ui/src/components/Option/Playground/hooks/usePlaygroundSubmit.ts`
 
-- [ ] **Step 1: Write failing import tests**
+- [x] **Step 1: Write failing import tests**
 
 Use a small test harness around the hook plus submit behavior. Required cases:
 
@@ -343,7 +343,7 @@ it("omits imported page context after the user removes the banner", async () => 
 it("shows non-blocking feedback for expired or malformed handoffs", async () => {})
 ```
 
-- [ ] **Step 2: Run tests to verify RED**
+- [x] **Step 2: Run tests to verify RED**
 
 Run:
 
@@ -353,7 +353,7 @@ bun run test src/components/Option/Playground/__tests__/sidepanel-chat-handoff-i
 
 Expected: fail because hook/banner do not exist.
 
-- [ ] **Step 3: Implement banner component**
+- [x] **Step 3: Implement banner component**
 
 Render a compact source-aware product banner above `AttachmentsSummary`, not inside a modal:
 
@@ -395,7 +395,7 @@ export function SidepanelImportedContextBanner({
 
 Use existing token classes and avoid new visual styling systems.
 
-- [ ] **Step 4: Implement import hook**
+- [x] **Step 4: Implement import hook**
 
 Hook responsibilities:
 
@@ -420,17 +420,17 @@ The hook should return:
 }
 ```
 
-- [ ] **Step 5: Wire PlaygroundForm**
+- [x] **Step 5: Wire PlaygroundForm**
 
 In `PlaygroundForm.tsx`:
 
-- Import `useLocation` from `react-router-dom`.
+- Import the handoff import hook.
 - Call the hook after `setMessageValue` is defined.
 - Render `SidepanelImportedContextBanner` above `AttachmentsSummary` when `importedContext` is present.
 - Render the existing-draft conflict inline near the composer, or use an existing non-blocking inline state primitive. Avoid a modal unless no suitable inline pattern exists.
 - Pass `importedSidepanelContext` and `clearImportedSidepanelContext` into `usePlaygroundSubmit`.
 
-- [ ] **Step 6: Wire request inclusion in usePlaygroundSubmit**
+- [x] **Step 6: Wire request inclusion in usePlaygroundSubmit**
 
 Extend deps:
 
@@ -448,19 +448,21 @@ const messageForModel = importedSidepanelContext
 
 await dispatch({
   ...
-  requestOverrides: messageForModel
-    ? { messageForModel }
-    : undefined,
+  ...(messageForModel
+    ? { requestOverrides: { messageForModel } }
+    : {}),
+}, {
+  afterSend: () => {
+    if (messageForModel) {
+      clearImportedSidepanelContext?.()
+    }
+  },
 })
-
-if (importedSidepanelContext) {
-  clearImportedSidepanelContext?.()
-}
 ```
 
 If future code adds request overrides here, merge with them rather than overwriting.
 
-- [ ] **Step 7: Run focused WebUI import tests**
+- [x] **Step 7: Run focused WebUI import tests**
 
 Run:
 
@@ -470,7 +472,7 @@ bun run test src/components/Option/Playground/__tests__/sidepanel-chat-handoff-i
 
 Expected: pass.
 
-- [ ] **Step 8: Commit**
+- [x] **Step 8: Commit**
 
 ```bash
 git add apps/packages/ui/src/components/Option/Playground/SidepanelImportedContextBanner.tsx apps/packages/ui/src/components/Option/Playground/hooks/useSidepanelChatHandoffImport.ts apps/packages/ui/src/components/Option/Playground/PlaygroundForm.tsx apps/packages/ui/src/components/Option/Playground/hooks/usePlaygroundSubmit.ts apps/packages/ui/src/components/Option/Playground/__tests__/sidepanel-chat-handoff-import.test.tsx

--- a/Docs/superpowers/plans/2026-05-29-sidepanel-chat-webui-handoff-implementation.md
+++ b/Docs/superpowers/plans/2026-05-29-sidepanel-chat-webui-handoff-implementation.md
@@ -1,0 +1,555 @@
+# Sidepanel Chat WebUI Handoff Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement the explicit sidepanel **Continue in WebUI** handoff so `/chat` opens with the current sidepanel draft and visible page context, without changing the existing route-only open action.
+
+**Architecture:** Add a focused extension-local handoff service that creates bounded, one-time packages and fails closed on storage errors. Wire a new ControlRow quick action to create a package and open `/chat?handoff=<id>`. In WebUI `/chat`, read the hash-route handoff, prefill the composer, render an imported-context banner, include that context in the next chat request, and consume the package only after a terminal import outcome.
+
+**Tech Stack:** React 18, TypeScript, WXT `browser`, `@plasmohq/storage` via `createSafeStorage`, React Router hash routes, Vitest/jsdom, Testing Library.
+
+---
+
+## Preconditions
+
+- Work from `/Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/chat-post-regression-next`.
+- Before code edits, create or claim a Backlog task for implementation work, separate from design task `TASK-546` and planning task `TASK-547`.
+- Keep the existing route-only full-screen/open behavior and tests intact.
+- Use `apps/packages/ui` as the test working directory.
+
+## File Structure
+
+- Create: `apps/packages/ui/src/services/sidepanel-chat-handoff.ts`
+  - Owns handoff types, constants, validation, payload bounding, storage create/read/consume/cleanup, route building, and model-message composition.
+  - Uses `createSafeStorage({ area: "local" })`, not `createLocalRegistryBucket`, because creation must fail closed.
+- Create: `apps/packages/ui/src/services/__tests__/sidepanel-chat-handoff.test.ts`
+  - Covers package creation, validation, read-back failure, expiry, consume, route merging, payload bounds, and message-for-model composition.
+- Modify: `apps/packages/ui/src/components/Sidepanel/Chat/ControlRow.tsx`
+  - Adds the **Continue in WebUI** quick action.
+  - Keeps `chat-open-full-app` route-only.
+  - Calls the handoff service, then opens the returned full app URL only after storage succeeds.
+  - Uses `useAntdNotification` or the nearest existing sidepanel notification helper for storage/create failure feedback.
+- Modify: `apps/packages/ui/src/components/Sidepanel/Chat/form.tsx`
+  - Passes `draftMessage={form.values.message}` to `ControlRow`.
+  - Passes a `getVisiblePageContextForHandoff` callback that returns selected tab mentions and active-tab title/URL when the existing Current page chip is active.
+- Create: `apps/packages/ui/src/components/Sidepanel/Chat/__tests__/ControlRow.chat-handoff.test.tsx`
+  - Covers the new action, disabled state, route-only action preservation, role-play query merge, storage failure, and no draft/context-in-URL leakage.
+- Create: `apps/packages/ui/src/components/Option/Playground/SidepanelImportedContextBanner.tsx`
+  - Renders imported page context above the composer with remove action and accessible labels.
+- Create: `apps/packages/ui/src/components/Option/Playground/hooks/useSidepanelChatHandoffImport.ts`
+  - Reads `location.search`, imports or prompts on existing drafts, consumes packages after terminal outcomes, and returns imported context state plus conflict actions.
+- Create: `apps/packages/ui/src/components/Option/Playground/__tests__/sidepanel-chat-handoff-import.test.tsx`
+  - Covers valid import, existing draft insert/replace/cancel, stale handoff feedback, hash-route cleanup, and request inclusion/removal through a small test harness.
+- Modify: `apps/packages/ui/src/components/Option/Playground/PlaygroundForm.tsx`
+  - Calls the import hook.
+  - Renders `SidepanelImportedContextBanner` above `AttachmentsSummary`.
+  - Passes imported context into submit and clears it after send or dismissal.
+- Modify: `apps/packages/ui/src/components/Option/Playground/hooks/usePlaygroundSubmit.ts`
+  - Accepts optional imported sidepanel context.
+  - Builds `requestOverrides.messageForModel` for the next send while keeping the visible user draft unchanged.
+  - Clears imported context only after dispatch starts.
+
+## Task 1: Handoff Storage Service
+
+**Files:**
+- Create: `apps/packages/ui/src/services/sidepanel-chat-handoff.ts`
+- Test: `apps/packages/ui/src/services/__tests__/sidepanel-chat-handoff.test.ts`
+
+- [ ] **Step 1: Write failing service tests**
+
+Cover these named scenarios:
+
+```ts
+it("creates bounded packages and verifies read-back before returning the id", async () => {})
+it("throws and does not return a handoff id when storage set fails", async () => {})
+it("throws when read-back verification cannot read the saved package", async () => {})
+it("returns null and removes expired or malformed packages", async () => {})
+it("consumes a package exactly once", async () => {})
+it("merges handoff into normal and character /chat hash routes", () => {})
+it("never puts draft text or snippet text into the route", () => {})
+it("builds messageForModel with visible sidepanel context", () => {})
+```
+
+- [ ] **Step 2: Run tests to verify RED**
+
+Run from `apps/packages/ui`:
+
+```bash
+bun run test src/services/__tests__/sidepanel-chat-handoff.test.ts
+```
+
+Expected: fail because the module does not exist.
+
+- [ ] **Step 3: Implement service types and constants**
+
+Use this shape as the starting point:
+
+```ts
+export const SIDEPANEL_CHAT_HANDOFF_TTL_MS = 10 * 60 * 1000
+export const SIDEPANEL_CHAT_HANDOFF_STORAGE_PREFIX =
+  "tldw:sidepanel-chat-handoff:"
+export const SIDEPANEL_CHAT_HANDOFF_MAX_SNIPPETS = 4
+export const SIDEPANEL_CHAT_HANDOFF_MAX_SNIPPET_CHARS = 4_000
+export const SIDEPANEL_CHAT_HANDOFF_MAX_TOTAL_SNIPPET_CHARS = 16_000
+export const SIDEPANEL_CHAT_HANDOFF_MAX_DRAFT_CHARS = 32_000
+
+export type SidepanelChatHandoffSnippet = {
+  kind: "selection" | "visible-context" | "captured-snippet"
+  text: string
+  label?: string
+  truncated?: boolean
+}
+
+export type SidepanelChatHandoffPageContext = {
+  title?: string
+  url?: string
+  snippets: SidepanelChatHandoffSnippet[]
+  truncated?: boolean
+}
+
+export type SidepanelChatHandoffPackage = {
+  id: string
+  source: "sidepanel-chat"
+  createdAt: string
+  expiresAt: string
+  consumedAt?: string
+  draft: { text: string; truncated?: boolean }
+  pageContext?: SidepanelChatHandoffPageContext
+  routeIntent?: {
+    path: string
+    mode?: "character"
+    characterId?: string
+  }
+}
+```
+
+- [ ] **Step 4: Implement create/read/consume**
+
+Requirements:
+
+- Generate ids with `crypto.randomUUID()`, with a fallback only for test environments that lack it.
+- Bound draft/snippet lengths before writing.
+- Write through `createSafeStorage({ area: "local" })`.
+- After write, read the same key and validate the package. If validation fails, remove the key and throw.
+- `readSidepanelChatHandoff(id)` returns `null` for missing, expired, consumed, or malformed records and removes bad/expired records.
+- `consumeSidepanelChatHandoff(id)` marks consumed or removes the record. Prefer removal unless preserving consumed metadata is needed for tests.
+
+Minimal create flow:
+
+```ts
+export const createSidepanelChatHandoff = async (
+  input: CreateSidepanelChatHandoffInput,
+): Promise<SidepanelChatHandoffPackage> => {
+  await cleanupExpiredSidepanelChatHandoffs()
+  const now = Date.now()
+  const pkg = buildPackage(input, now)
+  await storage.set(storageKey(pkg.id), pkg)
+  const saved = await readRawPackage(pkg.id)
+  if (!saved || saved.id !== pkg.id) {
+    await storage.remove(storageKey(pkg.id))
+    throw new Error("Sidepanel chat handoff could not be saved.")
+  }
+  return saved
+}
+```
+
+- [ ] **Step 5: Implement route and request helpers**
+
+Add helpers:
+
+```ts
+export const buildSidepanelChatHandoffRoute = (
+  baseChatPath: string,
+  handoffId: string,
+): string => {
+  const [path, rawQuery = ""] = baseChatPath.split("?")
+  const params = new URLSearchParams(rawQuery)
+  params.set("handoff", handoffId)
+  const query = params.toString()
+  return query ? `${path}?${query}` : path
+}
+
+export const buildSidepanelHandoffMessageForModel = (
+  visibleDraft: string,
+  pageContext?: SidepanelChatHandoffPageContext,
+): string => {
+  if (!pageContext) return visibleDraft
+  const lines = [
+    "Sidepanel page context:",
+    pageContext.title ? `Title: ${pageContext.title}` : null,
+    pageContext.url ? `URL: ${pageContext.url}` : null,
+    ...pageContext.snippets.map((snippet, index) =>
+      `Snippet ${index + 1}${snippet.label ? ` (${snippet.label})` : ""}: ${snippet.text}`,
+    ),
+    "",
+    "User draft:",
+    visibleDraft,
+  ].filter(Boolean)
+  return lines.join("\n")
+}
+```
+
+- [ ] **Step 6: Run service tests to verify GREEN**
+
+Run:
+
+```bash
+bun run test src/services/__tests__/sidepanel-chat-handoff.test.ts
+```
+
+Expected: pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/packages/ui/src/services/sidepanel-chat-handoff.ts apps/packages/ui/src/services/__tests__/sidepanel-chat-handoff.test.ts
+git commit -m "feat: add sidepanel chat handoff storage"
+```
+
+## Task 2: Sidepanel Continue In WebUI Action
+
+**Files:**
+- Modify: `apps/packages/ui/src/components/Sidepanel/Chat/ControlRow.tsx`
+- Modify: `apps/packages/ui/src/components/Sidepanel/Chat/form.tsx`
+- Create: `apps/packages/ui/src/components/Sidepanel/Chat/__tests__/ControlRow.chat-handoff.test.tsx`
+- Existing regression: `apps/packages/ui/src/components/Sidepanel/Chat/__tests__/ControlRow.role-play-handoff.test.tsx`
+- Existing regression: `apps/packages/ui/src/components/Sidepanel/Chat/__tests__/SidepanelHeaderSimple.fullscreen-route.test.tsx`
+
+- [ ] **Step 1: Write failing ControlRow tests**
+
+Test cases:
+
+```ts
+it("keeps Open full app route-only with no handoff parameter", async () => {})
+it("creates a handoff package and opens /chat?handoff=<id>", async () => {})
+it("merges handoff into active character route params", async () => {})
+it("does not serialize draft or snippets into the URL", async () => {})
+it("shows a disabled Continue in WebUI action when no draft or context exists", () => {})
+it("shows an error and does not open a tab when handoff creation fails", async () => {})
+```
+
+Mock `createSidepanelChatHandoff` and `buildSidepanelChatHandoffRoute` from the service.
+
+- [ ] **Step 2: Run tests to verify RED**
+
+Run:
+
+```bash
+bun run test src/components/Sidepanel/Chat/__tests__/ControlRow.chat-handoff.test.tsx
+```
+
+Expected: fail because props/action do not exist.
+
+- [ ] **Step 3: Add ControlRow props**
+
+Add props:
+
+```ts
+draftMessage?: string
+hasVisiblePageContextForHandoff?: boolean
+getVisiblePageContextForHandoff?: () =>
+  | Promise<SidepanelChatHandoffPageContext | undefined>
+  | SidepanelChatHandoffPageContext
+  | undefined
+```
+
+Use `draftMessage.trim().length > 0 || hasVisiblePageContextForHandoff` to determine whether **Continue in WebUI** is enabled. The async context callback still validates at click time; if it resolves no context and the draft is empty, show a non-blocking warning and do not open a tab.
+
+- [ ] **Step 4: Implement the new quick action**
+
+In `ControlRow`, add a second quick action near `chat-open-full-app`:
+
+```tsx
+<button
+  type="button"
+  onClick={() => void continueInWebUI()}
+  data-testid="chat-continue-in-webui"
+  className="w-full text-left text-sm px-3 py-2 rounded flex items-center gap-2 hover:bg-surface2 disabled:opacity-60"
+  title={continueInWebuiDescription}
+>
+  <ExternalLink className="size-4 text-text-subtle" />
+  {t("sidepanel:controlRow.continueInWebUI", "Continue in WebUI")}
+</button>
+```
+
+Click flow:
+
+1. Resolve visible page context from the callback.
+2. If draft/context are both empty, show a non-blocking warning and do not open a tab.
+3. Call `createSidepanelChatHandoff({ draftText, pageContext, routeIntent })`.
+4. Build route with `buildSidepanelChatHandoffRoute(fullAppChatPath, pkg.id)`.
+5. Open `/options.html#${handoffPath}` via `browser.runtime.getURL`, matching existing `openFullApp`.
+6. If storage creation fails, show error notification and do not open.
+
+- [ ] **Step 5: Pass sidepanel draft and visible page context from form**
+
+In `form.tsx`, pass:
+
+```tsx
+<ControlRow
+  draftMessage={form.values.message}
+  hasVisiblePageContextForHandoff={
+    pageContextActive || selectedDocuments.length > 0
+  }
+  getVisiblePageContextForHandoff={getVisiblePageContextForHandoff}
+  ...
+/>
+```
+
+Build context from:
+
+- selected tab mentions in `selectedDocuments`,
+- active current page title/URL when `pageContextActive` is true, using `browser.tabs.query({ active: true, currentWindow: true })`.
+
+Do not extract page body text in this callback.
+
+- [ ] **Step 6: Run focused sidepanel tests**
+
+Run:
+
+```bash
+bun run test src/components/Sidepanel/Chat/__tests__/ControlRow.chat-handoff.test.tsx src/components/Sidepanel/Chat/__tests__/ControlRow.role-play-handoff.test.tsx src/components/Sidepanel/Chat/__tests__/SidepanelHeaderSimple.fullscreen-route.test.tsx
+```
+
+Expected: pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/packages/ui/src/components/Sidepanel/Chat/ControlRow.tsx apps/packages/ui/src/components/Sidepanel/Chat/form.tsx apps/packages/ui/src/components/Sidepanel/Chat/__tests__/ControlRow.chat-handoff.test.tsx
+git commit -m "feat: add sidepanel continue in webui action"
+```
+
+## Task 3: WebUI Handoff Import And Request Inclusion
+
+**Files:**
+- Create: `apps/packages/ui/src/components/Option/Playground/SidepanelImportedContextBanner.tsx`
+- Create: `apps/packages/ui/src/components/Option/Playground/hooks/useSidepanelChatHandoffImport.ts`
+- Create: `apps/packages/ui/src/components/Option/Playground/__tests__/sidepanel-chat-handoff-import.test.tsx`
+- Modify: `apps/packages/ui/src/components/Option/Playground/PlaygroundForm.tsx`
+- Modify: `apps/packages/ui/src/components/Option/Playground/hooks/usePlaygroundSubmit.ts`
+
+- [ ] **Step 1: Write failing import tests**
+
+Use a small test harness around the hook plus submit behavior. Required cases:
+
+```ts
+it("imports a valid handoff, pre-fills the composer, renders context, then consumes the package", async () => {})
+it("does not consume before successful import", async () => {})
+it("offers insert, replace, and cancel when a local draft exists", async () => {})
+it("cleans only handoff from the hash-route query and preserves character params", async () => {})
+it("includes imported page context in requestOverrides.messageForModel", async () => {})
+it("omits imported page context after the user removes the banner", async () => {})
+it("shows non-blocking feedback for expired or malformed handoffs", async () => {})
+```
+
+- [ ] **Step 2: Run tests to verify RED**
+
+Run:
+
+```bash
+bun run test src/components/Option/Playground/__tests__/sidepanel-chat-handoff-import.test.tsx
+```
+
+Expected: fail because hook/banner do not exist.
+
+- [ ] **Step 3: Implement banner component**
+
+Render a compact source-aware product banner above `AttachmentsSummary`, not inside a modal:
+
+```tsx
+export function SidepanelImportedContextBanner({
+  context,
+  onRemove,
+}: {
+  context: SidepanelChatHandoffPageContext
+  onRemove: () => void
+}) {
+  const title = context.title || "Imported sidepanel context"
+  const count = context.snippets.length
+  return (
+    <section
+      aria-label="Imported sidepanel context"
+      className="mb-2 rounded-lg border border-border bg-surface2/70 px-3 py-2 text-sm text-text"
+    >
+      <div className="flex min-w-0 items-center justify-between gap-2">
+        <div className="min-w-0">
+          <div className="truncate font-medium">{title}</div>
+          <div className="truncate text-xs text-text-muted">
+            {context.url || `${count} snippet${count === 1 ? "" : "s"}`}
+          </div>
+        </div>
+        <button
+          type="button"
+          onClick={onRemove}
+          aria-label={`Remove imported context from ${title}`}
+          className="rounded p-1 text-text-subtle hover:bg-surface hover:text-text"
+        >
+          <X className="h-4 w-4" aria-hidden="true" />
+        </button>
+      </div>
+    </section>
+  )
+}
+```
+
+Use existing token classes and avoid new visual styling systems.
+
+- [ ] **Step 4: Implement import hook**
+
+Hook responsibilities:
+
+- Use React Router `location.search`, not `window.location.search`.
+- Read `handoff` param.
+- Call `readSidepanelChatHandoff(id)`.
+- If invalid, show feedback and remove only `handoff` from route.
+- If current composer is empty, import immediately and consume.
+- If current composer has draft, expose conflict state with `insert`, `replace`, and `cancel`.
+- Consume only after successful import or cancel.
+
+The hook should return:
+
+```ts
+{
+  importedContext,
+  removeImportedContext,
+  conflict,
+  insertHandoffDraft,
+  replaceWithHandoffDraft,
+  cancelHandoffImport,
+}
+```
+
+- [ ] **Step 5: Wire PlaygroundForm**
+
+In `PlaygroundForm.tsx`:
+
+- Import `useLocation` from `react-router-dom`.
+- Call the hook after `setMessageValue` is defined.
+- Render `SidepanelImportedContextBanner` above `AttachmentsSummary` when `importedContext` is present.
+- Render the existing-draft conflict inline near the composer, or use an existing non-blocking inline state primitive. Avoid a modal unless no suitable inline pattern exists.
+- Pass `importedSidepanelContext` and `clearImportedSidepanelContext` into `usePlaygroundSubmit`.
+
+- [ ] **Step 6: Wire request inclusion in usePlaygroundSubmit**
+
+Extend deps:
+
+```ts
+importedSidepanelContext?: SidepanelChatHandoffPageContext | null
+clearImportedSidepanelContext?: () => void
+```
+
+Before dispatch:
+
+```ts
+const messageForModel = importedSidepanelContext
+  ? buildSidepanelHandoffMessageForModel(trimmed, importedSidepanelContext)
+  : undefined
+
+await dispatch({
+  ...
+  requestOverrides: messageForModel
+    ? { messageForModel }
+    : undefined,
+})
+
+if (importedSidepanelContext) {
+  clearImportedSidepanelContext?.()
+}
+```
+
+If future code adds request overrides here, merge with them rather than overwriting.
+
+- [ ] **Step 7: Run focused WebUI import tests**
+
+Run:
+
+```bash
+bun run test src/components/Option/Playground/__tests__/sidepanel-chat-handoff-import.test.tsx
+```
+
+Expected: pass.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add apps/packages/ui/src/components/Option/Playground/SidepanelImportedContextBanner.tsx apps/packages/ui/src/components/Option/Playground/hooks/useSidepanelChatHandoffImport.ts apps/packages/ui/src/components/Option/Playground/PlaygroundForm.tsx apps/packages/ui/src/components/Option/Playground/hooks/usePlaygroundSubmit.ts apps/packages/ui/src/components/Option/Playground/__tests__/sidepanel-chat-handoff-import.test.tsx
+git commit -m "feat: import sidepanel chat handoff in webui"
+```
+
+## Task 4: Focused Regression And Packaged Smoke
+
+**Files:**
+- Possibly modify: `apps/packages/ui/src/components/Option/Playground/__tests__/Playground.cockpit-shell.test.tsx` only if route cleanup needs an existing integration assertion.
+- Possibly modify: `tests/e2e/...` only if there is already a sidepanel packaged smoke test harness for chat handoff.
+
+- [ ] **Step 1: Run focused unit regression set**
+
+Run from `apps/packages/ui`:
+
+```bash
+bun run test src/services/__tests__/sidepanel-chat-handoff.test.ts src/components/Sidepanel/Chat/__tests__/ControlRow.chat-handoff.test.tsx src/components/Sidepanel/Chat/__tests__/ControlRow.role-play-handoff.test.tsx src/components/Sidepanel/Chat/__tests__/SidepanelHeaderSimple.fullscreen-route.test.tsx src/components/Option/Playground/__tests__/sidepanel-chat-handoff-import.test.tsx
+```
+
+Expected: pass.
+
+- [ ] **Step 2: Run existing relevant playground/sidepanel tests**
+
+Run from `apps/packages/ui`:
+
+```bash
+bun run test src/utils/__tests__/sidepanel-full-app-route.test.ts src/utils/__tests__/character-chat-mode-intent.test.ts src/components/Option/Playground/__tests__/Playground.coordinator.integration.test.tsx src/components/Option/Playground/__tests__/Playground.cockpit-shell.test.tsx
+```
+
+Expected: pass, or document unrelated baseline failures with exact failing tests.
+
+- [ ] **Step 3: Type/build sanity**
+
+Run the narrowest repo-supported compile check available for `apps/packages/ui`. If no focused typecheck script exists, run the existing focused Vitest suite and document that full package typecheck is not available in `package.json`.
+
+- [ ] **Step 4: Packaged extension smoke**
+
+If the local packaged extension harness used by `TASK-534` is available, verify:
+
+- sidepanel route-only open still opens `/options.html#/chat`,
+- **Continue in WebUI** opens `/options.html#/chat?handoff=<id>`,
+- draft appears in WebUI composer,
+- imported context banner appears,
+- send includes imported context and then clears the banner,
+- role-play route preserves `mode=character&characterId=...`,
+- stale handoff shows non-blocking feedback and normal `/chat` remains usable.
+
+Record screenshot or terminal evidence in the implementation task.
+
+- [ ] **Step 5: Bandit**
+
+No Python is expected. Record Bandit skipped for UI-only TypeScript changes. If the implementation unexpectedly touches Python, run Bandit on the touched Python paths from the repo root:
+
+```bash
+source .venv/bin/activate && python -m bandit -r <touched_python_paths> -f json -o /tmp/bandit_sidepanel_chat_handoff.json
+```
+
+- [ ] **Step 6: Final implementation task update**
+
+Update the implementation Backlog task with:
+
+- touched files,
+- focused test commands and results,
+- packaged smoke evidence or explicit skip reason,
+- Bandit skip reason,
+- final summary.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git status --short
+git add <changed files and implementation task>
+git commit -m "test: verify sidepanel chat handoff"
+```
+
+## Plan Review Notes
+
+- The plan intentionally does not change the existing `SidepanelHeaderSimple` full-chat route-only action.
+- The plan uses request-scoped imported context, not durable server-backed draft persistence.
+- The plan does not perform fresh readable-page/body extraction at handoff time.
+- A plan-document-reviewer subagent was not dispatched from this session because the available subagent tool policy requires an explicit user request for delegation. Do a local review before execution, or ask for explicit subagent review if that gate should be used.

--- a/Docs/superpowers/specs/2026-05-29-sidepanel-chat-webui-handoff-design.md
+++ b/Docs/superpowers/specs/2026-05-29-sidepanel-chat-webui-handoff-design.md
@@ -13,10 +13,11 @@ This must not replace the existing full-screen/open action. The current open act
 
 ## Approved Decisions
 
-- Add a separate **Continue in WebUI** action near the existing full-app/open action.
+- Add a separate **Continue in WebUI** action in the sidepanel composer `ControlRow` quick-actions area, near the existing full-app/open action.
 - Transfer only the current sidepanel draft and already-visible page context.
 - Prefill the WebUI `/chat` composer; do not send automatically.
-- Show a visible context indicator in `/chat` before send.
+- Show a visible imported-context banner in `/chat` before send.
+- Include imported context in the next chat request unless the user removes it before sending.
 - Use a one-time, short-lived handoff package keyed by an opaque ID.
 - Preserve the original sidepanel draft after handoff.
 - Keep role-play route intent compatible with the handoff URL when active.
@@ -29,6 +30,8 @@ This must not replace the existing full-screen/open action. The current open act
 - Sidepanel and WebUI composers already use separate draft keys through `useComposerText`, so sidepanel draft preservation matches the existing storage model.
 - `chat-surface-coordinator` currently tracks route/surface and optional panel engagement only; it is not a cross-surface state-transfer mechanism.
 - Existing sidepanel handoff tests assert route-only behavior and role-play route preservation, so the new behavior must be additive instead of mutating the current route-only contract.
+- `SidepanelHeaderSimple` does not currently receive composer draft/context props, while `ControlRow` already receives conversation-context composition props. The transfer action belongs in `ControlRow`, not the header.
+- Existing `createLocalRegistryBucket` storage writes swallow `set` errors. The handoff service must not reuse that helper for package creation because this flow must fail closed before opening `/chat?handoff=<id>`.
 
 ## User Experience Contract
 
@@ -44,7 +47,7 @@ The existing full-screen/open action keeps its current semantics:
 
 ### New Explicit Transfer Action
 
-Add a separate **Continue in WebUI** action.
+Add a separate **Continue in WebUI** action in the sidepanel composer `ControlRow` quick-actions menu.
 
 Suggested copy:
 
@@ -62,9 +65,10 @@ If neither exists, the action should be disabled or visually deemphasized with a
 
 When `/chat?handoff=<id>` opens and the handoff is valid:
 
-- WebUI consumes the handoff once.
+- WebUI reads and validates the handoff package.
 - The composer is prefilled with the transferred draft.
-- The imported page context appears as a visible context attachment/indicator near the composer or active context rail.
+- The imported page context appears as a visible imported-context banner above the composer.
+- The imported context is included in the next chat request unless the user removes it.
 - The user can edit the draft before sending.
 - Nothing is submitted until the user explicitly sends.
 
@@ -81,6 +85,8 @@ The context indicator must expose enough information for user trust:
 - snippet/selection count or short snippet preview when available,
 - a remove/dismiss control before send.
 
+If the user removes the imported context, the prefilled draft should remain. Removing context only removes the contextual attachment from the next request.
+
 ## Handoff Package
 
 The URL carries only an opaque handoff ID:
@@ -92,6 +98,13 @@ If role-play route intent is active, merge the handoff parameter into the existi
 `/options.html#/chat?mode=character&characterId=<id>&handoff=<handoffId>`
 
 The package should be stored in extension/browser storage, not encoded into the URL.
+
+Implementation storage contract:
+
+- Use a dedicated sidepanel chat handoff service backed by extension local storage, preferably through `createSafeStorage({ area: "local" })`.
+- Package creation must return success or throw/return a typed failure. Do not use storage helpers that silently swallow write failures for package creation.
+- Package creation should verify the package can be read back before opening `/chat?handoff=<id>`.
+- Package contents must not be logged.
 
 Proposed package shape:
 
@@ -112,7 +125,9 @@ type SidepanelChatHandoffPackage = {
       kind: "selection" | "visible-context" | "captured-snippet"
       text: string
       label?: string
+      truncated?: boolean
     }>
+    truncated?: boolean
   }
   routeIntent?: {
     path: "/chat" | string
@@ -126,17 +141,33 @@ For the first implementation slice, `pageContext` must be limited to context alr
 
 Payloads should be bounded:
 
-- cap the number of snippets,
-- cap each snippet length,
-- truncate with an explicit indicator when needed,
+- max 4 snippets,
+- max 4,000 characters per snippet,
+- max 16,000 total snippet characters,
+- max 32,000 draft characters in the handoff package,
+- drafts longer than the current `PASTED_TEXT_CHAR_LIMIT` of 1,500 characters should prefill through the existing large-draft/collapse behavior instead of expanding the composer unexpectedly,
+- truncate with `truncated: true` when needed,
 - reject malformed package shapes before prefill.
+
+## Imported Context Request Semantics
+
+Imported page context is not only a visual banner. It is first-class composer context for the next send:
+
+- The banner is rendered above the composer so the user can review or remove it before send.
+- The next chat request should include the imported context in the same request-composition path used for explicit composer context, or in a dedicated sidepanel-handoff context block if that is the smallest safe integration.
+- Imported context is consumed by one user send or by user dismissal. It should not silently persist across unrelated drafts after send.
+- The first implementation slice should not write imported context as durable saved-conversation metadata beyond whatever is already captured by the sent message/request path.
+- Tests must assert that the outgoing chat request includes imported page title, URL, and snippets when the banner is present, and omits them after removal.
 
 ## Lifecycle Rules
 
 - Handoff packages are one-time consume.
 - Default expiry should be short, for example 10 minutes.
 - Handoff IDs should be unguessable, for example `crypto.randomUUID()`.
-- Consuming `/chat?handoff=<id>` marks the package consumed or removes it.
+- Opening `/chat?handoff=<id>` should not immediately destroy the package. Read and validate first, then mark consumed or remove it only after one of these terminal outcomes:
+  - successful composer prefill/import,
+  - user chooses `Cancel import` in an existing-draft conflict,
+  - user acknowledges a malformed/unsupported-package error.
 - Expired or consumed packages must not prefill composer state.
 - The sidepanel draft remains unchanged after handoff creation and after WebUI consumption.
 - Handoff cleanup should remove expired records opportunistically when creating or consuming a package.
@@ -148,6 +179,7 @@ If the handoff is missing, expired, malformed, or already consumed:
 - `/chat` still opens normally.
 - Show non-blocking feedback such as `The sidepanel handoff expired. Start a new handoff from the sidepanel to continue that draft.`
 - Do not block normal chat usage.
+- Remove the `handoff` query parameter from the React Router location after the feedback is shown, so reloads do not repeat the same stale handoff attempt.
 
 If the draft can be recovered but page context cannot:
 
@@ -160,6 +192,13 @@ If storage write fails in the sidepanel:
 - Show a failure notification.
 - Do not open `/chat?handoff=<id>` with a missing package.
 
+If `/chat` already has a local unsent draft:
+
+- Show the import conflict choice before changing composer text.
+- `Insert handoff draft` appends or inserts the handoff text according to the existing composer insertion behavior.
+- `Replace current draft` replaces the local draft with the handoff draft.
+- `Cancel import` leaves the local draft unchanged and consumes/removes the handoff package so reload does not prompt repeatedly.
+
 ## Privacy And Security Constraints
 
 - Do not put draft text or page snippets in the URL.
@@ -168,6 +207,14 @@ If storage write fails in the sidepanel:
 - Do not send the draft automatically.
 - Treat handoff context as user-visible input, not hidden model metadata.
 - Avoid logging package contents in errors or analytics.
+- Do not silently overwrite an existing WebUI draft.
+
+## Routing Requirements
+
+- Parse handoff parameters through React Router route state, for example `location.search` for `/chat?handoff=<id>`.
+- Do not parse handoff parameters from `window.location.search`; this app uses hash routes such as `/options.html#/chat?handoff=<id>`, where the meaningful query string lives inside the hash route.
+- Remove `handoff` from the route after a terminal outcome with router-aware navigation or `history.replaceState` that edits the hash-route query, not the outer document query.
+- Preserve existing role-play query parameters when adding or removing `handoff`.
 
 ## Accessibility Requirements
 
@@ -177,6 +224,7 @@ If storage write fails in the sidepanel:
 - Disabled state must be announced when no transferable state exists.
 - The imported context indicator in `/chat` must be keyboard reachable.
 - The context remove/dismiss action must have an accessible name that identifies the imported page context.
+- The existing-draft conflict choice must be keyboard reachable and must not trap focus.
 - Non-blocking error feedback must be available to assistive technology, not only visual toast color.
 
 ## Test Contract
@@ -189,11 +237,16 @@ Focused regression tests should cover:
 - Draft text and page snippets are not serialized into the URL.
 - Sidepanel draft is preserved after handoff creation.
 - Role-play route intent preserves `mode=character&characterId=...` alongside `handoff=<id>` when applicable.
-- `/chat` consumes a valid handoff once and pre-fills the composer.
-- `/chat` displays a visible imported-context indicator before send.
+- Handoff package creation fails closed when storage write or read-back verification fails.
+- `/chat` reads and validates a valid handoff, pre-fills the composer, then consumes it after successful import.
+- `/chat` displays a visible imported-context banner before send.
+- The next outgoing chat request includes imported page title, URL, and snippets while the banner is present.
+- Removing the imported-context banner removes the imported context from the outgoing chat request without clearing the draft.
 - Existing WebUI composer draft is not silently overwritten by an arriving handoff.
+- Existing-draft import conflict supports insert, replace, and cancel outcomes.
 - Expired, missing, malformed, and already-consumed handoffs open `/chat` normally with non-blocking feedback.
 - A storage write failure does not open a broken handoff URL.
+- Hash-router cleanup removes only `handoff` and preserves role-play route parameters.
 
 ## Implementation Boundaries
 
@@ -210,16 +263,15 @@ This design does not require:
 ## Suggested Implementation Slices
 
 1. Add a storage service and unit tests for creating, reading, consuming, expiring, and cleaning sidepanel chat handoff packages.
-2. Add the sidepanel **Continue in WebUI** action and tests that assert route-only open remains unchanged.
-3. Add `/chat` handoff consumption, composer prefill, visible context indicator, and error feedback tests.
-4. Run packaged extension smoke to verify sidepanel action, WebUI arrival, role-play route compatibility, and stale handoff behavior.
+2. Add the sidepanel **Continue in WebUI** action in `ControlRow` and tests that assert route-only open remains unchanged.
+3. Add `/chat` handoff read/validate/import/consume, composer prefill, imported-context banner, request inclusion, hash-route cleanup, and error feedback tests.
+4. Run packaged extension smoke to verify sidepanel action, WebUI arrival, role-play route compatibility, request context inclusion, and stale handoff behavior.
 
 ## Open Questions
 
-- Which existing context indicator component should render the imported sidepanel page context in `/chat`: composer attachment UI, context rail, or a small imported-context banner?
-- Should handoff packages be stored in `browser.storage.local`, an existing extension storage helper, or a new thin service wrapping the current storage abstraction?
-- Should imported context become part of the next chat request only, or should it also be visible in saved conversation metadata after send?
-- Should there be a small visual acknowledgement in the sidepanel after successful package creation, or is opening the WebUI enough feedback?
+- Whether imported sidepanel context should later be promoted into durable saved-conversation metadata. First slice keeps it request-scoped.
+- Whether a future slice should support fresh readable-page capture at handoff time. First slice uses only already-visible or explicitly captured context.
+- Whether a future slice should add a success acknowledgement in the sidepanel after package creation. First slice treats opening the WebUI tab as success feedback and reserves notifications for failure.
 
 ## Verification For This Spec
 

--- a/Docs/superpowers/specs/2026-05-29-sidepanel-chat-webui-handoff-design.md
+++ b/Docs/superpowers/specs/2026-05-29-sidepanel-chat-webui-handoff-design.md
@@ -1,0 +1,228 @@
+# Sidepanel Chat WebUI Handoff Design
+
+**Date:** 2026-05-29
+**Surface:** Browser extension sidepanel chat to WebUI `/chat`
+**Status:** Approved design
+**Backlog:** TASK-546
+
+## Goal
+
+Add an explicit sidepanel-to-WebUI handoff that lets a user continue the current sidepanel draft in the full `/chat` experience with the visible page context attached.
+
+This must not replace the existing full-screen/open action. The current open action remains route-only and continues to communicate that sidepanel draft, current page context, and unsaved sidepanel state stay in the sidepanel.
+
+## Approved Decisions
+
+- Add a separate **Continue in WebUI** action near the existing full-app/open action.
+- Transfer only the current sidepanel draft and already-visible page context.
+- Prefill the WebUI `/chat` composer; do not send automatically.
+- Show a visible context indicator in `/chat` before send.
+- Use a one-time, short-lived handoff package keyed by an opaque ID.
+- Preserve the original sidepanel draft after handoff.
+- Keep role-play route intent compatible with the handoff URL when active.
+
+## Current Evidence
+
+- `SidepanelHeaderSimple` opens `/options.html#/chat` for the full-chat button and describes the action as route-only.
+- `ControlRow` opens `/options.html#${fullAppChatPath}` and uses route-only accessible copy for normal and role-play handoff.
+- `buildSidepanelFullAppChatPath` already preserves normal `/chat` and character route intent.
+- Sidepanel and WebUI composers already use separate draft keys through `useComposerText`, so sidepanel draft preservation matches the existing storage model.
+- `chat-surface-coordinator` currently tracks route/surface and optional panel engagement only; it is not a cross-surface state-transfer mechanism.
+- Existing sidepanel handoff tests assert route-only behavior and role-play route preservation, so the new behavior must be additive instead of mutating the current route-only contract.
+
+## User Experience Contract
+
+### Existing Route-Only Action
+
+The existing full-screen/open action keeps its current semantics:
+
+- Opens `/chat` in the WebUI.
+- Does not transfer sidepanel draft text.
+- Does not transfer current page context.
+- Does not transfer unsaved sidepanel chat state.
+- Keeps accessible copy that states this limitation.
+
+### New Explicit Transfer Action
+
+Add a separate **Continue in WebUI** action.
+
+Suggested copy:
+
+- Label: `Continue in WebUI`
+- Tooltip/description: `Opens /chat with this draft and visible page context. Nothing is sent automatically.`
+
+The action should be enabled when there is either:
+
+- non-empty sidepanel draft text, or
+- visible page context that can be attached.
+
+If neither exists, the action should be disabled or visually deemphasized with a short disabled-state label such as `No draft or page context to continue`.
+
+### WebUI Arrival
+
+When `/chat?handoff=<id>` opens and the handoff is valid:
+
+- WebUI consumes the handoff once.
+- The composer is prefilled with the transferred draft.
+- The imported page context appears as a visible context attachment/indicator near the composer or active context rail.
+- The user can edit the draft before sending.
+- Nothing is submitted until the user explicitly sends.
+
+If the WebUI composer already has an unsent local draft, the handoff must not silently overwrite it. Show a small import conflict choice instead:
+
+- `Insert handoff draft`
+- `Replace current draft`
+- `Cancel import`
+
+The context indicator must expose enough information for user trust:
+
+- page title when available,
+- origin/domain or URL,
+- snippet/selection count or short snippet preview when available,
+- a remove/dismiss control before send.
+
+## Handoff Package
+
+The URL carries only an opaque handoff ID:
+
+`/options.html#/chat?handoff=<handoffId>`
+
+If role-play route intent is active, merge the handoff parameter into the existing route query rather than replacing it:
+
+`/options.html#/chat?mode=character&characterId=<id>&handoff=<handoffId>`
+
+The package should be stored in extension/browser storage, not encoded into the URL.
+
+Proposed package shape:
+
+```ts
+type SidepanelChatHandoffPackage = {
+  id: string
+  source: "sidepanel-chat"
+  createdAt: string
+  expiresAt: string
+  consumedAt?: string
+  draft: {
+    text: string
+  }
+  pageContext?: {
+    title?: string
+    url?: string
+    snippets: Array<{
+      kind: "selection" | "visible-context" | "captured-snippet"
+      text: string
+      label?: string
+    }>
+  }
+  routeIntent?: {
+    path: "/chat" | string
+    mode?: "character"
+    characterId?: string
+  }
+}
+```
+
+For the first implementation slice, `pageContext` must be limited to context already visible or explicitly captured in the sidepanel. Do not trigger a fresh readable-page/body capture at handoff time.
+
+Payloads should be bounded:
+
+- cap the number of snippets,
+- cap each snippet length,
+- truncate with an explicit indicator when needed,
+- reject malformed package shapes before prefill.
+
+## Lifecycle Rules
+
+- Handoff packages are one-time consume.
+- Default expiry should be short, for example 10 minutes.
+- Handoff IDs should be unguessable, for example `crypto.randomUUID()`.
+- Consuming `/chat?handoff=<id>` marks the package consumed or removes it.
+- Expired or consumed packages must not prefill composer state.
+- The sidepanel draft remains unchanged after handoff creation and after WebUI consumption.
+- Handoff cleanup should remove expired records opportunistically when creating or consuming a package.
+
+## Error And Edge States
+
+If the handoff is missing, expired, malformed, or already consumed:
+
+- `/chat` still opens normally.
+- Show non-blocking feedback such as `The sidepanel handoff expired. Start a new handoff from the sidepanel to continue that draft.`
+- Do not block normal chat usage.
+
+If the draft can be recovered but page context cannot:
+
+- Prefill the composer draft.
+- Show a warning on the context indicator or toast: `Draft imported. Page context could not be attached.`
+
+If storage write fails in the sidepanel:
+
+- Keep the user in the sidepanel.
+- Show a failure notification.
+- Do not open `/chat?handoff=<id>` with a missing package.
+
+## Privacy And Security Constraints
+
+- Do not put draft text or page snippets in the URL.
+- Do not store handoff packages longer than the expiry window.
+- Do not capture new page body text during handoff.
+- Do not send the draft automatically.
+- Treat handoff context as user-visible input, not hidden model metadata.
+- Avoid logging package contents in errors or analytics.
+
+## Accessibility Requirements
+
+- Both actions need distinct labels and descriptions:
+  - route-only open action,
+  - state-transfer Continue in WebUI action.
+- Disabled state must be announced when no transferable state exists.
+- The imported context indicator in `/chat` must be keyboard reachable.
+- The context remove/dismiss action must have an accessible name that identifies the imported page context.
+- Non-blocking error feedback must be available to assistive technology, not only visual toast color.
+
+## Test Contract
+
+Focused regression tests should cover:
+
+- Existing full-screen/open action still opens `/options.html#/chat` with no `handoff` parameter.
+- Existing route-only accessible copy remains present for full-screen/open.
+- **Continue in WebUI** creates a handoff package and opens `/options.html#/chat?handoff=<id>`.
+- Draft text and page snippets are not serialized into the URL.
+- Sidepanel draft is preserved after handoff creation.
+- Role-play route intent preserves `mode=character&characterId=...` alongside `handoff=<id>` when applicable.
+- `/chat` consumes a valid handoff once and pre-fills the composer.
+- `/chat` displays a visible imported-context indicator before send.
+- Existing WebUI composer draft is not silently overwritten by an arriving handoff.
+- Expired, missing, malformed, and already-consumed handoffs open `/chat` normally with non-blocking feedback.
+- A storage write failure does not open a broken handoff URL.
+
+## Implementation Boundaries
+
+This design does not require:
+
+- automatic send,
+- clearing or moving the sidepanel draft,
+- fresh readable-page extraction during handoff,
+- server-backed draft/session records,
+- cross-device resume,
+- changing the current full-screen/open route-only action,
+- broader `/chat` layout redesign.
+
+## Suggested Implementation Slices
+
+1. Add a storage service and unit tests for creating, reading, consuming, expiring, and cleaning sidepanel chat handoff packages.
+2. Add the sidepanel **Continue in WebUI** action and tests that assert route-only open remains unchanged.
+3. Add `/chat` handoff consumption, composer prefill, visible context indicator, and error feedback tests.
+4. Run packaged extension smoke to verify sidepanel action, WebUI arrival, role-play route compatibility, and stale handoff behavior.
+
+## Open Questions
+
+- Which existing context indicator component should render the imported sidepanel page context in `/chat`: composer attachment UI, context rail, or a small imported-context banner?
+- Should handoff packages be stored in `browser.storage.local`, an existing extension storage helper, or a new thin service wrapping the current storage abstraction?
+- Should imported context become part of the next chat request only, or should it also be visible in saved conversation metadata after send?
+- Should there be a small visual acknowledgement in the sidepanel after successful package creation, or is opening the WebUI enough feedback?
+
+## Verification For This Spec
+
+- `git diff --check`
+- Backlog task `TASK-546` references this design.
+- Bandit is skipped for this design-only Markdown task; no Python code is touched.

--- a/apps/packages/ui/src/components/Chat/composer/__tests__/useComposerSubmit.test.tsx
+++ b/apps/packages/ui/src/components/Chat/composer/__tests__/useComposerSubmit.test.tsx
@@ -36,8 +36,10 @@ describe("useComposerSubmit", () => {
     const order: string[] = []
     const sendMessage = vi.fn(async () => {
       order.push("send")
+      return "submitted"
     })
-    const afterSend = vi.fn(() => {
+    const afterSend = vi.fn((result: string) => {
+      expect(result).toBe("submitted")
       order.push("after")
     })
 
@@ -48,6 +50,7 @@ describe("useComposerSubmit", () => {
     })
 
     expect(order).toEqual(["send", "after"])
+    expect(afterSend).toHaveBeenCalledWith("submitted")
   })
 
   it("runs both hooks in the expected order: before → send → after", async () => {
@@ -105,10 +108,12 @@ describe("useComposerSubmit", () => {
     const sendMessage = vi.fn(async () => "ok")
     const { result } = renderHook(() => useComposerSubmit({ sendMessage }))
 
+    let dispatchResult: string | undefined
     await act(async () => {
-      await result.current.dispatch({ message: "hi" })
+      dispatchResult = await result.current.dispatch({ message: "hi" })
     })
 
     expect(sendMessage).toHaveBeenCalledOnce()
+    expect(dispatchResult).toBe("ok")
   })
 })

--- a/apps/packages/ui/src/components/Chat/composer/hooks/useComposerSubmit.ts
+++ b/apps/packages/ui/src/components/Chat/composer/hooks/useComposerSubmit.ts
@@ -16,31 +16,40 @@ import React from "react"
  *   awaited. Use it for optimistic UI actions: form.reset(), clear draft
  *   attachments, textAreaFocus(). Playground and Sidepanel both use this
  *   "clear immediately, let the request fly" pattern.
- * - `afterSend` runs only if the dispatch resolves. On rejection it's
- *   skipped and the error propagates so the caller can render it.
+ * - `afterSend` runs only if the dispatch resolves. It receives the resolved
+ *   `sendMessage` result so callers can distinguish successful submissions
+ *   from handled failed/skipped results. On rejection it's skipped and the
+ *   error propagates so the caller can render it.
  */
 
-export interface UseComposerSubmitOptions<TPayload> {
-  sendMessage: (payload: TPayload) => Promise<unknown>
+export interface UseComposerSubmitOptions<TPayload, TResult = unknown> {
+  sendMessage: (payload: TPayload) => Promise<TResult>
 }
 
-export interface ComposerSubmitHooks {
+export interface ComposerSubmitHooks<TResult = unknown> {
   beforeSend?: () => void
-  afterSend?: () => void
+  afterSend?: (result: TResult) => void
 }
 
-export interface UseComposerSubmitResult<TPayload> {
-  dispatch: (payload: TPayload, hooks?: ComposerSubmitHooks) => Promise<void>
+export interface UseComposerSubmitResult<TPayload, TResult = unknown> {
+  dispatch: (
+    payload: TPayload,
+    hooks?: ComposerSubmitHooks<TResult>
+  ) => Promise<TResult>
 }
 
-export function useComposerSubmit<TPayload>({
+export function useComposerSubmit<TPayload, TResult = unknown>({
   sendMessage,
-}: UseComposerSubmitOptions<TPayload>): UseComposerSubmitResult<TPayload> {
+}: UseComposerSubmitOptions<TPayload, TResult>): UseComposerSubmitResult<
+  TPayload,
+  TResult
+> {
   const dispatch = React.useCallback(
-    async (payload: TPayload, hooks?: ComposerSubmitHooks) => {
+    async (payload: TPayload, hooks?: ComposerSubmitHooks<TResult>) => {
       hooks?.beforeSend?.()
-      await sendMessage(payload)
-      hooks?.afterSend?.()
+      const result = await sendMessage(payload)
+      hooks?.afterSend?.(result)
+      return result
     },
     [sendMessage]
   )

--- a/apps/packages/ui/src/components/Option/Playground/PlaygroundForm.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/PlaygroundForm.tsx
@@ -183,6 +183,7 @@ import {
   PlaygroundSendControl,
   type PlaygroundSendBlocker,
 } from "./PlaygroundSendControl";
+import { SidepanelImportedContextBanner } from "./SidepanelImportedContextBanner";
 import { PlaygroundToolsPopover } from "./PlaygroundToolsPopover";
 import type { RolePlaySetupApplyPayload } from "./RolePlaySetupDrawer";
 import { TokenProgressBar } from "./TokenProgressBar";
@@ -224,6 +225,7 @@ import {
   usePlaygroundVoiceChat,
   usePromptTemplates,
 } from "./hooks";
+import { useSidepanelChatHandoffImport } from "./hooks/useSidepanelChatHandoffImport";
 // SessionInsightsPanel moved to PlaygroundContextWindowModal
 import { type ModelRecommendationAction } from "./model-recommendations";
 import {
@@ -1857,6 +1859,19 @@ export const PlaygroundForm = ({
   } = composerInput;
 
   const hasDraft = (form.values.message || "").trim().length > 0;
+  const {
+    importedContext: importedSidepanelContext,
+    removeImportedContext: clearImportedSidepanelContext,
+    conflict: sidepanelHandoffConflict,
+    insertHandoffDraft,
+    replaceWithHandoffDraft,
+    cancelHandoffImport,
+  } = useSidepanelChatHandoffImport({
+    draftValue: form.values.message || "",
+    setMessageValue,
+    notificationApi,
+    t,
+  });
   useIsomorphicLayoutEffect(() => {
     onDraftPresenceChange?.(hasDraft);
   }, [hasDraft, onDraftPresenceChange]);
@@ -3017,6 +3032,8 @@ export const PlaygroundForm = ({
     resolvedMaxContext,
     jsonMode: Boolean(currentChatModelSettings.jsonMode),
     researchContext,
+    importedSidepanelContext,
+    clearImportedSidepanelContext,
     sendMessage,
     clearSelectedDocuments,
     clearUploadedFiles,
@@ -4788,6 +4805,99 @@ export const PlaygroundForm = ({
                 !isConnectionReady ? "opacity-80" : ""
               }`}
             >
+              {importedSidepanelContext
+                ? wrapComposerProfile(
+                    "sidepanel-imported-context",
+                    <SidepanelImportedContextBanner
+                      context={importedSidepanelContext}
+                      onRemove={clearImportedSidepanelContext}
+                      labels={{
+                        defaultTitle: t(
+                          "playground:sidepanelHandoff.importedContextTitle",
+                          "Imported sidepanel context",
+                        ),
+                        regionLabel: t(
+                          "playground:sidepanelHandoff.importedContextLabel",
+                          "Imported sidepanel context",
+                        ),
+                        removeContext: (title) =>
+                          t(
+                            "playground:sidepanelHandoff.removeContext",
+                            "Remove imported context from {{title}}",
+                            { title },
+                          ),
+                        snippetSummary: (count) =>
+                          t(
+                            "playground:sidepanelHandoff.snippetSummary",
+                            count === 1
+                              ? "{{count}} snippet"
+                              : "{{count}} snippets",
+                            { count },
+                          ),
+                        noSnippets: t(
+                          "playground:sidepanelHandoff.noSnippets",
+                          "No snippets",
+                        ),
+                      }}
+                    />,
+                  )
+                : null}
+              {sidepanelHandoffConflict ? (
+                <div
+                  role="status"
+                  aria-label={t(
+                    "playground:sidepanelHandoff.conflictLabel",
+                    "Sidepanel handoff conflict",
+                  )}
+                  className="mb-2 rounded-md border border-border bg-surface2 px-3 py-2 text-xs text-text"
+                >
+                  <div className="flex flex-wrap items-center justify-between gap-2">
+                    <div className="min-w-0">
+                      <div className="font-medium">
+                        {t(
+                          "playground:sidepanelHandoff.conflictTitle",
+                          "Import sidepanel draft?",
+                        )}
+                      </div>
+                      <div className="text-text-muted">
+                        {t(
+                          "playground:sidepanelHandoff.conflictDescription",
+                          "Your composer already has a draft. Insert the sidepanel draft, replace yours, or cancel the import.",
+                        )}
+                      </div>
+                    </div>
+                    <div className="flex flex-wrap items-center gap-2">
+                      <button
+                        type="button"
+                        onClick={insertHandoffDraft}
+                        className="min-h-7 rounded border border-border bg-surface px-3 py-1 text-xs text-text hover:bg-surface3 focus:outline-none focus-visible:ring-2 focus-visible:ring-focus"
+                      >
+                        {t(
+                          "playground:sidepanelHandoff.insert",
+                          "Insert handoff draft",
+                        )}
+                      </button>
+                      <button
+                        type="button"
+                        onClick={replaceWithHandoffDraft}
+                        className="min-h-7 rounded border border-border bg-surface px-3 py-1 text-xs text-text hover:bg-surface3 focus:outline-none focus-visible:ring-2 focus-visible:ring-focus"
+                      >
+                        {t(
+                          "playground:sidepanelHandoff.replace",
+                          "Replace current draft",
+                        )}
+                      </button>
+                      <button
+                        type="button"
+                        onClick={cancelHandoffImport}
+                        className="min-h-7 rounded border border-border bg-surface px-3 py-1 text-xs text-text hover:bg-surface3 focus:outline-none focus-visible:ring-2 focus-visible:ring-focus"
+                      >
+                        {t("playground:sidepanelHandoff.cancel", "Cancel import")}
+                      </button>
+                    </div>
+                  </div>
+                </div>
+              ) : null}
               {/* Attachments summary (collapsed context management) */}
               {wrapComposerProfile(
                 "attachments-summary",

--- a/apps/packages/ui/src/components/Option/Playground/PlaygroundForm.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/PlaygroundForm.tsx
@@ -3602,6 +3602,7 @@ export const PlaygroundForm = ({
     resolveSubmissionIntent,
     formImage: form.values.image || "",
     formMessage: form.values.message || "",
+    importedSidepanelContext,
     researchContext: compareModeActive ? undefined : researchContext,
     notificationApi,
     t,

--- a/apps/packages/ui/src/components/Option/Playground/SidepanelImportedContextBanner.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/SidepanelImportedContextBanner.tsx
@@ -1,0 +1,63 @@
+import React from "react"
+import { X } from "lucide-react"
+
+import type { SidepanelChatHandoffPageContext } from "@/services/sidepanel-chat-handoff"
+
+export function SidepanelImportedContextBanner({
+  context,
+  onRemove,
+  labels,
+}: {
+  context: SidepanelChatHandoffPageContext
+  onRemove: () => void
+  labels?: {
+    defaultTitle?: string
+    regionLabel?: string
+    removeContext?: (title: string) => string
+    snippetSummary?: (count: number) => string
+    noSnippets?: string
+  }
+}) {
+  const title =
+    context.title || labels?.defaultTitle || "Imported sidepanel context"
+  const snippetCount = context.snippets.length
+  const snippetSummary =
+    snippetCount > 0
+      ? labels?.snippetSummary?.(snippetCount) ??
+        `${snippetCount} snippet${snippetCount === 1 ? "" : "s"}`
+      : labels?.noSnippets ?? "No snippets"
+  const firstSnippetPreview = context.snippets[0]?.text.trim()
+  const preview =
+    firstSnippetPreview && firstSnippetPreview.length > 0
+      ? firstSnippetPreview.slice(0, 120)
+      : null
+  const removeLabel =
+    labels?.removeContext?.(title) || `Remove imported context from ${title}`
+
+  return (
+    <section
+      aria-label={labels?.regionLabel || "Imported sidepanel context"}
+      className="mb-2 rounded-lg border border-border bg-surface2/70 px-3 py-2 text-sm text-text"
+    >
+      <div className="flex min-w-0 items-center justify-between gap-2">
+        <div className="min-w-0">
+          <div className="truncate font-medium">{title}</div>
+          {context.url ? (
+            <div className="truncate text-xs text-text-muted">{context.url}</div>
+          ) : null}
+          <div className="truncate text-xs text-text-muted">
+            {preview ? `${snippetSummary} - ${preview}` : snippetSummary}
+          </div>
+        </div>
+        <button
+          type="button"
+          onClick={onRemove}
+          aria-label={removeLabel}
+          className="rounded p-1 text-text-subtle hover:bg-surface hover:text-text focus:outline-none focus-visible:ring-2 focus-visible:ring-focus"
+        >
+          <X className="h-4 w-4" aria-hidden="true" />
+        </button>
+      </div>
+    </section>
+  )
+}

--- a/apps/packages/ui/src/components/Option/Playground/__tests__/sidepanel-chat-handoff-import.test.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/__tests__/sidepanel-chat-handoff-import.test.tsx
@@ -1,0 +1,657 @@
+// @vitest-environment jsdom
+import React from "react"
+import { render, renderHook, screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import {
+  MemoryRouter,
+  useLocation,
+} from "react-router-dom"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { SidepanelImportedContextBanner } from "../SidepanelImportedContextBanner"
+import { usePlaygroundQueueManagement } from "../hooks/usePlaygroundQueueManagement"
+import { usePlaygroundSubmit } from "../hooks/usePlaygroundSubmit"
+import { useSidepanelChatHandoffImport } from "../hooks/useSidepanelChatHandoffImport"
+import { buildQueuedRequest, type QueuedRequest } from "@/utils/chat-request-queue"
+import type {
+  SidepanelChatHandoffPackage,
+  SidepanelChatHandoffPageContext,
+} from "@/services/sidepanel-chat-handoff"
+
+const serviceMocks = vi.hoisted(() => ({
+  readSidepanelChatHandoff: vi.fn(),
+  consumeSidepanelChatHandoff: vi.fn(),
+  buildSidepanelHandoffMessageForModel: vi.fn(
+    (visibleDraft: string, context?: SidepanelChatHandoffPageContext) =>
+      context
+        ? `MODEL MESSAGE\nTitle: ${context.title ?? ""}\nUser draft: ${visibleDraft}`
+        : visibleDraft,
+  ),
+}))
+
+vi.mock("@/services/sidepanel-chat-handoff", () => serviceMocks)
+
+vi.mock("~/services/tldw-server", () => ({
+  defaultEmbeddingModelForRag: vi.fn(async () => "embedding-model"),
+}))
+
+vi.mock("@/services/search", () => ({
+  getIsSimpleInternetSearch: vi.fn(async () => false),
+}))
+
+vi.mock("@/utils/rag-format", () => ({
+  formatPinnedResults: vi.fn(() => ""),
+}))
+
+vi.mock("@/utils/chat-model-availability", () => ({
+  buildAvailableChatModelIds: vi.fn(() => new Set(["openai:gpt-4o-mini"])),
+  findUnavailableChatModel: vi.fn(() => null),
+  normalizeChatModelId: vi.fn((model: string | null | undefined) => model ?? ""),
+}))
+
+vi.mock("@/utils/image-generation-chat", () => ({
+  IMAGE_GENERATION_ASSISTANT_MESSAGE_TYPE: "image-generation-assistant",
+  IMAGE_GENERATION_USER_MESSAGE_TYPE: "image-generation-user",
+}))
+
+vi.mock("../usage-metrics", () => ({
+  projectTokenBudget: vi.fn(() => ({
+    isOverLimit: false,
+    isNearLimit: false,
+  })),
+}))
+
+vi.mock("@/hooks/chat/chat-action-utils", () => ({
+  isChatSubmitSuccess: vi.fn((result: { status?: string }) =>
+    result?.status === "submitted",
+  ),
+  normalizeChatSubmitResult: vi.fn((result) => result ?? { status: "submitted" }),
+  throwIfChatSubmitUnsuccessful: vi.fn(),
+}))
+
+vi.mock("lucide-react", () => {
+  const Icon = (props: React.SVGProps<SVGSVGElement>) => <svg {...props} />
+  return new Proxy(
+    { X: Icon },
+    {
+      get: (target, prop) => {
+        if (prop === "then") return undefined
+        return prop in target ? target[prop as keyof typeof target] : Icon
+      },
+    },
+  )
+})
+
+const importedPageContext: SidepanelChatHandoffPageContext = {
+  title: "Imported article",
+  url: "https://example.test/article",
+  snippets: [
+    {
+      kind: "visible-context",
+      label: "Current page",
+      text: "Important imported page context.",
+    },
+  ],
+}
+
+const buildPackage = (
+  overrides: Partial<SidepanelChatHandoffPackage> = {},
+): SidepanelChatHandoffPackage => ({
+  id: "handoff-1",
+  source: "sidepanel-chat",
+  createdAt: "2026-05-29T10:00:00.000Z",
+  expiresAt: "2026-05-29T10:10:00.000Z",
+  draft: { text: "Imported draft" },
+  pageContext: importedPageContext,
+  ...overrides,
+})
+
+const notificationApi = {
+  warning: vi.fn(),
+  error: vi.fn(),
+  info: vi.fn(),
+}
+
+const submitHarnessSendMessage = vi.fn<(payload: any) => Promise<null>>(
+  async () => null,
+)
+
+const t = (_key: string, fallback?: any) =>
+  typeof fallback === "string" ? fallback : _key
+
+const LocationProbe = ({
+  onChange,
+}: {
+  onChange?: (location: ReturnType<typeof useLocation>) => void
+}) => {
+  const location = useLocation()
+  React.useEffect(() => {
+    onChange?.(location)
+  }, [location, onChange])
+
+  return <div data-testid="location-search">{location.search}</div>
+}
+
+const HookHarness = ({
+  initialDraft = "",
+  onLocationChange,
+}: {
+  initialDraft?: string
+  onLocationChange?: (location: ReturnType<typeof useLocation>) => void
+}) => {
+  const [draft, setDraft] = React.useState(initialDraft)
+  const handoffImport = useSidepanelChatHandoffImport({
+    draftValue: draft,
+    setMessageValue: (value) => setDraft(value),
+    notificationApi,
+    t,
+  })
+
+  return (
+    <div>
+      <LocationProbe onChange={onLocationChange} />
+      <textarea
+        aria-label="Composer"
+        value={draft}
+        onChange={(event) => setDraft(event.target.value)}
+      />
+      {handoffImport.importedContext ? (
+        <SidepanelImportedContextBanner
+          context={handoffImport.importedContext}
+          onRemove={handoffImport.removeImportedContext}
+        />
+      ) : null}
+      {handoffImport.conflict ? (
+        <div role="status" aria-label="Sidepanel handoff conflict">
+          <button type="button" onClick={handoffImport.insertHandoffDraft}>
+            Insert
+          </button>
+          <button type="button" onClick={handoffImport.replaceWithHandoffDraft}>
+            Replace
+          </button>
+          <button type="button" onClick={handoffImport.cancelHandoffImport}>
+            Cancel
+          </button>
+        </div>
+      ) : null}
+    </div>
+  )
+}
+
+const baseSubmitDeps = (overrides: Record<string, unknown> = {}) => ({
+  form: {
+    onSubmit: (callback: (value: any) => void | Promise<void>) =>
+      () => void callback({ message: "Ask about this", image: "" }),
+    setFieldValue: vi.fn(),
+    setFieldError: vi.fn(),
+    reset: vi.fn(),
+  },
+  isSending: false,
+  isConnectionReady: true,
+  webSearch: false,
+  compareModeActive: false,
+  compareSelectedModels: [],
+  selectedModel: "openai:gpt-4o-mini",
+  fileRetrievalEnabled: false,
+  ragPinnedResults: [],
+  selectedDocuments: [],
+  uploadedFiles: [],
+  currentContextSnapshot: {},
+  conversationTokenCount: 0,
+  characterContextTokenEstimate: 0,
+  pinnedSourceTokenEstimate: 0,
+  resolvedMaxContext: 100_000,
+  jsonMode: false,
+  sendMessage: vi.fn(async () => null),
+  clearSelectedDocuments: vi.fn(),
+  clearUploadedFiles: vi.fn(),
+  textAreaFocus: vi.fn(),
+  setLastSubmittedContext: vi.fn(),
+  estimateTokensForText: vi.fn(() => 1),
+  resolveSubmissionIntent: vi.fn((message: string) => ({
+    message,
+    handled: false,
+    invalidImageCommand: false,
+    isImageCommand: false,
+  })),
+  queueSubmission: vi.fn(),
+  validateSelectedChatModelsAvailability: vi.fn(() => true),
+  compareModelsSupportCapability: vi.fn(() => true),
+  notificationApi,
+  t,
+  ...overrides,
+})
+
+const SubmitImportHarness = ({
+  submitOverrides,
+}: {
+  submitOverrides?: Record<string, unknown>
+}) => {
+  const [draft, setDraft] = React.useState("")
+  const handoffImport = useSidepanelChatHandoffImport({
+    draftValue: draft,
+    setMessageValue: (value) => setDraft(value),
+    notificationApi,
+    t,
+  })
+  const form = React.useMemo(
+    () => ({
+      values: { message: draft, image: "" },
+      onSubmit: (callback: (value: any) => void | Promise<void>) =>
+        () => void callback({ message: draft, image: "" }),
+      setFieldValue: (field: string, value: string) => {
+        if (field === "message") setDraft(value)
+      },
+      setFieldError: vi.fn(),
+      reset: () => setDraft(""),
+    }),
+    [draft],
+  )
+  const { submitForm } = usePlaygroundSubmit(
+    baseSubmitDeps({
+      form,
+      sendMessage: submitHarnessSendMessage,
+      importedSidepanelContext: handoffImport.importedContext,
+      clearImportedSidepanelContext: handoffImport.removeImportedContext,
+      ...(submitOverrides ?? {}),
+    }) as any,
+  )
+
+  return (
+    <div>
+      <textarea aria-label="Composer" value={draft} readOnly />
+      {handoffImport.importedContext ? (
+        <SidepanelImportedContextBanner
+          context={handoffImport.importedContext}
+          onRemove={handoffImport.removeImportedContext}
+        />
+      ) : null}
+      <button type="button" onClick={() => submitForm()}>
+        Send
+      </button>
+    </div>
+  )
+}
+
+const renderWithRoute = (
+  ui: React.ReactElement,
+  initialEntry = "/chat?handoff=handoff-1",
+) => render(<MemoryRouter initialEntries={[initialEntry]}>{ui}</MemoryRouter>)
+
+describe("sidepanel chat handoff import", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    submitHarnessSendMessage.mockResolvedValue(null)
+    serviceMocks.readSidepanelChatHandoff.mockResolvedValue(buildPackage())
+    serviceMocks.consumeSidepanelChatHandoff.mockResolvedValue(buildPackage())
+  })
+
+  it("imports a valid handoff, pre-fills the composer, renders context, then consumes the package", async () => {
+    renderWithRoute(<HookHarness />)
+
+    await waitFor(() =>
+      expect(screen.getByLabelText("Composer")).toHaveValue("Imported draft"),
+    )
+
+    expect(
+      screen.getByRole("region", { name: "Imported sidepanel context" }),
+    ).toHaveTextContent("Imported article")
+    expect(screen.getByTestId("location-search").textContent).toBe("")
+    await waitFor(() =>
+      expect(serviceMocks.consumeSidepanelChatHandoff).toHaveBeenCalledWith(
+        "handoff-1",
+      ),
+    )
+  })
+
+  it("does not consume before successful import when an existing local draft requires conflict resolution", async () => {
+    renderWithRoute(<HookHarness initialDraft="Local draft" />)
+
+    await screen.findByRole("status", {
+      name: "Sidepanel handoff conflict",
+    })
+
+    expect(screen.getByLabelText("Composer")).toHaveValue("Local draft")
+    expect(serviceMocks.consumeSidepanelChatHandoff).not.toHaveBeenCalled()
+  })
+
+  it("offers insert, replace, and cancel when a local draft exists", async () => {
+    const user = userEvent.setup()
+    let view = renderWithRoute(<HookHarness initialDraft="Local draft" />)
+
+    expect(
+      await screen.findByRole("button", { name: "Insert" }),
+    ).toBeVisible()
+    expect(screen.getByRole("button", { name: "Replace" })).toBeVisible()
+    expect(screen.getByRole("button", { name: "Cancel" })).toBeVisible()
+
+    await user.click(screen.getByRole("button", { name: "Insert" }))
+    expect(screen.getByLabelText("Composer")).toHaveValue(
+      "Local draft\n\nImported draft",
+    )
+    await waitFor(() =>
+      expect(serviceMocks.consumeSidepanelChatHandoff).toHaveBeenCalledWith(
+        "handoff-1",
+      ),
+    )
+
+    view.unmount()
+    vi.clearAllMocks()
+    serviceMocks.readSidepanelChatHandoff.mockResolvedValue(buildPackage())
+    view = renderWithRoute(<HookHarness initialDraft="Local draft" />)
+    await user.click(await screen.findByRole("button", { name: "Replace" }))
+    expect(screen.getByLabelText("Composer")).toHaveValue("Imported draft")
+    await waitFor(() =>
+      expect(serviceMocks.consumeSidepanelChatHandoff).toHaveBeenCalledWith(
+        "handoff-1",
+      ),
+    )
+
+    view.unmount()
+    vi.clearAllMocks()
+    serviceMocks.readSidepanelChatHandoff.mockResolvedValue(buildPackage())
+    renderWithRoute(<HookHarness initialDraft="Local draft" />)
+    await user.click(await screen.findByRole("button", { name: "Cancel" }))
+    expect(screen.getByLabelText("Composer")).toHaveValue("Local draft")
+    await waitFor(() =>
+      expect(serviceMocks.consumeSidepanelChatHandoff).toHaveBeenCalledWith(
+        "handoff-1",
+      ),
+    )
+  })
+
+  it("cleans only handoff from the hash-route query and preserves character params", async () => {
+    renderWithRoute(
+      <HookHarness />,
+      "/chat?mode=character&characterId=char-1&handoff=handoff-1",
+    )
+
+    await waitFor(() =>
+      expect(screen.getByLabelText("Composer")).toHaveValue("Imported draft"),
+    )
+
+    expect(screen.getByTestId("location-search").textContent).toBe(
+      "?mode=character&characterId=char-1",
+    )
+  })
+
+  it("includes imported page context in requestOverrides.messageForModel on submit", async () => {
+    const user = userEvent.setup()
+    renderWithRoute(<SubmitImportHarness />)
+
+    await waitFor(() =>
+      expect(screen.getByLabelText("Composer")).toHaveValue("Imported draft"),
+    )
+    await user.click(screen.getByRole("button", { name: "Send" }))
+
+    await waitFor(() =>
+      expect(
+        serviceMocks.buildSidepanelHandoffMessageForModel,
+      ).toHaveBeenCalledWith("Imported draft", importedPageContext),
+    )
+    expect(submitHarnessSendMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: "Imported draft",
+        requestOverrides: {
+          messageForModel:
+            "MODEL MESSAGE\nTitle: Imported article\nUser draft: Imported draft",
+        },
+      }),
+    )
+  })
+
+  it("sends a context-only handoff with a visible fallback prompt", async () => {
+    const user = userEvent.setup()
+    serviceMocks.readSidepanelChatHandoff.mockResolvedValue(
+      buildPackage({ draft: { text: "" } }),
+    )
+
+    renderWithRoute(<SubmitImportHarness />)
+
+    await screen.findByRole("region", { name: "Imported sidepanel context" })
+    expect(screen.getByLabelText("Composer")).toHaveValue("")
+
+    await user.click(screen.getByRole("button", { name: "Send" }))
+
+    await waitFor(() =>
+      expect(
+        serviceMocks.buildSidepanelHandoffMessageForModel,
+      ).toHaveBeenCalledWith("Summarize this page.", importedPageContext),
+    )
+    expect(submitHarnessSendMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: "Summarize this page.",
+        requestOverrides: {
+          messageForModel:
+            "MODEL MESSAGE\nTitle: Imported article\nUser draft: Summarize this page.",
+        },
+      }),
+    )
+  })
+
+  it("preserves imported page context when the send is queued", async () => {
+    const user = userEvent.setup()
+    const queueSubmission = vi.fn(() => ({ id: "queued-1" }))
+    renderWithRoute(
+      <SubmitImportHarness
+        submitOverrides={{ isSending: true, queueSubmission }}
+      />,
+    )
+
+    await waitFor(() =>
+      expect(screen.getByLabelText("Composer")).toHaveValue("Imported draft"),
+    )
+    await user.click(screen.getByRole("button", { name: "Send" }))
+
+    expect(queueSubmission).toHaveBeenCalledWith(
+      expect.objectContaining({
+        promptText: "Imported draft",
+        requestOverrides: {
+          messageForModel:
+            "MODEL MESSAGE\nTitle: Imported article\nUser draft: Imported draft",
+        },
+      }),
+    )
+    expect(submitHarnessSendMessage).not.toHaveBeenCalled()
+    expect(
+      screen.queryByRole("region", { name: "Imported sidepanel context" }),
+    ).not.toBeInTheDocument()
+  })
+
+  it("keeps imported page context when a resolved submit reports failure", async () => {
+    const user = userEvent.setup()
+    const sendMessage = vi.fn(async () => ({
+      status: "failed" as const,
+      errorMessage: "provider unavailable",
+    }))
+    renderWithRoute(<SubmitImportHarness submitOverrides={{ sendMessage }} />)
+
+    await waitFor(() =>
+      expect(screen.getByLabelText("Composer")).toHaveValue("Imported draft"),
+    )
+    await user.click(screen.getByRole("button", { name: "Send" }))
+
+    await waitFor(() => expect(sendMessage).toHaveBeenCalledTimes(1))
+    expect(
+      screen.getByRole("region", { name: "Imported sidepanel context" }),
+    ).toBeInTheDocument()
+  })
+
+  it("replays queued sidepanel context into requestOverrides.messageForModel", async () => {
+    const queued = buildQueuedRequest({
+      promptText: "Imported draft",
+      sourceContext: {
+        documents: [],
+        isImageCommand: false,
+        requestOverrides: {
+          messageForModel: "MODEL MESSAGE\nUser draft: Imported draft",
+        },
+      },
+      snapshot: {
+        selectedModel: "openai:gpt-4o-mini",
+        chatMode: "normal",
+        webSearch: false,
+        compareMode: false,
+        compareSelectedModels: [],
+        selectedSystemPrompt: null,
+        selectedQuickPrompt: null,
+        toolChoice: null,
+        useOCR: false,
+      },
+    })
+    const queueRef: { current: QueuedRequest[] } = { current: [queued] }
+    const setQueuedMessages = vi.fn(
+      (
+        next:
+          | QueuedRequest[]
+          | ((prev: QueuedRequest[]) => QueuedRequest[]),
+      ) => {
+        queueRef.current =
+          typeof next === "function" ? next(queueRef.current) : next
+      },
+    )
+    const sendMessage = vi.fn(async () => ({ status: "submitted" as const }))
+
+    renderHook(() =>
+      usePlaygroundQueueManagement({
+        composerModels: [{ id: "openai:gpt-4o-mini", is_configured: true }],
+        isConnectionReady: true,
+        isSending: false,
+        selectedModel: "openai:gpt-4o-mini",
+        chatMode: "normal",
+        webSearch: false,
+        compareMode: false,
+        compareModeActive: false,
+        compareSelectedModels: [],
+        selectedSystemPrompt: "",
+        selectedQuickPrompt: null,
+        toolChoice: "auto",
+        useOCR: false,
+        selectedDocuments: [],
+        uploadedFiles: [],
+        contextFiles: [],
+        documentContext: [],
+        queuedMessages: queueRef.current,
+        setQueuedMessages,
+        historyId: null,
+        serverChatId: null,
+        conversationTokenCount: 0,
+        resolvedMaxContext: 100_000,
+        estimateTokensForText: vi.fn(() => 1),
+        characterContextTokenEstimate: 0,
+        pinnedSourceTokenEstimate: 0,
+        currentContextSnapshot: {},
+        setLastSubmittedContext: vi.fn(),
+        setSelectedModel: vi.fn(),
+        setChatMode: vi.fn(),
+        setWebSearch: vi.fn(),
+        setCompareMode: vi.fn(),
+        setCompareSelectedModels: vi.fn(),
+        setSelectedSystemPrompt: vi.fn(),
+        setSelectedQuickPrompt: vi.fn(),
+        setToolChoice: vi.fn(),
+        setUseOCR: vi.fn(),
+        compareModelsSupportCapability: vi.fn(() => true),
+        sendMessage,
+        stopStreamingRequest: vi.fn(),
+        form: {
+          setFieldError: vi.fn(),
+          reset: vi.fn(),
+        },
+        clearSelectedDocuments: vi.fn(),
+        clearUploadedFiles: vi.fn(),
+        textAreaFocus: vi.fn(),
+        notificationApi,
+        t,
+      }),
+    )
+
+    await waitFor(() => expect(sendMessage).toHaveBeenCalledTimes(1))
+    expect(sendMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: "Imported draft",
+        requestOverrides: expect.objectContaining({
+          messageForModel: "MODEL MESSAGE\nUser draft: Imported draft",
+        }),
+      }),
+    )
+  })
+
+  it("omits imported page context after the user removes the banner", async () => {
+    const user = userEvent.setup()
+    const sendMessage = vi.fn<(payload: any) => Promise<null>>(async () => null)
+    const SubmitHarness = () => {
+      const [draft, setDraft] = React.useState("")
+      const handoffImport = useSidepanelChatHandoffImport({
+        draftValue: draft,
+        setMessageValue: (value) => setDraft(value),
+        notificationApi,
+        t,
+      })
+      const form = React.useMemo(
+        () => ({
+          values: { message: draft, image: "" },
+          onSubmit: (callback: (value: any) => void | Promise<void>) =>
+            () => void callback({ message: draft, image: "" }),
+          setFieldValue: (field: string, value: string) => {
+            if (field === "message") setDraft(value)
+          },
+          setFieldError: vi.fn(),
+          reset: () => setDraft(""),
+        }),
+        [draft],
+      )
+      const { submitForm } = usePlaygroundSubmit(
+        baseSubmitDeps({
+          form,
+          sendMessage,
+          importedSidepanelContext: handoffImport.importedContext,
+          clearImportedSidepanelContext: handoffImport.removeImportedContext,
+        }) as any,
+      )
+
+      return (
+        <div>
+          <textarea aria-label="Composer" value={draft} readOnly />
+          {handoffImport.importedContext ? (
+            <SidepanelImportedContextBanner
+              context={handoffImport.importedContext}
+              onRemove={handoffImport.removeImportedContext}
+            />
+          ) : null}
+          <button type="button" onClick={() => submitForm()}>
+            Send
+          </button>
+        </div>
+      )
+    }
+
+    renderWithRoute(<SubmitHarness />)
+
+    await screen.findByRole("region", { name: "Imported sidepanel context" })
+    await user.click(
+      screen.getByRole("button", {
+        name: /remove imported context from imported article/i,
+      }),
+    )
+    expect(
+      screen.queryByRole("region", { name: "Imported sidepanel context" }),
+    ).not.toBeInTheDocument()
+
+    await user.click(screen.getByRole("button", { name: "Send" }))
+
+    await waitFor(() => expect(sendMessage).toHaveBeenCalledTimes(1))
+    expect(sendMessage.mock.calls[0][0]).not.toHaveProperty("requestOverrides")
+  })
+
+  it("shows non-blocking feedback for expired or malformed handoffs", async () => {
+    serviceMocks.readSidepanelChatHandoff.mockResolvedValue(null)
+
+    renderWithRoute(<HookHarness initialDraft="Keep local" />)
+
+    await waitFor(() => expect(notificationApi.warning).toHaveBeenCalled())
+    expect(screen.getByLabelText("Composer")).toHaveValue("Keep local")
+    expect(screen.getByTestId("location-search").textContent).toBe("")
+    expect(serviceMocks.consumeSidepanelChatHandoff).not.toHaveBeenCalled()
+  })
+})

--- a/apps/packages/ui/src/components/Option/Playground/__tests__/usePlaygroundRawPreview.mcp-tools.test.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/__tests__/usePlaygroundRawPreview.mcp-tools.test.tsx
@@ -56,6 +56,73 @@ const buildDeps = (overrides: Partial<any> = {}) => ({
 })
 
 describe("usePlaygroundRawPreview MCP tools", () => {
+  it("includes imported sidepanel context in the normal raw request preview", async () => {
+    const { result } = renderHook(() =>
+      usePlaygroundRawPreview(
+        buildDeps({
+          formMessage: "What changed?",
+          importedSidepanelContext: {
+            title: "Release Notes",
+            url: "https://example.test/releases",
+            snippets: [
+              {
+                kind: "selection",
+                label: "selected text",
+                text: "The sidepanel handoff carries selected page context."
+              }
+            ]
+          }
+        })
+      )
+    )
+
+    await act(async () => {
+      await result.current.refreshRawRequestSnapshot()
+    })
+
+    const body = result.current.rawRequestSnapshot?.body as any
+    const lastMessage = body.messages.at(-1)
+    expect(lastMessage.content).toBe(
+      [
+        "Sidepanel page context:",
+        "Title: Release Notes",
+        "URL: https://example.test/releases",
+        "Snippet 1 (selected text): The sidepanel handoff carries selected page context.",
+        "User draft:",
+        "What changed?"
+      ].join("\n")
+    )
+  })
+
+  it("uses the context-only sidepanel fallback in the raw request preview", async () => {
+    const { result } = renderHook(() =>
+      usePlaygroundRawPreview(
+        buildDeps({
+          formMessage: "",
+          importedSidepanelContext: {
+            title: "Empty Draft Page",
+            snippets: [
+              {
+                kind: "visible-context",
+                text: "This is the only available context."
+              }
+            ]
+          }
+        })
+      )
+    )
+
+    await act(async () => {
+      await result.current.refreshRawRequestSnapshot()
+    })
+
+    const body = result.current.rawRequestSnapshot?.body as any
+    const lastMessage = body.messages.at(-1)
+    expect(lastMessage.content).toContain("Title: Empty Draft Page")
+    expect(lastMessage.content).toContain("Snippet 1: This is the only available context.")
+    expect(lastMessage.content).toContain("User draft:\nSummarize this page.")
+  })
+
   it("normalizes chat tools in the raw request preview", async () => {
     const { result } = renderHook(() =>
       usePlaygroundRawPreview(

--- a/apps/packages/ui/src/components/Option/Playground/hooks/usePlaygroundQueueManagement.ts
+++ b/apps/packages/ui/src/components/Option/Playground/hooks/usePlaygroundQueueManagement.ts
@@ -25,6 +25,9 @@ type PlaygroundQueuedSourceContext = {
   documents?: ChatDocuments
   imageBackendOverride?: string
   isImageCommand?: boolean
+  requestOverrides?: {
+    messageForModel?: string
+  }
 }
 
 type SubmissionIntent = {
@@ -351,6 +354,7 @@ export function usePlaygroundQueueManagement(
         requestOverrides: {
           selectedModel: item.snapshot.selectedModel,
           selectedSystemPrompt: item.snapshot.selectedSystemPrompt,
+          ...(sourceContext?.requestOverrides ?? {}),
           toolChoice:
             item.snapshot.toolChoice === "auto" ||
             item.snapshot.toolChoice === "required" ||
@@ -476,11 +480,15 @@ export function usePlaygroundQueueManagement(
     ({
       promptText,
       image,
-      intent
+      intent,
+      requestOverrides
     }: {
       promptText: string
       image: string
       intent: SubmissionIntent
+      requestOverrides?: {
+        messageForModel?: string
+      }
     }) => {
       const documents = buildQueuedDocuments()
       return queue.enqueue({
@@ -492,7 +500,8 @@ export function usePlaygroundQueueManagement(
           imageBackendOverride: intent.isImageCommand
             ? intent.imageBackendOverride
             : undefined,
-          isImageCommand: intent.isImageCommand
+          isImageCommand: intent.isImageCommand,
+          requestOverrides
         },
         blockedReason: isQueuedDispatchBlockedByComposerState
           ? "draft-attachments-conflict"

--- a/apps/packages/ui/src/components/Option/Playground/hooks/usePlaygroundRawPreview.ts
+++ b/apps/packages/ui/src/components/Option/Playground/hooks/usePlaygroundRawPreview.ts
@@ -17,6 +17,10 @@ import {
   deriveRolePlayCompatibility,
   type RolePlayCompatibility
 } from "../role-play-compatibility"
+import {
+  buildSidepanelHandoffMessageForModel,
+  type SidepanelChatHandoffPageContext
+} from "@/services/sidepanel-chat-handoff"
 
 // ---------------------------------------------------------------------------
 // Deps interface
@@ -80,6 +84,7 @@ export interface UsePlaygroundRawPreviewDeps {
   }
   formImage: string
   formMessage: string
+  importedSidepanelContext?: SidepanelChatHandoffPageContext | null
   researchContext?: ChatResearchContext
   notificationApi: {
     error: (opts: { message: string; description?: string }) => void
@@ -136,6 +141,7 @@ export function usePlaygroundRawPreview(deps: UsePlaygroundRawPreviewDeps) {
     resolveSubmissionIntent,
     formImage,
     formMessage,
+    importedSidepanelContext,
     researchContext,
     notificationApi,
     t,
@@ -385,6 +391,18 @@ export function usePlaygroundRawPreview(deps: UsePlaygroundRawPreviewDeps) {
       const pinnedText = formatPinnedResults(ragPinnedResults, "markdown")
       draftMessage = draftMessage ? `${draftMessage}\n\n${pinnedText}` : pinnedText
     }
+    const modelDraftMessage =
+      !intent.isImageCommand && importedSidepanelContext
+        ? buildSidepanelHandoffMessageForModel(
+            draftMessage.trim().length > 0
+              ? draftMessage.trim()
+              : t(
+                  "playground:sidepanelHandoff.contextOnlyDraft",
+                  "Summarize this page."
+                ),
+            importedSidepanelContext
+          )
+        : draftMessage
     const draftImage = intent.isImageCommand ? "" : String(formImage || "")
     const isCharacterFlow =
       Boolean(selectedCharacter?.id) &&
@@ -427,7 +445,7 @@ export function usePlaygroundRawPreview(deps: UsePlaygroundRawPreviewDeps) {
       const chatIdHint = serverChatId || "<new-chat-id>"
       const messagePayload: Record<string, unknown> = {
         role: "user",
-        content: draftMessage
+        content: modelDraftMessage
       }
       const normalizedImage = String(formImage || "")
       if (normalizedImage.startsWith("data:")) {
@@ -513,7 +531,7 @@ export function usePlaygroundRawPreview(deps: UsePlaygroundRawPreviewDeps) {
     if (limitedModels.length === 1) {
       const preview = await buildNormalPreviewRequest(
         limitedModels[0],
-        draftMessage,
+        modelDraftMessage,
         draftImage
       )
       return {
@@ -528,7 +546,7 @@ export function usePlaygroundRawPreview(deps: UsePlaygroundRawPreviewDeps) {
 
     const previews = await Promise.all(
       limitedModels.map((modelId) =>
-        buildNormalPreviewRequest(modelId, draftMessage, draftImage)
+        buildNormalPreviewRequest(modelId, modelDraftMessage, draftImage)
       )
     )
     return {
@@ -555,6 +573,7 @@ export function usePlaygroundRawPreview(deps: UsePlaygroundRawPreviewDeps) {
     formImage,
     formMessage,
     imageBackendDefaultTrimmed,
+    importedSidepanelContext,
     messageSteeringForceNarrate,
     messageSteeringMode,
     ragPinnedResults,
@@ -565,6 +584,7 @@ export function usePlaygroundRawPreview(deps: UsePlaygroundRawPreviewDeps) {
     serverChatId,
     serverChatSource,
     serverChatState,
+    t,
     temporaryChat
   ])
 

--- a/apps/packages/ui/src/components/Option/Playground/hooks/usePlaygroundSubmit.ts
+++ b/apps/packages/ui/src/components/Option/Playground/hooks/usePlaygroundSubmit.ts
@@ -11,7 +11,22 @@ import {
   projectTokenBudget
 } from "../usage-metrics"
 import { useComposerSubmit } from "@/components/Chat/composer/hooks/useComposerSubmit"
+import {
+  isChatSubmitSuccess,
+  normalizeChatSubmitResult
+} from "@/hooks/chat/chat-action-utils"
 import type { ChatResearchContext } from "@/services/tldw/TldwApiClient"
+import {
+  buildSidepanelHandoffMessageForModel,
+  type SidepanelChatHandoffPageContext
+} from "@/services/sidepanel-chat-handoff"
+
+type PlaygroundQueueSubmissionArgs = {
+  promptText: string
+  image: string
+  intent: any
+  requestOverrides?: Record<string, unknown>
+}
 
 export type UsePlaygroundSubmitDeps = {
   form: any
@@ -32,6 +47,8 @@ export type UsePlaygroundSubmitDeps = {
   resolvedMaxContext: number
   jsonMode: boolean
   researchContext?: ChatResearchContext
+  importedSidepanelContext?: SidepanelChatHandoffPageContext | null
+  clearImportedSidepanelContext?: () => void
   sendMessage: (args: any) => Promise<any>
   clearSelectedDocuments: () => void
   clearUploadedFiles: () => void
@@ -39,7 +56,7 @@ export type UsePlaygroundSubmitDeps = {
   setLastSubmittedContext: (ctx: any) => void
   estimateTokensForText: (text: string) => number
   resolveSubmissionIntent: (message: string) => any
-  queueSubmission: (args: any) => void
+  queueSubmission: (args: PlaygroundQueueSubmissionArgs) => unknown
   validateSelectedChatModelsAvailability: (models: string[]) => boolean
   compareModelsSupportCapability: (models: string[], cap: string) => boolean
   notificationApi: any
@@ -66,6 +83,8 @@ export function usePlaygroundSubmit(deps: UsePlaygroundSubmitDeps) {
     resolvedMaxContext,
     jsonMode,
     researchContext,
+    importedSidepanelContext,
+    clearImportedSidepanelContext,
     sendMessage,
     clearSelectedDocuments,
     clearUploadedFiles,
@@ -125,9 +144,28 @@ export function usePlaygroundSubmit(deps: UsePlaygroundSubmitDeps) {
         ? nextMessage
         : buildPinnedMessage(nextMessage, options)
       const trimmed = combinedMessage.trim()
-      if (
+      const visiblePrompt =
         !intent.isImageCommand &&
         trimmed.length === 0 &&
+        importedSidepanelContext
+          ? t(
+              "playground:sidepanelHandoff.contextOnlyDraft",
+              "Summarize this page."
+            )
+          : trimmed
+      const messageForModel =
+        !intent.isImageCommand && importedSidepanelContext
+          ? buildSidepanelHandoffMessageForModel(
+              visiblePrompt,
+              importedSidepanelContext
+            )
+          : undefined
+      const requestOverrides = messageForModel
+        ? { messageForModel }
+        : undefined
+      if (
+        !intent.isImageCommand &&
+        visiblePrompt.length === 0 &&
         value.image.length === 0 &&
         selectedDocuments.length === 0 &&
         uploadedFiles.length === 0
@@ -190,11 +228,15 @@ export function usePlaygroundSubmit(deps: UsePlaygroundSubmitDeps) {
       }
 
       if (shouldQueueInsteadOfSend) {
-        queueSubmission({
-          promptText: trimmed,
+        const queuedItem = queueSubmission({
+          promptText: visiblePrompt,
           image: value.image,
-          intent
+          intent,
+          requestOverrides
         })
+        if (queuedItem && messageForModel) {
+          clearImportedSidepanelContext?.()
+        }
         return
       }
 
@@ -215,7 +257,7 @@ export function usePlaygroundSubmit(deps: UsePlaygroundSubmitDeps) {
           conversationTokenCount +
           characterContextTokenEstimate +
           pinnedSourceTokenEstimate,
-        draftTokens: estimateTokensForText(trimmed),
+        draftTokens: estimateTokensForText(messageForModel ?? visiblePrompt),
         maxTokens: resolvedMaxContext
       })
       if (projectedForSubmission.isOverLimit || projectedForSubmission.isNearLimit) {
@@ -233,9 +275,10 @@ export function usePlaygroundSubmit(deps: UsePlaygroundSubmitDeps) {
         })
       }
       setLastSubmittedContext(currentContextSnapshot)
-      await dispatch({
+
+      const payload = {
         image: intent.isImageCommand ? "" : value.image,
-        message: trimmed,
+        message: visiblePrompt,
         docs: intent.isImageCommand
           ? []
           : selectedDocuments.map((doc: any) => ({
@@ -260,7 +303,19 @@ export function usePlaygroundSubmit(deps: UsePlaygroundSubmitDeps) {
         researchContext:
           intent.isImageCommand || compareModeActive
             ? undefined
-            : researchContext
+            : researchContext,
+        ...(requestOverrides ? { requestOverrides } : {})
+      }
+
+      await dispatch(payload, {
+        afterSend: (result) => {
+          if (
+            messageForModel &&
+            isChatSubmitSuccess(normalizeChatSubmitResult(result as any))
+          ) {
+            clearImportedSidepanelContext?.()
+          }
+        }
       })
     })()
   }

--- a/apps/packages/ui/src/components/Option/Playground/hooks/useSidepanelChatHandoffImport.ts
+++ b/apps/packages/ui/src/components/Option/Playground/hooks/useSidepanelChatHandoffImport.ts
@@ -1,0 +1,172 @@
+import React from "react"
+import { useLocation, useNavigate } from "react-router-dom"
+
+import {
+  consumeSidepanelChatHandoff,
+  readSidepanelChatHandoff,
+  type SidepanelChatHandoffPackage,
+  type SidepanelChatHandoffPageContext,
+} from "@/services/sidepanel-chat-handoff"
+
+type SetMessageValue = (
+  value: string,
+  options?: { collapseLarge?: boolean; forceCollapse?: boolean },
+) => void
+
+type NotificationApi = {
+  warning?: (args: { message: string; description?: string }) => void
+}
+
+export type SidepanelChatHandoffConflict = {
+  handoff: SidepanelChatHandoffPackage
+}
+
+type UseSidepanelChatHandoffImportDeps = {
+  draftValue: string
+  setMessageValue: SetMessageValue
+  notificationApi?: NotificationApi
+  t: (key: string, defaultValueOrOptions?: any, options?: any) => string
+}
+
+const appendImportedDraft = (currentDraft: string, importedDraft: string) => {
+  if (!currentDraft.trim()) return importedDraft
+  if (!importedDraft.trim()) return currentDraft
+  return `${currentDraft.trimEnd()}\n\n${importedDraft}`
+}
+
+export function useSidepanelChatHandoffImport({
+  draftValue,
+  setMessageValue,
+  notificationApi,
+  t,
+}: UseSidepanelChatHandoffImportDeps) {
+  const location = useLocation()
+  const navigate = useNavigate()
+  const [importedContext, setImportedContext] =
+    React.useState<SidepanelChatHandoffPageContext | null>(null)
+  const [conflict, setConflict] =
+    React.useState<SidepanelChatHandoffConflict | null>(null)
+  const draftValueRef = React.useRef(draftValue)
+  const handledHandoffIdsRef = React.useRef(new Set<string>())
+
+  React.useEffect(() => {
+    draftValueRef.current = draftValue
+  }, [draftValue])
+
+  const cleanRouteHandoff = React.useCallback(() => {
+    const params = new URLSearchParams(location.search)
+    if (!params.has("handoff")) return
+    params.delete("handoff")
+    const search = params.toString()
+    navigate(
+      {
+        pathname: location.pathname,
+        search: search ? `?${search}` : "",
+        hash: location.hash,
+      },
+      { replace: true },
+    )
+  }, [location.hash, location.pathname, location.search, navigate])
+
+  const showInvalidFeedback = React.useCallback(() => {
+    notificationApi?.warning?.({
+      message: t(
+        "playground:sidepanelHandoff.unavailableTitle",
+        "Sidepanel handoff unavailable",
+      ),
+      description: t(
+        "playground:sidepanelHandoff.unavailableDescription",
+        "The imported sidepanel draft expired or could not be read. You can keep chatting normally.",
+      ),
+    })
+  }, [notificationApi, t])
+
+  const consumeQuietly = React.useCallback((handoffId: string) => {
+    void consumeSidepanelChatHandoff(handoffId).catch(() => undefined)
+  }, [])
+
+  const applyImportedHandoff = React.useCallback(
+    (
+      handoff: SidepanelChatHandoffPackage,
+      nextDraft: string,
+      options?: { consume?: boolean },
+    ) => {
+      setMessageValue(nextDraft, { collapseLarge: true })
+      setImportedContext(handoff.pageContext ?? null)
+      setConflict(null)
+      cleanRouteHandoff()
+      handledHandoffIdsRef.current.add(handoff.id)
+      if (options?.consume !== false) {
+        queueMicrotask(() => consumeQuietly(handoff.id))
+      }
+    },
+    [cleanRouteHandoff, consumeQuietly, setMessageValue],
+  )
+
+  React.useEffect(() => {
+    const params = new URLSearchParams(location.search)
+    const handoffId = params.get("handoff")
+    if (!handoffId || handledHandoffIdsRef.current.has(handoffId)) return
+
+    let cancelled = false
+
+    void (async () => {
+      const handoff = await readSidepanelChatHandoff(handoffId)
+      if (cancelled) return
+
+      if (!handoff) {
+        handledHandoffIdsRef.current.add(handoffId)
+        setConflict(null)
+        showInvalidFeedback()
+        cleanRouteHandoff()
+        return
+      }
+
+      if (draftValueRef.current.trim().length > 0) {
+        handledHandoffIdsRef.current.add(handoff.id)
+        setConflict({ handoff })
+        return
+      }
+
+      applyImportedHandoff(handoff, handoff.draft.text)
+    })()
+
+    return () => {
+      cancelled = true
+    }
+  }, [applyImportedHandoff, cleanRouteHandoff, location.search, showInvalidFeedback])
+
+  const removeImportedContext = React.useCallback(() => {
+    setImportedContext(null)
+  }, [])
+
+  const insertHandoffDraft = React.useCallback(() => {
+    if (!conflict) return
+    applyImportedHandoff(
+      conflict.handoff,
+      appendImportedDraft(draftValueRef.current, conflict.handoff.draft.text),
+    )
+  }, [applyImportedHandoff, conflict])
+
+  const replaceWithHandoffDraft = React.useCallback(() => {
+    if (!conflict) return
+    applyImportedHandoff(conflict.handoff, conflict.handoff.draft.text)
+  }, [applyImportedHandoff, conflict])
+
+  const cancelHandoffImport = React.useCallback(() => {
+    if (!conflict) return
+    setConflict(null)
+    cleanRouteHandoff()
+    handledHandoffIdsRef.current.add(conflict.handoff.id)
+    consumeQuietly(conflict.handoff.id)
+  }, [cleanRouteHandoff, conflict, consumeQuietly])
+
+  return {
+    importedContext,
+    removeImportedContext,
+    conflict,
+    insertHandoffDraft,
+    replaceWithHandoffDraft,
+    cancelHandoffImport,
+  }
+}

--- a/apps/packages/ui/src/components/Sidepanel/Chat/ControlRow.tsx
+++ b/apps/packages/ui/src/components/Sidepanel/Chat/ControlRow.tsx
@@ -27,6 +27,7 @@ import { useStorage } from "@plasmohq/storage/hook"
 import { fetchChatModels } from "@/services/tldw-server"
 import {
   buildSidepanelChatHandoffRoute,
+  consumeSidepanelChatHandoff,
   createSidepanelChatHandoff,
   type SidepanelChatHandoffPageContext
 } from "@/services/sidepanel-chat-handoff"
@@ -433,29 +434,42 @@ const ControlRowBase: React.FC<ControlRowProps> = ({
     requestAnimationFrame(() => moreBtnRef.current?.focus())
   }
 
-  const openFullAppPath = React.useCallback((routePath: string) => {
+  const openFullAppPath = React.useCallback(async (routePath: string) => {
     const path = `/options.html#${routePath}`
+    const restoreFocus = () => {
+      setMoreOpen(false)
+      requestAnimationFrame(() => moreBtnRef.current?.focus())
+    }
+    const openFallback = (url: string) => {
+      const opened = window.open(url, "_blank")
+      if (opened) {
+        restoreFocus()
+        return true
+      }
+      return false
+    }
+
     try {
       const runtime = browser.runtime
       const url = runtime?.id && runtime.getURL ? runtime.getURL(path) : null
       if (url) {
         if (browser.tabs?.create) {
-          void browser.tabs.create({ url })
-        } else {
-          window.open(url, "_blank")
+          try {
+            await browser.tabs.create({ url })
+            restoreFocus()
+            return true
+          } catch {
+            return openFallback(url)
+          }
         }
-        setMoreOpen(false)
-        requestAnimationFrame(() => moreBtnRef.current?.focus())
-        return
+        return openFallback(url)
       }
     } catch {}
-    window.open(routePath, "_blank")
-    setMoreOpen(false)
-    requestAnimationFrame(() => moreBtnRef.current?.focus())
+    return openFallback(routePath)
   }, [])
 
   const openFullApp = () => {
-    openFullAppPath(fullAppChatPath)
+    void openFullAppPath(fullAppChatPath)
   }
 
   const pageContextHasVisibleContent = (
@@ -500,7 +514,17 @@ const ControlRowBase: React.FC<ControlRowProps> = ({
           routeIntent
         })
         const handoffPath = buildSidepanelChatHandoffRoute(fullAppChatPath, pkg.id)
-        openFullAppPath(handoffPath)
+        const opened = await openFullAppPath(handoffPath)
+        if (!opened) {
+          await consumeSidepanelChatHandoff(pkg.id).catch(() => undefined)
+          setHandoffFeedback({
+            tone: "error",
+            message: t(
+              "sidepanel:controlRow.continueInWebUIFailed",
+              "Could not continue in WebUI"
+            )
+          })
+        }
       } catch {
         setHandoffFeedback({
           tone: "error",

--- a/apps/packages/ui/src/components/Sidepanel/Chat/ControlRow.tsx
+++ b/apps/packages/ui/src/components/Sidepanel/Chat/ControlRow.tsx
@@ -117,6 +117,9 @@ const ControlRowBase: React.FC<ControlRowProps> = ({
     tone: "warning" | "error"
     message: string
   } | null>(null)
+  const continueInWebUIPendingRef = React.useRef(false)
+  const [continueInWebUIPending, setContinueInWebUIPending] =
+    React.useState(false)
   const [systemPromptOverride, setSystemPromptOverride] = React.useState<
     string | undefined
   >(undefined)
@@ -383,6 +386,8 @@ const ControlRowBase: React.FC<ControlRowProps> = ({
   const hasDraftForHandoff = draftText.trim().length > 0
   const continueInWebUIEnabled =
     hasDraftForHandoff || hasVisiblePageContextForHandoff
+  const continueInWebUIButtonDisabled =
+    !continueInWebUIEnabled || continueInWebUIPending
   const activeCharacterIdForRouteIntent =
     selectedAssistant?.kind === "character"
       ? String(selectedAssistant.id ?? "").trim()
@@ -464,43 +469,50 @@ const ControlRowBase: React.FC<ControlRowProps> = ({
     )
 
   const continueInWebUI = async () => {
-    if (!continueInWebUIEnabled) return
+    if (!continueInWebUIEnabled || continueInWebUIPendingRef.current) return
+    continueInWebUIPendingRef.current = true
+    setContinueInWebUIPending(true)
     setHandoffFeedback(null)
 
-    let pageContext: SidepanelChatHandoffPageContext | undefined
     try {
-      pageContext = await getVisiblePageContextForHandoff?.()
-    } catch {
-      pageContext = undefined
-    }
+      let pageContext: SidepanelChatHandoffPageContext | undefined
+      try {
+        pageContext = await getVisiblePageContextForHandoff?.()
+      } catch {
+        pageContext = undefined
+      }
 
-    if (!hasDraftForHandoff && !pageContextHasVisibleContent(pageContext)) {
-      setHandoffFeedback({
-        tone: "warning",
-        message: t(
-          "sidepanel:controlRow.continueInWebUINothingToSend",
-          "Nothing to continue in WebUI"
-        )
-      })
-      return
-    }
+      if (!hasDraftForHandoff && !pageContextHasVisibleContent(pageContext)) {
+        setHandoffFeedback({
+          tone: "warning",
+          message: t(
+            "sidepanel:controlRow.continueInWebUINothingToSend",
+            "Nothing to continue in WebUI"
+          )
+        })
+        return
+      }
 
-    try {
-      const pkg = await createSidepanelChatHandoff({
-        draftText,
-        pageContext,
-        routeIntent
-      })
-      const handoffPath = buildSidepanelChatHandoffRoute(fullAppChatPath, pkg.id)
-      openFullAppPath(handoffPath)
-    } catch {
-      setHandoffFeedback({
-        tone: "error",
-        message: t(
-          "sidepanel:controlRow.continueInWebUIFailed",
-          "Could not continue in WebUI"
-        )
-      })
+      try {
+        const pkg = await createSidepanelChatHandoff({
+          draftText,
+          pageContext,
+          routeIntent
+        })
+        const handoffPath = buildSidepanelChatHandoffRoute(fullAppChatPath, pkg.id)
+        openFullAppPath(handoffPath)
+      } catch {
+        setHandoffFeedback({
+          tone: "error",
+          message: t(
+            "sidepanel:controlRow.continueInWebUIFailed",
+            "Could not continue in WebUI"
+          )
+        })
+      }
+    } finally {
+      continueInWebUIPendingRef.current = false
+      setContinueInWebUIPending(false)
     }
   }
 
@@ -900,11 +912,12 @@ const ControlRowBase: React.FC<ControlRowProps> = ({
         onClick={() => {
           void continueInWebUI()
         }}
-        disabled={!continueInWebUIEnabled}
-        aria-disabled={!continueInWebUIEnabled}
+        disabled={continueInWebUIButtonDisabled}
+        aria-disabled={continueInWebUIButtonDisabled}
+        aria-busy={continueInWebUIPending || undefined}
         data-testid="chat-continue-in-webui"
         className={`w-full text-left text-sm px-3 py-2 rounded flex items-center gap-2 ${
-          continueInWebUIEnabled
+          !continueInWebUIButtonDisabled
             ? "hover:bg-surface2"
             : "cursor-not-allowed opacity-50"
         }`}

--- a/apps/packages/ui/src/components/Sidepanel/Chat/ControlRow.tsx
+++ b/apps/packages/ui/src/components/Sidepanel/Chat/ControlRow.tsx
@@ -26,6 +26,11 @@ import { browser } from "wxt/browser"
 import { useStorage } from "@plasmohq/storage/hook"
 import { fetchChatModels } from "@/services/tldw-server"
 import {
+  buildSidepanelChatHandoffRoute,
+  createSidepanelChatHandoff,
+  type SidepanelChatHandoffPageContext
+} from "@/services/sidepanel-chat-handoff"
+import {
   buildQuickIngestOpenDetailFromUrl,
   requestQuickIngestOpen,
   type QuickIngestOpenDetail
@@ -65,6 +70,12 @@ interface ControlRowProps {
   chatLoopStatus?: "idle" | "running" | "complete" | "error" | "cancelled"
   pendingApprovalsCount?: number
   runningToolCount?: number
+  draftMessage?: string
+  hasVisiblePageContextForHandoff?: boolean
+  getVisiblePageContextForHandoff?: () =>
+    | Promise<SidepanelChatHandoffPageContext | undefined>
+    | SidepanelChatHandoffPageContext
+    | undefined
   // Image upload
   onImageUpload: (file: File) => void
   // RAG toggle
@@ -92,6 +103,9 @@ const ControlRowBase: React.FC<ControlRowProps> = ({
   chatLoopStatus = "idle",
   pendingApprovalsCount = 0,
   runningToolCount = 0,
+  draftMessage = "",
+  hasVisiblePageContextForHandoff = false,
+  getVisiblePageContextForHandoff,
   onImageUpload,
   onToggleRag,
   isConnected
@@ -99,6 +113,10 @@ const ControlRowBase: React.FC<ControlRowProps> = ({
   const { t } = useTranslation(["sidepanel", "playground", "common"])
   const [selectedAssistant, setSelectedAssistant] = useSelectedAssistant(null)
   const [moreOpen, setMoreOpen] = React.useState(false)
+  const [handoffFeedback, setHandoffFeedback] = React.useState<{
+    tone: "warning" | "error"
+    message: string
+  } | null>(null)
   const [systemPromptOverride, setSystemPromptOverride] = React.useState<
     string | undefined
   >(undefined)
@@ -353,6 +371,38 @@ const ControlRowBase: React.FC<ControlRowProps> = ({
         "sidepanel:controlRow.openFullAppDescription",
         "Opens /chat in a new tab. Sidepanel draft, current page context, and unsaved chat state stay in the sidepanel."
       )
+  const continueInWebUIButtonLabel = t(
+    "sidepanel:controlRow.continueInWebUI",
+    "Continue in WebUI"
+  )
+  const continueInWebUIDescription = t(
+    "sidepanel:controlRow.continueInWebUIDescription",
+    "Creates a short-lived handoff with the sidepanel draft and visible page context, then opens /chat in the WebUI."
+  )
+  const draftText = draftMessage ?? ""
+  const hasDraftForHandoff = draftText.trim().length > 0
+  const continueInWebUIEnabled =
+    hasDraftForHandoff || hasVisiblePageContextForHandoff
+  const activeCharacterIdForRouteIntent =
+    selectedAssistant?.kind === "character"
+      ? String(selectedAssistant.id ?? "").trim()
+      : selectedAssistant?.kind === "persona"
+        ? ""
+      : selectedCharacterId == null
+        ? ""
+        : String(selectedCharacterId).trim()
+  const routeIntent = React.useMemo(
+    () => ({
+      path: fullAppChatPath,
+      ...(activeCharacterIdForRouteIntent
+        ? {
+            mode: "character" as const,
+            characterId: activeCharacterIdForRouteIntent
+          }
+        : {})
+    }),
+    [activeCharacterIdForRouteIntent, fullAppChatPath]
+  )
   const openRolePlayPicker = React.useCallback(() => {
     if (typeof window === "undefined") return
     window.dispatchEvent(
@@ -378,8 +428,8 @@ const ControlRowBase: React.FC<ControlRowProps> = ({
     requestAnimationFrame(() => moreBtnRef.current?.focus())
   }
 
-  const openFullApp = () => {
-    const path = `/options.html#${fullAppChatPath}`
+  const openFullAppPath = React.useCallback((routePath: string) => {
+    const path = `/options.html#${routePath}`
     try {
       const runtime = browser.runtime
       const url = runtime?.id && runtime.getURL ? runtime.getURL(path) : null
@@ -394,9 +444,64 @@ const ControlRowBase: React.FC<ControlRowProps> = ({
         return
       }
     } catch {}
-    window.open(fullAppChatPath, "_blank")
+    window.open(routePath, "_blank")
     setMoreOpen(false)
     requestAnimationFrame(() => moreBtnRef.current?.focus())
+  }, [])
+
+  const openFullApp = () => {
+    openFullAppPath(fullAppChatPath)
+  }
+
+  const pageContextHasVisibleContent = (
+    pageContext: SidepanelChatHandoffPageContext | undefined
+  ) =>
+    Boolean(
+      pageContext &&
+        (pageContext.title?.trim() ||
+          pageContext.url?.trim() ||
+          pageContext.snippets.some((snippet) => snippet.text.trim().length > 0))
+    )
+
+  const continueInWebUI = async () => {
+    if (!continueInWebUIEnabled) return
+    setHandoffFeedback(null)
+
+    let pageContext: SidepanelChatHandoffPageContext | undefined
+    try {
+      pageContext = await getVisiblePageContextForHandoff?.()
+    } catch {
+      pageContext = undefined
+    }
+
+    if (!hasDraftForHandoff && !pageContextHasVisibleContent(pageContext)) {
+      setHandoffFeedback({
+        tone: "warning",
+        message: t(
+          "sidepanel:controlRow.continueInWebUINothingToSend",
+          "Nothing to continue in WebUI"
+        )
+      })
+      return
+    }
+
+    try {
+      const pkg = await createSidepanelChatHandoff({
+        draftText,
+        pageContext,
+        routeIntent
+      })
+      const handoffPath = buildSidepanelChatHandoffRoute(fullAppChatPath, pkg.id)
+      openFullAppPath(handoffPath)
+    } catch {
+      setHandoffFeedback({
+        tone: "error",
+        message: t(
+          "sidepanel:controlRow.continueInWebUIFailed",
+          "Could not continue in WebUI"
+        )
+      })
+    }
   }
 
   const moreMenuContent = (
@@ -790,6 +895,34 @@ const ControlRowBase: React.FC<ControlRowProps> = ({
         <ExternalLink className="size-4 text-text-subtle" />
         {fullAppButtonLabel}
       </button>
+      <button
+        type="button"
+        onClick={() => {
+          void continueInWebUI()
+        }}
+        disabled={!continueInWebUIEnabled}
+        aria-disabled={!continueInWebUIEnabled}
+        data-testid="chat-continue-in-webui"
+        className={`w-full text-left text-sm px-3 py-2 rounded flex items-center gap-2 ${
+          continueInWebUIEnabled
+            ? "hover:bg-surface2"
+            : "cursor-not-allowed opacity-50"
+        }`}
+        title={continueInWebUIDescription}
+      >
+        <ExternalLink className="size-4 text-text-subtle" />
+        {continueInWebUIButtonLabel}
+      </button>
+      {handoffFeedback && (
+        <div
+          role={handoffFeedback.tone === "error" ? "alert" : "status"}
+          className={`px-3 text-xs ${
+            handoffFeedback.tone === "error" ? "text-danger" : "text-warning"
+          }`}
+        >
+          {handoffFeedback.message}
+        </div>
+      )}
       <span id={fullAppHandoffDescriptionId} className="sr-only">
         {fullAppHandoffDescription}
       </span>

--- a/apps/packages/ui/src/components/Sidepanel/Chat/__tests__/ControlRow.chat-handoff.test.tsx
+++ b/apps/packages/ui/src/components/Sidepanel/Chat/__tests__/ControlRow.chat-handoff.test.tsx
@@ -29,6 +29,16 @@ type MockInputProps = React.InputHTMLAttributes<HTMLInputElement> & {
   onPressEnter?: () => void
 }
 
+const createDeferred = <T,>() => {
+  let resolve!: (value: T) => void
+  let reject!: (reason?: unknown) => void
+  const promise = new Promise<T>((promiseResolve, promiseReject) => {
+    resolve = promiseResolve
+    reject = promiseReject
+  })
+  return { promise, resolve, reject }
+}
+
 const mocks = vi.hoisted(() => ({
   selectedAssistant: null as null | {
     kind: "character"
@@ -297,6 +307,43 @@ describe("ControlRow sidepanel chat handoff", () => {
     )
     expect(mocks.tabsCreate).toHaveBeenCalledWith({
       url: "chrome-extension://handoff/options.html#/chat?handoff=handoff-123"
+    })
+  })
+
+  it("ignores a second click while handoff creation is still pending", async () => {
+    const deferred = createDeferred<{
+      id: string
+      source: "sidepanel-chat"
+      createdAt: string
+      expiresAt: string
+      draft: { text: string }
+    }>()
+    mocks.createSidepanelChatHandoff.mockReturnValueOnce(deferred.promise)
+    render(<ControlRow {...defaultProps()} draftMessage="Summarize this" />)
+
+    const continueButton = screen.getByTestId("chat-continue-in-webui")
+    fireEvent.click(continueButton)
+    fireEvent.click(continueButton)
+
+    await waitFor(() => {
+      expect(mocks.createSidepanelChatHandoff).toHaveBeenCalledTimes(1)
+    })
+    expect(continueButton).toBeDisabled()
+    expect(mocks.tabsCreate).not.toHaveBeenCalled()
+
+    deferred.resolve({
+      id: "handoff-pending",
+      source: "sidepanel-chat",
+      createdAt: "2026-05-29T00:00:00.000Z",
+      expiresAt: "2026-05-29T00:10:00.000Z",
+      draft: { text: "Summarize this" }
+    })
+
+    await waitFor(() => {
+      expect(mocks.tabsCreate).toHaveBeenCalledTimes(1)
+    })
+    expect(mocks.tabsCreate).toHaveBeenCalledWith({
+      url: "chrome-extension://handoff/options.html#/chat?handoff=handoff-pending"
     })
   })
 

--- a/apps/packages/ui/src/components/Sidepanel/Chat/__tests__/ControlRow.chat-handoff.test.tsx
+++ b/apps/packages/ui/src/components/Sidepanel/Chat/__tests__/ControlRow.chat-handoff.test.tsx
@@ -1,0 +1,420 @@
+import React from "react"
+import { fireEvent, render, screen, waitFor } from "@testing-library/react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { ControlRow } from "../ControlRow"
+
+type MockSelectProps = {
+  children?: React.ReactNode
+  value?: string | string[] | null
+  onChange?: (value: string) => void
+  "aria-label"?: string
+}
+
+type MockChildrenProps = {
+  children?: React.ReactNode
+}
+
+type MockPopoverProps = MockChildrenProps & {
+  content?: React.ReactNode
+}
+
+type MockSwitchProps = {
+  checked?: boolean
+  disabled?: boolean
+  onChange?: (checked: boolean) => void
+  "aria-label"?: string
+}
+
+type MockInputProps = React.InputHTMLAttributes<HTMLInputElement> & {
+  onPressEnter?: () => void
+}
+
+const mocks = vi.hoisted(() => ({
+  selectedAssistant: null as null | {
+    kind: "character"
+    id: string
+    name: string
+  },
+  setSelectedAssistant: vi.fn(),
+  setSelectedCharacterId: vi.fn(),
+  setMoodBadge: vi.fn(),
+  setStorage: vi.fn(),
+  fetchChatModels: vi.fn(async () => []),
+  runtimeGetURL: vi.fn((path: string) => `chrome-extension://handoff${path}`),
+  tabsCreate: vi.fn(),
+  createSidepanelChatHandoff: vi.fn(),
+  buildSidepanelChatHandoffRoute: vi.fn(
+    (basePath: string, handoffId: string) => {
+      const separator = basePath.includes("?") ? "&" : "?"
+      return `${basePath}${separator}handoff=${handoffId}`
+    }
+  ),
+  setToolCatalog: vi.fn(),
+  setToolCatalogId: vi.fn(),
+  setToolModules: vi.fn(),
+  setToolCatalogStrict: vi.fn(),
+  setMcpToolEnabled: vi.fn(),
+  resetMcpToolFilter: vi.fn()
+}))
+
+vi.mock("wxt/browser", () => ({
+  browser: {
+    runtime: {
+      id: "handoff-extension",
+      getURL: mocks.runtimeGetURL
+    },
+    tabs: {
+      create: mocks.tabsCreate
+    }
+  }
+}))
+
+vi.mock("@/services/sidepanel-chat-handoff", () => ({
+  createSidepanelChatHandoff: mocks.createSidepanelChatHandoff,
+  buildSidepanelChatHandoffRoute: mocks.buildSidepanelChatHandoffRoute
+}))
+
+vi.mock("antd", () => {
+  const Select = ({ children, ...props }: MockSelectProps) => (
+    <select
+      aria-label={props["aria-label"]}
+      value={Array.isArray(props.value) ? props.value[0] ?? "" : props.value ?? ""}
+      onChange={(event) => props.onChange?.(event.target.value)}
+    >
+      {children}
+    </select>
+  )
+  Select.Option = ({ children, value }: MockChildrenProps & { value?: string }) => (
+    <option value={value}>{children}</option>
+  )
+  Select.OptGroup = ({
+    children,
+    label
+  }: MockChildrenProps & { label?: string }) => (
+    <optgroup label={label}>{children}</optgroup>
+  )
+
+  const Radio = {
+    Group: ({ children }: MockChildrenProps) => <div>{children}</div>,
+    Button: ({ children, value }: MockChildrenProps & { value?: string }) => (
+      <button type="button" data-value={value}>
+        {children}
+      </button>
+    )
+  }
+
+  return {
+    Input: ({ onPressEnter: _onPressEnter, ...props }: MockInputProps) => (
+      <input {...props} />
+    ),
+    InputNumber: (props: React.InputHTMLAttributes<HTMLInputElement>) => (
+      <input type="number" {...props} />
+    ),
+    Popover: ({ children, content }: MockPopoverProps) => (
+      <>
+        {children}
+        <div data-testid="mock-popover-content">{content}</div>
+      </>
+    ),
+    Radio,
+    Select,
+    Switch: ({
+      checked,
+      disabled,
+      onChange,
+      ...props
+    }: MockSwitchProps) => (
+      <button
+        type="button"
+        role="switch"
+        aria-checked={Boolean(checked)}
+        aria-label={props["aria-label"]}
+        disabled={disabled}
+        onClick={() => onChange?.(!checked)}
+      />
+    ),
+    Tooltip: ({ children }: MockChildrenProps) => <>{children}</>,
+    Upload: ({ children }: MockChildrenProps) => <>{children}</>
+  }
+})
+
+vi.mock("@tanstack/react-query", () => ({
+  useQuery: () => ({ data: [] })
+}))
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (_key: string, fallback?: string, options?: Record<string, unknown>) =>
+      String(fallback ?? _key).replace(/\{\{(\w+)\}\}/g, (_, key) =>
+        String(options?.[key] ?? "")
+      )
+  })
+}))
+
+vi.mock("@/components/Common/ModelSelect", () => ({
+  ModelSelect: () => <button type="button">Model</button>
+}))
+
+vi.mock("@/components/Common/PromptSelect", () => ({
+  PromptSelect: () => <button type="button">Prompt</button>
+}))
+
+vi.mock("@/components/Common/FeatureHint", () => ({
+  FeatureHint: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
+  useFeatureHintSeen: () => false
+}))
+
+vi.mock("@/components/Common/McpToolSelector", () => ({
+  McpToolSelector: () => <div data-testid="mcp-tool-selector" />
+}))
+
+vi.mock("../ConversationContextPopover", () => ({
+  ConversationContextPopover: () => <button type="button">Context</button>
+}))
+
+vi.mock("@/hooks/useChatMoodBadgePreference", () => ({
+  useChatMoodBadgePreference: () => [false, mocks.setMoodBadge] as const
+}))
+
+vi.mock("@/hooks/useServerCapabilities", () => ({
+  useServerCapabilities: () => ({
+    capabilities: {
+      hasMcp: false,
+      hasMediaPlaylistPreflight: false,
+      hasWebSearch: true
+    }
+  })
+}))
+
+vi.mock("@/hooks/useMcpTools", () => ({
+  useMcpTools: () => ({
+    hasMcp: false,
+    healthState: "unavailable",
+    discoveredTools: [],
+    chatTools: [],
+    toolCounts: { enabled: 0, total: 0 },
+    toolsLoading: false,
+    catalogs: [],
+    catalogsLoading: false,
+    toolCatalog: "",
+    toolCatalogId: null,
+    toolModules: [],
+    moduleOptions: [],
+    moduleOptionsLoading: false,
+    toolCatalogStrict: false,
+    setToolCatalog: mocks.setToolCatalog,
+    setToolCatalogId: mocks.setToolCatalogId,
+    setToolModules: mocks.setToolModules,
+    setToolCatalogStrict: mocks.setToolCatalogStrict,
+    setToolEnabled: mocks.setMcpToolEnabled,
+    resetToolFilter: mocks.resetMcpToolFilter
+  })
+}))
+
+vi.mock("@plasmohq/storage/hook", () => ({
+  useStorage: (_key: unknown, initialValue: unknown) =>
+    [initialValue ?? null, mocks.setStorage] as const
+}))
+
+vi.mock("@/services/tldw-server", () => ({
+  fetchChatModels: mocks.fetchChatModels
+}))
+
+vi.mock("@/utils/quick-ingest-open", () => ({
+  buildQuickIngestOpenDetailFromUrl: vi.fn(),
+  requestQuickIngestOpen: vi.fn()
+}))
+
+vi.mock("@/hooks/useSelectedAssistant", () => ({
+  useSelectedAssistant: () =>
+    [mocks.selectedAssistant, mocks.setSelectedAssistant] as const
+}))
+
+const defaultProps = () => ({
+  selectedSystemPrompt: undefined,
+  setSelectedSystemPrompt: vi.fn(),
+  setSelectedQuickPrompt: vi.fn(),
+  selectedCharacterId: null,
+  setSelectedCharacterId: mocks.setSelectedCharacterId,
+  webSearch: false,
+  setWebSearch: vi.fn(),
+  chatMode: "normal" as const,
+  setChatMode: vi.fn(),
+  toolChoice: "auto" as const,
+  setToolChoice: vi.fn(),
+  onImageUpload: vi.fn(),
+  onToggleRag: vi.fn(),
+  isConnected: true
+})
+
+describe("ControlRow sidepanel chat handoff", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.selectedAssistant = null
+    mocks.createSidepanelChatHandoff.mockResolvedValue({
+      id: "handoff-123",
+      source: "sidepanel-chat",
+      createdAt: "2026-05-29T00:00:00.000Z",
+      expiresAt: "2026-05-29T00:10:00.000Z",
+      draft: { text: "Summarize this" }
+    })
+    vi.spyOn(window, "open").mockImplementation(() => null)
+  })
+
+  it("keeps Open full app route-only with no handoff parameter", () => {
+    render(<ControlRow {...defaultProps()} draftMessage="draft text" />)
+
+    fireEvent.click(screen.getByTestId("chat-open-full-app"))
+
+    expect(mocks.runtimeGetURL).toHaveBeenCalledWith("/options.html#/chat")
+    expect(mocks.tabsCreate).toHaveBeenCalledWith({
+      url: "chrome-extension://handoff/options.html#/chat"
+    })
+    expect(mocks.createSidepanelChatHandoff).not.toHaveBeenCalled()
+    expect(mocks.buildSidepanelChatHandoffRoute).not.toHaveBeenCalled()
+  })
+
+  it("creates a handoff package and opens /chat?handoff=<id>", async () => {
+    render(<ControlRow {...defaultProps()} draftMessage="Summarize this" />)
+
+    fireEvent.click(screen.getByTestId("chat-continue-in-webui"))
+
+    await waitFor(() => {
+      expect(mocks.createSidepanelChatHandoff).toHaveBeenCalledWith({
+        draftText: "Summarize this",
+        pageContext: undefined,
+        routeIntent: {
+          path: "/chat"
+        }
+      })
+    })
+    expect(mocks.buildSidepanelChatHandoffRoute).toHaveBeenCalledWith(
+      "/chat",
+      "handoff-123"
+    )
+    expect(mocks.runtimeGetURL).toHaveBeenCalledWith(
+      "/options.html#/chat?handoff=handoff-123"
+    )
+    expect(mocks.tabsCreate).toHaveBeenCalledWith({
+      url: "chrome-extension://handoff/options.html#/chat?handoff=handoff-123"
+    })
+  })
+
+  it("merges handoff into active character route params", async () => {
+    mocks.selectedAssistant = {
+      kind: "character",
+      id: "char-review",
+      name: "Review Guide"
+    }
+
+    render(
+      <ControlRow
+        {...defaultProps()}
+        selectedCharacterId="char-review"
+        draftMessage="Continue the scene"
+      />
+    )
+
+    fireEvent.click(screen.getByTestId("chat-continue-in-webui"))
+
+    await waitFor(() => {
+      expect(mocks.createSidepanelChatHandoff).toHaveBeenCalledWith({
+        draftText: "Continue the scene",
+        pageContext: undefined,
+        routeIntent: {
+          path: "/chat?mode=character&characterId=char-review",
+          mode: "character",
+          characterId: "char-review"
+        }
+      })
+    })
+    expect(mocks.buildSidepanelChatHandoffRoute).toHaveBeenCalledWith(
+      "/chat?mode=character&characterId=char-review",
+      "handoff-123"
+    )
+    expect(mocks.runtimeGetURL).toHaveBeenCalledWith(
+      "/options.html#/chat?mode=character&characterId=char-review&handoff=handoff-123"
+    )
+  })
+
+  it("does not serialize draft, snippets, title, or URL content into the URL", async () => {
+    const pageContext = {
+      title: "Sensitive Article",
+      url: "https://example.test/private",
+      snippets: [
+        {
+          kind: "visible-context" as const,
+          label: "Selected tab",
+          text: "private selected snippet"
+        }
+      ]
+    }
+    render(
+      <ControlRow
+        {...defaultProps()}
+        draftMessage="private draft text"
+        hasVisiblePageContextForHandoff
+        getVisiblePageContextForHandoff={() => pageContext}
+      />
+    )
+
+    fireEvent.click(screen.getByTestId("chat-continue-in-webui"))
+
+    await waitFor(() => {
+      expect(mocks.tabsCreate).toHaveBeenCalled()
+    })
+    const openedUrl = String(mocks.tabsCreate.mock.calls.at(-1)?.[0]?.url)
+    expect(openedUrl).toContain("handoff=handoff-123")
+    expect(openedUrl).not.toContain("private%20draft")
+    expect(openedUrl).not.toContain("private selected snippet")
+    expect(openedUrl).not.toContain("Sensitive")
+    expect(openedUrl).not.toContain("example.test")
+    expect(mocks.createSidepanelChatHandoff).toHaveBeenCalledWith({
+      draftText: "private draft text",
+      pageContext,
+      routeIntent: {
+        path: "/chat"
+      }
+    })
+  })
+
+  it("shows a disabled Continue in WebUI action when no draft or context exists", () => {
+    render(<ControlRow {...defaultProps()} draftMessage="   " />)
+
+    const continueButton = screen.getByTestId("chat-continue-in-webui")
+
+    expect(continueButton).toBeDisabled()
+  })
+
+  it("shows a warning and does not open when visible context is gone at click time", async () => {
+    render(
+      <ControlRow
+        {...defaultProps()}
+        draftMessage="   "
+        hasVisiblePageContextForHandoff
+        getVisiblePageContextForHandoff={() => undefined}
+      />
+    )
+
+    fireEvent.click(screen.getByTestId("chat-continue-in-webui"))
+
+    expect(await screen.findByRole("status")).toHaveTextContent(
+      "Nothing to continue in WebUI"
+    )
+    expect(mocks.createSidepanelChatHandoff).not.toHaveBeenCalled()
+    expect(mocks.tabsCreate).not.toHaveBeenCalled()
+  })
+
+  it("shows an error and does not open a tab when handoff creation fails", async () => {
+    mocks.createSidepanelChatHandoff.mockRejectedValueOnce(new Error("storage failed"))
+    render(<ControlRow {...defaultProps()} draftMessage="Summarize this" />)
+
+    fireEvent.click(screen.getByTestId("chat-continue-in-webui"))
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      "Could not continue in WebUI"
+    )
+    expect(mocks.tabsCreate).not.toHaveBeenCalled()
+    expect(window.open).not.toHaveBeenCalled()
+  })
+})

--- a/apps/packages/ui/src/components/Sidepanel/Chat/__tests__/ControlRow.chat-handoff.test.tsx
+++ b/apps/packages/ui/src/components/Sidepanel/Chat/__tests__/ControlRow.chat-handoff.test.tsx
@@ -53,6 +53,7 @@ const mocks = vi.hoisted(() => ({
   runtimeGetURL: vi.fn((path: string) => `chrome-extension://handoff${path}`),
   tabsCreate: vi.fn(),
   createSidepanelChatHandoff: vi.fn(),
+  consumeSidepanelChatHandoff: vi.fn(),
   buildSidepanelChatHandoffRoute: vi.fn(
     (basePath: string, handoffId: string) => {
       const separator = basePath.includes("?") ? "&" : "?"
@@ -81,6 +82,7 @@ vi.mock("wxt/browser", () => ({
 
 vi.mock("@/services/sidepanel-chat-handoff", () => ({
   createSidepanelChatHandoff: mocks.createSidepanelChatHandoff,
+  consumeSidepanelChatHandoff: mocks.consumeSidepanelChatHandoff,
   buildSidepanelChatHandoffRoute: mocks.buildSidepanelChatHandoffRoute
 }))
 
@@ -463,5 +465,34 @@ describe("ControlRow sidepanel chat handoff", () => {
     )
     expect(mocks.tabsCreate).not.toHaveBeenCalled()
     expect(window.open).not.toHaveBeenCalled()
+  })
+
+  it("falls back to window.open when Continue in WebUI tab creation rejects", async () => {
+    mocks.tabsCreate.mockRejectedValueOnce(new Error("tab create blocked"))
+    vi.mocked(window.open).mockImplementationOnce(() => ({ closed: false }) as Window)
+    render(<ControlRow {...defaultProps()} draftMessage="Summarize this" />)
+
+    fireEvent.click(screen.getByTestId("chat-continue-in-webui"))
+
+    await waitFor(() => {
+      expect(window.open).toHaveBeenCalledWith(
+        "chrome-extension://handoff/options.html#/chat?handoff=handoff-123",
+        "_blank"
+      )
+    })
+    expect(mocks.consumeSidepanelChatHandoff).not.toHaveBeenCalled()
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument()
+  })
+
+  it("consumes the handoff and shows an error when Continue in WebUI cannot open", async () => {
+    mocks.tabsCreate.mockRejectedValueOnce(new Error("tab create blocked"))
+    render(<ControlRow {...defaultProps()} draftMessage="Summarize this" />)
+
+    fireEvent.click(screen.getByTestId("chat-continue-in-webui"))
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      "Could not continue in WebUI"
+    )
+    expect(mocks.consumeSidepanelChatHandoff).toHaveBeenCalledWith("handoff-123")
   })
 })

--- a/apps/packages/ui/src/components/Sidepanel/Chat/__tests__/sidepanel-chat-handoff-context.test.ts
+++ b/apps/packages/ui/src/components/Sidepanel/Chat/__tests__/sidepanel-chat-handoff-context.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest"
+import { buildVisibleDocumentHandoffSnippetText } from "../sidepanel-chat-handoff-context"
+
+describe("sidepanel chat handoff context helpers", () => {
+  it("omits missing document title and URL fields from snippet text", () => {
+    expect(
+      buildVisibleDocumentHandoffSnippetText({
+        title: "Research note"
+      })
+    ).toBe("Title: Research note")
+
+    expect(
+      buildVisibleDocumentHandoffSnippetText({
+        url: "https://example.test/source"
+      })
+    ).toBe("URL: https://example.test/source")
+
+    expect(buildVisibleDocumentHandoffSnippetText({})).toBe("")
+  })
+})

--- a/apps/packages/ui/src/components/Sidepanel/Chat/form.tsx
+++ b/apps/packages/ui/src/components/Sidepanel/Chat/form.tsx
@@ -148,6 +148,7 @@ import type { QueuedRequest } from "@/utils/chat-request-queue"
 import { AudioSourcePicker } from "@/components/Common/AudioSourcePicker"
 import { CharacterControlsSheet } from "@/components/Sidepanel/Chat/CharacterControlsSheet"
 import { getSidepanelOverlayResumeMarkerKey } from "@/utils/sidepanel-overlay-resume"
+import type { SidepanelChatHandoffPageContext } from "@/services/sidepanel-chat-handoff"
 
 type Props = {
   dropedFile: File | undefined
@@ -798,6 +799,55 @@ export const SidepanelForm = ({
         .join(" ")
     : ""
   const pageContextActive = chatMode === "rag" && chatWithWebsiteEmbedding
+  const getVisiblePageContextForHandoff = React.useCallback(async (): Promise<
+    SidepanelChatHandoffPageContext | undefined
+  > => {
+    const snippets = selectedDocuments.map((doc) => ({
+      kind: "visible-context" as const,
+      label: doc.title,
+      text: [`Title: ${doc.title}`, `URL: ${doc.url}`].join("\n")
+    }))
+
+    let activePage:
+      | {
+          title?: string
+          url?: string
+        }
+      | undefined
+
+    if (pageContextActive) {
+      try {
+        const tabs = await browser.tabs.query({
+          active: true,
+          currentWindow: true
+        })
+        const activeTab = tabs.find((tab) => tab.title || tab.url)
+        activePage = {
+          title:
+            typeof activeTab?.title === "string" &&
+            activeTab.title.trim().length > 0
+              ? activeTab.title
+              : undefined,
+          url:
+            typeof activeTab?.url === "string" && activeTab.url.trim().length > 0
+              ? activeTab.url
+              : undefined
+        }
+      } catch {
+        activePage = undefined
+      }
+    }
+
+    if (!activePage?.title && !activePage?.url && snippets.length === 0) {
+      return undefined
+    }
+
+    return {
+      ...(activePage?.title ? { title: activePage.title } : {}),
+      ...(activePage?.url ? { url: activePage.url } : {}),
+      snippets
+    }
+  }, [pageContextActive, selectedDocuments])
   const contextChips = [
     ...(replyTarget && isProMode
       ? [
@@ -3016,6 +3066,13 @@ export const SidepanelForm = ({
                               chatLoopStatus={chatLoopState.status}
                               pendingApprovalsCount={chatLoopState.pendingApprovals.length}
                               runningToolCount={chatLoopState.inflightToolCallIds.length}
+                              draftMessage={form.values.message}
+                              hasVisiblePageContextForHandoff={
+                                pageContextActive || selectedDocuments.length > 0
+                              }
+                              getVisiblePageContextForHandoff={
+                                getVisiblePageContextForHandoff
+                              }
                             />
                           )}
                           <div className="flex min-w-0 flex-wrap items-center justify-end gap-2">

--- a/apps/packages/ui/src/components/Sidepanel/Chat/form.tsx
+++ b/apps/packages/ui/src/components/Sidepanel/Chat/form.tsx
@@ -149,6 +149,7 @@ import { AudioSourcePicker } from "@/components/Common/AudioSourcePicker"
 import { CharacterControlsSheet } from "@/components/Sidepanel/Chat/CharacterControlsSheet"
 import { getSidepanelOverlayResumeMarkerKey } from "@/utils/sidepanel-overlay-resume"
 import type { SidepanelChatHandoffPageContext } from "@/services/sidepanel-chat-handoff"
+import { buildVisibleDocumentHandoffSnippetText } from "./sidepanel-chat-handoff-context"
 
 type Props = {
   dropedFile: File | undefined
@@ -805,7 +806,7 @@ export const SidepanelForm = ({
     const snippets = selectedDocuments.map((doc) => ({
       kind: "visible-context" as const,
       label: doc.title,
-      text: [`Title: ${doc.title}`, `URL: ${doc.url}`].join("\n")
+      text: buildVisibleDocumentHandoffSnippetText(doc)
     }))
 
     let activePage:

--- a/apps/packages/ui/src/components/Sidepanel/Chat/sidepanel-chat-handoff-context.ts
+++ b/apps/packages/ui/src/components/Sidepanel/Chat/sidepanel-chat-handoff-context.ts
@@ -1,0 +1,14 @@
+export type SidepanelHandoffDocumentSource = {
+  title?: string | null
+  url?: string | null
+}
+
+export const buildVisibleDocumentHandoffSnippetText = (
+  doc: SidepanelHandoffDocumentSource
+) =>
+  [
+    doc.title ? `Title: ${doc.title}` : null,
+    doc.url ? `URL: ${doc.url}` : null
+  ]
+    .filter(Boolean)
+    .join("\n")

--- a/apps/packages/ui/src/hooks/chat/useChatActions.ts
+++ b/apps/packages/ui/src/hooks/chat/useChatActions.ts
@@ -2870,6 +2870,7 @@ export const useChatActions = ({
           setIsProcessing(true)
 
           const compareChatModeParams = await buildChatModeParams({
+            ...(requestOverrides ?? {}),
             historyId: activeHistoryId,
             setHistory: () => {},
             setStreaming: () => {},

--- a/apps/packages/ui/src/services/__tests__/sidepanel-chat-handoff.test.ts
+++ b/apps/packages/ui/src/services/__tests__/sidepanel-chat-handoff.test.ts
@@ -1,0 +1,243 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const storageState = vi.hoisted(() => {
+  const store = new Map<string, unknown>()
+
+  return {
+    store,
+    get: vi.fn(async (key: string) => store.get(key)),
+    set: vi.fn(async (key: string, value: unknown) => {
+      store.set(key, value)
+    }),
+    remove: vi.fn(async (key: string) => {
+      store.delete(key)
+    }),
+    removeMany: vi.fn(async (keys: string[]) => {
+      keys.forEach((key) => store.delete(key))
+    }),
+    getAll: vi.fn(async () => Object.fromEntries(store.entries()))
+  }
+})
+
+vi.mock("@/utils/safe-storage", () => ({
+  createSafeStorage: () => ({
+    get: storageState.get,
+    set: storageState.set,
+    remove: storageState.remove,
+    removeMany: storageState.removeMany,
+    getAll: storageState.getAll
+  })
+}))
+
+import {
+  buildSidepanelChatHandoffRoute,
+  buildSidepanelHandoffMessageForModel,
+  cleanupExpiredSidepanelChatHandoffs,
+  consumeSidepanelChatHandoff,
+  createSidepanelChatHandoff,
+  readSidepanelChatHandoff,
+  SIDEPANEL_CHAT_HANDOFF_MAX_DRAFT_CHARS,
+  SIDEPANEL_CHAT_HANDOFF_MAX_SNIPPET_CHARS,
+  SIDEPANEL_CHAT_HANDOFF_MAX_SNIPPETS,
+  SIDEPANEL_CHAT_HANDOFF_STORAGE_PREFIX,
+  SIDEPANEL_CHAT_HANDOFF_TTL_MS,
+  type SidepanelChatHandoffPackage
+} from "@/services/sidepanel-chat-handoff"
+
+const NOW = new Date("2026-05-28T18:30:00.000Z")
+
+const storageKey = (id: string) => `${SIDEPANEL_CHAT_HANDOFF_STORAGE_PREFIX}${id}`
+
+const buildStoredPackage = (
+  overrides: Partial<SidepanelChatHandoffPackage> = {}
+): SidepanelChatHandoffPackage => ({
+  id: "handoff-existing",
+  source: "sidepanel-chat",
+  createdAt: NOW.toISOString(),
+  expiresAt: new Date(NOW.getTime() + SIDEPANEL_CHAT_HANDOFF_TTL_MS).toISOString(),
+  draft: { text: "saved draft" },
+  ...overrides
+})
+
+const getQueryParams = (route: string) => {
+  const queryIndex = route.indexOf("?")
+  return new URLSearchParams(queryIndex >= 0 ? route.slice(queryIndex + 1) : "")
+}
+
+describe("sidepanel chat handoff storage service", () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(NOW)
+    vi.clearAllMocks()
+    storageState.store.clear()
+  })
+
+  it("creates bounded packages and verifies read-back before returning the id", async () => {
+    const pkg = await createSidepanelChatHandoff({
+      draftText: "D".repeat(SIDEPANEL_CHAT_HANDOFF_MAX_DRAFT_CHARS + 12),
+      pageContext: {
+        title: "Reference Page",
+        url: "https://example.test/article",
+        snippets: [
+          {
+            kind: "selection",
+            label: "selection",
+            text: "S".repeat(SIDEPANEL_CHAT_HANDOFF_MAX_SNIPPET_CHARS + 20)
+          },
+          { kind: "visible-context", text: "visible context" },
+          { kind: "captured-snippet", text: "captured context" },
+          { kind: "selection", text: "second selection" },
+          { kind: "captured-snippet", text: "dropped extra snippet" }
+        ]
+      },
+      routeIntent: {
+        path: "/chat",
+        mode: "character",
+        characterId: "char-1"
+      }
+    })
+
+    expect(pkg.id).toBeTruthy()
+    expect(pkg.source).toBe("sidepanel-chat")
+    expect(pkg.createdAt).toBe(NOW.toISOString())
+    expect(pkg.expiresAt).toBe(
+      new Date(NOW.getTime() + SIDEPANEL_CHAT_HANDOFF_TTL_MS).toISOString()
+    )
+    expect(pkg.draft.text).toHaveLength(SIDEPANEL_CHAT_HANDOFF_MAX_DRAFT_CHARS)
+    expect(pkg.draft.truncated).toBe(true)
+    expect(pkg.pageContext?.snippets).toHaveLength(SIDEPANEL_CHAT_HANDOFF_MAX_SNIPPETS)
+    expect(pkg.pageContext?.snippets[0].text).toHaveLength(
+      SIDEPANEL_CHAT_HANDOFF_MAX_SNIPPET_CHARS
+    )
+    expect(pkg.pageContext?.snippets[0].truncated).toBe(true)
+    expect(pkg.pageContext?.truncated).toBe(true)
+    expect(storageState.set).toHaveBeenCalledWith(storageKey(pkg.id), pkg)
+    expect(storageState.get).toHaveBeenCalledWith(storageKey(pkg.id))
+
+    await expect(readSidepanelChatHandoff(pkg.id)).resolves.toEqual(pkg)
+  })
+
+  it("throws and does not return a handoff id when storage set fails", async () => {
+    storageState.set.mockRejectedValueOnce(new Error("storage quota exceeded"))
+
+    await expect(
+      createSidepanelChatHandoff({ draftText: "unsaved draft" })
+    ).rejects.toThrow("storage quota exceeded")
+
+    expect(storageState.store.size).toBe(0)
+    expect(storageState.remove).toHaveBeenCalledTimes(1)
+  })
+
+  it("throws when read-back verification cannot read the saved package", async () => {
+    storageState.get.mockResolvedValueOnce(null)
+
+    await expect(
+      createSidepanelChatHandoff({ draftText: "write without read-back" })
+    ).rejects.toThrow("Sidepanel chat handoff could not be saved.")
+
+    expect(storageState.store.size).toBe(0)
+    expect(storageState.remove).toHaveBeenCalledTimes(1)
+  })
+
+  it("returns null and removes expired or malformed packages", async () => {
+    const expired = buildStoredPackage({
+      id: "expired",
+      expiresAt: new Date(NOW.getTime() - 1).toISOString()
+    })
+    storageState.store.set(storageKey("expired"), expired)
+    storageState.store.set(storageKey("malformed"), {
+      id: "malformed",
+      source: "sidepanel-chat"
+    })
+
+    await expect(readSidepanelChatHandoff("expired")).resolves.toBeNull()
+    await expect(readSidepanelChatHandoff("malformed")).resolves.toBeNull()
+
+    expect(storageState.store.has(storageKey("expired"))).toBe(false)
+    expect(storageState.store.has(storageKey("malformed"))).toBe(false)
+
+    storageState.store.set(storageKey("cleanup-expired"), expired)
+    storageState.store.set(storageKey("cleanup-malformed"), { id: "bad" })
+
+    await expect(cleanupExpiredSidepanelChatHandoffs()).resolves.toBe(2)
+    expect(storageState.store.has(storageKey("cleanup-expired"))).toBe(false)
+    expect(storageState.store.has(storageKey("cleanup-malformed"))).toBe(false)
+  })
+
+  it("consumes a package exactly once", async () => {
+    const pkg = await createSidepanelChatHandoff({
+      draftText: "consume this once"
+    })
+
+    await expect(consumeSidepanelChatHandoff(pkg.id)).resolves.toEqual(pkg)
+    await expect(readSidepanelChatHandoff(pkg.id)).resolves.toBeNull()
+    await expect(consumeSidepanelChatHandoff(pkg.id)).resolves.toBeNull()
+  })
+
+  it("merges handoff into normal and character /chat hash routes", () => {
+    const normalRoute = buildSidepanelChatHandoffRoute("#/chat", "handoff-normal")
+    const normalParams = getQueryParams(normalRoute)
+    expect(normalRoute).toBe("#/chat?handoff=handoff-normal")
+    expect(normalParams.get("handoff")).toBe("handoff-normal")
+
+    const characterRoute = buildSidepanelChatHandoffRoute(
+      "#/chat?mode=character&characterId=char-1",
+      "handoff-character"
+    )
+    const characterParams = getQueryParams(characterRoute)
+    expect(characterRoute.startsWith("#/chat?")).toBe(true)
+    expect(characterParams.get("mode")).toBe("character")
+    expect(characterParams.get("characterId")).toBe("char-1")
+    expect(characterParams.get("handoff")).toBe("handoff-character")
+  })
+
+  it("never puts draft text or snippet text into the route", async () => {
+    const pkg = await createSidepanelChatHandoff({
+      draftText: "selected-secret-draft",
+      pageContext: {
+        snippets: [{ kind: "selection", text: "snippet-secret-text" }]
+      }
+    })
+
+    const route = buildSidepanelChatHandoffRoute(
+      "#/chat?mode=character&characterId=char-1",
+      pkg.id
+    )
+
+    expect(route).toContain(`handoff=${encodeURIComponent(pkg.id)}`)
+    expect(route).not.toContain("selected-secret-draft")
+    expect(route).not.toContain("snippet-secret-text")
+    expect(route).not.toContain("draft")
+    expect(route).not.toContain("snippet")
+  })
+
+  it("builds messageForModel with visible sidepanel context", () => {
+    const message = buildSidepanelHandoffMessageForModel("What should I inspect?", {
+      title: "Debugging Guide",
+      url: "https://example.test/debugging",
+      snippets: [
+        {
+          kind: "selection",
+          label: "selected text",
+          text: "The failing assertion mentions read-back verification."
+        },
+        {
+          kind: "visible-context",
+          text: "The visible paragraph describes storage cleanup."
+        }
+      ]
+    })
+
+    expect(message).toBe(
+      [
+        "Sidepanel page context:",
+        "Title: Debugging Guide",
+        "URL: https://example.test/debugging",
+        "Snippet 1 (selected text): The failing assertion mentions read-back verification.",
+        "Snippet 2: The visible paragraph describes storage cleanup.",
+        "User draft:",
+        "What should I inspect?"
+      ].join("\n")
+    )
+  })
+})

--- a/apps/packages/ui/src/services/__tests__/sidepanel-chat-handoff.test.ts
+++ b/apps/packages/ui/src/services/__tests__/sidepanel-chat-handoff.test.ts
@@ -164,6 +164,33 @@ describe("sidepanel chat handoff storage service", () => {
     expect(storageState.store.has(storageKey("cleanup-malformed"))).toBe(false)
   })
 
+  it("keeps valid serialized packages during cleanup and removes expired or malformed serialized packages", async () => {
+    const validSerialized = buildStoredPackage({ id: "serialized-valid" })
+    const expiredSerialized = buildStoredPackage({
+      id: "serialized-expired",
+      expiresAt: new Date(NOW.getTime() - 1).toISOString()
+    })
+
+    storageState.store.set(storageKey("serialized-valid"), JSON.stringify(validSerialized))
+    storageState.store.set(
+      storageKey("serialized-expired"),
+      JSON.stringify(expiredSerialized)
+    )
+    storageState.store.set(
+      storageKey("serialized-malformed"),
+      JSON.stringify({ id: "serialized-malformed" })
+    )
+
+    await expect(cleanupExpiredSidepanelChatHandoffs()).resolves.toBe(2)
+
+    expect(storageState.store.has(storageKey("serialized-valid"))).toBe(true)
+    expect(storageState.store.has(storageKey("serialized-expired"))).toBe(false)
+    expect(storageState.store.has(storageKey("serialized-malformed"))).toBe(false)
+    await expect(readSidepanelChatHandoff("serialized-valid")).resolves.toEqual(
+      validSerialized
+    )
+  })
+
   it("consumes a package exactly once", async () => {
     const pkg = await createSidepanelChatHandoff({
       draftText: "consume this once"

--- a/apps/packages/ui/src/services/__tests__/sidepanel-chat-handoff.test.ts
+++ b/apps/packages/ui/src/services/__tests__/sidepanel-chat-handoff.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
 const storageState = vi.hoisted(() => {
   const store = new Map<string, unknown>()
@@ -37,8 +37,12 @@ import {
   createSidepanelChatHandoff,
   readSidepanelChatHandoff,
   SIDEPANEL_CHAT_HANDOFF_MAX_DRAFT_CHARS,
+  SIDEPANEL_CHAT_HANDOFF_MAX_ROUTE_CHARACTER_ID_CHARS,
+  SIDEPANEL_CHAT_HANDOFF_MAX_ROUTE_PATH_CHARS,
   SIDEPANEL_CHAT_HANDOFF_MAX_SNIPPET_CHARS,
   SIDEPANEL_CHAT_HANDOFF_MAX_SNIPPETS,
+  SIDEPANEL_CHAT_HANDOFF_MAX_TITLE_CHARS,
+  SIDEPANEL_CHAT_HANDOFF_MAX_URL_CHARS,
   SIDEPANEL_CHAT_HANDOFF_STORAGE_PREFIX,
   SIDEPANEL_CHAT_HANDOFF_TTL_MS,
   type SidepanelChatHandoffPackage
@@ -70,6 +74,10 @@ describe("sidepanel chat handoff storage service", () => {
     vi.setSystemTime(NOW)
     vi.clearAllMocks()
     storageState.store.clear()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
   })
 
   it("creates bounded packages and verifies read-back before returning the id", async () => {
@@ -113,6 +121,40 @@ describe("sidepanel chat handoff storage service", () => {
     expect(pkg.pageContext?.truncated).toBe(true)
     expect(storageState.set).toHaveBeenCalledWith(storageKey(pkg.id), pkg)
     expect(storageState.get).toHaveBeenCalledWith(storageKey(pkg.id))
+
+    await expect(readSidepanelChatHandoff(pkg.id)).resolves.toEqual(pkg)
+  })
+
+  it("bounds page metadata and route intent strings before writing", async () => {
+    const pkg = await createSidepanelChatHandoff({
+      draftText: "bounded metadata",
+      pageContext: {
+        title: "T".repeat(SIDEPANEL_CHAT_HANDOFF_MAX_TITLE_CHARS + 12),
+        url: `https://example.test/${"u".repeat(SIDEPANEL_CHAT_HANDOFF_MAX_URL_CHARS)}`,
+        snippets: []
+      },
+      routeIntent: {
+        path: `#/chat?${"p".repeat(SIDEPANEL_CHAT_HANDOFF_MAX_ROUTE_PATH_CHARS)}`,
+        mode: "character",
+        characterId: "c".repeat(
+          SIDEPANEL_CHAT_HANDOFF_MAX_ROUTE_CHARACTER_ID_CHARS + 10
+        )
+      }
+    })
+
+    expect(pkg.pageContext?.title).toHaveLength(
+      SIDEPANEL_CHAT_HANDOFF_MAX_TITLE_CHARS
+    )
+    expect(pkg.pageContext?.url).toHaveLength(SIDEPANEL_CHAT_HANDOFF_MAX_URL_CHARS)
+    expect(pkg.pageContext?.truncated).toBe(true)
+    expect(pkg.routeIntent?.path).toHaveLength(
+      SIDEPANEL_CHAT_HANDOFF_MAX_ROUTE_PATH_CHARS
+    )
+    expect(pkg.routeIntent?.path.startsWith("#/chat?")).toBe(true)
+    expect(pkg.routeIntent?.mode).toBe("character")
+    expect(pkg.routeIntent?.characterId).toHaveLength(
+      SIDEPANEL_CHAT_HANDOFF_MAX_ROUTE_CHARACTER_ID_CHARS
+    )
 
     await expect(readSidepanelChatHandoff(pkg.id)).resolves.toEqual(pkg)
   })
@@ -162,6 +204,29 @@ describe("sidepanel chat handoff storage service", () => {
     await expect(cleanupExpiredSidepanelChatHandoffs()).resolves.toBe(2)
     expect(storageState.store.has(storageKey("cleanup-expired"))).toBe(false)
     expect(storageState.store.has(storageKey("cleanup-malformed"))).toBe(false)
+  })
+
+  it("returns null and removes packages whose storage key id does not match the body id", async () => {
+    const readMismatch = buildStoredPackage({
+      id: "body-id",
+      draft: { text: "wrong key body" }
+    })
+    storageState.store.set(storageKey("requested-id"), readMismatch)
+
+    await expect(readSidepanelChatHandoff("requested-id")).resolves.toBeNull()
+    expect(storageState.store.has(storageKey("requested-id"))).toBe(false)
+
+    const cleanupMismatch = buildStoredPackage({
+      id: "cleanup-body-id",
+      draft: { text: "cleanup wrong key body" }
+    })
+    storageState.store.set(
+      storageKey("cleanup-key-id"),
+      JSON.stringify(cleanupMismatch)
+    )
+
+    await expect(cleanupExpiredSidepanelChatHandoffs()).resolves.toBe(1)
+    expect(storageState.store.has(storageKey("cleanup-key-id"))).toBe(false)
   })
 
   it("keeps valid serialized packages during cleanup and removes expired or malformed serialized packages", async () => {
@@ -222,6 +287,8 @@ describe("sidepanel chat handoff storage service", () => {
     const pkg = await createSidepanelChatHandoff({
       draftText: "selected-secret-draft",
       pageContext: {
+        title: "secret-page-title",
+        url: "https://secret.example.test/private",
         snippets: [{ kind: "selection", text: "snippet-secret-text" }]
       }
     })
@@ -234,8 +301,12 @@ describe("sidepanel chat handoff storage service", () => {
     expect(route).toContain(`handoff=${encodeURIComponent(pkg.id)}`)
     expect(route).not.toContain("selected-secret-draft")
     expect(route).not.toContain("snippet-secret-text")
+    expect(route).not.toContain("secret-page-title")
+    expect(route).not.toContain("secret.example.test")
     expect(route).not.toContain("draft")
     expect(route).not.toContain("snippet")
+    expect(route).not.toContain("title")
+    expect(route).not.toContain("url")
   })
 
   it("builds messageForModel with visible sidepanel context", () => {

--- a/apps/packages/ui/src/services/__tests__/sidepanel-chat-handoff.test.ts
+++ b/apps/packages/ui/src/services/__tests__/sidepanel-chat-handoff.test.ts
@@ -125,6 +125,32 @@ describe("sidepanel chat handoff storage service", () => {
     await expect(readSidepanelChatHandoff(pkg.id)).resolves.toEqual(pkg)
   })
 
+  it("uses test fallback ids in jsdom tests without process env access", async () => {
+    const originalCrypto = globalThis.crypto
+    const originalNavigator = globalThis.navigator
+    const originalProcess = (globalThis as { process?: unknown }).process
+
+    vi.stubGlobal("crypto", { randomUUID: undefined })
+    vi.stubGlobal("navigator", {
+      ...originalNavigator,
+      userAgent: "Mozilla/5.0 (jsdom)"
+    })
+    vi.stubGlobal("process", undefined)
+
+    try {
+      const pkg = await createSidepanelChatHandoff({
+        draftText: "browser-style test id"
+      })
+
+      expect(pkg.id).toMatch(/^test-/)
+      await expect(readSidepanelChatHandoff(pkg.id)).resolves.toEqual(pkg)
+    } finally {
+      vi.stubGlobal("crypto", originalCrypto)
+      vi.stubGlobal("navigator", originalNavigator)
+      vi.stubGlobal("process", originalProcess)
+    }
+  })
+
   it("bounds page metadata and route intent strings before writing", async () => {
     const pkg = await createSidepanelChatHandoff({
       draftText: "bounded metadata",
@@ -281,6 +307,27 @@ describe("sidepanel chat handoff storage service", () => {
     expect(characterParams.get("mode")).toBe("character")
     expect(characterParams.get("characterId")).toBe("char-1")
     expect(characterParams.get("handoff")).toBe("handoff-character")
+  })
+
+  it("preserves route hash fragments while adding handoff query params", () => {
+    expect(buildSidepanelChatHandoffRoute("#/chat#draft", "handoff-hash")).toBe(
+      "#/chat?handoff=handoff-hash#draft"
+    )
+
+    const characterRoute = buildSidepanelChatHandoffRoute(
+      "#/chat?mode=character&characterId=char-1#draft",
+      "handoff-character-hash"
+    )
+    const query = characterRoute.slice(
+      characterRoute.indexOf("?") + 1,
+      characterRoute.indexOf("#draft")
+    )
+    const params = new URLSearchParams(query)
+
+    expect(characterRoute.endsWith("#draft")).toBe(true)
+    expect(params.get("mode")).toBe("character")
+    expect(params.get("characterId")).toBe("char-1")
+    expect(params.get("handoff")).toBe("handoff-character-hash")
   })
 
   it("never puts draft text or snippet text into the route", async () => {

--- a/apps/packages/ui/src/services/sidepanel-chat-handoff.ts
+++ b/apps/packages/ui/src/services/sidepanel-chat-handoff.ts
@@ -307,10 +307,13 @@ const parsePackage = (
 
   if (!isRecord(value)) return null
   if (typeof value.id !== "string" || value.id.length === 0) return null
-  if (expectedId != null && value.id !== expectedId) return null
+  const id = value.id
+  if (expectedId != null && id !== expectedId) return null
   if (value.source !== "sidepanel-chat") return null
   if (!isValidDateString(value.createdAt)) return null
+  const createdAt = value.createdAt
   if (!isValidDateString(value.expiresAt)) return null
+  const expiresAt = value.expiresAt
   let consumedAt: string | undefined
   if (value.consumedAt != null) {
     if (!isValidDateString(value.consumedAt)) return null
@@ -336,10 +339,10 @@ const parsePackage = (
   if (value.routeIntent != null && !routeIntent) return null
 
   return {
-    id: value.id,
+    id,
     source: "sidepanel-chat",
-    createdAt: value.createdAt,
-    expiresAt: value.expiresAt,
+    createdAt,
+    expiresAt,
     ...(consumedAt ? { consumedAt } : {}),
     draft: {
       text: draftText,

--- a/apps/packages/ui/src/services/sidepanel-chat-handoff.ts
+++ b/apps/packages/ui/src/services/sidepanel-chat-handoff.ts
@@ -74,15 +74,22 @@ const isValidDateString = (value: unknown): value is string =>
   typeof value === "string" && Number.isFinite(Date.parse(value))
 
 const isTestEnvironment = () => {
-  const maybeProcess = (
-    globalThis as {
-      process?: { env?: Record<string, string | undefined> }
-    }
-  ).process
+  const maybeGlobal = globalThis as {
+    process?: { env?: Record<string, string | undefined> }
+    __vitest__?: unknown
+    vitest?: unknown
+  }
+  const userAgent =
+    typeof navigator !== "undefined" && typeof navigator.userAgent === "string"
+      ? navigator.userAgent.toLowerCase()
+      : ""
 
   return (
-    maybeProcess?.env?.VITEST === "true" ||
-    maybeProcess?.env?.NODE_ENV === "test"
+    maybeGlobal.process?.env?.VITEST === "true" ||
+    maybeGlobal.process?.env?.NODE_ENV === "test" ||
+    maybeGlobal.__vitest__ != null ||
+    maybeGlobal.vitest != null ||
+    userAgent.includes("jsdom")
   )
 }
 
@@ -460,11 +467,20 @@ export const buildSidepanelChatHandoffRoute = (
   baseChatPath: string,
   handoffId: string
 ): string => {
-  const [path, rawQuery = ""] = baseChatPath.split("?")
+  const hashSearchStart = baseChatPath.startsWith("#") ? 1 : 0
+  const hashIndex = baseChatPath.indexOf("#", hashSearchStart)
+  const baseWithoutHash =
+    hashIndex >= 0 ? baseChatPath.slice(0, hashIndex) : baseChatPath
+  const hash = hashIndex >= 0 ? baseChatPath.slice(hashIndex) : ""
+  const queryIndex = baseWithoutHash.indexOf("?")
+  const path =
+    queryIndex >= 0 ? baseWithoutHash.slice(0, queryIndex) : baseWithoutHash
+  const rawQuery =
+    queryIndex >= 0 ? baseWithoutHash.slice(queryIndex + 1) : ""
   const params = new URLSearchParams(rawQuery)
   params.set("handoff", handoffId)
   const query = params.toString()
-  return query ? `${path}?${query}` : path
+  return query ? `${path}?${query}${hash}` : `${path}${hash}`
 }
 
 export const buildSidepanelHandoffMessageForModel = (

--- a/apps/packages/ui/src/services/sidepanel-chat-handoff.ts
+++ b/apps/packages/ui/src/services/sidepanel-chat-handoff.ts
@@ -1,0 +1,406 @@
+import { createSafeStorage } from "@/utils/safe-storage"
+
+export const SIDEPANEL_CHAT_HANDOFF_TTL_MS = 10 * 60 * 1000
+export const SIDEPANEL_CHAT_HANDOFF_STORAGE_PREFIX =
+  "tldw:sidepanel-chat-handoff:"
+export const SIDEPANEL_CHAT_HANDOFF_MAX_SNIPPETS = 4
+export const SIDEPANEL_CHAT_HANDOFF_MAX_SNIPPET_CHARS = 4_000
+export const SIDEPANEL_CHAT_HANDOFF_MAX_TOTAL_SNIPPET_CHARS = 16_000
+export const SIDEPANEL_CHAT_HANDOFF_MAX_DRAFT_CHARS = 32_000
+
+export type SidepanelChatHandoffSnippet = {
+  kind: "selection" | "visible-context" | "captured-snippet"
+  text: string
+  label?: string
+  truncated?: boolean
+}
+
+export type SidepanelChatHandoffPageContext = {
+  title?: string
+  url?: string
+  snippets: SidepanelChatHandoffSnippet[]
+  truncated?: boolean
+}
+
+export type SidepanelChatHandoffPackage = {
+  id: string
+  source: "sidepanel-chat"
+  createdAt: string
+  expiresAt: string
+  consumedAt?: string
+  draft: { text: string; truncated?: boolean }
+  pageContext?: SidepanelChatHandoffPageContext
+  routeIntent?: {
+    path: string
+    mode?: "character"
+    characterId?: string
+  }
+}
+
+export type CreateSidepanelChatHandoffInput = {
+  draftText: string
+  pageContext?: {
+    title?: string
+    url?: string
+    snippets?: SidepanelChatHandoffSnippet[]
+  }
+  routeIntent?: SidepanelChatHandoffPackage["routeIntent"]
+}
+
+const storage = createSafeStorage({ area: "local" })
+
+const storageKey = (id: string) => `${SIDEPANEL_CHAT_HANDOFF_STORAGE_PREFIX}${id}`
+
+const snippetKinds = new Set<SidepanelChatHandoffSnippet["kind"]>([
+  "selection",
+  "visible-context",
+  "captured-snippet"
+])
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value)
+
+const isValidDateString = (value: unknown): value is string =>
+  typeof value === "string" && Number.isFinite(Date.parse(value))
+
+const isTestEnvironment = () => {
+  const maybeProcess = (
+    globalThis as {
+      process?: { env?: Record<string, string | undefined> }
+    }
+  ).process
+
+  return (
+    maybeProcess?.env?.VITEST === "true" ||
+    maybeProcess?.env?.NODE_ENV === "test"
+  )
+}
+
+const createHandoffId = (): string => {
+  const randomUUID = globalThis.crypto?.randomUUID
+  if (typeof randomUUID === "function") {
+    return randomUUID.call(globalThis.crypto)
+  }
+
+  if (isTestEnvironment()) {
+    return `test-${Date.now().toString(36)}-${Math.random()
+      .toString(36)
+      .slice(2, 12)}`
+  }
+
+  throw new Error("crypto.randomUUID is required to create sidepanel chat handoffs.")
+}
+
+const truncateText = (
+  text: string,
+  maxChars: number
+): { text: string; truncated?: boolean } => {
+  if (text.length <= maxChars) return { text }
+  return { text: text.slice(0, maxChars), truncated: true }
+}
+
+const isValidSnippetKind = (
+  kind: unknown
+): kind is SidepanelChatHandoffSnippet["kind"] =>
+  typeof kind === "string" && snippetKinds.has(kind as SidepanelChatHandoffSnippet["kind"])
+
+const isValidSnippet = (
+  snippet: unknown
+): snippet is SidepanelChatHandoffSnippet => {
+  if (!isRecord(snippet)) return false
+  if (!isValidSnippetKind(snippet.kind)) return false
+  if (typeof snippet.text !== "string") return false
+  if (snippet.label != null && typeof snippet.label !== "string") return false
+  if (snippet.truncated != null && typeof snippet.truncated !== "boolean") {
+    return false
+  }
+  return true
+}
+
+const buildBoundedSnippets = (
+  snippets: SidepanelChatHandoffSnippet[] = []
+): { snippets: SidepanelChatHandoffSnippet[]; truncated: boolean } => {
+  let remainingChars = SIDEPANEL_CHAT_HANDOFF_MAX_TOTAL_SNIPPET_CHARS
+  let truncated = snippets.length > SIDEPANEL_CHAT_HANDOFF_MAX_SNIPPETS
+  const bounded: SidepanelChatHandoffSnippet[] = []
+
+  for (const snippet of snippets.slice(0, SIDEPANEL_CHAT_HANDOFF_MAX_SNIPPETS)) {
+    if (!isValidSnippet(snippet) || remainingChars <= 0) {
+      truncated = true
+      continue
+    }
+
+    const maxChars = Math.min(
+      SIDEPANEL_CHAT_HANDOFF_MAX_SNIPPET_CHARS,
+      remainingChars
+    )
+    const boundedText = snippet.text.slice(0, maxChars)
+    const wasTruncated = snippet.truncated || boundedText.length < snippet.text.length
+    remainingChars -= boundedText.length
+
+    bounded.push({
+      kind: snippet.kind,
+      text: boundedText,
+      ...(snippet.label != null ? { label: snippet.label } : {}),
+      ...(wasTruncated ? { truncated: true } : {})
+    })
+
+    if (wasTruncated) truncated = true
+  }
+
+  if (bounded.length < snippets.length) truncated = true
+
+  return { snippets: bounded, truncated }
+}
+
+const buildPageContext = (
+  pageContext: CreateSidepanelChatHandoffInput["pageContext"]
+): SidepanelChatHandoffPageContext | undefined => {
+  if (!pageContext) return undefined
+
+  const { snippets, truncated } = buildBoundedSnippets(pageContext.snippets)
+
+  return {
+    ...(pageContext.title != null ? { title: pageContext.title } : {}),
+    ...(pageContext.url != null ? { url: pageContext.url } : {}),
+    snippets,
+    ...(truncated ? { truncated: true } : {})
+  }
+}
+
+const buildRouteIntent = (
+  routeIntent: CreateSidepanelChatHandoffInput["routeIntent"]
+): SidepanelChatHandoffPackage["routeIntent"] => {
+  if (!routeIntent) return undefined
+
+  return {
+    path: routeIntent.path,
+    ...(routeIntent.mode === "character" ? { mode: "character" as const } : {}),
+    ...(routeIntent.characterId != null ? { characterId: routeIntent.characterId } : {})
+  }
+}
+
+const buildPackage = (
+  input: CreateSidepanelChatHandoffInput,
+  now: number
+): SidepanelChatHandoffPackage => {
+  const draft = truncateText(
+    String(input.draftText ?? ""),
+    SIDEPANEL_CHAT_HANDOFF_MAX_DRAFT_CHARS
+  )
+  const pageContext = buildPageContext(input.pageContext)
+  const routeIntent = buildRouteIntent(input.routeIntent)
+
+  return {
+    id: createHandoffId(),
+    source: "sidepanel-chat",
+    createdAt: new Date(now).toISOString(),
+    expiresAt: new Date(now + SIDEPANEL_CHAT_HANDOFF_TTL_MS).toISOString(),
+    draft,
+    ...(pageContext ? { pageContext } : {}),
+    ...(routeIntent ? { routeIntent } : {})
+  }
+}
+
+const parsePageContext = (
+  value: unknown
+): SidepanelChatHandoffPageContext | null => {
+  if (!isRecord(value)) return null
+  if (value.title != null && typeof value.title !== "string") return null
+  if (value.url != null && typeof value.url !== "string") return null
+  if (!Array.isArray(value.snippets)) return null
+  if (!value.snippets.every(isValidSnippet)) return null
+  if (value.truncated != null && typeof value.truncated !== "boolean") return null
+
+  return {
+    ...(value.title != null ? { title: value.title } : {}),
+    ...(value.url != null ? { url: value.url } : {}),
+    snippets: value.snippets,
+    ...(value.truncated != null ? { truncated: value.truncated } : {})
+  }
+}
+
+const parseRouteIntent = (
+  value: unknown
+): SidepanelChatHandoffPackage["routeIntent"] | null => {
+  if (!isRecord(value)) return null
+  if (typeof value.path !== "string") return null
+  if (value.mode != null && value.mode !== "character") return null
+  if (value.characterId != null && typeof value.characterId !== "string") return null
+
+  return {
+    path: value.path,
+    ...(value.mode === "character" ? { mode: "character" } : {}),
+    ...(value.characterId != null ? { characterId: value.characterId } : {})
+  }
+}
+
+const parsePackage = (value: unknown): SidepanelChatHandoffPackage | null => {
+  if (!isRecord(value)) return null
+  if (typeof value.id !== "string" || value.id.length === 0) return null
+  if (value.source !== "sidepanel-chat") return null
+  if (!isValidDateString(value.createdAt)) return null
+  if (!isValidDateString(value.expiresAt)) return null
+  if (value.consumedAt != null && !isValidDateString(value.consumedAt)) return null
+  if (!isRecord(value.draft)) return null
+  if (typeof value.draft.text !== "string") return null
+  if (value.draft.truncated != null && typeof value.draft.truncated !== "boolean") {
+    return null
+  }
+
+  const pageContext =
+    value.pageContext == null ? undefined : parsePageContext(value.pageContext)
+  if (value.pageContext != null && !pageContext) return null
+
+  const routeIntent =
+    value.routeIntent == null ? undefined : parseRouteIntent(value.routeIntent)
+  if (value.routeIntent != null && !routeIntent) return null
+
+  return {
+    id: value.id,
+    source: "sidepanel-chat",
+    createdAt: value.createdAt,
+    expiresAt: value.expiresAt,
+    ...(value.consumedAt != null ? { consumedAt: value.consumedAt } : {}),
+    draft: {
+      text: value.draft.text,
+      ...(value.draft.truncated != null
+        ? { truncated: value.draft.truncated }
+        : {})
+    },
+    ...(pageContext ? { pageContext } : {}),
+    ...(routeIntent ? { routeIntent } : {})
+  }
+}
+
+const readRawPackage = async (
+  id: string
+): Promise<SidepanelChatHandoffPackage | null> => {
+  const raw = await storage.get(storageKey(id))
+  return parsePackage(raw)
+}
+
+const isExpired = (pkg: SidepanelChatHandoffPackage, now = Date.now()) =>
+  Date.parse(pkg.expiresAt) <= now
+
+const removeKeyQuietly = async (key: string) => {
+  try {
+    await storage.remove(key)
+  } catch {
+    // Best-effort cleanup after failed writes or malformed records.
+  }
+}
+
+export const cleanupExpiredSidepanelChatHandoffs = async (): Promise<number> => {
+  try {
+    const entries = await storage.getAll()
+    const now = Date.now()
+    const keysToRemove = Object.entries(entries)
+      .filter(([key]) => key.startsWith(SIDEPANEL_CHAT_HANDOFF_STORAGE_PREFIX))
+      .filter(([, value]) => {
+        const pkg = parsePackage(value)
+        return !pkg || pkg.consumedAt != null || isExpired(pkg, now)
+      })
+      .map(([key]) => key)
+
+    if (keysToRemove.length > 0) {
+      await storage.removeMany(keysToRemove)
+    }
+
+    return keysToRemove.length
+  } catch {
+    return 0
+  }
+}
+
+export const createSidepanelChatHandoff = async (
+  input: CreateSidepanelChatHandoffInput
+): Promise<SidepanelChatHandoffPackage> => {
+  await cleanupExpiredSidepanelChatHandoffs()
+  const now = Date.now()
+  const pkg = buildPackage(input, now)
+  const key = storageKey(pkg.id)
+
+  try {
+    await storage.set(key, pkg)
+  } catch (error) {
+    await removeKeyQuietly(key)
+    throw error
+  }
+
+  let saved: SidepanelChatHandoffPackage | null
+  try {
+    saved = await readRawPackage(pkg.id)
+  } catch {
+    await removeKeyQuietly(key)
+    throw new Error("Sidepanel chat handoff could not be saved.")
+  }
+
+  if (!saved || saved.id !== pkg.id) {
+    await removeKeyQuietly(key)
+    throw new Error("Sidepanel chat handoff could not be saved.")
+  }
+
+  return saved
+}
+
+export const readSidepanelChatHandoff = async (
+  id: string
+): Promise<SidepanelChatHandoffPackage | null> => {
+  const key = storageKey(id)
+
+  try {
+    const raw = await storage.get(key)
+    if (raw == null) return null
+
+    const pkg = parsePackage(raw)
+    if (!pkg || pkg.consumedAt != null || isExpired(pkg)) {
+      await removeKeyQuietly(key)
+      return null
+    }
+
+    return pkg
+  } catch {
+    return null
+  }
+}
+
+export const consumeSidepanelChatHandoff = async (
+  id: string
+): Promise<SidepanelChatHandoffPackage | null> => {
+  const pkg = await readSidepanelChatHandoff(id)
+  if (!pkg) return null
+
+  await storage.remove(storageKey(id))
+  return pkg
+}
+
+export const buildSidepanelChatHandoffRoute = (
+  baseChatPath: string,
+  handoffId: string
+): string => {
+  const [path, rawQuery = ""] = baseChatPath.split("?")
+  const params = new URLSearchParams(rawQuery)
+  params.set("handoff", handoffId)
+  const query = params.toString()
+  return query ? `${path}?${query}` : path
+}
+
+export const buildSidepanelHandoffMessageForModel = (
+  visibleDraft: string,
+  pageContext?: SidepanelChatHandoffPageContext
+): string => {
+  if (!pageContext) return visibleDraft
+  const lines = [
+    "Sidepanel page context:",
+    pageContext.title ? `Title: ${pageContext.title}` : null,
+    pageContext.url ? `URL: ${pageContext.url}` : null,
+    ...pageContext.snippets.map((snippet, index) =>
+      `Snippet ${index + 1}${snippet.label ? ` (${snippet.label})` : ""}: ${snippet.text}`
+    ),
+    "",
+    "User draft:",
+    visibleDraft
+  ].filter(Boolean)
+  return lines.join("\n")
+}

--- a/apps/packages/ui/src/services/sidepanel-chat-handoff.ts
+++ b/apps/packages/ui/src/services/sidepanel-chat-handoff.ts
@@ -7,6 +7,10 @@ export const SIDEPANEL_CHAT_HANDOFF_MAX_SNIPPETS = 4
 export const SIDEPANEL_CHAT_HANDOFF_MAX_SNIPPET_CHARS = 4_000
 export const SIDEPANEL_CHAT_HANDOFF_MAX_TOTAL_SNIPPET_CHARS = 16_000
 export const SIDEPANEL_CHAT_HANDOFF_MAX_DRAFT_CHARS = 32_000
+export const SIDEPANEL_CHAT_HANDOFF_MAX_TITLE_CHARS = 512
+export const SIDEPANEL_CHAT_HANDOFF_MAX_URL_CHARS = 2_048
+export const SIDEPANEL_CHAT_HANDOFF_MAX_ROUTE_PATH_CHARS = 2_048
+export const SIDEPANEL_CHAT_HANDOFF_MAX_ROUTE_CHARACTER_ID_CHARS = 512
 
 export type SidepanelChatHandoffSnippet = {
   kind: "selection" | "visible-context" | "captured-snippet"
@@ -50,6 +54,12 @@ export type CreateSidepanelChatHandoffInput = {
 const storage = createSafeStorage({ area: "local" })
 
 const storageKey = (id: string) => `${SIDEPANEL_CHAT_HANDOFF_STORAGE_PREFIX}${id}`
+
+const idFromStorageKey = (key: string): string | null => {
+  if (!key.startsWith(SIDEPANEL_CHAT_HANDOFF_STORAGE_PREFIX)) return null
+  const id = key.slice(SIDEPANEL_CHAT_HANDOFF_STORAGE_PREFIX.length)
+  return id.length > 0 ? id : null
+}
 
 const snippetKinds = new Set<SidepanelChatHandoffSnippet["kind"]>([
   "selection",
@@ -158,11 +168,23 @@ const buildPageContext = (
 ): SidepanelChatHandoffPageContext | undefined => {
   if (!pageContext) return undefined
 
-  const { snippets, truncated } = buildBoundedSnippets(pageContext.snippets)
+  const { snippets, truncated: snippetsTruncated } = buildBoundedSnippets(
+    pageContext.snippets
+  )
+  const title =
+    pageContext.title == null
+      ? undefined
+      : truncateText(pageContext.title, SIDEPANEL_CHAT_HANDOFF_MAX_TITLE_CHARS)
+  const url =
+    pageContext.url == null
+      ? undefined
+      : truncateText(pageContext.url, SIDEPANEL_CHAT_HANDOFF_MAX_URL_CHARS)
+  const truncated =
+    snippetsTruncated || Boolean(title?.truncated) || Boolean(url?.truncated)
 
   return {
-    ...(pageContext.title != null ? { title: pageContext.title } : {}),
-    ...(pageContext.url != null ? { url: pageContext.url } : {}),
+    ...(title ? { title: title.text } : {}),
+    ...(url ? { url: url.text } : {}),
     snippets,
     ...(truncated ? { truncated: true } : {})
   }
@@ -172,11 +194,22 @@ const buildRouteIntent = (
   routeIntent: CreateSidepanelChatHandoffInput["routeIntent"]
 ): SidepanelChatHandoffPackage["routeIntent"] => {
   if (!routeIntent) return undefined
+  const path = truncateText(
+    routeIntent.path,
+    SIDEPANEL_CHAT_HANDOFF_MAX_ROUTE_PATH_CHARS
+  )
+  const characterId =
+    routeIntent.characterId == null
+      ? undefined
+      : truncateText(
+          routeIntent.characterId,
+          SIDEPANEL_CHAT_HANDOFF_MAX_ROUTE_CHARACTER_ID_CHARS
+        )
 
   return {
-    path: routeIntent.path,
+    path: path.text,
     ...(routeIntent.mode === "character" ? { mode: "character" as const } : {}),
-    ...(routeIntent.characterId != null ? { characterId: routeIntent.characterId } : {})
+    ...(characterId ? { characterId: characterId.text } : {})
   }
 }
 
@@ -246,12 +279,14 @@ const normalizeStoredPackageValue = (value: unknown): unknown => {
 }
 
 const parsePackage = (
-  storedValue: unknown
+  storedValue: unknown,
+  expectedId?: string
 ): SidepanelChatHandoffPackage | null => {
   const value = normalizeStoredPackageValue(storedValue)
 
   if (!isRecord(value)) return null
   if (typeof value.id !== "string" || value.id.length === 0) return null
+  if (expectedId != null && value.id !== expectedId) return null
   if (value.source !== "sidepanel-chat") return null
   if (!isValidDateString(value.createdAt)) return null
   if (!isValidDateString(value.expiresAt)) return null
@@ -291,7 +326,7 @@ const readRawPackage = async (
   id: string
 ): Promise<SidepanelChatHandoffPackage | null> => {
   const raw = await storage.get(storageKey(id))
-  return parsePackage(raw)
+  return parsePackage(raw, id)
 }
 
 const isExpired = (pkg: SidepanelChatHandoffPackage, now = Date.now()) =>
@@ -311,8 +346,9 @@ export const cleanupExpiredSidepanelChatHandoffs = async (): Promise<number> => 
     const now = Date.now()
     const keysToRemove = Object.entries(entries)
       .filter(([key]) => key.startsWith(SIDEPANEL_CHAT_HANDOFF_STORAGE_PREFIX))
-      .filter(([, value]) => {
-        const pkg = parsePackage(value)
+      .filter(([key, value]) => {
+        const expectedId = idFromStorageKey(key)
+        const pkg = expectedId ? parsePackage(value, expectedId) : null
         return !pkg || pkg.consumedAt != null || isExpired(pkg, now)
       })
       .map(([key]) => key)
@@ -367,7 +403,7 @@ export const readSidepanelChatHandoff = async (
     const raw = await storage.get(key)
     if (raw == null) return null
 
-    const pkg = parsePackage(raw)
+    const pkg = parsePackage(raw, id)
     if (!pkg || pkg.consumedAt != null || isExpired(pkg)) {
       await removeKeyQuietly(key)
       return null

--- a/apps/packages/ui/src/services/sidepanel-chat-handoff.ts
+++ b/apps/packages/ui/src/services/sidepanel-chat-handoff.ts
@@ -235,7 +235,21 @@ const parseRouteIntent = (
   }
 }
 
-const parsePackage = (value: unknown): SidepanelChatHandoffPackage | null => {
+const normalizeStoredPackageValue = (value: unknown): unknown => {
+  if (typeof value !== "string") return value
+
+  try {
+    return JSON.parse(value)
+  } catch {
+    return value
+  }
+}
+
+const parsePackage = (
+  storedValue: unknown
+): SidepanelChatHandoffPackage | null => {
+  const value = normalizeStoredPackageValue(storedValue)
+
   if (!isRecord(value)) return null
   if (typeof value.id !== "string" || value.id.length === 0) return null
   if (value.source !== "sidepanel-chat") return null

--- a/apps/packages/ui/src/services/sidepanel-chat-handoff.ts
+++ b/apps/packages/ui/src/services/sidepanel-chat-handoff.ts
@@ -239,17 +239,31 @@ const parsePageContext = (
   value: unknown
 ): SidepanelChatHandoffPageContext | null => {
   if (!isRecord(value)) return null
-  if (value.title != null && typeof value.title !== "string") return null
-  if (value.url != null && typeof value.url !== "string") return null
+  let title: string | undefined
+  let url: string | undefined
+  let truncated: boolean | undefined
+
+  if (value.title != null) {
+    if (typeof value.title !== "string") return null
+    title = value.title
+  }
+  if (value.url != null) {
+    if (typeof value.url !== "string") return null
+    url = value.url
+  }
   if (!Array.isArray(value.snippets)) return null
   if (!value.snippets.every(isValidSnippet)) return null
-  if (value.truncated != null && typeof value.truncated !== "boolean") return null
+  const snippets: SidepanelChatHandoffSnippet[] = value.snippets
+  if (value.truncated != null) {
+    if (typeof value.truncated !== "boolean") return null
+    truncated = value.truncated
+  }
 
   return {
-    ...(value.title != null ? { title: value.title } : {}),
-    ...(value.url != null ? { url: value.url } : {}),
-    snippets: value.snippets,
-    ...(value.truncated != null ? { truncated: value.truncated } : {})
+    ...(title ? { title } : {}),
+    ...(url ? { url } : {}),
+    snippets,
+    ...(truncated != null ? { truncated } : {})
   }
 }
 
@@ -257,14 +271,21 @@ const parseRouteIntent = (
   value: unknown
 ): SidepanelChatHandoffPackage["routeIntent"] | null => {
   if (!isRecord(value)) return null
+  let characterId: string | undefined
+
   if (typeof value.path !== "string") return null
+  const path: string = value.path
   if (value.mode != null && value.mode !== "character") return null
-  if (value.characterId != null && typeof value.characterId !== "string") return null
+  const mode = value.mode === "character" ? value.mode : undefined
+  if (value.characterId != null) {
+    if (typeof value.characterId !== "string") return null
+    characterId = value.characterId
+  }
 
   return {
-    path: value.path,
-    ...(value.mode === "character" ? { mode: "character" } : {}),
-    ...(value.characterId != null ? { characterId: value.characterId } : {})
+    path,
+    ...(mode === "character" ? { mode: "character" } : {}),
+    ...(characterId != null ? { characterId } : {})
   }
 }
 
@@ -290,11 +311,20 @@ const parsePackage = (
   if (value.source !== "sidepanel-chat") return null
   if (!isValidDateString(value.createdAt)) return null
   if (!isValidDateString(value.expiresAt)) return null
-  if (value.consumedAt != null && !isValidDateString(value.consumedAt)) return null
+  let consumedAt: string | undefined
+  if (value.consumedAt != null) {
+    if (!isValidDateString(value.consumedAt)) return null
+    consumedAt = value.consumedAt
+  }
   if (!isRecord(value.draft)) return null
   if (typeof value.draft.text !== "string") return null
-  if (value.draft.truncated != null && typeof value.draft.truncated !== "boolean") {
-    return null
+  const draftText: string = value.draft.text
+  let draftTruncated: boolean | undefined
+  if (value.draft.truncated != null) {
+    if (typeof value.draft.truncated !== "boolean") {
+      return null
+    }
+    draftTruncated = value.draft.truncated
   }
 
   const pageContext =
@@ -310,12 +340,10 @@ const parsePackage = (
     source: "sidepanel-chat",
     createdAt: value.createdAt,
     expiresAt: value.expiresAt,
-    ...(value.consumedAt != null ? { consumedAt: value.consumedAt } : {}),
+    ...(consumedAt ? { consumedAt } : {}),
     draft: {
-      text: value.draft.text,
-      ...(value.draft.truncated != null
-        ? { truncated: value.draft.truncated }
-        : {})
+      text: draftText,
+      ...(draftTruncated != null ? { truncated: draftTruncated } : {})
     },
     ...(pageContext ? { pageContext } : {}),
     ...(routeIntent ? { routeIntent } : {})

--- a/backlog/tasks/task-546 - Design-explicit-sidepanel-chat-WebUI-handoff.md
+++ b/backlog/tasks/task-546 - Design-explicit-sidepanel-chat-WebUI-handoff.md
@@ -1,12 +1,15 @@
 ---
 id: TASK-546
 title: Design explicit sidepanel chat WebUI handoff
-status: In Progress
+status: Done
+assignee: []
+created_date: ''
+updated_date: 2026-05-29 05:11
 labels:
 - chat
 - extension
 - ux
-priority: Medium
+dependencies: []
 references:
 - TASK-531
 - TASK-534
@@ -14,6 +17,7 @@ documentation:
 - Docs/superpowers/specs/2026-05-29-sidepanel-chat-webui-handoff-design.md
 modified_files:
 - Docs/superpowers/specs/2026-05-29-sidepanel-chat-webui-handoff-design.md
+priority: medium
 ---
 
 ## Description
@@ -24,6 +28,10 @@ Document the approved explicit sidepanel-to-WebUI /chat handoff design: route-on
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
+- [x] #1 Design spec documents explicit Continue in WebUI handoff in ControlRow while preserving the route-only open action.
+- [x] #2 Spec defines fail-closed handoff storage with read-back verification, unguessable IDs, TTL, one-time consume, and payload bounds.
+- [x] #3 Spec defines WebUI import behavior including composer prefill, existing-draft conflict choices, imported-context banner, request inclusion, removal behavior, and hash-router cleanup.
+- [x] #4 Spec defines focused regression tests and implementation slices for storage, sidepanel action, WebUI consumption, and packaged extension smoke.
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -35,21 +43,21 @@ Docs/superpowers/specs/2026-05-29-sidepanel-chat-webui-handoff-design.md
 ## Implementation Notes
 
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
-Design direction approved in brainstorming: separate Continue in WebUI action, ephemeral token, composer prefill without auto-send, visible already-captured page context only, one-time short-lived consume, sidepanel draft preserved. Local spec review added non-overwrite behavior for existing WebUI drafts, role-play query merge rules, unguessable IDs, payload bounds, and malformed package rejection.
+Design direction approved in brainstorming: separate Continue in WebUI action, ephemeral token, composer prefill without auto-send, visible already-captured page context only, one-time short-lived consume, sidepanel draft preserved. Local spec review added ControlRow placement, fail-closed storage, request inclusion semantics, safe consume timing, hash-router cleanup, non-overwrite behavior for existing WebUI drafts, role-play query merge rules, unguessable IDs, concrete payload bounds, and malformed package rejection.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-
+Reviewed and hardened the sidepanel-to-WebUI /chat handoff design before implementation planning. The spec now preserves the route-only open action, places the explicit Continue in WebUI action in ControlRow, defines a fail-closed local storage service contract, makes imported context part of the next chat request, protects existing WebUI drafts, handles hash-router query cleanup, and defines concrete regression coverage.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->

--- a/backlog/tasks/task-546 - Design-explicit-sidepanel-chat-WebUI-handoff.md
+++ b/backlog/tasks/task-546 - Design-explicit-sidepanel-chat-WebUI-handoff.md
@@ -1,0 +1,55 @@
+---
+id: TASK-546
+title: Design explicit sidepanel chat WebUI handoff
+status: In Progress
+labels:
+- chat
+- extension
+- ux
+priority: Medium
+references:
+- TASK-531
+- TASK-534
+documentation:
+- Docs/superpowers/specs/2026-05-29-sidepanel-chat-webui-handoff-design.md
+modified_files:
+- Docs/superpowers/specs/2026-05-29-sidepanel-chat-webui-handoff-design.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Document the approved explicit sidepanel-to-WebUI /chat handoff design: route-only launch remains default, while a separate Continue in WebUI action transfers the current sidepanel draft plus visible page context through a one-time short-lived handoff token.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Docs/superpowers/specs/2026-05-29-sidepanel-chat-webui-handoff-design.md
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Design direction approved in brainstorming: separate Continue in WebUI action, ephemeral token, composer prefill without auto-send, visible already-captured page context only, one-time short-lived consume, sidepanel draft preserved. Local spec review added non-overwrite behavior for existing WebUI drafts, role-play query merge rules, unguessable IDs, payload bounds, and malformed package rejection.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-547 - Plan-sidepanel-chat-WebUI-handoff-implementation.md
+++ b/backlog/tasks/task-547 - Plan-sidepanel-chat-WebUI-handoff-implementation.md
@@ -1,0 +1,56 @@
+---
+id: TASK-547
+title: Plan sidepanel chat WebUI handoff implementation
+status: Done
+labels:
+- chat
+- extension
+- planning
+documentation:
+- Docs/superpowers/plans/2026-05-29-sidepanel-chat-webui-handoff-implementation.md
+modified_files:
+- Docs/superpowers/plans/2026-05-29-sidepanel-chat-webui-handoff-implementation.md
+priority: Medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Create a task-by-task implementation plan for the approved sidepanel chat Continue in WebUI handoff: fail-closed handoff storage, ControlRow action, /chat import and request inclusion, and packaged extension smoke.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Plan file documents exact implementation tasks for storage service, sidepanel action, WebUI import/request inclusion, and focused smoke verification.
+- [x] #2 Plan names exact files to create or modify and exact focused test commands.
+- [x] #3 Plan preserves design constraints from TASK-546, including route-only open behavior, explicit state transfer, fail-closed storage, no auto-send, and no fresh page-body capture.
+- [x] #4 Plan records why subagent plan review was not dispatched in this session.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Docs/superpowers/plans/2026-05-29-sidepanel-chat-webui-handoff-implementation.md
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Created a task-by-task implementation plan from the approved and hardened handoff design. The plan uses TDD slices, focused commits, exact file paths, and focused Vitest commands. Subagent plan review was not dispatched because the available subagent tool policy requires explicit user permission for delegation.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Implementation plan written for sidepanel chat WebUI handoff. It splits the work into storage, sidepanel action, WebUI import/request inclusion, and smoke verification, with explicit regression coverage for route-only behavior, role-play query preservation, imported-context request semantics, and stale handoff handling.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-548 - Implement-sidepanel-chat-handoff-storage-service.md
+++ b/backlog/tasks/task-548 - Implement-sidepanel-chat-handoff-storage-service.md
@@ -1,0 +1,51 @@
+---
+id: TASK-548
+title: Implement sidepanel chat handoff storage service
+status: In Progress
+labels:
+- chat
+- extension
+- implementation
+priority: Medium
+references:
+- TASK-546
+- TASK-547
+documentation:
+- Docs/superpowers/specs/2026-05-29-sidepanel-chat-webui-handoff-design.md
+- Docs/superpowers/plans/2026-05-29-sidepanel-chat-webui-handoff-implementation.md
+modified_files:
+- apps/packages/ui/src/services/sidepanel-chat-handoff.ts
+- apps/packages/ui/src/services/__tests__/sidepanel-chat-handoff.test.ts
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement Task 1 from the sidepanel chat WebUI handoff plan: create a fail-closed extension-local handoff storage service with validation, payload bounds, one-time consume, route merge helpers, message-for-model composition, and focused Vitest coverage.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-548 - Implement-sidepanel-chat-handoff-storage-service.md
+++ b/backlog/tasks/task-548 - Implement-sidepanel-chat-handoff-storage-service.md
@@ -1,18 +1,22 @@
 ---
 id: TASK-548
 title: Implement sidepanel chat handoff storage service
-status: In Progress
+status: Done
+assignee: []
+created_date: ''
+updated_date: 2026-05-29 06:27
 labels:
 - chat
 - extension
 - implementation
-priority: Medium
+dependencies: []
 references:
 - TASK-546
 - TASK-547
 documentation:
 - Docs/superpowers/specs/2026-05-29-sidepanel-chat-webui-handoff-design.md
 - Docs/superpowers/plans/2026-05-29-sidepanel-chat-webui-handoff-implementation.md
+priority: medium
 modified_files:
 - apps/packages/ui/src/services/sidepanel-chat-handoff.ts
 - apps/packages/ui/src/services/__tests__/sidepanel-chat-handoff.test.ts
@@ -26,26 +30,29 @@ Implement Task 1 from the sidepanel chat WebUI handoff plan: create a fail-close
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
+- [x] #1 Storage service creates bounded sidepanel chat handoff packages and verifies read-back before returning the saved package.
+- [x] #2 Storage failures, failed read-back, expired records, malformed records, and mismatched key/body ids fail closed without exposing handoff ids.
+- [x] #3 Read, consume, cleanup, route merge, URL leakage, serialized storage values, metadata bounds, and message-for-model helpers have focused regression coverage.
 <!-- AC:END -->
 
 ## Implementation Notes
 
-<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
-
-<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+<!-- SECTION:NOTES:BEGIN -->
+Implemented sidepanel-chat-handoff.ts and focused service tests. Spec review passed after serialized Plasmo getAll values were normalized before validation. Code-quality review passed after adding key/body id validation, page metadata/route bounds, route leakage assertions, and timer cleanup. Verification: bun run test src/services/__tests__/sidepanel-chat-handoff.test.ts passed with 11 tests; git diff --check d73fded19a..HEAD passed. Bandit is not applicable to TypeScript-only service/test changes; package-wide TypeScript check previously hit Node heap OOM and remains a known environment limitation for this slice.
+<!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-
+Task 1 is complete. The sidepanel chat handoff storage service now stores short-lived, bounded, one-time handoff packages in local extension storage, validates read-back, tolerates serialized Plasmo `getAll()` values, removes expired/malformed/mismatched records, avoids URL payload leakage, and composes imported page context for the next model request. Focused Vitest coverage passes with 11 tests.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->

--- a/backlog/tasks/task-549 - Implement-sidepanel-Continue-in-WebUI-action.md
+++ b/backlog/tasks/task-549 - Implement-sidepanel-Continue-in-WebUI-action.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-549
 title: Implement sidepanel Continue in WebUI action
-status: To Do
+status: In Progress
 labels:
 - chat
 - extension

--- a/backlog/tasks/task-549 - Implement-sidepanel-Continue-in-WebUI-action.md
+++ b/backlog/tasks/task-549 - Implement-sidepanel-Continue-in-WebUI-action.md
@@ -1,23 +1,24 @@
 ---
 id: TASK-549
 title: Implement sidepanel Continue in WebUI action
-status: In Progress
+status: Done
+assignee: []
+created_date: ''
+updated_date: '2026-05-29 06:52'
 labels:
-- chat
-- extension
-- implementation
-priority: Medium
+  - chat
+  - extension
+  - implementation
+dependencies: []
 references:
-- TASK-546
-- TASK-547
-- TASK-548
+  - TASK-546
+  - TASK-547
+  - TASK-548
 documentation:
-- Docs/superpowers/specs/2026-05-29-sidepanel-chat-webui-handoff-design.md
-- Docs/superpowers/plans/2026-05-29-sidepanel-chat-webui-handoff-implementation.md
-modified_files:
-- apps/packages/ui/src/components/Sidepanel/Chat/ControlRow.tsx
-- apps/packages/ui/src/components/Sidepanel/Chat/form.tsx
-- apps/packages/ui/src/components/Sidepanel/Chat/__tests__/ControlRow.chat-handoff.test.tsx
+  - Docs/superpowers/specs/2026-05-29-sidepanel-chat-webui-handoff-design.md
+  - >-
+    Docs/superpowers/plans/2026-05-29-sidepanel-chat-webui-handoff-implementation.md
+priority: medium
 ---
 
 ## Description
@@ -28,26 +29,31 @@ Implement Task 2 from the sidepanel chat WebUI handoff plan: add a sidepanel Con
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
+- [x] #1 ControlRow keeps the existing Open full app action route-only with no handoff creation or handoff query parameter.
+- [x] #2 ControlRow provides a Continue in WebUI action that creates one handoff package, merges the handoff id into the current /chat route, preserves character route params, and avoids serializing draft/context content into the URL.
+- [x] #3 Continue in WebUI handles empty context, storage failure, and rapid duplicate clicks without opening unintended tabs.
+- [x] #4 Sidepanel form passes the current draft and visible page context callback based only on selected tab mentions and active tab title/URL, with no page-body capture.
+- [x] #5 Focused sidepanel handoff and existing full-app route regressions pass.
 <!-- AC:END -->
 
 ## Implementation Notes
 
-<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
-
-<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+<!-- SECTION:NOTES:BEGIN -->
+Implemented chat-continue-in-webui in ControlRow.tsx using the Task 1 handoff service and existing full-app route opener. Added draftMessage, hasVisiblePageContextForHandoff, and getVisiblePageContextForHandoff props to ControlRow. Added selected-document and active-tab title/URL context construction in form.tsx; no page body text is captured. Added ControlRow.chat-handoff.test.tsx covering route-only full-app behavior, handoff creation, character route merge, URL privacy, disabled empty state, stale context warning, storage failure, and duplicate-click prevention. Spec compliance review passed. Code-quality review requested an in-flight guard; fixed with a synchronous ref guard plus pending UI state and deferred-promise regression, then re-review passed. Verification: focused sidepanel suite passed with 14 tests; broader handoff suite passed with 24 tests after including service tests; UI typecheck passed after TASK-550 fixed service parser narrowing. Bandit is not applicable to TypeScript/TSX UI changes; worker attempt produced parser errors for TSX.
+<!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-
+Task 2 is complete. The sidepanel now has a distinct Continue in WebUI quick action that stores the current draft/context in a handoff package and opens `/chat` with only the handoff id in the URL, while the existing Open full app action remains route-only. The sidepanel form supplies visible context from selected tabs and active tab metadata only, and the action now guards duplicate clicks, empty context, and storage failures.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->

--- a/backlog/tasks/task-549 - Implement-sidepanel-Continue-in-WebUI-action.md
+++ b/backlog/tasks/task-549 - Implement-sidepanel-Continue-in-WebUI-action.md
@@ -1,0 +1,53 @@
+---
+id: TASK-549
+title: Implement sidepanel Continue in WebUI action
+status: To Do
+labels:
+- chat
+- extension
+- implementation
+priority: Medium
+references:
+- TASK-546
+- TASK-547
+- TASK-548
+documentation:
+- Docs/superpowers/specs/2026-05-29-sidepanel-chat-webui-handoff-design.md
+- Docs/superpowers/plans/2026-05-29-sidepanel-chat-webui-handoff-implementation.md
+modified_files:
+- apps/packages/ui/src/components/Sidepanel/Chat/ControlRow.tsx
+- apps/packages/ui/src/components/Sidepanel/Chat/form.tsx
+- apps/packages/ui/src/components/Sidepanel/Chat/__tests__/ControlRow.chat-handoff.test.tsx
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement Task 2 from the sidepanel chat WebUI handoff plan: add a sidepanel ControlRow Continue in WebUI action that creates a handoff package, opens /chat with the handoff id, preserves the existing route-only full-app action, passes draft and visible page context from the sidepanel form, and covers the flow with focused regression tests.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-550 - Fix-sidepanel-handoff-service-typecheck-narrowing.md
+++ b/backlog/tasks/task-550 - Fix-sidepanel-handoff-service-typecheck-narrowing.md
@@ -1,0 +1,55 @@
+---
+id: TASK-550
+title: Fix sidepanel handoff service typecheck narrowing
+status: Done
+assignee: []
+created_date: ''
+updated_date: '2026-05-29 06:43'
+labels:
+  - chat
+  - extension
+  - typecheck
+dependencies: []
+references:
+  - TASK-548
+  - TASK-549
+documentation:
+  - >-
+    Docs/superpowers/plans/2026-05-29-sidepanel-chat-webui-handoff-implementation.md
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Fix TypeScript narrowing errors in the sidepanel chat handoff storage service so the branch typecheck can pass after Task 1 and Task 2. The runtime validators are present; the fix should preserve behavior while making validated `Record<string, unknown>` fields explicit typed locals before returning package shapes.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Sidepanel handoff service parser fields use explicit typed locals after runtime validation so package shapes typecheck cleanly.
+- [x] #2 UI package typecheck passes with the memory-raised command used during verification.
+- [x] #3 Focused sidepanel handoff service/UI regressions still pass after the type-only fix.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Root cause: TypeScript did not narrow optional Record<string, unknown> fields through conditional object spreads in parsePageContext, parseRouteIntent, and parsePackage, even though runtime guards were present. Fix: bind validated title, url, truncated, route character id, draft truncated, and consumedAt values into typed locals before returning normalized handoff shapes. Verification: NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit --pretty false passed from apps/packages/ui; focused handoff service/UI Vitest run passed with 24 tests; git diff --check passed.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Fixed the sidepanel handoff service TypeScript narrowing errors without changing runtime behavior. The parser now exposes validated fields as typed locals before returning handoff package shapes, allowing the UI package typecheck to pass while keeping the focused handoff regressions green.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-551 - Import-sidepanel-chat-handoff-in-WebUI-chat.md
+++ b/backlog/tasks/task-551 - Import-sidepanel-chat-handoff-in-WebUI-chat.md
@@ -2,26 +2,25 @@
 id: TASK-551
 title: Import sidepanel chat handoff in WebUI chat
 status: In Progress
+assignee: []
+created_date: ''
+updated_date: '2026-05-29 07:47'
 labels:
-- chat
-- extension
-- implementation
-priority: Medium
+  - chat
+  - extension
+  - implementation
+dependencies: []
 references:
-- TASK-546
-- TASK-547
-- TASK-548
-- TASK-549
-- TASK-550
+  - TASK-546
+  - TASK-547
+  - TASK-548
+  - TASK-549
+  - TASK-550
 documentation:
-- Docs/superpowers/specs/2026-05-29-sidepanel-chat-webui-handoff-design.md
-- Docs/superpowers/plans/2026-05-29-sidepanel-chat-webui-handoff-implementation.md
-modified_files:
-- apps/packages/ui/src/components/Option/Playground/SidepanelImportedContextBanner.tsx
-- apps/packages/ui/src/components/Option/Playground/hooks/useSidepanelChatHandoffImport.ts
-- apps/packages/ui/src/components/Option/Playground/PlaygroundForm.tsx
-- apps/packages/ui/src/components/Option/Playground/hooks/usePlaygroundSubmit.ts
-- apps/packages/ui/src/components/Option/Playground/__tests__/sidepanel-chat-handoff-import.test.tsx
+  - Docs/superpowers/specs/2026-05-29-sidepanel-chat-webui-handoff-design.md
+  - >-
+    Docs/superpowers/plans/2026-05-29-sidepanel-chat-webui-handoff-implementation.md
+priority: medium
 ---
 
 ## Description
@@ -32,26 +31,42 @@ Implement Task 3 from the sidepanel chat WebUI handoff plan: make `/chat` read s
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
+- [x] #1 WebUI /chat reads sidepanel handoff ids, cleans only the handoff query param, and handles invalid handoffs with non-blocking feedback.
+- [x] #2 Valid handoffs prefill or conflict-resolve the composer without overwriting local drafts, then consume only on import or cancel.
+- [x] #3 Imported page context is visible, removable, included in the next model request, preserved through queue replay and compare mode, and not sent after removal.
+- [x] #4 Context-only handoffs remain sendable with an explicit fallback prompt and failed submissions keep imported context available for retry.
 <!-- AC:END -->
 
 ## Implementation Notes
 
+<!-- SECTION:NOTES:BEGIN -->
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
 
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
+Implemented WebUI /chat sidepanel handoff import, imported context banner, draft conflict actions, context-only fallback prompt, queued request messageForModel preservation/replay, compare-mode requestOverrides propagation, and submit-result-gated context clearing.
+
+Verification: bun run test src/components/Option/Playground/__tests__/sidepanel-chat-handoff-import.test.tsx src/components/Chat/composer/__tests__/useComposerSubmit.test.tsx --maxWorkers=1 --no-file-parallelism; NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit --pretty false; bun run test src/services/__tests__/sidepanel-chat-handoff.test.ts src/components/Sidepanel/Chat/__tests__/ControlRow.chat-handoff.test.tsx src/components/Sidepanel/Chat/__tests__/ControlRow.role-play-handoff.test.tsx src/components/Sidepanel/Chat/__tests__/SidepanelHeaderSimple.fullscreen-route.test.tsx src/components/Option/Playground/__tests__/sidepanel-chat-handoff-import.test.tsx src/components/Chat/composer/__tests__/useComposerSubmit.test.tsx --maxWorkers=1 --no-file-parallelism; git diff --check.
+
+Bandit: skipped because this task touched TypeScript/TSX and markdown only; Bandit is Python AST analysis and is not meaningful for this scope. Known skips/blockers: no live browser smoke in Task 3; packaged/live smoke remains Task 4.
+<!-- SECTION:NOTES:END -->
+
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Task 3 is implemented and locally verified. /chat now imports sidepanel handoffs, handles draft conflicts, shows removable source context, preserves context through normal, queued, context-only, and compare sends, and keeps context available when a resolved submit reports failure.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
 
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->

--- a/backlog/tasks/task-551 - Import-sidepanel-chat-handoff-in-WebUI-chat.md
+++ b/backlog/tasks/task-551 - Import-sidepanel-chat-handoff-in-WebUI-chat.md
@@ -57,10 +57,6 @@ Bandit: skipped because this task touched TypeScript/TSX and markdown only; Band
 Task 3 is implemented and locally verified. /chat now imports sidepanel handoffs, handles draft conflicts, shows removable source context, preserves context through normal, queued, context-only, and compare sends, and keeps context available when a resolved submit reports failure.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
-<!-- SECTION:FINAL_SUMMARY:END -->
-
-<!-- SECTION:FINAL_SUMMARY:END -->
-
 ## Definition of Done
 <!-- DOD:BEGIN -->
 - [x] #1 Acceptance criteria completed

--- a/backlog/tasks/task-551 - Import-sidepanel-chat-handoff-in-WebUI-chat.md
+++ b/backlog/tasks/task-551 - Import-sidepanel-chat-handoff-in-WebUI-chat.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-551
 title: Import sidepanel chat handoff in WebUI chat
-status: In Progress
+status: Done
 assignee: []
 created_date: ''
-updated_date: '2026-05-29 07:47'
+updated_date: '2026-05-29 07:48'
 labels:
   - chat
   - extension

--- a/backlog/tasks/task-551 - Import-sidepanel-chat-handoff-in-WebUI-chat.md
+++ b/backlog/tasks/task-551 - Import-sidepanel-chat-handoff-in-WebUI-chat.md
@@ -1,0 +1,57 @@
+---
+id: TASK-551
+title: Import sidepanel chat handoff in WebUI chat
+status: In Progress
+labels:
+- chat
+- extension
+- implementation
+priority: Medium
+references:
+- TASK-546
+- TASK-547
+- TASK-548
+- TASK-549
+- TASK-550
+documentation:
+- Docs/superpowers/specs/2026-05-29-sidepanel-chat-webui-handoff-design.md
+- Docs/superpowers/plans/2026-05-29-sidepanel-chat-webui-handoff-implementation.md
+modified_files:
+- apps/packages/ui/src/components/Option/Playground/SidepanelImportedContextBanner.tsx
+- apps/packages/ui/src/components/Option/Playground/hooks/useSidepanelChatHandoffImport.ts
+- apps/packages/ui/src/components/Option/Playground/PlaygroundForm.tsx
+- apps/packages/ui/src/components/Option/Playground/hooks/usePlaygroundSubmit.ts
+- apps/packages/ui/src/components/Option/Playground/__tests__/sidepanel-chat-handoff-import.test.tsx
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement Task 3 from the sidepanel chat WebUI handoff plan: make `/chat` read sidepanel handoff ids, prefill or resolve draft conflicts, render imported page context, include imported context in the next request's model message, clear/consume the handoff safely, and cover the import flow with focused tests.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-552 - Verify-sidepanel-chat-handoff-regression-and-packaged-smoke.md
+++ b/backlog/tasks/task-552 - Verify-sidepanel-chat-handoff-regression-and-packaged-smoke.md
@@ -1,0 +1,67 @@
+---
+id: TASK-552
+title: Verify sidepanel chat handoff regression and packaged smoke
+status: In Progress
+assignee: []
+created_date: ''
+updated_date: '2026-05-29 07:49'
+labels:
+  - chat
+  - extension
+  - verification
+dependencies: []
+references:
+  - TASK-546
+  - TASK-547
+  - TASK-548
+  - TASK-549
+  - TASK-551
+documentation:
+  - Docs/superpowers/specs/2026-05-29-sidepanel-chat-webui-handoff-design.md
+  - >-
+    Docs/superpowers/plans/2026-05-29-sidepanel-chat-webui-handoff-implementation.md
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Execute Task 4 from the sidepanel chat WebUI handoff plan: run focused unit regressions, relevant existing playground/sidepanel tests, UI type/build sanity, packaged/browser smoke where available, record evidence and skips, and close the sidepanel chat handoff implementation verification slice.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Focused sidepanel handoff unit regression set passes or any unrelated baseline failures are documented.
+- [ ] #2 Existing relevant playground/sidepanel tests pass or failures are documented with exact failing tests.
+- [ ] #3 UI type/build sanity is run and recorded.
+- [ ] #4 Packaged/browser smoke is run when a harness is available, otherwise the skip reason is recorded.
+- [ ] #5 Bandit skip reason is documented for UI-only TypeScript/markdown scope.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-552 - Verify-sidepanel-chat-handoff-regression-and-packaged-smoke.md
+++ b/backlog/tasks/task-552 - Verify-sidepanel-chat-handoff-regression-and-packaged-smoke.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-552
 title: Verify sidepanel chat handoff regression and packaged smoke
-status: In Progress
+status: Done
 assignee: []
 created_date: ''
 updated_date: '2026-05-29 07:49'
@@ -31,17 +31,36 @@ Execute Task 4 from the sidepanel chat WebUI handoff plan: run focused unit regr
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Focused sidepanel handoff unit regression set passes or any unrelated baseline failures are documented.
-- [ ] #2 Existing relevant playground/sidepanel tests pass or failures are documented with exact failing tests.
-- [ ] #3 UI type/build sanity is run and recorded.
-- [ ] #4 Packaged/browser smoke is run when a harness is available, otherwise the skip reason is recorded.
-- [ ] #5 Bandit skip reason is documented for UI-only TypeScript/markdown scope.
+- [x] #1 Focused sidepanel handoff unit regression set passes or any unrelated baseline failures are documented.
+- [x] #2 Existing relevant playground/sidepanel tests pass or failures are documented with exact failing tests.
+- [x] #3 UI type/build sanity is run and recorded.
+- [x] #4 Packaged/browser smoke is run when a harness is available, otherwise the skip reason is recorded.
+- [x] #5 Bandit skip reason is documented for UI-only TypeScript/markdown scope.
 <!-- AC:END -->
 
 ## Implementation Notes
 
 <!-- SECTION:NOTES:BEGIN -->
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Verification evidence:
+
+- Focused handoff regression set passed from `apps/packages/ui`:
+  `bun run test src/services/__tests__/sidepanel-chat-handoff.test.ts src/components/Sidepanel/Chat/__tests__/ControlRow.chat-handoff.test.tsx src/components/Sidepanel/Chat/__tests__/ControlRow.role-play-handoff.test.tsx src/components/Sidepanel/Chat/__tests__/SidepanelHeaderSimple.fullscreen-route.test.tsx src/components/Option/Playground/__tests__/sidepanel-chat-handoff-import.test.tsx --maxWorkers=1 --no-file-parallelism`
+  Result: 5 files, 36 tests passed. Only the known Node localStorage ExperimentalWarning was emitted.
+- Existing relevant playground/sidepanel regression set passed from `apps/packages/ui`:
+  `bun run test src/utils/__tests__/sidepanel-full-app-route.test.ts src/utils/__tests__/character-chat-mode-intent.test.ts src/components/Option/Playground/__tests__/Playground.coordinator.integration.test.tsx src/components/Option/Playground/__tests__/Playground.cockpit-shell.test.tsx --maxWorkers=1 --no-file-parallelism`
+  Result: 4 files, 46 tests passed. Existing provider-status mock warnings were emitted (`getProvidersStatus is not a function` and mock provider config fetch warnings); no tests failed.
+- UI type sanity passed from `apps/packages/ui`:
+  `NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit --pretty false`
+- Packaged extension smoke harness exists at `apps/extension/tests/e2e/sidepanel-chat-smoke.spec.ts` and global setup built `.output/chrome-mv3` successfully. The full smoke command was run from `apps/extension`:
+  `npx playwright test tests/e2e/sidepanel-chat-smoke.spec.ts --project=chromium-extension --reporter=line --workers=1`
+  Result: 3 skipped. JSON follow-up for the handoff case reported `Extension launch unavailable in this environment (TimeoutError: browserType.launchPersistentContext: Timeout 30000ms exceeded...)`.
+- Additional packaged-smoke diagnosis:
+  `npx playwright test ... --grep "keeps packaged /chat"` outside the sandbox still skipped at the default browser launch timeout.
+  `TLDW_E2E_EXTENSION_LAUNCH_TIMEOUT_MS=90000 npx playwright test ... --grep "keeps packaged /chat"` reached the longer launch wait but failed the test timeout before `/chat` assertions ran.
+  `TLDW_E2E_EXTENSION_HEADLESS=1 TLDW_E2E_EXTENSION_LAUNCH_TIMEOUT_MS=90000 npx playwright test ... --grep "keeps packaged /chat"` skipped with `Could not determine extension id from [no extension targets]`.
+  Conclusion: packaged browser smoke is unavailable on this host because Chrome extension launch does not become controllable; no packaged `/chat` product assertion ran or failed.
+- Bandit skipped: touched verification scope is TypeScript/TSX/markdown and generated extension build output only; no Python paths were changed.
 
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 <!-- SECTION:NOTES:END -->
@@ -49,19 +68,15 @@ Execute Task 4 from the sidepanel chat WebUI handoff plan: run focused unit regr
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-<!-- SECTION:FINAL_SUMMARY:BEGIN -->
-
-<!-- SECTION:FINAL_SUMMARY:END -->
-<!-- SECTION:FINAL_SUMMARY:END -->
-
+Completed the Task 4 verification pass for sidepanel chat handoff. Focused unit regressions, existing relevant playground/sidepanel regressions, and UI type sanity all pass. The packaged smoke harness builds successfully but cannot execute product assertions on this host because Playwright cannot complete Chrome extension launch in headful mode, and CI-style headless mode starts without extension targets.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->

--- a/backlog/tasks/task-553 - Address-PR-2131-sidepanel-handoff-review-feedback.md
+++ b/backlog/tasks/task-553 - Address-PR-2131-sidepanel-handoff-review-feedback.md
@@ -1,0 +1,66 @@
+---
+id: TASK-553
+title: Address PR 2131 sidepanel handoff review feedback
+status: Done
+labels:
+- chat
+- extension
+- review-fix
+references:
+- PR-2131
+- TASK-548
+- TASK-549
+- TASK-551
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Address concrete PR #2131 review feedback for sidepanel chat handoff: handle tab-open failures after handoff creation, tighten handoff parser type narrowing, avoid undefined interpolation in sidepanel page-context snippets, verify locally, push, and resolve review threads.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 `browser.tabs.create` failures in the sidepanel WebUI handoff path surface feedback and do not silently strand a handoff package.
+- [x] #2 Handoff package parsing binds validated required fields to narrowed local variables.
+- [x] #3 Sidepanel page-context snippet construction omits missing title/URL fields instead of interpolating `undefined`.
+- [x] #4 Focused sidepanel handoff regressions and UI typecheck pass after fixes.
+- [x] #5 PR review threads are addressed/resolved or documented if not resolvable locally.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Review feedback addressed:
+
+- Qodo unhandled `browser.tabs.create` rejection: `ControlRow` now awaits tab creation, falls back to `window.open` when tab creation rejects, and best-effort consumes the created handoff plus shows the existing error feedback if both open paths fail.
+- Gemini parser narrowing: `parsePackage` now binds validated `id`, `createdAt`, and `expiresAt` to local variables before returning the parsed package.
+- Gemini snippet interpolation: sidepanel document snippet text now uses `buildVisibleDocumentHandoffSnippetText`, which only includes present title/URL fields and avoids `Title: undefined` / `URL: undefined`.
+
+Verification:
+
+- RED: `bun run test src/components/Sidepanel/Chat/__tests__/ControlRow.chat-handoff.test.tsx src/components/Sidepanel/Chat/__tests__/sidepanel-chat-handoff-context.test.ts --maxWorkers=1 --no-file-parallelism` failed before implementation with the new fallback/cleanup assertions and missing helper module.
+- GREEN: same command passed after implementation: 2 files, 11 tests.
+- Focused regression: `bun run test src/services/__tests__/sidepanel-chat-handoff.test.ts src/components/Sidepanel/Chat/__tests__/ControlRow.chat-handoff.test.tsx src/components/Sidepanel/Chat/__tests__/ControlRow.role-play-handoff.test.tsx src/components/Sidepanel/Chat/__tests__/SidepanelHeaderSimple.fullscreen-route.test.tsx src/components/Sidepanel/Chat/__tests__/sidepanel-chat-handoff-context.test.ts src/components/Option/Playground/__tests__/sidepanel-chat-handoff-import.test.tsx --maxWorkers=1 --no-file-parallelism` passed: 6 files, 39 tests.
+- Typecheck: `NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit --pretty false` passed from `apps/packages/ui`.
+- `git diff --check` passed.
+- Bandit skipped: TypeScript/TSX/markdown-only review fix; no Python changed.
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Addressed all concrete PR #2131 review feedback: hardened tab-open failure handling in the sidepanel WebUI handoff path, tightened handoff parser narrowing, and removed undefined title/URL interpolation from handoff document snippets. Focused regressions and UI typecheck pass.
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-553 - Address-PR-2131-sidepanel-handoff-review-feedback.md
+++ b/backlog/tasks/task-553 - Address-PR-2131-sidepanel-handoff-review-feedback.md
@@ -26,6 +26,9 @@ Address concrete PR #2131 review feedback for sidepanel chat handoff: handle tab
 - [x] #3 Sidepanel page-context snippet construction omits missing title/URL fields instead of interpolating `undefined`.
 - [x] #4 Focused sidepanel handoff regressions and UI typecheck pass after fixes.
 - [x] #5 PR review threads are addressed/resolved or documented if not resolvable locally.
+- [x] #6 Raw Request preview includes imported sidepanel handoff context when the actual submit request will send it.
+- [x] #7 Handoff route construction preserves URL hash fragments while adding the `handoff` query parameter.
+- [x] #8 Test-only fallback handoff IDs work in jsdom/browser-style tests that do not expose `process.env`.
 <!-- AC:END -->
 
 ## Implementation Notes
@@ -36,12 +39,19 @@ Review feedback addressed:
 - Qodo unhandled `browser.tabs.create` rejection: `ControlRow` now awaits tab creation, falls back to `window.open` when tab creation rejects, and best-effort consumes the created handoff plus shows the existing error feedback if both open paths fail.
 - Gemini parser narrowing: `parsePackage` now binds validated `id`, `createdAt`, and `expiresAt` to local variables before returning the parsed package.
 - Gemini snippet interpolation: sidepanel document snippet text now uses `buildVisibleDocumentHandoffSnippetText`, which only includes present title/URL fields and avoids `Title: undefined` / `URL: undefined`.
+- CodeRabbit raw preview parity: Raw Request preview now receives imported sidepanel context and uses the same model-facing message builder and context-only fallback prompt as actual submit.
+- CodeRabbit test fallback detection: handoff ID creation now recognizes jsdom/Vitest globals when `process.env` is unavailable, while still requiring `crypto.randomUUID` outside test environments.
+- CodeRabbit route hash handling: handoff route construction now preserves hash fragments after inserting the `handoff` query parameter.
+- CodeRabbit Backlog marker cleanup: removed duplicate final-summary closing markers from TASK-551.
 
 Verification:
 
 - RED: `bun run test src/components/Sidepanel/Chat/__tests__/ControlRow.chat-handoff.test.tsx src/components/Sidepanel/Chat/__tests__/sidepanel-chat-handoff-context.test.ts --maxWorkers=1 --no-file-parallelism` failed before implementation with the new fallback/cleanup assertions and missing helper module.
+- RED: `bun run test src/components/Option/Playground/__tests__/usePlaygroundRawPreview.mcp-tools.test.tsx src/services/__tests__/sidepanel-chat-handoff.test.ts --maxWorkers=1 --no-file-parallelism` failed before implementation with the new raw-preview context, jsdom fallback ID, and route-hash assertions.
 - GREEN: same command passed after implementation: 2 files, 11 tests.
+- GREEN: same raw-preview/service command passed after implementation: 2 files, 23 tests.
 - Focused regression: `bun run test src/services/__tests__/sidepanel-chat-handoff.test.ts src/components/Sidepanel/Chat/__tests__/ControlRow.chat-handoff.test.tsx src/components/Sidepanel/Chat/__tests__/ControlRow.role-play-handoff.test.tsx src/components/Sidepanel/Chat/__tests__/SidepanelHeaderSimple.fullscreen-route.test.tsx src/components/Sidepanel/Chat/__tests__/sidepanel-chat-handoff-context.test.ts src/components/Option/Playground/__tests__/sidepanel-chat-handoff-import.test.tsx --maxWorkers=1 --no-file-parallelism` passed: 6 files, 39 tests.
+- Focused regression: `bun run test src/services/__tests__/sidepanel-chat-handoff.test.ts src/components/Sidepanel/Chat/__tests__/ControlRow.chat-handoff.test.tsx src/components/Sidepanel/Chat/__tests__/ControlRow.role-play-handoff.test.tsx src/components/Sidepanel/Chat/__tests__/SidepanelHeaderSimple.fullscreen-route.test.tsx src/components/Sidepanel/Chat/__tests__/sidepanel-chat-handoff-context.test.ts src/components/Option/Playground/__tests__/sidepanel-chat-handoff-import.test.tsx src/components/Option/Playground/__tests__/usePlaygroundRawPreview.mcp-tools.test.tsx --maxWorkers=1 --no-file-parallelism` passed: 7 files, 51 tests.
 - Typecheck: `NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit --pretty false` passed from `apps/packages/ui`.
 - `git diff --check` passed.
 - Bandit skipped: TypeScript/TSX/markdown-only review fix; no Python changed.
@@ -51,7 +61,7 @@ Verification:
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Addressed all concrete PR #2131 review feedback: hardened tab-open failure handling in the sidepanel WebUI handoff path, tightened handoff parser narrowing, and removed undefined title/URL interpolation from handoff document snippets. Focused regressions and UI typecheck pass.
+Addressed all concrete PR #2131 review feedback: hardened tab-open failure handling in the sidepanel WebUI handoff path, tightened handoff parser narrowing, removed undefined title/URL interpolation from handoff document snippets, kept Raw Request preview aligned with imported sidepanel context sends, preserved handoff route hash fragments, broadened test-only ID fallback detection for browser-style tests, and cleaned duplicate Backlog final-summary markers. Focused regressions and UI typecheck pass.
 
 <!-- SECTION:FINAL_SUMMARY:END -->
 


### PR DESCRIPTION
## Summary

- What changed:
  - Restores a bounded, storage-backed sidepanel chat handoff for **Continue in WebUI** so the extension can open `/chat?handoff=<id>` without leaking draft or page context into the URL.
  - Imports sidepanel drafts and page context on `/chat`, handles draft conflicts, shows/removes the imported context banner, and includes context in the next model request while keeping the visible composer text unchanged.
  - Adds focused regressions for handoff storage, sidepanel actions, WebUI import/conflict/send behavior, role-play route preservation, and route-only full-chat behavior.
- Why:
  - The restored rails were back, but the extension still needed a safe handoff path into the real `/chat` workflow without reviving the removed character-controls rail or losing sidepanel intent.

## Change summary (maintainer-owned)

Maintainer note required before merge: replace this section with a human-written summary of what changed and why these implementation choices were made.

## Validation

- [x] Tests added/updated for behavior changes
- [x] Relevant unit/integration tests pass locally
- [x] Docs updated (if behavior, routes, or config changed)

Local validation after rebasing onto current `origin/dev`:

- `cd apps/packages/ui && bun run test src/services/__tests__/sidepanel-chat-handoff.test.ts src/components/Sidepanel/Chat/__tests__/ControlRow.chat-handoff.test.tsx src/components/Sidepanel/Chat/__tests__/ControlRow.role-play-handoff.test.tsx src/components/Sidepanel/Chat/__tests__/SidepanelHeaderSimple.fullscreen-route.test.tsx src/components/Option/Playground/__tests__/sidepanel-chat-handoff-import.test.tsx --maxWorkers=1 --no-file-parallelism`
  - Result: 5 files, 36 tests passed.
- `cd apps/packages/ui && NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit --pretty false`
  - Result: passed.
- `cd apps/packages/ui && bun run test src/utils/__tests__/sidepanel-full-app-route.test.ts src/utils/__tests__/character-chat-mode-intent.test.ts src/components/Option/Playground/__tests__/Playground.coordinator.integration.test.tsx src/components/Option/Playground/__tests__/Playground.cockpit-shell.test.tsx --maxWorkers=1 --no-file-parallelism`
  - Result: 4 files, 46 tests passed. Existing provider-status mock warnings were emitted; no tests failed.
- `cd apps/extension && npx playwright test tests/e2e/sidepanel-chat-smoke.spec.ts --project=chromium-extension --reporter=line --workers=1`
  - Result: extension built successfully, but all 3 smoke cases skipped because this host could not complete Chrome extension launch.
  - Follow-up evidence: headful launch timed out before `/chat` assertions; CI-style headless launch skipped with `Could not determine extension id from [no extension targets]`.
- Bandit: skipped because this PR changes TypeScript/TSX/markdown only.

## UX Audit Checklist (v2 Stage 5)

- [ ] `npm run e2e:smoke:stage5` passes
- [ ] `npx playwright test e2e/smoke/all-pages.spec.ts --reporter=line` passes (or failures documented)
- [ ] No listed AntD deprecations in console output: `Drawer.width`, `Space.direction`, `Alert.message`, `List`
- [ ] No `Maximum update depth exceeded` warnings on audited routes
- [ ] No unresolved `{{...}}` placeholders on audited routes
- [ ] WebUI/extension parity validated for shared UI fixes
- [ ] For Flashcards UI changes: tabs remain `Study` / `Manage` / `Transfer` and secondary create CTAs route through manager create-entry path
- [ ] For Flashcards drawer changes: use `FLASHCARDS_DRAWER_WIDTH_PX` and keep footer action order `Cancel -> secondary -> primary`
- [ ] For Flashcards help/copy/import UX changes: update `Docs/User_Guides/WebUI_Extension/Flashcards_Study_Guide.md` and keep in-app help links pointed at guide section anchors

Notes:
- Stage 5 all-pages smoke was not run; this PR used route-scoped `/chat` and sidepanel handoff regressions.
- WebUI/extension parity is covered by focused unit/component tests and the packaged smoke harness build. Full packaged browser assertions could not run on this host due Chrome extension launch availability.
- Flashcards checklist items are not applicable.

## Watchlists Accessibility Checklist (Group 09 Stage 5)

- [ ] If Watchlists UI behavior changed: `cd apps/packages/ui && bun run test:watchlists:a11y` passes locally
- [ ] If Watchlists UI behavior changed: keyboard-only path still works for Overview -> Feeds -> Monitors -> Activity -> Articles -> Reports
- [ ] If Watchlists UI behavior changed: list/table labels and live-region copy remain localized (no new hardcoded assistive text)
- [ ] If Watchlists UI behavior changed: monitor/feed active state is not color-only (explicit text or icon signal is present)
- [ ] If Watchlists UI behavior changed: known assistive-tech constraints reviewed in `Docs/Plans/WATCHLISTS_ASSISTIVE_TECH_AUDIT_2026_02_24.md`

Notes:
- Not applicable; this PR does not change Watchlists UI behavior.

## Watchlists Scale Checklist (Group 10 Stage 5)

- [ ] If Watchlists UI behavior changed: `cd apps/packages/ui && bun run test:watchlists:scale` passes locally
- [ ] If Watchlists polling/notifications behavior changed: no duplicate terminal notifications during in-flight polling overlap
- [ ] If Watchlists Activity polling changed: auto-refresh is gated to active + visible Activity context (no background tab polling churn)
- [ ] If Watchlists batch triage behavior changed: partial-failure retry path remains available and updates only failed IDs
- [ ] If Watchlists scale behavior changed: constraints/mitigations reviewed in `Docs/Plans/WATCHLISTS_SCALE_READINESS_RUNBOOK_2026_02_24.md`

Notes:
- Not applicable; this PR does not change Watchlists polling, notifications, Activity refresh, or scale behavior.

## Risk & Rollback

- Risk level: Medium
- Rollback plan: Revert this PR to remove the new sidepanel handoff package, ControlRow action, `/chat` import hook/banner wiring, and related tests/docs. The route-only full-chat action remains covered by regression tests.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores a storage-backed sidepanel-to-WebUI chat handoff with a new “Continue in WebUI” flow that moves the draft and visible page context into /chat without leaking it in the URL. Adds one-time import with a removable banner, includes imported context in the next request, aligns the raw preview to show that context, and handles tab-open failures safely.

- New Features
  - Adds bounded, TTL-backed handoff storage with one-time consume and cleanup.
  - Adds sidepanel “Continue in WebUI” that packages draft + visible page context and opens `/chat?handoff=<id>`.
  - Imports handoff in `/chat`: prefill or merge draft on conflict, show removable banner, include page context in the next request without changing the visible message.
  - Keeps the existing full-screen/open action route-only.
  - Focused tests cover storage, sidepanel action, WebUI import/conflict/send, role-play route preservation, route-only behavior, and page-context snippet text.
  - Aligns with TASK-546 design; implements TASK-548–TASK-553.

- Bug Fixes
  - Aligns the raw request preview to include imported sidepanel context.
  - Handles tab-open failures after handoff creation without stranding packages.
  - Omits undefined fields in sidepanel page-context snippet text.

<sup>Written for commit 754cb56fd7c5ca560dfac995405c0092490f1ece. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2131?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

