### PR TITLE
Add MCP Unified Stage 4B gateway protocol surface

### DIFF
--- a/Docs/superpowers/plans/2026-05-30-mcp-unified-stage4b-gateway-protocol-surface-plan.md
+++ b/Docs/superpowers/plans/2026-05-30-mcp-unified-stage4b-gateway-protocol-surface-plan.md
@@ -1,0 +1,176 @@
+# MCP Unified Stage 4B Gateway Protocol Surface Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extend the standalone gateway skeleton from Stage 4A to cover the package JSON-RPC discovery surface for resources, prompts, and modules through an injected runtime protocol.
+
+**Architecture:** Keep the transport package-owned under `mcp_unified.gateway` and continue to avoid `tldw_Server_API` imports. The FastAPI gateway remains a thin JSON-RPC transport: it validates envelope/params, builds `GatewayRequestContext`, and delegates runtime-owned behavior through `GatewayRuntime`. This slice intentionally avoids SQLite wiring, external MCP lifecycle, client-facing stdio, default-profile enforcement, and host route integration.
+
+**Tech Stack:** Python 3.11, FastAPI, Pydantic v1/v2 compatibility, pytest, Ruff, Bandit.
+
+---
+
+### Task 1: Gateway Protocol Surface RED Tests
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py`
+- Modify: `mcp_unified/gateway/runtime.py`
+- Modify: `mcp_unified/gateway/fastapi.py`
+
+- [x] **Step 1: Extend the fake runtime fixture**
+
+Add fake runtime methods and call capture lists for:
+
+```python
+async def list_resources(self, context): ...
+async def read_resource(self, uri, context): ...
+async def list_prompts(self, context): ...
+async def get_prompt(self, name, arguments, context): ...
+async def list_modules(self, context): ...
+async def get_modules_health(self, context): ...
+```
+
+- [x] **Step 2: Write failing tests for resource, prompt, and module methods**
+
+Add tests that POST to `/mcp/request` and expect:
+
+```python
+{"jsonrpc": "2.0", "method": "resources/list", "params": {}, "id": "resources-1"}
+```
+
+returns `result.resources`, and:
+
+```python
+{"jsonrpc": "2.0", "method": "resources/read", "params": {"uri": "resource://unit/doc"}, "id": "read-1"}
+```
+
+returns `result.contents`.
+
+Add equivalent prompt and module checks for:
+
+- `prompts/list` -> `result.prompts`
+- `prompts/get` with `{"name": "review.prompt", "arguments": {"topic": "gateway"}}` -> runtime prompt result
+- `modules/list` -> `result.modules`
+- `modules/health` -> `result.health`
+
+Assert each runtime call receives the expected `request_id` in its context.
+
+- [x] **Step 3: Write failing validation tests**
+
+Add tests that verify:
+
+- `resources/read` without a non-empty string `uri` returns JSON-RPC `-32602`
+- `prompts/get` without a non-empty string `name` returns JSON-RPC `-32602`
+- `prompts/get.arguments` as a falsy non-object such as `[]` returns JSON-RPC `-32602` and does not call the runtime
+
+- [x] **Step 4: Run RED tests**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py -q
+```
+
+Expected: the new tests fail with `Method not found` or missing runtime protocol methods while the existing Stage 4A tests remain valid.
+
+Evidence: `4 failed, 11 passed, 3 warnings`; the new resource/prompt/module tests failed with JSON-RPC `Method not found` responses before implementation.
+
+### Task 2: Gateway Runtime Protocol And Dispatch
+
+**Files:**
+- Modify: `mcp_unified/gateway/runtime.py`
+- Modify: `mcp_unified/gateway/fastapi.py`
+- Modify: `tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py`
+
+- [x] **Step 1: Extend `GatewayRuntime`**
+
+Add protocol methods:
+
+```python
+async def list_resources(self, context: GatewayRequestContext) -> list[dict[str, Any]]: ...
+async def read_resource(self, uri: str, context: GatewayRequestContext) -> dict[str, Any]: ...
+async def list_prompts(self, context: GatewayRequestContext) -> list[dict[str, Any]]: ...
+async def get_prompt(self, name: str, arguments: dict[str, Any], context: GatewayRequestContext) -> dict[str, Any]: ...
+async def list_modules(self, context: GatewayRequestContext) -> list[dict[str, Any]]: ...
+async def get_modules_health(self, context: GatewayRequestContext) -> dict[str, Any]: ...
+```
+
+- [x] **Step 2: Add small string validators in `fastapi.py`**
+
+Add a helper that accepts a value and field name and raises `ValueError` unless the value is a non-empty string after stripping.
+
+- [x] **Step 3: Extend `_dispatch_jsonrpc()`**
+
+Add branches:
+
+```python
+if method == "resources/list":
+    return {"resources": await runtime.list_resources(context)}
+if method == "resources/read":
+    uri = _required_string(params.get("uri"), "resources/read requires a non-empty string uri")
+    return await runtime.read_resource(uri, context)
+if method == "prompts/list":
+    return {"prompts": await runtime.list_prompts(context)}
+if method == "prompts/get":
+    name = _required_string(params.get("name"), "prompts/get requires a non-empty string name")
+    arguments = _object_or_empty(params.get("arguments"), "prompts/get arguments must be an object")
+    return await runtime.get_prompt(name, arguments, context)
+if method == "modules/list":
+    return {"modules": await runtime.list_modules(context)}
+if method == "modules/health":
+    return {"health": await runtime.get_modules_health(context)}
+```
+
+Do not introduce profile/default policy behavior in this slice.
+
+- [x] **Step 4: Run GREEN tests**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py -q
+```
+
+Expected: all gateway package tests pass.
+
+Evidence: `15 passed, 3 warnings`.
+
+### Task 3: Compatibility, Security, And Task Closeout
+
+**Files:**
+- Modify: `Docs/superpowers/plans/2026-05-30-mcp-unified-stage4b-gateway-protocol-surface-plan.md`
+- Modify: `backlog/tasks/task-559 - Implement-MCP-Unified-Stage-4B-gateway-protocol-surface.md`
+
+- [x] **Step 1: Run host compatibility tests**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_extraction_contracts.py tldw_Server_API/app/core/MCP_unified/tests/test_http_mapping.py -q
+```
+
+Expected: existing host extraction and HTTP mapping tests pass.
+
+Evidence: `47 passed, 4 warnings`.
+
+- [x] **Step 2: Run lint, security, and whitespace checks**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m ruff check mcp_unified/gateway tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r mcp_unified/gateway -f json -o /tmp/bandit_mcp_stage4b_gateway_protocol_surface.json
+git diff --check
+```
+
+Expected: Ruff passes, Bandit reports no findings for `mcp_unified/gateway`, and whitespace check is clean.
+
+Evidence: Ruff reported `All checks passed!`; Bandit JSON reported `"results": []`; `git diff --check` exited cleanly.
+
+- [x] **Step 3: Update plan and Backlog task**
+
+Record RED/GREEN and final verification evidence in this plan and TASK-559. Check off completed acceptance criteria and Definition of Done.
+
+- [x] **Step 4: Commit and push**
+
+Commit the plan, runtime/transport/test changes, and Backlog task update together.

--- a/backlog/tasks/task-559 - Implement-MCP-Unified-Stage-4B-gateway-protocol-surface.md
+++ b/backlog/tasks/task-559 - Implement-MCP-Unified-Stage-4B-gateway-protocol-surface.md
@@ -42,12 +42,23 @@ Verification recorded:
 - Ruff: `All checks passed!`.
 - Bandit: `/tmp/bandit_mcp_stage4b_gateway_protocol_surface.json` reported `"results": []`.
 - `git diff --check` exited cleanly.
+
+Review pass after PR #2141:
+- Rebasing onto latest `origin/dev` completed cleanly.
+- Open review threads found on initialize capability advertisement and optional prompt arguments in the fake runtime; both verified against current code before edits.
+- RED review test run: `2 failed, 14 passed, 3 warnings`; failures matched stale initialize capability flags and prompt fake runtime `KeyError` with missing arguments.
+- Fixed initialize capability advertisement to derive resource and prompt availability from the injected runtime method surface.
+- Fixed the fake runtime prompt result to tolerate omitted optional prompt arguments and added regression coverage for that path.
+- GREEN gateway review run: `16 passed, 3 warnings`.
+- Review validation: host compatibility `47 passed, 4 warnings`; Ruff `All checks passed!`; Bandit `/tmp/bandit_mcp_stage4b_gateway_review_fix.json` reported `"results": []`; `git diff --check` exited cleanly.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
 Stage 4B adds the standalone gateway protocol surface for resources, prompts, and module discovery/health through the injected runtime contract. The slice remains package-isolated, preserves host compatibility tests, and intentionally leaves storage wiring, stdio transport, external lifecycle, profile policy, and host route integration for later stages. No known skips or blockers.
+
+Post-PR review pass rebased the branch onto latest `origin/dev` and addressed the verified Qodo/CodeRabbit initialize capability finding plus the Gemini fake runtime optional-arguments finding.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-559 - Implement-MCP-Unified-Stage-4B-gateway-protocol-surface.md
+++ b/backlog/tasks/task-559 - Implement-MCP-Unified-Stage-4B-gateway-protocol-surface.md
@@ -1,0 +1,61 @@
+---
+id: TASK-559
+title: Implement MCP Unified Stage 4B gateway protocol surface
+status: Done
+labels:
+- mcp-unified
+- standalone-extraction
+- gateway
+priority: medium
+references:
+- https://github.com/rmusser01/tldw_server/pull/2139
+- Docs/superpowers/specs/2026-05-26-mcp-unified-standalone-library-gateway-design.md
+- Docs/superpowers/plans/2026-05-30-mcp-unified-stage4a-gateway-entrypoint-plan.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement the next narrow Stage 4B standalone gateway slice after Stage 4A: extend the package-owned FastAPI JSON-RPC gateway to route resources, prompts, and module discovery/health methods through the injected runtime protocol while preserving package isolation and host compatibility.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Gateway runtime contract supports resources/list, resources/read, prompts/list, prompts/get, modules/list, and modules/health without importing tldw_Server_API.
+- [x] #2 Gateway JSON-RPC dispatch validates params for the new methods and maps missing required fields to JSON-RPC invalid params responses.
+- [x] #3 Focused gateway tests prove the new method surface, context propagation, package isolation, unsupported method behavior, and notification/batch semantics remain intact.
+- [x] #4 Host extraction and HTTP mapping compatibility tests continue to pass.
+- [x] #5 Ruff, Bandit, and git diff hygiene are recorded before PR handoff.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Started from merged Stage 4A baseline on origin/dev commit 71f0edfe8c. Next narrow slice is gateway protocol surface parity for resources, prompts, and module discovery/health through the injected runtime, without storage, stdio, external lifecycle, or host route wiring.
+
+Implemented the Stage 4B protocol surface by extending the package-owned `GatewayRuntime` protocol and FastAPI JSON-RPC dispatch for `resources/list`, `resources/read`, `prompts/list`, `prompts/get`, `modules/list`, and `modules/health`. Added focused tests that verify runtime delegation, request context propagation, parameter validation, and preservation of existing Stage 4A behavior.
+
+Verification recorded:
+- RED gateway test run: `4 failed, 11 passed, 3 warnings` before implementation; new methods returned `Method not found`.
+- GREEN gateway test run: `15 passed, 3 warnings`.
+- Host compatibility: `47 passed, 4 warnings` for extraction contracts and HTTP mapping tests.
+- Ruff: `All checks passed!`.
+- Bandit: `/tmp/bandit_mcp_stage4b_gateway_protocol_surface.json` reported `"results": []`.
+- `git diff --check` exited cleanly.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Stage 4B adds the standalone gateway protocol surface for resources, prompts, and module discovery/health through the injected runtime contract. The slice remains package-isolated, preserves host compatibility tests, and intentionally leaves storage wiring, stdio transport, external lifecycle, profile policy, and host route integration for later stages. No known skips or blockers.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/mcp_unified/gateway/fastapi.py
+++ b/mcp_unified/gateway/fastapi.py
@@ -144,6 +144,12 @@ def _required_string(value: Any, message: str) -> str:
     return value.strip()
 
 
+def _runtime_supports(runtime: GatewayRuntime, *method_names: str) -> bool:
+    """Return whether the injected runtime exposes each named method."""
+
+    return all(callable(getattr(runtime, method_name, None)) for method_name in method_names)
+
+
 def _request_context(
     payload: GatewayJSONRPCRequest,
     request: Request,
@@ -171,8 +177,8 @@ async def _handle_initialize(
         "protocolVersion": _PROTOCOL_VERSION,
         "capabilities": {
             "tools": {"available": True},
-            "resources": {"available": False},
-            "prompts": {"available": False},
+            "resources": {"available": _runtime_supports(runtime, "list_resources", "read_resource")},
+            "prompts": {"available": _runtime_supports(runtime, "list_prompts", "get_prompt")},
         },
         "serverInfo": {
             "name": _runtime_name(runtime),

--- a/mcp_unified/gateway/fastapi.py
+++ b/mcp_unified/gateway/fastapi.py
@@ -136,6 +136,14 @@ def _object_or_empty(value: Any, message: str) -> dict[str, Any]:
     raise ValueError(message)
 
 
+def _required_string(value: Any, message: str) -> str:
+    """Return a stripped string value or reject missing and non-string input."""
+
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(message)
+    return value.strip()
+
+
 def _request_context(
     payload: GatewayJSONRPCRequest,
     request: Request,
@@ -197,9 +205,26 @@ async def _dispatch_jsonrpc(
             params.get("arguments"),
             "tools/call arguments must be an object",
         )
-        if not isinstance(tool_name, str) or not tool_name.strip():
-            raise ValueError("tools/call requires a non-empty string name")
+        tool_name = _required_string(tool_name, "tools/call requires a non-empty string name")
         return await runtime.call_tool(tool_name, arguments, context)
+    if method == "resources/list":
+        return {"resources": await runtime.list_resources(context)}
+    if method == "resources/read":
+        uri = _required_string(params.get("uri"), "resources/read requires a non-empty string uri")
+        return await runtime.read_resource(uri, context)
+    if method == "prompts/list":
+        return {"prompts": await runtime.list_prompts(context)}
+    if method == "prompts/get":
+        name = _required_string(params.get("name"), "prompts/get requires a non-empty string name")
+        arguments = _object_or_empty(
+            params.get("arguments"),
+            "prompts/get arguments must be an object",
+        )
+        return await runtime.get_prompt(name, arguments, context)
+    if method == "modules/list":
+        return {"modules": await runtime.list_modules(context)}
+    if method == "modules/health":
+        return {"health": await runtime.get_modules_health(context)}
 
     raise NotImplementedError(str(method))
 

--- a/mcp_unified/gateway/runtime.py
+++ b/mcp_unified/gateway/runtime.py
@@ -34,3 +34,36 @@ class GatewayRuntime(Protocol):
     ) -> dict[str, Any]:
         """Execute a tool call for the current request context."""
         ...
+
+    async def list_resources(self, context: GatewayRequestContext) -> list[dict[str, Any]]:
+        """Return resources visible to the current request context."""
+        ...
+
+    async def read_resource(
+        self,
+        uri: str,
+        context: GatewayRequestContext,
+    ) -> dict[str, Any]:
+        """Read one resource for the current request context."""
+        ...
+
+    async def list_prompts(self, context: GatewayRequestContext) -> list[dict[str, Any]]:
+        """Return prompts visible to the current request context."""
+        ...
+
+    async def get_prompt(
+        self,
+        name: str,
+        arguments: dict[str, Any],
+        context: GatewayRequestContext,
+    ) -> dict[str, Any]:
+        """Return one prompt result for the current request context."""
+        ...
+
+    async def list_modules(self, context: GatewayRequestContext) -> list[dict[str, Any]]:
+        """Return module registrations visible to the current request context."""
+        ...
+
+    async def get_modules_health(self, context: GatewayRequestContext) -> dict[str, Any]:
+        """Return module health details visible to the current request context."""
+        ...

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py
@@ -30,6 +30,12 @@ class _FakeGatewayRuntime:
     def __init__(self) -> None:
         self.list_contexts: list[Any] = []
         self.call_requests: list[tuple[str, dict[str, Any], Any]] = []
+        self.resource_list_contexts: list[Any] = []
+        self.resource_read_requests: list[tuple[str, Any]] = []
+        self.prompt_list_contexts: list[Any] = []
+        self.prompt_get_requests: list[tuple[str, dict[str, Any], Any]] = []
+        self.module_list_contexts: list[Any] = []
+        self.module_health_contexts: list[Any] = []
 
     async def list_tools(self, context: Any) -> list[dict[str, Any]]:
         self.list_contexts.append(context)
@@ -60,6 +66,72 @@ class _FakeGatewayRuntime:
                     "text": f"{name}:{arguments['query']}",
                 }
             ]
+        }
+
+    async def list_resources(self, context: Any) -> list[dict[str, Any]]:
+        self.resource_list_contexts.append(context)
+        return [
+            {
+                "uri": "resource://unit/doc",
+                "name": "Unit Doc",
+                "mimeType": "text/plain",
+            }
+        ]
+
+    async def read_resource(self, uri: str, context: Any) -> dict[str, Any]:
+        self.resource_read_requests.append((uri, context))
+        return {
+            "contents": [
+                {
+                    "uri": uri,
+                    "mimeType": "text/plain",
+                    "text": "hello resource",
+                }
+            ]
+        }
+
+    async def list_prompts(self, context: Any) -> list[dict[str, Any]]:
+        self.prompt_list_contexts.append(context)
+        return [
+            {
+                "name": "review.prompt",
+                "description": "Review a focused topic.",
+            }
+        ]
+
+    async def get_prompt(
+        self,
+        name: str,
+        arguments: dict[str, Any],
+        context: Any,
+    ) -> dict[str, Any]:
+        self.prompt_get_requests.append((name, arguments, context))
+        return {
+            "description": "Review a focused topic.",
+            "messages": [
+                {
+                    "role": "user",
+                    "content": {
+                        "type": "text",
+                        "text": f"{name}:{arguments['topic']}",
+                    },
+                }
+            ],
+        }
+
+    async def list_modules(self, context: Any) -> list[dict[str, Any]]:
+        self.module_list_contexts.append(context)
+        return [{"module_id": "unit", "name": "Unit Module"}]
+
+    async def get_modules_health(self, context: Any) -> dict[str, Any]:
+        self.module_health_contexts.append(context)
+        return {
+            "unit": {
+                "status": "healthy",
+                "message": "ok",
+                "checks": {},
+                "last_check": None,
+            }
         }
 
 
@@ -185,6 +257,85 @@ def test_gateway_request_rejects_malformed_json_with_jsonrpc_parse_error() -> No
     _assert_jsonrpc_error(response.json(), code=-32700, request_id=None)
 
 
+def test_gateway_fastapi_app_handles_resource_prompt_and_module_methods() -> None:
+    runtime = _FakeGatewayRuntime()
+    app = create_gateway_app(runtime, prefix="/mcp")
+
+    with TestClient(app) as client:
+        resources = client.post(
+            "/mcp/request",
+            json={"jsonrpc": "2.0", "method": "resources/list", "params": {}, "id": "resources-1"},
+        )
+        assert resources.status_code == 200
+        resources_body = resources.json()
+        assert resources_body["id"] == "resources-1"
+        assert resources_body["result"]["resources"][0]["uri"] == "resource://unit/doc"
+        assert runtime.resource_list_contexts[-1].request_id == "resources-1"
+
+        resource = client.post(
+            "/mcp/request",
+            json={
+                "jsonrpc": "2.0",
+                "method": "resources/read",
+                "params": {"uri": "resource://unit/doc"},
+                "id": "read-1",
+            },
+        )
+        assert resource.status_code == 200
+        resource_body = resource.json()
+        assert resource_body["id"] == "read-1"
+        assert resource_body["result"]["contents"][0]["text"] == "hello resource"
+        assert runtime.resource_read_requests[-1][0] == "resource://unit/doc"
+        assert runtime.resource_read_requests[-1][1].request_id == "read-1"
+
+        prompts = client.post(
+            "/mcp/request",
+            json={"jsonrpc": "2.0", "method": "prompts/list", "params": {}, "id": "prompts-1"},
+        )
+        assert prompts.status_code == 200
+        prompts_body = prompts.json()
+        assert prompts_body["id"] == "prompts-1"
+        assert prompts_body["result"]["prompts"][0]["name"] == "review.prompt"
+        assert runtime.prompt_list_contexts[-1].request_id == "prompts-1"
+
+        prompt = client.post(
+            "/mcp/request",
+            json={
+                "jsonrpc": "2.0",
+                "method": "prompts/get",
+                "params": {"name": "review.prompt", "arguments": {"topic": "gateway"}},
+                "id": "prompt-1",
+            },
+        )
+        assert prompt.status_code == 200
+        prompt_body = prompt.json()
+        assert prompt_body["id"] == "prompt-1"
+        assert prompt_body["result"]["messages"][0]["content"]["text"] == "review.prompt:gateway"
+        assert runtime.prompt_get_requests[-1][0] == "review.prompt"
+        assert runtime.prompt_get_requests[-1][1] == {"topic": "gateway"}
+        assert runtime.prompt_get_requests[-1][2].request_id == "prompt-1"
+
+        modules = client.post(
+            "/mcp/request",
+            json={"jsonrpc": "2.0", "method": "modules/list", "params": {}, "id": "modules-1"},
+        )
+        assert modules.status_code == 200
+        modules_body = modules.json()
+        assert modules_body["id"] == "modules-1"
+        assert modules_body["result"]["modules"][0]["module_id"] == "unit"
+        assert runtime.module_list_contexts[-1].request_id == "modules-1"
+
+        health = client.post(
+            "/mcp/request",
+            json={"jsonrpc": "2.0", "method": "modules/health", "params": {}, "id": "health-1"},
+        )
+        assert health.status_code == 200
+        health_body = health.json()
+        assert health_body["id"] == "health-1"
+        assert health_body["result"]["health"]["unit"]["status"] == "healthy"
+        assert runtime.module_health_contexts[-1].request_id == "health-1"
+
+
 def test_gateway_request_rejects_missing_jsonrpc_member() -> None:
     runtime = _FakeGatewayRuntime()
     app = create_gateway_app(runtime, prefix="/mcp")
@@ -249,6 +400,59 @@ def test_gateway_request_rejects_non_object_tool_arguments_without_coercion() ->
     assert response.status_code == 200
     _assert_jsonrpc_error(response.json(), code=-32602, request_id="bad-args")
     assert runtime.call_requests == []
+
+
+def test_gateway_request_rejects_missing_resource_uri() -> None:
+    runtime = _FakeGatewayRuntime()
+    app = create_gateway_app(runtime, prefix="/mcp")
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/mcp/request",
+            json={"jsonrpc": "2.0", "method": "resources/read", "params": {}, "id": "bad-resource"},
+        )
+
+    assert response.status_code == 200
+    _assert_jsonrpc_error(response.json(), code=-32602, request_id="bad-resource")
+    assert runtime.resource_read_requests == []
+
+
+def test_gateway_request_rejects_missing_prompt_name() -> None:
+    runtime = _FakeGatewayRuntime()
+    app = create_gateway_app(runtime, prefix="/mcp")
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/mcp/request",
+            json={"jsonrpc": "2.0", "method": "prompts/get", "params": {}, "id": "bad-prompt"},
+        )
+
+    assert response.status_code == 200
+    _assert_jsonrpc_error(response.json(), code=-32602, request_id="bad-prompt")
+    assert runtime.prompt_get_requests == []
+
+
+def test_gateway_request_rejects_non_object_prompt_arguments_without_coercion() -> None:
+    runtime = _FakeGatewayRuntime()
+    app = create_gateway_app(runtime, prefix="/mcp")
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/mcp/request",
+            json={
+                "jsonrpc": "2.0",
+                "method": "prompts/get",
+                "params": {
+                    "name": "review.prompt",
+                    "arguments": [],
+                },
+                "id": "bad-prompt-args",
+            },
+        )
+
+    assert response.status_code == 200
+    _assert_jsonrpc_error(response.json(), code=-32602, request_id="bad-prompt-args")
+    assert runtime.prompt_get_requests == []
 
 
 def test_gateway_request_maps_custom_runtime_exceptions_to_jsonrpc_internal_error() -> None:

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py
@@ -106,6 +106,7 @@ class _FakeGatewayRuntime:
         context: Any,
     ) -> dict[str, Any]:
         self.prompt_get_requests.append((name, arguments, context))
+        topic = arguments.get("topic", "")
         return {
             "description": "Review a focused topic.",
             "messages": [
@@ -113,7 +114,7 @@ class _FakeGatewayRuntime:
                     "role": "user",
                     "content": {
                         "type": "text",
-                        "text": f"{name}:{arguments['topic']}",
+                        "text": f"{name}:{topic}",
                     },
                 }
             ],
@@ -210,6 +211,9 @@ def test_gateway_fastapi_app_handles_basic_jsonrpc_flow() -> None:
             "name": "unit-gateway",
             "version": "0.0-test",
         }
+        capabilities = initialized.json()["result"]["capabilities"]
+        assert capabilities["resources"]["available"] is True
+        assert capabilities["prompts"]["available"] is True
 
         listed = client.post(
             "/mcp/request",
@@ -430,6 +434,28 @@ def test_gateway_request_rejects_missing_prompt_name() -> None:
     assert response.status_code == 200
     _assert_jsonrpc_error(response.json(), code=-32602, request_id="bad-prompt")
     assert runtime.prompt_get_requests == []
+
+
+def test_gateway_prompt_get_accepts_missing_arguments() -> None:
+    runtime = _FakeGatewayRuntime()
+    app = create_gateway_app(runtime, prefix="/mcp")
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/mcp/request",
+            json={
+                "jsonrpc": "2.0",
+                "method": "prompts/get",
+                "params": {"name": "review.prompt"},
+                "id": "prompt-no-args",
+            },
+        )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["id"] == "prompt-no-args"
+    assert body["result"]["messages"][0]["content"]["text"] == "review.prompt:"
+    assert runtime.prompt_get_requests[-1][1] == {}
 
 
 def test_gateway_request_rejects_non_object_prompt_arguments_without_coercion() -> None:


### PR DESCRIPTION
## Change summary (maintainer-owned)

- Extends the package-owned `mcp_unified.gateway` runtime protocol with resource, prompt, and module discovery/health methods.
- Routes `resources/list`, `resources/read`, `prompts/list`, `prompts/get`, `modules/list`, and `modules/health` through the FastAPI JSON-RPC gateway while preserving runtime injection and package isolation.
- Adds focused gateway regression coverage for the new method surface, context propagation, invalid params handling, and existing Stage 4A behavior.

## Why

Stage 4A established the standalone gateway entrypoint for initialize, ping, and tools. This Stage 4B slice expands the same package-owned transport seam to the next MCP discovery surfaces without pulling in host-only implementation code, storage wiring, stdio transport, lifecycle orchestration, profile policy, or host route integration.

## Validation

- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py -q` -> `15 passed, 3 warnings`
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_extraction_contracts.py tldw_Server_API/app/core/MCP_unified/tests/test_http_mapping.py -q` -> `47 passed, 4 warnings`
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m ruff check mcp_unified/gateway tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py` -> `All checks passed!`
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r mcp_unified/gateway -f json -o /tmp/bandit_mcp_stage4b_gateway_protocol_surface.json` -> `"results": []`
- `git diff --check`

## UX Audit Checklist

- [x] Backend/package transport only; no user-facing UI changes.

## Watchlists

- [x] MCP Unified standalone extraction
- [x] Package isolation from `tldw_Server_API`
- [x] Host extraction and HTTP mapping compatibility

## Rollback

Revert `05cc90467b` to remove the Stage 4B gateway protocol surface and tests.

Backlog: `TASK-559`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Stage 4B gateway protocol surface for resources, prompts, and modules. The `mcp_unified.gateway` runtime and `FastAPI` JSON-RPC app now route these methods with validation, context propagation, and accurate capability flags during initialize.

- New Features
  - Runtime protocol adds: list_resources, read_resource, list_prompts, get_prompt, list_modules, get_modules_health.
  - Gateway routes added: resources/list, resources/read, prompts/list, prompts/get, modules/list, modules/health.
  - Initialize advertises resources and prompts availability based on runtime support; prompts/get accepts missing arguments (defaults to {}) and rejects non-object values.
  - Preserves runtime injection and package isolation; focused tests cover the new surface and keep Stage 4A behavior unchanged.

<sup>Written for commit 376b4b7a954874755569cc992757805ac7ddac5d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2141?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

