### PR TITLE
fix: stabilize full-suite backend flakes

### DIFF
--- a/backlog/tasks/task-551 - Stabilize-full-suite-backend-flakes-blocking-Evaluations-alert-PR.md
+++ b/backlog/tasks/task-551 - Stabilize-full-suite-backend-flakes-blocking-Evaluations-alert-PR.md
@@ -45,7 +45,7 @@ PR #2129 review-fix CI exposed unrelated full-suite backend flakes on Windows/ma
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Opened PR #2134 from `codex/task-549-full-suite-flakes` after rebasing onto `origin/dev`. The branch isolates the full-suite flake fixes exposed by PR #2129: deterministic invitation ordering for tied `created_at` timestamps, less race-prone audio heartbeat failure-log coverage, handled audit stop `LookupError` cleanup, and a bounded audit cleanup wait in tests. Verification passed locally: Admin invitation suite 32 tests, Audio transcription hotword suite 23 tests, Audit DB deps suite 17 tests, `py_compile` on touched Python files, `git diff --check`, and Bandit on touched backend code with 0 findings.
+Opened PR #2134 from `codex/task-549-full-suite-flakes` after rebasing onto `origin/dev`. The branch isolates the full-suite flake fixes exposed by PR #2129: deterministic invitation ordering for tied `created_at` timestamps, less race-prone audio heartbeat failure-log coverage, handled audit stop `LookupError` cleanup, and a bounded audit cleanup wait in tests. Review feedback on PR #2134 has been addressed by using reverse + stable sort for invitation ties and moving the audio heartbeat polling inside the `TestClient` lifetime. Verification passed locally: Admin invitation suite 32 tests, Audio transcription hotword suite 23 tests, Audit DB deps suite 17 tests, `py_compile` on touched Python files, `git diff --check`, and Bandit on touched backend code with 0 findings. Remote PR check rollup is pending rerun after push.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-551 - Stabilize-full-suite-backend-flakes-blocking-Evaluations-alert-PR.md
+++ b/backlog/tasks/task-551 - Stabilize-full-suite-backend-flakes-blocking-Evaluations-alert-PR.md
@@ -1,0 +1,59 @@
+---
+id: TASK-551
+title: Stabilize full-suite backend flakes blocking Evaluations alert PR
+status: In Progress
+labels:
+- ci
+- tests
+- backend
+- flake
+- TASK-45.44.5.2-followup
+priority: High
+references:
+- https://github.com/rmusser01/tldw_server/pull/2134
+modified_files:
+- tldw_Server_API/app/services/admin_system_ops_service.py
+- tldw_Server_API/app/api/v1/API_Deps/Audit_DB_Deps.py
+- tldw_Server_API/tests/Admin/test_admin_invitations.py
+- tldw_Server_API/tests/Audio/test_audio_transcriptions_hotwords.py
+- tldw_Server_API/tests/Audit/test_audit_db_deps.py
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+PR #2129 review-fix CI exposed unrelated full-suite backend flakes on Windows/macOS after the EvaluationsPage alert migration. Stabilize the failing tests or underlying behavior without broadening the UI migration logic.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Windows/macOS full-suite failure causes are addressed or explicitly documented as unrelated baseline if not safely fixable.
+- [x] #2 Focused tests for the failing Admin, Audio, and Audit cases pass locally.
+- [ ] #3 PR #2134 check rollup is rerun after fixes or status is documented if remote CI remains pending.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+- PR #2129 full-suite Windows log showed unrelated backend failures after the EvaluationsPage alert migration: `TestListInvitations::test_list_sorted_newest_first`, `test_audio_transcriptions_sanitizes_heartbeat_jobs_failure_log`, and `test_schedule_service_stop_clears_flag_on_failure`.
+- Invitation listing now preserves newest-first behavior even when two invitations share the same `created_at` timestamp by using creation order as a tie-breaker.
+- Audio heartbeat log coverage now waits briefly for the background heartbeat task to emit the sanitized failure log, avoiding scheduler timing races on slower runners.
+- Audit service stop cleanup now treats `LookupError` from `service.stop()` as a handled stop failure and the async cleanup test waits with a bounded timeout for background cleanup.
+- Opened follow-up PR #2134 from `codex/task-549-full-suite-flakes` after rebasing onto `origin/dev`; the branch diff now contains only this stabilization work on top of the merged Evaluations alert PR.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Opened PR #2134 from `codex/task-549-full-suite-flakes` after rebasing onto `origin/dev`. The branch isolates the full-suite flake fixes exposed by PR #2129: deterministic invitation ordering for tied `created_at` timestamps, less race-prone audio heartbeat failure-log coverage, handled audit stop `LookupError` cleanup, and a bounded audit cleanup wait in tests. Verification passed locally: Admin invitation suite 32 tests, Audio transcription hotword suite 23 tests, Audit DB deps suite 17 tests, `py_compile` on touched Python files, `git diff --check`, and Bandit on touched backend code with 0 findings.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-554 - Stabilize-full-suite-backend-flakes-blocking-Evaluations-alert-PR.md
+++ b/backlog/tasks/task-554 - Stabilize-full-suite-backend-flakes-blocking-Evaluations-alert-PR.md
@@ -42,7 +42,7 @@ PR #2129 review-fix CI exposed unrelated full-suite backend flakes on Windows/ma
 - Opened follow-up PR #2134 from `codex/task-549-full-suite-flakes` after rebasing onto `origin/dev`; the branch diff now contains only this stabilization work on top of the merged Evaluations alert PR.
 - PR #2134 review feedback was addressed by using reverse plus stable sort for invitation ties and moving the audio heartbeat polling inside the `TestClient` lifetime.
 - Latest `origin/dev` introduced a canonical sidepanel `TASK-551`; this stabilization tracker was moved to `TASK-554` to avoid a duplicate Backlog ID.
