### PR TITLE
Migrate OrgsTeamsPage guard alerts to design system

### DIFF
--- a/apps/packages/ui/scripts/design-system-product-state-baseline.json
+++ b/apps/packages/ui/scripts/design-system-product-state-baseline.json
@@ -187,28 +187,6 @@
     "migrationQueue": "shared-product-state"
   },
   {
-    "id": "antd-product-state-import:src/components/Option/Admin/OrgsTeamsPage.tsx:Alert#antd-alert-orgsteamspage-type-error-access-denied-you-do-4x14e5",
-    "path": "src/components/Option/Admin/OrgsTeamsPage.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/Option/Admin/OrgsTeamsPage.tsx before the stable duplicate-id guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
-    "id": "antd-product-state-import:src/components/Option/Admin/OrgsTeamsPage.tsx:Alert#antd-alert-orgsteamspage-type-warning-not-available-orga-ykcbnf",
-    "path": "src/components/Option/Admin/OrgsTeamsPage.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/Option/Admin/OrgsTeamsPage.tsx before the stable duplicate-id guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
     "id": "antd-product-state-import:src/components/Option/Admin/RateLimitingPage.tsx:Alert#antd-alert-ratelimitingpage-type-error-access-denied-you-snzu3t",
     "path": "src/components/Option/Admin/RateLimitingPage.tsx",
     "rule": "antd-product-state-import",

--- a/apps/packages/ui/src/components/Option/Admin/OrgsTeamsPage.tsx
+++ b/apps/packages/ui/src/components/Option/Admin/OrgsTeamsPage.tsx
@@ -6,7 +6,6 @@ import {
   Input,
   Modal,
   Select,
-  Alert,
   Space,
   Popconfirm,
   message,
@@ -20,6 +19,7 @@ import {
   ReloadOutlined,
   TeamOutlined
 } from "@ant-design/icons"
+import { Alert } from "@/components/ui/primitives"
 import {
   deriveAdminGuardFromError,
   sanitizeAdminErrorMessage
@@ -573,10 +573,18 @@ const OrgsTeamsPage: React.FC = () => {
   // ── Render ──
 
   if (adminGuard === "forbidden") {
-    return <Alert type="error" message="Access Denied" description="You don't have permission to manage organizations." showIcon />
+    return (
+      <Alert variant="error" title="Access Denied">
+        You don't have permission to manage organizations.
+      </Alert>
+    )
   }
   if (adminGuard === "notFound") {
-    return <Alert type="warning" message="Not Available" description="Organization management is not available on this server." showIcon />
+    return (
+      <Alert variant="warning" title="Not Available">
+        Organization management is not available on this server.
+      </Alert>
+    )
   }
 
   return (

--- a/apps/packages/ui/src/components/Option/Admin/__tests__/OrgsTeamsPage.design-system.test.tsx
+++ b/apps/packages/ui/src/components/Option/Admin/__tests__/OrgsTeamsPage.design-system.test.tsx
@@ -1,0 +1,53 @@
+// @vitest-environment jsdom
+
+import React from "react"
+import { render, screen } from "@testing-library/react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import OrgsTeamsPage from "../OrgsTeamsPage"
+
+const apiMock = vi.hoisted(() => ({
+  listOrgs: vi.fn()
+}))
+
+vi.mock("@/services/tldw/TldwApiClient", () => ({
+  tldwClient: apiMock
+}))
+
+const expectDesignSystemAlertForTitle = async (titleText: string) => {
+  const title = await screen.findByText(titleText)
+  const alert = title.closest('[data-ds-component="Alert"]')
+
+  expect(alert).not.toBeNull()
+  const alertEl = alert as HTMLElement
+  expect(alertEl).toHaveAttribute("role", "alert")
+  return alertEl
+}
+
+describe("OrgsTeamsPage design-system states", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    apiMock.listOrgs.mockResolvedValue([])
+  })
+
+  it("renders forbidden guard feedback through the design-system Alert primitive", async () => {
+    apiMock.listOrgs.mockRejectedValueOnce({ status: 403 })
+
+    render(<OrgsTeamsPage />)
+
+    const alert = await expectDesignSystemAlertForTitle("Access Denied")
+    expect(alert).toHaveTextContent(
+      "You don't have permission to manage organizations."
+    )
+  })
+
+  it("renders missing-endpoint guard feedback through the design-system Alert primitive", async () => {
+    apiMock.listOrgs.mockRejectedValueOnce({ status: 404 })
+
+    render(<OrgsTeamsPage />)
+
+    const alert = await expectDesignSystemAlertForTitle("Not Available")
+    expect(alert).toHaveTextContent(
+      "Organization management is not available on this server."
+    )
+  })
+})

--- a/backlog/tasks/task-45.44.7 - Migrate-design-system-product-state-Admin-and-health-expansion.md
+++ b/backlog/tasks/task-45.44.7 - Migrate-design-system-product-state-Admin-and-health-expansion.md
@@ -4,7 +4,7 @@ title: 'Migrate design-system product state: Admin and health expansion'
 status: In Progress
 assignee: []
 created_date: '2026-05-14 03:19'
-updated_date: '2026-05-30 11:12'
+updated_date: '2026-05-30 11:15'
 labels:
   - design-system
   - webui
@@ -101,8 +101,9 @@ documentation:
       - scoped verifier log had no BillingDashboardPage findings
       - full verifier remains blocked by unrelated current-dev drift outside this slice
 
-    TASK-45.44.7.7 migrated OrgsTeamsPage forbidden and not-available guard
-    feedback from AntD Alert to the design-system Alert primitive.
+    TASK-45.44.7.7 / PR #2153 migrated OrgsTeamsPage forbidden and
+    not-available guard feedback from AntD Alert to the design-system Alert
+    primitive.
 
     Baseline file evidence:
       - total baseline rows: 185 -> 183

--- a/backlog/tasks/task-45.44.7 - Migrate-design-system-product-state-Admin-and-health-expansion.md
+++ b/backlog/tasks/task-45.44.7 - Migrate-design-system-product-state-Admin-and-health-expansion.md
@@ -4,7 +4,7 @@ title: 'Migrate design-system product state: Admin and health expansion'
 status: In Progress
 assignee: []
 created_date: '2026-05-14 03:19'
-updated_date: '2026-05-30 11:02'
+updated_date: '2026-05-30 11:12'
 labels:
   - design-system
   - webui
@@ -99,6 +99,18 @@ documentation:
 
     Verifier evidence:
       - scoped verifier log had no BillingDashboardPage findings
+      - full verifier remains blocked by unrelated current-dev drift outside this slice
+
+    TASK-45.44.7.7 migrated OrgsTeamsPage forbidden and not-available guard
+    feedback from AntD Alert to the design-system Alert primitive.
+
+    Baseline file evidence:
+      - total baseline rows: 185 -> 183
+      - Admin path rows: 27 -> 25
+      - OrgsTeamsPage target rows: 2 -> 0
+
+    Verifier evidence:
+      - scoped verifier log had no OrgsTeamsPage findings
       - full verifier remains blocked by unrelated current-dev drift outside this slice
 parent_task_id: TASK-45.44
 priority: medium

--- a/backlog/tasks/task-45.44.7.7 - Migrate-OrgsTeamsPage-guard-alerts-to-design-system-Alert.md
+++ b/backlog/tasks/task-45.44.7.7 - Migrate-OrgsTeamsPage-guard-alerts-to-design-system-Alert.md
@@ -1,0 +1,69 @@
+---
+id: TASK-45.44.7.7
+title: Migrate OrgsTeamsPage guard alerts to design-system Alert
+status: Done
+labels:
+- design-system
+- webui
+- product-state
+priority: medium
+parent_task_id: TASK-45.44.7
+modified_files:
+- apps/packages/ui/src/components/Option/Admin/OrgsTeamsPage.tsx
+- apps/packages/ui/src/components/Option/Admin/__tests__/OrgsTeamsPage.design-system.test.tsx
+- apps/packages/ui/scripts/design-system-product-state-baseline.json
+- backlog/tasks/task-45.44.7 - Migrate-design-system-product-state-Admin-and-health-expansion.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Replace OrgsTeamsPage's forbidden and not-available admin guard AntD Alerts with the shared design-system Alert primitive while preserving copy and guard behavior. Remove matching product-state baseline entries and record focused verification.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 OrgsTeamsPage forbidden guard feedback renders through data-ds-component="Alert" with error urgency semantics.
+- [x] #2 OrgsTeamsPage not-found guard feedback renders through data-ds-component="Alert" while preserving the Not Available copy.
+- [x] #3 The matching OrgsTeamsPage AntD Alert baseline entries are removed without introducing an OrgsTeamsPage verifier finding.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Implemented the narrow OrgsTeamsPage admin guard slice:
+
+- Added focused jsdom regression coverage for forbidden and not-found guard states, with a hard null check before using the nearest `data-ds-component="Alert"` ancestor.
+- Verified the test failed before implementation because the existing AntD Alert markup had no design-system Alert ancestor.
+- Replaced the two guard-return AntD Alerts with the shared design-system Alert primitive while preserving the existing title/body copy and error/warning urgency.
+- Removed the two OrgsTeamsPage entries from the product-state baseline.
+
+Verification:
+
+- RED: `bunx vitest run src/components/Option/Admin/__tests__/OrgsTeamsPage.design-system.test.tsx --reporter=dot` failed with `expected null not to be null` before the migration.
+- GREEN: `bunx vitest run src/components/Option/Admin/__tests__/OrgsTeamsPage.design-system.test.tsx --reporter=dot` passed with 2 tests.
+- `bunx vitest run src/design-system/__tests__/product-state-guard.test.ts --reporter=dot` passed with 54 tests.
+- Baseline count script reported `{"total":183,"orgsTeams":0,"admin":25}`.
+- `env NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit --pretty false` completed with no output.
+- `git diff --check` completed with no output.
+- `bun run verify:design-system-state` still exits 1 because of unrelated current-dev product-state drift and stale IntegrationPolicyPanel baseline rows; `/tmp/orgs-teams-design-state.log` has no OrgsTeamsPage findings.
+- Bandit not run: this slice touched TypeScript UI, JSON baseline data, and Backlog task markdown only.
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Migrated OrgsTeamsPage forbidden and not-found admin guard feedback from AntD Alert to the design-system Alert primitive, added focused regression coverage for both states, and removed the two matching product-state baseline exceptions.
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-45.44.7.7 - Migrate-OrgsTeamsPage-guard-alerts-to-design-system-Alert.md
+++ b/backlog/tasks/task-45.44.7.7 - Migrate-OrgsTeamsPage-guard-alerts-to-design-system-Alert.md
@@ -13,6 +13,8 @@ modified_files:
 - apps/packages/ui/src/components/Option/Admin/__tests__/OrgsTeamsPage.design-system.test.tsx
 - apps/packages/ui/scripts/design-system-product-state-baseline.json
 - backlog/tasks/task-45.44.7 - Migrate-design-system-product-state-Admin-and-health-expansion.md
+references:
+- https://github.com/rmusser01/tldw_server/pull/2153
 ---
 
 ## Description
@@ -48,13 +50,14 @@ Verification:
 - `git diff --check` completed with no output.
 - `bun run verify:design-system-state` still exits 1 because of unrelated current-dev product-state drift and stale IntegrationPolicyPanel baseline rows; `/tmp/orgs-teams-design-state.log` has no OrgsTeamsPage findings.
 - Bandit not run: this slice touched TypeScript UI, JSON baseline data, and Backlog task markdown only.
+- PR: https://github.com/rmusser01/tldw_server/pull/2153
 
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Migrated OrgsTeamsPage forbidden and not-found admin guard feedback from AntD Alert to the design-system Alert primitive, added focused regression coverage for both states, and removed the two matching product-state baseline exceptions.
+Migrated OrgsTeamsPage forbidden and not-found admin guard feedback from AntD Alert to the design-system Alert primitive, added focused regression coverage for both states, removed the two matching product-state baseline exceptions, and opened PR #2153.
 
 <!-- SECTION:FINAL_SUMMARY:END -->
 


### PR DESCRIPTION
## Summary

- Migrates `OrgsTeamsPage` forbidden and not-found guard feedback from AntD `Alert` to the design-system `Alert` primitive.
- Adds focused regression coverage for both guard states and asserts the design-system marker before using the alert element.
- Removes the two matching `OrgsTeamsPage` product-state baseline exceptions and records the slice in Backlog.md.

## Verification

- `bunx vitest run src/components/Option/Admin/__tests__/OrgsTeamsPage.design-system.test.tsx --reporter=dot`
- `bunx vitest run src/design-system/__tests__/product-state-guard.test.ts --reporter=dot`
- `node -e "const fs=require('fs'); const data=JSON.parse(fs.readFileSync('apps/packages/ui/scripts/design-system-product-state-baseline.json','utf8')); console.log(JSON.stringify({total:data.length,orgsTeams:data.filter(e=>e.path==='src/components/Option/Admin/OrgsTeamsPage.tsx').length,admin:data.filter(e=>e.path?.startsWith('src/components/Option/Admin/')).length}));"` -> `{"total":183,"orgsTeams":0,"admin":25}`
- `env NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit --pretty false`
- `git diff --check`
- `bun run verify:design-system-state` exits 1 from unrelated current-dev product-state drift and stale IntegrationPolicyPanel baseline rows; no `OrgsTeamsPage` findings were present in `/tmp/orgs-teams-design-state.log`.

## Change summary (maintainer-owned)

Maintainer note required before merge: please replace this section with your own summary explaining what changed and why these implementation choices were made.

## UX Audit Checklist

- [x] Existing guard copy is preserved.
- [x] Forbidden state keeps error urgency semantics.
- [x] Missing endpoint state keeps warning urgency semantics.
- [x] No user-visible behavior changes outside the two guard branches.

## Bandit

Not run. This slice touched TypeScript UI, JSON baseline data, and Backlog task markdown only.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrated `OrgsTeamsPage` guard feedback to the design-system `Alert`, replacing `antd` alerts for forbidden and not-found states. Copy and severity are unchanged; added tests and removed baseline exceptions.

- **Refactors**
  - Swapped `antd` `Alert` for design-system `Alert` in `OrgsTeamsPage` forbidden/not-found branches.
  - Added focused tests that assert `data-ds-component="Alert"` and exact messages.
  - Removed two `OrgsTeamsPage` product-state baseline exceptions and recorded the migration in backlog tasks.

<sup>Written for commit 59ec23e74ec90c6b83b3c8d08093632afc728c80. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2153?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

