### PR TITLE
Migrate BillingDashboardPage guard alerts to design system

### DIFF
--- a/apps/packages/ui/scripts/design-system-product-state-baseline.json
+++ b/apps/packages/ui/scripts/design-system-product-state-baseline.json
@@ -44,28 +44,6 @@
     "migrationQueue": "shared-product-state"
   },
   {
-    "id": "antd-product-state-import:src/components/Option/Admin/BillingDashboardPage.tsx:Alert#antd-alert-billingdashboardpage-type-error-access-denied-1jl5m6e",
-    "path": "src/components/Option/Admin/BillingDashboardPage.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/Option/Admin/BillingDashboardPage.tsx before the stable duplicate-id guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
-    "id": "antd-product-state-import:src/components/Option/Admin/BillingDashboardPage.tsx:Alert#antd-alert-billingdashboardpage-type-warning-not-availab-15ux9fb",
-    "path": "src/components/Option/Admin/BillingDashboardPage.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/Option/Admin/BillingDashboardPage.tsx before the stable duplicate-id guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
     "id": "antd-product-state-import:src/components/Option/Admin/DataOpsPage.tsx:Alert#antd-alert-dataopspage-type-error-access-denied-you-don-q5np3m",
     "path": "src/components/Option/Admin/DataOpsPage.tsx",
     "rule": "antd-product-state-import",

--- a/apps/packages/ui/src/components/Option/Admin/BillingDashboardPage.tsx
+++ b/apps/packages/ui/src/components/Option/Admin/BillingDashboardPage.tsx
@@ -8,7 +8,6 @@ import {
   InputNumber,
   Modal,
   Select,
-  Alert,
   Space,
   Statistic,
   Form,
@@ -16,6 +15,7 @@ import {
   message
 } from "antd"
 import { ReloadOutlined } from "@ant-design/icons"
+import { Alert } from "@/components/ui/primitives"
 import {
   deriveAdminGuardFromError,
   sanitizeAdminErrorMessage
@@ -467,25 +467,21 @@ const BillingDashboardPage: React.FC = () => {
 
   if (adminGuard === "forbidden") {
     return (
-      <Alert
-        type="error"
-        title="Access Denied"
-        description="You do not have permission to view the billing dashboard."
-        showIcon
-        style={{ margin: 24 }}
-      />
+      <div style={{ padding: 24 }}>
+        <Alert variant="error" title="Access Denied">
+          You do not have permission to view the billing dashboard.
+        </Alert>
+      </div>
     )
   }
 
   if (adminGuard === "notFound") {
     return (
-      <Alert
-        type="warning"
-        title="Not Available"
-        description="Billing endpoints are not available on this server."
-        showIcon
-        style={{ margin: 24 }}
-      />
+      <div style={{ padding: 24 }}>
+        <Alert variant="warning" title="Not Available">
+          Billing endpoints are not available on this server.
+        </Alert>
+      </div>
     )
   }
 

--- a/apps/packages/ui/src/components/Option/Admin/__tests__/BillingDashboardPage.test.tsx
+++ b/apps/packages/ui/src/components/Option/Admin/__tests__/BillingDashboardPage.test.tsx
@@ -33,6 +33,16 @@ import BillingDashboardPage from "../BillingDashboardPage"
 const fetchMock = vi.fn()
 vi.stubGlobal("fetch", fetchMock)
 
+const expectDesignSystemAlertForTitle = async (titleText: string) => {
+  const title = await screen.findByText(titleText)
+  const alert = title.closest('[data-ds-component="Alert"]')
+
+  expect(alert).not.toBeNull()
+  const alertEl = alert as HTMLElement
+  expect(alertEl).toHaveAttribute("role", "alert")
+  return alertEl
+}
+
 describe("BillingDashboardPage", () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -57,11 +67,32 @@ describe("BillingDashboardPage", () => {
 
     render(<BillingDashboardPage />)
 
+    const alert = await expectDesignSystemAlertForTitle("Not Available")
     expect(
-      await screen.findByText("Billing endpoints are not available on this server.")
-    ).toBeInTheDocument()
+      alert
+    ).toHaveTextContent("Billing endpoints are not available on this server.")
     expect(mocks.getBillingOverview).not.toHaveBeenCalled()
     expect(mocks.listAllSubscriptions).not.toHaveBeenCalled()
     expect(mocks.listBillingEvents).not.toHaveBeenCalled()
+  })
+
+  it("renders forbidden guard feedback through the design-system Alert primitive", async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        paths: {
+          "/api/v1/admin/billing/overview": {}
+        }
+      })
+    })
+    mocks.getBillingOverview.mockRejectedValueOnce({ status: 403 })
+    mocks.getStorageQuotaSummary.mockResolvedValueOnce({})
+
+    render(<BillingDashboardPage />)
+
+    const alert = await expectDesignSystemAlertForTitle("Access Denied")
+    expect(alert).toHaveTextContent(
+      "You do not have permission to view the billing dashboard."
+    )
   })
 })

