### PR TITLE
Migrate UsageAnalyticsPage guard alerts to design system

### DIFF
--- a/apps/packages/ui/scripts/design-system-product-state-baseline.json
+++ b/apps/packages/ui/scripts/design-system-product-state-baseline.json
@@ -319,28 +319,6 @@
     "migrationQueue": "shared-product-state"
   },
   {
-    "id": "antd-product-state-import:src/components/Option/Admin/UsageAnalyticsPage.tsx:Alert#antd-alert-usageanalyticspage-type-error-access-denied-y-14wdvha",
-    "path": "src/components/Option/Admin/UsageAnalyticsPage.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/Option/Admin/UsageAnalyticsPage.tsx before the stable duplicate-id guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
-    "id": "antd-product-state-import:src/components/Option/Admin/UsageAnalyticsPage.tsx:Alert#antd-alert-usageanalyticspage-type-warning-not-available-1ihsr55",
-    "path": "src/components/Option/Admin/UsageAnalyticsPage.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/Option/Admin/UsageAnalyticsPage.tsx before the stable duplicate-id guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
     "id": "antd-product-state-import:src/components/Option/AudiobookStudio/AudiobookStudioPage.tsx:Tag",
     "path": "src/components/Option/AudiobookStudio/AudiobookStudioPage.tsx",
     "rule": "antd-product-state-import",

--- a/apps/packages/ui/src/components/Option/Admin/UsageAnalyticsPage.tsx
+++ b/apps/packages/ui/src/components/Option/Admin/UsageAnalyticsPage.tsx
@@ -4,12 +4,12 @@ import {
   Table,
   Button,
   Select,
-  Alert,
   Space,
   Collapse,
   Statistic,
   message
 } from "antd"
+import { Alert } from "@/components/ui/primitives"
 import {
   deriveAdminGuardFromError,
   sanitizeAdminErrorMessage
@@ -242,10 +242,18 @@ const UsageAnalyticsPage: React.FC = () => {
   // ── Render ──
 
   if (adminGuard === "forbidden") {
-    return <Alert type="error" title="Access Denied" description="You don't have permission to access usage analytics." showIcon />
+    return (
+      <Alert variant="error" title="Access Denied">
+        You don't have permission to access usage analytics.
+      </Alert>
+    )
   }
   if (adminGuard === "notFound") {
-    return <Alert type="warning" title="Not Available" description="Usage analytics is not available on this server." showIcon />
+    return (
+      <Alert variant="warning" title="Not Available">
+        Usage analytics is not available on this server.
+      </Alert>
+    )
   }
 
   return (

--- a/apps/packages/ui/src/components/Option/Admin/__tests__/UsageAnalyticsPage.design-system.test.tsx
+++ b/apps/packages/ui/src/components/Option/Admin/__tests__/UsageAnalyticsPage.design-system.test.tsx
@@ -1,0 +1,67 @@
+// @vitest-environment jsdom
+
+import React from "react"
+import { render, screen } from "@testing-library/react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import UsageAnalyticsPage from "../UsageAnalyticsPage"
+
+const apiMock = vi.hoisted(() => ({
+  getDailyUsage: vi.fn(),
+  getTopUsage: vi.fn(),
+  getLlmUsage: vi.fn(),
+  getLlmUsageSummary: vi.fn(),
+  getLlmTopSpenders: vi.fn(),
+  getRouterAnalyticsProviders: vi.fn(),
+  exportDailyUsageCsv: vi.fn(),
+  exportTopUsageCsv: vi.fn()
+}))
+
+vi.mock("@/services/tldw/TldwApiClient", () => ({
+  tldwClient: apiMock
+}))
+
+const expectDesignSystemAlertForTitle = async (titleText: string) => {
+  const title = await screen.findByText(titleText)
+  const alert = title.closest('[data-ds-component="Alert"]')
+
+  expect(alert).not.toBeNull()
+  const alertEl = alert as HTMLElement
+  expect(alertEl).toHaveAttribute("role", "alert")
+  return alertEl
+}
+
+describe("UsageAnalyticsPage design-system states", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    apiMock.getDailyUsage.mockResolvedValue([])
+    apiMock.getTopUsage.mockResolvedValue([])
+    apiMock.getLlmUsage.mockResolvedValue([])
+    apiMock.getLlmUsageSummary.mockResolvedValue({})
+    apiMock.getLlmTopSpenders.mockResolvedValue([])
+    apiMock.getRouterAnalyticsProviders.mockResolvedValue([])
+    apiMock.exportDailyUsageCsv.mockResolvedValue("")
+    apiMock.exportTopUsageCsv.mockResolvedValue("")
+  })
+
+  it("renders forbidden guard feedback through the design-system Alert primitive", async () => {
+    apiMock.getDailyUsage.mockRejectedValueOnce({ status: 403 })
+
+    render(<UsageAnalyticsPage />)
+
+    const alert = await expectDesignSystemAlertForTitle("Access Denied")
+    expect(alert).toHaveTextContent(
+      "You don't have permission to access usage analytics."
+    )
+  })
+
+  it("renders missing-endpoint guard feedback through the design-system Alert primitive", async () => {
+    apiMock.getDailyUsage.mockRejectedValueOnce({ status: 404 })
+
+    render(<UsageAnalyticsPage />)
+
+    const alert = await expectDesignSystemAlertForTitle("Not Available")
+    expect(alert).toHaveTextContent(
+      "Usage analytics is not available on this server."
+    )
+  })
+})

--- a/backlog/tasks/task-45.44.7 - Migrate-design-system-product-state-Admin-and-health-expansion.md
+++ b/backlog/tasks/task-45.44.7 - Migrate-design-system-product-state-Admin-and-health-expansion.md
@@ -4,7 +4,7 @@ title: 'Migrate design-system product state: Admin and health expansion'
 status: In Progress
 assignee: []
 created_date: '2026-05-14 03:19'
-updated_date: '2026-05-30 10:45'
+updated_date: '2026-05-30 10:49'
 labels:
   - design-system
   - webui
@@ -75,8 +75,9 @@ documentation:
       - scoped verifier log had no MaintenancePage findings
       - full verifier remains blocked by unrelated current-dev drift outside this slice
 
-    TASK-45.44.7.5 migrated UsageAnalyticsPage forbidden and not-available
-    guard feedback from AntD Alert to the design-system Alert primitive.
+    TASK-45.44.7.5 / PR #2149 migrated UsageAnalyticsPage forbidden and
+    not-available guard feedback from AntD Alert to the design-system Alert
+    primitive.
 
     Baseline file evidence:
       - total baseline rows: 189 -> 187

--- a/backlog/tasks/task-45.44.7 - Migrate-design-system-product-state-Admin-and-health-expansion.md
+++ b/backlog/tasks/task-45.44.7 - Migrate-design-system-product-state-Admin-and-health-expansion.md
@@ -4,7 +4,7 @@ title: 'Migrate design-system product state: Admin and health expansion'
 status: In Progress
 assignee: []
 created_date: '2026-05-14 03:19'
-updated_date: '2026-05-30 09:27'
+updated_date: '2026-05-30 10:45'
 labels:
   - design-system
   - webui
@@ -73,6 +73,18 @@ documentation:
 
     Verifier evidence:
       - scoped verifier log had no MaintenancePage findings
+      - full verifier remains blocked by unrelated current-dev drift outside this slice
+
+    TASK-45.44.7.5 migrated UsageAnalyticsPage forbidden and not-available
+    guard feedback from AntD Alert to the design-system Alert primitive.
+
+    Baseline file evidence:
+      - total baseline rows: 189 -> 187
+      - Admin path rows: 31 -> 29
+      - UsageAnalyticsPage target rows: 2 -> 0
+
+    Verifier evidence:
+      - scoped verifier log had no UsageAnalyticsPage findings
       - full verifier remains blocked by unrelated current-dev drift outside this slice
 parent_task_id: TASK-45.44
 priority: medium

--- a/backlog/tasks/task-45.44.7.5 - Migrate-UsageAnalyticsPage-guard-alerts-to-design-system-Alert.md
+++ b/backlog/tasks/task-45.44.7.5 - Migrate-UsageAnalyticsPage-guard-alerts-to-design-system-Alert.md
@@ -13,6 +13,8 @@ modified_files:
 - apps/packages/ui/src/components/Option/Admin/__tests__/UsageAnalyticsPage.design-system.test.tsx
 - apps/packages/ui/scripts/design-system-product-state-baseline.json
 - backlog/tasks/task-45.44.7 - Migrate-design-system-product-state-Admin-and-health-expansion.md
+references:
+- https://github.com/rmusser01/tldw_server/pull/2149
 ---
 
 ## Description
@@ -48,13 +50,14 @@ Verification:
 - `git diff --check` completed with no output.
 - `bun run verify:design-system-state` still exits 1 because of unrelated current-dev product-state drift and stale IntegrationPolicyPanel baseline rows; `/tmp/usage-analytics-design-state.log` has no UsageAnalyticsPage findings.
 - Bandit not run: this slice touched TypeScript UI, JSON baseline data, and Backlog task markdown only.
+- PR: https://github.com/rmusser01/tldw_server/pull/2149
 
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Migrated UsageAnalyticsPage forbidden and not-found admin guard feedback from AntD Alert to the design-system Alert primitive, added focused regression coverage for both states, and removed the two matching product-state baseline exceptions.
+Migrated UsageAnalyticsPage forbidden and not-found admin guard feedback from AntD Alert to the design-system Alert primitive, added focused regression coverage for both states, removed the two matching product-state baseline exceptions, and opened PR #2149.
 
 <!-- SECTION:FINAL_SUMMARY:END -->
 

--- a/backlog/tasks/task-45.44.7.5 - Migrate-UsageAnalyticsPage-guard-alerts-to-design-system-Alert.md
+++ b/backlog/tasks/task-45.44.7.5 - Migrate-UsageAnalyticsPage-guard-alerts-to-design-system-Alert.md
@@ -1,0 +1,69 @@
+---
+id: TASK-45.44.7.5
+title: Migrate UsageAnalyticsPage guard alerts to design-system Alert
+status: Done
+labels:
+- design-system
+- webui
+- product-state
+priority: medium
+parent_task_id: TASK-45.44.7
+modified_files:
+- apps/packages/ui/src/components/Option/Admin/UsageAnalyticsPage.tsx
+- apps/packages/ui/src/components/Option/Admin/__tests__/UsageAnalyticsPage.design-system.test.tsx
+- apps/packages/ui/scripts/design-system-product-state-baseline.json
+- backlog/tasks/task-45.44.7 - Migrate-design-system-product-state-Admin-and-health-expansion.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Replace UsageAnalyticsPage's forbidden and not-available admin guard AntD Alerts with the shared design-system Alert primitive while preserving copy and guard behavior. Remove matching product-state baseline entries and record focused verification.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 UsageAnalyticsPage forbidden guard feedback renders through data-ds-component="Alert" with error urgency semantics.
+- [x] #2 UsageAnalyticsPage not-found guard feedback renders through data-ds-component="Alert" while preserving the Not Available copy.
+- [x] #3 The matching UsageAnalyticsPage AntD Alert baseline entries are removed without introducing a UsageAnalyticsPage verifier finding.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Implemented the narrow UsageAnalyticsPage admin guard slice:
+
+- Added focused jsdom regression coverage for forbidden and not-found guard states, with a hard null check before using the nearest `data-ds-component="Alert"` ancestor.
+- Verified the test failed before implementation because the existing AntD Alert markup had no design-system Alert ancestor.
+- Replaced the two guard-return AntD Alerts with the shared design-system Alert primitive while preserving the existing title/body copy and error/warning urgency.
+- Removed the two UsageAnalyticsPage entries from the product-state baseline.
+
+Verification:
+
+- RED: `bunx vitest run src/components/Option/Admin/__tests__/UsageAnalyticsPage.design-system.test.tsx --reporter=dot` failed with `expected null not to be null` before the migration.
+- GREEN: `bunx vitest run src/components/Option/Admin/__tests__/UsageAnalyticsPage.design-system.test.tsx --reporter=dot` passed with 2 tests.
+- `bunx vitest run src/design-system/__tests__/product-state-guard.test.ts --reporter=dot` passed with 54 tests.
+- Baseline count script reported `{"total":187,"usage":0,"admin":29}`.
+- `env NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit --pretty false` completed with no output.
+- `git diff --check` completed with no output.
+- `bun run verify:design-system-state` still exits 1 because of unrelated current-dev product-state drift and stale IntegrationPolicyPanel baseline rows; `/tmp/usage-analytics-design-state.log` has no UsageAnalyticsPage findings.
+- Bandit not run: this slice touched TypeScript UI, JSON baseline data, and Backlog task markdown only.
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Migrated UsageAnalyticsPage forbidden and not-found admin guard feedback from AntD Alert to the design-system Alert primitive, added focused regression coverage for both states, and removed the two matching product-state baseline exceptions.
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## Summary

- Migrates `UsageAnalyticsPage` forbidden and not-found guard feedback from AntD `Alert` to the design-system `Alert` primitive.
- Adds focused regression coverage for both guard states and asserts the design-system marker before using the alert element.
- Removes the two matching `UsageAnalyticsPage` product-state baseline exceptions and records the slice in Backlog.md.

## Verification

- `bunx vitest run src/components/Option/Admin/__tests__/UsageAnalyticsPage.design-system.test.tsx --reporter=dot`
- `bunx vitest run src/design-system/__tests__/product-state-guard.test.ts --reporter=dot`
- `node -e "const fs=require('fs'); const data=JSON.parse(fs.readFileSync('apps/packages/ui/scripts/design-system-product-state-baseline.json','utf8')); console.log(JSON.stringify({total:data.length,usage:data.filter(e=>e.path==='src/components/Option/Admin/UsageAnalyticsPage.tsx').length,admin:data.filter(e=>e.path?.startsWith('src/components/Option/Admin/')).length}));"` -> `{"total":187,"usage":0,"admin":29}`
- `env NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit --pretty false`
- `git diff --check`
- `bun run verify:design-system-state` exits 1 from unrelated current-dev product-state drift and stale IntegrationPolicyPanel baseline rows; no `UsageAnalyticsPage` findings were present in `/tmp/usage-analytics-design-state.log`.

## Change summary (maintainer-owned)

Maintainer note required before merge: please replace this section with your own summary explaining what changed and why these implementation choices were made.

## UX Audit Checklist

- [x] Existing guard copy is preserved.
- [x] Forbidden state keeps error urgency semantics.
- [x] Missing endpoint state keeps warning urgency semantics.
- [x] No user-visible layout expansion beyond the two guard branches.

## Bandit

Not run. This slice touched TypeScript UI, JSON baseline data, and Backlog task markdown only.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrated `UsageAnalyticsPage` guard alerts from `antd` to the design-system `Alert` to unify product-state UI and preserve copy and urgency. Added focused tests, cleaned up the product-state baseline, and recorded the migration in backlog tasks.

- **Refactors**
  - Replaced `antd` `Alert` with design-system `Alert` for forbidden and not-found states.
  - Added tests that assert the `data-ds-component="Alert"` marker and guard text.
  - Removed two `UsageAnalyticsPage` entries from the baseline and updated the backlog task record.

<sup>Written for commit b10eb5c740421e3576e4a0031c6f89be69010660. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2149?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

