### PR TITLE
Extract MCP external transport contracts

### DIFF
--- a/Docs/superpowers/plans/2026-05-29-mcp-unified-stage3j-external-transport-contracts-plan.md
+++ b/Docs/superpowers/plans/2026-05-29-mcp-unified-stage3j-external-transport-contracts-plan.md
@@ -1,0 +1,17 @@
+## Stage 1: Contract Boundary Tests
+**Goal**: Prove the host external transport base reuses package-owned neutral contracts.
+**Success Criteria**: Failing tests show `BrokeredExternalCredential` is missing from `mcp_unified.federation` and host/base dataclasses are not package identities.
+**Tests**: Focused `test_runtime_package_boundary.py` contract tests.
+**Status**: Complete
+
+## Stage 2: Package Contract Extraction
+**Goal**: Add the missing brokered credential contract to `mcp_unified.federation` and make the host base re-export package contracts.
+**Success Criteria**: Host imports remain compatible while neutral dataclasses are package-owned.
+**Tests**: Focused MCP Unified package-boundary and external transport tests.
+**Status**: Complete
+
+## Stage 3: Verification And PR
+**Goal**: Record focused test, lint, security, and whitespace verification before opening the PR.
+**Success Criteria**: Pytest, Ruff, Bandit, and `git diff --check` results are captured in Backlog and the PR.
+**Tests**: Focused pytest suite plus Ruff and Bandit on touched files.
+**Status**: Complete

--- a/backlog/tasks/task-551 - Implement-MCP-Unified-Stage-3J-external-transport-contract-seam.md
+++ b/backlog/tasks/task-551 - Implement-MCP-Unified-Stage-3J-external-transport-contract-seam.md
@@ -4,12 +4,12 @@ title: Implement MCP Unified Stage 3J external transport contract seam
 status: Done
 assignee: []
 created_date: ''
-updated_date: 2026-05-29 20:45
+updated_date: '2026-05-29 21:59'
 labels:
-- mcp
-- mcp-unified
-- standalone
-- stage3
+  - mcp
+  - mcp-unified
+  - standalone
+  - stage3
 dependencies: []
 ---
 
@@ -36,9 +36,7 @@ Docs/superpowers/plans/2026-05-29-mcp-unified-stage3j-external-transport-contrac
 ## Implementation Notes
 
 <!-- SECTION:NOTES:BEGIN -->
-<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
-
-<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+PR review follow-up: added docstrings to the two newly added package-boundary tests after Qodo flagged the repo docstring rule.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
@@ -65,9 +63,3 @@ Verification:
 - [x] #5 Final summary added
 - [x] #6 Known skips or blockers documented
 <!-- DOD:END -->
-
-## Implementation Notes
-
-<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
-PR review follow-up: added docstrings to the two newly added package-boundary tests after Qodo flagged the repo docstring rule.
-<!-- SECTION:IMPLEMENTATION_NOTES:END -->

--- a/backlog/tasks/task-551 - Implement-MCP-Unified-Stage-3J-external-transport-contract-seam.md
+++ b/backlog/tasks/task-551 - Implement-MCP-Unified-Stage-3J-external-transport-contract-seam.md
@@ -1,0 +1,66 @@
+---
+id: TASK-551
+title: Implement MCP Unified Stage 3J external transport contract seam
+status: Done
+assignee: []
+created_date: ''
+updated_date: '2026-05-29 20:45'
+labels:
+  - mcp
+  - mcp-unified
+  - standalone
+  - stage3
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Move the package-neutral external transport data contracts into the standalone `mcp_unified` package surface while preserving host adapter compatibility.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Standalone `mcp_unified.federation` exports `BrokeredExternalCredential` with caller-owned copy behavior.
+- [x] #2 Host `external_servers.transports.base` reuses package `ExternalToolDefinition`, `ExternalToolCallResult`, and `BrokeredExternalCredential` contracts instead of duplicating dataclasses.
+- [x] #3 Existing host transport imports remain compatible and adapter tests still pass.
+- [x] #4 Focused pytest, Ruff, Bandit, and diff whitespace verification are recorded.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Docs/superpowers/plans/2026-05-29-mcp-unified-stage3j-external-transport-contracts-plan.md
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Implemented Stage 3J external transport contract seam. Added standalone BrokeredExternalCredential with caller-owned copy behavior, made the host transport base re-export package ExternalToolDefinition, ExternalToolCallResult, and BrokeredExternalCredential, and added package-boundary regression tests.
+
+Verification:
+- RED: `.venv/bin/python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py -k external_transport -q` failed on duplicate host ExternalToolDefinition identity.
+- RED: `.venv/bin/python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py -k brokered_external_credential -q` failed because package BrokeredExternalCredential was missing.
+- GREEN: `.venv/bin/python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py tldw_Server_API/app/core/MCP_unified/tests/test_federation_shell_contracts.py tldw_Server_API/app/core/MCP_unified/tests/test_external_server_manager.py tldw_Server_API/app/core/MCP_unified/tests/test_external_stdio_adapter.py tldw_Server_API/app/core/MCP_unified/tests/test_external_websocket_adapter.py tldw_Server_API/app/core/MCP_unified/tests/test_external_credential_broker_runtime.py -q` passed 48 tests.
+- Ruff passed on touched Python files.
+- Bandit passed on touched runtime Python files with zero findings in `/tmp/bandit_mcp_stage3j_external_transport_contracts.json`.
+- `git diff --check` passed.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-551 - Implement-MCP-Unified-Stage-3J-external-transport-contract-seam.md
+++ b/backlog/tasks/task-551 - Implement-MCP-Unified-Stage-3J-external-transport-contract-seam.md
@@ -4,12 +4,12 @@ title: Implement MCP Unified Stage 3J external transport contract seam
 status: Done
 assignee: []
 created_date: ''
