### PR TITLE
Migrate RuntimeConfigPage guard alerts to design system

### DIFF
--- a/apps/packages/ui/scripts/design-system-product-state-baseline.json
+++ b/apps/packages/ui/scripts/design-system-product-state-baseline.json
@@ -308,28 +308,6 @@
     "migrationQueue": "shared-product-state"
   },
   {
-    "id": "antd-product-state-import:src/components/Option/Admin/RuntimeConfigPage.tsx:Alert#antd-alert-runtimeconfigpage-type-error-forbidden-you-do-1f85wr6",
-    "path": "src/components/Option/Admin/RuntimeConfigPage.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/Option/Admin/RuntimeConfigPage.tsx before the stable duplicate-id guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
-    "id": "antd-product-state-import:src/components/Option/Admin/RuntimeConfigPage.tsx:Alert#antd-alert-runtimeconfigpage-type-warning-not-available-1s74nym",
-    "path": "src/components/Option/Admin/RuntimeConfigPage.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/Option/Admin/RuntimeConfigPage.tsx before the stable duplicate-id guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
     "id": "antd-product-state-import:src/components/Option/Admin/ServerAdminPage.tsx:Alert#antd-alert-serveradminpage-type-error-line-656-1j15pps",
     "path": "src/components/Option/Admin/ServerAdminPage.tsx",
     "rule": "antd-product-state-import",

--- a/apps/packages/ui/src/components/Option/Admin/RuntimeConfigPage.tsx
+++ b/apps/packages/ui/src/components/Option/Admin/RuntimeConfigPage.tsx
@@ -6,7 +6,6 @@ import {
   Form,
   Switch,
   Space,
-  Alert,
   Spin,
   message,
   InputNumber,
@@ -17,6 +16,7 @@ import {
   sanitizeAdminErrorMessage
 } from "./admin-error-utils"
 import { tldwClient } from "@/services/tldw/TldwApiClient"
+import { Alert as DesignSystemAlert } from "@/components/ui/primitives"
 
 // ---------------------------------------------------------------------------
 // RuntimeConfigPage -- load / edit / save cleanup & registration settings
@@ -126,10 +126,18 @@ const RuntimeConfigPage: React.FC = () => {
   // ── Guard Rendering ──
 
   if (adminGuard === "forbidden") {
-    return <Alert type="error" showIcon message="Forbidden" description="You do not have permission to view runtime configuration." />
+    return (
+      <DesignSystemAlert variant="error" title="Forbidden">
+        You do not have permission to view runtime configuration.
+      </DesignSystemAlert>
+    )
   }
   if (adminGuard === "notFound") {
-    return <Alert type="warning" showIcon message="Not Available" description="The runtime configuration endpoints are not available on this server." />
+    return (
+      <DesignSystemAlert variant="warning" title="Not Available">
+        The runtime configuration endpoints are not available on this server.
+      </DesignSystemAlert>
+    )
   }
 
   return (

--- a/apps/packages/ui/src/components/Option/Admin/__tests__/RuntimeConfigPage.design-system.test.tsx
+++ b/apps/packages/ui/src/components/Option/Admin/__tests__/RuntimeConfigPage.design-system.test.tsx
@@ -1,0 +1,67 @@
+// @vitest-environment jsdom
+
+import React from "react"
+import { render, screen } from "@testing-library/react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import RuntimeConfigPage from "../RuntimeConfigPage"
+
+const apiMock = vi.hoisted(() => ({
+  getCleanupSettings: vi.fn(),
+  getRegistrationSettings: vi.fn(),
+  updateCleanupSettings: vi.fn(),
+  updateRegistrationSettings: vi.fn()
+}))
+
+vi.mock("@/services/tldw/TldwApiClient", () => ({
+  tldwClient: apiMock
+}))
+
+const expectDesignSystemAlertForTitle = async (titleText: string) => {
+  const title = await screen.findByText(titleText)
+  const alert = title.closest('[data-ds-component="Alert"]')
+
+  expect(alert).not.toBeNull()
+  const alertEl = alert as HTMLElement
+  expect(alertEl).toHaveAttribute("role", "alert")
+  return alertEl
+}
+
+describe("RuntimeConfigPage design-system states", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    apiMock.getCleanupSettings.mockResolvedValue({
+      soft_delete_retention_days: 30,
+      orphan_cleanup_enabled: true,
+      orphan_cleanup_interval_hours: 24,
+      log_retention_days: 14
+    })
+    apiMock.getRegistrationSettings.mockResolvedValue({
+      open_registration: false,
+      require_email_verification: true,
+      default_role: "user",
+      max_users: 0
+    })
+  })
+
+  it("renders forbidden guard feedback through the design-system Alert primitive", async () => {
+    apiMock.getCleanupSettings.mockRejectedValueOnce({ status: 403 })
+
+    render(<RuntimeConfigPage />)
+
+    const alert = await expectDesignSystemAlertForTitle("Forbidden")
+    expect(alert).toHaveTextContent(
+      "You do not have permission to view runtime configuration."
+    )
+  })
+
+  it("renders missing-endpoint guard feedback through the design-system Alert primitive", async () => {
+    apiMock.getCleanupSettings.mockRejectedValueOnce({ status: 404 })
+
+    render(<RuntimeConfigPage />)
+
+    const alert = await expectDesignSystemAlertForTitle("Not Available")
+    expect(alert).toHaveTextContent(
+      "The runtime configuration endpoints are not available on this server."
+    )
+  })
+})

--- a/backlog/tasks/task-45.44.7 - Migrate-design-system-product-state-Admin-and-health-expansion.md
+++ b/backlog/tasks/task-45.44.7 - Migrate-design-system-product-state-Admin-and-health-expansion.md
@@ -50,6 +50,18 @@ documentation:
     Verifier evidence:
       - scoped verifier log had no RbacEditorPage findings
       - full verifier remains blocked by unrelated current-dev drift outside this slice
+
+    TASK-45.44.7.3 migrated RuntimeConfigPage forbidden and not-available guard
+    feedback from AntD Alert to the design-system Alert primitive.
+
+    Baseline file evidence:
+      - total baseline rows: 193 -> 191
+      - Admin path rows: 35 -> 33
+      - RuntimeConfigPage target rows: 2 -> 0
+
+    Verifier evidence:
+      - scoped verifier log had no RuntimeConfigPage findings
+      - full verifier remains blocked by unrelated current-dev drift outside this slice
 parent_task_id: TASK-45.44
 priority: medium
 ---

--- a/backlog/tasks/task-45.44.7 - Migrate-design-system-product-state-Admin-and-health-expansion.md
+++ b/backlog/tasks/task-45.44.7 - Migrate-design-system-product-state-Admin-and-health-expansion.md
@@ -52,7 +52,7 @@ documentation:
       - full verifier remains blocked by unrelated current-dev drift outside this slice
 
     TASK-45.44.7.3 migrated RuntimeConfigPage forbidden and not-available guard
-    feedback from AntD Alert to the design-system Alert primitive.
+    feedback from AntD Alert to the design-system Alert primitive in PR #2145.
 
     Baseline file evidence:
       - total baseline rows: 193 -> 191

--- a/backlog/tasks/task-45.44.7.3 - Migrate-RuntimeConfigPage-guard-alerts-to-design-system-Alert.md
+++ b/backlog/tasks/task-45.44.7.3 - Migrate-RuntimeConfigPage-guard-alerts-to-design-system-Alert.md
@@ -40,7 +40,7 @@ Replace RuntimeConfigPage's forbidden and not-available admin guard AntD Alerts 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Migrated RuntimeConfigPage forbidden and not-available guard feedback from AntD Alert to the shared design-system Alert primitive, added focused regression coverage for both guard states, and removed the two obsolete RuntimeConfigPage baseline exceptions. Focused tests, guard unit coverage, and UI TypeScript pass; the full design-state verifier remains blocked by unrelated current-dev product-state drift outside this slice.
+Migrated RuntimeConfigPage forbidden and not-available guard feedback from AntD Alert to the shared design-system Alert primitive, added focused regression coverage for both guard states, and removed the two obsolete RuntimeConfigPage baseline exceptions. Focused tests, guard unit coverage, and UI TypeScript pass; the full design-state verifier remains blocked by unrelated current-dev product-state drift outside this slice. PR: https://github.com/rmusser01/tldw_server/pull/2145.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-45.44.7.3 - Migrate-RuntimeConfigPage-guard-alerts-to-design-system-Alert.md
+++ b/backlog/tasks/task-45.44.7.3 - Migrate-RuntimeConfigPage-guard-alerts-to-design-system-Alert.md
@@ -1,0 +1,54 @@
+---
+id: TASK-45.44.7.3
+title: Migrate RuntimeConfigPage guard alerts to design-system Alert
+status: Done
+labels:
+- design-system
+- webui
+- product-state
+priority: medium
+parent_task_id: TASK-45.44.7
+modified_files:
+- apps/packages/ui/src/components/Option/Admin/RuntimeConfigPage.tsx
+- apps/packages/ui/src/components/Option/Admin/__tests__/RuntimeConfigPage.design-system.test.tsx
+- apps/packages/ui/scripts/design-system-product-state-baseline.json
+- backlog/tasks/task-45.44.7 - Migrate-design-system-product-state-Admin-and-health-expansion.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Replace RuntimeConfigPage's forbidden and not-available admin guard AntD Alerts with the shared design-system Alert primitive while preserving copy and guard behavior. Remove matching product-state baseline entries and record focused verification.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 RuntimeConfigPage forbidden guard feedback renders through data-ds-component="Alert" with error urgency semantics.
+- [x] #2 RuntimeConfigPage not-found guard feedback renders through data-ds-component="Alert" while preserving the Not Available copy.
+- [x] #3 The matching RuntimeConfigPage AntD Alert baseline entries are removed without introducing a RuntimeConfigPage verifier finding.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+- TDD red/green completed. The new RuntimeConfigPage design-system test failed while the forbidden and Not Available guard messages were still rendered by AntD Alert without a data-ds-component="Alert" ancestor.
+- Migrated only the forbidden and not-found guard branches to the shared design-system Alert primitive. RuntimeConfigPage forms, AntD layout components, loading states, and save behavior were left unchanged.
+- Removed the two RuntimeConfigPage AntD Alert baseline entries. Baseline JSON evidence after removal: total rows 191, RuntimeConfigPage rows 0, Admin rows 33.
+- Verification: focused RuntimeConfigPage design-system Vitest passed 2/2; product-state guard unit test passed 54/54; UI TypeScript passed; `git diff --check` passed; full `bun run verify:design-system-state` still exits 1 on unrelated Integrations, WritingActionBar, Notes, and ResearchWorkspace drift, with no RuntimeConfigPage finding. Bandit is not applicable because this slice touches only frontend TSX/test/JSON and Backlog metadata.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Migrated RuntimeConfigPage forbidden and not-available guard feedback from AntD Alert to the shared design-system Alert primitive, added focused regression coverage for both guard states, and removed the two obsolete RuntimeConfigPage baseline exceptions. Focused tests, guard unit coverage, and UI TypeScript pass; the full design-state verifier remains blocked by unrelated current-dev product-state drift outside this slice.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## Summary
- Migrate RuntimeConfigPage forbidden and not-available admin guard feedback from AntD Alert to the shared design-system Alert primitive.
- Add focused regression coverage for both RuntimeConfigPage guard states requiring `data-ds-component="Alert"`.
- Remove the two obsolete RuntimeConfigPage product-state baseline exceptions and record count evidence in Backlog.

## Verification
- RED: `bunx vitest run src/components/Option/Admin/__tests__/RuntimeConfigPage.design-system.test.tsx --reporter=dot` failed on missing `data-ds-component="Alert"` ancestors before the migration.
- PASS: `bunx vitest run src/components/Option/Admin/__tests__/RuntimeConfigPage.design-system.test.tsx --reporter=dot` (2/2)
- PASS: `bunx vitest run src/design-system/__tests__/product-state-guard.test.ts --reporter=dot` (54/54)
- PASS: baseline JSON parse/count check (`total=191`, `RuntimeConfigPage=0`, `Admin=33`)
- PASS: `env NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit --pretty false`
- PASS: `git diff --check`
- KNOWN BASELINE: `bun run verify:design-system-state` still exits 1 on unrelated current-dev Integrations, WritingActionBar, Notes, and ResearchWorkspace findings plus stale IntegrationPolicyPanel baseline entries. No RuntimeConfigPage findings remain.

## Change summary (maintainer-owned)
Maintainer to fill before merge: describe what changed and why these implementation choices are appropriate for the design-system migration.

## UX Audit Checklist
- [x] Copy preserved for forbidden and not-available guard states.
- [x] Guard feedback now uses the canonical design-system Alert primitive.
- [x] No broader RuntimeConfigPage layout, form, loading, or save behavior changed.

## Bandit
- Not applicable. This slice touches frontend TSX/test/JSON and Backlog markdown only.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrates RuntimeConfigPage forbidden and not-available admin guard alerts from AntD `Alert` to the design-system `Alert` for a consistent UI. No other page behavior changed.

- **Refactors**
  - Replaced AntD usage with `Alert` from the design system for the two guard states.
  - Added focused tests that assert `data-ds-component="Alert"` and correct titles/content for both states.
  - Removed two obsolete RuntimeConfigPage product-state baseline exceptions.

<sup>Written for commit 3f80eeddb37ae5e377cb0d68bc78e7563bfe2836. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2145?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

