### PR TITLE
Add Stage 4G gateway config bootstrap

### DIFF
--- a/Docs/superpowers/plans/2026-05-30-mcp-unified-stage4g-gateway-config-bootstrap-plan.md
+++ b/Docs/superpowers/plans/2026-05-30-mcp-unified-stage4g-gateway-config-bootstrap-plan.md
@@ -1,0 +1,126 @@
+# MCP Unified Stage 4G Gateway Config Bootstrap Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:test-driven-development for behavior changes and keep this slice package-owned.
+
+**Goal:** Add package-owned gateway config bootstrap helpers that construct profile-aware gateway runtimes from explicit memory or SQLite profile-store configuration.
+
+**Architecture:** Keep the config layer under `mcp_unified.gateway` with no `tldw_Server_API` imports. Use small dataclasses instead of a broad settings framework. The config helper should resolve the profile store, then delegate to the Stage 4F `bootstrap_profile_gateway()` function so profile seeding, collision behavior, and runtime creation stay centralized.
+
+**Tech Stack:** Python 3.11, dataclasses, package-local gateway/profile/storage primitives, pytest, Ruff, Bandit.
+
+---
+
+### Task 1: Config Bootstrap RED Tests
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py`
+- Create: `mcp_unified/gateway/config.py`
+- Modify: `mcp_unified/gateway/__init__.py`
+
+- [x] **Step 1: Add failing config-bootstrap tests**
+
+Add tests that assert:
+- a memory-store config can seed a built-in default preset and build a `ProfileAwareGatewayRuntime`;
+- a SQLite-store config creates a `SQLiteMCPStore`, seeds the default preset, and persists the profile;
+- an injected profile store is preserved even when config contains a different store setting;
+- invalid store kinds and missing/blank SQLite paths raise clear `ValueError`s;
+- profile mapping inputs are copy-isolated during config construction.
+
+- [x] **Step 2: Run RED tests**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/mcp-unified-stage4g-gateway-config-bootstrap/.venv/bin/python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py -q
+```
+
+Expected: new tests fail because `mcp_unified.gateway.config` does not exist.
+
+Result: `5 failed, 43 passed, 4 warnings`; all new failures were the expected missing `mcp_unified.gateway.config` module.
+
+### Task 2: Package Config Helper
+
+**Files:**
+- Create: `mcp_unified/gateway/config.py`
+- Modify: `mcp_unified/gateway/__init__.py`
+
+- [x] **Step 1: Add config dataclasses**
+
+Implement:
+- `GatewayProfileStoreConfig(kind="memory" | "sqlite", sqlite_path=None)`;
+- `GatewayProfileBootstrapConfig(store=..., profiles=..., default_profile_id=None, default_preset_id=None)`;
+- validation that rejects unknown store kinds and SQLite configs without a path.
+
+- [x] **Step 2: Add config bootstrap helper**
+
+Implement `bootstrap_profile_gateway_from_config(backend, config, *, profile_store=None)`:
+- validate the config;
+- use the injected `profile_store` when supplied;
+- otherwise create `InMemoryProfileStore` or `SQLiteMCPStore` from config;
+- delegate to `bootstrap_profile_gateway()`;
+- return `GatewayProfileBootstrap`.
+
+- [x] **Step 3: Export the public config APIs**
+
+Export the config dataclasses and helper from `mcp_unified.gateway` without importing host code or eagerly importing SQLite.
+
+- [x] **Step 4: Run GREEN tests**
+
+Run the focused gateway package tests and confirm all pass.
+
+Result: `48 passed, 4 warnings`.
+
+- [x] **Step 5: Address review follow-up**
+
+After rebasing onto `origin/dev` `1c91138f5320a623002e4da160966cbfbeab9ead`, verify and address the still-valid review comments:
+- reject empty or whitespace-only SQLite profile-store paths;
+- copy-isolate profile mapping/model inputs during config construction;
+- keep the bootstrap store normalization type-safe;
+- add intent docstrings to the Stage 4G config bootstrap tests.
+
+Review RED result: `3 failed, 48 passed, 4 warnings`.
+Review GREEN result: `51 passed, 4 warnings`.
+
+### Task 3: Compatibility, Security, And PR Handoff
+
+**Files:**
+- Modify: `Docs/superpowers/plans/2026-05-30-mcp-unified-stage4g-gateway-config-bootstrap-plan.md`
+- Modify: `backlog/tasks/task-564 - Implement-MCP-Unified-Stage-4G-gateway-config-bootstrap.md`
+
+- [x] **Step 1: Run host compatibility tests**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/mcp-unified-stage4g-gateway-config-bootstrap/.venv/bin/python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_extraction_contracts.py tldw_Server_API/app/core/MCP_unified/tests/test_http_mapping.py -q
+```
+
+- [x] **Step 2: Run lint, security, and whitespace checks**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/mcp-unified-stage4g-gateway-config-bootstrap/.venv/bin/python -m ruff check mcp_unified/gateway tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/mcp-unified-stage4g-gateway-config-bootstrap/.venv/bin/python -m bandit -r mcp_unified/gateway -f json -o /tmp/bandit_mcp_stage4g_gateway_config_bootstrap.json
+git diff --check
+```
+
+- [x] **Step 3: Update plan and Backlog task**
+
+Record RED/GREEN and final verification evidence. Check off acceptance criteria and Definition of Done.
+
+- [x] **Step 4: Commit, push, and open PR**
+
+Commit the plan, gateway/test changes, and Backlog task update together, push the branch, and open a PR against `dev`.
+
+## Verification
+
+- Baseline: `43 passed, 4 warnings` for `test_gateway_fastapi_package.py` on merged Stage 4F.
+- RED: `5 failed, 43 passed, 4 warnings`; expected missing config module failures only.
+- GREEN: `48 passed, 4 warnings` for `test_gateway_fastapi_package.py`.
+- Review RED: `3 failed, 48 passed, 4 warnings` for blank SQLite path validation and profile input copy isolation.
+- Review GREEN: `51 passed, 4 warnings` for `test_gateway_fastapi_package.py`.
+- Compatibility: `47 passed, 4 warnings` for `test_extraction_contracts.py` and `test_http_mapping.py`.
+- Ruff: `All checks passed!` for `mcp_unified/gateway` and the focused gateway package tests.
+- Bandit: `0` results and no errors for `mcp_unified/gateway`.
+- Whitespace: `git diff --check` passed.

