### PR TITLE
Add Stage 4E gateway profile runtime

### DIFF
--- a/Docs/superpowers/plans/2026-05-30-mcp-unified-stage4e-gateway-profile-runtime-plan.md
+++ b/Docs/superpowers/plans/2026-05-30-mcp-unified-stage4e-gateway-profile-runtime-plan.md
@@ -1,0 +1,124 @@
+# MCP Unified Stage 4E Gateway Profile Runtime Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a package-owned profile-aware gateway runtime wrapper for standalone MCP gateway discovery and tool execution.
+
+**Architecture:** Keep profile enforcement host-neutral and package-owned under `mcp_unified.gateway`. The wrapper resolves the explicit transport-selected profile or configured standalone default profile, derives the effective profile policy through existing profile resolution primitives, filters `tools/list`, and denies `tools/call` before backend delegation when the profile is missing, disabled, unavailable, or does not allow the requested tool/capability. This slice intentionally avoids external MCP lifecycle, upstream process spawning, SQLite CLI/config commands, preset duplication flows, and `tldw_server` host route integration.
+
+**Tech Stack:** Python 3.11, Pydantic profile models, package-local profile resolver/store primitives, FastAPI metadata extraction, pytest, Ruff, Bandit.
+
+---
+
+### Task 1: Profile-Aware Gateway RED Tests
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py`
+- Create: `mcp_unified/gateway/profile_runtime.py`
+- Modify: `mcp_unified/gateway/runtime.py`
+- Modify: `mcp_unified/gateway/jsonrpc.py`
+- Modify: `mcp_unified/gateway/fastapi.py`
+- Modify: `mcp_unified/gateway/__init__.py`
+
+- [x] **Step 1: Add fake profile-gated runtime coverage**
+
+Add tests that construct a profile-aware gateway runtime around a fake backend runtime and an in-memory profile store.
+
+Required failing behaviors:
+- no default or explicit profile returns an empty `tools/list`;
+- no default or explicit profile denies `tools/call` with a structured JSON-RPC policy error carrying `reason_code="profile_required"`;
+- a default profile allows the configured tool and filters denied tools from discovery;
+- an explicit FastAPI profile header selects the profile when no default is configured;
+- denied tools produce a machine-readable policy denial and do not reach the backend runtime.
+
+- [x] **Step 2: Run RED tests**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py -q
+```
+
+Expected: fail because `mcp_unified.gateway.profile_runtime` and policy-error JSON-RPC mapping do not exist yet.
+
+Evidence: baseline gateway package tests passed with `29 passed, 4 warnings`. After adding the Stage 4E tests, RED failed with `4 failed, 29 passed, 4 warnings`; all four new tests failed with `ModuleNotFoundError: No module named 'mcp_unified.gateway.profile_runtime'`.
+
+### Task 2: Profile Runtime Wrapper And Transport Metadata
+
+**Files:**
+- Create: `mcp_unified/gateway/profile_runtime.py`
+- Modify: `mcp_unified/gateway/runtime.py`
+- Modify: `mcp_unified/gateway/jsonrpc.py`
+- Modify: `mcp_unified/gateway/fastapi.py`
+- Modify: `mcp_unified/gateway/__init__.py`
+
+- [x] **Step 1: Add structured gateway policy denial**
+
+Add a package-local exception for policy denials with reason code, status, provenance, and warnings. Map it in JSON-RPC to a custom server error response so execution denials are machine-readable rather than generic internal errors.
+
+- [x] **Step 2: Add `ProfileAwareGatewayRuntime`**
+
+Implement a wrapper that:
+- proxies runtime identity to the backend runtime;
+- resolves profiles from existing `StoreBackedProfileResolver` / structured resolution primitives;
+- reads explicit profile selection from `GatewayRequestContext.metadata["profile_id"]`;
+- returns no executable tools for unresolved profiles;
+- filters `tools/list` by effective profile policy;
+- denies `tools/call` before backend delegation when profile resolution or tool policy fails;
+- delegates resource, prompt, and module methods unchanged in this slice.
+
+- [x] **Step 3: Add lightweight FastAPI profile metadata extraction**
+
+Propagate an optional profile id from `X-MCP-Profile` / `X-MCP-Profile-Id` headers, or `profile_id` / `profileId` query params, into the gateway request metadata for HTTP and WebSocket transports. Existing requests without profile metadata must keep their current behavior for unwrapped runtimes.
+
+- [x] **Step 4: Run GREEN gateway tests**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py -q
+```
+
+Expected: all gateway package tests pass.
+
+Evidence: gateway package tests passed with `33 passed, 4 warnings` after adding `ProfileAwareGatewayRuntime`, structured policy-denial JSON-RPC mapping, and HTTP/WebSocket profile metadata propagation.
+
+### Task 3: Compatibility, Security, And PR Handoff
+
+**Files:**
+- Modify: `Docs/superpowers/plans/2026-05-30-mcp-unified-stage4e-gateway-profile-runtime-plan.md`
+- Modify: `backlog/tasks/task-562 - Implement-MCP-Unified-Stage-4E-gateway-profile-runtime.md`
+
+- [x] **Step 1: Run host compatibility tests**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_extraction_contracts.py tldw_Server_API/app/core/MCP_unified/tests/test_http_mapping.py -q
+```
+
+Expected: existing host extraction and HTTP mapping tests pass.
+
+Evidence: host compatibility tests passed with `47 passed, 4 warnings`.
+
+- [x] **Step 2: Run lint, security, and whitespace checks**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m ruff check mcp_unified/gateway tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r mcp_unified/gateway -f json -o /tmp/bandit_mcp_stage4e_gateway_profile_runtime.json
+git diff --check
+```
+
+Expected: Ruff passes, Bandit reports no findings for `mcp_unified/gateway`, and whitespace check is clean.
+
+Evidence: Ruff reported `All checks passed!`; Bandit JSON at `/tmp/bandit_mcp_stage4e_gateway_profile_runtime.json` reported `0` findings and no errors; `git diff --check` exited cleanly.
+
+- [x] **Step 3: Update plan and Backlog task**
+
+Record RED/GREEN and final verification evidence in this plan and TASK-562. Check off completed acceptance criteria and Definition of Done.
+
+- [x] **Step 4: Commit, push, and open PR**
+
+Commit the plan, gateway/test changes, and Backlog task update together, push the branch, and open a PR against `dev`.

--- a/backlog/tasks/task-562 - Implement-MCP-Unified-Stage-4E-gateway-profile-runtime.md
+++ b/backlog/tasks/task-562 - Implement-MCP-Unified-Stage-4E-gateway-profile-runtime.md
@@ -1,0 +1,71 @@
+---
+id: TASK-562
+title: Implement MCP Unified Stage 4E gateway profile runtime
+status: Done
+labels:
+- mcp-unified
+- standalone-extraction
+- gateway
+priority: medium
+references:
+- Docs/superpowers/specs/2026-05-26-mcp-unified-standalone-library-gateway-design.md
+- Docs/superpowers/plans/2026-05-30-mcp-unified-stage4e-gateway-profile-runtime-plan.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement the next narrow Stage 4E standalone gateway slice after Stage 4D: add a package-owned profile-aware gateway runtime wrapper that resolves standalone default or explicit profiles before discovery/execution and delegates allowed calls to an injected backend runtime. This slice intentionally avoids external MCP lifecycle, upstream process spawning, SQLite CLI/config commands, and tldw_server host route integration.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Package gateway exposes a profile-aware runtime wrapper without importing `tldw_Server_API`.
+- [x] #2 No-profile standalone tool discovery returns no executable tools and tool execution denies with structured `profile_required` data when no default profile is configured.
+- [x] #3 Explicit or default profiles filter `tools/list` and allow/deny `tools/call` by profile policy before delegating to the backend runtime.
+- [x] #4 FastAPI transports can select a profile through lightweight request metadata without changing existing no-header behavior.
+- [x] #5 Focused gateway tests cover default-profile allow, explicit-profile header selection, no-profile fail-closed behavior, and deny reason payloads.
+- [x] #6 Host extraction and HTTP mapping compatibility tests, Ruff, Bandit, and whitespace checks are recorded before PR handoff.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Started from merged Stage 4D baseline on origin/dev commit 4ae10d2a7e. Baseline gateway package tests passed with `29 passed, 4 warnings`.
+
+Added Stage 4E RED coverage for a profile-aware gateway runtime wrapper: no-profile fail-closed discovery/execution, default-profile allow/filter behavior, explicit HTTP header profile selection, and WebSocket query profile selection. RED run failed as expected with `4 failed, 29 passed, 4 warnings` because `mcp_unified.gateway.profile_runtime` did not exist.
+
+Added `GatewayPolicyDenied` for machine-readable gateway policy denials, mapped it to JSON-RPC server error `-32001`, and added `ProfileAwareGatewayRuntime`. The wrapper resolves explicit or default profiles through existing structured profile resolver/store primitives, returns no tools for unresolved standalone profiles, filters `tools/list`, denies `tools/call` before backend delegation when profile policy does not allow the tool, and delegates resources/prompts/modules unchanged for this slice. FastAPI HTTP and WebSocket transports now propagate optional profile ids from `X-MCP-Profile` / `X-MCP-Profile-Id` headers or `profile_id` / `profileId` query params into request metadata.
+
+Verification recorded:
+- GREEN gateway package tests: `33 passed, 4 warnings`.
+- Host compatibility: `47 passed, 4 warnings` for extraction contracts and HTTP mapping tests.
+- Ruff: `All checks passed!`.
+- Bandit: `/tmp/bandit_mcp_stage4e_gateway_profile_runtime.json` reported `0` findings and no errors.
+- `git diff --check` exited cleanly.
+
+PR review closeout after rebasing onto origin/dev commit 112108c103:
+- Verified current Qodo and Gemini review threads against rebased code.
+- Fixed Qodo docstring coverage for new profile-runtime test helpers.
+- Fixed denied tool calls so explicit tool-policy denials do not invoke backend discovery.
+- Added capability-policy fail-closed handling when backend metadata discovery raises.
+- Added defensive handling for non-list backend tool discovery payloads, invalid tool descriptors, and transport doubles missing headers/query_params.
+- Re-ran focused validation: gateway package tests `38 passed, 4 warnings`; extraction/http compatibility tests `47 passed, 4 warnings`; Ruff passed; Bandit reported `0` findings; `git diff --check` passed.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Stage 4E adds a package-owned profile-aware gateway runtime wrapper for standalone gateway tool discovery and execution. It keeps the existing transport-neutral JSON-RPC and FastAPI/WebSocket behavior intact while allowing gateway callers to select a profile through lightweight metadata and enabling default-profile standalone behavior through existing profile resolver/store primitives. Tool discovery now filters through effective profile policy, and tool execution fails closed with structured `profile_required` / `tool_not_allowed` denial data before backend delegation. This slice remains package-isolated and intentionally leaves external MCP lifecycle, upstream process spawning, SQLite CLI/config commands, preset duplication flows, and host route integration for later stages. No known skips or blockers.
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/mcp_unified/gateway/__init__.py
+++ b/mcp_unified/gateway/__init__.py
@@ -2,16 +2,19 @@
 
 from typing import TYPE_CHECKING, Any
 
-from .runtime import GatewayRequestContext, GatewayRuntime
+from .profile_runtime import ProfileAwareGatewayRuntime
+from .runtime import GatewayPolicyDenied, GatewayRequestContext, GatewayRuntime
 from .stdio import GatewayStdioServer, handle_stdio_line
 
 if TYPE_CHECKING:
     from .fastapi import create_gateway_app, create_gateway_router
 
 __all__ = [
+    "GatewayPolicyDenied",
     "GatewayRequestContext",
     "GatewayRuntime",
     "GatewayStdioServer",
+    "ProfileAwareGatewayRuntime",
     "create_gateway_app",
     "create_gateway_router",
     "handle_stdio_line",

--- a/mcp_unified/gateway/fastapi.py
+++ b/mcp_unified/gateway/fastapi.py
@@ -35,6 +35,9 @@ from .jsonrpc import (
 )
 from .runtime import GatewayRuntime
 
+_PROFILE_HEADER_NAMES = ("x-mcp-profile", "x-mcp-profile-id")
+_PROFILE_QUERY_NAMES = ("profile_id", "profileId")
+
 
 async def _parse_json_body(request: Request) -> Any:
     """Parse raw JSON so malformed bodies return JSON-RPC parse errors."""
@@ -48,6 +51,35 @@ def _client_host(request: Request | WebSocket) -> str | None:
     if request.client is None:
         return None
     return request.client.host
+
+
+def _request_metadata(request: Request | WebSocket) -> dict[str, Any]:
+    """Build host-neutral metadata from lightweight transport selectors."""
+
+    metadata: dict[str, Any] = {}
+    profile_id = _profile_id_from_transport(request)
+    if profile_id is not None:
+        metadata["profile_id"] = profile_id
+    return metadata
+
+
+def _profile_id_from_transport(request: Request | WebSocket) -> str | None:
+    """Return an optional profile id selected by header or query parameter."""
+
+    headers = getattr(request, "headers", None)
+    if headers is not None:
+        for header_name in _PROFILE_HEADER_NAMES:
+            value = headers.get(header_name)
+            if isinstance(value, str) and value.strip():
+                return value.strip()
+
+    query_params = getattr(request, "query_params", None)
+    if query_params is not None:
+        for query_name in _PROFILE_QUERY_NAMES:
+            value = query_params.get(query_name)
+            if isinstance(value, str) and value.strip():
+                return value.strip()
+    return None
 
 
 async def _send_websocket_response(
@@ -120,6 +152,7 @@ def create_gateway_router(runtime: GatewayRuntime) -> APIRouter:
             payload,
             path=str(request.url.path),
             client_host=_client_host(request),
+            metadata=_request_metadata(request),
         )
         return _to_http_response(response)
 
@@ -145,6 +178,7 @@ def create_gateway_router(runtime: GatewayRuntime) -> APIRouter:
                     payload,
                     path=str(websocket.url.path),
                     client_host=_client_host(websocket),
+                    metadata=_request_metadata(websocket),
                 )
                 await _send_websocket_response(websocket, response)
         except (WebSocketDisconnect, RuntimeError):

--- a/mcp_unified/gateway/jsonrpc.py
+++ b/mcp_unified/gateway/jsonrpc.py
@@ -35,7 +35,7 @@ try:
 except ImportError:  # pragma: no cover - defensive fallback for future pydantic changes
     _pydantic_encoder = None
 
-from .runtime import GatewayRequestContext, GatewayRuntime
+from .runtime import GatewayPolicyDenied, GatewayRequestContext, GatewayRuntime
 
 PROTOCOL_VERSION = "2024-11-05"
 JSONRPC_VERSION = "2.0"
@@ -45,6 +45,7 @@ INVALID_REQUEST = -32600
 METHOD_NOT_FOUND = -32601
 INVALID_PARAMS = -32602
 INTERNAL_ERROR = -32603
+POLICY_DENIED = -32001
 _GATEWAY_RUNTIME_ERRORS = Exception
 _JSON_PARSE_ERRORS = (json.JSONDecodeError, UnicodeDecodeError)
 _RESERVED_CONTEXT_METADATA_KEYS = frozenset({"client_host", "method", "path"})
@@ -336,6 +337,8 @@ async def handle_single_jsonrpc(
             client_host=client_host,
             metadata=metadata,
         )
+    except GatewayPolicyDenied as exc:
+        error = jsonrpc_error(POLICY_DENIED, str(exc), request_id, data=exc.to_error_data())
     except ValueError as exc:
         error = jsonrpc_error(INVALID_PARAMS, str(exc), request_id)
     except NotImplementedError:
@@ -408,6 +411,7 @@ def parse_json_payload(payload: str | bytes) -> Any | GatewayJSONRPCErrorRespons
 __all__ = [
     "GATEWAY_RESPONSE_TYPES",
     "INVALID_REQUEST",
+    "POLICY_DENIED",
     "GatewayJSONRPCError",
     "GatewayJSONRPCErrorResponse",
     "GatewayJSONRPCRequest",

--- a/mcp_unified/gateway/profile_runtime.py
+++ b/mcp_unified/gateway/profile_runtime.py
@@ -1,0 +1,337 @@
+"""Profile-aware gateway runtime wrapper for standalone MCP gateways."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Any, Protocol
+
+from mcp_unified.interfaces.storage import ProfileStore
+from mcp_unified.profiles.models import MCPProfile
+from mcp_unified.profiles.resolution import (
+    EffectivePolicyResult,
+    ProfileResolutionResult,
+    build_effective_policy_result,
+)
+from mcp_unified.profiles.resolver import StoreBackedProfileResolver
+
+from .runtime import GatewayPolicyDenied, GatewayRequestContext, GatewayRuntime
+
+
+class GatewayProfileResolver(Protocol):
+    """Structured profile resolver needed by the profile-aware gateway runtime."""
+
+    async def resolve_profile_result(
+        self,
+        profile_id: str | None,
+        *,
+        user_id: str | None = None,
+    ) -> ProfileResolutionResult:
+        """Resolve a profile into a structured outcome."""
+        ...
+
+
+class ProfileAwareGatewayRuntime:
+    """Apply standalone profile policy before delegating tool calls."""
+
+    def __init__(
+        self,
+        backend: GatewayRuntime,
+        *,
+        profile_store: ProfileStore | None = None,
+        profile_resolver: GatewayProfileResolver | None = None,
+        default_profile_id: str | None = None,
+    ) -> None:
+        if profile_resolver is None:
+            if profile_store is None:
+                raise ValueError("profile_store or profile_resolver is required")
+            profile_resolver = StoreBackedProfileResolver(
+                profile_store,
+                default_profile_id=default_profile_id,
+            )
+        self._backend = backend
+        self._profile_resolver = profile_resolver
+
+    @property
+    def name(self) -> str:
+        """Return the wrapped runtime name."""
+
+        return str(getattr(self._backend, "name", "mcp-unified-gateway"))
+
+    @property
+    def version(self) -> str:
+        """Return the wrapped runtime version."""
+
+        return str(getattr(self._backend, "version", "0.1.0"))
+
+    async def list_tools(self, context: GatewayRequestContext) -> list[dict[str, Any]]:
+        """Return backend tools allowed by the resolved profile policy."""
+
+        profile_result = await self._resolve_profile(context)
+        if profile_result.status != "resolved" or profile_result.profile is None:
+            return []
+
+        tools = await self._backend.list_tools(context)
+        if not isinstance(tools, list):
+            return []
+
+        allowed_tools: list[dict[str, Any]] = []
+        for tool in tools:
+            if not isinstance(tool, dict):
+                continue
+            if _tool_name(tool) is not None and _tool_allowed_by_profile(
+                profile_result.profile,
+                tool,
+            ):
+                allowed_tools.append(tool)
+        return allowed_tools
+
+    async def call_tool(
+        self,
+        name: str,
+        arguments: dict[str, Any],
+        context: GatewayRequestContext,
+    ) -> dict[str, Any]:
+        """Execute an allowed backend tool or raise a structured policy denial."""
+
+        profile = await self._require_profile(context)
+        policy_result = _allowed_policy_result_for_tool(profile, name, None)
+        if _policy_needs_backend_tool_metadata(profile, policy_result):
+            try:
+                tool = await self._find_backend_tool(name, context)
+            except Exception as exc:
+                raise GatewayPolicyDenied(
+                    "Gateway profile could not inspect backend tool metadata",
+                    reason_code="tool_metadata_unavailable",
+                    provenance={
+                        "tool_name": name,
+                        "backend_error": type(exc).__name__,
+                    },
+                ) from exc
+            policy_result = _allowed_policy_result_for_tool(profile, name, tool)
+        if policy_result.status != "resolved":
+            raise _policy_denied(
+                policy_result,
+                message=f"Gateway profile denied tool execution: {policy_result.reason_code}",
+            )
+        return await self._backend.call_tool(name, arguments, context)
+
+    async def list_resources(self, context: GatewayRequestContext) -> list[dict[str, Any]]:
+        """Delegate resource discovery unchanged for this profile slice."""
+
+        return await self._backend.list_resources(context)
+
+    async def read_resource(
+        self,
+        uri: str,
+        context: GatewayRequestContext,
+    ) -> dict[str, Any]:
+        """Delegate resource reads unchanged for this profile slice."""
+
+        return await self._backend.read_resource(uri, context)
+
+    async def list_prompts(self, context: GatewayRequestContext) -> list[dict[str, Any]]:
+        """Delegate prompt discovery unchanged for this profile slice."""
+
+        return await self._backend.list_prompts(context)
+
+    async def get_prompt(
+        self,
+        name: str,
+        arguments: dict[str, Any],
+        context: GatewayRequestContext,
+    ) -> dict[str, Any]:
+        """Delegate prompt reads unchanged for this profile slice."""
+
+        return await self._backend.get_prompt(name, arguments, context)
+
+    async def list_modules(self, context: GatewayRequestContext) -> list[dict[str, Any]]:
+        """Delegate module discovery unchanged for this profile slice."""
+
+        return await self._backend.list_modules(context)
+
+    async def get_modules_health(self, context: GatewayRequestContext) -> dict[str, Any]:
+        """Delegate module health unchanged for this profile slice."""
+
+        return await self._backend.get_modules_health(context)
+
+    async def _resolve_profile(
+        self,
+        context: GatewayRequestContext,
+    ) -> ProfileResolutionResult:
+        profile_id = _context_profile_id(context)
+        return await self._profile_resolver.resolve_profile_result(
+            profile_id,
+            user_id=context.user_id,
+        )
+
+    async def _require_profile(self, context: GatewayRequestContext) -> MCPProfile:
+        profile_result = await self._resolve_profile(context)
+        if profile_result.status != "resolved" or profile_result.profile is None:
+            raise GatewayPolicyDenied(
+                f"Gateway profile resolution failed: {profile_result.reason_code}",
+                status=profile_result.status,
+                reason_code=profile_result.reason_code,
+                provenance=profile_result.provenance,
+                warnings=profile_result.warnings,
+            )
+        return profile_result.profile
+
+    async def _find_backend_tool(
+        self,
+        name: str,
+        context: GatewayRequestContext,
+    ) -> dict[str, Any] | None:
+        tools = await self._backend.list_tools(context)
+        if not isinstance(tools, list):
+            return None
+        return next(
+            (
+                tool
+                for tool in tools
+                if isinstance(tool, dict) and _tool_name(tool) == name
+            ),
+            None,
+        )
+
+
+def _context_profile_id(context: GatewayRequestContext) -> str | None:
+    """Return an explicit profile id from transport metadata, if present."""
+
+    for key in ("profile_id", "profileId", "mcp_profile", "mcp-profile"):
+        value = context.metadata.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return None
+
+
+def _tool_name(tool: Any) -> str | None:
+    """Return a valid tool name from a backend tool descriptor."""
+
+    if not isinstance(tool, dict):
+        return None
+    name = tool.get("name")
+    return name.strip() if isinstance(name, str) and name.strip() else None
+
+
+def _tool_allowed_by_profile(profile: MCPProfile, tool: Any) -> bool:
+    """Return whether a backend tool descriptor is visible for a profile."""
+
+    name = _tool_name(tool)
+    if name is None:
+        return False
+    return _allowed_policy_result_for_tool(profile, name, tool).status == "resolved"
+
+
+def _allowed_policy_result_for_tool(
+    profile: MCPProfile,
+    tool_name: str,
+    tool: Any,
+) -> EffectivePolicyResult:
+    """Return the first allow result, preserving exact tool-deny precedence."""
+
+    name_only_result = _effective_policy_for_tool(profile, tool_name, None)
+    if (
+        name_only_result.status == "resolved"
+        or name_only_result.reason_code != "tool_not_allowed"
+    ):
+        return name_only_result
+
+    for capability in _tool_capabilities(tool):
+        if capability is None:
+            continue
+        capability_result = _effective_policy_for_tool(
+            profile,
+            tool_name,
+            tool,
+            capability=capability,
+        )
+        if capability_result.status == "resolved":
+            return capability_result
+    return name_only_result
+
+
+def _policy_needs_backend_tool_metadata(
+    profile: MCPProfile,
+    policy_result: EffectivePolicyResult,
+) -> bool:
+    """Return whether policy needs tool metadata before final denial."""
+
+    if policy_result.status == "resolved" or policy_result.reason_code != "tool_not_allowed":
+        return False
+    policy_document = profile.policy_document
+    if policy_document.allowed_tools:
+        return False
+    return bool(policy_document.capabilities or policy_document.denied_capabilities)
+
+
+def _effective_policy_for_tool(
+    profile: MCPProfile,
+    tool_name: str,
+    tool: Any,
+    *,
+    capability: str | None = None,
+) -> EffectivePolicyResult:
+    """Build the effective policy outcome for one tool descriptor."""
+
+    return build_effective_policy_result(
+        profile,
+        tool_name=tool_name,
+        capability=capability if capability is not None else _primary_capability(tool),
+    )
+
+
+def _primary_capability(tool: Any) -> str | None:
+    """Return the first advertised tool capability, if any."""
+
+    capabilities = _tool_capabilities(tool)
+    return capabilities[0] if capabilities else None
+
+
+def _tool_capabilities(tool: Any) -> list[str | None]:
+    """Return advertised capabilities plus a no-capability fallback."""
+
+    if not isinstance(tool, dict):
+        return [None]
+    metadata = tool.get("metadata")
+    capability_values: list[Any] = []
+    if isinstance(metadata, dict):
+        capability_values.extend(_as_sequence(metadata.get("capabilities")))
+        capability_values.extend(_as_sequence(metadata.get("capability")))
+    capability_values.extend(_as_sequence(tool.get("capabilities")))
+    capabilities = [
+        value.strip()
+        for value in capability_values
+        if isinstance(value, str) and value.strip()
+    ]
+    return [*capabilities, None]
+
+
+def _as_sequence(value: Any) -> Sequence[Any]:
+    """Normalize scalar-or-sequence metadata values into a sequence."""
+
+    if value is None:
+        return ()
+    if isinstance(value, str):
+        return (value,)
+    if isinstance(value, Sequence):
+        return value
+    return ()
+
+
+def _policy_denied(
+    policy_result: EffectivePolicyResult,
+    *,
+    message: str,
+) -> GatewayPolicyDenied:
+    """Build a structured denial from an effective policy result."""
+
+    return GatewayPolicyDenied(
+        message,
+        status=policy_result.status,
+        reason_code=policy_result.reason_code,
+        provenance=policy_result.provenance,
+        warnings=policy_result.warnings,
+    )
+
+
+__all__ = ["GatewayProfileResolver", "ProfileAwareGatewayRuntime"]

--- a/mcp_unified/gateway/runtime.py
+++ b/mcp_unified/gateway/runtime.py
@@ -6,6 +6,35 @@ from dataclasses import dataclass, field
 from typing import Any, Protocol
 
 
+class GatewayPolicyDenied(PermissionError):
+    """Raised when gateway profile policy denies execution."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        reason_code: str,
+        status: str = "denied",
+        provenance: dict[str, Any] | None = None,
+        warnings: list[dict[str, Any]] | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.reason_code = reason_code
+        self.status = status
+        self.provenance = provenance or {}
+        self.warnings = warnings or []
+
+    def to_error_data(self) -> dict[str, Any]:
+        """Return a JSON-serializable denial payload for JSON-RPC errors."""
+
+        return {
+            "status": self.status,
+            "reason_code": self.reason_code,
+            "provenance": self.provenance,
+            "warnings": self.warnings,
+        }
+
+
 @dataclass(slots=True)
 class GatewayRequestContext:
     """Host-neutral context passed from gateway transports to runtimes."""

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py
@@ -150,6 +150,47 @@ class _CustomExplodingGatewayRuntime(_FakeGatewayRuntime):
         raise self.RuntimeBackendError("backend unavailable")
 
 
+class _MultiToolGatewayRuntime(_FakeGatewayRuntime):
+    """Fake runtime that advertises multiple tools for profile filtering tests."""
+
+    async def list_tools(self, context: Any) -> list[dict[str, Any]]:
+        """Return tools with distinct capabilities so profiles can filter them."""
+
+        self.list_contexts.append(context)
+        return [
+            {
+                "name": "echo.search",
+                "description": "Echo a query.",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {"query": {"type": "string"}},
+                    "required": ["query"],
+                },
+                "metadata": {"category": "test", "capability": "code_search"},
+            },
+            {
+                "name": "admin.delete",
+                "description": "Delete an admin resource.",
+                "inputSchema": {"type": "object", "properties": {}},
+                "metadata": {"category": "test", "capability": "admin.delete"},
+            },
+        ]
+
+
+class _CustomToolListGatewayRuntime(_FakeGatewayRuntime):
+    """Fake runtime that returns caller-supplied tool discovery payloads."""
+
+    def __init__(self, tools: Any) -> None:
+        super().__init__()
+        self._tools = tools
+
+    async def list_tools(self, context: Any) -> Any:
+        """Return the configured discovery payload without normalizing it."""
+
+        self.list_contexts.append(context)
+        return self._tools
+
+
 class _FakeLogger:
     def __init__(self) -> None:
         self.opt_calls: list[dict[str, Any]] = []
@@ -173,6 +214,30 @@ def _assert_jsonrpc_error(
     assert body["id"] == request_id
     assert body["error"]["code"] == code
     assert "message" in body["error"]
+
+
+def _profile_with_allowed_tools(profile_id: str, allowed_tools: list[str]) -> Any:
+    """Build a profile that allows only the supplied explicit tool names."""
+
+    from mcp_unified.profiles.models import MCPProfile, ProfilePolicy
+
+    return MCPProfile(
+        id=profile_id,
+        name=f"Profile {profile_id}",
+        policy_document=ProfilePolicy(allowed_tools=allowed_tools),
+    )
+
+
+def _profile_with_capabilities(profile_id: str, capabilities: list[str]) -> Any:
+    """Build a profile that allows tools by advertised capability metadata."""
+
+    from mcp_unified.profiles.models import MCPProfile, ProfilePolicy
+
+    return MCPProfile(
+        id=profile_id,
+        name=f"Profile {profile_id}",
+        policy_document=ProfilePolicy(capabilities=capabilities),
+    )
 
 
 def test_gateway_package_does_not_import_tldw_server_api() -> None:
@@ -204,6 +269,257 @@ def test_gateway_stdio_submodule_import_does_not_eagerly_import_fastapi_transpor
     )
 
     assert result.stdout.strip() == "False"
+
+
+def test_gateway_profile_runtime_requires_profile_for_tool_execution() -> None:
+    from mcp_unified.gateway.profile_runtime import ProfileAwareGatewayRuntime
+    from mcp_unified.profiles.store import InMemoryProfileStore
+
+    backend = _MultiToolGatewayRuntime()
+    runtime = ProfileAwareGatewayRuntime(backend, profile_store=InMemoryProfileStore())
+    app = create_gateway_app(runtime, prefix="/mcp")
+
+    with TestClient(app) as client:
+        listed = client.post(
+            "/mcp/request",
+            json={"jsonrpc": "2.0", "method": "tools/list", "params": {}, "id": "tools-profile"},
+        )
+        called = client.post(
+            "/mcp/request",
+            json={
+                "jsonrpc": "2.0",
+                "method": "tools/call",
+                "params": {"name": "echo.search", "arguments": {"query": "hello"}},
+                "id": "call-profile",
+            },
+        )
+
+    assert listed.status_code == 200
+    assert listed.json()["result"]["tools"] == []
+    assert called.status_code == 200
+    body = called.json()
+    _assert_jsonrpc_error(body, code=-32001, request_id="call-profile")
+    assert body["error"]["data"]["reason_code"] == "profile_required"
+    assert backend.call_requests == []
+
+
+def test_gateway_profile_runtime_filters_and_allows_default_profile_tools() -> None:
+    from mcp_unified.gateway.profile_runtime import ProfileAwareGatewayRuntime
+    from mcp_unified.profiles.store import InMemoryProfileStore
+
+    backend = _MultiToolGatewayRuntime()
+    profile = _profile_with_allowed_tools("reviewer", ["echo.search"])
+    runtime = ProfileAwareGatewayRuntime(
+        backend,
+        profile_store=InMemoryProfileStore([profile]),
+        default_profile_id="reviewer",
+    )
+    app = create_gateway_app(runtime, prefix="/mcp")
+
+    with TestClient(app) as client:
+        listed = client.post(
+            "/mcp/request",
+            json={"jsonrpc": "2.0", "method": "tools/list", "params": {}, "id": "tools-default"},
+        )
+        allowed = client.post(
+            "/mcp/request",
+            json={
+                "jsonrpc": "2.0",
+                "method": "tools/call",
+                "params": {"name": "echo.search", "arguments": {"query": "hello"}},
+                "id": "call-allowed",
+            },
+        )
+        denied = client.post(
+            "/mcp/request",
+            json={
+                "jsonrpc": "2.0",
+                "method": "tools/call",
+                "params": {"name": "admin.delete", "arguments": {}},
+                "id": "call-denied",
+            },
+        )
+
+    assert [tool["name"] for tool in listed.json()["result"]["tools"]] == ["echo.search"]
+    assert allowed.json()["result"]["content"][0]["text"] == "echo.search:hello"
+    assert backend.call_requests[-1][0] == "echo.search"
+    denied_body = denied.json()
+    _assert_jsonrpc_error(denied_body, code=-32001, request_id="call-denied")
+    assert denied_body["error"]["data"]["reason_code"] == "tool_not_allowed"
+    assert all(call[0] != "admin.delete" for call in backend.call_requests)
+
+
+def test_gateway_profile_runtime_denies_explicit_tool_before_backend_discovery() -> None:
+    from mcp_unified.gateway.profile_runtime import ProfileAwareGatewayRuntime
+    from mcp_unified.profiles.store import InMemoryProfileStore
+
+    backend = _CustomExplodingGatewayRuntime()
+    profile = _profile_with_allowed_tools("reviewer", ["echo.search"])
+    runtime = ProfileAwareGatewayRuntime(
+        backend,
+        profile_store=InMemoryProfileStore([profile]),
+        default_profile_id="reviewer",
+    )
+    app = create_gateway_app(runtime, prefix="/mcp")
+
+    with TestClient(app) as client:
+        denied = client.post(
+            "/mcp/request",
+            json={
+                "jsonrpc": "2.0",
+                "method": "tools/call",
+                "params": {"name": "admin.delete", "arguments": {}},
+                "id": "call-denied-without-discovery",
+            },
+        )
+
+    denied_body = denied.json()
+    _assert_jsonrpc_error(
+        denied_body,
+        code=-32001,
+        request_id="call-denied-without-discovery",
+    )
+    assert denied_body["error"]["data"]["reason_code"] == "tool_not_allowed"
+    assert backend.call_requests == []
+
+
+def test_gateway_profile_runtime_fails_closed_when_capability_discovery_fails() -> None:
+    from mcp_unified.gateway.profile_runtime import ProfileAwareGatewayRuntime
+    from mcp_unified.profiles.store import InMemoryProfileStore
+
+    backend = _CustomExplodingGatewayRuntime()
+    profile = _profile_with_capabilities("researcher", ["code_search"])
+    runtime = ProfileAwareGatewayRuntime(
+        backend,
+        profile_store=InMemoryProfileStore([profile]),
+        default_profile_id="researcher",
+    )
+    app = create_gateway_app(runtime, prefix="/mcp")
+
+    with TestClient(app) as client:
+        denied = client.post(
+            "/mcp/request",
+            json={
+                "jsonrpc": "2.0",
+                "method": "tools/call",
+                "params": {"name": "echo.search", "arguments": {"query": "hello"}},
+                "id": "capability-discovery-failed",
+            },
+        )
+
+    denied_body = denied.json()
+    _assert_jsonrpc_error(
+        denied_body,
+        code=-32001,
+        request_id="capability-discovery-failed",
+    )
+    assert denied_body["error"]["data"]["reason_code"] == "tool_metadata_unavailable"
+    assert backend.call_requests == []
+
+
+def test_gateway_profile_runtime_ignores_invalid_backend_tool_descriptors() -> None:
+    from mcp_unified.gateway.profile_runtime import ProfileAwareGatewayRuntime
+    from mcp_unified.gateway.runtime import GatewayRequestContext
+    from mcp_unified.profiles.store import InMemoryProfileStore
+
+    backend = _CustomToolListGatewayRuntime(
+        [
+            None,
+            "not-a-tool",
+            {"name": "  "},
+            {"name": "echo.search", "metadata": {"capability": "code_search"}},
+        ]
+    )
+    profile = _profile_with_capabilities("researcher", ["code_search"])
+    runtime = ProfileAwareGatewayRuntime(
+        backend,
+        profile_store=InMemoryProfileStore([profile]),
+        default_profile_id="researcher",
+    )
+
+    tools = asyncio.run(runtime.list_tools(GatewayRequestContext(request_id="invalid-tools")))
+
+    assert [tool["name"] for tool in tools] == ["echo.search"]
+
+
+def test_gateway_profile_runtime_treats_non_list_backend_tools_as_empty() -> None:
+    from mcp_unified.gateway.profile_runtime import ProfileAwareGatewayRuntime
+    from mcp_unified.gateway.runtime import GatewayRequestContext
+    from mcp_unified.profiles.store import InMemoryProfileStore
+
+    backend = _CustomToolListGatewayRuntime(None)
+    profile = _profile_with_allowed_tools("reviewer", ["echo.search"])
+    runtime = ProfileAwareGatewayRuntime(
+        backend,
+        profile_store=InMemoryProfileStore([profile]),
+        default_profile_id="reviewer",
+    )
+
+    assert asyncio.run(runtime.list_tools(GatewayRequestContext(request_id="non-list-tools"))) == []
+
+
+def test_gateway_transport_profile_selector_handles_missing_request_attributes() -> None:
+    class _BareRequest:
+        """Request double without FastAPI transport attributes."""
+
+    assert gateway_fastapi._profile_id_from_transport(_BareRequest()) is None
+
+
+def test_gateway_profile_runtime_selects_profile_from_http_header() -> None:
+    from mcp_unified.gateway.profile_runtime import ProfileAwareGatewayRuntime
+    from mcp_unified.profiles.store import InMemoryProfileStore
+
+    backend = _MultiToolGatewayRuntime()
+    profile = _profile_with_allowed_tools("reviewer", ["echo.search"])
+    runtime = ProfileAwareGatewayRuntime(
+        backend,
+        profile_store=InMemoryProfileStore([profile]),
+    )
+    app = create_gateway_app(runtime, prefix="/mcp")
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/mcp/request",
+            headers={"X-MCP-Profile": "reviewer"},
+            json={
+                "jsonrpc": "2.0",
+                "method": "tools/call",
+                "params": {"name": "echo.search", "arguments": {"query": "header"}},
+                "id": "call-header-profile",
+            },
+        )
+
+    assert response.status_code == 200
+    assert response.json()["result"]["content"][0]["text"] == "echo.search:header"
+    assert backend.call_requests[-1][2].metadata["profile_id"] == "reviewer"
+
+
+def test_gateway_profile_runtime_selects_profile_from_websocket_query() -> None:
+    from mcp_unified.gateway.profile_runtime import ProfileAwareGatewayRuntime
+    from mcp_unified.profiles.store import InMemoryProfileStore
+
+    backend = _MultiToolGatewayRuntime()
+    profile = _profile_with_allowed_tools("reviewer", ["echo.search"])
+    runtime = ProfileAwareGatewayRuntime(
+        backend,
+        profile_store=InMemoryProfileStore([profile]),
+    )
+    app = create_gateway_app(runtime, prefix="/mcp")
+
+    with TestClient(app) as client:
+        with client.websocket_connect("/mcp/ws?profile_id=reviewer") as websocket:
+            websocket.send_json(
+                {
+                    "jsonrpc": "2.0",
+                    "method": "tools/call",
+                    "params": {"name": "echo.search", "arguments": {"query": "ws"}},
+                    "id": "call-ws-profile",
+                }
+            )
+            body = websocket.receive_json()
+
+    assert body["result"]["content"][0]["text"] == "echo.search:ws"
+    assert backend.call_requests[-1][2].metadata["profile_id"] == "reviewer"
 
 
 def test_gateway_fastapi_app_handles_basic_jsonrpc_flow() -> None:


### PR DESCRIPTION
## Change Summary (Maintainer-Owned)

Pending maintainer-authored summary before merge per the AI-generated PR policy.

## Summary

- What changed:
  - Added `ProfileAwareGatewayRuntime`, a package-owned wrapper that resolves explicit/default profiles before gateway tool discovery and execution.
  - Added `GatewayPolicyDenied` and JSON-RPC `-32001` mapping so standalone profile denials return machine-readable reason data.
  - Added optional FastAPI HTTP/WebSocket profile selection via `X-MCP-Profile`, `X-MCP-Profile-Id`, `profile_id`, or `profileId`.
  - Added Stage 4E plan and Backlog TASK-562.
- Why:
  - Continue the standalone gateway extraction after Stage 4D by adding the first profile enforcement runtime path without introducing external lifecycle, process spawning, config commands, or host route integration.
  - Preserve existing unwrapped gateway behavior while giving standalone gateway runtimes fail-closed profile semantics.

## Validation

- [x] Tests added/updated for behavior changes
- [x] Relevant unit/integration tests pass locally
- [x] Docs updated (if behavior, routes, or config changed)

Commands:
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py -q` -> `33 passed, 4 warnings`
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_extraction_contracts.py tldw_Server_API/app/core/MCP_unified/tests/test_http_mapping.py -q` -> `47 passed, 4 warnings`
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m ruff check mcp_unified/gateway tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py` -> `All checks passed!`
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r mcp_unified/gateway -f json -o /tmp/bandit_mcp_stage4e_gateway_profile_runtime.json` -> `0` findings, no errors
- `git diff --check` -> clean

## UX Audit Checklist (v2 Stage 5)

N/A - package gateway runtime/backend-only slice; no WebUI or extension UI routes changed.

## Watchlists Accessibility Checklist (Group 09 Stage 5)

N/A - no Watchlists UI behavior changed.

## Watchlists Scale Checklist (Group 10 Stage 5)

N/A - no Watchlists polling, notification, or scale behavior changed.

## Risk & Rollback

- Risk level: Low
- Rollback plan: Revert this PR to restore the Stage 4D transport-only gateway implementation.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a profile-aware gateway runtime to `mcp_unified.gateway` that enforces profiles before tool discovery and execution. Adds structured JSON-RPC policy denials and lightweight profile selection for HTTP/WebSocket. Implements TASK-562 (Stage 4E).

- **New Features**
  - Added `ProfileAwareGatewayRuntime` that resolves explicit/default profiles, filters `tools/list`, and denies `tools/call` before backend delegation; resources/prompts/modules are delegated unchanged.
  - Enforces capability-based policy and fails closed when backend tool metadata isn’t available; ignores invalid tool descriptors and treats non-list discovery payloads as empty.
  - Added `GatewayPolicyDenied` mapped to JSON-RPC error `-32001` with `reason_code`, `status`, `provenance`, and `warnings`; exported from `mcp_unified.gateway`.
  - FastAPI transport now accepts profile selectors via `X-MCP-Profile` or `X-MCP-Profile-Id` headers, and `profile_id` or `profileId` query params; metadata is passed through unchanged for unwrapped runtimes. Standalone gateways fail closed when no profile is selected or allowed.

- **Migration**
  - Wrap your existing `GatewayRuntime` with `ProfileAwareGatewayRuntime` and provide a `profile_store`; set `default_profile_id` if desired.
  - Clients can select a profile by sending `X-MCP-Profile`/`X-MCP-Profile-Id` headers or `profile_id`/`profileId` query params.

<sup>Written for commit 394e3398918a16fefc0ec36c6fa837410f2a0cfd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2150?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

