### PR TITLE
Migrate RbacEditorPage guard alert to design system

### DIFF
--- a/apps/packages/ui/scripts/design-system-product-state-baseline.json
+++ b/apps/packages/ui/scripts/design-system-product-state-baseline.json
@@ -308,17 +308,6 @@
     "migrationQueue": "shared-product-state"
   },
   {
-    "id": "antd-product-state-import:src/components/Option/Admin/RbacEditorPage.tsx:Alert",
-    "path": "src/components/Option/Admin/RbacEditorPage.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/Option/Admin/RbacEditorPage.tsx before the guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
     "id": "antd-product-state-import:src/components/Option/Admin/RuntimeConfigPage.tsx:Alert#antd-alert-runtimeconfigpage-type-error-forbidden-you-do-1f85wr6",
     "path": "src/components/Option/Admin/RuntimeConfigPage.tsx",
     "rule": "antd-product-state-import",

--- a/apps/packages/ui/src/components/Option/Admin/RbacEditorPage.tsx
+++ b/apps/packages/ui/src/components/Option/Admin/RbacEditorPage.tsx
@@ -7,7 +7,6 @@ import {
   Input,
   Modal,
   Select,
-  Alert,
   Space,
   Popconfirm,
   Form,
@@ -27,6 +26,7 @@ import {
   sanitizeAdminErrorMessage
 } from "./admin-error-utils"
 import { tldwClient } from "@/services/tldw/TldwApiClient"
+import { Alert as DesignSystemAlert } from "@/components/ui/primitives"
 
 // ── Types ──
 
@@ -768,13 +768,9 @@ const RbacEditorPage: React.FC = () => {
 
   if (guardError) {
     return (
-      <Alert
-        type="warning"
-        showIcon
-        message="Access Restricted"
-        description={guardError}
-        style={{ margin: 24 }}
-      />
+      <DesignSystemAlert variant="warning" title="Access Restricted" className="m-6">
+        {guardError}
+      </DesignSystemAlert>
     )
   }
 

--- a/apps/packages/ui/src/components/Option/Admin/__tests__/RbacEditorPage.design-system.test.tsx
+++ b/apps/packages/ui/src/components/Option/Admin/__tests__/RbacEditorPage.design-system.test.tsx
@@ -1,0 +1,42 @@
+// @vitest-environment jsdom
+
+import React from "react"
+import { render, screen } from "@testing-library/react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import RbacEditorPage from "../RbacEditorPage"
+
+const apiMock = vi.hoisted(() => ({
+  getRolePermissionMatrix: vi.fn(),
+  listPermissionCategories: vi.fn()
+}))
+
+vi.mock("@/services/tldw/TldwApiClient", () => ({
+  tldwClient: apiMock
+}))
+
+describe("RbacEditorPage design-system states", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    apiMock.getRolePermissionMatrix.mockResolvedValue({
+      roles: [],
+      permissions: [],
+      grid: {}
+    })
+    apiMock.listPermissionCategories.mockResolvedValue([])
+  })
+
+  it("renders admin guard feedback through the design-system Alert primitive", async () => {
+    apiMock.getRolePermissionMatrix.mockRejectedValueOnce({ status: 403 })
+
+    render(<RbacEditorPage />)
+
+    const title = await screen.findByText("Access Restricted")
+    const alert = title.closest('[data-ds-component="Alert"]')
+
+    expect(alert).not.toBeNull()
+    const alertEl = alert as HTMLElement
+    expect(alertEl).toHaveAttribute("role", "alert")
+    expect(alertEl).toHaveTextContent("Access Restricted")
+    expect(alertEl).toHaveTextContent("forbidden")
+  })
+})

--- a/backlog/tasks/task-45.44.7 - Migrate-design-system-product-state-Admin-and-health-expansion.md
+++ b/backlog/tasks/task-45.44.7 - Migrate-design-system-product-state-Admin-and-health-expansion.md
@@ -4,7 +4,7 @@ title: 'Migrate design-system product state: Admin and health expansion'
 status: In Progress
 assignee: []
 created_date: '2026-05-14 03:19'
-updated_date: '2026-05-30 08:58'
+updated_date: '2026-05-30 09:27'
 labels:
   - design-system
   - webui
@@ -37,6 +37,18 @@ documentation:
 
     Verifier evidence:
       - scoped verifier log had no ServerArgsEditor findings
+      - full verifier remains blocked by unrelated current-dev drift outside this slice
+
+    TASK-45.44.7.2 migrated RbacEditorPage admin guard feedback from AntD Alert
+    to the design-system Alert primitive.
+
+    Baseline file evidence:
+      - total baseline rows: 194 -> 193
+      - Admin path rows: 36 -> 35
+      - RbacEditorPage target row: 1 -> 0
+
+    Verifier evidence:
+      - scoped verifier log had no RbacEditorPage findings
       - full verifier remains blocked by unrelated current-dev drift outside this slice
 parent_task_id: TASK-45.44
 priority: medium