-- PR #2134 was rebased onto latest `origin/dev` at `87409dded3` and force-pushed with lease at head `d35280b6a3`; GitHub check rollup restarted and was pending/skipped when checked immediately after push.
+- PR #2134 was rebased onto latest `origin/dev` at `87409dded3` and force-pushed with lease; GitHub check rollup restarted and was pending/skipped when checked immediately after push.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-554 - Stabilize-full-suite-backend-flakes-blocking-Evaluations-alert-PR.md
+++ b/backlog/tasks/task-554 - Stabilize-full-suite-backend-flakes-blocking-Evaluations-alert-PR.md
@@ -1,5 +1,5 @@
 ---
-id: TASK-551
+id: TASK-554
 title: Stabilize full-suite backend flakes blocking Evaluations alert PR
 status: In Progress
 labels:
@@ -29,7 +29,7 @@ PR #2129 review-fix CI exposed unrelated full-suite backend flakes on Windows/ma
 <!-- AC:BEGIN -->
 - [x] #1 Windows/macOS full-suite failure causes are addressed or explicitly documented as unrelated baseline if not safely fixable.
 - [x] #2 Focused tests for the failing Admin, Audio, and Audit cases pass locally.
-- [ ] #3 PR #2134 check rollup is rerun after fixes or status is documented if remote CI remains pending.
+- [x] #3 PR #2134 check rollup is rerun after fixes or status is documented if remote CI remains pending.
 <!-- AC:END -->
 
 ## Implementation Notes
@@ -40,17 +40,20 @@ PR #2129 review-fix CI exposed unrelated full-suite backend flakes on Windows/ma
 - Audio heartbeat log coverage now waits briefly for the background heartbeat task to emit the sanitized failure log, avoiding scheduler timing races on slower runners.
 - Audit service stop cleanup now treats `LookupError` from `service.stop()` as a handled stop failure and the async cleanup test waits with a bounded timeout for background cleanup.
 - Opened follow-up PR #2134 from `codex/task-549-full-suite-flakes` after rebasing onto `origin/dev`; the branch diff now contains only this stabilization work on top of the merged Evaluations alert PR.
