### PR TITLE
Migrate MaintenancePage guard alerts to design system

### DIFF
--- a/apps/packages/ui/scripts/design-system-product-state-baseline.json
+++ b/apps/packages/ui/scripts/design-system-product-state-baseline.json
@@ -88,28 +88,6 @@
     "migrationQueue": "shared-product-state"
   },
   {
-    "id": "antd-product-state-import:src/components/Option/Admin/MaintenancePage.tsx:Alert#antd-alert-maintenancepage-type-error-access-denied-you-jdy41q",
-    "path": "src/components/Option/Admin/MaintenancePage.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/Option/Admin/MaintenancePage.tsx before the stable duplicate-id guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
-    "id": "antd-product-state-import:src/components/Option/Admin/MaintenancePage.tsx:Alert#antd-alert-maintenancepage-type-warning-not-available-th-wmzruk",
-    "path": "src/components/Option/Admin/MaintenancePage.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/Option/Admin/MaintenancePage.tsx before the stable duplicate-id guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
     "id": "antd-product-state-import:src/components/Option/Admin/MlxAdminPage.tsx:Alert#antd-alert-mlxadminpage-type-info-line-667-t3pi54",
     "path": "src/components/Option/Admin/MlxAdminPage.tsx",
     "rule": "antd-product-state-import",

--- a/apps/packages/ui/src/components/Option/Admin/MaintenancePage.tsx
+++ b/apps/packages/ui/src/components/Option/Admin/MaintenancePage.tsx
@@ -7,7 +7,6 @@ import {
   Form,
   Tag,
   Space,
-  Alert,
   Select,
   Switch,
   Popconfirm,
@@ -19,6 +18,7 @@ import {
   sanitizeAdminErrorMessage
 } from "./admin-error-utils"
 import { tldwClient } from "@/services/tldw/TldwApiClient"
+import { Alert as DesignSystemAlert } from "@/components/ui/primitives"
 
 const { TextArea } = Input
 
@@ -345,10 +345,18 @@ const MaintenancePage: React.FC = () => {
   // ── Render ──
 
   if (adminGuard === "forbidden") {
-    return <Alert type="error" title="Access Denied" description="You don't have permission to access the maintenance console." showIcon />
+    return (
+      <DesignSystemAlert variant="error" title="Access Denied">
+        You don't have permission to access the maintenance console.
+      </DesignSystemAlert>
+    )
   }
   if (adminGuard === "notFound") {
-    return <Alert type="warning" title="Not Available" description="The maintenance console is not available on this server." showIcon />
+    return (
+      <DesignSystemAlert variant="warning" title="Not Available">
+        The maintenance console is not available on this server.
+      </DesignSystemAlert>
+    )
   }
 
   return (

--- a/apps/packages/ui/src/components/Option/Admin/MaintenancePage.tsx
+++ b/apps/packages/ui/src/components/Option/Admin/MaintenancePage.tsx
@@ -18,7 +18,7 @@ import {
   sanitizeAdminErrorMessage
 } from "./admin-error-utils"
 import { tldwClient } from "@/services/tldw/TldwApiClient"
-import { Alert as DesignSystemAlert } from "@/components/ui/primitives"
+import { Alert } from "@/components/ui/primitives"
 
 const { TextArea } = Input
 
@@ -346,16 +346,16 @@ const MaintenancePage: React.FC = () => {
 
   if (adminGuard === "forbidden") {
     return (
-      <DesignSystemAlert variant="error" title="Access Denied">
+      <Alert variant="error" title="Access Denied">
         You don't have permission to access the maintenance console.
-      </DesignSystemAlert>
+      </Alert>
     )
   }
   if (adminGuard === "notFound") {
     return (
-      <DesignSystemAlert variant="warning" title="Not Available">
+      <Alert variant="warning" title="Not Available">
         The maintenance console is not available on this server.
-      </DesignSystemAlert>
+      </Alert>
     )
   }
 

--- a/apps/packages/ui/src/components/Option/Admin/__tests__/MaintenancePage.design-system.test.tsx
+++ b/apps/packages/ui/src/components/Option/Admin/__tests__/MaintenancePage.design-system.test.tsx
@@ -1,0 +1,70 @@
+// @vitest-environment jsdom
+
+import React from "react"
+import { render, screen } from "@testing-library/react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import MaintenancePage from "../MaintenancePage"
+
+const apiMock = vi.hoisted(() => ({
+  getMaintenanceState: vi.fn(),
+  listFeatureFlags: vi.fn(),
+  listIncidents: vi.fn(),
+  listRotationRuns: vi.fn(),
+  updateMaintenanceState: vi.fn(),
+  updateFeatureFlag: vi.fn(),
+  deleteFeatureFlag: vi.fn(),
+  createIncident: vi.fn(),
+  updateIncident: vi.fn(),
+  deleteIncident: vi.fn(),
+  createRotationRun: vi.fn()
+}))
+
+vi.mock("@/services/tldw/TldwApiClient", () => ({
+  tldwClient: apiMock
+}))
+
+const expectDesignSystemAlertForTitle = async (titleText: string) => {
+  const title = await screen.findByText(titleText)
+  const alert = title.closest('[data-ds-component="Alert"]')
+
+  expect(alert).not.toBeNull()
+  const alertEl = alert as HTMLElement
+  expect(alertEl).toHaveAttribute("role", "alert")
+  return alertEl
+}
+
+describe("MaintenancePage design-system states", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    apiMock.getMaintenanceState.mockResolvedValue({
+      enabled: false,
+      message: "",
+      allowlist: []
+    })
+    apiMock.listFeatureFlags.mockResolvedValue([])
+    apiMock.listIncidents.mockResolvedValue([])
+    apiMock.listRotationRuns.mockResolvedValue([])
+  })
+
+  it("renders forbidden guard feedback through the design-system Alert primitive", async () => {
+    apiMock.getMaintenanceState.mockRejectedValueOnce({ status: 403 })
+
+    render(<MaintenancePage />)
+
+    const alert = await expectDesignSystemAlertForTitle("Access Denied")
+    expect(alert).toHaveTextContent(
+      "You don't have permission to access the maintenance console."
+    )
+  })
+
+  it("renders missing-endpoint guard feedback through the design-system Alert primitive", async () => {
+    apiMock.getMaintenanceState.mockRejectedValueOnce({ status: 404 })
+
+    render(<MaintenancePage />)
+
+    const alert = await expectDesignSystemAlertForTitle("Not Available")
+    expect(alert).toHaveTextContent(
+      "The maintenance console is not available on this server."
+    )
+  })
+})

--- a/backlog/tasks/task-45.44.7 - Migrate-design-system-product-state-Admin-and-health-expansion.md
+++ b/backlog/tasks/task-45.44.7 - Migrate-design-system-product-state-Admin-and-health-expansion.md
@@ -62,6 +62,18 @@ documentation:
     Verifier evidence:
       - scoped verifier log had no RuntimeConfigPage findings
       - full verifier remains blocked by unrelated current-dev drift outside this slice
+
+    TASK-45.44.7.4 migrated MaintenancePage forbidden and not-available guard
+    feedback from AntD Alert to the design-system Alert primitive.
+
+    Baseline file evidence:
+      - total baseline rows: 191 -> 189
+      - Admin path rows: 33 -> 31
+      - MaintenancePage target rows: 2 -> 0
+
+    Verifier evidence:
+      - scoped verifier log had no MaintenancePage findings
+      - full verifier remains blocked by unrelated current-dev drift outside this slice
 parent_task_id: TASK-45.44
 priority: medium
 ---

--- a/backlog/tasks/task-45.44.7 - Migrate-design-system-product-state-Admin-and-health-expansion.md
+++ b/backlog/tasks/task-45.44.7 - Migrate-design-system-product-state-Admin-and-health-expansion.md
@@ -64,7 +64,7 @@ documentation:
       - full verifier remains blocked by unrelated current-dev drift outside this slice
 
     TASK-45.44.7.4 migrated MaintenancePage forbidden and not-available guard
-    feedback from AntD Alert to the design-system Alert primitive.
+    feedback from AntD Alert to the design-system Alert primitive in PR #2148.
 
     Baseline file evidence:
       - total baseline rows: 191 -> 189

--- a/backlog/tasks/task-45.44.7.4 - Migrate-MaintenancePage-guard-alerts-to-design-system-Alert.md
+++ b/backlog/tasks/task-45.44.7.4 - Migrate-MaintenancePage-guard-alerts-to-design-system-Alert.md
@@ -1,0 +1,54 @@
+---
+id: TASK-45.44.7.4
+title: Migrate MaintenancePage guard alerts to design-system Alert
+status: Done
+labels:
+- design-system
+- webui
+- product-state
+priority: medium
+parent_task_id: TASK-45.44.7
+modified_files:
+- apps/packages/ui/src/components/Option/Admin/MaintenancePage.tsx
+- apps/packages/ui/src/components/Option/Admin/__tests__/MaintenancePage.design-system.test.tsx
+- apps/packages/ui/scripts/design-system-product-state-baseline.json
+- backlog/tasks/task-45.44.7 - Migrate-design-system-product-state-Admin-and-health-expansion.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Replace MaintenancePage's forbidden and not-available admin guard AntD Alerts with the shared design-system Alert primitive while preserving copy and guard behavior. Remove matching product-state baseline entries and record focused verification.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 MaintenancePage forbidden guard feedback renders through data-ds-component="Alert" with error urgency semantics.
+- [x] #2 MaintenancePage not-found guard feedback renders through data-ds-component="Alert" while preserving the Not Available copy.
+- [x] #3 The matching MaintenancePage AntD Alert baseline entries are removed without introducing a MaintenancePage verifier finding.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+- TDD red/green completed. The new MaintenancePage design-system test failed while the Access Denied and Not Available guard messages were still rendered by AntD Alert without a data-ds-component="Alert" ancestor.
+- Migrated only the forbidden and not-found guard branches to the shared design-system Alert primitive. Maintenance mode, feature flag, incident, rotation run, and AntD table/form mechanics were left unchanged.
+- Removed the two MaintenancePage AntD Alert baseline entries. Baseline JSON evidence after removal: total rows 189, MaintenancePage rows 0, Admin rows 31.
+- Verification: focused MaintenancePage design-system Vitest passed 2/2; product-state guard unit test passed 54/54; UI TypeScript passed; `git diff --check` passed; full `bun run verify:design-system-state` still exits 1 on unrelated Integrations, WritingActionBar, Notes, and ResearchWorkspace drift, with no MaintenancePage finding. Bandit is not applicable because this slice touches only frontend TSX/test/JSON and Backlog metadata.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Migrated MaintenancePage forbidden and not-available guard feedback from AntD Alert to the shared design-system Alert primitive, added focused regression coverage for both guard states, and removed the two obsolete MaintenancePage baseline exceptions. Focused tests, guard unit coverage, and UI TypeScript pass; the full design-state verifier remains blocked by unrelated current-dev product-state drift outside this slice.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-45.44.7.4 - Migrate-MaintenancePage-guard-alerts-to-design-system-Alert.md
+++ b/backlog/tasks/task-45.44.7.4 - Migrate-MaintenancePage-guard-alerts-to-design-system-Alert.md
@@ -40,7 +40,7 @@ Replace MaintenancePage's forbidden and not-available admin guard AntD Alerts wi
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Migrated MaintenancePage forbidden and not-available guard feedback from AntD Alert to the shared design-system Alert primitive, added focused regression coverage for both guard states, and removed the two obsolete MaintenancePage baseline exceptions. Focused tests, guard unit coverage, and UI TypeScript pass; the full design-state verifier remains blocked by unrelated current-dev product-state drift outside this slice.
+Migrated MaintenancePage forbidden and not-available guard feedback from AntD Alert to the shared design-system Alert primitive, added focused regression coverage for both guard states, and removed the two obsolete MaintenancePage baseline exceptions. Focused tests, guard unit coverage, and UI TypeScript pass; the full design-state verifier remains blocked by unrelated current-dev product-state drift outside this slice. PR: https://github.com/rmusser01/tldw_server/pull/2148.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done


### PR DESCRIPTION
## Summary
- Migrate MaintenancePage forbidden and not-available admin guard feedback from AntD Alert to the shared design-system Alert primitive.
- Add focused regression coverage for both MaintenancePage guard states requiring `data-ds-component="Alert"`.
- Remove the two obsolete MaintenancePage product-state baseline exceptions and record count evidence in Backlog.

## Verification
- RED: `bunx vitest run src/components/Option/Admin/__tests__/MaintenancePage.design-system.test.tsx --reporter=dot` failed on missing `data-ds-component="Alert"` ancestors before the migration.
- PASS: `bunx vitest run src/components/Option/Admin/__tests__/MaintenancePage.design-system.test.tsx --reporter=dot` (2/2)
- PASS: `bunx vitest run src/design-system/__tests__/product-state-guard.test.ts --reporter=dot` (54/54)
- PASS: baseline JSON parse/count check (`total=189`, `MaintenancePage=0`, `Admin=31`)
- PASS: `env NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit --pretty false`
- PASS: `git diff --check`
- KNOWN BASELINE: `bun run verify:design-system-state` still exits 1 on unrelated current-dev Integrations, WritingActionBar, Notes, and ResearchWorkspace findings plus stale IntegrationPolicyPanel baseline entries. No MaintenancePage findings remain.

## Change summary (maintainer-owned)
Maintainer to fill before merge: describe what changed and why these implementation choices are appropriate for the design-system migration.

## UX Audit Checklist
- [x] Copy preserved for forbidden and not-available guard states.
- [x] Guard feedback now uses the canonical design-system Alert primitive.
- [x] No broader MaintenancePage layout, form, table, or admin action behavior changed.

## Bandit
- Not applicable. This slice touches frontend TSX/test/JSON and Backlog markdown only.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrates MaintenancePage admin guard messages from AntD `Alert` to the design-system `Alert`, preserving copy and behavior. Adds focused tests, removes the two baseline exceptions, and simplifies the `Alert` import.

- **Refactors**
  - Import `Alert` from `@/components/ui/primitives`; use `variant="error"` for 403 and `variant="warning"` for 404.
  - Add tests asserting `data-ds-component="Alert"`, `role="alert"`, and the guard copy.
  - Remove two MaintenancePage AntD `Alert` exceptions from `design-system-product-state-baseline.json`.

<sup>Written for commit 3f341b9f6526fe1b8ea83607611be9684bced1f8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2148?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