--- a/backlog/tasks/task-45.44.7 - Migrate-design-system-product-state-Admin-and-health-expansion.md
+++ b/backlog/tasks/task-45.44.7 - Migrate-design-system-product-state-Admin-and-health-expansion.md
@@ -4,7 +4,7 @@ title: 'Migrate design-system product state: Admin and health expansion'
 status: In Progress
 assignee: []
 created_date: '2026-05-14 03:19'
-updated_date: '2026-05-30 10:59'
+updated_date: '2026-05-30 11:02'
 labels:
   - design-system
   - webui
@@ -88,8 +88,9 @@ documentation:
       - scoped verifier log had no UsageAnalyticsPage findings
       - full verifier remains blocked by unrelated current-dev drift outside this slice
 
-    TASK-45.44.7.6 migrated BillingDashboardPage forbidden and unsupported-route
-    guard feedback from AntD Alert to the design-system Alert primitive.
+    TASK-45.44.7.6 / PR #2152 migrated BillingDashboardPage forbidden and
+    unsupported-route guard feedback from AntD Alert to the design-system Alert
+    primitive.
 
     Baseline file evidence:
       - total baseline rows: 187 -> 185

--- a/backlog/tasks/task-45.44.7 - Migrate-design-system-product-state-Admin-and-health-expansion.md
+++ b/backlog/tasks/task-45.44.7 - Migrate-design-system-product-state-Admin-and-health-expansion.md
@@ -4,7 +4,7 @@ title: 'Migrate design-system product state: Admin and health expansion'
 status: In Progress
 assignee: []
 created_date: '2026-05-14 03:19'
-updated_date: '2026-05-30 10:49'
+updated_date: '2026-05-30 10:59'
 labels:
   - design-system
   - webui
@@ -86,6 +86,18 @@ documentation:
 
     Verifier evidence:
       - scoped verifier log had no UsageAnalyticsPage findings
+      - full verifier remains blocked by unrelated current-dev drift outside this slice
+
+    TASK-45.44.7.6 migrated BillingDashboardPage forbidden and unsupported-route
+    guard feedback from AntD Alert to the design-system Alert primitive.
+
+    Baseline file evidence:
+      - total baseline rows: 187 -> 185
+      - Admin path rows: 29 -> 27
+      - BillingDashboardPage target rows: 2 -> 0
+
+    Verifier evidence:
+      - scoped verifier log had no BillingDashboardPage findings
       - full verifier remains blocked by unrelated current-dev drift outside this slice
 parent_task_id: TASK-45.44
 priority: medium

--- a/backlog/tasks/task-45.44.7.6 - Migrate-BillingDashboardPage-guard-alerts-to-design-system-Alert.md
+++ b/backlog/tasks/task-45.44.7.6 - Migrate-BillingDashboardPage-guard-alerts-to-design-system-Alert.md
@@ -13,6 +13,8 @@ modified_files:
 - apps/packages/ui/src/components/Option/Admin/__tests__/BillingDashboardPage.test.tsx
 - apps/packages/ui/scripts/design-system-product-state-baseline.json
 - backlog/tasks/task-45.44.7 - Migrate-design-system-product-state-Admin-and-health-expansion.md
+references:
+- https://github.com/rmusser01/tldw_server/pull/2152
 ---
 
 ## Description
@@ -49,13 +51,14 @@ Verification:
 - `git diff --check` completed with no output.
 - `bun run verify:design-system-state` still exits 1 because of unrelated current-dev product-state drift and stale IntegrationPolicyPanel baseline rows; `/tmp/billing-dashboard-design-state.log` has no BillingDashboardPage findings.
 - Bandit not run: this slice touched TypeScript UI, JSON baseline data, and Backlog task markdown only.
+- PR: https://github.com/rmusser01/tldw_server/pull/2152
 
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Migrated BillingDashboardPage forbidden and unsupported-route guard feedback from AntD Alert to the design-system Alert primitive, added focused regression coverage for both states, and removed the two matching product-state baseline exceptions.
+Migrated BillingDashboardPage forbidden and unsupported-route guard feedback from AntD Alert to the design-system Alert primitive, added focused regression coverage for both states, removed the two matching product-state baseline exceptions, and opened PR #2152.
 
 <!-- SECTION:FINAL_SUMMARY:END -->
 