+- PR #2134 review feedback was addressed by using reverse plus stable sort for invitation ties and moving the audio heartbeat polling inside the `TestClient` lifetime.
+- Latest `origin/dev` introduced a canonical sidepanel `TASK-551`; this stabilization tracker was moved to `TASK-554` to avoid a duplicate Backlog ID.
+- PR #2134 was rebased onto latest `origin/dev` at `87409dded3` and force-pushed with lease at head `d35280b6a3`; GitHub check rollup restarted and was pending/skipped when checked immediately after push.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Opened PR #2134 from `codex/task-549-full-suite-flakes` after rebasing onto `origin/dev`. The branch isolates the full-suite flake fixes exposed by PR #2129: deterministic invitation ordering for tied `created_at` timestamps, less race-prone audio heartbeat failure-log coverage, handled audit stop `LookupError` cleanup, and a bounded audit cleanup wait in tests. Review feedback on PR #2134 has been addressed by using reverse + stable sort for invitation ties and moving the audio heartbeat polling inside the `TestClient` lifetime. Verification passed locally: Admin invitation suite 32 tests, Audio transcription hotword suite 23 tests, Audit DB deps suite 17 tests, `py_compile` on touched Python files, `git diff --check`, and Bandit on touched backend code with 0 findings. Remote PR check rollup is pending rerun after push.
+Opened PR #2134 from `codex/task-549-full-suite-flakes` after rebasing onto `origin/dev`. The branch isolates the full-suite flake fixes exposed by PR #2129: deterministic invitation ordering for tied `created_at` timestamps, less race-prone audio heartbeat failure-log coverage, handled audit stop `LookupError` cleanup, and a bounded audit cleanup wait in tests. Review feedback on PR #2134 has been addressed by using reverse plus stable sort for invitation ties and moving the audio heartbeat polling inside the `TestClient` lifetime. Verification passed locally after the latest rebase: Admin invitation suite 32 tests, Audio transcription hotword suite 23 tests, Audit DB deps suite 17 tests, `py_compile` on touched Python files, `git diff --check`, and Bandit on touched backend code with 0 findings. Remote PR check rollup was restarted after the rebased push and was still pending/skipped when checked.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
+- [x] #1 Acceptance criteria completed
 - [x] #2 Tests or verification recorded
 - [x] #3 Documentation updated when relevant
 - [x] #4 Bandit run for touched code when applicable or document non-code/environment skip

