### PR TITLE
Continue Admin design-system product-state migration

### DIFF
--- a/apps/packages/ui/scripts/design-system-product-state-baseline.json
+++ b/apps/packages/ui/scripts/design-system-product-state-baseline.json
@@ -374,17 +374,6 @@
     "migrationQueue": "shared-product-state"
   },
   {
-    "id": "antd-product-state-import:src/components/Option/Admin/ServerArgsEditor.tsx:Alert",
-    "path": "src/components/Option/Admin/ServerArgsEditor.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/Option/Admin/ServerArgsEditor.tsx before the guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
     "id": "antd-product-state-import:src/components/Option/Admin/UsageAnalyticsPage.tsx:Alert#antd-alert-usageanalyticspage-type-error-access-denied-y-14wdvha",
     "path": "src/components/Option/Admin/UsageAnalyticsPage.tsx",
     "rule": "antd-product-state-import",

--- a/apps/packages/ui/src/components/Option/Admin/ServerArgsEditor.tsx
+++ b/apps/packages/ui/src/components/Option/Admin/ServerArgsEditor.tsx
@@ -1,6 +1,7 @@
 import React from "react"
-import { Input, Button, Space, Typography, Switch, Alert } from "antd"
+import { Input, Button, Space, Typography, Switch } from "antd"
 import { Plus, Trash2 } from "lucide-react"
+import { Alert as DesignSystemAlert } from "@/components/ui/primitives"
 
 const { Text } = Typography
 const { TextArea } = Input
@@ -141,11 +142,10 @@ export const ServerArgsEditor: React.FC<ServerArgsEditorProps> = ({
             className="font-mono text-xs"
           />
           {jsonError && (
-            <Alert
-              type="error"
+            <DesignSystemAlert
+              variant="error"
               title={jsonError}
               className="mt-2"
-              showIcon
             />
           )}
         </div>

--- a/apps/packages/ui/src/components/Option/Admin/ServerArgsEditor.tsx
+++ b/apps/packages/ui/src/components/Option/Admin/ServerArgsEditor.tsx
@@ -125,6 +125,7 @@ export const ServerArgsEditor: React.FC<ServerArgsEditorProps> = ({
           </Text>
           <Switch
             size="small"
+            aria-label="Toggle JSON mode"
             checked={jsonMode}
             onChange={handleModeSwitch}
           />

--- a/apps/packages/ui/src/components/Option/Admin/__tests__/ServerArgsEditor.design-system.test.tsx
+++ b/apps/packages/ui/src/components/Option/Admin/__tests__/ServerArgsEditor.design-system.test.tsx
@@ -1,0 +1,36 @@
+// @vitest-environment jsdom
+import React from "react"
+import { fireEvent, render, screen } from "@testing-library/react"
+import { describe, expect, it, vi } from "vitest"
+import { ServerArgsEditor } from "../ServerArgsEditor"
+
+describe("ServerArgsEditor design-system states", () => {
+  it("renders JSON validation feedback through the design-system Alert primitive", async () => {
+    render(<ServerArgsEditor value={{ threads: 4 }} onChange={vi.fn()} />)
+
+    fireEvent.click(screen.getByRole("switch"))
+    const editor = screen.getByRole("textbox")
+
+    fireEvent.change(editor, {
+      target: { value: "{" }
+    })
+
+    await expectDesignSystemAlert("Invalid JSON")
+
+    fireEvent.change(editor, {
+      target: { value: "[]" }
+    })
+
+    await expectDesignSystemAlert("Must be a JSON object")
+  })
+})
+
+async function expectDesignSystemAlert(message: string) {
+  const title = await screen.findByText(message)
+  const alert = title.closest('[data-ds-component="Alert"]')
+
+  expect(alert).not.toBeNull()
+  const alertEl = alert as HTMLElement
+  expect(alertEl).toHaveAttribute("role", "alert")
+  expect(alertEl).toHaveTextContent(message)
+}

--- a/apps/packages/ui/src/components/Option/Admin/__tests__/ServerArgsEditor.design-system.test.tsx
+++ b/apps/packages/ui/src/components/Option/Admin/__tests__/ServerArgsEditor.design-system.test.tsx
@@ -8,8 +8,8 @@ describe("ServerArgsEditor design-system states", () => {
   it("renders JSON validation feedback through the design-system Alert primitive", async () => {
     render(<ServerArgsEditor value={{ threads: 4 }} onChange={vi.fn()} />)
 
-    fireEvent.click(screen.getByRole("switch"))
-    const editor = screen.getByRole("textbox")
+    fireEvent.click(screen.getByRole("switch", { name: /json mode/i }))
+    const editor = await screen.findByPlaceholderText('{"key": "value"}')
 
     fireEvent.change(editor, {
       target: { value: "{" }

--- a/backlog/tasks/task-45.44.7 - Migrate-design-system-product-state-Admin-and-health-expansion.md
+++ b/backlog/tasks/task-45.44.7 - Migrate-design-system-product-state-Admin-and-health-expansion.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-45.44.7
 title: 'Migrate design-system product state: Admin and health expansion'
-status: To Do
+status: In Progress
 assignee: []
 created_date: '2026-05-14 03:19'
-updated_date: '2026-05-24 01:05'
+updated_date: '2026-05-30 08:58'
 labels:
   - design-system
   - webui
@@ -26,6 +26,18 @@ documentation:
       - Admin and health expansion exceptions: 41 -> 39
       - WatchlistsPage target rows: 2 -> 0
     Verification recorded in TASK-45.44.3.9.
+
+    TASK-45.44.7.1 migrated ServerArgsEditor JSON validation feedback from AntD
+    Alert to the design-system Alert primitive.
+
+    Baseline file evidence:
+      - total baseline rows: 195 -> 194
+      - Admin path rows: 37 -> 36
+      - ServerArgsEditor target row: 1 -> 0
+
+    Verifier evidence:
+      - scoped verifier log had no ServerArgsEditor findings
+      - full verifier remains blocked by unrelated current-dev drift outside this slice
 parent_task_id: TASK-45.44
 priority: medium
 ---

--- a/backlog/tasks/task-45.44.7.1 - Migrate-ServerArgsEditor-alert-to-design-system-Alert.md
+++ b/backlog/tasks/task-45.44.7.1 - Migrate-ServerArgsEditor-alert-to-design-system-Alert.md
@@ -1,0 +1,58 @@
+---
+id: TASK-45.44.7.1
+title: Migrate ServerArgsEditor alert to design-system Alert
+status: Done
+assignee: []
+created_date: '2026-05-30 15:49'
+labels:
+  - design-system
+  - webui
+  - admin
+  - product-state
+dependencies: []
+references:
+  - apps/packages/ui/src/components/Option/Admin/ServerArgsEditor.tsx
+  - apps/packages/ui/scripts/design-system-product-state-baseline.json
+parent_task_id: TASK-45.44.7
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Continue the Admin and health expansion design-system migration by replacing ServerArgsEditor's remaining AntD Alert product-state usage with the shared design-system Alert primitive while preserving the existing JSON validation copy.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 ServerArgsEditor renders JSON validation feedback through the shared design-system Alert primitive instead of AntD Alert.
+- [x] #2 Focused coverage asserts the validation feedback uses the design-system Alert marker and preserves the existing copy.
+- [x] #3 The ServerArgsEditor AntD Alert baseline exception is removed without introducing new product-state guard findings for the component.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+- Red verification: `bunx vitest run src/components/Option/Admin/__tests__/ServerArgsEditor.design-system.test.tsx` failed because the JSON validation feedback had no `data-ds-component="Alert"` ancestor.
+- Replaced the JSON validation AntD Alert with the shared design-system Alert primitive and preserved the existing `Invalid JSON` / `Must be a JSON object` title copy.
+- Removed the `ServerArgsEditor` AntD Alert baseline exception from `apps/packages/ui/scripts/design-system-product-state-baseline.json`.
+- Verification: focused ServerArgsEditor design-system Vitest passed; product-state guard unit test passed (54 tests); baseline JSON parsed; scoped verifier log at `/tmp/server-args-editor-design-state.log` has no `ServerArgsEditor` findings and reports baseline exceptions at 190.
+- Full `bun run verify:design-system-state` still exits 1 on current-dev drift outside this slice: IntegrationPolicyPanel, WritingActionBar, Notes, ResearchWorkspace, plus stale IntegrationPolicyPanel baseline entries.
+- Bandit skipped because this slice only touches frontend TypeScript/TSX, JSON baseline, and Backlog metadata.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Migrated ServerArgsEditor JSON validation feedback from AntD Alert to the shared design-system Alert primitive, added focused coverage for the design-system Alert marker and preserved copy, and removed the matching ServerArgsEditor product-state baseline exception. Focused component coverage, product-state guard unit coverage, baseline JSON parsing, and scoped verifier inspection were recorded. The full product-state verifier remains blocked by unrelated current-dev drift, with no ServerArgsEditor findings.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-45.44.7.1 - Migrate-ServerArgsEditor-alert-to-design-system-Alert.md
+++ b/backlog/tasks/task-45.44.7.1 - Migrate-ServerArgsEditor-alert-to-design-system-Alert.md
@@ -39,12 +39,14 @@ Continue the Admin and health expansion design-system migration by replacing Ser
 - Verification: focused ServerArgsEditor design-system Vitest passed; product-state guard unit test passed (54 tests); baseline JSON parsed; scoped verifier log at `/tmp/server-args-editor-design-state.log` has no `ServerArgsEditor` findings and reports baseline exceptions at 190.
 - Full `bun run verify:design-system-state` still exits 1 on current-dev drift outside this slice: IntegrationPolicyPanel, WritingActionBar, Notes, ResearchWorkspace, plus stale IntegrationPolicyPanel baseline entries.
 - Bandit skipped because this slice only touches frontend TypeScript/TSX, JSON baseline, and Backlog metadata.
+- Review fix: Qodo flagged the focused test's generic `switch` / `textbox` selectors as brittle. Added an accessible name to the JSON mode switch and tightened the test to query the named switch plus the JSON editor placeholder. Red verification failed on the unnamed switch, then focused Vitest passed after the component fix.
+- Review-fix verification: focused ServerArgsEditor design-system Vitest passed; product-state guard unit test passed (54 tests); baseline JSON parsed; `git diff --check` passed; scoped verifier log still has no `ServerArgsEditor` findings.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Migrated ServerArgsEditor JSON validation feedback from AntD Alert to the shared design-system Alert primitive, added focused coverage for the design-system Alert marker and preserved copy, and removed the matching ServerArgsEditor product-state baseline exception. Focused component coverage, product-state guard unit coverage, baseline JSON parsing, and scoped verifier inspection were recorded. The full product-state verifier remains blocked by unrelated current-dev drift, with no ServerArgsEditor findings.
+Migrated ServerArgsEditor JSON validation feedback from AntD Alert to the shared design-system Alert primitive, added focused coverage for the design-system Alert marker and preserved copy, removed the matching ServerArgsEditor product-state baseline exception, and tightened the review-fix selectors by naming the JSON mode switch and querying the JSON editor directly. Focused component coverage, product-state guard unit coverage, baseline JSON parsing, whitespace checks, and scoped verifier inspection were recorded. The full product-state verifier remains blocked by unrelated current-dev drift, with no ServerArgsEditor findings.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-45.49 - Migrate-ReportBuilderDrawer-ready-label-to-design-system-registry.md
+++ b/backlog/tasks/task-45.49 - Migrate-ReportBuilderDrawer-ready-label-to-design-system-registry.md
@@ -25,6 +25,10 @@ Continue the tldw_server WebUI design-system migration by routing the Watchlists
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
+- [x] #1 ReportBuilderDrawer readiness success fallback uses READY_STATE_LABEL from the design-system state registry.
+- [x] #2 Focused ReportBuilderDrawer coverage proves the readiness label comes from the registry contract.
+- [x] #3 The matching canonical-state-label baseline entry is removed.
+- [x] #4 Verification results and inherited TypeScript baseline debt are recorded.
 <!-- AC:END -->
 
 ## Implementation Notes
@@ -41,10 +45,10 @@ Routed ReportBuilderDrawer's readiness success fallback through READY_STATE_LABE
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->

--- a/backlog/tasks/task-45.50 - Migrate-ReportBuilderDrawer-ready-badge-to-design-system-Badge.md
+++ b/backlog/tasks/task-45.50 - Migrate-ReportBuilderDrawer-ready-badge-to-design-system-Badge.md
@@ -24,6 +24,10 @@ Continue the tldw_server WebUI design-system migration by replacing ReportBuilde
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
+- [x] #1 ReportBuilderDrawer readiness success tag is replaced with the shared design-system Badge primitive.
+- [x] #2 The ready badge preserves READY_STATE_LABEL and the existing watchlists i18n key.
+- [x] #3 Focused ReportBuilderDrawer coverage asserts the ready label renders inside a success design-system Badge.
+- [x] #4 Product-state guard verification and inherited TypeScript baseline debt are recorded.
 <!-- AC:END -->
 
 ## Implementation Notes
@@ -40,10 +44,10 @@ Replaced ReportBuilderDrawer's ready readiness AntD Tag with the shared design-s
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->

--- a/backlog/tasks/task-551 - Stabilize-audio-transcription-heartbeat-test-dependency-overrides.md
+++ b/backlog/tasks/task-551 - Stabilize-audio-transcription-heartbeat-test-dependency-overrides.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-551
 title: Stabilize audio transcription heartbeat test dependency overrides
-status: In Progress
+status: Done
 assignee: []
 created_date: ''
 updated_date: '2026-05-30 06:45'
@@ -25,7 +25,7 @@ Fix the PR #2133 full-suite Audio test failure where the heartbeat create_task f
 - [x] #1 The hotwords audio test helper bypasses AuthNZ DB/principal dependencies for endpoint-level tests.
 - [x] #2 The failing heartbeat task startup regression test passes locally.
 - [x] #3 Existing design-system dictionary verification remains unchanged.
-- [ ] #4 PR #2133 CI no longer fails in the Audio full-suite module for this test.
+- [x] #4 PR #2133 CI no longer fails in the Audio full-suite module for this test.
 <!-- AC:END -->
 
 ## Implementation Notes
@@ -51,15 +51,15 @@ Additional local verification:
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-
+PR #2133 merged on 2026-05-30 after the audio heartbeat dependency override and deterministic heartbeat jobs wait fixes were included. The original Audio full-suite failures no longer block the merged PR. Local verification covered the focused heartbeat startup failure test, the heartbeat jobs log test, the full hotwords audio test file, the dictionary design-system regression, diff whitespace, and Bandit for touched Admin/Audio files with only low-severity test assert findings.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
+- [x] #1 Acceptance criteria completed
 - [x] #2 Tests or verification recorded
 - [x] #3 Documentation updated when relevant
 - [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->

--- a/backlog/tasks/task-552 - Stabilize-Windows-admin-bundle-AuthNZ-backup-path-resolution.md
+++ b/backlog/tasks/task-552 - Stabilize-Windows-admin-bundle-AuthNZ-backup-path-resolution.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-552
 title: Stabilize Windows admin bundle AuthNZ backup path resolution
-status: In Progress
+status: Done
 assignee: []
 created_date: ''
 updated_date: '2026-05-30 06:45'
@@ -24,7 +24,7 @@ Fix PR #2133 Windows full-suite failure where Admin bundle export returns export
 <!-- AC:BEGIN -->
 - [x] #1 Windows-style sqlite DATABASE_URL paths like sqlite:///C:\\... resolve to a valid filesystem path for AuthNZ backups.
 - [x] #2 The Admin authnz-only bundle test still passes locally.
-- [ ] #3 PR #2133 CI no longer fails the Admin full-suite module for this path.
+- [x] #3 PR #2133 CI no longer fails the Admin full-suite module for this path.
 <!-- AC:END -->
 
 ## Implementation Notes
@@ -41,15 +41,15 @@ Local verification:
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-
+PR #2133 merged on 2026-05-30 after the Windows sqlite AuthNZ path normalization fix was included. The Admin full-suite bundle failure no longer blocks the merged PR. Local verification covered the focused Windows-style sqlite URL regression, the authnz-only bundle test, diff whitespace, and Bandit for touched Admin/Audio files with only low-severity test assert findings.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
+- [x] #1 Acceptance criteria completed
 - [x] #2 Tests or verification recorded
 - [x] #3 Documentation updated when relevant
 - [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->


### PR DESCRIPTION
## Summary
- Close merged design-system follow-up Backlog records that were left incomplete after the previous PR.
- Migrate `ServerArgsEditor` JSON validation feedback from AntD `Alert` to the shared design-system `Alert` primitive.
- Add focused regression coverage, remove the matching product-state baseline row, and update the Admin/health tracker with before/after evidence.

## Verification
- `bunx vitest run src/components/Option/Admin/__tests__/ServerArgsEditor.design-system.test.tsx`
- `bunx vitest run src/design-system/__tests__/product-state-guard.test.ts --reporter=dot`
- `node -e "JSON.parse(require('fs').readFileSync('apps/packages/ui/scripts/design-system-product-state-baseline.json','utf8')); console.log('baseline json ok')"`
- `git diff --check`
- `bun run verify:design-system-state > /tmp/server-args-editor-design-state.log 2>&1` still exits 1 on unrelated current-dev drift: IntegrationPolicyPanel, WritingActionBar, Notes, ResearchWorkspace, and stale IntegrationPolicyPanel baseline rows. The scoped log has no `ServerArgsEditor` findings and reports `Baseline exceptions: 190` / `Admin and health expansion: 36`.

## Change summary (maintainer-owned)
Pending maintainer-written summary before merge. The summary should explain what changed and why these implementation choices were made.

## Notes
- Bandit skipped for the new slice because the touched implementation is frontend TS/TSX plus JSON/Backlog metadata only.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrated `ServerArgsEditor` JSON validation feedback from `antd` `Alert` to the design-system `Alert`, aligning Admin with the post-2133 migration and improving a11y/test stability.

- **Refactors**
  - Replace `antd` `Alert` with design-system `Alert` in `ServerArgsEditor` (keeps messages; uses `variant="error"`).
  - Add accessible name to the JSON mode `Switch` (`aria-label="Toggle JSON mode"`) for stable queries.
  - Remove `ServerArgsEditor` `Alert` exception from `apps/packages/ui/scripts/design-system-product-state-baseline.json`.
  - Add a focused test asserting `data-ds-component="Alert"` and `role="alert"`; tighten selectors to use the named switch and JSON editor placeholder.

<sup>Written for commit 008c3f98a7dac1ce69628ee95251dfdc0b03ecbe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2142?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