--- a/backlog/tasks/task-564 - Implement-MCP-Unified-Stage-4G-gateway-config-bootstrap.md
+++ b/backlog/tasks/task-564 - Implement-MCP-Unified-Stage-4G-gateway-config-bootstrap.md
@@ -1,0 +1,65 @@
+---
+id: TASK-564
+title: Implement MCP Unified Stage 4G gateway config bootstrap
+status: Done
+labels:
+- mcp-unified
+- standalone-extraction
+- gateway
+priority: medium
+references:
+- Docs/superpowers/specs/2026-05-26-mcp-unified-standalone-library-gateway-design.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Add the next narrow Stage 4 standalone gateway slice after Stage 4F: package-owned gateway config models and bootstrap helpers that construct the profile store/default profile settings from explicit configuration while preserving caller injection. This slice intentionally avoids CLI commands, host route integration, real external MCP process lifecycle, and broad settings frameworks.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Gateway package exposes config/bootstrap helpers without importing `tldw_Server_API`.
+- [x] #2 Config can select an in-memory or SQLite profile store and build a `ProfileAwareGatewayRuntime` from an injected backend.
+- [x] #3 Config can seed a default built-in preset with deterministic default profile behavior.
+- [x] #4 Caller-supplied/injected profile stores remain supported and cannot be silently replaced by config defaults.
+- [x] #5 Invalid store kinds and missing/blank SQLite paths fail fast with clear `ValueError`.
+- [x] #6 Focused gateway tests, host extraction/http compatibility tests, Ruff, Bandit, and whitespace checks are recorded before PR handoff.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+- Started from merged Stage 4F baseline on `origin/dev` `c6f192ce8a1c2e3ff822477a92d577d3d381f1eb`.
+- Added package-owned `mcp_unified.gateway.config` with `GatewayProfileStoreConfig`, `GatewayProfileBootstrapConfig`, and `bootstrap_profile_gateway_from_config`.
+- Config bootstrap supports memory and SQLite profile stores, validates unknown store kinds and missing SQLite paths, preserves an injected profile store when supplied, and delegates profile seeding/runtime creation to the Stage 4F bootstrap helper.
+- SQLite store import is deferred until a SQLite config is used so gateway imports do not eagerly require the SQLite backend path.
+- RED evidence: `5 failed, 43 passed, 4 warnings` for the focused gateway package tests; all new failures were the expected missing config module.
+- GREEN evidence: `48 passed, 4 warnings` for `test_gateway_fastapi_package.py`.
+- Compatibility evidence: `47 passed, 4 warnings` for `test_extraction_contracts.py` and `test_http_mapping.py`.
+- Quality evidence: Ruff passed, Bandit reported `0` results and no errors for `mcp_unified/gateway`, and `git diff --check` passed.
+- Review follow-up started from rebased `origin/dev` `1c91138f5320a623002e4da160966cbfbeab9ead`.
+- Verified Gemini/Qodo blank `sqlite_path` comments as valid and now reject empty or whitespace-only SQLite paths before store construction.
+- Verified the Qodo immutability advisory as valid and now copy-isolate profile mapping/model inputs during config construction.
+- Verified the Qodo test-docstring comment as valid and added intent docstrings to the Stage 4G config bootstrap tests.
+- Review RED evidence: `3 failed, 48 passed, 4 warnings` before the review fixes; failures covered blank path validation and copy isolation.
+- Review GREEN evidence: `51 passed, 4 warnings` for `test_gateway_fastapi_package.py`.
+- Review compatibility evidence: `47 passed, 4 warnings` for `test_extraction_contracts.py` and `test_http_mapping.py`.
+- Review quality evidence: Ruff passed, Bandit reported `0` results and no errors for `mcp_unified/gateway`, and `git diff --check` passed.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Stage 4G adds an explicit gateway config bootstrap seam. Standalone callers can now choose in-memory or SQLite profile storage through package-owned dataclasses, seed default presets, or inject a caller-owned store without the config layer replacing it. Review follow-up tightened SQLite path validation, copy-isolated profile config inputs, and documented the focused config tests. This remains intentionally below full CLI/config commands, external MCP lifecycle, and host route integration.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/mcp_unified/gateway/__init__.py
+++ b/mcp_unified/gateway/__init__.py
@@ -7,6 +7,12 @@ from .bootstrap import (
     bootstrap_profile_gateway,
     build_profile_gateway_runtime,
 )
