### PR TITLE
Add MCP Unified Stage 4C gateway WebSocket transport

### DIFF
--- a/Docs/superpowers/plans/2026-05-30-mcp-unified-stage4c-gateway-websocket-transport-plan.md
+++ b/Docs/superpowers/plans/2026-05-30-mcp-unified-stage4c-gateway-websocket-transport-plan.md
@@ -1,0 +1,138 @@
+# MCP Unified Stage 4C Gateway WebSocket Transport Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add package-owned FastAPI WebSocket JSON-RPC transport for the standalone MCP gateway.
+
+**Architecture:** Keep the package transport thin and host-neutral. The WebSocket endpoint accepts JSON text/object frames, reuses the existing JSON-RPC validation/dispatch/error mapping, sends only JSON-RPC response envelopes, and suppresses notification-only responses the same way HTTP returns 204. This slice does not add auth/session policy, stdio, SQLite wiring, external lifecycle, or host route integration.
+
+**Tech Stack:** Python 3.11, FastAPI/TestClient WebSocket support, Pydantic v1/v2 compatibility, pytest, Ruff, Bandit.
+
+---
+
+### Task 1: Gateway WebSocket RED Tests
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py`
+- Modify: `mcp_unified/gateway/fastapi.py`
+
+- [x] **Step 1: Add WebSocket success coverage**
+
+Add a package gateway test that connects to `/mcp/ws`, sends `initialize`, `ping`, and one Stage 4B discovery request such as `resources/list`, and asserts:
+
+- every response has `jsonrpc == "2.0"`
+- response ids are echoed
+- payloads match the HTTP transport results
+- runtime context request ids are propagated
+
+- [x] **Step 2: Add WebSocket parse-error coverage**
+
+Add a test that sends invalid JSON text over `/mcp/ws` and expects a JSON-RPC `-32700` parse error response with `id: null`.
+
+- [x] **Step 3: Add notification and batch coverage**
+
+Add a test that sends a notification-only `ping` frame and then a regular `ping` request on the same WebSocket, proving the notification produces no response and the next request still succeeds.
+
+Add a test that sends a mixed batch with one notification and one request and asserts only the request response is sent.
+
+- [x] **Step 4: Run RED tests**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py -q
+```
+
+Expected: the new WebSocket tests fail because `/mcp/ws` is not exposed yet.
+
+Evidence: `4 failed, 16 passed, 3 warnings`; all new WebSocket tests failed at connection setup because `/mcp/ws` was not registered.
+
+### Task 2: Package WebSocket Transport
+
+**Files:**
+- Modify: `mcp_unified/gateway/fastapi.py`
+- Modify: `tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py`
+
+- [x] **Step 1: Import FastAPI WebSocket primitives**
+
+Add `WebSocket` and `WebSocketDisconnect` imports from FastAPI.
+
+- [x] **Step 2: Add raw payload parsing helper**
+
+Extract raw JSON parsing into a helper that accepts a text/bytes frame and returns the same JSON-RPC parse error object used by HTTP for malformed JSON.
+
+- [x] **Step 3: Add WebSocket send helper**
+
+Add a helper that sends JSON-RPC response models/lists through `websocket.send_json(...)` and intentionally does nothing for notification-only `Response(status_code=204)` results.
+
+- [x] **Step 4: Add `/ws` route**
+
+Inside `create_gateway_router(runtime)`, add:
+
+```python
+@router.websocket("/ws")
+async def gateway_websocket(websocket: WebSocket) -> None:
+    await websocket.accept()
+    while True:
+        frame = await websocket.receive_text()
+        payload = _parse_json_payload(frame)
+        if isinstance(payload, _GATEWAY_RESPONSE_TYPES):
+            await websocket.send_json(_response_to_json(payload))
+            continue
+        response = await _handle_jsonrpc(runtime, payload, websocket)
+        await _send_websocket_response(websocket, response)
+```
+
+Use a request-context metadata path compatible with WebSocket objects.
+
+- [x] **Step 5: Run GREEN tests**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py -q
+```
+
+Expected: all gateway package tests pass.
+
+Evidence: `20 passed, 3 warnings`.
+
+### Task 3: Compatibility, Security, And PR Handoff
+
+**Files:**
+- Modify: `Docs/superpowers/plans/2026-05-30-mcp-unified-stage4c-gateway-websocket-transport-plan.md`
+- Modify: `backlog/tasks/task-560 - Implement-MCP-Unified-Stage-4C-gateway-WebSocket-transport.md`
+
+- [x] **Step 1: Run host compatibility tests**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_extraction_contracts.py tldw_Server_API/app/core/MCP_unified/tests/test_http_mapping.py -q
+```
+
+Expected: existing host extraction and HTTP mapping tests pass.
+
+Evidence: `47 passed, 4 warnings`.
+
+- [x] **Step 2: Run lint, security, and whitespace checks**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m ruff check mcp_unified/gateway tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r mcp_unified/gateway -f json -o /tmp/bandit_mcp_stage4c_gateway_websocket_transport.json
+git diff --check
+```
+
+Expected: Ruff passes, Bandit reports no findings for `mcp_unified/gateway`, and whitespace check is clean.
+
+Evidence: Ruff reported `All checks passed!`; Bandit JSON reported `"results": []`; `git diff --check` exited cleanly.
+
+- [x] **Step 3: Update plan and Backlog task**
+
+Record RED/GREEN and final verification evidence in this plan and TASK-560. Check off completed acceptance criteria and Definition of Done.
+
+- [x] **Step 4: Commit, push, and open PR**
+
+Commit the plan, gateway/test changes, and Backlog task update together, push the branch, and open a PR against `dev`.

--- a/backlog/tasks/task-560 - Implement-MCP-Unified-Stage-4C-gateway-WebSocket-transport.md
+++ b/backlog/tasks/task-560 - Implement-MCP-Unified-Stage-4C-gateway-WebSocket-transport.md
@@ -43,12 +43,23 @@ Verification recorded:
 - Ruff: `All checks passed!`.
 - Bandit: `/tmp/bandit_mcp_stage4c_gateway_websocket_transport.json` reported `"results": []`.
 - `git diff --check` exited cleanly.
+
+Review pass after PR #2143:
+- Rebasing onto latest `origin/dev` completed cleanly.
+- Open review threads found on binary/non-text WebSocket frames, Pydantic v1 JSON-safe serialization fallback, and disconnects during WebSocket send/processing; each was verified against current code before edits.
+- RED review test run: `2 failed, 20 passed, 3 warnings`; failures matched binary WebSocket frame handling and the Pydantic v1-like non-JSON-safe fallback.
+- Fixed the WebSocket receive loop to accept text and bytes frames, return JSON-RPC invalid-request errors for unsupported frame shapes, and absorb disconnect/closed-socket exceptions across receive, dispatch, and send.
+- Fixed the Pydantic v1 fallback path to JSON-encode the v1 `.dict()` payload before `send_json`.
+- GREEN gateway review run: `22 passed, 3 warnings`.
+- Review validation: host compatibility `47 passed, 4 warnings`; Ruff `All checks passed!`; Bandit `/tmp/bandit_mcp_stage4c_gateway_review_fix.json` reported `"results": []`; `git diff --check` exited cleanly.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
 Stage 4C adds the standalone package FastAPI WebSocket transport for JSON-RPC messages while keeping runtime dispatch, validation, notification behavior, and batch response filtering shared with the HTTP transport. This slice remains package-isolated and intentionally leaves auth/session policy, stdio, SQLite wiring, external lifecycle, and host route integration for later stages. No known skips or blockers.
+
+Post-PR review pass rebased the branch onto latest `origin/dev` and addressed the verified WebSocket reliability findings for binary frames, JSON-safe v1 serialization fallback, and disconnect handling.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-560 - Implement-MCP-Unified-Stage-4C-gateway-WebSocket-transport.md
+++ b/backlog/tasks/task-560 - Implement-MCP-Unified-Stage-4C-gateway-WebSocket-transport.md
@@ -8,7 +8,7 @@ labels:
 - gateway
 priority: medium
 references:
-- https://github.com/rmusser01/tldw_server/pull/2141
+- https://github.com/rmusser01/tldw_server/pull/2143
 - Docs/superpowers/specs/2026-05-26-mcp-unified-standalone-library-gateway-design.md
 - Docs/superpowers/plans/2026-05-30-mcp-unified-stage4b-gateway-protocol-surface-plan.md
 ---

--- a/backlog/tasks/task-560 - Implement-MCP-Unified-Stage-4C-gateway-WebSocket-transport.md
+++ b/backlog/tasks/task-560 - Implement-MCP-Unified-Stage-4C-gateway-WebSocket-transport.md
@@ -1,0 +1,62 @@
+---
+id: TASK-560
+title: Implement MCP Unified Stage 4C gateway WebSocket transport
+status: Done
+labels:
+- mcp-unified
+- standalone-extraction
+- gateway
+priority: medium
+references:
+- https://github.com/rmusser01/tldw_server/pull/2141
+- Docs/superpowers/specs/2026-05-26-mcp-unified-standalone-library-gateway-design.md
+- Docs/superpowers/plans/2026-05-30-mcp-unified-stage4b-gateway-protocol-surface-plan.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement the next narrow Stage 4C standalone gateway slice after Stage 4B: add package-owned FastAPI WebSocket JSON-RPC transport that reuses the existing gateway dispatcher and preserves package isolation and host compatibility.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Gateway FastAPI router exposes a package-owned WebSocket endpoint for JSON-RPC messages without importing tldw_Server_API.
+- [x] #2 WebSocket transport handles initialize, ping, resources/prompts/modules/tools requests using the same dispatcher and response envelope behavior as HTTP.
+- [x] #3 WebSocket transport maps malformed JSON text frames to JSON-RPC parse errors and suppresses notification responses consistently with HTTP notification behavior.
+- [x] #4 Focused gateway tests cover WebSocket success, parse error, notification/no-response, batch behavior, and package isolation.
+- [x] #5 Host extraction and HTTP mapping compatibility tests continue to pass; Ruff, Bandit, and git diff hygiene are recorded before PR handoff.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Started from merged Stage 4B baseline on origin/dev commit 27f2b4b7eb. Implemented the next narrow Stage 4C gateway transport slice by adding package-owned `/ws` WebSocket JSON-RPC handling in `mcp_unified.gateway.fastapi`.
+
+The WebSocket route accepts text frames, reuses the existing JSON-RPC parser/dispatcher/error mapping, serializes the existing Pydantic response models for `send_json`, and suppresses notification-only responses consistently with HTTP notification behavior.
+
+Verification recorded:
+- Baseline gateway package tests before edits: `16 passed, 3 warnings`.
+- RED WebSocket test run: `4 failed, 16 passed, 3 warnings`; all new WebSocket tests failed because `/mcp/ws` was not registered.
+- GREEN gateway package tests: `20 passed, 3 warnings`.
+- Host compatibility: `47 passed, 4 warnings` for extraction contracts and HTTP mapping tests.
+- Ruff: `All checks passed!`.
+- Bandit: `/tmp/bandit_mcp_stage4c_gateway_websocket_transport.json` reported `"results": []`.
+- `git diff --check` exited cleanly.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Stage 4C adds the standalone package FastAPI WebSocket transport for JSON-RPC messages while keeping runtime dispatch, validation, notification behavior, and batch response filtering shared with the HTTP transport. This slice remains package-isolated and intentionally leaves auth/session policy, stdio, SQLite wiring, external lifecycle, and host route integration for later stages. No known skips or blockers.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/mcp_unified/gateway/fastapi.py
+++ b/mcp_unified/gateway/fastapi.py
@@ -6,6 +6,7 @@ import json
 from typing import Any, Literal
 
 from fastapi import APIRouter, FastAPI, Request, Response, WebSocket, WebSocketDisconnect
+from fastapi.encoders import jsonable_encoder
 from loguru import logger
 from pydantic import BaseModel, Field, ValidationError
 
@@ -133,7 +134,7 @@ def _response_to_json(response: GatewayJSONRPCResponse) -> dict[str, Any]:
     try:
         return response.model_dump(mode="json")  # type: ignore[attr-defined]
     except AttributeError:  # pragma: no cover - pydantic v1 fallback
-        return response.dict()
+        return jsonable_encoder(response.dict())
 
 
 def _object_or_empty(value: Any, message: str) -> dict[str, Any]:
@@ -350,6 +351,23 @@ async def _send_websocket_response(
     await websocket.send_json(_response_to_json(response))
 
 
+def _websocket_message_payload(message: dict[str, Any]) -> str | bytes | None:
+    """Extract a JSON-RPC payload from a raw WebSocket ASGI message."""
+
+    if message.get("type") == "websocket.disconnect":
+        raise WebSocketDisconnect(
+            code=message.get("code", 1000),
+            reason=message.get("reason", ""),
+        )
+    raw_payload = message.get("text")
+    if raw_payload is not None:
+        return raw_payload
+    raw_payload = message.get("bytes")
+    if raw_payload is not None:
+        return raw_payload
+    return None
+
+
 def create_gateway_router(runtime: GatewayRuntime) -> APIRouter:
     """Create a package-owned FastAPI router for a standalone MCP runtime."""
 
@@ -383,17 +401,22 @@ def create_gateway_router(runtime: GatewayRuntime) -> APIRouter:
         """Process JSON-RPC messages over a standalone gateway WebSocket."""
 
         await websocket.accept()
-        while True:
-            try:
-                raw_payload = await websocket.receive_text()
-            except WebSocketDisconnect:
-                return
-            payload = _parse_json_payload(raw_payload)
-            if isinstance(payload, _GATEWAY_RESPONSE_TYPES):
-                await websocket.send_json(_response_to_json(payload))
-                continue
-            response = await _handle_jsonrpc(runtime, payload, websocket)
-            await _send_websocket_response(websocket, response)
+        try:
+            while True:
+                raw_payload = _websocket_message_payload(await websocket.receive())
+                if raw_payload is None:
+                    await websocket.send_json(
+                        _response_to_json(_jsonrpc_error(_INVALID_REQUEST, "Invalid WebSocket message", None))
+                    )
+                    continue
+                payload = _parse_json_payload(raw_payload)
+                if isinstance(payload, _GATEWAY_RESPONSE_TYPES):
+                    await websocket.send_json(_response_to_json(payload))
+                    continue
+                response = await _handle_jsonrpc(runtime, payload, websocket)
+                await _send_websocket_response(websocket, response)
+        except (WebSocketDisconnect, RuntimeError):
+            return
 
     return router
 

--- a/mcp_unified/gateway/fastapi.py
+++ b/mcp_unified/gateway/fastapi.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 from typing import Any, Literal
 
-from fastapi import APIRouter, FastAPI, Request, Response
+from fastapi import APIRouter, FastAPI, Request, Response, WebSocket, WebSocketDisconnect
 from loguru import logger
 from pydantic import BaseModel, Field, ValidationError
 
@@ -38,6 +38,7 @@ _INVALID_PARAMS = -32602
 _INTERNAL_ERROR = -32603
 _GATEWAY_RUNTIME_ERRORS = Exception
 _JSON_PARSE_ERRORS = (json.JSONDecodeError, UnicodeDecodeError)
+_REQUEST_LIKE_TYPES = Request | WebSocket
 
 
 class GatewayJSONRPCRequest(BaseModel):
@@ -126,6 +127,15 @@ def _jsonrpc_error(
     )
 
 
+def _response_to_json(response: GatewayJSONRPCResponse) -> dict[str, Any]:
+    """Return a JSON-serializable response mapping for WebSocket sends."""
+
+    try:
+        return response.model_dump(mode="json")  # type: ignore[attr-defined]
+    except AttributeError:  # pragma: no cover - pydantic v1 fallback
+        return response.dict()
+
+
 def _object_or_empty(value: Any, message: str) -> dict[str, Any]:
     """Return an object payload or reject non-object values without coercion."""
 
@@ -152,7 +162,7 @@ def _runtime_supports(runtime: GatewayRuntime, *method_names: str) -> bool:
 
 def _request_context(
     payload: GatewayJSONRPCRequest,
-    request: Request,
+    request: _REQUEST_LIKE_TYPES,
 ) -> GatewayRequestContext:
     """Derive the host-neutral gateway request context from a JSON-RPC request."""
 
@@ -190,7 +200,7 @@ async def _handle_initialize(
 async def _dispatch_jsonrpc(
     runtime: GatewayRuntime,
     payload: GatewayJSONRPCRequest,
-    request: Request,
+    request: _REQUEST_LIKE_TYPES,
 ) -> Any:
     """Dispatch one validated JSON-RPC request to the injected runtime."""
 
@@ -247,7 +257,7 @@ def _validate_jsonrpc_request(payload: dict[str, Any]) -> GatewayJSONRPCRequest:
 async def _handle_single_jsonrpc(
     runtime: GatewayRuntime,
     payload: Any,
-    request: Request,
+    request: _REQUEST_LIKE_TYPES,
 ) -> GatewayJSONRPCResponse | Response:
     """Handle one JSON-RPC request, including notifications and error mapping."""
 
@@ -290,7 +300,7 @@ async def _handle_single_jsonrpc(
 async def _handle_jsonrpc(
     runtime: GatewayRuntime,
     payload: Any,
-    request: Request,
+    request: _REQUEST_LIKE_TYPES,
 ) -> GatewayJSONRPCResponse | list[GatewayJSONRPCResponse] | Response:
     """Handle single or batch JSON-RPC payloads for the gateway endpoint."""
 
@@ -309,16 +319,35 @@ async def _handle_jsonrpc(
     return await _handle_single_jsonrpc(runtime, payload, request)
 
 
+def _parse_json_payload(payload: str | bytes) -> Any | GatewayJSONRPCErrorResponse:
+    """Parse a raw JSON-RPC payload or return a JSON-RPC parse error."""
+
+    if not payload:
+        return _jsonrpc_error(_PARSE_ERROR, "Parse error: Empty request body", None)
+    try:
+        return json.loads(payload)
+    except _JSON_PARSE_ERRORS:
+        return _jsonrpc_error(_PARSE_ERROR, "Parse error: Invalid JSON", None)
+
+
 async def _parse_json_body(request: Request) -> Any | GatewayJSONRPCErrorResponse:
     """Parse raw JSON so malformed bodies return JSON-RPC parse errors."""
 
-    body = await request.body()
-    if not body:
-        return _jsonrpc_error(_PARSE_ERROR, "Parse error: Empty request body", None)
-    try:
-        return json.loads(body)
-    except _JSON_PARSE_ERRORS:
-        return _jsonrpc_error(_PARSE_ERROR, "Parse error: Invalid JSON", None)
+    return _parse_json_payload(await request.body())
+
+
+async def _send_websocket_response(
+    websocket: WebSocket,
+    response: GatewayJSONRPCResponse | list[GatewayJSONRPCResponse] | Response,
+) -> None:
+    """Send JSON-RPC responses while suppressing notification-only results."""
+
+    if isinstance(response, Response):
+        return
+    if isinstance(response, list):
+        await websocket.send_json([_response_to_json(item) for item in response])
+        return
+    await websocket.send_json(_response_to_json(response))
 
 
 def create_gateway_router(runtime: GatewayRuntime) -> APIRouter:
@@ -348,6 +377,23 @@ def create_gateway_router(runtime: GatewayRuntime) -> APIRouter:
         if isinstance(payload, _GATEWAY_RESPONSE_TYPES):
             return payload
         return await _handle_jsonrpc(runtime, payload, request)
+
+    @router.websocket("/ws")
+    async def gateway_websocket(websocket: WebSocket) -> None:
+        """Process JSON-RPC messages over a standalone gateway WebSocket."""
+
+        await websocket.accept()
+        while True:
+            try:
+                raw_payload = await websocket.receive_text()
+            except WebSocketDisconnect:
+                return
+            payload = _parse_json_payload(raw_payload)
+            if isinstance(payload, _GATEWAY_RESPONSE_TYPES):
+                await websocket.send_json(_response_to_json(payload))
+                continue
+            response = await _handle_jsonrpc(runtime, payload, websocket)
+            await _send_websocket_response(websocket, response)
 
     return router
 

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import ast
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
@@ -394,6 +395,18 @@ def test_gateway_websocket_maps_invalid_json_to_parse_error() -> None:
     assert "Parse error" in body["error"]["message"]
 
 
+def test_gateway_websocket_accepts_binary_json_frames() -> None:
+    runtime = _FakeGatewayRuntime()
+    app = create_gateway_app(runtime, prefix="/mcp")
+
+    with TestClient(app) as client:
+        with client.websocket_connect("/mcp/ws") as websocket:
+            websocket.send_bytes(b'{"jsonrpc":"2.0","method":"ping","id":"binary-ping"}')
+            body = websocket.receive_json()
+
+    assert body == {"jsonrpc": "2.0", "result": {"pong": True}, "id": "binary-ping"}
+
+
 def test_gateway_websocket_suppresses_notification_response() -> None:
     runtime = _FakeGatewayRuntime()
     app = create_gateway_app(runtime, prefix="/mcp")
@@ -422,6 +435,16 @@ def test_gateway_websocket_batch_omits_notification_responses() -> None:
             body = websocket.receive_json()
 
     assert body == [{"jsonrpc": "2.0", "result": {"pong": True}, "id": "batch-ping"}]
+
+
+def test_gateway_response_to_json_fallback_is_json_serializable() -> None:
+    class _PydanticV1LikeResponse:
+        def dict(self) -> dict[str, Any]:
+            return {"created_at": datetime(2026, 5, 30, 16, 0, tzinfo=timezone.utc)}
+
+    body = gateway_fastapi._response_to_json(_PydanticV1LikeResponse())  # noqa: SLF001
+
+    assert body == {"created_at": "2026-05-30T16:00:00+00:00"}
 
 
 def test_gateway_request_rejects_missing_jsonrpc_member() -> None:

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py
@@ -340,6 +340,90 @@ def test_gateway_fastapi_app_handles_resource_prompt_and_module_methods() -> Non
         assert runtime.module_health_contexts[-1].request_id == "health-1"
 
 
+def test_gateway_websocket_handles_basic_jsonrpc_flow() -> None:
+    runtime = _FakeGatewayRuntime()
+    app = create_gateway_app(runtime, prefix="/mcp")
+
+    with TestClient(app) as client:
+        with client.websocket_connect("/mcp/ws") as websocket:
+            websocket.send_json(
+                {
+                    "jsonrpc": "2.0",
+                    "method": "initialize",
+                    "params": {"clientInfo": {"name": "pytest-ws"}},
+                    "id": "ws-init",
+                }
+            )
+            initialized = websocket.receive_json()
+            assert initialized["jsonrpc"] == "2.0"
+            assert initialized["id"] == "ws-init"
+            assert initialized["result"]["protocolVersion"] == "2024-11-05"
+
+            websocket.send_json({"jsonrpc": "2.0", "method": "ping", "id": "ws-ping"})
+            ping = websocket.receive_json()
+            assert ping == {"jsonrpc": "2.0", "result": {"pong": True}, "id": "ws-ping"}
+
+            websocket.send_json(
+                {
+                    "jsonrpc": "2.0",
+                    "method": "resources/list",
+                    "params": {},
+                    "id": "ws-resources",
+                }
+            )
+            resources = websocket.receive_json()
+            assert resources["jsonrpc"] == "2.0"
+            assert resources["id"] == "ws-resources"
+            assert resources["result"]["resources"][0]["uri"] == "resource://unit/doc"
+            assert runtime.resource_list_contexts[-1].request_id == "ws-resources"
+            assert runtime.resource_list_contexts[-1].metadata["path"] == "/mcp/ws"
+
+
+def test_gateway_websocket_maps_invalid_json_to_parse_error() -> None:
+    runtime = _FakeGatewayRuntime()
+    app = create_gateway_app(runtime, prefix="/mcp")
+
+    with TestClient(app) as client:
+        with client.websocket_connect("/mcp/ws") as websocket:
+            websocket.send_text("not-json")
+            body = websocket.receive_json()
+
+    assert body["jsonrpc"] == "2.0"
+    assert body["id"] is None
+    assert body["error"]["code"] == -32700
+    assert "Parse error" in body["error"]["message"]
+
+
+def test_gateway_websocket_suppresses_notification_response() -> None:
+    runtime = _FakeGatewayRuntime()
+    app = create_gateway_app(runtime, prefix="/mcp")
+
+    with TestClient(app) as client:
+        with client.websocket_connect("/mcp/ws") as websocket:
+            websocket.send_json({"jsonrpc": "2.0", "method": "ping"})
+            websocket.send_json({"jsonrpc": "2.0", "method": "ping", "id": "after-notification"})
+            body = websocket.receive_json()
+
+    assert body == {"jsonrpc": "2.0", "result": {"pong": True}, "id": "after-notification"}
+
+
+def test_gateway_websocket_batch_omits_notification_responses() -> None:
+    runtime = _FakeGatewayRuntime()
+    app = create_gateway_app(runtime, prefix="/mcp")
+
+    with TestClient(app) as client:
+        with client.websocket_connect("/mcp/ws") as websocket:
+            websocket.send_json(
+                [
+                    {"jsonrpc": "2.0", "method": "ping"},
+                    {"jsonrpc": "2.0", "method": "ping", "id": "batch-ping"},
+                ]
+            )
+            body = websocket.receive_json()
+
+    assert body == [{"jsonrpc": "2.0", "result": {"pong": True}, "id": "batch-ping"}]
+
+
 def test_gateway_request_rejects_missing_jsonrpc_member() -> None:
     runtime = _FakeGatewayRuntime()
     app = create_gateway_app(runtime, prefix="/mcp")


### PR DESCRIPTION
## Change summary (maintainer-owned)

- Adds a package-owned `/ws` WebSocket endpoint to the standalone `mcp_unified.gateway` FastAPI router.
- Reuses the existing JSON-RPC parser, dispatcher, response envelopes, notification suppression, and batch response filtering for WebSocket messages.
- Adds focused package gateway tests for WebSocket initialize/ping/discovery, malformed JSON parse errors, notification suppression, and mixed batch behavior.

## Why

Stage 4A established the HTTP gateway entrypoint and Stage 4B expanded the protocol method surface. Stage 4C closes the next transport parity gap from the standalone gateway spec by exposing the same runtime through FastAPI WebSocket without adding auth/session policy, stdio, SQLite wiring, external lifecycle management, or host route integration.

## Validation

- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py -q` -> `20 passed, 3 warnings`
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_extraction_contracts.py tldw_Server_API/app/core/MCP_unified/tests/test_http_mapping.py -q` -> `47 passed, 4 warnings`
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m ruff check mcp_unified/gateway tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py` -> `All checks passed!`
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r mcp_unified/gateway -f json -o /tmp/bandit_mcp_stage4c_gateway_websocket_transport.json` -> `"results": []`
- `git diff --check`

## UX Audit Checklist

- [x] Backend/package transport only; no user-facing UI changes.

## Watchlists

- [x] MCP Unified standalone extraction
- [x] Package isolation from `tldw_Server_API`
- [x] FastAPI HTTP/WebSocket transport parity
- [x] Host extraction and HTTP mapping compatibility

## Rollback

Revert `c88d507681` to remove the Stage 4C WebSocket transport and tests.

Backlog: `TASK-560`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a package-owned WebSocket JSON-RPC transport at `/ws` to the standalone `mcp_unified.gateway` FastAPI router for parity with HTTP. Supports text and binary frames, reuses shared dispatch/error handling, and keeps package isolation (aligns with TASK-560).

- **New Features**
  - Adds `/ws` endpoint; accepts text/bytes frames, uses shared JSON-RPC parser/dispatcher, suppresses notification responses, and filters batches like HTTP.
  - Maps invalid JSON to parse errors (`-32700`, `id: null`) and unsupported WS messages to invalid-request; echoes request ids, propagates context metadata, and serializes via Pydantic v2 `model_dump` with a v1-safe `jsonable_encoder` fallback.

- **Bug Fixes**
  - Handles disconnects and closed-socket errors in the receive/send loop.
  - Adds tests for initialize/ping/resources flow, binary frames, parse errors, notification suppression, mixed batches, and v1 serialization fallback; host extraction and HTTP mapping tests remain green.

<sup>Written for commit cb740689915571574f31d970b9108f8781a2e785. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2143?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

