### PR TITLE
Migrate dictionary version alerts to design system

### DIFF
--- a/apps/packages/ui/scripts/design-system-product-state-baseline.json
+++ b/apps/packages/ui/scripts/design-system-product-state-baseline.json
@@ -803,28 +803,6 @@
     "migrationQueue": "shared-product-state"
   },
   {
-    "id": "antd-product-state-import:src/components/Option/Dictionaries/DictionaryVersionHistoryModal.tsx:Alert#antd-alert-dictionaryversionhistorymodal-type-error-vers-1pavdz5",
-    "path": "src/components/Option/Dictionaries/DictionaryVersionHistoryModal.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/Option/Dictionaries/DictionaryVersionHistoryModal.tsx before the stable duplicate-id guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
-    "id": "antd-product-state-import:src/components/Option/Dictionaries/DictionaryVersionHistoryModal.tsx:Alert#antd-alert-dictionaryversionhistorymodal-type-success-re-1knmxw4",
-    "path": "src/components/Option/Dictionaries/DictionaryVersionHistoryModal.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/Option/Dictionaries/DictionaryVersionHistoryModal.tsx before the stable duplicate-id guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
     "id": "antd-product-state-import:src/components/Option/Integrations/IntegrationPolicyPanel.tsx:Alert#antd-alert-telegrampolicyeditor-type-error-line-336-tzh99k",
     "path": "src/components/Option/Integrations/IntegrationPolicyPanel.tsx",
     "rule": "antd-product-state-import",

--- a/apps/packages/ui/src/components/Option/Dictionaries/DictionaryVersionHistoryModal.tsx
+++ b/apps/packages/ui/src/components/Option/Dictionaries/DictionaryVersionHistoryModal.tsx
@@ -1,5 +1,6 @@
 import React from "react"
-import { Alert, Button, Modal, Skeleton } from "antd"
+import { Button, Modal, Skeleton } from "antd"
+import { Alert } from "@/components/ui/primitives/Alert"
 import { tldwClient } from "@/services/tldw/TldwApiClient"
 import { formatRelativeTimestamp } from "./listUtils"
 
@@ -135,21 +136,21 @@ export function DictionaryVersionHistoryModal({
     >
       {errorMessage ? (
         <Alert
-          type="error"
-          showIcon
+          variant="error"
           className="mb-3"
           title="Version history failed"
-          description={errorMessage}
-        />
+        >
+          {errorMessage}
+        </Alert>
       ) : null}
       {revertMessage ? (
         <Alert
-          type="success"
-          showIcon
+          variant="success"
           className="mb-3"
           title="Revision restored"
-          description={revertMessage}
-        />
+        >
+          {revertMessage}
+        </Alert>
       ) : null}
 
       {versionsStatus === "loading" ? (

--- a/apps/packages/ui/src/components/Option/Dictionaries/__tests__/DictionariesWorkspace.layout.test.tsx
+++ b/apps/packages/ui/src/components/Option/Dictionaries/__tests__/DictionariesWorkspace.layout.test.tsx
@@ -9,7 +9,14 @@ const { useLayoutUiStoreMock } = vi.hoisted(() => ({
 }))
 
 const routerMocks = vi.hoisted(() => ({
-  navigate: vi.fn()
+  navigate: vi.fn(),
+  location: {
+    pathname: "/dictionaries",
+    search: "",
+    hash: "",
+    state: null,
+    key: "dictionaries-layout-test"
+  }
 }))
 
 const connectionMocks = vi.hoisted(() => ({
@@ -36,6 +43,7 @@ vi.mock("react-i18next", () => ({
 }))
 
 vi.mock("react-router-dom", () => ({
+  useLocation: () => routerMocks.location,
   useNavigate: () => routerMocks.navigate
 }))
 

--- a/apps/packages/ui/src/components/Option/Dictionaries/__tests__/DictionaryVersionHistoryModal.design-system.test.tsx
+++ b/apps/packages/ui/src/components/Option/Dictionaries/__tests__/DictionaryVersionHistoryModal.design-system.test.tsx
@@ -1,0 +1,97 @@
+import React from "react"
+import { render, screen, within } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { DictionaryVersionHistoryModal } from "../DictionaryVersionHistoryModal"
+import { tldwClient } from "@/services/tldw/TldwApiClient"
+
+vi.mock("@/services/tldw/TldwApiClient", () => ({
+  tldwClient: {
+    dictionaryVersions: vi.fn(),
+    dictionaryVersionSnapshot: vi.fn(),
+    revertDictionaryVersion: vi.fn()
+  }
+}))
+
+const tldwClientMock = vi.mocked(tldwClient)
+
+const dictionary = {
+  id: 7,
+  name: "Core Terms"
+}
+
+describe("DictionaryVersionHistoryModal design-system alerts", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("renders version-history load failures through the design-system Alert primitive", async () => {
+    tldwClientMock.dictionaryVersions.mockRejectedValueOnce(
+      new Error("Could not reach dictionary history")
+    )
+
+    render(
+      <DictionaryVersionHistoryModal
+        open
+        dictionary={dictionary}
+        onClose={vi.fn()}
+      />
+    )
+
+    const title = await screen.findByText("Version history failed")
+    const alert = title.closest('[data-ds-component="Alert"]')
+
+    expect(alert).not.toBeNull()
+    const alertEl = alert as HTMLElement
+
+    expect(alertEl).toHaveTextContent("Could not reach dictionary history")
+  })
+
+  it("renders revision-restored messages through the design-system Alert primitive", async () => {
+    const user = userEvent.setup()
+    tldwClientMock.dictionaryVersions.mockResolvedValue({
+      versions: [
+        {
+          revision: 3,
+          created_at: "2026-05-29T12:00:00Z",
+          change_type: "update",
+          entry_count: 2
+        }
+      ]
+    })
+    tldwClientMock.dictionaryVersionSnapshot.mockResolvedValue({
+      revision: 3,
+      change_type: "update",
+      created_at: "2026-05-29T12:00:00Z",
+      dictionary: {
+        name: "Core Terms",
+        is_active: true,
+        category: "General"
+      },
+      entries: [{ term: "alpha" }, { term: "beta" }]
+    })
+    tldwClientMock.revertDictionaryVersion.mockResolvedValue({
+      message: "Revision 3 restored."
+    })
+
+    render(
+      <DictionaryVersionHistoryModal
+        open
+        dictionary={dictionary}
+        onClose={vi.fn()}
+      />
+    )
+
+    await screen.findByText("r3")
+    await user.click(screen.getByRole("button", { name: "Revert to revision 3" }))
+
+    const title = await screen.findByText("Revision restored")
+    const alert = title.closest('[data-ds-component="Alert"]')
+
+    expect(alert).not.toBeNull()
+    const alertEl = alert as HTMLElement
+
+    expect(alertEl).toHaveTextContent("Revision 3 restored.")
+    expect(within(alertEl).getByText("Revision 3 restored.")).toBeInTheDocument()
+  })
+})

--- a/backlog/tasks/task-45.44.11.6 - Migrate-DictionaryVersionHistoryModal-alerts-to-design-system-Alert.md
+++ b/backlog/tasks/task-45.44.11.6 - Migrate-DictionaryVersionHistoryModal-alerts-to-design-system-Alert.md
@@ -1,0 +1,77 @@
+---
+id: TASK-45.44.11.6
+title: Migrate DictionaryVersionHistoryModal alerts to design-system Alert
+status: Done
+labels:
+- design-system
+- webui
+- dictionaries
+- product-state
+priority: medium
+parent_task_id: TASK-45.44.11
+references:
+- apps/packages/ui/src/components/Option/Dictionaries/DictionaryVersionHistoryModal.tsx
+- apps/packages/ui/scripts/design-system-product-state-baseline.json
+modified_files:
+- apps/packages/ui/src/components/Option/Dictionaries/DictionaryVersionHistoryModal.tsx
+- apps/packages/ui/src/components/Option/Dictionaries/__tests__/DictionariesWorkspace.layout.test.tsx
+- apps/packages/ui/src/components/Option/Dictionaries/__tests__/DictionaryVersionHistoryModal.design-system.test.tsx
+- apps/packages/ui/scripts/design-system-product-state-baseline.json
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Migrate DictionaryVersionHistoryModal's error and success product-state AntD Alerts to the canonical design-system Alert primitive while preserving version-history error copy and revision-restored messaging.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 DictionaryVersionHistoryModal error message renders through the design-system Alert primitive with the existing title and details.
+- [x] #2 DictionaryVersionHistoryModal revision-restored message renders through the design-system Alert primitive with the existing title and details.
+- [x] #3 The matching DictionaryVersionHistoryModal Alert product-state baseline exceptions are removed and focused guard coverage has no DictionaryVersionHistoryModal findings.
+- [x] #4 Focused regression coverage proves both migrated alert states use design-system primitives.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+- [x] Add focused failing tests that render the version-history load failure and revision-restored states and assert each alert uses the shared design-system Alert marker.
+- [x] Replace the DictionaryVersionHistoryModal AntD Alert usages with the shared design-system Alert primitive while preserving copy.
+- [x] Remove the migrated DictionaryVersionHistoryModal Alert rows from the product-state baseline.
+- [x] Run focused tests, product-state guard/unit verifier checks, TypeScript check, and git diff whitespace checks.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+- Added `DictionaryVersionHistoryModal.design-system.test.tsx`; red state failed because the existing AntD Alerts did not provide the `data-ds-component="Alert"` marker.
+- Replaced the version-history error and revision-restored AntD `Alert` usages with the shared design-system `Alert` using `variant="error"` and `variant="success"`. Existing title/detail copy is unchanged.
+- Removed both `DictionaryVersionHistoryModal` Alert baseline rows.
+- Verification: `bunx vitest run src/components/Option/Dictionaries/__tests__/DictionaryVersionHistoryModal.design-system.test.tsx` passed.
+- Review follow-up: added explicit null guards before narrowing the focused Alert container query results to `HTMLElement`, so missing design-system wrappers fail as assertion failures instead of later `within()`/property access errors.
+- CI follow-up: fixed `DictionariesWorkspace.layout.test.tsx`'s local `react-router-dom` mock to provide `useLocation`, matching `WorkspaceConnectionGate`'s current dependency.
+- Verification: `bunx vitest run src/components/Option/Dictionaries/__tests__/DictionariesWorkspace.layout.test.tsx --maxWorkers=1 --no-file-parallelism` passed after reproducing the CI failure locally.
+- Verification: `bun run test:dictionaries` passed with 30 test files / 124 tests.
+- Verification: `bunx vitest run src/design-system/__tests__/product-state-guard.test.ts --reporter=dot` passed.
+- Verification: `NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit --pretty false` passed with an empty `/tmp/dictionary-version-alerts-tsc-after-ci-fix.log`.
+- Verification: `git diff --check` passed.
+- Product-state verifier: `bun run verify:design-system-state` still exits 1 on existing current-dev guard drift in IntegrationPolicyPanel, WritingActionBar, Notes, and ResearchWorkspace surfaces plus stale IntegrationPolicyPanel baseline entries; `/tmp/design-system-dictionary-version-alerts-post-rebase.log` contains no `DictionaryVersionHistoryModal` findings and reports 205 remaining baseline exceptions.
+- Bandit: skipped because this slice only touches frontend TypeScript/TSX, JSON, and Backlog task metadata.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Migrated the `DictionaryVersionHistoryModal` version-history error and revision-restored states to the shared design-system Alert primitive, added focused marker coverage for both states with explicit null guards, and removed the retired product-state baseline exceptions. Also fixed the dictionary layout test's stale router mock after the PR's dictionary CI job exposed its missing `useLocation` export. Focused regression coverage, the full dictionary Vitest script, product-state guard unit coverage, TypeScript, and diff whitespace checks passed; the full product-state verifier remains blocked by existing current-dev guard drift outside this slice and has no DictionaryVersionHistoryModal findings.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-551 - Stabilize-audio-transcription-heartbeat-test-dependency-overrides.md
+++ b/backlog/tasks/task-551 - Stabilize-audio-transcription-heartbeat-test-dependency-overrides.md
@@ -4,7 +4,7 @@ title: Stabilize audio transcription heartbeat test dependency overrides
 status: In Progress
 assignee: []
 created_date: ''
-updated_date: '2026-05-30 05:03'
+updated_date: '2026-05-30 06:45'
 labels:
   - ci
   - tests
@@ -39,19 +39,27 @@ Local verification:
 - `bunx vitest run src/components/Option/Dictionaries/__tests__/DictionaryVersionHistoryModal.design-system.test.tsx` passed: 2 tests.
 - `git diff --check` passed.
 - Bandit ran on the touched test file; remaining findings are existing low-severity test-file assert usage, with no B106 or medium/high findings after removing the token_type literal.
+
+Follow-up Windows full-suite Audio artifact for PR #2133 showed `test_audio_transcriptions_sanitizes_heartbeat_jobs_failure_log` racing the heartbeat task on Windows. Replaced the 10ms sleep in the mocked jobs-start increment with an event-gated wait that is released by the failing heartbeat callback, so the test deterministically observes the sanitized heartbeat log before request cleanup can cancel the task.
+
+Additional local verification:
+- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest -q tldw_Server_API/tests/Audio/test_audio_transcriptions_hotwords.py::test_audio_transcriptions_sanitizes_heartbeat_jobs_failure_log` passed.
+- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest -q tldw_Server_API/tests/Audio/test_audio_transcriptions_hotwords.py` passed: 23 tests.
+- Bandit ran on touched Admin/Audio files; remaining findings are low-severity test assert usage only, with no B106 or medium/high findings.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
+
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
 - [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
 - [ ] #5 Final summary added
 - [ ] #6 Known skips or blockers documented
 <!-- DOD:END -->

--- a/backlog/tasks/task-551 - Stabilize-audio-transcription-heartbeat-test-dependency-overrides.md
+++ b/backlog/tasks/task-551 - Stabilize-audio-transcription-heartbeat-test-dependency-overrides.md
@@ -1,0 +1,57 @@
+---
+id: TASK-551
+title: Stabilize audio transcription heartbeat test dependency overrides
+status: In Progress
+assignee: []
+created_date: ''
+updated_date: '2026-05-30 05:03'
+labels:
+  - ci
+  - tests
+  - audio
+  - pr-2133
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Fix the PR #2133 full-suite Audio test failure where the heartbeat create_task failure test leaks its asyncio.create_task monkeypatch into AuthNZ dependency initialization before the endpoint exercises the heartbeat branch.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 The hotwords audio test helper bypasses AuthNZ DB/principal dependencies for endpoint-level tests.
+- [x] #2 The failing heartbeat task startup regression test passes locally.
+- [x] #3 Existing design-system dictionary verification remains unchanged.
+- [ ] #4 PR #2133 CI no longer fails in the Audio full-suite module for this test.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+CI evidence from PR #2133 Full Suite Ubuntu/Python 3.11 showed `test_audio_transcriptions_sanitizes_heartbeat_task_start_failure_log` failing in the Audio module because the test-injected `asyncio.create_task` error reached AuthNZ database pool initialization. Updated `_setup_stubbed_audio_app` to override `get_auth_principal` and `get_db_transaction`, matching the existing retention/redaction audio endpoint test helper so the test remains focused on the endpoint heartbeat branch.
+
+Local verification:
+- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest -q tldw_Server_API/tests/Audio/test_audio_transcriptions_hotwords.py::test_audio_transcriptions_sanitizes_heartbeat_task_start_failure_log` passed.
+- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest -q tldw_Server_API/tests/Audio/test_audio_transcriptions_hotwords.py` passed: 23 tests.
+- `bunx vitest run src/components/Option/Dictionaries/__tests__/DictionaryVersionHistoryModal.design-system.test.tsx` passed: 2 tests.
+- `git diff --check` passed.
+- Bandit ran on the touched test file; remaining findings are existing low-severity test-file assert usage, with no B106 or medium/high findings after removing the token_type literal.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-552 - Stabilize-Windows-admin-bundle-AuthNZ-backup-path-resolution.md
+++ b/backlog/tasks/task-552 - Stabilize-Windows-admin-bundle-AuthNZ-backup-path-resolution.md
@@ -1,0 +1,55 @@
+---
+id: TASK-552
+title: Stabilize Windows admin bundle AuthNZ backup path resolution
+status: In Progress
+assignee: []
+created_date: ''
+updated_date: '2026-05-30 06:45'
+labels:
+  - ci
+  - tests
+  - admin
+  - pr-2133
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Fix PR #2133 Windows full-suite failure where Admin bundle export returns export_error for the AuthNZ-only bundle test because Windows sqlite DATABASE_URL paths with backslashes can be resolved with a leading slash and fail backup path existence checks.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Windows-style sqlite DATABASE_URL paths like sqlite:///C:\\... resolve to a valid filesystem path for AuthNZ backups.
+- [x] #2 The Admin authnz-only bundle test still passes locally.
+- [ ] #3 PR #2133 CI no longer fails the Admin full-suite module for this path.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Windows full-suite Admin artifact for PR #2133 showed `test_create_bundle_authnz_only` returning `export_error`. The failing path shape was a Windows sqlite URL with a backslash drive path that parsed as `/C:\...`; the existing normalizer only stripped `/C:/...`. Updated `_resolve_dataset_db_path()` to strip the leading slash for both slash and backslash drive separators, and added a focused regression test for `sqlite:///C:\...` AuthNZ DATABASE_URL resolution.
+
+Local verification:
+- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest -q tldw_Server_API/tests/Admin/test_bundle_ops.py::test_authnz_backup_path_normalizes_windows_sqlite_url tldw_Server_API/tests/Admin/test_bundle_ops.py::test_create_bundle_authnz_only` passed: 2 tests.
+- `git diff --check` passed.
+- Bandit ran on touched Admin/Audio files; remaining findings are low-severity test assert usage only, with no B106 or medium/high findings.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/tldw_Server_API/app/services/admin_data_ops_service.py
+++ b/tldw_Server_API/app/services/admin_data_ops_service.py
@@ -177,7 +177,7 @@ def _resolve_dataset_db_path(dataset: str, user_id: int | None) -> tuple[str, in
             fs_path = unquote(parsed.path or url)
             if fs_path.startswith("//"):
                 fs_path = fs_path[1:]
-            if re.match(r"^/[A-Za-z]:/", fs_path):
+            if re.match(r"^/[A-Za-z]:[\\/]", fs_path):
                 fs_path = fs_path[1:]
             if fs_path in {":memory:", "/:memory:"}:
                 return ":memory:", None

--- a/tldw_Server_API/tests/Admin/test_bundle_ops.py
+++ b/tldw_Server_API/tests/Admin/test_bundle_ops.py
@@ -56,6 +56,24 @@ async def _reset_state():
     admin_bundle_service._rate_limit_windows.clear()
 
 
+def test_authnz_backup_path_normalizes_windows_sqlite_url(monkeypatch):
+    from tldw_Server_API.app.core.AuthNZ.settings import reset_settings
+    from tldw_Server_API.app.services.admin_data_ops_service import _resolve_dataset_db_path
+
+    windows_path = "C:\\Users\\runneradmin\\AppData\\Local\\Temp\\users_test_bundle_ops.db"
+    monkeypatch.setenv("AUTH_MODE", "single_user")
+    monkeypatch.setenv("DATABASE_URL", f"sqlite:///{windows_path}")
+    reset_settings()
+
+    try:
+        db_path, user_id = _resolve_dataset_db_path("authnz", None)
+    finally:
+        reset_settings()
+
+    assert db_path == windows_path
+    assert user_id is None
+
+
 async def _seed_authnz_data() -> int:
     from tldw_Server_API.app.core.AuthNZ.database import get_db_pool, is_postgres_backend
 

--- a/tldw_Server_API/tests/Audio/test_audio_transcriptions_hotwords.py
+++ b/tldw_Server_API/tests/Audio/test_audio_transcriptions_hotwords.py
@@ -636,13 +636,15 @@ def test_audio_transcriptions_sanitizes_heartbeat_jobs_failure_log(
 
     original_shim_attr = audio_tx._audio_shim_attr
     heartbeat_calls = 0
+    heartbeat_observed = audio_tx.asyncio.Event()
 
     async def _slow_increment_jobs_started(*_args, **_kwargs):
-        await audio_tx.asyncio.sleep(0.01)
+        await audio_tx.asyncio.wait_for(heartbeat_observed.wait(), timeout=1.0)
 
     async def _failing_heartbeat_jobs(*_args, **_kwargs):
         nonlocal heartbeat_calls
         heartbeat_calls += 1
+        heartbeat_observed.set()
         if heartbeat_calls == 1:
             raise RuntimeError("heartbeat job leaked /private/rg-heartbeat")
         raise audio_tx.asyncio.CancelledError()

--- a/tldw_Server_API/tests/Audio/test_audio_transcriptions_hotwords.py
+++ b/tldw_Server_API/tests/Audio/test_audio_transcriptions_hotwords.py
@@ -154,6 +154,12 @@ def _setup_stubbed_audio_app(
     monkeypatch.setenv("SINGLE_USER_API_KEY", TEST_API_KEY)
     monkeypatch.setenv("SINGLE_USER_FIXED_ID", "1")
 
+    from types import SimpleNamespace
+    from tldw_Server_API.app.api.v1.API_Deps.auth_deps import (
+        get_auth_principal,
+        get_db_transaction,
+    )
+    from tldw_Server_API.app.core.AuthNZ.principal_model import AuthPrincipal
     from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import User, get_request_user
     import tldw_Server_API.app.api.v1.endpoints.audio.audio as audio_ep
     import tldw_Server_API.app.core.Ingestion_Media_Processing.Audio.Audio_Transcription_Lib as atlib
@@ -163,6 +169,26 @@ def _setup_stubbed_audio_app(
 
     async def _fake_get_request_user() -> User:
         return User(id=1, username="single_user")
+
+    async def _fake_get_auth_principal() -> AuthPrincipal:
+        return AuthPrincipal(
+            kind="user",
+            user_id=1,
+            api_key_id=None,
+            username="single_user",
+            email=None,
+            subject="single_user",
+            token_type=None,
+            jti=None,
+            roles=["admin"],
+            permissions=["*"],
+            is_admin=True,
+            org_ids=[],
+            team_ids=[],
+        )
+
+    async def _fake_get_db_transaction():
+        yield SimpleNamespace()
 
     async def _allow_job(*_args, **_kwargs):
         return True, None
@@ -216,6 +242,8 @@ def _setup_stubbed_audio_app(
 
     app = FastAPI()
     app.dependency_overrides[get_request_user] = _fake_get_request_user
+    app.dependency_overrides[get_auth_principal] = _fake_get_auth_principal
+    app.dependency_overrides[get_db_transaction] = _fake_get_db_transaction
     app.include_router(audio_router, prefix="/api/v1/audio")
     return app, captured
 


### PR DESCRIPTION
## Change summary (maintainer-owned)

Maintainer follow-up before merge: replace this section with a human-written summary of what changed and why these implementation choices were made.

## Implementation summary

- Migrated `DictionaryVersionHistoryModal` version-history error and revision-restored messages from AntD `Alert` to the shared design-system `Alert` primitive.
- Added focused regression coverage proving both alert states render with `data-ds-component="Alert"` while preserving the existing titles and message text.
- Removed the two retired `DictionaryVersionHistoryModal` Alert exceptions from the product-state baseline.
- Fixed the dictionary layout test's stale `react-router-dom` mock after CI exposed that it was missing `useLocation` for `WorkspaceConnectionGate`.
- Closed `TASK-45.44.11.6` with verification notes and known guard drift documented.

## Verification

- `bunx vitest run src/components/Option/Dictionaries/__tests__/DictionaryVersionHistoryModal.design-system.test.tsx`
- `bunx vitest run src/components/Option/Dictionaries/__tests__/DictionariesWorkspace.layout.test.tsx --maxWorkers=1 --no-file-parallelism`
- `bun run test:dictionaries`
- `bunx vitest run src/design-system/__tests__/product-state-guard.test.ts --reporter=dot`
- `NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit --pretty false`
- `git diff --check`
- `node -e "JSON.parse(require('fs').readFileSync('apps/packages/ui/scripts/design-system-product-state-baseline.json','utf8'))"`

## Known current-dev guard drift

`bun run verify:design-system-state` still exits 1 on existing unrelated guard drift in IntegrationPolicyPanel, WritingActionBar, Notes, and ResearchWorkspace surfaces plus stale IntegrationPolicyPanel baseline entries. The post-rebase verifier log has no `DictionaryVersionHistoryModal` findings and reports 205 remaining baseline exceptions.
