### PR TITLE
Add flashcards deck dashboard session history

### DIFF
--- a/apps/packages/ui/src/components/Flashcards/components/RecentStudySessions.tsx
+++ b/apps/packages/ui/src/components/Flashcards/components/RecentStudySessions.tsx
@@ -71,6 +71,28 @@ const getReviewedCountLabel = (
   })
 }
 
+const getDeckLabel = (
+  session: FlashcardReviewSessionSummary,
+  deckNamesById: Map<number, string>,
+  t: ReturnType<typeof useTranslation>["t"]
+) => {
+  const snapshotName = session.deck_name_snapshot?.trim()
+  if (snapshotName) return snapshotName
+
+  if (session.deck_id == null) {
+    return t("option:flashcards.recentStudySessionsAllDecks", {
+      defaultValue: "All decks"
+    })
+  }
+
+  return (
+    deckNamesById.get(session.deck_id) ??
+    t("option:flashcards.recentStudySessionsDeckUnavailable", {
+      defaultValue: "Deck unavailable"
+    })
+  )
+}
+
 /**
  * Shows recently completed flashcard review sessions and lets the user reopen one.
  */
@@ -151,18 +173,7 @@ export const RecentStudySessions: React.FC<RecentStudySessionsProps> = ({
           dataSource={sessions}
           renderItem={(session) => {
             const isSelected = selectedSessionId === session.id
-            const deckName =
-              session.deck_id == null ? null : deckNamesById.get(session.deck_id) ?? null
-            const deckLabel =
-              deckName ??
-              (session.deck_id != null
-                ? t("option:flashcards.recentStudySessionsDeckFallback", {
-                    defaultValue: "Deck {{id}}",
-                    id: session.deck_id
-                  })
-                : t("option:flashcards.recentStudySessionsAllDecks", {
-                    defaultValue: "All decks"
-                  }))
+            const deckLabel = getDeckLabel(session, deckNamesById, t)
             const modeLabel = getSessionModeLabel(session, t)
             const reviewedCountLabel = getReviewedCountLabel(session, t)
             const completedAtLabel = formatFlashcardAbsoluteDateTime(

--- a/apps/packages/ui/src/components/Flashcards/components/__tests__/RecentStudySessions.test.tsx
+++ b/apps/packages/ui/src/components/Flashcards/components/__tests__/RecentStudySessions.test.tsx
@@ -191,6 +191,91 @@ describe("RecentStudySessions", () => {
     expect(screen.queryByText("due:deck:12")).not.toBeInTheDocument()
   })
 
+  it("prefers the saved deck snapshot over the current deck name", () => {
+    mockRecentSessionsQuery({
+      data: [
+        {
+          id: 83,
+          deck_id: 12,
+          deck_name_snapshot: "Renal Biology",
+          review_mode: "due",
+          tag_filter: null,
+          scope_key: "due:deck:12",
+          status: "completed",
+          started_at: "2026-04-05T18:00:00Z",
+          last_activity_at: "2026-04-05T18:10:00Z",
+          completed_at: "2026-04-05T18:12:00Z",
+          cards_reviewed: 4,
+          client_id: "test"
+        }
+      ],
+      isLoading: false,
+      isFetching: false
+    })
+
+    render(
+      <RecentStudySessions
+        deckId={12}
+        selectedSessionId={null}
+        onOpenSession={sessionsMock}
+        isActive
+        decks={[
+          {
+            id: 12,
+            name: "Renamed Biology",
+            review_prompt_side: "front",
+            deleted: false,
+            client_id: "test",
+            version: 1,
+            scheduler_type: "sm2_plus",
+            scheduler_settings: DEFAULT_SCHEDULER_SETTINGS_ENVELOPE
+          }
+        ]}
+      />
+    )
+
+    expect(screen.getByText("Renal Biology")).toBeInTheDocument()
+    expect(screen.queryByText("Renamed Biology")).not.toBeInTheDocument()
+    expect(screen.queryByText("Deck 12")).not.toBeInTheDocument()
+  })
+
+  it("uses a non-technical fallback when a deck is no longer available", () => {
+    mockRecentSessionsQuery({
+      data: [
+        {
+          id: 84,
+          deck_id: 12,
+          deck_name_snapshot: null,
+          review_mode: "due",
+          tag_filter: null,
+          scope_key: "due:deck:12",
+          status: "completed",
+          started_at: "2026-04-05T18:00:00Z",
+          last_activity_at: "2026-04-05T18:10:00Z",
+          completed_at: "2026-04-05T18:12:00Z",
+          cards_reviewed: 2,
+          client_id: "test"
+        }
+      ],
+      isLoading: false,
+      isFetching: false
+    })
+
+    render(
+      <RecentStudySessions
+        deckId={12}
+        selectedSessionId={null}
+        onOpenSession={sessionsMock}
+        isActive
+        decks={[]}
+      />
+    )
+
+    expect(screen.getByText("Deck unavailable")).toBeInTheDocument()
+    expect(screen.queryByText("Deck 12")).not.toBeInTheDocument()
+    expect(screen.queryByText("due:deck:12")).not.toBeInTheDocument()
+  })
+
   it("uses the singular reviewed-count fallback when one card was reviewed", () => {
     mockRecentSessionsQuery({
       data: [

--- a/apps/packages/ui/src/components/Flashcards/tabs/ReviewTab.tsx
+++ b/apps/packages/ui/src/components/Flashcards/tabs/ReviewTab.tsx
@@ -165,6 +165,7 @@ export const ReviewTab: React.FC<ReviewTabProps> = ({
   const [isReviewOnboardingDismissed, setIsReviewOnboardingDismissed] = React.useState(false)
   const [activeReviewSessionId, setActiveReviewSessionId] = React.useState<number | null>(null)
   const [selectedStudySessionId, setSelectedStudySessionId] = React.useState<number | null>(null)
+  const [allDeckReviewStarted, setAllDeckReviewStarted] = React.useState(false)
   const [shortcutHintDensity, setShortcutHintDensity] = useFlashcardsShortcutHintDensity()
   const [sessionReviewPromptSide, setSessionReviewPromptSide] = React.useState<DeckReviewPromptSide | null>(null)
 
@@ -217,7 +218,16 @@ export const ReviewTab: React.FC<ReviewTabProps> = ({
   const nextDueQuery = useNextDueQuery(reviewDeckId, directPathVisibilityOptions)
   const endReviewSessionMutation = useEndFlashcardReviewSessionMutation()
   const activeCramTagFilter = reviewMode === "cram" ? cramTagFilter : undefined
-  const dueModeActiveCard = localOverrideCard ?? reviewOverrideCard ?? reviewQuery.data
+  const rawDueModeActiveCard = localOverrideCard ?? reviewOverrideCard ?? reviewQuery.data
+  const isAllDeckDueReview = reviewMode === "due" && reviewDeckId == null
+  const canShowAllDeckDashboard =
+    isAllDeckDueReview &&
+    hasCardsQuery.data !== false &&
+    rawDueModeActiveCard != null &&
+    !allDeckReviewStarted &&
+    !reviewOverrideCard &&
+    !localOverrideCard
+  const dueModeActiveCard = canShowAllDeckDashboard ? null : rawDueModeActiveCard
   const isReviewCardLoading =
     reviewMode === "due" && (reviewQuery.isLoading || reviewQuery.isFetching)
   const isDueModeCaughtUp =
@@ -275,7 +285,7 @@ export const ReviewTab: React.FC<ReviewTabProps> = ({
           (dueCountsQuery.data.learning ?? 0)
         : undefined
   const isCramMode = reviewMode === "cram"
-  const showTopBarCreateCta = !activeCard
+  const showTopBarCreateCta = !activeCard && !canShowAllDeckDashboard
   const handleDashboardReviewDeck = React.useCallback(
     (deckId: number) => {
       onReviewDeckChange(deckId)
@@ -300,6 +310,10 @@ export const ReviewTab: React.FC<ReviewTabProps> = ({
     },
     [onClearOverride, onReviewDeckChange, reviewOverrideCard]
   )
+  const handleStartAllDeckReview = React.useCallback(() => {
+    setAllDeckReviewStarted(true)
+    setSelectedStudySessionId(null)
+  }, [])
   const reviewScopeKey = React.useMemo(
     () => [
       reviewMode,
@@ -1043,6 +1057,7 @@ export const ReviewTab: React.FC<ReviewTabProps> = ({
     setLastReviewedCard(null)
     setUndoCountdown(0)
     setSelectedStudySessionId(null)
+    setAllDeckReviewStarted(false)
     setSessionReviewPromptSide(null)
     autoEndSessionAttemptedRef.current = null
     autoRevealAnswerRef.current = false
@@ -1195,6 +1210,40 @@ export const ReviewTab: React.FC<ReviewTabProps> = ({
           </Button>
         )}
       </div>
+
+      {canShowAllDeckDashboard && (
+        <div
+          className="mb-3 rounded border border-border bg-surface2 p-3"
+          data-testid="flashcards-review-deck-dashboard"
+        >
+          <div className="flex flex-wrap items-center justify-between gap-3">
+            <div className="min-w-0">
+              <Text strong className="block">
+                {t("option:flashcards.allDeckReviewDashboardTitle", {
+                  defaultValue: "Choose a study path"
+                })}
+              </Text>
+              <Text type="secondary" className="text-sm">
+                {t("option:flashcards.allDeckReviewDashboardDescription", {
+                  defaultValue:
+                    "Start with all due cards, or pick a specific deck below."
+                })}
+              </Text>
+            </div>
+            <Button
+              type="primary"
+              onClick={handleStartAllDeckReview}
+              loading={isReviewCardLoading}
+              disabled={!rawDueModeActiveCard}
+              data-testid="flashcards-review-all-due"
+            >
+              {t("option:flashcards.reviewAllDue", {
+                defaultValue: "Review all due"
+              })}
+            </Button>
+          </div>
+        </div>
+      )}
 
       {!activeCard && (
         <DeckStudyDashboard

--- a/apps/packages/ui/src/components/Flashcards/tabs/__tests__/ReviewTab.create-cta.test.tsx
+++ b/apps/packages/ui/src/components/Flashcards/tabs/__tests__/ReviewTab.create-cta.test.tsx
@@ -159,6 +159,30 @@ if (!(globalThis as any).ResizeObserver) {
   }
 }
 
+const createReviewCard = (overrides: Record<string, unknown> = {}) => ({
+  uuid: "active-card-1",
+  deck_id: 11,
+  front: "Question",
+  back: "Answer",
+  notes: null,
+  extra: null,
+  is_cloze: false,
+  tags: [],
+  ef: 2.5,
+  interval_days: 1,
+  repetitions: 1,
+  lapses: 0,
+  due_at: null,
+  last_reviewed_at: null,
+  last_modified: null,
+  deleted: false,
+  client_id: "test",
+  version: 1,
+  model_type: "basic",
+  reverse: false,
+  ...overrides
+})
+
 describe("ReviewTab create CTA visibility", () => {
   const originalMatchMedia = window.matchMedia
 
@@ -503,6 +527,177 @@ describe("ReviewTab create CTA visibility", () => {
     expect(onNavigateToManageDeck).toHaveBeenCalledWith(11)
     expect(onNavigateToSchedulerDeck).toHaveBeenCalledWith(11)
     expect(onNavigateToExportDeck).toHaveBeenCalledWith(11)
+  })
+
+  it("shows the all-deck dashboard before starting an all-deck due review", () => {
+    vi.mocked(useDecksQuery).mockReturnValue({
+      data: [{ id: 11, name: "Biology" }],
+      isLoading: false
+    } as any)
+    vi.mocked(useReviewQuery).mockReturnValue({
+      data: createReviewCard({ front: "Global due question" }),
+      isLoading: false,
+      isFetching: false,
+      refetch: vi.fn().mockResolvedValue(undefined)
+    } as any)
+    vi.mocked(useHasCardsQuery).mockReturnValue({ data: true } as any)
+    vi.mocked(useDueCountsQuery).mockReturnValue({
+      data: { due: 1, new: 0, learning: 0, total: 1 }
+    } as any)
+    vi.mocked(useReviewAnalyticsSummaryQuery).mockReturnValue({
+      data: {
+        reviewed_today: 0,
+        retention_rate_today: null,
+        lapse_rate_today: null,
+        avg_answer_time_ms_today: null,
+        study_streak_days: 0,
+        generated_at: "2026-02-18T12:00:00.000Z",
+        decks: [
+          {
+            deck_id: 11,
+            deck_name: "Biology",
+            total: 20,
+            new: 2,
+            learning: 1,
+            due: 1,
+            mature: 16
+          }
+        ]
+      },
+      isLoading: false
+    } as any)
+
+    render(
+      <ReviewTab
+        onNavigateToCreate={() => {}}
+        onNavigateToImport={() => {}}
+        reviewDeckId={undefined}
+        onReviewDeckChange={() => {}}
+        isActive
+      />
+    )
+
+    expect(screen.getByTestId("flashcards-review-deck-dashboard")).toBeInTheDocument()
+    expect(screen.getByTestId("flashcards-deck-study-dashboard")).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Review all due" })).toBeInTheDocument()
+    expect(screen.queryByText("Global due question")).not.toBeInTheDocument()
+  })
+
+  it("starts the all-deck due review from the dashboard action", () => {
+    vi.mocked(useDecksQuery).mockReturnValue({
+      data: [{ id: 11, name: "Biology" }],
+      isLoading: false
+    } as any)
+    vi.mocked(useReviewQuery).mockReturnValue({
+      data: createReviewCard({ front: "Global due question" }),
+      isLoading: false,
+      isFetching: false,
+      refetch: vi.fn().mockResolvedValue(undefined)
+    } as any)
+    vi.mocked(useHasCardsQuery).mockReturnValue({ data: true } as any)
+    vi.mocked(useDueCountsQuery).mockReturnValue({
+      data: { due: 1, new: 0, learning: 0, total: 1 }
+    } as any)
+
+    render(
+      <ReviewTab
+        onNavigateToCreate={() => {}}
+        onNavigateToImport={() => {}}
+        reviewDeckId={undefined}
+        onReviewDeckChange={() => {}}
+        isActive
+      />
+    )
+
+    fireEvent.click(screen.getByRole("button", { name: "Review all due" }))
+
+    expect(screen.getByTestId("flashcards-review-active-card")).toBeInTheDocument()
+    expect(screen.getByText("Global due question")).toBeInTheDocument()
+    expect(screen.queryByTestId("flashcards-review-deck-dashboard")).not.toBeInTheDocument()
+  })
+
+  it("keeps the selected-deck study path direct", () => {
+    vi.mocked(useDecksQuery).mockReturnValue({
+      data: [{ id: 11, name: "Biology" }],
+      isLoading: false
+    } as any)
+    vi.mocked(useReviewQuery).mockReturnValue({
+      data: createReviewCard({ front: "Selected deck question" }),
+      isLoading: false,
+      isFetching: false,
+      refetch: vi.fn().mockResolvedValue(undefined)
+    } as any)
+    vi.mocked(useHasCardsQuery).mockReturnValue({ data: true } as any)
+    vi.mocked(useDueCountsQuery).mockReturnValue({
+      data: { due: 1, new: 0, learning: 0, total: 1 }
+    } as any)
+
+    render(
+      <ReviewTab
+        onNavigateToCreate={() => {}}
+        onNavigateToImport={() => {}}
+        reviewDeckId={11}
+        onReviewDeckChange={() => {}}
+        isActive
+      />
+    )
+
+    expect(screen.getByTestId("flashcards-review-active-card")).toBeInTheDocument()
+    expect(screen.getByText("Selected deck question")).toBeInTheDocument()
+    expect(screen.queryByTestId("flashcards-review-deck-dashboard")).not.toBeInTheDocument()
+  })
+
+  it("resets the all-deck dashboard gate after scope changes", () => {
+    vi.mocked(useDecksQuery).mockReturnValue({
+      data: [{ id: 11, name: "Biology" }],
+      isLoading: false
+    } as any)
+    vi.mocked(useReviewQuery).mockReturnValue({
+      data: createReviewCard({ front: "Global due question" }),
+      isLoading: false,
+      isFetching: false,
+      refetch: vi.fn().mockResolvedValue(undefined)
+    } as any)
+    vi.mocked(useHasCardsQuery).mockReturnValue({ data: true } as any)
+    vi.mocked(useDueCountsQuery).mockReturnValue({
+      data: { due: 1, new: 0, learning: 0, total: 1 }
+    } as any)
+
+    const { rerender } = render(
+      <ReviewTab
+        onNavigateToCreate={() => {}}
+        onNavigateToImport={() => {}}
+        reviewDeckId={undefined}
+        onReviewDeckChange={() => {}}
+        isActive
+      />
+    )
+    fireEvent.click(screen.getByRole("button", { name: "Review all due" }))
+    expect(screen.getByText("Global due question")).toBeInTheDocument()
+
+    rerender(
+      <ReviewTab
+        onNavigateToCreate={() => {}}
+        onNavigateToImport={() => {}}
+        reviewDeckId={11}
+        onReviewDeckChange={() => {}}
+        isActive
+      />
+    )
+    expect(screen.getByTestId("flashcards-review-active-card")).toBeInTheDocument()
+
+    rerender(
+      <ReviewTab
+        onNavigateToCreate={() => {}}
+        onNavigateToImport={() => {}}
+        reviewDeckId={undefined}
+        onReviewDeckChange={() => {}}
+        isActive
+      />
+    )
+
+    expect(screen.getByTestId("flashcards-review-deck-dashboard")).toBeInTheDocument()
+    expect(screen.queryByText("Global due question")).not.toBeInTheDocument()
   })
 
   it("does not fetch dashboard analytics while the review card query is loading", () => {

--- a/apps/packages/ui/src/services/flashcards.ts
+++ b/apps/packages/ui/src/services/flashcards.ts
@@ -442,6 +442,7 @@ export type FlashcardNextReviewResponse = {
 export type FlashcardReviewSessionSummary = {
   id: number
   deck_id?: number | null
+  deck_name_snapshot?: string | null
   review_mode: string
   tag_filter?: string | null
   scope_key: string

--- a/backlog/tasks/task-555 - Implement-flashcards-dashboard-and-session-history.md
+++ b/backlog/tasks/task-555 - Implement-flashcards-dashboard-and-session-history.md
@@ -1,0 +1,67 @@
+---
+id: TASK-555
+title: Implement flashcards dashboard and session history
+status: Done
+labels:
+- ux
+- flashcards
+- implementation
+- webui
+references:
+- Docs/superpowers/plans/2026-05-29-flashcards-narrow-ux-remediation-implementation-plan.md
+- Docs/superpowers/specs/2026-05-29-flashcards-narrow-ux-remediation-design.md
+modified_files:
+- apps/packages/ui/src/components/Flashcards/tabs/ReviewTab.tsx
+- apps/packages/ui/src/components/Flashcards/tabs/__tests__/ReviewTab.create-cta.test.tsx
+- apps/packages/ui/src/components/Flashcards/components/RecentStudySessions.tsx
+- apps/packages/ui/src/components/Flashcards/components/__tests__/RecentStudySessions.test.tsx
+- apps/packages/ui/src/services/flashcards.ts
+- tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py
+- tldw_Server_API/app/api/v1/schemas/flashcards.py
+- tldw_Server_API/tests/StudySuggestions/test_flashcard_review_sessions.py
+- tldw_Server_API/tests/StudySuggestions/test_study_suggestions_endpoints_api.py
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement PR 2 from the approved narrow flashcards UX remediation plan: make all-deck Study dashboard-first and preserve user-facing deck names in recent review session history. Scope is limited to /flashcards Study/session-history behavior and direct supporting backend/API fields only if current payload inspection proves a deck-name snapshot is missing.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 All-deck Study shows a deck dashboard before starting review.
+- [x] #2 Review all due starts all-deck due review without selecting a deck.
+- [x] #3 Selected-deck Study remains a fast path into that deck review.
+- [x] #4 Recent session history shows preserved or resolved user-facing deck names, not raw deck ids or scope keys.
+- [x] #5 Payload inspection decision is recorded; backend/API schema is changed only if no adequate deck-name snapshot exists.
+- [x] #6 Focused frontend tests pass; backend tests and Bandit run if backend changes.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+- Payload inspection found no preserved deck-name snapshot in `flashcard_review_sessions`, `FlashcardReviewSessionSummary`, or the UI `FlashcardReviewSessionSummary` type. This slice adds nullable `deck_name_snapshot` at review-session creation and returns it through the DB/API/client contract.
+- All-deck due review now gates the fetched global card behind a dashboard launch panel. Selected-deck review continues to show the active card directly.
+- Recent study sessions prefer `deck_name_snapshot`, then current deck names, then a non-technical unavailable fallback.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+- Added an all-deck due-review launch gate in `ReviewTab` so power users see the deck dashboard first, can choose `Review all due`, and selected-deck review remains direct.
+- Added nullable `deck_name_snapshot` persistence for flashcard review sessions and surfaced it through the API schema and UI client type.
+- Updated recent session history to prefer preserved deck names, fall back to current deck names, and avoid raw deck IDs/scope keys when decks are unavailable.
+- Verification: `python -m pytest tldw_Server_API/tests/StudySuggestions/test_flashcard_review_sessions.py tldw_Server_API/tests/StudySuggestions/test_study_suggestions_endpoints_api.py -v` -> 43 passed, 1 skipped; `bunx vitest run src/components/Flashcards/components/__tests__/RecentStudySessions.test.tsx src/components/Flashcards/tabs/__tests__/ReviewTab.create-cta.test.tsx` -> 30 passed; `NODE_OPTIONS=--max-old-space-size=8192 bunx tsc -p tsconfig.json --noEmit` -> exit 0; Bandit touched Python scope -> 0 findings; `git diff --check` -> exit 0.
+- Browser smoke: `/flashcards` route loaded in the Next dev server after first-run skip, but the local backend was unavailable on the configured API port, so live dashboard data could not be browser-verified in this pass.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/tldw_Server_API/app/api/v1/schemas/flashcards.py
+++ b/tldw_Server_API/app/api/v1/schemas/flashcards.py
@@ -420,6 +420,7 @@ class FlashcardReviewSessionSummary(BaseModel):
 
     id: int
     deck_id: Optional[int] = None
+    deck_name_snapshot: Optional[str] = None
     review_mode: str
     tag_filter: Optional[str] = None
     scope_key: str

--- a/tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py
+++ b/tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py
@@ -1640,6 +1640,7 @@ CREATE INDEX IF NOT EXISTS idx_flashcard_reviews_time ON flashcard_reviews(revie
 CREATE TABLE IF NOT EXISTS flashcard_review_sessions(
   id               INTEGER PRIMARY KEY AUTOINCREMENT,
   deck_id          INTEGER REFERENCES decks(id) ON DELETE SET NULL,
+  deck_name_snapshot TEXT,
   review_mode      TEXT NOT NULL DEFAULT 'due',
   tag_filter       TEXT,
   scope_key        TEXT NOT NULL,
@@ -10817,6 +10818,7 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
                 CREATE TABLE IF NOT EXISTS flashcard_review_sessions(
                   id               INTEGER PRIMARY KEY AUTOINCREMENT,
                   deck_id          INTEGER REFERENCES decks(id) ON DELETE SET NULL,
+                  deck_name_snapshot TEXT,
                   review_mode      TEXT NOT NULL DEFAULT 'due',
                   tag_filter       TEXT,
                   scope_key        TEXT NOT NULL,
@@ -10837,6 +10839,8 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
             }
             if "cards_reviewed" not in session_cols:
                 conn.execute("ALTER TABLE flashcard_review_sessions ADD COLUMN cards_reviewed INTEGER DEFAULT 0")
+            if "deck_name_snapshot" not in session_cols:
+                conn.execute("ALTER TABLE flashcard_review_sessions ADD COLUMN deck_name_snapshot TEXT")
             if "correct_count" not in session_cols:
                 conn.execute("ALTER TABLE flashcard_review_sessions ADD COLUMN correct_count INTEGER DEFAULT 0")
             if "source_bundle_json" not in session_cols:
@@ -11114,6 +11118,7 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
                 CREATE TABLE IF NOT EXISTS flashcard_review_sessions(
                   id BIGSERIAL PRIMARY KEY,
                   deck_id INTEGER REFERENCES decks(id) ON DELETE SET NULL,
+                  deck_name_snapshot TEXT,
                   review_mode TEXT NOT NULL DEFAULT 'due',
                   tag_filter TEXT,
                   scope_key TEXT NOT NULL,
@@ -11132,6 +11137,10 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
             )
             self.backend.execute(
                 "ALTER TABLE flashcard_review_sessions ADD COLUMN IF NOT EXISTS cards_reviewed INTEGER DEFAULT 0",
+                connection=conn,
+            )
+            self.backend.execute(
+                "ALTER TABLE flashcard_review_sessions ADD COLUMN IF NOT EXISTS deck_name_snapshot TEXT",
                 connection=conn,
             )
             self.backend.execute(
@@ -19829,16 +19838,34 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
             item["correct_count"] = int(item["correct_count"])
         if item.get("study_pack_id") is not None:
             item["study_pack_id"] = int(item["study_pack_id"])
+        item["deck_name_snapshot"] = self._normalize_nullable_text(item.get("deck_name_snapshot"))
 
         normalized_bundle = self._normalize_flashcard_review_session_source_bundle(item.get("source_bundle_json"))
         item["source_bundle_json"] = normalized_bundle or None
         item["source_bundle"] = normalized_bundle
         return item
 
+    def _get_flashcard_review_session_deck_name_snapshot_for_conn(
+        self,
+        conn: Any,
+        deck_id: int | None,
+    ) -> str | None:
+        """Return the current deck name to snapshot when a review session starts."""
+        if deck_id is None:
+            return None
+        row = conn.execute("SELECT name FROM decks WHERE id = ?", (int(deck_id),)).fetchone()
+        if not row:
+            return None
+        try:
+            raw_name = row["name"]
+        except (KeyError, IndexError, TypeError):
+            raw_name = row[0]
+        return self._normalize_nullable_text(raw_name)
+
     def _get_flashcard_review_session_row_for_conn(self, conn: Any, session_id: int) -> dict[str, Any] | None:
         row = conn.execute(
             """
-            SELECT id, deck_id, review_mode, tag_filter, scope_key, status,
+            SELECT id, deck_id, deck_name_snapshot, review_mode, tag_filter, scope_key, status,
                    started_at, last_activity_at, completed_at, client_id,
                    cards_reviewed, correct_count, source_bundle_json, study_pack_id
               FROM flashcard_review_sessions
@@ -19923,7 +19950,7 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
         self.abandon_stale_flashcard_review_sessions(scope_key=scope_key)
         query_parts = [
             """
-            SELECT id, deck_id, review_mode, tag_filter, scope_key, status,
+            SELECT id, deck_id, deck_name_snapshot, review_mode, tag_filter, scope_key, status,
                    started_at, last_activity_at, completed_at, client_id,
                    cards_reviewed, correct_count, source_bundle_json, study_pack_id
               FROM flashcard_review_sessions
@@ -19970,7 +19997,7 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
             with self.transaction() as conn:
                 rows = conn.execute(
                     """
-                    SELECT id, deck_id, review_mode, tag_filter, scope_key, status,
+                    SELECT id, deck_id, deck_name_snapshot, review_mode, tag_filter, scope_key, status,
                            started_at, last_activity_at, completed_at, client_id,
                            cards_reviewed, correct_count, source_bundle_json, study_pack_id
                       FROM flashcard_review_sessions
@@ -19992,26 +20019,31 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
                         """
                         UPDATE flashcard_review_sessions
                            SET last_activity_at = ?
-                         WHERE id = ?
+                        WHERE id = ?
                         """,
                         (now, int(authoritative["id"])),
                     )
                     authoritative["last_activity_at"] = now
                     return authoritative
 
+                deck_name_snapshot = self._get_flashcard_review_session_deck_name_snapshot_for_conn(
+                    conn,
+                    deck_id,
+                )
                 if self.backend_type == BackendType.POSTGRESQL:
                     cursor = conn.execute(
                         """
                         INSERT INTO flashcard_review_sessions(
-                            deck_id, review_mode, tag_filter, scope_key, status,
+                            deck_id, deck_name_snapshot, review_mode, tag_filter, scope_key, status,
                             started_at, last_activity_at, completed_at, cards_reviewed,
                             correct_count, source_bundle_json, study_pack_id, client_id
                         )
-                        VALUES(?, ?, ?, ?, 'active', ?, ?, NULL, 0, 0, NULL, NULL, ?)
+                        VALUES(?, ?, ?, ?, ?, 'active', ?, ?, NULL, 0, 0, NULL, NULL, ?)
                         RETURNING id
                         """,
                         (
                             int(deck_id) if deck_id is not None else None,
+                            deck_name_snapshot,
                             normalized_mode,
                             normalized_tag_filter,
                             normalized_scope_key,
@@ -20026,14 +20058,15 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
                     cursor = conn.execute(
                         """
                         INSERT INTO flashcard_review_sessions(
-                            deck_id, review_mode, tag_filter, scope_key, status,
+                            deck_id, deck_name_snapshot, review_mode, tag_filter, scope_key, status,
                             started_at, last_activity_at, completed_at, cards_reviewed,
                             correct_count, source_bundle_json, study_pack_id, client_id
                         )
-                        VALUES(?, ?, ?, ?, 'active', ?, ?, NULL, 0, 0, NULL, NULL, ?)
+                        VALUES(?, ?, ?, ?, ?, 'active', ?, ?, NULL, 0, 0, NULL, NULL, ?)
                         """,
                         (
                             int(deck_id) if deck_id is not None else None,
+                            deck_name_snapshot,
                             normalized_mode,
                             normalized_tag_filter,
                             normalized_scope_key,
@@ -20047,7 +20080,7 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
                     raise CharactersRAGDBError("Failed to determine flashcard review session ID after insert")  # noqa: TRY003
                 row = conn.execute(
                     """
-                    SELECT id, deck_id, review_mode, tag_filter, scope_key, status,
+                    SELECT id, deck_id, deck_name_snapshot, review_mode, tag_filter, scope_key, status,
                            started_at, last_activity_at, completed_at, client_id,
                            cards_reviewed, correct_count, source_bundle_json, study_pack_id
                       FROM flashcard_review_sessions
@@ -20065,7 +20098,7 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
         """Fetch a single flashcard review session by id, or None if not found."""
         cursor = self.execute_query(
             """
-            SELECT id, deck_id, review_mode, tag_filter, scope_key, status,
+            SELECT id, deck_id, deck_name_snapshot, review_mode, tag_filter, scope_key, status,
                    started_at, last_activity_at, completed_at, client_id,
                    cards_reviewed, correct_count, source_bundle_json, study_pack_id
               FROM flashcard_review_sessions
@@ -20095,7 +20128,7 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
                 raise ConflictError("Flashcard review session not found", entity="flashcard_review_sessions", entity_id=session_id)  # noqa: TRY003
             row = self.execute_query(
                 """
-                SELECT id, deck_id, review_mode, tag_filter, scope_key, status,
+                SELECT id, deck_id, deck_name_snapshot, review_mode, tag_filter, scope_key, status,
                        started_at, last_activity_at, completed_at, client_id,
                        cards_reviewed, correct_count, source_bundle_json, study_pack_id
                   FROM flashcard_review_sessions

--- a/tldw_Server_API/tests/StudySuggestions/test_flashcard_review_sessions.py
+++ b/tldw_Server_API/tests/StudySuggestions/test_flashcard_review_sessions.py
@@ -253,6 +253,19 @@ def test_review_flashcard_without_review_session_id_auto_creates_active_session(
     assert sessions[0]["scope_key"] == f"due:deck:{deck_id}"  # nosec B101
 
 
+def test_review_session_preserves_deck_name_snapshot_after_deck_rename(db: CharactersRAGDB):
+    deck_id, card_uuid = _create_card(db, deck_name="Original Deck Name")
+
+    updated = db.review_flashcard(card_uuid, rating=4, answer_time_ms=700)
+    session_id = int(updated["review_session_id"])
+    db.update_deck(deck_id, name="Renamed Deck")
+
+    sessions = db.list_flashcard_review_sessions(deck_id=deck_id)
+
+    assert int(sessions[0]["id"]) == session_id  # nosec B101
+    assert sessions[0]["deck_name_snapshot"] == "Original Deck Name"  # nosec B101
+
+
 def test_review_flashcard_rejects_unknown_or_wrong_deck_review_session_id(db: CharactersRAGDB):
     deck_id, card_uuid = _create_card(db, deck_name="Primary Session Deck")
     other_deck_id, _ = _create_card(db, deck_name="Other Session Deck")

--- a/tldw_Server_API/tests/StudySuggestions/test_study_suggestions_endpoints_api.py
+++ b/tldw_Server_API/tests/StudySuggestions/test_study_suggestions_endpoints_api.py
@@ -475,6 +475,7 @@ def test_review_sessions_list_route_returns_db_sessions_with_filters(
         scope_key=f"due:deck:{deck_id}:tag:renal",
     )
     db.mark_flashcard_review_session_completed(int(completed_session["id"]))
+    db.update_deck(deck_id, name="Renamed Review Route Deck")
 
     response = client.get(
         "/api/v1/flashcards/review-sessions",
@@ -488,6 +489,7 @@ def test_review_sessions_list_route_returns_db_sessions_with_filters(
     assert int(body[0]["id"]) == int(completed_session["id"])  # nosec B101
     assert body[0]["status"] == "completed"  # nosec B101
     assert body[0]["tag_filter"] == "renal"  # nosec B101
+    assert body[0]["deck_name_snapshot"] == "Review Route Deck"  # nosec B101
     assert int(active_session["id"]) != int(body[0]["id"])  # nosec B101
 
 


### PR DESCRIPTION
## Change Summary (maintainer-owned)

Maintainer: replace this placeholder with a human-written summary explaining what changed and why before merge. The implementation notes below are AI-generated context and do not satisfy the AI-generated PR merge gate by themselves.

## Summary

- What changed:
  - Added an all-deck flashcards Study launch gate so users see the deck dashboard before starting an all-deck due review, with a `Review all due` action to begin the global session.
  - Preserved review-session deck names by adding nullable `deck_name_snapshot` persistence through the DB, API schema, and UI client type.
  - Updated recent study sessions to prefer preserved deck names, fall back to current deck names, and avoid raw deck IDs/scope keys when a deck is unavailable.
- Why:
  - This addresses the approved `/flashcards` remediation slice for a dashboard-first all-deck Study path and stable, user-facing recent-session history after deck renames/deletes.

## Validation

- [x] Tests added/updated for behavior changes
- [x] Relevant unit/integration tests pass locally
- [x] Docs updated (Backlog task `TASK-555` records implementation and verification; no user-guide copy/help/import changes in this slice)

Commands run:

- `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tldw_Server_API/tests/StudySuggestions/test_flashcard_review_sessions.py tldw_Server_API/tests/StudySuggestions/test_study_suggestions_endpoints_api.py -v`
  - Result: 43 passed, 1 skipped
- `cd apps/packages/ui && bunx vitest run src/components/Flashcards/components/__tests__/RecentStudySessions.test.tsx src/components/Flashcards/tabs/__tests__/ReviewTab.create-cta.test.tsx`
  - Result: 30 passed
- `cd apps/packages/ui && NODE_OPTIONS=--max-old-space-size=8192 bunx tsc -p tsconfig.json --noEmit`
  - Result: passed
- `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m bandit -r tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py tldw_Server_API/app/api/v1/schemas/flashcards.py -f json -o /tmp/bandit_flashcards_session_history_rerun.json`
  - Result: 0 findings
- `git diff --check`
  - Result: passed

Browser smoke:

- `/flashcards` loaded in a local Next dev server after first-run skip.
- Live dashboard data could not be browser-verified because the configured backend API port was unavailable locally during the smoke.

## UX Audit Checklist (v2 Stage 5)

- [ ] `npm run e2e:smoke:stage5` passes
- [ ] `npx playwright test e2e/smoke/all-pages.spec.ts --reporter=line` passes (or failures documented)
- [x] No listed AntD deprecations in console output: `Drawer.width`, `Space.direction`, `Alert.message`, `List`
- [x] No `Maximum update depth exceeded` warnings on audited routes
- [x] No unresolved `{{...}}` placeholders on audited routes
- [x] WebUI/extension parity validated for shared UI fixes (shared UI package tests cover the directly connected WebUI/extension component surface)
- [x] For Flashcards UI changes: tabs remain `Study` / `Manage` / `Transfer` and secondary create CTAs route through manager create-entry path
- [x] For Flashcards drawer changes: not applicable; no drawer behavior changed
- [x] For Flashcards help/copy/import UX changes: not applicable; no help/copy/import UX changed

## Watchlists Accessibility Checklist (Group 09 Stage 5)

- [x] Not applicable; Watchlists UI behavior did not change

## Watchlists Scale Checklist (Group 10 Stage 5)

- [x] Not applicable; Watchlists scale/polling behavior did not change

## Risk & Rollback

- Risk level: Medium
- Rollback plan: Revert this PR. The new `deck_name_snapshot` column is nullable and additive; reverting UI/API usage would leave existing session history readable without requiring destructive data migration.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a dashboard-first launch for all-deck due review and preserves deck names in session history via a new deck_name_snapshot field. This clarifies the global study path and keeps recent sessions readable after deck renames or deletes (Linear TASK-555).

- New Features
  - Show the deck dashboard before starting an all-deck due review, with a “Review all due” action; selected-deck review stays direct.
  - Persist nullable deck_name_snapshot at session creation and expose it through the API and UI types.
  - Recent sessions prefer the snapshot name, then current deck name, and fall back to “Deck unavailable”; avoids raw IDs/scope keys.

<sup>Written for commit 9f0b60d9c06fa54343d3877af28ebba55ba72e99. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2137?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