--- a/backlog/tasks/task-45.44.7.2 - Migrate-RbacEditorPage-guard-alert-to-design-system-Alert.md
+++ b/backlog/tasks/task-45.44.7.2 - Migrate-RbacEditorPage-guard-alert-to-design-system-Alert.md
@@ -1,0 +1,55 @@
+---
+id: TASK-45.44.7.2
+title: Migrate RbacEditorPage guard alert to design-system Alert
+status: Done
+labels:
+- design-system
+- webui
+- admin
+- product-state
+priority: medium
+parent_task_id: TASK-45.44.7
+references:
+- apps/packages/ui/src/components/Option/Admin/RbacEditorPage.tsx
+- apps/packages/ui/scripts/design-system-product-state-baseline.json
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Continue the Admin and health expansion design-system migration by replacing RbacEditorPage's remaining AntD Alert guard state with the shared design-system Alert primitive while preserving the existing access-restricted copy.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 RbacEditorPage renders admin guard feedback through the shared design-system Alert primitive instead of AntD Alert.
+- [x] #2 Focused coverage asserts the access-restricted guard feedback uses the design-system Alert marker and preserves existing copy.
+- [x] #3 The RbacEditorPage AntD Alert baseline exception is removed without introducing new product-state guard findings for the component.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+- Red verification: `bunx vitest run src/components/Option/Admin/__tests__/RbacEditorPage.design-system.test.tsx` failed because the access-restricted guard had no `data-ds-component="Alert"` ancestor.
+- Replaced the RbacEditorPage guard AntD Alert with the shared design-system Alert primitive and preserved the existing `Access Restricted` title plus guard detail text.
+- Removed the `RbacEditorPage` AntD Alert baseline exception from `apps/packages/ui/scripts/design-system-product-state-baseline.json`.
+- Verification: focused RbacEditorPage design-system Vitest passed; product-state guard unit test passed (54 tests); baseline JSON parsed; `git diff --check` passed; scoped verifier log at `/tmp/rbac-editor-design-state.log` has no `RbacEditorPage` findings and reports baseline exceptions at 189.
+- Full `bun run verify:design-system-state` still exits 1 on current-dev drift outside this slice: IntegrationPolicyPanel, WritingActionBar, Notes, ResearchWorkspace, plus stale IntegrationPolicyPanel baseline entries.
+- Bandit skipped because this slice only touches frontend TypeScript/TSX, JSON baseline, and Backlog metadata.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Migrated RbacEditorPage admin guard feedback from AntD Alert to the shared design-system Alert primitive, added focused regression coverage for the design-system Alert marker and existing copy, and removed the matching RbacEditorPage product-state baseline exception. Focused component coverage, product-state guard unit coverage, baseline JSON parsing, whitespace checks, and scoped verifier inspection were recorded. The full product-state verifier remains blocked by unrelated current-dev drift, with no RbacEditorPage findings.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## Summary
- Migrate `RbacEditorPage` admin guard feedback from AntD `Alert` to the shared design-system `Alert` primitive.
- Add focused regression coverage for the design-system Alert marker and existing access-restricted copy.
- Remove the matching `RbacEditorPage` product-state baseline row and update the Admin/health tracker evidence.

## Verification
- `bunx vitest run src/components/Option/Admin/__tests__/RbacEditorPage.design-system.test.tsx`
- `bunx vitest run src/design-system/__tests__/product-state-guard.test.ts --reporter=dot`
- `node -e "JSON.parse(require('fs').readFileSync('apps/packages/ui/scripts/design-system-product-state-baseline.json','utf8')); console.log('baseline json ok')"`
- `git diff --check`
- `bun run verify:design-system-state > /tmp/rbac-editor-design-state.log 2>&1` still exits 1 on unrelated current-dev drift: IntegrationPolicyPanel, WritingActionBar, Notes, ResearchWorkspace, and stale IntegrationPolicyPanel baseline rows. The scoped log has no `RbacEditorPage` findings and reports `Baseline exceptions: 189` / `Admin and health expansion: 35`.

## Change summary (maintainer-owned)
Pending maintainer-written summary before merge. The summary should explain what changed and why these implementation choices were made.

## Notes
- Bandit skipped because the touched implementation is frontend TS/TSX plus JSON/Backlog metadata only.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrated `RbacEditorPage` admin guard from AntD `Alert` to the design-system `Alert`, preserving the "Access Restricted" copy and accessibility. Added focused tests and removed the matching product-state baseline row.

- **Refactors**
  - Replaced AntD `Alert` with `Alert` from `@/components/ui/primitives` (`variant="warning"`, `title="Access Restricted"`).
  - Added a test to assert the design-system alert marker (`data-ds-component="Alert"`) and preserved text.
  - Removed the `RbacEditorPage` AntD `Alert` baseline exception from `design-system-product-state-baseline.json`.

<sup>Written for commit 5d84bcbd9227d1dc5a410f815b0a5d31be237715. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2144?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

