### PR TITLE
Migrate DataOpsPage guard alerts to design system

### DIFF
--- a/apps/packages/ui/scripts/design-system-product-state-baseline.json
+++ b/apps/packages/ui/scripts/design-system-product-state-baseline.json
@@ -44,28 +44,6 @@
     "migrationQueue": "shared-product-state"
   },
   {
-    "id": "antd-product-state-import:src/components/Option/Admin/DataOpsPage.tsx:Alert#antd-alert-dataopspage-type-error-access-denied-you-don-q5np3m",
-    "path": "src/components/Option/Admin/DataOpsPage.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/Option/Admin/DataOpsPage.tsx before the stable duplicate-id guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
-    "id": "antd-product-state-import:src/components/Option/Admin/DataOpsPage.tsx:Alert#antd-alert-dataopspage-type-warning-not-available-data-o-1w6u3jf",
-    "path": "src/components/Option/Admin/DataOpsPage.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/Option/Admin/DataOpsPage.tsx before the stable duplicate-id guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
     "id": "antd-product-state-import:src/components/Option/Admin/MlxAdminPage.tsx:Alert#antd-alert-mlxadminpage-type-info-line-667-t3pi54",
     "path": "src/components/Option/Admin/MlxAdminPage.tsx",
     "rule": "antd-product-state-import",

--- a/apps/packages/ui/src/components/Option/Admin/DataOpsPage.tsx
+++ b/apps/packages/ui/src/components/Option/Admin/DataOpsPage.tsx
@@ -8,7 +8,6 @@ import {
   InputNumber,
   Modal,
   Select,
-  Alert,
   Space,
   Popconfirm,
   Form,
@@ -24,6 +23,7 @@ import {
   PlayCircleOutlined,
   EyeOutlined
 } from "@ant-design/icons"
+import { Alert } from "@/components/ui/primitives"
 import {
   deriveAdminGuardFromError,
   sanitizeAdminErrorMessage
@@ -889,10 +889,18 @@ const DataOpsPage: React.FC = () => {
   }, [])
 
   if (adminGuard === "forbidden") {
-    return <Alert type="error" message="Access Denied" description="You don't have permission to access data operations." showIcon />
+    return (
+      <Alert variant="error" title="Access Denied">
+        You don't have permission to access data operations.
+      </Alert>
+    )
   }
   if (adminGuard === "notFound") {
-    return <Alert type="warning" message="Not Available" description="Data operations are not available on this server." showIcon />
+    return (
+      <Alert variant="warning" title="Not Available">
+        Data operations are not available on this server.
+      </Alert>
+    )
   }
 
   const tabItems = [

--- a/apps/packages/ui/src/components/Option/Admin/__tests__/DataOpsPage.design-system.test.tsx
+++ b/apps/packages/ui/src/components/Option/Admin/__tests__/DataOpsPage.design-system.test.tsx
@@ -1,0 +1,55 @@
+// @vitest-environment jsdom
+
+import React from "react"
+import { render, screen } from "@testing-library/react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import DataOpsPage from "../DataOpsPage"
+
+const apiMock = vi.hoisted(() => ({
+  listBackups: vi.fn(),
+  listBackupSchedules: vi.fn()
+}))
+
+vi.mock("@/services/tldw/TldwApiClient", () => ({
+  tldwClient: apiMock
+}))
+
+const expectDesignSystemAlertForTitle = async (titleText: string) => {
+  const title = await screen.findByText(titleText)
+  const alert = title.closest('[data-ds-component="Alert"]')
+
+  expect(alert).not.toBeNull()
+  const alertEl = alert as HTMLElement
+  expect(alertEl).toHaveAttribute("role", "alert")
+  return alertEl
+}
+
+describe("DataOpsPage design-system states", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    apiMock.listBackups.mockResolvedValue([])
+    apiMock.listBackupSchedules.mockResolvedValue([])
+  })
+
+  it("renders forbidden guard feedback through the design-system Alert primitive", async () => {
+    apiMock.listBackups.mockRejectedValueOnce({ status: 403 })
+
+    render(<DataOpsPage />)
+
+    const alert = await expectDesignSystemAlertForTitle("Access Denied")
+    expect(alert).toHaveTextContent(
+      "You don't have permission to access data operations."
+    )
+  })
+
+  it("renders missing-endpoint guard feedback through the design-system Alert primitive", async () => {
+    apiMock.listBackups.mockRejectedValueOnce({ status: 404 })
+
+    render(<DataOpsPage />)
+
+    const alert = await expectDesignSystemAlertForTitle("Not Available")
+    expect(alert).toHaveTextContent(
+      "Data operations are not available on this server."
+    )
+  })
+})

--- a/backlog/tasks/task-45.44.7 - Migrate-design-system-product-state-Admin-and-health-expansion.md
+++ b/backlog/tasks/task-45.44.7 - Migrate-design-system-product-state-Admin-and-health-expansion.md
@@ -4,7 +4,7 @@ title: 'Migrate design-system product state: Admin and health expansion'
 status: In Progress
 assignee: []
 created_date: '2026-05-14 03:19'
