### PR TITLE
Migrate Evaluations component alerts to design-system Alert

### DIFF
--- a/apps/packages/ui/scripts/design-system-product-state-baseline.json
+++ b/apps/packages/ui/scripts/design-system-product-state-baseline.json
@@ -825,72 +825,6 @@
     "migrationQueue": "shared-product-state"
   },
   {
-    "id": "antd-product-state-import:src/components/Option/Evaluations/components/CreateEvaluationWizard.tsx:Alert",
-    "path": "src/components/Option/Evaluations/components/CreateEvaluationWizard.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/Option/Evaluations/components/CreateEvaluationWizard.tsx before the guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
-    "id": "antd-product-state-import:src/components/Option/Evaluations/components/DatasetUpload.tsx:Alert",
-    "path": "src/components/Option/Evaluations/components/DatasetUpload.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/Option/Evaluations/components/DatasetUpload.tsx before the guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
-    "id": "antd-product-state-import:src/components/Option/Evaluations/components/RateLimitsWidget.tsx:Alert#antd-alert-ratelimitswidget-type-info-line-100-19cp72r",
-    "path": "src/components/Option/Evaluations/components/RateLimitsWidget.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/Option/Evaluations/components/RateLimitsWidget.tsx before the stable duplicate-id guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
-    "id": "antd-product-state-import:src/components/Option/Evaluations/components/RateLimitsWidget.tsx:Alert#antd-alert-ratelimitswidget-type-warning-line-86-1f7w62a",
-    "path": "src/components/Option/Evaluations/components/RateLimitsWidget.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/Option/Evaluations/components/RateLimitsWidget.tsx before the stable duplicate-id guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
-    "id": "antd-product-state-import:src/components/Option/Evaluations/components/VisualSpecBuilder.tsx:Alert#antd-alert-visualspecbuilder-type-info-line-93-19mulrg",
-    "path": "src/components/Option/Evaluations/components/VisualSpecBuilder.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/Option/Evaluations/components/VisualSpecBuilder.tsx before the stable duplicate-id guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
-    "id": "antd-product-state-import:src/components/Option/Evaluations/components/VisualSpecBuilder.tsx:Alert#antd-alert-visualspecbuilder-type-warning-line-165-1xuibfu",
-    "path": "src/components/Option/Evaluations/components/VisualSpecBuilder.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/Option/Evaluations/components/VisualSpecBuilder.tsx before the stable duplicate-id guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
     "id": "antd-product-state-import:src/components/Option/Evaluations/tabs/recipe-configs/RagAnswerQualityConfig.tsx:Alert#antd-alert-raganswerqualityconfig-type-error-line-469-ctgble",
     "path": "src/components/Option/Evaluations/tabs/recipe-configs/RagAnswerQualityConfig.tsx",
     "rule": "antd-product-state-import",
@@ -2306,17 +2240,6 @@
     "state": "allowed_legacy_exception",
     "owner": "design-system",
     "reason": "Existing AntD Alert product-state UI in src/components/WorkflowEditor/NodePalette.tsx before the guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
-    "id": "antd-product-state-import:src/components/Option/Evaluations/tabs/recipe-configs/EmbeddingsModelSelectionConfig.tsx:Alert",
-    "path": "src/components/Option/Evaluations/tabs/recipe-configs/EmbeddingsModelSelectionConfig.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing Alert product-state UI in src/components/Option/Evaluations/tabs/recipe-configs/EmbeddingsModelSelectionConfig.tsx after the embeddings recipe flow merge; baseline refresh captures current dev debt.",
     "replacement": "tldw design-system state primitive",
     "migrationQueue": "shared-product-state"
   }