-updated_date: '2026-05-29 20:45'
+updated_date: 2026-05-29 20:45
 labels:
-  - mcp
-  - mcp-unified
-  - standalone
-  - stage3
+- mcp
+- mcp-unified
+- standalone
+- stage3
 dependencies: []
 ---
 
@@ -44,13 +44,14 @@ Docs/superpowers/plans/2026-05-29-mcp-unified-stage3j-external-transport-contrac
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Implemented Stage 3J external transport contract seam. Added standalone BrokeredExternalCredential with caller-owned copy behavior, made the host transport base re-export package ExternalToolDefinition, ExternalToolCallResult, and BrokeredExternalCredential, and added package-boundary regression tests.
+Implemented Stage 3J external transport contract seam. Added standalone BrokeredExternalCredential with caller-owned copy behavior, made the host transport base re-export package ExternalToolDefinition, ExternalToolCallResult, and BrokeredExternalCredential, and added package-boundary regression tests. Addressed Qodo review feedback by documenting the two newly added test functions.
 
 Verification:
 - RED: `.venv/bin/python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py -k external_transport -q` failed on duplicate host ExternalToolDefinition identity.
 - RED: `.venv/bin/python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py -k brokered_external_credential -q` failed because package BrokeredExternalCredential was missing.
 - GREEN: `.venv/bin/python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py tldw_Server_API/app/core/MCP_unified/tests/test_federation_shell_contracts.py tldw_Server_API/app/core/MCP_unified/tests/test_external_server_manager.py tldw_Server_API/app/core/MCP_unified/tests/test_external_stdio_adapter.py tldw_Server_API/app/core/MCP_unified/tests/test_external_websocket_adapter.py tldw_Server_API/app/core/MCP_unified/tests/test_external_credential_broker_runtime.py -q` passed 48 tests.
-- Ruff passed on touched Python files.
+- REVIEW FIX: `.venv/bin/python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py -q` passed 7 tests.
+- Ruff passed on touched Python files, including the review-fix test file.
 - Bandit passed on touched runtime Python files with zero findings in `/tmp/bandit_mcp_stage3j_external_transport_contracts.json`.
 - `git diff --check` passed.
 <!-- SECTION:FINAL_SUMMARY:END -->
@@ -64,3 +65,9 @@ Verification:
 - [x] #5 Final summary added
 - [x] #6 Known skips or blockers documented
 <!-- DOD:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+PR review follow-up: added docstrings to the two newly added package-boundary tests after Qodo flagged the repo docstring rule.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->