-updated_date: '2026-05-30 11:24'
+updated_date: '2026-05-30 11:26'
 labels:
   - design-system
   - webui
@@ -114,8 +114,9 @@ documentation:
       - scoped verifier log had no OrgsTeamsPage findings
       - full verifier remains blocked by unrelated current-dev drift outside this slice
 
-    TASK-45.44.7.8 migrated DataOpsPage forbidden and not-available guard
-    feedback from AntD Alert to the design-system Alert primitive.
+    TASK-45.44.7.8 / PR #2154 migrated DataOpsPage forbidden and
+    not-available guard feedback from AntD Alert to the design-system Alert
+    primitive.
 
     Baseline file evidence:
       - total baseline rows: 183 -> 181

--- a/backlog/tasks/task-45.44.7 - Migrate-design-system-product-state-Admin-and-health-expansion.md
+++ b/backlog/tasks/task-45.44.7 - Migrate-design-system-product-state-Admin-and-health-expansion.md
@@ -4,7 +4,7 @@ title: 'Migrate design-system product state: Admin and health expansion'
 status: In Progress
 assignee: []
 created_date: '2026-05-14 03:19'
-updated_date: '2026-05-30 11:15'
+updated_date: '2026-05-30 11:24'
 labels:
   - design-system
   - webui
@@ -112,6 +112,18 @@ documentation:
 
     Verifier evidence:
       - scoped verifier log had no OrgsTeamsPage findings
+      - full verifier remains blocked by unrelated current-dev drift outside this slice
+
+    TASK-45.44.7.8 migrated DataOpsPage forbidden and not-available guard
+    feedback from AntD Alert to the design-system Alert primitive.
+
+    Baseline file evidence:
+      - total baseline rows: 183 -> 181
+      - Admin path rows: 25 -> 23
+      - DataOpsPage target rows: 2 -> 0
+
+    Verifier evidence:
+      - scoped verifier log had no DataOpsPage findings
       - full verifier remains blocked by unrelated current-dev drift outside this slice
 parent_task_id: TASK-45.44
 priority: medium

--- a/backlog/tasks/task-45.44.7.8 - Migrate-DataOpsPage-guard-alerts-to-design-system-Alert.md
+++ b/backlog/tasks/task-45.44.7.8 - Migrate-DataOpsPage-guard-alerts-to-design-system-Alert.md
@@ -13,6 +13,8 @@ modified_files:
 - apps/packages/ui/src/components/Option/Admin/__tests__/DataOpsPage.design-system.test.tsx
 - apps/packages/ui/scripts/design-system-product-state-baseline.json
 - backlog/tasks/task-45.44.7 - Migrate-design-system-product-state-Admin-and-health-expansion.md
+references:
+- https://github.com/rmusser01/tldw_server/pull/2154
 ---
 
 ## Description
@@ -48,13 +50,14 @@ Verification:
 - `git diff --check` completed with no output.
 - `bun run verify:design-system-state` still exits 1 because of unrelated current-dev product-state drift and stale IntegrationPolicyPanel baseline rows; `/tmp/data-ops-design-state.log` has no DataOpsPage findings.
 - Bandit not run: this slice touched TypeScript UI, JSON baseline data, and Backlog task markdown only.
+- PR: https://github.com/rmusser01/tldw_server/pull/2154
 
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Migrated DataOpsPage forbidden and not-found admin guard feedback from AntD Alert to the design-system Alert primitive, added focused regression coverage for both states, and removed the two matching product-state baseline exceptions.
+Migrated DataOpsPage forbidden and not-found admin guard feedback from AntD Alert to the design-system Alert primitive, added focused regression coverage for both states, removed the two matching product-state baseline exceptions, and opened PR #2154.
 
 <!-- SECTION:FINAL_SUMMARY:END -->
 