--- a/apps/packages/ui/src/components/Option/Evaluations/components/CreateEvaluationWizard.tsx
+++ b/apps/packages/ui/src/components/Option/Evaluations/components/CreateEvaluationWizard.tsx
@@ -144,11 +144,14 @@ export const CreateEvaluationWizard: React.FC<CreateEvaluationWizardProps> = ({
           <div className="space-y-4">
             <DsAlert
               variant="info"
-              className="text-xs"
-              title={t("evaluations:evalTypesHint", {
-                defaultValue:
-                  "Supported: model_graded, response_quality, rag, rag_pipeline, geval, exact_match, includes, fuzzy_match, proposition_extraction, qa3, label_choice, nli_factcheck, ocr."
-              })}
+              title={
+                <span className="text-xs">
+                  {t("evaluations:evalTypesHint", {
+                    defaultValue:
+                      "Supported: model_graded, response_quality, rag, rag_pipeline, geval, exact_match, includes, fuzzy_match, proposition_extraction, qa3, label_choice, nli_factcheck, ocr."
+                  })}
+                </span>
+              }
             />
             <Form.Item
               label={t("evaluations:evalNameLabel", { defaultValue: "Name" })}

--- a/apps/packages/ui/src/components/Option/Evaluations/components/CreateEvaluationWizard.tsx
+++ b/apps/packages/ui/src/components/Option/Evaluations/components/CreateEvaluationWizard.tsx
@@ -5,7 +5,6 @@
 
 import React, { useMemo, useState } from "react"
 import {
-  Alert,
   Button,
   Checkbox,
   Collapse,
@@ -19,6 +18,7 @@ import {
 import type { FormInstance } from "antd"
 import { ArrowLeft, ArrowRight } from "lucide-react"
 import { useTranslation } from "react-i18next"
+import { Alert as DsAlert } from "@/components/ui/primitives"
 import { evalTypeOptions, getDefaultEvalSpecForType } from "../hooks/useEvaluations"
 import { JsonEditor } from "./JsonEditor"
 import { VisualSpecBuilder } from "./VisualSpecBuilder"
@@ -142,9 +142,8 @@ export const CreateEvaluationWizard: React.FC<CreateEvaluationWizardProps> = ({
       case 0:
         return (
           <div className="space-y-4">
-            <Alert
-              type="info"
-              showIcon
+            <DsAlert
+              variant="info"
               className="text-xs"
               title={t("evaluations:evalTypesHint", {
                 defaultValue:

--- a/apps/packages/ui/src/components/Option/Evaluations/components/DatasetUpload.tsx
+++ b/apps/packages/ui/src/components/Option/Evaluations/components/DatasetUpload.tsx
@@ -4,9 +4,10 @@
  */
 
 import React, { useState } from "react"
-import { Alert, Upload } from "antd"
+import { Upload } from "antd"
 import { UploadCloud } from "lucide-react"
 import { useTranslation } from "react-i18next"
+import { Alert as DsAlert } from "@/components/ui/primitives"
 
 interface DatasetUploadProps {
   onSamplesLoaded: (samples: any[]) => void
@@ -85,14 +86,14 @@ export const DatasetUpload: React.FC<DatasetUploadProps> = ({
         </p>
       </Upload.Dragger>
       {error && (
-        <Alert
-          type="error"
-          showIcon
+        <DsAlert
+          variant="error"
           title={t("evaluations:datasetUploadErrorTitle", {
             defaultValue: "Upload failed"
           })}
-          description={error}
-        />
+        >
+          {error}
+        </DsAlert>
       )}
     </div>
   )

--- a/apps/packages/ui/src/components/Option/Evaluations/components/RateLimitsWidget.tsx
+++ b/apps/packages/ui/src/components/Option/Evaluations/components/RateLimitsWidget.tsx
@@ -4,9 +4,10 @@
  */
 
 import React, { useMemo } from "react"
-import { Alert, Progress, Spin, Typography } from "antd"
+import { Progress, Spin, Typography } from "antd"
 import { useTranslation } from "react-i18next"
 import type { EvaluationRateLimitStatus } from "@/services/evaluations"
+import { Alert as DsAlert } from "@/components/ui/primitives"
 
 const { Text } = Typography
 
@@ -83,9 +84,8 @@ export const RateLimitsWidget: React.FC<RateLimitsWidgetProps> = ({
 
   if (isError) {
     return (
-      <Alert
-        type="warning"
-        showIcon
+      <DsAlert
+        variant="warning"
         title={t("evaluations:rateLimitsErrorTitle", {
           defaultValue: "Unable to fetch rate limits"
         })}
@@ -97,15 +97,15 @@ export const RateLimitsWidget: React.FC<RateLimitsWidgetProps> = ({
   // Show quota snapshot if available (from response headers)
   if (quotaSnapshot && quotaText) {
     return (
-      <Alert
-        type="info"
-        showIcon
+      <DsAlert
+        variant="info"
         title={t("evaluations:rateLimitsTitle", {
           defaultValue: "Evaluation limits"
         })}
-        description={quotaText}
         className={className}
-      />
+      >
+        {quotaText}
+      </DsAlert>
     )
   }
 

--- a/apps/packages/ui/src/components/Option/Evaluations/components/VisualSpecBuilder.tsx
+++ b/apps/packages/ui/src/components/Option/Evaluations/components/VisualSpecBuilder.tsx
@@ -4,8 +4,9 @@
  */
 
 import React, { useMemo, useState, useEffect } from "react"
-import { Alert, Checkbox, Divider, InputNumber, Slider, Switch } from "antd"
+import { Checkbox, Divider, InputNumber, Slider, Switch } from "antd"
 import { useTranslation } from "react-i18next"
+import { Alert as DsAlert } from "@/components/ui/primitives"
 import { JsonEditor } from "./JsonEditor"
 import {
   getEvalSpecSchema,
@@ -90,9 +91,8 @@ export const VisualSpecBuilder: React.FC<VisualSpecBuilderProps> = ({
   const renderBuilder = () => {
     if (!schema || schema.builder === "json") {
       return (
-        <Alert
-          type="info"
-          showIcon
+        <DsAlert
+          variant="info"
           title={t("evaluations:specBuilderJsonOnly", {
             defaultValue:
               "This evaluation type uses JSON configuration. Use the editor below."
@@ -162,15 +162,15 @@ export const VisualSpecBuilder: React.FC<VisualSpecBuilderProps> = ({
   return (
     <div className="space-y-3">
       {parseError && (
-        <Alert
-          type="warning"
-          showIcon
+        <DsAlert
+          variant="warning"
           title={t("evaluations:specBuilderParseWarning", {
             defaultValue:
               "Spec JSON is invalid. Fix the JSON to use the visual builder."
           })}
-          description={parseError}
-        />
+        >
+          {parseError}
+        </DsAlert>
       )}
 
       {renderBuilder()}

--- a/apps/packages/ui/src/components/Option/Evaluations/components/__tests__/EvaluationComponentAlerts.design-system.test.tsx
+++ b/apps/packages/ui/src/components/Option/Evaluations/components/__tests__/EvaluationComponentAlerts.design-system.test.tsx
@@ -1,0 +1,137 @@
+// @vitest-environment jsdom
+
+import { describe, expect, it, vi } from "vitest"
+import { fireEvent, render, screen, waitFor } from "@testing-library/react"
+import React from "react"
+import { Form } from "antd"
+import { CreateEvaluationWizard } from "../CreateEvaluationWizard"
+import { DatasetUpload } from "../DatasetUpload"
+import { RateLimitsWidget } from "../RateLimitsWidget"
+import { VisualSpecBuilder } from "../VisualSpecBuilder"
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (
+      _key: string,
+      defaultValueOrOptions?:
+        | string
+        | {
+            defaultValue?: string
+            [key: string]: unknown
+          }
+    ) => {
+      if (typeof defaultValueOrOptions === "string") return defaultValueOrOptions
+      if (defaultValueOrOptions?.defaultValue) {
+        return defaultValueOrOptions.defaultValue.replace(
+          /\{\{(\w+)\}\}/g,
+          (_match, key) => String(defaultValueOrOptions[key] ?? "")
+        )
+      }
+      return _key
+    }
+  })
+}))
+
+if (!(globalThis as any).ResizeObserver) {
+  ;(globalThis as any).ResizeObserver = class ResizeObserver {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  }
+}
+
+const expectDesignSystemAlert = (text: string | RegExp) => {
+  const node = screen.getByText(text)
+  expect(node.closest('[data-ds-component="Alert"]')).toBeInTheDocument()
+}
+
+const CreateEvaluationWizardHarness = () => {
+  const [form] = Form.useForm()
+
+  return (
+    <CreateEvaluationWizard
+      form={form}
+      datasets={[]}
+      evalDefaults={null}
+      evalSpecText="{}"
+      evalSpecError={null}
+      inlineDatasetEnabled={false}
+      inlineDatasetText=""
+      evalIdempotencyKey="eval-key-1"
+      onSpecChange={vi.fn()}
+      onSpecError={vi.fn()}
+      onInlineDatasetEnabled={vi.fn()}
+      onInlineDatasetText={vi.fn()}
+      onRegenerateIdempotencyKey={() => "eval-key-2"}
+      onCancel={vi.fn()}
+      onSubmit={vi.fn()}
+    />
+  )
+}
+
+describe("Evaluation component product-state alerts", () => {
+  it("renders the evaluation type hint with the design-system Alert", () => {
+    render(<CreateEvaluationWizardHarness />)
+
+    expectDesignSystemAlert(/Supported: model_graded/)
+  })
+
+  it("renders dataset upload parse failures with the design-system Alert", async () => {
+    const { container } = render(<DatasetUpload onSamplesLoaded={vi.fn()} />)
+    const input = container.querySelector('input[type="file"]')
+
+    expect(input).not.toBeNull()
+    fireEvent.change(input!, {
+      target: {
+        files: [new File(["not-json"], "dataset.json", { type: "application/json" })]
+      }
+    })
+
+    await waitFor(() => expect(screen.getByText("Upload failed")).toBeInTheDocument())
+    expectDesignSystemAlert("Upload failed")
+  })
+
+  it("renders rate-limit error and quota snapshots with the design-system Alert", () => {
+    const { rerender } = render(<RateLimitsWidget isError />)
+
+    expectDesignSystemAlert("Unable to fetch rate limits")
+
+    rerender(
+      <RateLimitsWidget
+        quotaSnapshot={{
+          limitDay: 100,
+          remainingDay: 75,
+          limitMinute: 10,
+          remainingMinute: 8,
+          reset: "2026-05-29T23:00:00Z"
+        }}
+      />
+    )
+
+    expectDesignSystemAlert("Evaluation limits")
+  })
+
+  it("renders visual spec builder guidance and parse warnings with the design-system Alert", () => {
+    const { rerender } = render(
+      <VisualSpecBuilder
+        evalType="ocr"
+        specText="{}"
+        onSpecChange={vi.fn()}
+        onValidationError={vi.fn()}
+      />
+    )
+
+    expectDesignSystemAlert(/This evaluation type uses JSON configuration/)
+
+    rerender(
+      <VisualSpecBuilder
+        evalType="response_quality"
+        specText="{"
+        onSpecChange={vi.fn()}
+        onValidationError={vi.fn()}
+      />
+    )
+
+    expectDesignSystemAlert(/Spec JSON is invalid/)
+  })
+})

--- a/apps/packages/ui/src/components/Option/Evaluations/components/__tests__/EvaluationComponentAlerts.design-system.test.tsx
+++ b/apps/packages/ui/src/components/Option/Evaluations/components/__tests__/EvaluationComponentAlerts.design-system.test.tsx
@@ -74,6 +74,7 @@ describe("Evaluation component product-state alerts", () => {
     render(<CreateEvaluationWizardHarness />)
 
     expectDesignSystemAlert(/Supported: model_graded/)
+    expect(screen.getByText(/Supported: model_graded/)).toHaveClass("text-xs")
   })
 
   it("renders dataset upload parse failures with the design-system Alert", async () => {

--- a/apps/packages/ui/src/components/Option/Evaluations/tabs/__tests__/EmbeddingsModelSelectionConfig.test.tsx
+++ b/apps/packages/ui/src/components/Option/Evaluations/tabs/__tests__/EmbeddingsModelSelectionConfig.test.tsx
@@ -333,7 +333,8 @@ describe("EmbeddingsModelSelectionConfig", () => {
     await waitFor(() =>
       expect(screen.getByText("Media search failed.")).toBeInTheDocument()
     )
-    expect(screen.getByText("Search failed")).toBeInTheDocument()
+    expect(screen.queryByText("Search failed")).not.toBeInTheDocument()
+    expect(screen.getByText("Media search failed.")).toHaveClass("font-medium")
     expect(
       screen
         .getByText("Media search failed.")

--- a/apps/packages/ui/src/components/Option/Evaluations/tabs/__tests__/EmbeddingsModelSelectionConfig.test.tsx
+++ b/apps/packages/ui/src/components/Option/Evaluations/tabs/__tests__/EmbeddingsModelSelectionConfig.test.tsx
@@ -309,4 +309,34 @@ describe("EmbeddingsModelSelectionConfig", () => {
       expect.objectContaining({ expected_ids: ["42"] })
     ])
   })
+
+  it("renders media search failures with the design-system Alert", async () => {
+    vi.mocked(tldwClient.searchMedia).mockRejectedValueOnce(
+      new Error("Media search failed.")
+    )
+
+    render(
+      <EmbeddingsModelSelectionConfig
+        datasetSource="inline"
+        dataset={[{ query_id: "q-1", input: "query", expected_ids: [] } as DatasetSample]}
+        runConfig={{ comparison_mode: "embedding_only", candidates: [] }}
+        manifest={manifest}
+        onDatasetChange={vi.fn()}
+        onRunConfigChange={vi.fn()}
+      />
+    )
+
+    fireEvent.change(screen.getByLabelText("Find expected sources for query 1"), {
+      target: { value: "launch notes" }
+    })
+
+    await waitFor(() =>
+      expect(screen.getByText("Media search failed.")).toBeInTheDocument()
+    )
+    expect(
+      screen
+        .getByText("Media search failed.")
+        .closest('[data-ds-component="Alert"]')
+    ).toBeInTheDocument()
+  })
 })

--- a/apps/packages/ui/src/components/Option/Evaluations/tabs/__tests__/EmbeddingsModelSelectionConfig.test.tsx
+++ b/apps/packages/ui/src/components/Option/Evaluations/tabs/__tests__/EmbeddingsModelSelectionConfig.test.tsx
@@ -333,6 +333,7 @@ describe("EmbeddingsModelSelectionConfig", () => {
     await waitFor(() =>
       expect(screen.getByText("Media search failed.")).toBeInTheDocument()
     )
+    expect(screen.getByText("Search failed")).toBeInTheDocument()
     expect(
       screen
         .getByText("Media search failed.")

--- a/apps/packages/ui/src/components/Option/Evaluations/tabs/recipe-configs/EmbeddingsModelSelectionConfig.tsx
+++ b/apps/packages/ui/src/components/Option/Evaluations/tabs/recipe-configs/EmbeddingsModelSelectionConfig.tsx
@@ -498,12 +498,8 @@ export const EmbeddingsModelSelectionConfig: React.FC<Props> = ({
                     <DsAlert
                       className="mt-2"
                       variant="error"
-                      title={t("evaluations:embeddingRecipeMediaSearchErrorTitle", {
-                        defaultValue: "Search failed"
-                      })}
-                    >
-                      {searchErrors[index]}
-                    </DsAlert>
+                      title={searchErrors[index]}
+                    />
                   )}
                   {rowResults.length > 0 && (
                     <div className="mt-2 grid gap-2 md:grid-cols-2">

--- a/apps/packages/ui/src/components/Option/Evaluations/tabs/recipe-configs/EmbeddingsModelSelectionConfig.tsx
+++ b/apps/packages/ui/src/components/Option/Evaluations/tabs/recipe-configs/EmbeddingsModelSelectionConfig.tsx
@@ -1,10 +1,11 @@
 import React from "react"
-import { Alert, Button, Card, Checkbox, Input, InputNumber, Tag, Typography } from "antd"
+import { Button, Card, Checkbox, Input, InputNumber, Tag, Typography } from "antd"
 import type {
   DatasetSample,
   EmbeddingRecipeCandidateHint,
   RecipeManifest
 } from "@/services/evaluations"
+import { Alert as DsAlert } from "@/components/ui/primitives"
 import { tldwClient } from "@/services/tldw/TldwApiClient"
 import { useTranslation } from "react-i18next"
 import { useEmbeddingRecipeCandidates } from "../../hooks/useRecipes"
@@ -494,7 +495,9 @@ export const EmbeddingsModelSelectionConfig: React.FC<Props> = ({
                     </Button>
                   </div>
                   {searchErrors[index] && (
-                    <Alert className="mt-2" type="error" showIcon message={searchErrors[index]} />
+                    <DsAlert className="mt-2" variant="error">
+                      {searchErrors[index]}
+                    </DsAlert>
                   )}
                   {rowResults.length > 0 && (
                     <div className="mt-2 grid gap-2 md:grid-cols-2">

--- a/apps/packages/ui/src/components/Option/Evaluations/tabs/recipe-configs/EmbeddingsModelSelectionConfig.tsx
+++ b/apps/packages/ui/src/components/Option/Evaluations/tabs/recipe-configs/EmbeddingsModelSelectionConfig.tsx
@@ -495,7 +495,13 @@ export const EmbeddingsModelSelectionConfig: React.FC<Props> = ({
                     </Button>
                   </div>
                   {searchErrors[index] && (
-                    <DsAlert className="mt-2" variant="error">
+                    <DsAlert
+                      className="mt-2"
+                      variant="error"
+                      title={t("evaluations:embeddingRecipeMediaSearchErrorTitle", {
+                        defaultValue: "Search failed"
+                      })}
+                    >
                       {searchErrors[index]}
                     </DsAlert>
                   )}

--- a/backlog/tasks/task-45.44.5 - Migrate-design-system-product-state-Evaluations.md
+++ b/backlog/tasks/task-45.44.5 - Migrate-design-system-product-state-Evaluations.md
@@ -1,20 +1,19 @@
 ---
 id: TASK-45.44.5
 title: 'Migrate design-system product state: Evaluations'
-status: To Do
+status: In Progress
 assignee: []
-created_date: '2026-05-14 03:19'
+created_date: 2026-05-14 03:19
 labels:
-  - design-system
-  - webui
-  - extension
-  - product-state
+- design-system
+- webui
+- extension
+- product-state
 dependencies: []
 references:
-  - 'https://github.com/rmusser01/tldw_server/issues/1662'
-  - >-
-    Docs/superpowers/specs/2026-05-14-design-system-remaining-work-tracker-design.md
-  - apps/packages/ui/scripts/design-system-product-state-baseline.json
+- https://github.com/rmusser01/tldw_server/issues/1662
+- Docs/superpowers/specs/2026-05-14-design-system-remaining-work-tracker-design.md
+- apps/packages/ui/scripts/design-system-product-state-baseline.json
 parent_task_id: TASK-45.44
 priority: medium
 ---
@@ -28,9 +27,17 @@ Mirror the linked GitHub product-area migration issue. Closure requires zero cur
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
 - [ ] #1 The linked GitHub issue owns current count and public status.
-- [ ] #2 Implementation PR tasks are created under this child when the area is too broad for one PR.
+- [x] #2 Implementation PR tasks are created under this child when the area is too broad for one PR.
 - [ ] #3 Backlog notes record PR links and before/after count evidence.
 <!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+- Created child `TASK-45.44.5.3` for the smaller Evaluations component Alert migration.
+- Before `TASK-45.44.5.3`, `bun run verify:design-system-state` reported `Evaluations: 14` baseline exceptions.
+- After `TASK-45.44.5.3`, the verifier reports `Evaluations: 7` baseline exceptions; the remaining Evaluations rows are the larger RAG recipe config alerts.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->

--- a/backlog/tasks/task-45.44.5 - Migrate-design-system-product-state-Evaluations.md
+++ b/backlog/tasks/task-45.44.5 - Migrate-design-system-product-state-Evaluations.md
@@ -12,6 +12,7 @@ labels:
 dependencies: []
 references:
 - https://github.com/rmusser01/tldw_server/issues/1662
+- https://github.com/rmusser01/tldw_server/pull/2135
 - Docs/superpowers/specs/2026-05-14-design-system-remaining-work-tracker-design.md
 - apps/packages/ui/scripts/design-system-product-state-baseline.json
 parent_task_id: TASK-45.44
@@ -26,17 +27,19 @@ Mirror the linked GitHub product-area migration issue. Closure requires zero cur
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 The linked GitHub issue owns current count and public status.
+- [x] #1 The linked GitHub issue owns current count and public status.
 - [x] #2 Implementation PR tasks are created under this child when the area is too broad for one PR.
-- [ ] #3 Backlog notes record PR links and before/after count evidence.
+- [x] #3 Backlog notes record PR links and before/after count evidence.
 <!-- AC:END -->
 
 ## Implementation Notes
 
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
 - Created child `TASK-45.44.5.3` for the smaller Evaluations component Alert migration.
+- PR #2135: https://github.com/rmusser01/tldw_server/pull/2135.
 - Before `TASK-45.44.5.3`, `bun run verify:design-system-state` reported `Evaluations: 14` baseline exceptions.
 - After `TASK-45.44.5.3`, the verifier reports `Evaluations: 7` baseline exceptions; the remaining Evaluations rows are the larger RAG recipe config alerts.
+- GitHub issue #1662 was updated with the current count/status for this slice.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-45.44.5.3 - Migrate-Evaluations-component-alerts-to-design-system-Alert.md
+++ b/backlog/tasks/task-45.44.5.3 - Migrate-Evaluations-component-alerts-to-design-system-Alert.md
@@ -49,6 +49,8 @@ Migrate the smaller Evaluations component AntD Alert product-state findings to t
 - Slice scope is smaller Evaluations components first; larger RAG recipe config
   alerts remain a separate follow-up unless the embeddings selector stays small.
 - PR: https://github.com/rmusser01/tldw_server/pull/2135.
+- Review follow-up kept the wizard hint text size on the Alert title content and
+  restored message-only prominence for the embeddings media-search error alert.
 <!-- SECTION:NOTES:END -->
 
 ## Definition of Done
@@ -64,5 +66,5 @@ Migrate the smaller Evaluations component AntD Alert product-state findings to t
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Migrated the smaller Evaluations component AntD Alert product-state findings to the shared design-system Alert primitive in PR #2135: CreateEvaluationWizard, DatasetUpload, RateLimitsWidget, VisualSpecBuilder, and the EmbeddingsModelSelectionConfig media-search error. Added focused design-system assertions for those alert states and removed the seven matching baseline rows. `bun run verify:design-system-state` now reports Evaluations down from 14 to 7 baseline exceptions; the remaining Evaluations rows are the larger RAG recipe config alerts. Verification passed: focused Vitest suite 9 tests, `NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit --pretty false`, and `git diff --check`. The verifier still exits 1 due unrelated global baseline findings and the remaining RAG recipe config Evaluations rows. Bandit skipped because this slice touched TypeScript/TSX, JSON, and Backlog markdown only.
+Migrated the smaller Evaluations component AntD Alert product-state findings to the shared design-system Alert primitive in PR #2135: CreateEvaluationWizard, DatasetUpload, RateLimitsWidget, VisualSpecBuilder, and the EmbeddingsModelSelectionConfig media-search error. Added focused design-system assertions for those alert states and removed the seven matching baseline rows. Review follow-up preserved the wizard hint `text-xs` class on the rendered Alert title and restored message-only prominence for the embeddings media-search error. `bun run verify:design-system-state` now reports Evaluations down from 14 to 7 baseline exceptions; the remaining Evaluations rows are the larger RAG recipe config alerts. Verification passed: focused Vitest suite 9 tests, `NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit --pretty false`, and `git diff --check`. The verifier still exits 1 due unrelated global baseline findings and the remaining RAG recipe config Evaluations rows. Bandit skipped because this slice touched TypeScript/TSX, JSON, and Backlog markdown only.
 <!-- SECTION:FINAL_SUMMARY:END -->

--- a/backlog/tasks/task-45.44.5.3 - Migrate-Evaluations-component-alerts-to-design-system-Alert.md
+++ b/backlog/tasks/task-45.44.5.3 - Migrate-Evaluations-component-alerts-to-design-system-Alert.md
@@ -1,0 +1,63 @@
+---
+id: TASK-45.44.5.3
+title: Migrate Evaluations component alerts to design-system Alert
+status: Done
+assignee: []
+created_date: 2026-05-29 23:13
+labels:
+- design-system
+- webui
+- product-state
+- evaluations
+dependencies: []
+references:
+- TASK-45.44.5
+- https://github.com/rmusser01/tldw_server/issues/1662
+- apps/packages/ui/scripts/design-system-product-state-baseline.json
+parent_task_id: TASK-45.44.5
+priority: medium
+modified_files:
+- apps/packages/ui/src/components/Option/Evaluations/components/CreateEvaluationWizard.tsx
+- apps/packages/ui/src/components/Option/Evaluations/components/DatasetUpload.tsx
+- apps/packages/ui/src/components/Option/Evaluations/components/RateLimitsWidget.tsx
+- apps/packages/ui/src/components/Option/Evaluations/components/VisualSpecBuilder.tsx
+- apps/packages/ui/src/components/Option/Evaluations/components/__tests__/EvaluationComponentAlerts.design-system.test.tsx
+- apps/packages/ui/src/components/Option/Evaluations/tabs/recipe-configs/EmbeddingsModelSelectionConfig.tsx
+- apps/packages/ui/src/components/Option/Evaluations/tabs/__tests__/EmbeddingsModelSelectionConfig.test.tsx
+- apps/packages/ui/scripts/design-system-product-state-baseline.json
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Migrate the smaller Evaluations component AntD Alert product-state findings to the shared design-system Alert primitive, remove matching baseline exceptions, and record before/after verifier evidence. Larger RAG recipe config alert migrations remain out of scope for this slice.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Smaller Evaluations component AntD Alert findings are migrated to the shared design-system Alert primitive without changing user-facing behavior.
+- [x] #2 Matching Evaluations component baseline exceptions are removed and the remaining Evaluations count is documented.
+- [x] #3 Focused tests or existing relevant tests pass, and design-system verifier output confirms migrated findings do not reappear.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Before count from bun run verify:design-system-state on origin/dev: Evaluations 14 baseline exceptions. Slice scope is smaller Evaluations components first; larger RAG recipe config alerts remain a separate follow-up unless the embeddings selector stays small.
+<!-- SECTION:NOTES:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Migrated the smaller Evaluations component AntD Alert product-state findings to the shared design-system Alert primitive: CreateEvaluationWizard, DatasetUpload, RateLimitsWidget, VisualSpecBuilder, and the EmbeddingsModelSelectionConfig media-search error. Added focused design-system assertions for those alert states and removed the seven matching baseline rows. `bun run verify:design-system-state` now reports Evaluations down from 14 to 7 baseline exceptions; the remaining Evaluations rows are the larger RAG recipe config alerts. Verification passed: focused Vitest suite 9 tests, `NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit --pretty false`, and `git diff --check`. The verifier still exits 1 due unrelated global baseline findings and the remaining RAG recipe config Evaluations rows. Bandit skipped because this slice touched TypeScript/TSX, JSON, and Backlog markdown only.
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/backlog/tasks/task-45.44.5.3 - Migrate-Evaluations-component-alerts-to-design-system-Alert.md
+++ b/backlog/tasks/task-45.44.5.3 - Migrate-Evaluations-component-alerts-to-design-system-Alert.md
@@ -13,6 +13,7 @@ dependencies: []
 references:
 - TASK-45.44.5
 - https://github.com/rmusser01/tldw_server/issues/1662
+- https://github.com/rmusser01/tldw_server/pull/2135
 - apps/packages/ui/scripts/design-system-product-state-baseline.json
 parent_task_id: TASK-45.44.5
 priority: medium
@@ -43,7 +44,7 @@ Migrate the smaller Evaluations component AntD Alert product-state findings to t
 ## Implementation Notes
 
 <!-- SECTION:NOTES:BEGIN -->
-Before count from bun run verify:design-system-state on origin/dev: Evaluations 14 baseline exceptions. Slice scope is smaller Evaluations components first; larger RAG recipe config alerts remain a separate follow-up unless the embeddings selector stays small.
+Before count from bun run verify:design-system-state on origin/dev: Evaluations 14 baseline exceptions. Slice scope is smaller Evaluations components first; larger RAG recipe config alerts remain a separate follow-up unless the embeddings selector stays small. PR: https://github.com/rmusser01/tldw_server/pull/2135.
 <!-- SECTION:NOTES:END -->
 
 ## Definition of Done
@@ -59,5 +60,5 @@ Before count from bun run verify:design-system-state on origin/dev: Evaluations 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Migrated the smaller Evaluations component AntD Alert product-state findings to the shared design-system Alert primitive: CreateEvaluationWizard, DatasetUpload, RateLimitsWidget, VisualSpecBuilder, and the EmbeddingsModelSelectionConfig media-search error. Added focused design-system assertions for those alert states and removed the seven matching baseline rows. `bun run verify:design-system-state` now reports Evaluations down from 14 to 7 baseline exceptions; the remaining Evaluations rows are the larger RAG recipe config alerts. Verification passed: focused Vitest suite 9 tests, `NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit --pretty false`, and `git diff --check`. The verifier still exits 1 due unrelated global baseline findings and the remaining RAG recipe config Evaluations rows. Bandit skipped because this slice touched TypeScript/TSX, JSON, and Backlog markdown only.
+Migrated the smaller Evaluations component AntD Alert product-state findings to the shared design-system Alert primitive in PR #2135: CreateEvaluationWizard, DatasetUpload, RateLimitsWidget, VisualSpecBuilder, and the EmbeddingsModelSelectionConfig media-search error. Added focused design-system assertions for those alert states and removed the seven matching baseline rows. `bun run verify:design-system-state` now reports Evaluations down from 14 to 7 baseline exceptions; the remaining Evaluations rows are the larger RAG recipe config alerts. Verification passed: focused Vitest suite 9 tests, `NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit --pretty false`, and `git diff --check`. The verifier still exits 1 due unrelated global baseline findings and the remaining RAG recipe config Evaluations rows. Bandit skipped because this slice touched TypeScript/TSX, JSON, and Backlog markdown only.
 <!-- SECTION:FINAL_SUMMARY:END -->

--- a/backlog/tasks/task-45.44.5.3 - Migrate-Evaluations-component-alerts-to-design-system-Alert.md
+++ b/backlog/tasks/task-45.44.5.3 - Migrate-Evaluations-component-alerts-to-design-system-Alert.md
@@ -44,7 +44,11 @@ Migrate the smaller Evaluations component AntD Alert product-state findings to t
 ## Implementation Notes
 
 <!-- SECTION:NOTES:BEGIN -->
-Before count from bun run verify:design-system-state on origin/dev: Evaluations 14 baseline exceptions. Slice scope is smaller Evaluations components first; larger RAG recipe config alerts remain a separate follow-up unless the embeddings selector stays small. PR: https://github.com/rmusser01/tldw_server/pull/2135.
+- Before count from `bun run verify:design-system-state` on `origin/dev`:
+  Evaluations 14 baseline exceptions.
+- Slice scope is smaller Evaluations components first; larger RAG recipe config
+  alerts remain a separate follow-up unless the embeddings selector stays small.
+- PR: https://github.com/rmusser01/tldw_server/pull/2135.
 <!-- SECTION:NOTES:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-554 - Stabilize-full-suite-backend-flakes-blocking-Evaluations-alert-PR.md
+++ b/backlog/tasks/task-554 - Stabilize-full-suite-backend-flakes-blocking-Evaluations-alert-PR.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-554
 title: Stabilize full-suite backend flakes blocking Evaluations alert PR
-status: In Progress
+status: Done
 labels:
 - ci
 - tests
@@ -48,7 +48,7 @@ PR #2129 review-fix CI exposed unrelated full-suite backend flakes on Windows/ma
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Opened PR #2134 from `codex/task-549-full-suite-flakes` after rebasing onto `origin/dev`. The branch isolates the full-suite flake fixes exposed by PR #2129: deterministic invitation ordering for tied `created_at` timestamps, less race-prone audio heartbeat failure-log coverage, handled audit stop `LookupError` cleanup, and a bounded audit cleanup wait in tests. Review feedback on PR #2134 has been addressed by using reverse plus stable sort for invitation ties and moving the audio heartbeat polling inside the `TestClient` lifetime. Verification passed locally after the latest rebase: Admin invitation suite 32 tests, Audio transcription hotword suite 23 tests, Audit DB deps suite 17 tests, `py_compile` on touched Python files, `git diff --check`, and Bandit on touched backend code with 0 findings. Remote PR check rollup was restarted after the rebased push and was still pending/skipped when checked.
+PR #2134 merged into `dev` at merge commit `8a67a5a596`. The branch isolated full-suite flake fixes exposed by PR #2129: deterministic invitation ordering for tied `created_at` timestamps, less race-prone audio heartbeat failure-log coverage, handled audit stop `LookupError` cleanup, and a bounded audit cleanup wait in tests. Review feedback was addressed before merge, the tracker ID collision was corrected to `TASK-554`, and local verification passed: Admin invitation suite 32 tests, Audio transcription hotword suite 23 tests, Audit DB deps suite 17 tests, `py_compile` on touched Python files, `git diff --check`, and Bandit on touched backend code with 0 findings.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done


### PR DESCRIPTION
## Change summary (maintainer-owned)
Maintainer to fill before merge per the AI-generated PR change-summary policy.

## What changed
- Migrated seven smaller Evaluations product-state Alert usages from AntD Alert to the shared design-system Alert primitive.
- Added focused regression coverage for the migrated Evaluations component alerts and the media-search error in Embeddings model selection.
- Removed the migrated Evaluations baseline exceptions and recorded TASK-45.44.5.3 plus the TASK-554 closeout.

## Why
- Continues TASK-45.44.5 by reducing Evaluations design-system product-state debt from 14 baseline entries to 7, leaving the larger RAG recipe configs for a separate slice.
- Preserves the existing UX copy and behavior while moving product-state alerts onto the shared primitive.

## Verification
- [x] `bun run test src/components/Option/Evaluations/components/__tests__/EvaluationComponentAlerts.design-system.test.tsx src/components/Option/Evaluations/tabs/__tests__/EmbeddingsModelSelectionConfig.test.tsx --maxWorkers=1 --no-file-parallelism`
- [x] `git diff --check`
- [x] `env NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit --pretty false`
- [x] `bun run verify:design-system-state` exits 1 for unrelated global baseline debt; Evaluations is now 7 and the migrated rows do not reappear.

## Validation notes
- Focused Vitest output still includes pre-existing localStorage and Prism key-spread warnings from the test environment.
- Bandit skipped because this slice only changes TS/TSX, JSON, and Backlog markdown.

## Risk and rollback
- Risk is low and scoped to Evaluations alert rendering. Rollback is reverting the Alert imports/usages, the focused tests, and the seven baseline removals.

## Watchlists
- [ ] Confirm no unrelated design-system verifier rows are attributed to this PR.
- [ ] Remaining Evaluations RAG recipe Alert rows stay tracked under TASK-45.44.5 for a follow-up slice.

Refs TASK-45.44.5.3
Refs TASK-45.44.5
Refs TASK-554

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrated seven Evaluations alerts from `antd` to the design-system `Alert`, preserving behavior and keeping the embeddings media-search error as a message-only title for clarity. Reduces Evaluations design-system debt from 14 to 7 per TASK-45.44.5 and completes TASK-45.44.5.3.

- **Refactors**
  - Replaced `antd` `Alert` with design-system `Alert` in CreateEvaluationWizard (hint via title content), DatasetUpload (upload error), RateLimitsWidget (warning + info), VisualSpecBuilder (JSON-only info + parse warning), and EmbeddingsModelSelectionConfig (media-search error using title-only).
  - Removed seven matching baseline exceptions in `design-system-product-state-baseline.json`.
  - Added focused tests asserting design-system `Alert` renders, including embeddings media-search failures with message-only prominence; updated TASK-45.44.5(.3) notes with links and current counts.

<sup>Written for commit 8e41f8fff7094a9e11d3f06b98262d4777ff4316. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2135?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

