### PR TITLE
Add Stage 4F gateway profile bootstrap

### DIFF
--- a/Docs/superpowers/plans/2026-05-30-mcp-unified-stage4f-gateway-profile-bootstrap-plan.md
+++ b/Docs/superpowers/plans/2026-05-30-mcp-unified-stage4f-gateway-profile-bootstrap-plan.md
@@ -1,0 +1,134 @@
+# MCP Unified Stage 4F Gateway Profile Bootstrap Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:test-driven-development for behavior changes and keep this slice package-owned.
+
+**Goal:** Add package-owned helpers that bootstrap a profile-aware standalone gateway runtime from built-in presets or caller-supplied profiles.
+
+**Architecture:** Keep bootstrap code under `mcp_unified.gateway` with no `tldw_Server_API` imports. The helper should accept an injected backend `GatewayRuntime`, seed an in-memory or caller-provided `ProfileStore`, select a default profile id, and return `ProfileAwareGatewayRuntime`. This slice intentionally avoids SQLite CLI/config commands, external MCP lifecycle, upstream process spawning, preset editing flows, and host route integration.
+
+**Tech Stack:** Python 3.11, package-local gateway/profile/store primitives, pytest, Ruff, Bandit.
+
+---
+
+### Task 1: Bootstrap Contract RED Tests
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py`
+- Create: `mcp_unified/gateway/bootstrap.py`
+- Modify: `mcp_unified/gateway/__init__.py`
+
+- [x] **Step 1: Add import-boundary coverage**
+
+The existing gateway package import scan must include the new bootstrap module and continue to reject any `tldw_Server_API` imports.
+
+- [x] **Step 2: Write failing bootstrap tests**
+
+Add tests that assert:
+- `build_profile_gateway_runtime(backend, default_preset_id="project-researcher")` seeds a duplicated default profile and allows a tool advertising `code_search`.
+- Caller-supplied profiles can be combined with a default profile id without duplicating built-in presets.
+- Unknown default preset ids fail fast with `ValueError`.
+
+- [x] **Step 3: Run RED tests**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/mcp-unified-stage4f-gateway-profile-bootstrap/.venv/bin/python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py -q
+```
+
+Expected: new bootstrap tests fail because `mcp_unified.gateway.bootstrap` does not exist.
+
+Result: `3 failed, 38 passed, 4 warnings`; all new failures were the expected missing `mcp_unified.gateway.bootstrap` module.
+
+### Task 2: Package Bootstrap Helper
+
+**Files:**
+- Create: `mcp_unified/gateway/bootstrap.py`
+- Modify: `mcp_unified/gateway/__init__.py`
+
+- [x] **Step 1: Add bootstrap config and helper**
+
+Implement a small helper that:
+- accepts a backend `GatewayRuntime`;
+- accepts optional `profile_store`, `profiles`, `default_profile_id`, and `default_preset_id`;
+- duplicates `default_preset_id` into a deterministic profile id when no explicit `default_profile_id` is supplied;
+- stores caller-supplied profiles before preset defaults so explicit profiles remain addressable;
+- returns `ProfileAwareGatewayRuntime` with the selected default profile id.
+
+- [x] **Step 2: Keep exports lazy and dependency-light**
+
+Export the helper from `mcp_unified.gateway` without making stdio imports require FastAPI and without adding host imports.
+
+- [x] **Step 3: Run GREEN tests**
+
+Run the focused gateway package tests and confirm all pass.
+
+Result after implementation and rebase onto `origin/dev` `53d224c4fb`: `41 passed, 4 warnings`.
+
+### Task 3: Compatibility, Security, And PR Handoff
+
+**Files:**
+- Modify: `Docs/superpowers/plans/2026-05-30-mcp-unified-stage4f-gateway-profile-bootstrap-plan.md`
+- Modify: `backlog/tasks/task-563 - Implement-MCP-Unified-Stage-4F-gateway-profile-bootstrap.md`
+
+- [x] **Step 1: Run host compatibility tests**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/mcp-unified-stage4f-gateway-profile-bootstrap/.venv/bin/python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_extraction_contracts.py tldw_Server_API/app/core/MCP_unified/tests/test_http_mapping.py -q
+```
+
+- [x] **Step 2: Run lint, security, and whitespace checks**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/mcp-unified-stage4f-gateway-profile-bootstrap/.venv/bin/python -m ruff check mcp_unified/gateway tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/mcp-unified-stage4f-gateway-profile-bootstrap/.venv/bin/python -m bandit -r mcp_unified/gateway -f json -o /tmp/bandit_mcp_stage4f_gateway_profile_bootstrap.json
+git diff --check
+```
+
+- [x] **Step 3: Update plan and Backlog task**
+
+Record RED/GREEN and final verification evidence. Check off acceptance criteria and Definition of Done.
+
+- [x] **Step 4: Commit, push, and open PR**
+
+Commit the plan, gateway/test changes, and Backlog task update together, push the branch, and open a PR against `dev`.
+
+### Task 4: PR Review Collision Fix
+
+**Files:**
+- Modify: `mcp_unified/gateway/bootstrap.py`
+- Modify: `tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py`
+- Modify: `Docs/superpowers/plans/2026-05-30-mcp-unified-stage4f-gateway-profile-bootstrap-plan.md`
+- Modify: `backlog/tasks/task-563 - Implement-MCP-Unified-Stage-4F-gateway-profile-bootstrap.md`
+
+- [x] **Step 1: Verify review findings**
+
+Confirmed the Qodo and Gemini comments identify a real policy overwrite risk: preset seeding used the resolved default id, so a caller profile could be replaced by the preset profile.
+
+- [x] **Step 2: Add RED collision coverage**
+
+Added regression tests for an explicit caller default plus seeded preset, and for direct preset-id collision. RED result: `2 failed, 41 passed, 4 warnings`.
+
+- [x] **Step 3: Preserve caller profiles and reject collisions**
+
+Preset seeding now uses the built-in preset id as the seeded profile id and raises `ValueError` if that profile id already exists in the selected store.
+
+- [x] **Step 4: Re-run focused and compatibility validation**
+
+Focused gateway package tests passed with `43 passed, 4 warnings`; compatibility tests passed with `47 passed, 4 warnings`.
+
+## Verification
+
+- Baseline before RED: `38 passed, 4 warnings` for `test_gateway_fastapi_package.py`.
+- RED: `3 failed, 38 passed, 4 warnings`; expected missing bootstrap module failures only.
+- GREEN after rebase onto `origin/dev` `53d224c4fb`: `41 passed, 4 warnings` for `test_gateway_fastapi_package.py`.
+- PR review RED after rebase onto `origin/dev` `7ef87742ac`: `2 failed, 41 passed, 4 warnings`; expected preset overwrite/collision failures only.
+- PR review GREEN after collision fix: `43 passed, 4 warnings` for `test_gateway_fastapi_package.py`.
+- Compatibility: `47 passed, 4 warnings` for `test_extraction_contracts.py` and `test_http_mapping.py`.
+- Ruff: `All checks passed!` for `mcp_unified/gateway` and the focused gateway package tests.
+- Bandit: `0` results and no errors for `mcp_unified/gateway`.
+- Whitespace: `git diff --check` passed.