--- a/backlog/tasks/task-45.44.7.8 - Migrate-DataOpsPage-guard-alerts-to-design-system-Alert.md
+++ b/backlog/tasks/task-45.44.7.8 - Migrate-DataOpsPage-guard-alerts-to-design-system-Alert.md
@@ -1,0 +1,69 @@
+---
+id: TASK-45.44.7.8
+title: Migrate DataOpsPage guard alerts to design-system Alert
+status: Done
+labels:
+- design-system
+- webui
+- product-state
+priority: medium
+parent_task_id: TASK-45.44.7
+modified_files:
+- apps/packages/ui/src/components/Option/Admin/DataOpsPage.tsx
+- apps/packages/ui/src/components/Option/Admin/__tests__/DataOpsPage.design-system.test.tsx
+- apps/packages/ui/scripts/design-system-product-state-baseline.json
+- backlog/tasks/task-45.44.7 - Migrate-design-system-product-state-Admin-and-health-expansion.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Replace DataOpsPage's forbidden and not-available admin guard AntD Alerts with the shared design-system Alert primitive while preserving copy and guard behavior. Remove matching product-state baseline entries and record focused verification.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 DataOpsPage forbidden guard feedback renders through data-ds-component="Alert" with error urgency semantics.
+- [x] #2 DataOpsPage not-found guard feedback renders through data-ds-component="Alert" while preserving the Not Available copy.
+- [x] #3 The matching DataOpsPage AntD Alert baseline entries are removed without introducing a DataOpsPage verifier finding.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Implemented the narrow DataOpsPage admin guard slice:
+
+- Added focused jsdom regression coverage for forbidden and not-found guard states, with a hard null check before using the nearest `data-ds-component="Alert"` ancestor.
+- Verified the test failed before implementation because the existing AntD Alert markup had no design-system Alert ancestor.
+- Replaced the two guard-return AntD Alerts with the shared design-system Alert primitive while preserving the existing title/body copy and error/warning urgency.
+- Removed the two DataOpsPage entries from the product-state baseline.
+
+Verification:
+
+- RED: `bunx vitest run src/components/Option/Admin/__tests__/DataOpsPage.design-system.test.tsx --reporter=dot` failed with `expected null not to be null` before the migration.
+- GREEN: `bunx vitest run src/components/Option/Admin/__tests__/DataOpsPage.design-system.test.tsx --reporter=dot` passed with 2 tests. jsdom emitted existing CSS parse warnings from AntD styles.
+- `bunx vitest run src/design-system/__tests__/product-state-guard.test.ts --reporter=dot` passed with 54 tests.
+- Baseline count script reported `{"total":181,"dataOps":0,"admin":23}`.
+- `env NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit --pretty false` completed with no output.
+- `git diff --check` completed with no output.
+- `bun run verify:design-system-state` still exits 1 because of unrelated current-dev product-state drift and stale IntegrationPolicyPanel baseline rows; `/tmp/data-ops-design-state.log` has no DataOpsPage findings.
+- Bandit not run: this slice touched TypeScript UI, JSON baseline data, and Backlog task markdown only.
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Migrated DataOpsPage forbidden and not-found admin guard feedback from AntD Alert to the design-system Alert primitive, added focused regression coverage for both states, and removed the two matching product-state baseline exceptions.
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## Summary

- Migrates `DataOpsPage` forbidden and not-found guard feedback from AntD `Alert` to the design-system `Alert` primitive.
- Adds focused regression coverage for both guard states and asserts the design-system marker before using the alert element.
- Removes the two matching `DataOpsPage` product-state baseline exceptions and records the slice in Backlog.md.

## Verification

- `bunx vitest run src/components/Option/Admin/__tests__/DataOpsPage.design-system.test.tsx --reporter=dot`
- `bunx vitest run src/design-system/__tests__/product-state-guard.test.ts --reporter=dot`
- `node -e "const fs=require('fs'); const data=JSON.parse(fs.readFileSync('apps/packages/ui/scripts/design-system-product-state-baseline.json','utf8')); console.log(JSON.stringify({total:data.length,dataOps:data.filter(e=>e.path==='src/components/Option/Admin/DataOpsPage.tsx').length,admin:data.filter(e=>e.path?.startsWith('src/components/Option/Admin/')).length}));"` -> `{"total":181,"dataOps":0,"admin":23}`
- `env NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit --pretty false`
- `git diff --check`
- `bun run verify:design-system-state` exits 1 from unrelated current-dev product-state drift and stale IntegrationPolicyPanel baseline rows; no `DataOpsPage` findings were present in `/tmp/data-ops-design-state.log`.

## Change summary (maintainer-owned)

Maintainer note required before merge: please replace this section with your own summary explaining what changed and why these implementation choices were made.

## UX Audit Checklist

- [x] Existing guard copy is preserved.
- [x] Forbidden state keeps error urgency semantics.
- [x] Missing endpoint state keeps warning urgency semantics.
- [x] No user-visible behavior changes outside the two guard branches.

## Bandit

Not run. This slice touched TypeScript UI, JSON baseline data, and Backlog task markdown only.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrates `DataOpsPage` guard alerts from AntD `Alert` to the design-system `Alert` to standardize product-state UI. Adds focused tests and updates backlog records; no behavior changes outside these guard states.

- **Refactors**
  - Replaced forbidden and not-found guard `Alert`s with design-system `Alert` (`variant="error"`/`"warning"`) and kept titles/copy.
  - Added tests that assert `data-ds-component="Alert"` and expected messages for both guard states.
  - Removed two `DataOpsPage` `Alert` exceptions from `design-system-product-state-baseline.json` and recorded the migration in backlog tasks.

<sup>Written for commit 8206dcb203f52f194c98f7bf5c777ba29c1ca585. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2154?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

