### PR TITLE
Add MCP Unified Stage 4A gateway skeleton

### DIFF
--- a/Docs/superpowers/plans/2026-05-30-mcp-unified-stage4a-gateway-entrypoint-plan.md
+++ b/Docs/superpowers/plans/2026-05-30-mcp-unified-stage4a-gateway-entrypoint-plan.md
@@ -1,0 +1,99 @@
+# MCP Unified Stage 4A Gateway Entrypoint Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add the smallest package-owned FastAPI gateway skeleton for standalone MCP use.
+
+**Architecture:** Keep runtime code inside `mcp_unified.gateway` so it can be imported without `tldw_Server_API`. Keep tests in the existing host MCP test suite so they are not packaged with the standalone runtime. The gateway exposes an app/router factory that accepts an injected runtime protocol and handles status, `initialize`, `ping`, `tools/list`, and `tools/call` JSON-RPC requests for fake or future standalone runtimes.
+
+**Tech Stack:** Python 3.11, FastAPI, pytest, package-local `mcp_unified` interfaces.
+
+---
+
+### Task 1: Gateway Skeleton Contract Tests
+
+**Files:**
+- Create: `tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py`
+- Create: `mcp_unified/gateway/__init__.py`
+- Create: `mcp_unified/gateway/runtime.py`
+- Create: `mcp_unified/gateway/fastapi.py`
+
+- [x] **Step 1: Write the failing tests**
+
+Add tests that:
+- AST-scan `mcp_unified/gateway/*.py` and fail on any `tldw_Server_API` import.
+- Build a minimal app with `create_gateway_app(fake_runtime)`.
+- Assert `GET /mcp/status` returns gateway metadata.
+- Assert `POST /mcp/request` handles `initialize`, `tools/list`, and `tools/call`.
+
+- [x] **Step 2: Run tests to verify RED**
+
+Run:
+
+```bash
+.venv/bin/python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py -q
+```
+
+Expected: fail because `mcp_unified.gateway` does not exist.
+
+- [x] **Step 3: Implement the minimal package gateway**
+
+Create:
+- `GatewayRequestContext` dataclass with request id, client id, user id, metadata.
+- `GatewayRuntime` protocol with `name`, `version`, `list_tools()`, and `call_tool()`.
+- `create_gateway_router(runtime)` and `create_gateway_app(runtime, prefix="/mcp")`.
+
+Keep implementation deliberately small:
+- No SQLite store wiring.
+- No client-facing stdio.
+- No upstream external stdio process lifecycle.
+- No host `MCPServer` or `MCPProtocol` import.
+
+- [x] **Step 4: Run focused tests to verify GREEN**
+
+Run:
+
+```bash
+.venv/bin/python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py -q
+```
+
+Expected: pass.
+
+### Task 2: Host Compatibility And Validation
+
+**Files:**
+- Modify: `backlog/tasks/task-557 - Implement-MCP-Unified-Stage-4A-gateway-entrypoint-skeleton.md`
+
+- [x] **Step 1: Run focused host compatibility tests**
+
+Run:
+
+```bash
+.venv/bin/python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_extraction_contracts.py tldw_Server_API/app/core/MCP_unified/tests/test_http_mapping.py -q
+```
+
+Expected: existing host extraction and HTTP behavior remains compatible.
+
+- [x] **Step 2: Run lint, security, and whitespace checks**
+
+Run:
+
+```bash
+.venv/bin/python -m ruff check mcp_unified/gateway tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py
+.venv/bin/python -m bandit -r mcp_unified/gateway -f json -o /tmp/bandit_mcp_stage4a_gateway.json
+git diff --check
+```
+
+Expected: Ruff passes, Bandit reports 0 findings, whitespace check is clean.
+
+- [x] **Step 3: Record Backlog verification and commit**
+
+Update TASK-557 with implementation notes, verification results, known skips, and final summary. Commit the plan, gateway code, tests, and task update together.
+
+**Verification:**
+- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest mcp_unified/tests/test_gateway_fastapi.py -q` -> RED failed with `ModuleNotFoundError: No module named 'mcp_unified.gateway'`.
+- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py -q` -> 2 passed, 3 warnings.
+- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_extraction_contracts.py tldw_Server_API/app/core/MCP_unified/tests/test_http_mapping.py -q` -> 47 passed, 4 warnings.
+- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m ruff check mcp_unified/gateway tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py` -> All checks passed.
+- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r mcp_unified/gateway -f json -o /tmp/bandit_mcp_stage4a_gateway.json` -> 0 findings.
+- `git diff --check` -> clean.

--- a/backlog/tasks/task-557 - Implement-MCP-Unified-Stage-4A-gateway-entrypoint-skeleton.md
+++ b/backlog/tasks/task-557 - Implement-MCP-Unified-Stage-4A-gateway-entrypoint-skeleton.md
@@ -4,12 +4,14 @@ title: Implement MCP Unified Stage 4A gateway entrypoint skeleton
 status: Done
 assignee: []
 created_date: ''
-updated_date: '2026-05-30 06:17'
+updated_date: '2026-05-30 06:29'
 labels:
   - mcp-unified
   - standalone-extraction
   - stage-4
 dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/pull/2139'
 documentation:
   - >-
     Docs/superpowers/specs/2026-05-26-mcp-unified-standalone-library-gateway-design.md

--- a/backlog/tasks/task-557 - Implement-MCP-Unified-Stage-4A-gateway-entrypoint-skeleton.md
+++ b/backlog/tasks/task-557 - Implement-MCP-Unified-Stage-4A-gateway-entrypoint-skeleton.md
@@ -1,0 +1,61 @@
+---
+id: TASK-557
+title: Implement MCP Unified Stage 4A gateway entrypoint skeleton
+status: Done
+assignee: []
+created_date: ''
+updated_date: '2026-05-30 06:17'
+labels:
+  - mcp-unified
+  - standalone-extraction
+  - stage-4
+dependencies: []
+documentation:
+  - >-
+    Docs/superpowers/specs/2026-05-26-mcp-unified-standalone-library-gateway-design.md
+  - >-
+    Docs/superpowers/plans/2026-05-30-mcp-unified-stage4a-gateway-entrypoint-plan.md
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Start Stage 4 with the smallest standalone gateway slice: a package-owned FastAPI gateway app/router skeleton that can be imported without the tldw_Server_API host and exposes basic status/tools plumbing through fake adapters, while preserving host compatibility.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Standalone gateway entrypoint/router code lives under the package boundary and does not import tldw_Server_API.
+- [x] #2 Focused tests prove the gateway skeleton can be imported and exercised in a minimal FastAPI app with fake adapters.
+- [x] #3 Host MCP behavior remains compatible for existing focused tests touched by the slice.
+- [x] #4 Plan, verification, and known skips are recorded before PR closeout.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Docs/superpowers/plans/2026-05-30-mcp-unified-stage4a-gateway-entrypoint-plan.md
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented the Stage 4A gateway skeleton as package-owned code under mcp_unified.gateway. Added GatewayRequestContext and GatewayRuntime contracts plus FastAPI router/app factories for /mcp/status and /mcp/request. The JSON-RPC skeleton handles initialize, ping, tools/list, and tools/call through an injected runtime only. Kept SQLite store wiring, upstream external stdio lifecycle, client-facing stdio, host MCPServer imports, and host MCPProtocol imports out of scope. Tests live in the existing host MCP test suite to avoid shipping package tests while still asserting the gateway package has no tldw_Server_API imports.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Stage 4A gateway entrypoint skeleton complete. Verification: RED gateway test failed on missing mcp_unified.gateway; focused gateway package test passed (2 passed, 3 warnings); host extraction/http compatibility passed (47 passed, 4 warnings); Ruff passed; Bandit reported 0 findings for mcp_unified/gateway; git diff --check clean. Known note: the fresh worktree has no local .venv symlink, so verification used the main repo venv at /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-557 - Implement-MCP-Unified-Stage-4A-gateway-entrypoint-skeleton.md
+++ b/backlog/tasks/task-557 - Implement-MCP-Unified-Stage-4A-gateway-entrypoint-skeleton.md
@@ -49,7 +49,7 @@ Implemented the Stage 4A gateway skeleton as package-owned code under mcp_unifie
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Stage 4A gateway entrypoint skeleton complete. Verification: RED gateway test failed on missing mcp_unified.gateway; focused gateway package test passed (2 passed, 3 warnings); host extraction/http compatibility passed (47 passed, 4 warnings); Ruff passed; Bandit reported 0 findings for mcp_unified/gateway; git diff --check clean. Known note: the fresh worktree has no local .venv symlink, so verification used the main repo venv at /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python.
+Stage 4A gateway entrypoint skeleton complete. Verification: RED gateway test failed on missing mcp_unified.gateway; focused gateway package test passed (2 passed, 3 warnings); host extraction/http compatibility passed (47 passed, 4 warnings); Ruff passed; Bandit reported 0 findings for mcp_unified/gateway; git diff --check clean. Known note: verification used the repository virtualenv because the fresh worktree had no local .venv symlink.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-558 - Address-PR-2139-gateway-review-comments.md
+++ b/backlog/tasks/task-558 - Address-PR-2139-gateway-review-comments.md
@@ -1,0 +1,59 @@
+---
+id: TASK-558
+title: Address PR 2139 gateway review comments
+status: Done
+assignee: []
+created_date: ''
+updated_date: '2026-05-30 06:41'
+labels:
+  - mcp-unified
+  - standalone-extraction
+  - review-fix
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/pull/2139'
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Rebase PR 2139 onto latest dev and address Qodo/Gemini review feedback for the Stage 4A standalone gateway JSON-RPC skeleton.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 PR branch rebased onto latest origin/dev or verified up to date.
+- [x] #2 Gateway request parsing and envelope validation use Pydantic models while preserving JSON-RPC parse-error behavior.
+- [x] #3 JSON-RPC id, params, and tools/call arguments type validation reject malformed input without silent coercion.
+- [x] #4 Gateway internal errors, missing jsonrpc, helper docstrings, and review tests are addressed or explicitly documented if skipped.
+- [x] #5 Focused tests, Ruff, Bandit, and diff checks are recorded before pushing.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Verify review findings against current code. Add failing regression tests for malformed JSON, missing jsonrpc, invalid id, falsy non-dict params, falsy non-dict tools/call arguments, and unexpected runtime exceptions. Implement a minimal Pydantic envelope layer plus raw-body parsing, add docstrings, then rerun focused validation and push.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Verified PR 2139 was already up to date with origin/dev; git rebase origin/dev was a no-op. Verified Qodo/Gemini findings against current code and fixed all still-valid items. Added Pydantic JSON-RPC request/response envelope models, manual raw JSON parsing for JSON-RPC parse errors, strict id validation before echoing ids, non-coercing object validation for params and tools/call arguments, broad standard Exception mapping to JSON-RPC internal errors at the transport boundary, and docstrings for the new gateway helpers. Added regression tests for malformed JSON, missing jsonrpc, invalid id, non-object params, non-object arguments, and custom runtime exceptions. No review findings were skipped.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Review fixes complete. Validation: gateway package tests 8 passed/3 warnings; host extraction and HTTP mapping tests 47 passed/4 warnings; Ruff passed; Bandit reported 0 findings for mcp_unified/gateway; git diff --check clean. Existing host compatibility command still prints OpenTelemetry span JSON to stdout, but tests passed.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-558 - Address-PR-2139-gateway-review-comments.md
+++ b/backlog/tasks/task-558 - Address-PR-2139-gateway-review-comments.md
@@ -4,7 +4,7 @@ title: Address PR 2139 gateway review comments
 status: Done
 assignee: []
 created_date: ''
-updated_date: '2026-05-30 06:41'
+updated_date: '2026-05-30 06:49'
 labels:
   - mcp-unified
   - standalone-extraction
@@ -28,24 +28,25 @@ Rebase PR 2139 onto latest dev and address Qodo/Gemini review feedback for the S
 - [x] #3 JSON-RPC id, params, and tools/call arguments type validation reject malformed input without silent coercion.
 - [x] #4 Gateway internal errors, missing jsonrpc, helper docstrings, and review tests are addressed or explicitly documented if skipped.
 - [x] #5 Focused tests, Ruff, Bandit, and diff checks are recorded before pushing.
+- [x] #6 Follow-up CodeRabbit comments from the refreshed PR review are addressed or explicitly documented if skipped.
 <!-- AC:END -->
 
 ## Implementation Plan
 
 <!-- SECTION:PLAN:BEGIN -->
-Verify review findings against current code. Add failing regression tests for malformed JSON, missing jsonrpc, invalid id, falsy non-dict params, falsy non-dict tools/call arguments, and unexpected runtime exceptions. Implement a minimal Pydantic envelope layer plus raw-body parsing, add docstrings, then rerun focused validation and push.
+Verify review findings against current code. Add failing regression tests for malformed JSON, missing jsonrpc, invalid id, falsy non-dict params, falsy non-dict tools/call arguments, and unexpected runtime exceptions. Implement a minimal Pydantic envelope layer plus raw-body parsing, add docstrings, then rerun focused validation and push. After GitHub refresh, verify CodeRabbit follow-up comments, add failing coverage for notification error suppression and runtime exception logging, make the smallest transport/test/doc updates, and revalidate.
 <!-- SECTION:PLAN:END -->
 
 ## Implementation Notes
 
 <!-- SECTION:NOTES:BEGIN -->
-Verified PR 2139 was already up to date with origin/dev; git rebase origin/dev was a no-op. Verified Qodo/Gemini findings against current code and fixed all still-valid items. Added Pydantic JSON-RPC request/response envelope models, manual raw JSON parsing for JSON-RPC parse errors, strict id validation before echoing ids, non-coercing object validation for params and tools/call arguments, broad standard Exception mapping to JSON-RPC internal errors at the transport boundary, and docstrings for the new gateway helpers. Added regression tests for malformed JSON, missing jsonrpc, invalid id, non-object params, non-object arguments, and custom runtime exceptions. No review findings were skipped.
+Verified PR 2139 was already up to date with origin/dev; git rebase origin/dev was a no-op. Verified Qodo/Gemini findings against current code and fixed all still-valid items. Added Pydantic JSON-RPC request/response envelope models, manual raw JSON parsing for JSON-RPC parse errors, strict id validation before echoing ids, non-coercing object validation for params and tools/call arguments, broad standard Exception mapping to JSON-RPC internal errors at the transport boundary, and docstrings for the new gateway helpers. Added regression tests for malformed JSON, missing jsonrpc, invalid id, non-object params, non-object arguments, and custom runtime exceptions. After refreshing GitHub, verified and fixed additional still-valid CodeRabbit comments: notification dispatch errors now suppress responses, runtime exceptions are logged before -32603 mapping, the tools/call flow test asserts arguments and request context, and TASK-557 no longer records a machine-specific venv path. No review findings were skipped.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Review fixes complete. Validation: gateway package tests 8 passed/3 warnings; host extraction and HTTP mapping tests 47 passed/4 warnings; Ruff passed; Bandit reported 0 findings for mcp_unified/gateway; git diff --check clean. Existing host compatibility command still prints OpenTelemetry span JSON to stdout, but tests passed.
+Review fixes complete. Validation: gateway package tests 11 passed/3 warnings; host extraction and HTTP mapping tests 47 passed/4 warnings; Ruff passed; Bandit reported 0 findings for mcp_unified/gateway; git diff --check clean; TASK-557 absolute venv path scan returned no matches. Existing host compatibility command still prints OpenTelemetry span JSON to stdout, but tests passed.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/mcp_unified/gateway/__init__.py
+++ b/mcp_unified/gateway/__init__.py
@@ -1,0 +1,11 @@
+"""Standalone MCP gateway entrypoint helpers."""
+
+from .fastapi import create_gateway_app, create_gateway_router
+from .runtime import GatewayRequestContext, GatewayRuntime
+
+__all__ = [
+    "GatewayRequestContext",
+    "GatewayRuntime",
+    "create_gateway_app",
+    "create_gateway_router",
+]

--- a/mcp_unified/gateway/fastapi.py
+++ b/mcp_unified/gateway/fastapi.py
@@ -6,6 +6,7 @@ import json
 from typing import Any, Literal
 
 from fastapi import APIRouter, FastAPI, Request, Response
+from loguru import logger
 from pydantic import BaseModel, Field, ValidationError
 
 try:
@@ -235,15 +236,24 @@ async def _handle_single_jsonrpc(
     try:
         result = await _dispatch_jsonrpc(runtime, gateway_request, request)
     except ValueError as exc:
-        return _jsonrpc_error(_INVALID_PARAMS, str(exc), request_id)
+        error = _jsonrpc_error(_INVALID_PARAMS, str(exc), request_id)
     except NotImplementedError:
-        return _jsonrpc_error(_METHOD_NOT_FOUND, f"Method not found: {gateway_request.method}", request_id)
+        error = _jsonrpc_error(_METHOD_NOT_FOUND, f"Method not found: {gateway_request.method}", request_id)
     except _GATEWAY_RUNTIME_ERRORS as exc:  # noqa: BLE001 - JSON-RPC requires mapping runtime failures to -32603.
-        return _jsonrpc_error(_INTERNAL_ERROR, "Internal server error", request_id, data=exc.__class__.__name__)
+        logger.opt(exception=True).error(
+            "Gateway runtime error while handling method={!r} request_id={!r}",
+            gateway_request.method,
+            request_id,
+        )
+        error = _jsonrpc_error(_INTERNAL_ERROR, "Internal server error", request_id, data=exc.__class__.__name__)
+    else:
+        if request_id is None:
+            return Response(status_code=204)
+        return _jsonrpc_result(result, request_id)
 
     if request_id is None:
         return Response(status_code=204)
-    return _jsonrpc_result(result, request_id)
+    return error
 
 
 async def _handle_jsonrpc(

--- a/mcp_unified/gateway/fastapi.py
+++ b/mcp_unified/gateway/fastapi.py
@@ -1,0 +1,190 @@
+"""FastAPI transport skeleton for standalone MCP gateway runtimes."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter, Body, FastAPI, Request, Response
+
+from .runtime import GatewayRequestContext, GatewayRuntime
+
+_PROTOCOL_VERSION = "2024-11-05"
+_JSONRPC_VERSION = "2.0"
+
+_INVALID_REQUEST = -32600
+_METHOD_NOT_FOUND = -32601
+_INVALID_PARAMS = -32602
+_INTERNAL_ERROR = -32603
+_GATEWAY_RUNTIME_ERRORS = (
+    AttributeError,
+    LookupError,
+    RuntimeError,
+    TypeError,
+)
+
+
+def _runtime_name(runtime: GatewayRuntime) -> str:
+    return str(getattr(runtime, "name", "mcp-unified-gateway"))
+
+
+def _runtime_version(runtime: GatewayRuntime) -> str:
+    return str(getattr(runtime, "version", "0.1.0"))
+
+
+def _jsonrpc_result(result: Any, request_id: str | int | None) -> dict[str, Any]:
+    return {"jsonrpc": _JSONRPC_VERSION, "result": result, "id": request_id}
+
+
+def _jsonrpc_error(
+    code: int,
+    message: str,
+    request_id: str | int | None,
+    *,
+    data: Any | None = None,
+) -> dict[str, Any]:
+    error: dict[str, Any] = {"code": code, "message": message}
+    if data is not None:
+        error["data"] = data
+    return {"jsonrpc": _JSONRPC_VERSION, "error": error, "id": request_id}
+
+
+def _request_context(
+    payload: dict[str, Any],
+    request: Request,
+) -> GatewayRequestContext:
+    request_id = payload.get("id")
+    metadata: dict[str, Any] = {
+        "method": payload.get("method"),
+        "path": str(request.url.path),
+    }
+    if request.client is not None:
+        metadata["client_host"] = request.client.host
+    return GatewayRequestContext(
+        request_id=str(request_id if request_id is not None else "notification"),
+        metadata=metadata,
+    )
+
+
+async def _handle_initialize(
+    runtime: GatewayRuntime,
+) -> dict[str, Any]:
+    return {
+        "protocolVersion": _PROTOCOL_VERSION,
+        "capabilities": {
+            "tools": {"available": True},
+            "resources": {"available": False},
+            "prompts": {"available": False},
+        },
+        "serverInfo": {
+            "name": _runtime_name(runtime),
+            "version": _runtime_version(runtime),
+        },
+    }
+
+
+async def _dispatch_jsonrpc(
+    runtime: GatewayRuntime,
+    payload: dict[str, Any],
+    request: Request,
+) -> Any:
+    method = payload.get("method")
+    params = payload.get("params") or {}
+    if not isinstance(params, dict):
+        raise ValueError("params must be an object")
+
+    context = _request_context(payload, request)
+
+    if method == "initialize":
+        return await _handle_initialize(runtime)
+    if method == "ping":
+        return {"pong": True}
+    if method == "tools/list":
+        return {"tools": await runtime.list_tools(context)}
+    if method == "tools/call":
+        tool_name = params.get("name")
+        arguments = params.get("arguments") or {}
+        if not isinstance(tool_name, str) or not tool_name.strip():
+            raise ValueError("tools/call requires a non-empty string name")
+        if not isinstance(arguments, dict):
+            raise ValueError("tools/call arguments must be an object")
+        return await runtime.call_tool(tool_name, arguments, context)
+
+    raise NotImplementedError(str(method))
+
+
+async def _handle_single_jsonrpc(
+    runtime: GatewayRuntime,
+    payload: Any,
+    request: Request,
+) -> dict[str, Any] | Response:
+    if not isinstance(payload, dict):
+        return _jsonrpc_error(_INVALID_REQUEST, "Request must be an object", None)
+
+    request_id = payload.get("id")
+    if payload.get("jsonrpc", _JSONRPC_VERSION) != _JSONRPC_VERSION:
+        return _jsonrpc_error(_INVALID_REQUEST, "jsonrpc must be 2.0", request_id)
+
+    method = payload.get("method")
+    if not isinstance(method, str) or not method:
+        return _jsonrpc_error(_INVALID_REQUEST, "method must be a non-empty string", request_id)
+
+    try:
+        result = await _dispatch_jsonrpc(runtime, payload, request)
+    except ValueError as exc:
+        return _jsonrpc_error(_INVALID_PARAMS, str(exc), request_id)
+    except NotImplementedError:
+        return _jsonrpc_error(_METHOD_NOT_FOUND, f"Method not found: {method}", request_id)
+    except _GATEWAY_RUNTIME_ERRORS as exc:
+        return _jsonrpc_error(_INTERNAL_ERROR, "Internal server error", request_id, data=exc.__class__.__name__)
+
+    if request_id is None:
+        return Response(status_code=204)
+    return _jsonrpc_result(result, request_id)
+
+
+async def _handle_jsonrpc(
+    runtime: GatewayRuntime,
+    payload: Any,
+    request: Request,
+) -> dict[str, Any] | list[dict[str, Any]] | Response:
+    if isinstance(payload, list):
+        if not payload:
+            return _jsonrpc_error(_INVALID_REQUEST, "Batch request must not be empty", None)
+        responses: list[dict[str, Any]] = []
+        for item in payload:
+            response = await _handle_single_jsonrpc(runtime, item, request)
+            if isinstance(response, dict):
+                responses.append(response)
+        if not responses:
+            return Response(status_code=204)
+        return responses
+
+    return await _handle_single_jsonrpc(runtime, payload, request)
+
+
+def create_gateway_router(runtime: GatewayRuntime) -> APIRouter:
+    """Create a package-owned FastAPI router for a standalone MCP runtime."""
+
+    router = APIRouter()
+
+    @router.get("/status")
+    async def gateway_status() -> dict[str, str]:
+        return {
+            "status": "ok",
+            "name": _runtime_name(runtime),
+            "version": _runtime_version(runtime),
+        }
+
+    @router.post("/request")
+    async def gateway_request(request: Request, payload: Any = Body(...)) -> Any:
+        return await _handle_jsonrpc(runtime, payload, request)
+
+    return router
+
+
+def create_gateway_app(runtime: GatewayRuntime, *, prefix: str = "/mcp") -> FastAPI:
+    """Create a minimal FastAPI app exposing the standalone MCP gateway router."""
+
+    app = FastAPI(title="MCP Unified Gateway", version=_runtime_version(runtime))
+    app.include_router(create_gateway_router(runtime), prefix=prefix)
+    return app

--- a/mcp_unified/gateway/fastapi.py
+++ b/mcp_unified/gateway/fastapi.py
@@ -2,37 +2,112 @@
 
 from __future__ import annotations
 
-from typing import Any
+import json
+from typing import Any, Literal
 
-from fastapi import APIRouter, Body, FastAPI, Request, Response
+from fastapi import APIRouter, FastAPI, Request, Response
+from pydantic import BaseModel, Field, ValidationError
+
+try:
+    from pydantic import field_validator as _pydantic_field_validator
+except ImportError:  # pragma: no cover - pydantic v1 fallback
+    from pydantic import validator as _pydantic_validator  # type: ignore
+
+    def _before_validator(*fields: str):
+        """Create a pydantic v1 pre-validation decorator."""
+
+        return _pydantic_validator(*fields, pre=True, allow_reuse=True)
+
+else:
+
+    def _before_validator(*fields: str):
+        """Create a pydantic v2 before-validation decorator."""
+
+        return _pydantic_field_validator(*fields, mode="before")
 
 from .runtime import GatewayRequestContext, GatewayRuntime
 
 _PROTOCOL_VERSION = "2024-11-05"
 _JSONRPC_VERSION = "2.0"
 
+_PARSE_ERROR = -32700
 _INVALID_REQUEST = -32600
 _METHOD_NOT_FOUND = -32601
 _INVALID_PARAMS = -32602
 _INTERNAL_ERROR = -32603
-_GATEWAY_RUNTIME_ERRORS = (
-    AttributeError,
-    LookupError,
-    RuntimeError,
-    TypeError,
-)
+_GATEWAY_RUNTIME_ERRORS = Exception
+_JSON_PARSE_ERRORS = (json.JSONDecodeError, UnicodeDecodeError)
+
+
+class GatewayJSONRPCRequest(BaseModel):
+    """Validated JSON-RPC request envelope accepted by the gateway."""
+
+    jsonrpc: Literal["2.0"]
+    method: str = Field(..., min_length=1, max_length=100)
+    params: Any | None = None
+    id: str | int | None = None
+
+    @_before_validator("id")
+    def _validate_id(cls, value: Any) -> str | int | None:
+        """Reject JSON-RPC ids that cannot be safely echoed for correlation."""
+
+        return _validate_request_id(value)
+
+
+class GatewayJSONRPCError(BaseModel):
+    """JSON-RPC error object returned by the gateway."""
+
+    code: int
+    message: str
+    data: Any | None = None
+
+
+class GatewayJSONRPCSuccessResponse(BaseModel):
+    """JSON-RPC success response envelope returned by the gateway."""
+
+    jsonrpc: Literal["2.0"] = _JSONRPC_VERSION
+    result: Any
+    id: str | int | None = None
+
+
+class GatewayJSONRPCErrorResponse(BaseModel):
+    """JSON-RPC error response envelope returned by the gateway."""
+
+    jsonrpc: Literal["2.0"] = _JSONRPC_VERSION
+    error: GatewayJSONRPCError
+    id: str | int | None = None
+
+
+GatewayJSONRPCResponse = GatewayJSONRPCSuccessResponse | GatewayJSONRPCErrorResponse
+_GATEWAY_RESPONSE_TYPES = (GatewayJSONRPCSuccessResponse, GatewayJSONRPCErrorResponse)
 
 
 def _runtime_name(runtime: GatewayRuntime) -> str:
+    """Return the runtime display name with a standalone default."""
+
     return str(getattr(runtime, "name", "mcp-unified-gateway"))
 
 
 def _runtime_version(runtime: GatewayRuntime) -> str:
+    """Return the runtime version with a standalone default."""
+
     return str(getattr(runtime, "version", "0.1.0"))
 
 
-def _jsonrpc_result(result: Any, request_id: str | int | None) -> dict[str, Any]:
-    return {"jsonrpc": _JSONRPC_VERSION, "result": result, "id": request_id}
+def _validate_request_id(value: Any) -> str | int | None:
+    """Validate the gateway's JSON-RPC id contract before response echoing."""
+
+    if value is None:
+        return None
+    if isinstance(value, bool) or not isinstance(value, (str, int)):
+        raise ValueError("id must be a string, number, or null")
+    return value
+
+
+def _jsonrpc_result(result: Any, request_id: str | int | None) -> GatewayJSONRPCSuccessResponse:
+    """Build a successful JSON-RPC response envelope."""
+
+    return GatewayJSONRPCSuccessResponse(result=result, id=request_id)
 
 
 def _jsonrpc_error(
@@ -41,26 +116,39 @@ def _jsonrpc_error(
     request_id: str | int | None,
     *,
     data: Any | None = None,
-) -> dict[str, Any]:
-    error: dict[str, Any] = {"code": code, "message": message}
-    if data is not None:
-        error["data"] = data
-    return {"jsonrpc": _JSONRPC_VERSION, "error": error, "id": request_id}
+) -> GatewayJSONRPCErrorResponse:
+    """Build a JSON-RPC error response envelope."""
+
+    return GatewayJSONRPCErrorResponse(
+        error=GatewayJSONRPCError(code=code, message=message, data=data),
+        id=request_id,
+    )
+
+
+def _object_or_empty(value: Any, message: str) -> dict[str, Any]:
+    """Return an object payload or reject non-object values without coercion."""
+
+    if value is None:
+        return {}
+    if isinstance(value, dict):
+        return value
+    raise ValueError(message)
 
 
 def _request_context(
-    payload: dict[str, Any],
+    payload: GatewayJSONRPCRequest,
     request: Request,
 ) -> GatewayRequestContext:
-    request_id = payload.get("id")
+    """Derive the host-neutral gateway request context from a JSON-RPC request."""
+
     metadata: dict[str, Any] = {
-        "method": payload.get("method"),
+        "method": payload.method,
         "path": str(request.url.path),
     }
     if request.client is not None:
         metadata["client_host"] = request.client.host
     return GatewayRequestContext(
-        request_id=str(request_id if request_id is not None else "notification"),
+        request_id=str(payload.id if payload.id is not None else "notification"),
         metadata=metadata,
     )
 
@@ -68,6 +156,8 @@ def _request_context(
 async def _handle_initialize(
     runtime: GatewayRuntime,
 ) -> dict[str, Any]:
+    """Return the gateway's initial MCP capability advertisement."""
+
     return {
         "protocolVersion": _PROTOCOL_VERSION,
         "capabilities": {
@@ -84,13 +174,13 @@ async def _handle_initialize(
 
 async def _dispatch_jsonrpc(
     runtime: GatewayRuntime,
-    payload: dict[str, Any],
+    payload: GatewayJSONRPCRequest,
     request: Request,
 ) -> Any:
-    method = payload.get("method")
-    params = payload.get("params") or {}
-    if not isinstance(params, dict):
-        raise ValueError("params must be an object")
+    """Dispatch one validated JSON-RPC request to the injected runtime."""
+
+    method = payload.method
+    params = _object_or_empty(payload.params, "params must be an object")
 
     context = _request_context(payload, request)
 
@@ -102,39 +192,53 @@ async def _dispatch_jsonrpc(
         return {"tools": await runtime.list_tools(context)}
     if method == "tools/call":
         tool_name = params.get("name")
-        arguments = params.get("arguments") or {}
+        arguments = _object_or_empty(
+            params.get("arguments"),
+            "tools/call arguments must be an object",
+        )
         if not isinstance(tool_name, str) or not tool_name.strip():
             raise ValueError("tools/call requires a non-empty string name")
-        if not isinstance(arguments, dict):
-            raise ValueError("tools/call arguments must be an object")
         return await runtime.call_tool(tool_name, arguments, context)
 
     raise NotImplementedError(str(method))
+
+
+def _validate_jsonrpc_request(payload: dict[str, Any]) -> GatewayJSONRPCRequest:
+    """Validate a raw mapping as a gateway JSON-RPC request envelope."""
+
+    try:
+        return GatewayJSONRPCRequest.model_validate(payload)
+    except AttributeError:  # pragma: no cover - pydantic v1 fallback
+        return GatewayJSONRPCRequest.parse_obj(payload)
 
 
 async def _handle_single_jsonrpc(
     runtime: GatewayRuntime,
     payload: Any,
     request: Request,
-) -> dict[str, Any] | Response:
+) -> GatewayJSONRPCResponse | Response:
+    """Handle one JSON-RPC request, including notifications and error mapping."""
+
     if not isinstance(payload, dict):
         return _jsonrpc_error(_INVALID_REQUEST, "Request must be an object", None)
 
-    request_id = payload.get("id")
-    if payload.get("jsonrpc", _JSONRPC_VERSION) != _JSONRPC_VERSION:
-        return _jsonrpc_error(_INVALID_REQUEST, "jsonrpc must be 2.0", request_id)
-
-    method = payload.get("method")
-    if not isinstance(method, str) or not method:
-        return _jsonrpc_error(_INVALID_REQUEST, "method must be a non-empty string", request_id)
+    try:
+        request_id = _validate_request_id(payload.get("id"))
+    except ValueError as exc:
+        return _jsonrpc_error(_INVALID_REQUEST, str(exc), None)
 
     try:
-        result = await _dispatch_jsonrpc(runtime, payload, request)
+        gateway_request = _validate_jsonrpc_request(payload)
+    except ValidationError as exc:
+        return _jsonrpc_error(_INVALID_REQUEST, "Invalid request", request_id, data=exc.errors())
+
+    try:
+        result = await _dispatch_jsonrpc(runtime, gateway_request, request)
     except ValueError as exc:
         return _jsonrpc_error(_INVALID_PARAMS, str(exc), request_id)
     except NotImplementedError:
-        return _jsonrpc_error(_METHOD_NOT_FOUND, f"Method not found: {method}", request_id)
-    except _GATEWAY_RUNTIME_ERRORS as exc:
+        return _jsonrpc_error(_METHOD_NOT_FOUND, f"Method not found: {gateway_request.method}", request_id)
+    except _GATEWAY_RUNTIME_ERRORS as exc:  # noqa: BLE001 - JSON-RPC requires mapping runtime failures to -32603.
         return _jsonrpc_error(_INTERNAL_ERROR, "Internal server error", request_id, data=exc.__class__.__name__)
 
     if request_id is None:
@@ -146,20 +250,34 @@ async def _handle_jsonrpc(
     runtime: GatewayRuntime,
     payload: Any,
     request: Request,
-) -> dict[str, Any] | list[dict[str, Any]] | Response:
+) -> GatewayJSONRPCResponse | list[GatewayJSONRPCResponse] | Response:
+    """Handle single or batch JSON-RPC payloads for the gateway endpoint."""
+
     if isinstance(payload, list):
         if not payload:
             return _jsonrpc_error(_INVALID_REQUEST, "Batch request must not be empty", None)
-        responses: list[dict[str, Any]] = []
+        responses: list[GatewayJSONRPCResponse] = []
         for item in payload:
             response = await _handle_single_jsonrpc(runtime, item, request)
-            if isinstance(response, dict):
+            if isinstance(response, _GATEWAY_RESPONSE_TYPES):
                 responses.append(response)
         if not responses:
             return Response(status_code=204)
         return responses
 
     return await _handle_single_jsonrpc(runtime, payload, request)
+
+
+async def _parse_json_body(request: Request) -> Any | GatewayJSONRPCErrorResponse:
+    """Parse raw JSON so malformed bodies return JSON-RPC parse errors."""
+
+    body = await request.body()
+    if not body:
+        return _jsonrpc_error(_PARSE_ERROR, "Parse error: Empty request body", None)
+    try:
+        return json.loads(body)
+    except _JSON_PARSE_ERRORS:
+        return _jsonrpc_error(_PARSE_ERROR, "Parse error: Invalid JSON", None)
 
 
 def create_gateway_router(runtime: GatewayRuntime) -> APIRouter:
@@ -169,14 +287,25 @@ def create_gateway_router(runtime: GatewayRuntime) -> APIRouter:
 
     @router.get("/status")
     async def gateway_status() -> dict[str, str]:
+        """Return lightweight gateway health and runtime identity metadata."""
+
         return {
             "status": "ok",
             "name": _runtime_name(runtime),
             "version": _runtime_version(runtime),
         }
 
-    @router.post("/request")
-    async def gateway_request(request: Request, payload: Any = Body(...)) -> Any:
+    @router.post(
+        "/request",
+        response_model=GatewayJSONRPCResponse | list[GatewayJSONRPCResponse],
+        responses={204: {"description": "JSON-RPC notification accepted."}},
+    )
+    async def gateway_request(request: Request) -> GatewayJSONRPCResponse | list[GatewayJSONRPCResponse] | Response:
+        """Process a raw JSON-RPC HTTP request body for the standalone gateway."""
+
+        payload = await _parse_json_body(request)
+        if isinstance(payload, _GATEWAY_RESPONSE_TYPES):
+            return payload
         return await _handle_jsonrpc(runtime, payload, request)
 
     return router

--- a/mcp_unified/gateway/runtime.py
+++ b/mcp_unified/gateway/runtime.py
@@ -1,0 +1,36 @@
+"""Runtime contracts for standalone MCP gateway transports."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Protocol
+
+
+@dataclass(slots=True)
+class GatewayRequestContext:
+    """Host-neutral context passed from gateway transports to runtimes."""
+
+    request_id: str
+    client_id: str | None = None
+    user_id: str | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+class GatewayRuntime(Protocol):
+    """Minimal runtime surface needed by the standalone gateway skeleton."""
+
+    name: str
+    version: str
+
+    async def list_tools(self, context: GatewayRequestContext) -> list[dict[str, Any]]:
+        """Return tools visible to the current request context."""
+        ...
+
+    async def call_tool(
+        self,
+        name: str,
+        arguments: dict[str, Any],
+        context: GatewayRequestContext,
+    ) -> dict[str, Any]:
+        """Execute a tool call for the current request context."""
+        ...

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py
@@ -4,6 +4,7 @@ import ast
 from pathlib import Path
 from typing import Any
 
+import mcp_unified.gateway.fastapi as gateway_fastapi
 from fastapi.testclient import TestClient
 from mcp_unified.gateway import create_gateway_app
 
@@ -68,6 +69,19 @@ class _CustomExplodingGatewayRuntime(_FakeGatewayRuntime):
 
     async def list_tools(self, context: Any) -> list[dict[str, Any]]:
         raise self.RuntimeBackendError("backend unavailable")
+
+
+class _FakeLogger:
+    def __init__(self) -> None:
+        self.opt_calls: list[dict[str, Any]] = []
+        self.error_calls: list[tuple[str, tuple[Any, ...]]] = []
+
+    def opt(self, **kwargs: Any) -> _FakeLogger:
+        self.opt_calls.append(kwargs)
+        return self
+
+    def error(self, message: str, *args: Any) -> None:
+        self.error_calls.append((message, args))
 
 
 def _assert_jsonrpc_error(
@@ -152,6 +166,8 @@ def test_gateway_fastapi_app_handles_basic_jsonrpc_flow() -> None:
         assert called_body["id"] == "call-1"
         assert called_body["result"]["content"][0]["text"] == "echo.search:hello"
         assert runtime.call_requests[-1][0] == "echo.search"
+        assert runtime.call_requests[-1][1] == {"query": "hello"}
+        assert runtime.call_requests[-1][2].request_id == "call-1"
 
 
 def test_gateway_request_rejects_malformed_json_with_jsonrpc_parse_error() -> None:
@@ -247,3 +263,53 @@ def test_gateway_request_maps_custom_runtime_exceptions_to_jsonrpc_internal_erro
 
     assert response.status_code == 200
     _assert_jsonrpc_error(response.json(), code=-32603, request_id="explode")
+
+
+def test_gateway_request_logs_custom_runtime_exceptions(monkeypatch: Any) -> None:
+    runtime = _CustomExplodingGatewayRuntime()
+    app = create_gateway_app(runtime, prefix="/mcp")
+    fake_logger = _FakeLogger()
+    monkeypatch.setattr(gateway_fastapi, "logger", fake_logger, raising=False)
+
+    with TestClient(app, raise_server_exceptions=False) as client:
+        response = client.post(
+            "/mcp/request",
+            json={"jsonrpc": "2.0", "method": "tools/list", "params": {}, "id": "explode"},
+        )
+
+    assert response.status_code == 200
+    assert fake_logger.opt_calls == [{"exception": True}]
+    assert fake_logger.error_calls == [
+        ("Gateway runtime error while handling method={!r} request_id={!r}", ("tools/list", "explode"))
+    ]
+
+
+def test_gateway_notification_runtime_errors_do_not_return_jsonrpc_response() -> None:
+    runtime = _CustomExplodingGatewayRuntime()
+    app = create_gateway_app(runtime, prefix="/mcp")
+
+    with TestClient(app, raise_server_exceptions=False) as client:
+        response = client.post(
+            "/mcp/request",
+            json={"jsonrpc": "2.0", "method": "tools/list", "params": {}},
+        )
+
+    assert response.status_code == 204
+    assert response.content == b""
+
+
+def test_gateway_batch_omits_notification_runtime_errors() -> None:
+    runtime = _CustomExplodingGatewayRuntime()
+    app = create_gateway_app(runtime, prefix="/mcp")
+
+    with TestClient(app, raise_server_exceptions=False) as client:
+        response = client.post(
+            "/mcp/request",
+            json=[
+                {"jsonrpc": "2.0", "method": "tools/list", "params": {}},
+                {"jsonrpc": "2.0", "method": "ping", "id": "ok"},
+            ],
+        )
+
+    assert response.status_code == 200
+    assert response.json() == [{"jsonrpc": "2.0", "result": {"pong": True}, "id": "ok"}]

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+from typing import Any
+
+from fastapi.testclient import TestClient
+from mcp_unified.gateway import create_gateway_app
+
+REPO_ROOT = Path(__file__).resolve().parents[5]
+GATEWAY_ROOT = REPO_ROOT / "mcp_unified" / "gateway"
+
+
+def _import_sources(path: Path) -> list[str]:
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    imports: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imports.extend(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            imports.append(node.module)
+    return imports
+
+
+class _FakeGatewayRuntime:
+    name = "unit-gateway"
+    version = "0.0-test"
+
+    def __init__(self) -> None:
+        self.list_contexts: list[Any] = []
+        self.call_requests: list[tuple[str, dict[str, Any], Any]] = []
+
+    async def list_tools(self, context: Any) -> list[dict[str, Any]]:
+        self.list_contexts.append(context)
+        return [
+            {
+                "name": "echo.search",
+                "description": "Echo a query.",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {"query": {"type": "string"}},
+                    "required": ["query"],
+                },
+                "metadata": {"category": "test"},
+            }
+        ]
+
+    async def call_tool(
+        self,
+        name: str,
+        arguments: dict[str, Any],
+        context: Any,
+    ) -> dict[str, Any]:
+        self.call_requests.append((name, arguments, context))
+        return {
+            "content": [
+                {
+                    "type": "text",
+                    "text": f"{name}:{arguments['query']}",
+                }
+            ]
+        }
+
+
+def test_gateway_package_does_not_import_tldw_server_api() -> None:
+    assert GATEWAY_ROOT.exists()
+    offenders: dict[str, list[str]] = {}
+    for path in GATEWAY_ROOT.rglob("*.py"):
+        blocked = sorted(
+            source
+            for source in _import_sources(path)
+            if source == "tldw_Server_API" or source.startswith("tldw_Server_API.")
+        )
+        if blocked:
+            offenders[str(path.relative_to(REPO_ROOT))] = blocked
+
+    assert offenders == {}
+
+
+def test_gateway_fastapi_app_handles_basic_jsonrpc_flow() -> None:
+    runtime = _FakeGatewayRuntime()
+    app = create_gateway_app(runtime, prefix="/mcp")
+
+    with TestClient(app) as client:
+        status = client.get("/mcp/status")
+        assert status.status_code == 200
+        assert status.json() == {
+            "status": "ok",
+            "name": "unit-gateway",
+            "version": "0.0-test",
+        }
+
+        initialized = client.post(
+            "/mcp/request",
+            json={
+                "jsonrpc": "2.0",
+                "method": "initialize",
+                "params": {"clientInfo": {"name": "pytest"}},
+                "id": "init-1",
+            },
+        )
+        assert initialized.status_code == 200
+        assert initialized.json()["result"]["serverInfo"] == {
+            "name": "unit-gateway",
+            "version": "0.0-test",
+        }
+
+        listed = client.post(
+            "/mcp/request",
+            json={"jsonrpc": "2.0", "method": "tools/list", "params": {}, "id": "tools-1"},
+        )
+        assert listed.status_code == 200
+        listed_body = listed.json()
+        assert listed_body["id"] == "tools-1"
+        assert listed_body["result"]["tools"][0]["name"] == "echo.search"
+        assert runtime.list_contexts[-1].request_id == "tools-1"
+
+        called = client.post(
+            "/mcp/request",
+            json={
+                "jsonrpc": "2.0",
+                "method": "tools/call",
+                "params": {
+                    "name": "echo.search",
+                    "arguments": {"query": "hello"},
+                },
+                "id": "call-1",
+            },
+        )
+        assert called.status_code == 200
+        called_body = called.json()
+        assert called_body["id"] == "call-1"
+        assert called_body["result"]["content"][0]["text"] == "echo.search:hello"
+        assert runtime.call_requests[-1][0] == "echo.search"

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py
@@ -62,6 +62,26 @@ class _FakeGatewayRuntime:
         }
 
 
+class _CustomExplodingGatewayRuntime(_FakeGatewayRuntime):
+    class RuntimeBackendError(Exception):
+        pass
+
+    async def list_tools(self, context: Any) -> list[dict[str, Any]]:
+        raise self.RuntimeBackendError("backend unavailable")
+
+
+def _assert_jsonrpc_error(
+    body: dict[str, Any],
+    *,
+    code: int,
+    request_id: Any,
+) -> None:
+    assert body["jsonrpc"] == "2.0"
+    assert body["id"] == request_id
+    assert body["error"]["code"] == code
+    assert "message" in body["error"]
+
+
 def test_gateway_package_does_not_import_tldw_server_api() -> None:
     assert GATEWAY_ROOT.exists()
     offenders: dict[str, list[str]] = {}
@@ -132,3 +152,98 @@ def test_gateway_fastapi_app_handles_basic_jsonrpc_flow() -> None:
         assert called_body["id"] == "call-1"
         assert called_body["result"]["content"][0]["text"] == "echo.search:hello"
         assert runtime.call_requests[-1][0] == "echo.search"
+
+
+def test_gateway_request_rejects_malformed_json_with_jsonrpc_parse_error() -> None:
+    runtime = _FakeGatewayRuntime()
+    app = create_gateway_app(runtime, prefix="/mcp")
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/mcp/request",
+            content=b"{not valid json",
+            headers={"content-type": "application/json"},
+        )
+
+    assert response.status_code == 200
+    _assert_jsonrpc_error(response.json(), code=-32700, request_id=None)
+
+
+def test_gateway_request_rejects_missing_jsonrpc_member() -> None:
+    runtime = _FakeGatewayRuntime()
+    app = create_gateway_app(runtime, prefix="/mcp")
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/mcp/request",
+            json={"method": "ping", "id": "missing-version"},
+        )
+
+    assert response.status_code == 200
+    _assert_jsonrpc_error(response.json(), code=-32600, request_id="missing-version")
+
+
+def test_gateway_request_rejects_invalid_jsonrpc_id_type() -> None:
+    runtime = _FakeGatewayRuntime()
+    app = create_gateway_app(runtime, prefix="/mcp")
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/mcp/request",
+            json={"jsonrpc": "2.0", "method": "ping", "id": {"bad": 1}},
+        )
+
+    assert response.status_code == 200
+    _assert_jsonrpc_error(response.json(), code=-32600, request_id=None)
+
+
+def test_gateway_request_rejects_non_object_params_without_coercion() -> None:
+    runtime = _FakeGatewayRuntime()
+    app = create_gateway_app(runtime, prefix="/mcp")
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/mcp/request",
+            json={"jsonrpc": "2.0", "method": "tools/list", "params": [], "id": "bad-params"},
+        )
+
+    assert response.status_code == 200
+    _assert_jsonrpc_error(response.json(), code=-32602, request_id="bad-params")
+    assert runtime.list_contexts == []
+
+
+def test_gateway_request_rejects_non_object_tool_arguments_without_coercion() -> None:
+    runtime = _FakeGatewayRuntime()
+    app = create_gateway_app(runtime, prefix="/mcp")
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/mcp/request",
+            json={
+                "jsonrpc": "2.0",
+                "method": "tools/call",
+                "params": {
+                    "name": "echo.search",
+                    "arguments": [],
+                },
+                "id": "bad-args",
+            },
+        )
+
+    assert response.status_code == 200
+    _assert_jsonrpc_error(response.json(), code=-32602, request_id="bad-args")
+    assert runtime.call_requests == []
+
+
+def test_gateway_request_maps_custom_runtime_exceptions_to_jsonrpc_internal_error() -> None:
+    runtime = _CustomExplodingGatewayRuntime()
+    app = create_gateway_app(runtime, prefix="/mcp")
+
+    with TestClient(app, raise_server_exceptions=False) as client:
+        response = client.post(
+            "/mcp/request",
+            json={"jsonrpc": "2.0", "method": "tools/list", "params": {}, "id": "explode"},
+        )
+
+    assert response.status_code == 200
+    _assert_jsonrpc_error(response.json(), code=-32603, request_id="explode")


### PR DESCRIPTION
## Change summary (maintainer-owned)

- Starts Stage 4A with a package-owned `mcp_unified.gateway` skeleton that can be imported without the `tldw_Server_API` host.
- Adds a minimal `GatewayRuntime` protocol, `GatewayRequestContext`, and FastAPI app/router factory for `/mcp/status` and `/mcp/request`.
- Handles the first standalone JSON-RPC surface through injected runtime methods: `initialize`, `ping`, `tools/list`, and `tools/call`, while deliberately leaving SQLite wiring, external stdio lifecycle, and client-facing stdio out of this slice.
- Tightens JSON-RPC request handling from review feedback: Pydantic envelope models, raw-body parse errors, strict id/params/arguments validation, runtime exception mapping/logging, and notification error suppression.
- Records TASK-557 and TASK-558 so the next gateway slices have a concrete baseline and review-fix trail.

## Validation

- [x] Tests added/updated
- [x] Relevant tests pass locally
- [x] Docs/task records updated
- [x] Security scan run on touched gateway package

Validated on the rebased branch:

- `python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py -q` -> 11 passed, 3 warnings
- `python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_extraction_contracts.py tldw_Server_API/app/core/MCP_unified/tests/test_http_mapping.py -q` -> 47 passed, 4 warnings
- `python -m ruff check mcp_unified/gateway tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py` -> passed
- `python -m bandit -r mcp_unified/gateway -f json -o /tmp/bandit_mcp_stage4a_gateway_review.json` -> 0 findings
- `git diff --check` -> clean
- `rg -n "/Users/macbook-dev|/Users/|venv/bin/python" "backlog/tasks/task-557 - Implement-MCP-Unified-Stage-4A-gateway-entrypoint-skeleton.md"` -> no matches

## Risk level

Low. This is a standalone gateway package skeleton and focused test/task documentation update. It does not wire the gateway into existing host MCP routes or change existing host request handling.

## Rollback plan

Revert this PR branch's four Stage 4A commits to remove the standalone gateway skeleton and associated task/test records. Because the slice is not wired into the existing host MCP runtime, rollback should not require data migration or runtime configuration changes.

## Notes

- The host compatibility pytest command still prints existing OpenTelemetry span JSON to stdout; the tests pass.
- CodeRabbit's repo-wide docstring coverage warning is broader than this slice. The new/changed gateway helpers now include docstrings, and the related Qodo docstring thread is resolved.