--- a/backlog/tasks/task-563 - Implement-MCP-Unified-Stage-4F-gateway-profile-bootstrap.md
+++ b/backlog/tasks/task-563 - Implement-MCP-Unified-Stage-4F-gateway-profile-bootstrap.md
@@ -1,0 +1,63 @@
+---
+id: TASK-563
+title: Implement MCP Unified Stage 4F gateway profile bootstrap
+status: Done
+labels:
+- mcp-unified
+- standalone-extraction
+- gateway
+priority: medium
+references:
+- Docs/superpowers/specs/2026-05-26-mcp-unified-standalone-library-gateway-design.md
+- Docs/superpowers/plans/2026-05-30-mcp-unified-stage4f-gateway-profile-bootstrap-plan.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Add the next narrow Stage 4F standalone gateway slice after Stage 4E: provide package-owned gateway profile bootstrap helpers that seed/select a default profile from built-in presets or caller-supplied profiles and return a ProfileAwareGatewayRuntime around an injected backend runtime. This slice intentionally avoids SQLite CLI/config commands, external MCP lifecycle, upstream process spawning, and tldw_server host route integration.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Gateway package exposes profile-bootstrap helpers without importing `tldw_Server_API`.
+- [x] #2 Bootstrap can seed a deterministic default profile from a built-in preset and return a `ProfileAwareGatewayRuntime`.
+- [x] #3 Bootstrap preserves caller-supplied profiles and supports selecting one as the default without duplicating presets.
+- [x] #4 Unknown default preset ids fail fast with a clear `ValueError`.
+- [x] #5 Focused gateway tests cover preset seeding, caller profile defaults, and unknown preset failure.
+- [x] #6 Host extraction/http compatibility tests, Ruff, Bandit, and whitespace checks are recorded before PR handoff.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+- Started from merged Stage 4E baseline and rebased final work onto `origin/dev` `53d224c4fb`.
+- Added package-owned `mcp_unified.gateway.bootstrap` with `GatewayProfileBootstrap`, `bootstrap_profile_gateway`, and `build_profile_gateway_runtime`.
+- Bootstrap accepts an injected backend runtime plus optional profile store, caller profiles, default profile id, and default preset id.
+- Built-in default presets are duplicated into deterministic profile ids when no explicit default id is provided; caller profiles are stored before preset defaults and remain addressable.
+- Unknown preset ids fail fast through the existing preset duplicate path with `ValueError`.
+- RED evidence: `3 failed, 38 passed, 4 warnings` for the focused gateway package tests; all new failures were the expected missing bootstrap module.
+- GREEN evidence after rebase: `41 passed, 4 warnings` for `test_gateway_fastapi_package.py`.
+- PR review follow-up verified Qodo and Gemini's preset/profile collision finding as still valid.
+- Review RED evidence after rebasing onto `origin/dev` `7ef87742ac`: `2 failed, 41 passed, 4 warnings`; the failures showed the caller default being overwritten and no collision error.
+- Preset seeding now uses the built-in preset id for the seeded profile and rejects an existing seeded profile id with `ValueError` instead of silently overwriting.
+- Review GREEN evidence: `43 passed, 4 warnings` for `test_gateway_fastapi_package.py`.
+- Compatibility evidence: `47 passed, 4 warnings` for `test_extraction_contracts.py` and `test_http_mapping.py`.
+- Quality evidence: Ruff passed, Bandit reported `0` results and no errors for `mcp_unified/gateway`, and `git diff --check` passed.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Stage 4F adds the standalone gateway profile bootstrap seam. Callers can now build a `ProfileAwareGatewayRuntime` from an injected `GatewayRuntime`, optional caller profiles, and an optional built-in preset default without importing host `tldw_Server_API` code or introducing SQLite/config/lifecycle concerns. PR review follow-up also prevents built-in preset seeding from silently overwriting an existing profile id. No known blockers remain; external MCP lifecycle, persistent config, and host route integration stay intentionally out of scope for later stages.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/mcp_unified/gateway/__init__.py
+++ b/mcp_unified/gateway/__init__.py
@@ -2,6 +2,11 @@
 
 from typing import TYPE_CHECKING, Any
 