--- a/tldw_Server_API/app/api/v1/API_Deps/Audit_DB_Deps.py
+++ b/tldw_Server_API/app/api/v1/API_Deps/Audit_DB_Deps.py
@@ -307,7 +307,7 @@ def _schedule_service_stop(user_id: Optional[Union[int, str]], service: UnifiedA
                 break
             await service.stop()
             logger.info(f"Audit service for user {user_id} stopped ({reason}).")
-        except (OSError, RuntimeError, TypeError, ValueError) as exc:
+        except (LookupError, OSError, RuntimeError, TypeError, ValueError) as exc:
             logger.error(
                 f"Failed to stop audit service for user {user_id} ({reason}): {exc}",
                 exc_info=True,
@@ -336,7 +336,7 @@ def _schedule_service_stop(user_id: Optional[Union[int, str]], service: UnifiedA
     def _run():
         try:
             asyncio.run(_stop())
-        except (OSError, RuntimeError, TypeError, ValueError) as e:
+        except (LookupError, OSError, RuntimeError, TypeError, ValueError) as e:
             logger.error(
                 f"Audit service stop failed for user {user_id} in fallback thread: {type(e).__name__}: {e}"
             )

--- a/tldw_Server_API/app/services/admin_system_ops_service.py
+++ b/tldw_Server_API/app/services/admin_system_ops_service.py
@@ -1186,12 +1186,9 @@ def list_invitations(
         if status_norm in _INVITATION_STATUSES:
             invitations = [inv for inv in invitations if inv.get("status") == status_norm]
 
-    indexed_invitations = list(enumerate(invitations))
-    indexed_invitations.sort(
-        key=lambda item: (item[1].get("created_at") or "", item[0]),
-        reverse=True,
-    )
-    return [invitation for _, invitation in indexed_invitations]
+    invitations.reverse()
+    invitations.sort(key=lambda item: item.get("created_at") or "", reverse=True)
+    return invitations
 
 
 def create_invitation(

--- a/tldw_Server_API/app/services/admin_system_ops_service.py
+++ b/tldw_Server_API/app/services/admin_system_ops_service.py
@@ -1186,8 +1186,12 @@ def list_invitations(
         if status_norm in _INVITATION_STATUSES:
             invitations = [inv for inv in invitations if inv.get("status") == status_norm]
 
-    invitations.sort(key=lambda item: item.get("created_at") or "", reverse=True)
-    return invitations
+    indexed_invitations = list(enumerate(invitations))
+    indexed_invitations.sort(
+        key=lambda item: (item[1].get("created_at") or "", item[0]),
+        reverse=True,
+    )
+    return [invitation for _, invitation in indexed_invitations]
 
 
 def create_invitation(

--- a/tldw_Server_API/tests/Admin/test_admin_invitations.py
+++ b/tldw_Server_API/tests/Admin/test_admin_invitations.py
@@ -139,6 +139,20 @@ class TestListInvitations:
         # The second created should appear first (newest)
         assert result[0]["email"] == "second@example.com"
 
+    def test_list_sorted_newest_first_when_created_at_ties(self, monkeypatch, tmp_path):
+        """Creation order breaks ties when timestamps match."""
+        svc = _configure_store(monkeypatch, tmp_path)
+        monkeypatch.setattr(svc, "_now_iso", lambda: "2026-01-01T00:00:00+00:00")
+
+        svc.create_invitation(email="first@example.com")
+        svc.create_invitation(email="second@example.com")
+
+        result = svc.list_invitations()
+        assert [item["email"] for item in result[:2]] == [
+            "second@example.com",
+            "first@example.com",
+        ]
+
     def test_list_filter_by_status(self, monkeypatch, tmp_path):
         """Filtering by status works."""
         svc = _configure_store(monkeypatch, tmp_path)

--- a/tldw_Server_API/tests/Audio/test_audio_transcriptions_hotwords.py
+++ b/tldw_Server_API/tests/Audio/test_audio_transcriptions_hotwords.py
@@ -648,18 +648,18 @@ def test_audio_transcriptions_sanitizes_heartbeat_jobs_failure_log(
             pytest.skip("audio/transcriptions endpoint not mounted in this build")
         assert resp.status_code == 200, resp.text
 
-    deadline = time.monotonic() + 1.0
-    heartbeat_logs = []
-    while time.monotonic() < deadline:
-        heartbeat_logs = [
-            msg
-            for msg in logger_stub.debugs
-            if msg.startswith("audio.transcriptions heartbeat_jobs failed")
-            or msg.startswith("audio.transcriptions job heartbeat failed")
-        ]
-        if heartbeat_logs:
-            break
-        time.sleep(0.01)
+        deadline = time.monotonic() + 1.0
+        heartbeat_logs = []
+        while time.monotonic() < deadline:
+            heartbeat_logs = [
+                msg
+                for msg in logger_stub.debugs
+                if msg.startswith("audio.transcriptions heartbeat_jobs failed")
+                or msg.startswith("audio.transcriptions job heartbeat failed")
+            ]
+            if heartbeat_logs:
+                break
+            time.sleep(0.01)
 
     assert heartbeat_logs == ["audio.transcriptions job heartbeat failed; continuing"]
 

--- a/tldw_Server_API/tests/Audio/test_audio_transcriptions_hotwords.py
+++ b/tldw_Server_API/tests/Audio/test_audio_transcriptions_hotwords.py
@@ -1,5 +1,6 @@
 import io
 import os as real_os
+import time
 from unittest.mock import call
 
 import numpy as np
@@ -647,12 +648,19 @@ def test_audio_transcriptions_sanitizes_heartbeat_jobs_failure_log(
             pytest.skip("audio/transcriptions endpoint not mounted in this build")
         assert resp.status_code == 200, resp.text
 
-    heartbeat_logs = [
-        msg
-        for msg in logger_stub.debugs
-        if msg.startswith("audio.transcriptions heartbeat_jobs failed")
-        or msg.startswith("audio.transcriptions job heartbeat failed")
-    ]
+    deadline = time.monotonic() + 1.0
+    heartbeat_logs = []
+    while time.monotonic() < deadline:
+        heartbeat_logs = [
+            msg
+            for msg in logger_stub.debugs
+            if msg.startswith("audio.transcriptions heartbeat_jobs failed")
+            or msg.startswith("audio.transcriptions job heartbeat failed")
+        ]
+        if heartbeat_logs:
+            break
+        time.sleep(0.01)
+
     assert heartbeat_logs == ["audio.transcriptions job heartbeat failed; continuing"]
 
 

--- a/tldw_Server_API/tests/Audit/test_audit_db_deps.py
+++ b/tldw_Server_API/tests/Audit/test_audit_db_deps.py
@@ -169,8 +169,9 @@ async def test_schedule_service_stop_clears_flag_on_failure(monkeypatch):
 
     deps._schedule_service_stop(1, svc, "test")
 
-    for _ in range(20):
-        await asyncio.sleep(0)
+    deadline = loop.time() + 1.0
+    while loop.time() < deadline:
+        await asyncio.sleep(0.01)
         if not getattr(svc, "_tldw_stop_scheduled", True):
             break
 


### PR DESCRIPTION
## Change summary (maintainer-owned)
- [ ] Maintainer to fill in before merge.

## What changed
- Stabilized invitation listing when two invitations share the same `created_at` timestamp by reversing the local list and relying on Python's stable sort to preserve newest-created tie order.
- Made the audio transcription heartbeat failure-log test wait inside the `TestClient` lifetime so the app event loop can run the background heartbeat task.
- Treated `LookupError` from audit service shutdown as a handled stop failure and gave the cleanup test a bounded wait.
- Added `TASK-554` Backlog tracking for the CI stabilization follow-up after the latest `dev` rebase made `TASK-551` a canonical sidepanel handoff task.

## Why
- PR #2129 exposed unrelated full-suite backend flakes on Windows/macOS after the Evaluations alert migration had already merged. This isolates those flake fixes in a dedicated follow-up PR.
- The latest `dev` tip introduced a Backlog ID collision with the earlier stabilization tracker, so the tracker was moved to `TASK-554`.

## Verification
- `python -m pytest tldw_Server_API/tests/Admin/test_admin_invitations.py -q` passed: 32 tests.
- `python -m pytest tldw_Server_API/tests/Audio/test_audio_transcriptions_hotwords.py -q` passed: 23 tests.
- `python -m pytest tldw_Server_API/tests/Audit/test_audit_db_deps.py -q` passed: 17 tests.
- `python -m py_compile ...` passed for touched Python files.
- `git diff --check` passed.
- `python -m bandit -r tldw_Server_API/app/services/admin_system_ops_service.py tldw_Server_API/app/api/v1/API_Deps/Audit_DB_Deps.py -f json -o /tmp/bandit_task_551_rebased.json` completed with 0 findings.

## Validation
- [x] Rebased onto latest `origin/dev` at `87409dded3`.
- [x] Focused Admin invitation suite passes.
- [x] Focused Audio transcription hotword/logging suite passes.
- [x] Focused Audit DB dependency suite passes.
- [x] Security scan on touched backend code has 0 findings.
- [x] Gemini/Qodo inline review threads resolved after applying the requested fixes.
- [x] No user-facing docs needed; Backlog task record updated.

## Risk & Rollback
- Risk: Low to medium. The invitation ordering change affects same-timestamp ordering only. The audit change broadens handled stop failures to include `LookupError`. The audio change is test-only.
- Rollback: Revert this PR to restore the prior invitation sort, audit stop exception handling, and test timing behavior.

## Watchlists
- [x] CI full-suite Windows/macOS flakes that originally blocked #2129 are the target of this PR.
- [x] Backlog ID collision corrected: `TASK-554` is the stabilization tracker; existing `TASK-551` sidepanel handoff task and `TASK-549` MCP task remain unchanged in this PR.
- [x] GitHub check rollup restarted after the rebased push; remote checks were pending/skipped when last checked.