--- a/mcp_unified/federation/__init__.py
+++ b/mcp_unified/federation/__init__.py
@@ -20,6 +20,7 @@ from .config_schema import (
 )
 from .manager import ExternalFederationManager
 from .models import (
+    BrokeredExternalCredential,
     ExternalToolCallResult,
     ExternalToolDefinition,
     FederatedToolResult,
@@ -31,6 +32,7 @@ from .models import (
 from .transports import ExternalFederationTransport, FakeExternalTransport
 
 __all__ = [
+    "BrokeredExternalCredential",
     "ExternalAuthConfig",
     "ExternalAuthMode",
     "ExternalCircuitBreakerConfig",

--- a/mcp_unified/federation/models.py
+++ b/mcp_unified/federation/models.py
@@ -30,6 +30,23 @@ def _copy_mapping(value: dict[str, Any] | None) -> dict[str, Any]:
 
 
 @dataclass(slots=True)
+class BrokeredExternalCredential:
+    """Ephemeral per-call auth material resolved outside long-lived adapter state."""
+
+    headers: dict[str, str] = field(default_factory=dict)
+    env: dict[str, str] = field(default_factory=dict)
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def copy(self) -> BrokeredExternalCredential:
+        """Return caller-owned brokered credential data."""
+        return BrokeredExternalCredential(
+            headers=dict(self.headers or {}),
+            env=dict(self.env or {}),
+            metadata=_copy_mapping(self.metadata),
+        )
+
+
+@dataclass(slots=True)
 class ExternalToolDefinition:
     """Normalized external tool metadata discovered from a transport."""
 

--- a/tldw_Server_API/app/core/MCP_unified/external_servers/transports/base.py
+++ b/tldw_Server_API/app/core/MCP_unified/external_servers/transports/base.py
@@ -2,42 +2,20 @@
 
 from __future__ import annotations
 
-from abc import ABC, abstractmethod
-from dataclasses import dataclass, field
 import inspect
-from typing import TYPE_CHECKING, Any, Callable, Optional
+from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING, Any, Callable
+
+from mcp_unified.federation.models import (
+    BrokeredExternalCredential,
+    ExternalToolCallResult,
+    ExternalToolDefinition,
+)
 
 if TYPE_CHECKING:  # pragma: no cover
     from tldw_Server_API.app.core.MCP_unified.protocol import RequestContext
+
     from ..config_schema import ExternalMCPServerConfig
-
-
-@dataclass(slots=True)
-class ExternalToolDefinition:
-    """Normalized external tool metadata used by federation logic."""
-
-    name: str
-    description: str = ""
-    input_schema: dict[str, Any] = field(default_factory=lambda: {"type": "object"})
-    metadata: dict[str, Any] = field(default_factory=dict)
-
-
-@dataclass(slots=True)
-class ExternalToolCallResult:
-    """Normalized external tool execution result."""
-
-    content: Any
-    is_error: bool = False
-    metadata: dict[str, Any] = field(default_factory=dict)
-
-
-@dataclass(slots=True)
-class BrokeredExternalCredential:
-    """Ephemeral per-call auth material resolved outside long-lived adapter state."""
-
-    headers: dict[str, str] = field(default_factory=dict)
-    env: dict[str, str] = field(default_factory=dict)
-    metadata: dict[str, Any] = field(default_factory=dict)
 
 
 class ExternalMCPTransportAdapter(ABC):
@@ -72,7 +50,7 @@ class ExternalMCPTransportAdapter(ABC):
         self,
         tool_name: str,
         arguments: dict[str, Any],
-        context: Optional["RequestContext"] = None,
+        context: RequestContext | None = None,
         runtime_auth: BrokeredExternalCredential | None = None,
     ) -> ExternalToolCallResult:
         """Execute a tool on the external server and normalize the result."""
@@ -88,8 +66,8 @@ def adapter_supports_runtime_auth(adapter: ExternalMCPTransportAdapter) -> bool:
 
 
 def clone_external_server_config(
-    server_config: "ExternalMCPServerConfig",
-) -> "ExternalMCPServerConfig":
+    server_config: ExternalMCPServerConfig,
+) -> ExternalMCPServerConfig:
     """Deep-copy an external server config without mutating long-lived adapter state."""
     if hasattr(server_config, "model_copy"):
         return server_config.model_copy(deep=True)  # type: ignore[attr-defined]
@@ -98,9 +76,9 @@ def clone_external_server_config(
 
 async def call_tool_with_ephemeral_adapter(
     *,
-    server_config: "ExternalMCPServerConfig",
-    adapter_factory: Callable[["ExternalMCPServerConfig"], ExternalMCPTransportAdapter],
-    prepare_config: Callable[["ExternalMCPServerConfig"], None],
+    server_config: ExternalMCPServerConfig,
+    adapter_factory: Callable[[ExternalMCPServerConfig], ExternalMCPTransportAdapter],
+    prepare_config: Callable[[ExternalMCPServerConfig], None],
     tool_name: str,
     arguments: dict[str, Any],
 ) -> ExternalToolCallResult:

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py
@@ -72,6 +72,7 @@ def test_host_external_config_schema_shim_reexports_package_contracts() -> None:
 
 
 def test_host_external_transport_base_reexports_package_contracts() -> None:
+    """Host transport base must reuse the package-owned external contracts."""
     package_models = importlib.import_module("mcp_unified.federation.models")
     package_federation = importlib.import_module("mcp_unified.federation")
     host_base = importlib.import_module(
@@ -85,6 +86,7 @@ def test_host_external_transport_base_reexports_package_contracts() -> None:
 
 
 def test_brokered_external_credential_copy_returns_caller_owned_data() -> None:
+    """Brokered credential copies must not expose mutable source state."""
     package_models = importlib.import_module("mcp_unified.federation.models")
     credential = package_models.BrokeredExternalCredential(
         headers={"Authorization": "Bearer token"},

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py
@@ -71,6 +71,37 @@ def test_host_external_config_schema_shim_reexports_package_contracts() -> None:
     assert host_schema.parse_external_server_registry is package_schema.parse_external_server_registry
 
 
+def test_host_external_transport_base_reexports_package_contracts() -> None:
+    package_models = importlib.import_module("mcp_unified.federation.models")
+    package_federation = importlib.import_module("mcp_unified.federation")
+    host_base = importlib.import_module(
+        "tldw_Server_API.app.core.MCP_unified.external_servers.transports.base"
+    )
+
+    assert host_base.ExternalToolDefinition is package_models.ExternalToolDefinition
+    assert host_base.ExternalToolCallResult is package_models.ExternalToolCallResult
+    assert host_base.BrokeredExternalCredential is package_models.BrokeredExternalCredential
+    assert package_federation.BrokeredExternalCredential is package_models.BrokeredExternalCredential
+
+
+def test_brokered_external_credential_copy_returns_caller_owned_data() -> None:
+    package_models = importlib.import_module("mcp_unified.federation.models")
+    credential = package_models.BrokeredExternalCredential(
+        headers={"Authorization": "Bearer token"},
+        env={"TOKEN": "secret"},
+        metadata={"nested": {"source": "broker"}},
+    )
+
+    copied = credential.copy()
+    copied.headers["Authorization"] = "changed"
+    copied.env["TOKEN"] = "changed"
+    copied.metadata["nested"]["source"] = "changed"
+
+    assert credential.headers == {"Authorization": "Bearer token"}
+    assert credential.env == {"TOKEN": "secret"}
+    assert credential.metadata == {"nested": {"source": "broker"}}
+
+
 def test_profile_defaults_are_safe_and_preserve_extension_metadata() -> None:
     from mcp_unified.profiles.models import MCPProfile
 


### PR DESCRIPTION
## Change summary (maintainer-owned)

TODO: Maintainer to replace this with a human-written summary explaining what changed and why these implementation choices were made.

## What changed

- Added `BrokeredExternalCredential` to the standalone `mcp_unified.federation` model/export surface with caller-owned copy behavior.
- Changed the host external transport base to reuse package-owned `ExternalToolDefinition`, `ExternalToolCallResult`, and `BrokeredExternalCredential` instead of duplicating those dataclasses.
- Added package-boundary regression tests proving host re-export identity and brokered credential copy isolation.
- Added Backlog task `TASK-551` and the Stage 3J implementation plan.

## Why

This keeps package-neutral external transport data contracts in the standalone package while leaving host-owned adapter behavior, request context typing, runtime auth handling, and spawning transports in `tldw_Server_API`.

## Verification

- RED: `.venv/bin/python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py -k external_transport -q` failed on duplicate host `ExternalToolDefinition` identity.
- RED: `.venv/bin/python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py -k brokered_external_credential -q` failed because package `BrokeredExternalCredential` was missing.
- GREEN: `.venv/bin/python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py tldw_Server_API/app/core/MCP_unified/tests/test_federation_shell_contracts.py tldw_Server_API/app/core/MCP_unified/tests/test_external_server_manager.py tldw_Server_API/app/core/MCP_unified/tests/test_external_stdio_adapter.py tldw_Server_API/app/core/MCP_unified/tests/test_external_websocket_adapter.py tldw_Server_API/app/core/MCP_unified/tests/test_external_credential_broker_runtime.py -q` passed 48 tests.
- `.venv/bin/python -m ruff check mcp_unified/federation/models.py mcp_unified/federation/__init__.py tldw_Server_API/app/core/MCP_unified/external_servers/transports/base.py tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py`
- `.venv/bin/python -m bandit -r mcp_unified/federation/models.py tldw_Server_API/app/core/MCP_unified/external_servers/transports/base.py -f json -o /tmp/bandit_mcp_stage3j_external_transport_contracts.json` produced zero findings.
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracted neutral external transport contracts into `mcp_unified.federation` and made both the package and host transport base re-export them. Added `BrokeredExternalCredential` with a safe caller-owned copy for per-call auth; satisfies TASK-551.

- **Refactors**
  - Host `external_servers.transports.base` now imports and re-exports `ExternalToolDefinition`, `ExternalToolCallResult`, and `BrokeredExternalCredential` from the package; `mcp_unified.federation` also re-exports the credential.
  - Added package-boundary tests for re-export identity and brokered credential copy; added docstrings per review.
  - Minor typing cleanups in the transport base (PEP 604 unions, narrowed generics).
  - Added Stage 3J plan docs and cleaned backlog notes.

<sup>Written for commit 391d46c70de58ba8a3fa3e207f393099cb103640. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2132?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