+from .bootstrap import (
+    GatewayProfileBootstrap,
+    bootstrap_profile_gateway,
+    build_profile_gateway_runtime,
+)
 from .profile_runtime import ProfileAwareGatewayRuntime
 from .runtime import GatewayPolicyDenied, GatewayRequestContext, GatewayRuntime
 from .stdio import GatewayStdioServer, handle_stdio_line
@@ -11,10 +16,13 @@ if TYPE_CHECKING:
 
 __all__ = [
     "GatewayPolicyDenied",
+    "GatewayProfileBootstrap",
     "GatewayRequestContext",
     "GatewayRuntime",
     "GatewayStdioServer",
     "ProfileAwareGatewayRuntime",
+    "bootstrap_profile_gateway",
+    "build_profile_gateway_runtime",
     "create_gateway_app",
     "create_gateway_router",
     "handle_stdio_line",

--- a/mcp_unified/gateway/bootstrap.py
+++ b/mcp_unified/gateway/bootstrap.py
@@ -1,0 +1,103 @@
+"""Profile bootstrap helpers for standalone MCP gateway runtimes."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass
+from typing import Any
+
+from mcp_unified.interfaces.storage import ProfileStore
+from mcp_unified.profiles.models import MCPProfile
+from mcp_unified.profiles.presets import duplicate_builtin_preset
+from mcp_unified.profiles.store import InMemoryProfileStore
+
+from .profile_runtime import ProfileAwareGatewayRuntime
+from .runtime import GatewayRuntime
+
+
+@dataclass(frozen=True, slots=True)
+class GatewayProfileBootstrap:
+    """Result of preparing a profile-aware standalone gateway runtime."""
+
+    runtime: ProfileAwareGatewayRuntime
+    profile_store: ProfileStore
+    default_profile_id: str | None
+    seeded_profile_ids: tuple[str, ...]
+
+
+async def bootstrap_profile_gateway(
+    backend: GatewayRuntime,
+    *,
+    profile_store: ProfileStore | None = None,
+    profiles: Iterable[MCPProfile | Mapping[str, Any]] | None = None,
+    default_profile_id: str | None = None,
+    default_preset_id: str | None = None,
+) -> GatewayProfileBootstrap:
+    """Seed profile data and return a profile-aware gateway runtime."""
+
+    store = profile_store if profile_store is not None else InMemoryProfileStore()
+    for profile in profiles or ():
+        await store.upsert_profile(_validate_profile(profile))
+
+    seeded_profile_ids: tuple[str, ...] = ()
+    resolved_default_profile_id = default_profile_id
+    if default_preset_id is not None:
+        resolved_default_profile_id = default_profile_id or default_preset_id
+        if await store.get_profile(default_preset_id) is not None:
+            raise ValueError(
+                f"Cannot seed MCP profile preset '{default_preset_id}': "
+                f"profile id '{default_preset_id}' already exists"
+            )
+        preset_profile = duplicate_builtin_preset(
+            default_preset_id,
+            profile_id=default_preset_id,
+        )
+        await store.upsert_profile(preset_profile)
+        seeded_profile_ids = (preset_profile.id,)
+
+    runtime = ProfileAwareGatewayRuntime(
+        backend,
+        profile_store=store,
+        default_profile_id=resolved_default_profile_id,
+    )
+    return GatewayProfileBootstrap(
+        runtime=runtime,
+        profile_store=store,
+        default_profile_id=resolved_default_profile_id,
+        seeded_profile_ids=seeded_profile_ids,
+    )
+
+
+async def build_profile_gateway_runtime(
+    backend: GatewayRuntime,
+    *,
+    profile_store: ProfileStore | None = None,
+    profiles: Iterable[MCPProfile | Mapping[str, Any]] | None = None,
+    default_profile_id: str | None = None,
+    default_preset_id: str | None = None,
+) -> ProfileAwareGatewayRuntime:
+    """Return only the profile-aware runtime for simple gateway callers."""
+
+    bootstrap = await bootstrap_profile_gateway(
+        backend,
+        profile_store=profile_store,
+        profiles=profiles,
+        default_profile_id=default_profile_id,
+        default_preset_id=default_preset_id,
+    )
+    return bootstrap.runtime
+
+
+def _validate_profile(profile: MCPProfile | Mapping[str, Any]) -> MCPProfile:
+    """Return a validated caller-owned profile model for storage."""
+
+    if isinstance(profile, MCPProfile):
+        return profile.model_copy(deep=True)
+    return MCPProfile.model_validate(profile)
+
+
+__all__ = [
+    "GatewayProfileBootstrap",
+    "bootstrap_profile_gateway",
+    "build_profile_gateway_runtime",
+]

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py
@@ -11,6 +11,7 @@ from typing import Any
 
 import mcp_unified.gateway.fastapi as gateway_fastapi
 import mcp_unified.gateway.jsonrpc as gateway_jsonrpc
+import pytest
 from fastapi.testclient import TestClient
 from mcp_unified.gateway import create_gateway_app
 
@@ -456,6 +457,123 @@ def test_gateway_profile_runtime_treats_non_list_backend_tools_as_empty() -> Non
     )
 
     assert asyncio.run(runtime.list_tools(GatewayRequestContext(request_id="non-list-tools"))) == []
+
+
+def test_gateway_profile_bootstrap_seeds_default_builtin_preset_profile() -> None:
+    from mcp_unified.gateway.bootstrap import bootstrap_profile_gateway
+
+    backend = _MultiToolGatewayRuntime()
+    bootstrap = asyncio.run(
+        bootstrap_profile_gateway(
+            backend,
+            default_preset_id="project-researcher",
+        )
+    )
+    app = create_gateway_app(bootstrap.runtime, prefix="/mcp")
+
+    with TestClient(app) as client:
+        listed = client.post(
+            "/mcp/request",
+            json={"jsonrpc": "2.0", "method": "tools/list", "params": {}, "id": "tools-bootstrap"},
+        )
+        allowed = client.post(
+            "/mcp/request",
+            json={
+                "jsonrpc": "2.0",
+                "method": "tools/call",
+                "params": {"name": "echo.search", "arguments": {"query": "bootstrap"}},
+                "id": "call-bootstrap",
+            },
+        )
+
+    assert bootstrap.default_profile_id == "project-researcher"
+    assert bootstrap.seeded_profile_ids == ("project-researcher",)
+    assert [tool["name"] for tool in listed.json()["result"]["tools"]] == ["echo.search"]
+    assert allowed.json()["result"]["content"][0]["text"] == "echo.search:bootstrap"
+
+
+def test_gateway_profile_bootstrap_uses_caller_profiles_as_default() -> None:
+    from mcp_unified.gateway.bootstrap import bootstrap_profile_gateway
+
+    backend = _MultiToolGatewayRuntime()
+    profile = _profile_with_allowed_tools("reviewer", ["echo.search"])
+
+    bootstrap = asyncio.run(
+        bootstrap_profile_gateway(
+            backend,
+            profiles=[profile],
+            default_profile_id="reviewer",
+        )
+    )
+    stored_profiles = asyncio.run(bootstrap.profile_store.list_profiles())
+    app = create_gateway_app(bootstrap.runtime, prefix="/mcp")
+
+    with TestClient(app) as client:
+        listed = client.post(
+            "/mcp/request",
+            json={"jsonrpc": "2.0", "method": "tools/list", "params": {}, "id": "tools-caller-default"},
+        )
+
+    assert bootstrap.default_profile_id == "reviewer"
+    assert bootstrap.seeded_profile_ids == ()
+    assert [profile.id for profile in stored_profiles] == ["reviewer"]
+    assert [tool["name"] for tool in listed.json()["result"]["tools"]] == ["echo.search"]
+
+
+def test_gateway_profile_bootstrap_keeps_explicit_default_when_seeding_preset() -> None:
+    from mcp_unified.gateway.bootstrap import bootstrap_profile_gateway
+
+    backend = _MultiToolGatewayRuntime()
+    profile = _profile_with_allowed_tools("reviewer", ["admin.delete"])
+
+    bootstrap = asyncio.run(
+        bootstrap_profile_gateway(
+            backend,
+            profiles=[profile],
+            default_profile_id="reviewer",
+            default_preset_id="project-researcher",
+        )
+    )
+    stored_profiles = asyncio.run(bootstrap.profile_store.list_profiles())
+    app = create_gateway_app(bootstrap.runtime, prefix="/mcp")
+
+    with TestClient(app) as client:
+        listed = client.post(
+            "/mcp/request",
+            json={"jsonrpc": "2.0", "method": "tools/list", "params": {}, "id": "tools-caller-plus-preset"},
+        )
+
+    assert bootstrap.default_profile_id == "reviewer"
+    assert bootstrap.seeded_profile_ids == ("project-researcher",)
+    assert {profile.id for profile in stored_profiles} == {"reviewer", "project-researcher"}
+    assert [tool["name"] for tool in listed.json()["result"]["tools"]] == ["admin.delete"]
+
+
+def test_gateway_profile_bootstrap_rejects_existing_preset_profile_collision() -> None:
+    from mcp_unified.gateway.bootstrap import bootstrap_profile_gateway
+
+    profile = _profile_with_allowed_tools("project-researcher", ["admin.delete"])
+
+    with pytest.raises(ValueError, match="profile id 'project-researcher' already exists"):
+        asyncio.run(
+            bootstrap_profile_gateway(
+                _MultiToolGatewayRuntime(),
+                profiles=[profile],
+                default_preset_id="project-researcher",
+            )
+        )
+
+
+def test_gateway_profile_bootstrap_rejects_unknown_default_preset() -> None:
+    from mcp_unified.gateway.bootstrap import bootstrap_profile_gateway
+
+    with pytest.raises(ValueError, match="Unknown MCP profile preset"):
+        asyncio.run(
+            bootstrap_profile_gateway(
+                _MultiToolGatewayRuntime(),
+                default_preset_id="not-a-preset",
+            )
+        )
 
 
 def test_gateway_transport_profile_selector_handles_missing_request_attributes() -> None:


### PR DESCRIPTION
## Change summary (maintainer-owned)

- Maintainer to replace this section with a human-authored summary before merge.

## Summary

- What changed:
  - Added `mcp_unified.gateway.bootstrap` with helpers to seed caller-supplied profiles or a built-in default preset and return a `ProfileAwareGatewayRuntime`.
  - Exported the bootstrap result/helper APIs from `mcp_unified.gateway`.
  - Added focused package tests for built-in preset seeding, caller profile defaults, unknown preset rejection, explicit default preservation, and preset-id collision rejection.
  - Addressed review feedback by seeding presets under the built-in preset id and raising `ValueError` before any preset upsert would overwrite an existing profile id.
- Why:
  - Stage 4F adds the next standalone MCP gateway seam without pulling in host `tldw_Server_API` code, SQLite/config commands, external process lifecycle, or route integration.

## Validation

- [x] Tests added/updated for behavior changes
- [x] Relevant unit/integration tests pass locally
- [x] Docs updated (if behavior, routes, or config changed)

Commands:

- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/mcp-unified-stage4f-gateway-profile-bootstrap/.venv/bin/python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py -q` -> `43 passed, 4 warnings`
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/mcp-unified-stage4f-gateway-profile-bootstrap/.venv/bin/python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_extraction_contracts.py tldw_Server_API/app/core/MCP_unified/tests/test_http_mapping.py -q` -> `47 passed, 4 warnings`
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/mcp-unified-stage4f-gateway-profile-bootstrap/.venv/bin/python -m ruff check mcp_unified/gateway tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py` -> `All checks passed!`
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/mcp-unified-stage4f-gateway-profile-bootstrap/.venv/bin/python -m bandit -r mcp_unified/gateway -f json -o /tmp/bandit_mcp_stage4f_gateway_profile_bootstrap.json` -> `0` findings, no errors
- `git diff --check` -> passed

## UX Audit Checklist (v2 Stage 5)

- [x] N/A - MCP package-only backend/library change; no WebUI or extension UI behavior changed.

## Watchlists Accessibility Checklist (Group 09 Stage 5)

- [x] N/A - no Watchlists UI behavior changed.

## Watchlists Scale Checklist (Group 10 Stage 5)

- [x] N/A - no Watchlists polling, notification, Activity, batch triage, or scale behavior changed.

## Risk & Rollback

- Risk level: Low
- Rollback plan: Revert this single commit to remove the bootstrap helper/export and associated focused tests.