--- a/backlog/tasks/task-45.44.7.6 - Migrate-BillingDashboardPage-guard-alerts-to-design-system-Alert.md
+++ b/backlog/tasks/task-45.44.7.6 - Migrate-BillingDashboardPage-guard-alerts-to-design-system-Alert.md
@@ -1,0 +1,70 @@
+---
+id: TASK-45.44.7.6
+title: Migrate BillingDashboardPage guard alerts to design-system Alert
+status: Done
+labels:
+- design-system
+- webui
+- product-state
+priority: medium
+parent_task_id: TASK-45.44.7
+modified_files:
+- apps/packages/ui/src/components/Option/Admin/BillingDashboardPage.tsx
+- apps/packages/ui/src/components/Option/Admin/__tests__/BillingDashboardPage.test.tsx
+- apps/packages/ui/scripts/design-system-product-state-baseline.json
+- backlog/tasks/task-45.44.7 - Migrate-design-system-product-state-Admin-and-health-expansion.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Replace BillingDashboardPage's forbidden and not-available admin guard AntD Alerts with the shared design-system Alert primitive while preserving copy, route capability behavior, and guard semantics. Remove matching product-state baseline entries and record focused verification.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 BillingDashboardPage forbidden guard feedback renders through data-ds-component="Alert" with error urgency semantics.
+- [x] #2 BillingDashboardPage unsupported-route guard feedback renders through data-ds-component="Alert" while preserving the Not Available copy.
+- [x] #3 The matching BillingDashboardPage AntD Alert baseline entries are removed without introducing a BillingDashboardPage verifier finding.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Implemented the narrow BillingDashboardPage admin guard slice:
+
+- Extended the existing unsupported-route regression test to assert the nearest `data-ds-component="Alert"` ancestor with a hard null check before element usage.
+- Added forbidden guard regression coverage by allowing the billing capability probe and making the overview endpoint reject with a 403 guard error.
+- Verified the focused test failed before implementation because the existing AntD Alert markup had no design-system Alert ancestor.
+- Replaced the two guard-return AntD Alerts with the shared design-system Alert primitive while preserving title/body copy, error/warning urgency, and page padding around the guard feedback.
+- Removed the two BillingDashboardPage entries from the product-state baseline.
+
+Verification:
+
+- RED: `bunx vitest run src/components/Option/Admin/__tests__/BillingDashboardPage.test.tsx --reporter=dot` failed with `expected null not to be null` after adding the design-system marker assertions.
+- GREEN: `bunx vitest run src/components/Option/Admin/__tests__/BillingDashboardPage.test.tsx --reporter=dot` passed with 2 tests. jsdom emitted existing CSS parse warnings from AntD styles.
+- `bunx vitest run src/design-system/__tests__/product-state-guard.test.ts --reporter=dot` passed with 54 tests.
+- Baseline count script reported `{"total":185,"billing":0,"admin":27}`.
+- `env NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit --pretty false` completed with no output.
+- `git diff --check` completed with no output.
+- `bun run verify:design-system-state` still exits 1 because of unrelated current-dev product-state drift and stale IntegrationPolicyPanel baseline rows; `/tmp/billing-dashboard-design-state.log` has no BillingDashboardPage findings.
+- Bandit not run: this slice touched TypeScript UI, JSON baseline data, and Backlog task markdown only.
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Migrated BillingDashboardPage forbidden and unsupported-route guard feedback from AntD Alert to the design-system Alert primitive, added focused regression coverage for both states, and removed the two matching product-state baseline exceptions.
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## Summary

- Migrates `BillingDashboardPage` forbidden and unsupported-route guard feedback from AntD `Alert` to the design-system `Alert` primitive.
- Extends focused regression coverage to assert the design-system Alert marker for both guard states.
- Removes the two matching `BillingDashboardPage` product-state baseline exceptions and records the slice in Backlog.md.

## Verification

- `bunx vitest run src/components/Option/Admin/__tests__/BillingDashboardPage.test.tsx --reporter=dot`
- `bunx vitest run src/design-system/__tests__/product-state-guard.test.ts --reporter=dot`
- `node -e "const fs=require('fs'); const data=JSON.parse(fs.readFileSync('apps/packages/ui/scripts/design-system-product-state-baseline.json','utf8')); console.log(JSON.stringify({total:data.length,billing:data.filter(e=>e.path==='src/components/Option/Admin/BillingDashboardPage.tsx').length,admin:data.filter(e=>e.path?.startsWith('src/components/Option/Admin/')).length}));"` -> `{"total":185,"billing":0,"admin":27}`
- `env NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit --pretty false`
- `git diff --check`
- `bun run verify:design-system-state` exits 1 from unrelated current-dev product-state drift and stale IntegrationPolicyPanel baseline rows; no `BillingDashboardPage` findings were present in `/tmp/billing-dashboard-design-state.log`.

## Change summary (maintainer-owned)

Maintainer note required before merge: please replace this section with your own summary explaining what changed and why these implementation choices were made.

## UX Audit Checklist

- [x] Existing guard copy is preserved.
- [x] Forbidden state keeps error urgency semantics.
- [x] Unsupported-route state keeps warning urgency semantics.
- [x] Guard feedback keeps page padding comparable to the previous AntD Alert margin.

## Bandit

Not run. This slice touched TypeScript UI, JSON baseline data, and Backlog task markdown only.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrated `BillingDashboardPage` guard alerts from AntD `Alert` to the design-system `Alert` to unify product-state feedback. Added focused tests and removed two baseline exceptions; copy, severity, and spacing are unchanged.

- **Refactors**
  - Replaced AntD `Alert` with design-system `Alert` from `@/components/ui/primitives` for forbidden and notFound guards; preserved titles/messages and error/warning severity; kept page padding.
  - Added regression tests asserting `[data-ds-component="Alert"]` and `role="alert"` for both guard states.
  - Removed two legacy baseline exceptions and recorded the migration in the backlog task.

<sup>Written for commit cbf83d9a22c7f7b99cbf0ccc94d1c023f9b3febf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2152?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