+from .config import (
+    GatewayProfileBootstrapConfig,
+    GatewayProfileStoreConfig,
+    GatewayProfileStoreKind,
+    bootstrap_profile_gateway_from_config,
+)
 from .profile_runtime import ProfileAwareGatewayRuntime
 from .runtime import GatewayPolicyDenied, GatewayRequestContext, GatewayRuntime
 from .stdio import GatewayStdioServer, handle_stdio_line
@@ -17,11 +23,15 @@ if TYPE_CHECKING:
 __all__ = [
     "GatewayPolicyDenied",
     "GatewayProfileBootstrap",
+    "GatewayProfileBootstrapConfig",
     "GatewayRequestContext",
     "GatewayRuntime",
     "GatewayStdioServer",
+    "GatewayProfileStoreConfig",
+    "GatewayProfileStoreKind",
     "ProfileAwareGatewayRuntime",
     "bootstrap_profile_gateway",
+    "bootstrap_profile_gateway_from_config",
     "build_profile_gateway_runtime",
     "create_gateway_app",
     "create_gateway_router",

--- a/mcp_unified/gateway/config.py
+++ b/mcp_unified/gateway/config.py
@@ -1,0 +1,138 @@
+"""Configuration bootstrap helpers for standalone MCP gateway runtimes."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Literal
+
+from mcp_unified.interfaces.storage import ProfileStore
+from mcp_unified.profiles.models import MCPProfile
+from mcp_unified.profiles.store import InMemoryProfileStore
+
+from .bootstrap import GatewayProfileBootstrap, bootstrap_profile_gateway
+from .runtime import GatewayRuntime
+
+GatewayProfileStoreKind = Literal["memory", "sqlite"]
+
+
+@dataclass(frozen=True, slots=True)
+class GatewayProfileStoreConfig:
+    """Profile-store selection for standalone gateway bootstrap."""
+
+    kind: GatewayProfileStoreKind = "memory"
+    sqlite_path: str | Path | None = None
+
+    def __post_init__(self) -> None:
+        """Validate and normalize the configured profile store kind."""
+
+        normalized_kind = str(self.kind).strip().lower()
+        if normalized_kind not in {"memory", "sqlite"}:
+            raise ValueError(
+                f"Unsupported gateway profile store kind: {self.kind!r}"
+            )
+        object.__setattr__(self, "kind", normalized_kind)
+        if normalized_kind == "sqlite":
+            if self.sqlite_path is None:
+                raise ValueError("sqlite_path is required for sqlite profile store")
+            if not str(self.sqlite_path).strip():
+                raise ValueError("sqlite_path cannot be empty")
+
+
+@dataclass(frozen=True, slots=True)
+class GatewayProfileBootstrapConfig:
+    """Profile bootstrap configuration for a standalone gateway runtime."""
+
+    store: GatewayProfileStoreConfig | Mapping[str, Any] = field(
+        default_factory=GatewayProfileStoreConfig
+    )
+    profiles: Iterable[MCPProfile | Mapping[str, Any]] = field(default_factory=tuple)
+    default_profile_id: str | None = None
+    default_preset_id: str | None = None
+
+    def __post_init__(self) -> None:
+        """Normalize nested config values into copy-isolated profile data."""
+
+        store = self.store
+        if isinstance(store, Mapping):
+            store = GatewayProfileStoreConfig(**store)
+        elif not isinstance(store, GatewayProfileStoreConfig):
+            raise TypeError("store must be a GatewayProfileStoreConfig or mapping")
+
+        object.__setattr__(self, "store", store)
+        object.__setattr__(
+            self,
+            "profiles",
+            tuple(_copy_profile(profile) for profile in self.profiles or ()),
+        )
+
+
+async def bootstrap_profile_gateway_from_config(
+    backend: GatewayRuntime,
+    config: GatewayProfileBootstrapConfig | Mapping[str, Any] | None = None,
+    *,
+    profile_store: ProfileStore | None = None,
+) -> GatewayProfileBootstrap:
+    """Build a profile-aware gateway runtime from explicit gateway config."""
+
+    resolved_config = _validate_bootstrap_config(config)
+    store = profile_store
+    if store is None:
+        store_config = resolved_config.store
+        if isinstance(store_config, Mapping):
+            store_config = GatewayProfileStoreConfig(**store_config)
+        store = _build_profile_store(store_config)
+
+    return await bootstrap_profile_gateway(
+        backend,
+        profile_store=store,
+        profiles=resolved_config.profiles,
+        default_profile_id=resolved_config.default_profile_id,
+        default_preset_id=resolved_config.default_preset_id,
+    )
+
+
+def _validate_bootstrap_config(
+    config: GatewayProfileBootstrapConfig | Mapping[str, Any] | None,
+) -> GatewayProfileBootstrapConfig:
+    """Return a validated bootstrap config model."""
+
+    if config is None:
+        return GatewayProfileBootstrapConfig()
+    if isinstance(config, GatewayProfileBootstrapConfig):
+        return config
+    return GatewayProfileBootstrapConfig(**config)
+
+
+def _build_profile_store(store_config: GatewayProfileStoreConfig) -> ProfileStore:
+    """Create the configured profile store without importing optional stores early."""
+
+    if store_config.kind == "memory":
+        return InMemoryProfileStore()
+    if store_config.kind == "sqlite":
+        from mcp_unified.storage.sqlite import SQLiteMCPStore
+
+        sqlite_path = store_config.sqlite_path
+        if sqlite_path is None:
+            raise ValueError("sqlite_path is required for sqlite profile store")
+        return SQLiteMCPStore(sqlite_path)
+    raise ValueError(
+        f"Unsupported gateway profile store kind: {store_config.kind!r}"
+    )
+
+
+def _copy_profile(profile: MCPProfile | Mapping[str, Any]) -> MCPProfile:
+    """Return a validated, copy-isolated profile config value."""
+
+    if isinstance(profile, MCPProfile):
+        return profile.model_copy(deep=True)
+    return MCPProfile.model_validate(profile).model_copy(deep=True)
+
+
+__all__ = [
+    "GatewayProfileBootstrapConfig",
+    "GatewayProfileStoreConfig",
+    "GatewayProfileStoreKind",
+    "bootstrap_profile_gateway_from_config",
+]

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py
@@ -576,6 +576,158 @@ def test_gateway_profile_bootstrap_rejects_unknown_default_preset() -> None:
         )
 
 
+def test_gateway_config_bootstrap_uses_memory_store_default_preset() -> None:
+    """Build a profile runtime from default memory-store config and preset."""
+
+    from mcp_unified.gateway.config import (
+        GatewayProfileBootstrapConfig,
+        bootstrap_profile_gateway_from_config,
+    )
+
+    bootstrap = asyncio.run(
+        bootstrap_profile_gateway_from_config(
+            _MultiToolGatewayRuntime(),
+            GatewayProfileBootstrapConfig(default_preset_id="project-researcher"),
+        )
+    )
+    app = create_gateway_app(bootstrap.runtime, prefix="/mcp")
+
+    with TestClient(app) as client:
+        listed = client.post(
+            "/mcp/request",
+            json={"jsonrpc": "2.0", "method": "tools/list", "params": {}, "id": "tools-config-memory"},
+        )
+
+    assert bootstrap.default_profile_id == "project-researcher"
+    assert bootstrap.seeded_profile_ids == ("project-researcher",)
+    assert [tool["name"] for tool in listed.json()["result"]["tools"]] == ["echo.search"]
+
+
+def test_gateway_config_bootstrap_uses_sqlite_profile_store(tmp_path: Path) -> None:
+    """Build a profile runtime backed by the configured SQLite profile store."""
+
+    from mcp_unified.gateway.config import (
+        GatewayProfileBootstrapConfig,
+        GatewayProfileStoreConfig,
+        bootstrap_profile_gateway_from_config,
+    )
+    from mcp_unified.storage.sqlite import SQLiteMCPStore
+
+    sqlite_path = tmp_path / "gateway.db"
+
+    bootstrap = asyncio.run(
+        bootstrap_profile_gateway_from_config(
+            _MultiToolGatewayRuntime(),
+            GatewayProfileBootstrapConfig(
+                store=GatewayProfileStoreConfig(kind="sqlite", sqlite_path=sqlite_path),
+                default_preset_id="project-researcher",
+            ),
+        )
+    )
+    stored_profiles = asyncio.run(bootstrap.profile_store.list_profiles())
+
+    assert isinstance(bootstrap.profile_store, SQLiteMCPStore)
+    assert sqlite_path.exists()
+    assert [profile.id for profile in stored_profiles] == ["project-researcher"]
+    asyncio.run(bootstrap.profile_store.aclose())
+
+
+def test_gateway_config_bootstrap_preserves_injected_profile_store(tmp_path: Path) -> None:
+    """Prefer caller-injected stores over config-selected store creation."""
+
+    from mcp_unified.gateway.config import (
+        GatewayProfileBootstrapConfig,
+        GatewayProfileStoreConfig,
+        bootstrap_profile_gateway_from_config,
+    )
+    from mcp_unified.profiles.store import InMemoryProfileStore
+
+    sqlite_path = tmp_path / "unused.db"
+    profile = _profile_with_allowed_tools("reviewer", ["admin.delete"])
+    injected_store = InMemoryProfileStore([profile])
+
+    bootstrap = asyncio.run(
+        bootstrap_profile_gateway_from_config(
+            _MultiToolGatewayRuntime(),
+            GatewayProfileBootstrapConfig(
+                store=GatewayProfileStoreConfig(kind="sqlite", sqlite_path=sqlite_path),
+                default_profile_id="reviewer",
+            ),
+            profile_store=injected_store,
+        )
+    )
+    app = create_gateway_app(bootstrap.runtime, prefix="/mcp")
+
+    with TestClient(app) as client:
+        listed = client.post(
+            "/mcp/request",
+            json={"jsonrpc": "2.0", "method": "tools/list", "params": {}, "id": "tools-config-injected"},
+        )
+
+    assert bootstrap.profile_store is injected_store
+    assert not sqlite_path.exists()
+    assert [tool["name"] for tool in listed.json()["result"]["tools"]] == ["admin.delete"]
+
+
+def test_gateway_config_rejects_invalid_store_kind() -> None:
+    """Reject unsupported profile-store kinds during config construction."""
+
+    from mcp_unified.gateway.config import GatewayProfileStoreConfig
+
+    with pytest.raises(ValueError, match="Unsupported gateway profile store kind"):
+        GatewayProfileStoreConfig(kind="postgres")
+
+
+def test_gateway_config_rejects_sqlite_store_without_path() -> None:
+    """Reject SQLite profile-store config when no database path is supplied."""
+
+    from mcp_unified.gateway.config import GatewayProfileStoreConfig
+
+    with pytest.raises(ValueError, match="sqlite_path is required"):
+        GatewayProfileStoreConfig(kind="sqlite")
+
+
+@pytest.mark.parametrize("sqlite_path", ["", "   "])
+def test_gateway_config_rejects_blank_sqlite_store_path(sqlite_path: str) -> None:
+    """Reject blank SQLite profile-store paths before store construction."""
+
+    from mcp_unified.gateway.config import GatewayProfileStoreConfig
+
+    with pytest.raises(ValueError, match="sqlite_path cannot be empty"):
+        GatewayProfileStoreConfig(kind="sqlite", sqlite_path=sqlite_path)
+
+
+def test_gateway_config_bootstrap_copies_profile_mapping_inputs() -> None:
+    """Copy profile mapping inputs so later caller mutation cannot affect policy."""
+
+    from mcp_unified.gateway.config import (
+        GatewayProfileBootstrapConfig,
+        bootstrap_profile_gateway_from_config,
+    )
+
+    profile_payload = _profile_with_allowed_tools("reviewer", ["echo.search"]).model_dump(
+        mode="json"
+    )
+    config = GatewayProfileBootstrapConfig(
+        profiles=[profile_payload],
+        default_profile_id="reviewer",
+    )
+    profile_payload["policy_document"]["allowed_tools"] = ["admin.delete"]
+
+    bootstrap = asyncio.run(
+        bootstrap_profile_gateway_from_config(_MultiToolGatewayRuntime(), config)
+    )
+    app = create_gateway_app(bootstrap.runtime, prefix="/mcp")
+
+    with TestClient(app) as client:
+        listed = client.post(
+            "/mcp/request",
+            json={"jsonrpc": "2.0", "method": "tools/list", "params": {}, "id": "tools-config-copy"},
+        )
+
+    assert [tool["name"] for tool in listed.json()["result"]["tools"]] == ["echo.search"]
+
+
 def test_gateway_transport_profile_selector_handles_missing_request_attributes() -> None:
     class _BareRequest:
         """Request double without FastAPI transport attributes."""


### PR DESCRIPTION
## Change summary (maintainer-owned)

- Maintainer to replace this section with a human-authored summary before merge.

## Summary

- What changed:
  - Added `mcp_unified.gateway.config` with small dataclass config models for memory and SQLite profile-store bootstrap.
  - Added `bootstrap_profile_gateway_from_config()` to construct a profile-aware gateway runtime from explicit config while preserving caller-injected stores.
  - Exported the config bootstrap APIs from `mcp_unified.gateway`.
  - Added focused tests for memory config, SQLite config, injected store preservation, fail-fast config validation, blank SQLite paths, and profile input copy isolation.
  - Addressed review feedback by rejecting empty/whitespace SQLite paths, copy-isolating profile mappings/models, keeping store normalization type-safe, and documenting the new config tests.
- Why:
  - Stage 4G adds the next standalone gateway seam after profile bootstrap without introducing CLI commands, host route integration, external server lifecycle, or a broad settings framework.

## Validation

- [x] Tests added/updated for behavior changes
- [x] Relevant unit/integration tests pass locally
- [x] Docs updated (if behavior, routes, or config changed)

Commands:

- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/mcp-unified-stage4g-gateway-config-bootstrap/.venv/bin/python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py -q` -> `51 passed, 4 warnings`
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/mcp-unified-stage4g-gateway-config-bootstrap/.venv/bin/python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_extraction_contracts.py tldw_Server_API/app/core/MCP_unified/tests/test_http_mapping.py -q` -> `47 passed, 4 warnings`
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/mcp-unified-stage4g-gateway-config-bootstrap/.venv/bin/python -m ruff check mcp_unified/gateway tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py` -> `All checks passed!`
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/mcp-unified-stage4g-gateway-config-bootstrap/.venv/bin/python -m bandit -r mcp_unified/gateway -f json -o /tmp/bandit_mcp_stage4g_gateway_config_bootstrap.json` -> `0` findings, no errors
- `git diff --check` -> passed

## UX Audit Checklist (v2 Stage 5)

- [x] N/A - MCP package-only backend/library change; no WebUI or extension UI behavior changed.

## Watchlists Accessibility Checklist (Group 09 Stage 5)

- [x] N/A - no Watchlists UI behavior changed.

## Watchlists Scale Checklist (Group 10 Stage 5)

- [x] N/A - no Watchlists polling, notification, Activity, batch triage, or scale behavior changed.

## Risk & Rollback

- Risk level: Low
- Rollback plan: Revert this single commit to remove the config bootstrap helper/export and associated focused tests.
