### PR TITLE
Migrate ServerAdminPage error alerts to design system

### DIFF
--- a/apps/packages/ui/scripts/design-system-product-state-baseline.json
+++ b/apps/packages/ui/scripts/design-system-product-state-baseline.json
@@ -220,39 +220,6 @@
     "migrationQueue": "shared-product-state"
   },
   {
-    "id": "antd-product-state-import:src/components/Option/Admin/ServerAdminPage.tsx:Alert#antd-alert-serveradminpage-type-error-line-656-1j15pps",
-    "path": "src/components/Option/Admin/ServerAdminPage.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/Option/Admin/ServerAdminPage.tsx before the stable duplicate-id guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
-    "id": "antd-product-state-import:src/components/Option/Admin/ServerAdminPage.tsx:Alert#antd-alert-serveradminpage-type-error-line-738-s93pyv",
-    "path": "src/components/Option/Admin/ServerAdminPage.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/Option/Admin/ServerAdminPage.tsx before the stable duplicate-id guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
-    "id": "antd-product-state-import:src/components/Option/Admin/ServerAdminPage.tsx:Alert#antd-alert-serveradminpage-type-error-line-907-16o46fj",
-    "path": "src/components/Option/Admin/ServerAdminPage.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/Option/Admin/ServerAdminPage.tsx before the stable duplicate-id guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
     "id": "antd-product-state-import:src/components/Option/AudiobookStudio/AudiobookStudioPage.tsx:Tag",
     "path": "src/components/Option/AudiobookStudio/AudiobookStudioPage.tsx",
     "rule": "antd-product-state-import",

--- a/apps/packages/ui/src/components/Option/Admin/ServerAdminPage.tsx
+++ b/apps/packages/ui/src/components/Option/Admin/ServerAdminPage.tsx
@@ -5,7 +5,6 @@ import {
   Descriptions,
   Button,
   Space,
-  Alert,
   Table,
   Tag,
   Select,
@@ -36,6 +35,7 @@ import {
   RecoveryCallout,
   StatePanel
 } from "@/components/ui/state"
+import { Alert } from "@/components/ui/primitives"
 
 const { Title, Text } = Typography
 const SYSTEM_STATS_TIMEOUT_MS = 10_000
@@ -654,11 +654,10 @@ export const ServerAdminPage: React.FC = () => {
               <Space orientation="vertical" size="middle" className="w-full">
                 {usersError && (
                   <Alert
-                    type="error"
-                    title={t("settings:admin.usersError", "Unable to load users")}
-                    description={usersError}
-                    showIcon
-                  />
+                    variant="error"
+                    title={t("settings:admin.usersError", "Unable to load users")}>
+                    {usersError}
+                  </Alert>
                 )}
                 <Space align="center" wrap>
                   <Text strong>
@@ -736,11 +735,10 @@ export const ServerAdminPage: React.FC = () => {
 
                 {rolesError && (
                   <Alert
-                    type="error"
-                    title={t("settings:admin.rolesError", "Unable to load roles")}
-                    description={rolesError}
-                    showIcon
-                  />
+                    variant="error"
+                    title={t("settings:admin.rolesError", "Unable to load roles")}>
+                    {rolesError}
+                  </Alert>
                 )}
 
                 <Space orientation="vertical" size="small" className="w-full">
@@ -905,14 +903,13 @@ export const ServerAdminPage: React.FC = () => {
 
                 {mediaBudgetError && (
                   <Alert
-                    type="error"
-                    showIcon
+                    variant="error"
                     title={t(
                       "settings:admin.mediaBudget.errorTitle",
                       "Unable to load media ingestion budget diagnostics"
-                    )}
-                    description={mediaBudgetError}
-                  />
+                    )}>
+                    {mediaBudgetError}
+                  </Alert>
                 )}
 
                 {mediaBudget ? (

--- a/apps/packages/ui/src/components/Option/Admin/__tests__/ServerAdminPage.design-system.test.tsx
+++ b/apps/packages/ui/src/components/Option/Admin/__tests__/ServerAdminPage.design-system.test.tsx
@@ -104,6 +104,16 @@ const resolveBaseAdminCalls = () => {
   })
 }
 
+const expectDesignSystemAlertForTitle = async (titleText: string) => {
+  const title = await screen.findByText(titleText)
+  const alert = title.closest('[data-ds-component="Alert"]')
+
+  expect(alert).not.toBeNull()
+  const alertEl = alert as HTMLElement
+  expect(alertEl).toHaveAttribute("role", "alert")
+  return alertEl
+}
+
 describe("ServerAdminPage design-system states", () => {
   const docsUrl = "https://github.com/rmusser01/tldw_server#documentation--resources"
 
@@ -196,5 +206,36 @@ describe("ServerAdminPage design-system states", () => {
     expect(
       screen.getByText("Select a user to inspect media ingestion limits and usage.")
     ).toBeInTheDocument()
+  })
+
+  it("renders user-load errors through the design-system Alert primitive", async () => {
+    apiMock.listAdminUsers.mockRejectedValueOnce(new Error("Users exploded"))
+
+    render(<ServerAdminPage />)
+
+    const alert = await expectDesignSystemAlertForTitle("Unable to load users")
+    expect(alert).toHaveTextContent("Users exploded")
+  })
+
+  it("renders role-load errors through the design-system Alert primitive", async () => {
+    apiMock.listAdminRoles.mockRejectedValueOnce(new Error("Roles exploded"))
+
+    render(<ServerAdminPage />)
+
+    const alert = await expectDesignSystemAlertForTitle("Unable to load roles")
+    expect(alert).toHaveTextContent("Roles exploded")
+  })
+
+  it("renders media budget diagnostic errors through the design-system Alert primitive", async () => {
+    apiMock.getMediaIngestionBudgetDiagnostics.mockRejectedValueOnce(
+      new Error("Budget exploded")
+    )
+
+    render(<ServerAdminPage />)
+
+    const alert = await expectDesignSystemAlertForTitle(
+      "Unable to load media ingestion budget diagnostics"
+    )
+    expect(alert).toHaveTextContent("Budget exploded")
   })
 })

--- a/backlog/tasks/task-45.44.7 - Migrate-design-system-product-state-Admin-and-health-expansion.md
+++ b/backlog/tasks/task-45.44.7 - Migrate-design-system-product-state-Admin-and-health-expansion.md
@@ -3,129 +3,76 @@ id: TASK-45.44.7
 title: 'Migrate design-system product state: Admin and health expansion'
 status: In Progress
 assignee: []
-created_date: '2026-05-14 03:19'
-updated_date: '2026-05-30 11:26'
+created_date: 2026-05-14 03:19
+updated_date: 2026-05-30 11:26
 labels:
-  - design-system
-  - webui
-  - extension
-  - product-state
+- design-system
+- webui
+- extension
+- product-state
 dependencies: []
 references:
-  - 'https://github.com/rmusser01/tldw_server/issues/1664'
-  - >-
-    Docs/superpowers/specs/2026-05-14-design-system-remaining-work-tracker-design.md
-  - apps/packages/ui/scripts/design-system-product-state-baseline.json
+- https://github.com/rmusser01/tldw_server/issues/1664
+- Docs/superpowers/specs/2026-05-14-design-system-remaining-work-tracker-design.md
+- apps/packages/ui/scripts/design-system-product-state-baseline.json
 documentation:
-  - >-
-    TASK-45.44.3.9 / PR #2019 migrated Admin WatchlistsPage forbidden/not-found
-    guard Alerts to the design-system Alert primitive.
+- "TASK-45.44.3.9 / PR #2019 migrated Admin WatchlistsPage forbidden/not-found guard\
+  \ Alerts to the design-system Alert primitive.\nBaseline evidence:\n  - total product-state\
+  \ exceptions: 256 -> 254\n  - Admin and health expansion exceptions: 41 -> 39\n\
+  \  - WatchlistsPage target rows: 2 -> 0\nVerification recorded in TASK-45.44.3.9.\n\
+  TASK-45.44.7.1 migrated ServerArgsEditor JSON validation feedback from AntD Alert\
+  \ to the design-system Alert primitive.\nBaseline file evidence:\n  - total baseline\
+  \ rows: 195 -> 194\n  - Admin path rows: 37 -> 36\n  - ServerArgsEditor target row:\
+  \ 1 -> 0\n\nVerifier evidence:\n  - scoped verifier log had no ServerArgsEditor\
+  \ findings\n  - full verifier remains blocked by unrelated current-dev drift outside\
+  \ this slice\n\nTASK-45.44.7.2 migrated RbacEditorPage admin guard feedback from\
+  \ AntD Alert to the design-system Alert primitive.\nBaseline file evidence:\n  -\
+  \ total baseline rows: 194 -> 193\n  - Admin path rows: 36 -> 35\n  - RbacEditorPage\
+  \ target row: 1 -> 0\n\nVerifier evidence:\n  - scoped verifier log had no RbacEditorPage\
+  \ findings\n  - full verifier remains blocked by unrelated current-dev drift outside\
+  \ this slice\n\nTASK-45.44.7.3 migrated RuntimeConfigPage forbidden and not-available\
+  \ guard feedback from AntD Alert to the design-system Alert primitive in PR #2145.\n\
+  Baseline file evidence:\n  - total baseline rows: 193 -> 191\n  - Admin path rows:\
+  \ 35 -> 33\n  - RuntimeConfigPage target rows: 2 -> 0\n\nVerifier evidence:\n  -\
+  \ scoped verifier log had no RuntimeConfigPage findings\n  - full verifier remains\
+  \ blocked by unrelated current-dev drift outside this slice\n\nTASK-45.44.7.4 migrated\
+  \ MaintenancePage forbidden and not-available guard feedback from AntD Alert to\
+  \ the design-system Alert primitive in PR #2148.\nBaseline file evidence:\n  - total\
+  \ baseline rows: 191 -> 189\n  - Admin path rows: 33 -> 31\n  - MaintenancePage\
+  \ target rows: 2 -> 0\n\nVerifier evidence:\n  - scoped verifier log had no MaintenancePage\
+  \ findings\n  - full verifier remains blocked by unrelated current-dev drift outside\
+  \ this slice\n\nTASK-45.44.7.5 / PR #2149 migrated UsageAnalyticsPage forbidden\
+  \ and not-available guard feedback from AntD Alert to the design-system Alert primitive.\n\
+  Baseline file evidence:\n  - total baseline rows: 189 -> 187\n  - Admin path rows:\
+  \ 31 -> 29\n  - UsageAnalyticsPage target rows: 2 -> 0\n\nVerifier evidence:\n \
+  \ - scoped verifier log had no UsageAnalyticsPage findings\n  - full verifier remains\
+  \ blocked by unrelated current-dev drift outside this slice\n\nTASK-45.44.7.6 /\
+  \ PR #2152 migrated BillingDashboardPage forbidden and unsupported-route guard feedback\
+  \ from AntD Alert to the design-system Alert primitive.\nBaseline file evidence:\n\
+  \  - total baseline rows: 187 -> 185\n  - Admin path rows: 29 -> 27\n  - BillingDashboardPage\
+  \ target rows: 2 -> 0\n\nVerifier evidence:\n  - scoped verifier log had no BillingDashboardPage\
+  \ findings\n  - full verifier remains blocked by unrelated current-dev drift outside\
+  \ this slice\n\nTASK-45.44.7.7 / PR #2153 migrated OrgsTeamsPage forbidden and not-available\
+  \ guard feedback from AntD Alert to the design-system Alert primitive.\nBaseline\
+  \ file evidence:\n  - total baseline rows: 185 -> 183\n  - Admin path rows: 27 ->\
+  \ 25\n  - OrgsTeamsPage target rows: 2 -> 0\n\nVerifier evidence:\n  - scoped verifier\
+  \ log had no OrgsTeamsPage findings\n  - full verifier remains blocked by unrelated\
+  \ current-dev drift outside this slice\n\nTASK-45.44.7.8 / PR #2154 migrated DataOpsPage\
+  \ forbidden and not-available guard feedback from AntD Alert to the design-system\
+  \ Alert primitive.\nBaseline file evidence:\n  - total baseline rows: 183 -> 181\n\
+  \  - Admin path rows: 25 -> 23\n  - DataOpsPage target rows: 2 -> 0\n\nVerifier\
+  \ evidence:\n  - scoped verifier log had no DataOpsPage findings\n  - full verifier\
+  \ remains blocked by unrelated current-dev drift outside this slice"
+- |-
+  TASK-45.44.7.9 / PR #2156 migrated ServerAdminPage users, roles, and media budget inline error feedback from AntD Alert to the design-system Alert primitive.
+  Baseline file evidence:
+    - total baseline rows: 181 -> 178
+    - Admin path rows: 23 -> 20
+    - ServerAdminPage target rows: 3 -> 0
 
-    Baseline evidence:
-      - total product-state exceptions: 256 -> 254
-      - Admin and health expansion exceptions: 41 -> 39
-      - WatchlistsPage target rows: 2 -> 0
-    Verification recorded in TASK-45.44.3.9.
-
-    TASK-45.44.7.1 migrated ServerArgsEditor JSON validation feedback from AntD
-    Alert to the design-system Alert primitive.
-
-    Baseline file evidence:
-      - total baseline rows: 195 -> 194
-      - Admin path rows: 37 -> 36
-      - ServerArgsEditor target row: 1 -> 0
-
-    Verifier evidence:
-      - scoped verifier log had no ServerArgsEditor findings
-      - full verifier remains blocked by unrelated current-dev drift outside this slice
-
-    TASK-45.44.7.2 migrated RbacEditorPage admin guard feedback from AntD Alert
-    to the design-system Alert primitive.
-
-    Baseline file evidence:
-      - total baseline rows: 194 -> 193
-      - Admin path rows: 36 -> 35
-      - RbacEditorPage target row: 1 -> 0
-
-    Verifier evidence:
-      - scoped verifier log had no RbacEditorPage findings
-      - full verifier remains blocked by unrelated current-dev drift outside this slice
-
-    TASK-45.44.7.3 migrated RuntimeConfigPage forbidden and not-available guard
-    feedback from AntD Alert to the design-system Alert primitive in PR #2145.
-
-    Baseline file evidence:
-      - total baseline rows: 193 -> 191
-      - Admin path rows: 35 -> 33
-      - RuntimeConfigPage target rows: 2 -> 0
-
-    Verifier evidence:
-      - scoped verifier log had no RuntimeConfigPage findings
-      - full verifier remains blocked by unrelated current-dev drift outside this slice
-
-    TASK-45.44.7.4 migrated MaintenancePage forbidden and not-available guard
-    feedback from AntD Alert to the design-system Alert primitive in PR #2148.
-
-    Baseline file evidence:
-      - total baseline rows: 191 -> 189
-      - Admin path rows: 33 -> 31
-      - MaintenancePage target rows: 2 -> 0
-
-    Verifier evidence:
-      - scoped verifier log had no MaintenancePage findings
-      - full verifier remains blocked by unrelated current-dev drift outside this slice
-
-    TASK-45.44.7.5 / PR #2149 migrated UsageAnalyticsPage forbidden and
-    not-available guard feedback from AntD Alert to the design-system Alert
-    primitive.
-
-    Baseline file evidence:
-      - total baseline rows: 189 -> 187
-      - Admin path rows: 31 -> 29
-      - UsageAnalyticsPage target rows: 2 -> 0
-
-    Verifier evidence:
-      - scoped verifier log had no UsageAnalyticsPage findings
-      - full verifier remains blocked by unrelated current-dev drift outside this slice
-
-    TASK-45.44.7.6 / PR #2152 migrated BillingDashboardPage forbidden and
-    unsupported-route guard feedback from AntD Alert to the design-system Alert
-    primitive.
-
-    Baseline file evidence:
-      - total baseline rows: 187 -> 185
-      - Admin path rows: 29 -> 27
-      - BillingDashboardPage target rows: 2 -> 0
-
-    Verifier evidence:
-      - scoped verifier log had no BillingDashboardPage findings
-      - full verifier remains blocked by unrelated current-dev drift outside this slice
-
-    TASK-45.44.7.7 / PR #2153 migrated OrgsTeamsPage forbidden and
-    not-available guard feedback from AntD Alert to the design-system Alert
-    primitive.
-
-    Baseline file evidence:
-      - total baseline rows: 185 -> 183
-      - Admin path rows: 27 -> 25
-      - OrgsTeamsPage target rows: 2 -> 0
-
-    Verifier evidence:
-      - scoped verifier log had no OrgsTeamsPage findings
-      - full verifier remains blocked by unrelated current-dev drift outside this slice
-
-    TASK-45.44.7.8 / PR #2154 migrated DataOpsPage forbidden and
-    not-available guard feedback from AntD Alert to the design-system Alert
-    primitive.
-
-    Baseline file evidence:
-      - total baseline rows: 183 -> 181
-      - Admin path rows: 25 -> 23
-      - DataOpsPage target rows: 2 -> 0
-
-    Verifier evidence:
-      - scoped verifier log had no DataOpsPage findings
-      - full verifier remains blocked by unrelated current-dev drift outside this slice
+  Verifier evidence:
+    - scoped verifier log had no ServerAdminPage findings
+    - full verifier remains blocked by unrelated current-dev IntegrationPolicyPanel baseline drift/stale rows outside this slice
 parent_task_id: TASK-45.44
 priority: medium
 ---

--- a/backlog/tasks/task-45.44.7.9 - Migrate-ServerAdminPage-inline-error-alerts-to-design-system-Alert.md
+++ b/backlog/tasks/task-45.44.7.9 - Migrate-ServerAdminPage-inline-error-alerts-to-design-system-Alert.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-45.44.7.9
 title: Migrate ServerAdminPage inline error alerts to design-system Alert
-status: In Progress
+status: Done
 labels:
 - design-system
 - webui
@@ -10,6 +10,7 @@ priority: medium
 parent_task_id: TASK-45.44.7
 references:
 - https://github.com/rmusser01/tldw_server/issues/1664
+- https://github.com/rmusser01/tldw_server/pull/2156
 - apps/packages/ui/scripts/design-system-product-state-baseline.json
 modified_files:
 - apps/packages/ui/src/components/Option/Admin/ServerAdminPage.tsx
@@ -29,7 +30,7 @@ Migrate the remaining ServerAdminPage inline user, role, and media budget error 
 - [x] #1 ServerAdminPage users, roles, and media budget inline error states render through the design-system Alert primitive.
 - [x] #2 The product-state baseline no longer contains ServerAdminPage entries.
 - [x] #3 Focused regression coverage proves these error states use the design-system Alert contract.
-- [ ] #4 PR link, verification results, known skips, and final summary are recorded before closeout.
+- [x] #4 PR link, verification results, known skips, and final summary are recorded before closeout.
 <!-- AC:END -->
 
 ## Implementation Notes
@@ -52,15 +53,15 @@ Migrate the remaining ServerAdminPage inline user, role, and media budget error 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-
+Migrated ServerAdminPage users, roles, and media budget diagnostic inline error feedback from AntD Alert to the design-system Alert primitive in PR #2156. Added focused regression coverage for all three error branches, removed the three ServerAdminPage baseline exceptions, and recorded verification evidence. Package-wide TypeScript and the full design-system verifier remain blocked by unrelated current-dev debt outside this slice, documented in Implementation Notes.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->

--- a/backlog/tasks/task-45.44.7.9 - Migrate-ServerAdminPage-inline-error-alerts-to-design-system-Alert.md
+++ b/backlog/tasks/task-45.44.7.9 - Migrate-ServerAdminPage-inline-error-alerts-to-design-system-Alert.md
@@ -1,0 +1,66 @@
+---
+id: TASK-45.44.7.9
+title: Migrate ServerAdminPage inline error alerts to design-system Alert
+status: In Progress
+labels:
+- design-system
+- webui
+- product-state
+priority: medium
+parent_task_id: TASK-45.44.7
+references:
+- https://github.com/rmusser01/tldw_server/issues/1664
+- apps/packages/ui/scripts/design-system-product-state-baseline.json
+modified_files:
+- apps/packages/ui/src/components/Option/Admin/ServerAdminPage.tsx
+- apps/packages/ui/src/components/Option/Admin/__tests__/ServerAdminPage.design-system.test.tsx
+- apps/packages/ui/scripts/design-system-product-state-baseline.json
+- backlog/tasks/task-45.44.7 - Migrate-design-system-product-state-Admin-and-health-expansion.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Migrate the remaining ServerAdminPage inline user, role, and media budget error feedback from AntD Alert to the design-system Alert primitive, with focused regression coverage and baseline cleanup.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 ServerAdminPage users, roles, and media budget inline error states render through the design-system Alert primitive.
+- [x] #2 The product-state baseline no longer contains ServerAdminPage entries.
+- [x] #3 Focused regression coverage proves these error states use the design-system Alert contract.
+- [ ] #4 PR link, verification results, known skips, and final summary are recorded before closeout.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+2026-05-30:
+- Added focused ServerAdminPage design-system regression coverage for usersError, rolesError, and mediaBudgetError.
+- RED evidence: `bunx vitest run src/components/Option/Admin/__tests__/ServerAdminPage.design-system.test.tsx --reporter=dot` failed with 3 assertions at `expect(alert).not.toBeNull()`, proving the existing AntD Alert branches lacked a design-system Alert ancestor.
+- Migrated those three inline error branches from AntD Alert props to the design-system Alert primitive with `variant="error"` while preserving existing title text and sanitized error message content.
+- Removed the three ServerAdminPage baseline entries.
+- GREEN evidence: `bunx vitest run src/components/Option/Admin/__tests__/ServerAdminPage.design-system.test.tsx --reporter=dot` passed 1 file / 7 tests.
+- Guard evidence: `bunx vitest run src/design-system/__tests__/product-state-guard.test.ts --reporter=dot` passed 1 file / 54 tests.
+- Baseline count evidence: total rows 181 -> 178; Admin path rows 23 -> 20; ServerAdminPage target rows 3 -> 0.
+- `git diff --check` passed.
+- `env NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit --pretty false` remains blocked by unrelated current-dev TypeScript debt in `src/components/Option/ResearchWorkspace/__tests__/StudioPane.literature-workproducts.test.tsx:684` (`status` missing from a fixture).
+- `bun run verify:design-system-state` remains blocked by unrelated current-dev IntegrationPolicyPanel baseline drift/stale entries; the verifier log contains no ServerAdminPage findings.
+- Bandit skipped because this slice only touches TypeScript, TSX, JSON, and Backlog markdown.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## Summary

- Migrates `ServerAdminPage` user, role, and media budget diagnostic error feedback from AntD `Alert` to the design-system `Alert` primitive.
- Adds focused regression coverage for all three error branches and asserts the design-system marker before using the alert element.
- Removes the three matching `ServerAdminPage` product-state baseline exceptions and records the slice in Backlog.md.

## Verification

- `bunx vitest run src/components/Option/Admin/__tests__/ServerAdminPage.design-system.test.tsx --reporter=dot`
- `bunx vitest run src/design-system/__tests__/product-state-guard.test.ts --reporter=dot`
- `node -e "const fs=require('fs'); const data=JSON.parse(fs.readFileSync('apps/packages/ui/scripts/design-system-product-state-baseline.json','utf8')); console.log(JSON.stringify({total:data.length,serverAdmin:data.filter(e=>e.path==='src/components/Option/Admin/ServerAdminPage.tsx').length,admin:data.filter(e=>e.path?.startsWith('src/components/Option/Admin/')).length}));"` -> `{"total":178,"serverAdmin":0,"admin":20}`
- `git diff --check`
- `env NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit --pretty false` exits 2 from unrelated current-dev TypeScript debt in `src/components/Option/ResearchWorkspace/__tests__/StudioPane.literature-workproducts.test.tsx:684`; no `ServerAdminPage` entries were present in `/tmp/server-admin-tsc.log`.
- `bun run verify:design-system-state` exits 1 from unrelated current-dev IntegrationPolicyPanel baseline drift/stale rows; no `ServerAdminPage` findings were present in `/tmp/server-admin-design-state.log`.

## Change summary (maintainer-owned)

Maintainer note required before merge: please replace this section with your own summary explaining what changed and why these implementation choices were made.

## UX Audit Checklist

- [x] Existing inline error titles are preserved.
- [x] Error states keep alert urgency semantics.
- [x] Sanitized error message content remains visible.
- [x] No user-visible behavior changes outside the three error branches.

## Bandit

Not run. This slice touched TypeScript UI, JSON baseline data, and Backlog task markdown only.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrated `ServerAdminPage` users, roles, and media budget error alerts from AntD `Alert` to the design-system `Alert` for consistent styling and accessibility. Added focused tests and removed legacy baseline exceptions.

- **Refactors**
  - Replaced AntD `Alert` with design-system `Alert variant="error"` in all three error branches (users, roles, media budget).
  - Added tests asserting the design-system marker, `role="alert"`, and displayed error text.
  - Removed the three `ServerAdminPage` product-state baseline entries and recorded the migration in backlog tasks.

<sup>Written for commit 7d7c2de76035126ae07330b3623d3fb97e172afb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2156?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

