### PR TITLE
Migrate MlxAdminPage product states to design system

### DIFF
--- a/apps/packages/ui/scripts/design-system-product-state-baseline.json
+++ b/apps/packages/ui/scripts/design-system-product-state-baseline.json
@@ -44,50 +44,6 @@
     "migrationQueue": "shared-product-state"
   },
   {
-    "id": "antd-product-state-import:src/components/Option/Admin/MlxAdminPage.tsx:Alert#antd-alert-mlxadminpage-type-info-line-667-t3pi54",
-    "path": "src/components/Option/Admin/MlxAdminPage.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/Option/Admin/MlxAdminPage.tsx before the stable duplicate-id guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
-    "id": "antd-product-state-import:src/components/Option/Admin/MlxAdminPage.tsx:Alert#antd-alert-mlxadminpage-type-warning-line-268-yqafzn",
-    "path": "src/components/Option/Admin/MlxAdminPage.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/Option/Admin/MlxAdminPage.tsx before the stable duplicate-id guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
-    "id": "antd-product-state-import:src/components/Option/Admin/MlxAdminPage.tsx:Alert#antd-alert-mlxadminpage-type-warning-line-356-42av15",
-    "path": "src/components/Option/Admin/MlxAdminPage.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/Option/Admin/MlxAdminPage.tsx before the stable duplicate-id guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
-    "id": "antd-product-state-import:src/components/Option/Admin/MlxAdminPage.tsx:Tag",
-    "path": "src/components/Option/Admin/MlxAdminPage.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Tag",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Tag product-state UI in src/components/Option/Admin/MlxAdminPage.tsx before the guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
     "id": "antd-product-state-import:src/components/Option/Admin/MonitoringDashboardPage.tsx:Alert#antd-alert-monitoringdashboardpage-type-error-access-den-19nq744",
     "path": "src/components/Option/Admin/MonitoringDashboardPage.tsx",
     "rule": "antd-product-state-import",

--- a/apps/packages/ui/src/components/Option/Admin/MlxAdminPage.tsx
+++ b/apps/packages/ui/src/components/Option/Admin/MlxAdminPage.tsx
@@ -3,9 +3,7 @@ import {
   Typography,
   Card,
   List,
-  Tag,
   Space,
-  Alert,
   Button,
   Input,
   Select,
@@ -20,6 +18,7 @@ import { PageShell } from "@/components/Common/PageShell"
 import { buildMlxLoadRequest } from "@/utils/build-mlx-load-request"
 import { StatusBanner } from "./StatusBanner"
 import { CollapsibleSection } from "./CollapsibleSection"
+import { Alert, Badge } from "@/components/ui/primitives"
 import {
   deriveAdminGuardFromError,
   sanitizeAdminErrorMessage
@@ -266,34 +265,31 @@ export const MlxAdminPage: React.FC = () => {
         {/* Admin Guard Alert */}
         {adminGuard && (
           <Alert
-            type="warning"
-            showIcon
+            variant="warning"
             title={
               adminGuard === "forbidden"
                 ? t("settings:admin.adminGuardForbiddenTitle", "Admin access required")
                 : t("settings:admin.adminGuardNotFoundTitle", "Admin APIs not available")
-            }
-            description={
-              <span>
-                {adminGuard === "forbidden"
-                  ? t(
-                      "settings:admin.adminGuardForbiddenBody",
-                      "Sign in as an admin user on your tldw server to access these controls."
-                    )
-                  : t(
-                      "settings:admin.adminGuardNotFoundBody",
-                      "This tldw server does not expose the admin endpoints."
-                    )}{" "}
-                <a
-                  href="https://github.com/rmusser01/tldw_server#documentation--resources"
-                  target="_blank"
-                  rel="noreferrer"
-                >
-                  {t("settings:admin.adminGuardLearnMore", "Learn more")}
-                </a>
-              </span>
-            }
-          />
+            }>
+            <span>
+              {adminGuard === "forbidden"
+                ? t(
+                    "settings:admin.adminGuardForbiddenBody",
+                    "Sign in as an admin user on your tldw server to access these controls."
+                  )
+                : t(
+                    "settings:admin.adminGuardNotFoundBody",
+                    "This tldw server does not expose the admin endpoints."
+                  )}{" "}
+              <a
+                href="https://github.com/rmusser01/tldw_server#documentation--resources"
+                target="_blank"
+                rel="noreferrer"
+              >
+                {t("settings:admin.adminGuardLearnMore", "Learn more")}
+              </a>
+            </span>
+          </Alert>
         )}
 
         {/* Page Header */}
@@ -354,8 +350,7 @@ export const MlxAdminPage: React.FC = () => {
             )}
             {statusUnavailable && (
               <Alert
-                type="warning"
-                showIcon
+                variant="warning"
                 title={t(
                   "settings:admin.mlxUnavailableHint",
                   "MLX controls are temporarily unavailable until status checks succeed."
@@ -556,9 +551,10 @@ export const MlxAdminPage: React.FC = () => {
                         onChange={setTrustRemoteCode}
                       />
                       {trustRemoteCode && (
-                        <Tag color="warning" icon={<AlertTriangle size={12} />}>
+                        <Badge variant="warning" size="sm" outline>
+                          <AlertTriangle size={12} aria-hidden="true" />
                           {t("settings:admin.mlxTrustRemoteCodeWarning", "Security risk")}
-                        </Tag>
+                        </Badge>
                       )}
                     </div>
 
@@ -665,12 +661,11 @@ export const MlxAdminPage: React.FC = () => {
 
                 {status?.active && (
                   <Alert
-                    type="info"
+                    variant="info"
                     title={t(
                       "settings:admin.mlxAlreadyLoaded",
                       "A model is currently loaded. Unload it first or load a different model to replace it."
                     )}
-                    showIcon
                   />
                 )}
               </Space>
@@ -711,19 +706,19 @@ export const MlxAdminPage: React.FC = () => {
                           <div className="flex flex-wrap items-center gap-2">
                             <Text code>{idLabel}</Text>
                             {capabilities?.vision && (
-                              <Tag color="purple">
+                              <Badge variant="primary" size="sm">
                                 {t("settings:admin.mlxVision", "Vision")}
-                              </Tag>
+                              </Badge>
                             )}
                             {capabilities?.tool_use && (
-                              <Tag color="geekblue">
+                              <Badge variant="info" size="sm">
                                 {t("settings:admin.mlxTools", "Tools")}
-                              </Tag>
+                              </Badge>
                             )}
                             {capabilities?.audio_input && (
-                              <Tag color="volcano">
+                              <Badge variant="warning" size="sm">
                                 {t("settings:admin.mlxAudio", "Audio")}
-                              </Tag>
+                              </Badge>
                             )}
                           </div>
                           {notes && (

--- a/apps/packages/ui/src/components/Option/Admin/__tests__/MlxAdminPage.test.tsx
+++ b/apps/packages/ui/src/components/Option/Admin/__tests__/MlxAdminPage.test.tsx
@@ -1,6 +1,6 @@
 import React from "react"
 import { beforeEach, describe, expect, it, vi } from "vitest"
-import { render, screen } from "@testing-library/react"
+import { fireEvent, render, screen, within } from "@testing-library/react"
 import MlxAdminPage from "../MlxAdminPage"
 
 const apiMock = vi.hoisted(() => ({
@@ -39,6 +39,14 @@ vi.mock("@/services/tldw/TldwApiClient", () => ({
 vi.mock("@/components/Common/PageShell", () => ({
   PageShell: ({ children }: { children: React.ReactNode }) => <div>{children}</div>
 }))
+
+const expectDesignSystemAlertForText = async (text: string) => {
+  const title = await screen.findByText(text)
+  const alert = title.closest('[data-ds-component="Alert"]')
+
+  expect(alert).not.toBeNull()
+  return alert as HTMLElement
+}
 
 describe("MlxAdminPage", () => {
   beforeEach(() => {
@@ -100,7 +108,8 @@ describe("MlxAdminPage", () => {
 
     render(<MlxAdminPage />)
 
-    expect(await screen.findByText("Admin APIs not available")).toBeTruthy()
+    const alert = await expectDesignSystemAlertForText("Admin APIs not available")
+    expect(alert).toHaveAttribute("role", "alert")
     expect(screen.queryByText("Load Model")).toBeNull()
   })
 
@@ -109,13 +118,44 @@ describe("MlxAdminPage", () => {
 
     render(<MlxAdminPage />)
 
-    expect(
-      await screen.findByText(
-        "MLX controls are temporarily unavailable until status checks succeed."
-      )
-    ).toBeTruthy()
+    const alert = await expectDesignSystemAlertForText(
+      "MLX controls are temporarily unavailable until status checks succeed."
+    )
+    expect(alert).toHaveAttribute("role", "alert")
 
     expect(screen.getByRole("button", { name: "Load Model" })).toBeDisabled()
     expect(screen.getByRole("button", { name: "Unload Model" })).toBeDisabled()
+  })
+
+  it("renders the active-model notice through the design-system Alert primitive", async () => {
+    apiMock.getMlxStatus.mockResolvedValueOnce({
+      active: true,
+      model: "mlx-community/test-model",
+      max_concurrent: 2
+    })
+
+    render(<MlxAdminPage />)
+
+    const alert = await expectDesignSystemAlertForText(
+      "A model is currently loaded. Unload it first or load a different model to replace it."
+    )
+    expect(alert).toHaveAttribute("role", "status")
+  })
+
+  it("renders the trust-remote-code warning through the design-system Badge primitive", async () => {
+    render(<MlxAdminPage />)
+
+    fireEvent.click(await screen.findByText("Advanced Settings"))
+    await screen.findByText("Trust remote code:")
+
+    const trustRemoteCodeLabel = screen.getByText("Trust remote code:")
+    const trustRemoteCodeRow = trustRemoteCodeLabel.closest("div")
+    expect(trustRemoteCodeRow).not.toBeNull()
+
+    fireEvent.click(within(trustRemoteCodeRow as HTMLElement).getByRole("switch"))
+
+    const warning = await screen.findByText("Security risk")
+    const badge = warning.closest('[data-ds-component="Badge"]')
+    expect(badge).not.toBeNull()
   })
 })

--- a/backlog/tasks/task-45.44.7 - Migrate-design-system-product-state-Admin-and-health-expansion.md
+++ b/backlog/tasks/task-45.44.7 - Migrate-design-system-product-state-Admin-and-health-expansion.md
@@ -73,6 +73,16 @@ documentation:
   Verifier evidence:
     - scoped verifier log had no ServerAdminPage findings
     - full verifier remains blocked by unrelated current-dev IntegrationPolicyPanel baseline drift/stale rows outside this slice
+- |-
+  TASK-45.44.7.10 / PR #2158 migrated MlxAdminPage admin guard, temporary-unavailable, active-model, and security-risk product-state UI from AntD Alert/Tag to the design-system Alert/Badge primitives.
+  Baseline file evidence:
+    - total baseline rows: 178 -> 174
+    - Admin path rows: 20 -> 16
+    - MlxAdminPage target rows: 4 -> 0
+
+  Verifier evidence:
+    - scoped verifier log had no MlxAdminPage findings
+    - full verifier remains blocked by unrelated current-dev IntegrationPolicyPanel baseline drift/stale rows outside this slice
 parent_task_id: TASK-45.44
 priority: medium
 ---

--- a/backlog/tasks/task-45.44.7.10 - Migrate-MlxAdminPage-alerts-and-security-badge-to-design-system-primitives.md
+++ b/backlog/tasks/task-45.44.7.10 - Migrate-MlxAdminPage-alerts-and-security-badge-to-design-system-primitives.md
@@ -1,0 +1,66 @@
+---
+id: TASK-45.44.7.10
+title: Migrate MlxAdminPage alerts and security badge to design-system primitives
+status: In Progress
+labels:
+- design-system
+- webui
+- product-state
+priority: medium
+parent_task_id: TASK-45.44.7
+references:
+- https://github.com/rmusser01/tldw_server/issues/1664
+- apps/packages/ui/scripts/design-system-product-state-baseline.json
+modified_files:
+- apps/packages/ui/src/components/Option/Admin/MlxAdminPage.tsx
+- apps/packages/ui/src/components/Option/Admin/__tests__/MlxAdminPage.test.tsx
+- apps/packages/ui/scripts/design-system-product-state-baseline.json
+- backlog/tasks/task-45.44.7 - Migrate-design-system-product-state-Admin-and-health-expansion.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Migrate MlxAdminPage admin guard, unavailable, loaded-model, and security-risk product-state UI from AntD Alert/Tag to design-system Alert/Badge primitives with focused regression coverage and baseline cleanup.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 MlxAdminPage admin guard, status-unavailable, active-model notice, and trust-remote-code security risk product-state UI render through design-system primitives.
+- [x] #2 The product-state baseline no longer contains MlxAdminPage entries.
+- [x] #3 Focused regression coverage proves the relevant Alert/Badge design-system contracts.
+- [ ] #4 PR link, verification results, known skips, and final summary are recorded before closeout.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+2026-05-30:
+- Added focused MlxAdminPage design-system assertions for the admin guard warning, temporary-unavailable warning, active-model info notice, and trust-remote-code security-risk badge.
+- RED evidence: `bunx vitest run src/components/Option/Admin/__tests__/MlxAdminPage.test.tsx --reporter=dot` failed with 4 expected assertions at missing `data-ds-component="Alert"` / `data-ds-component="Badge"` ancestors after opening the collapsed Advanced Settings section.
+- Migrated the three AntD Alert branches to the design-system Alert primitive and moved the AntD Tag security/capability labels to the design-system Badge primitive.
+- Removed the four MlxAdminPage baseline entries.
+- GREEN evidence: `bunx vitest run src/components/Option/Admin/__tests__/MlxAdminPage.test.tsx --reporter=dot` passed 1 file / 5 tests.
+- Guard evidence: `bunx vitest run src/design-system/__tests__/product-state-guard.test.ts --reporter=dot` passed 1 file / 54 tests.
+- Baseline count evidence: total rows 178 -> 174; Admin path rows 20 -> 16; MlxAdminPage target rows 4 -> 0.
+- `git diff --check` passed.
+- `env NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit --pretty false` remains blocked by unrelated current-dev TypeScript debt in `src/components/Option/ResearchWorkspace/__tests__/StudioPane.literature-workproducts.test.tsx:684` (`status` missing from a fixture).
+- `bun run verify:design-system-state` remains blocked by unrelated current-dev IntegrationPolicyPanel baseline drift/stale entries; the verifier log contains no MlxAdminPage findings.
+- Bandit skipped because this slice only touches TypeScript, TSX, JSON, and Backlog markdown.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-45.44.7.10 - Migrate-MlxAdminPage-alerts-and-security-badge-to-design-system-primitives.md
+++ b/backlog/tasks/task-45.44.7.10 - Migrate-MlxAdminPage-alerts-and-security-badge-to-design-system-primitives.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-45.44.7.10
 title: Migrate MlxAdminPage alerts and security badge to design-system primitives
-status: In Progress
+status: Done
 labels:
 - design-system
 - webui
@@ -10,6 +10,7 @@ priority: medium
 parent_task_id: TASK-45.44.7
 references:
 - https://github.com/rmusser01/tldw_server/issues/1664
+- https://github.com/rmusser01/tldw_server/pull/2158
 - apps/packages/ui/scripts/design-system-product-state-baseline.json
 modified_files:
 - apps/packages/ui/src/components/Option/Admin/MlxAdminPage.tsx
@@ -29,7 +30,7 @@ Migrate MlxAdminPage admin guard, unavailable, loaded-model, and security-risk p
 - [x] #1 MlxAdminPage admin guard, status-unavailable, active-model notice, and trust-remote-code security risk product-state UI render through design-system primitives.
 - [x] #2 The product-state baseline no longer contains MlxAdminPage entries.
 - [x] #3 Focused regression coverage proves the relevant Alert/Badge design-system contracts.
-- [ ] #4 PR link, verification results, known skips, and final summary are recorded before closeout.
+- [x] #4 PR link, verification results, known skips, and final summary are recorded before closeout.
 <!-- AC:END -->
 
 ## Implementation Notes
@@ -52,15 +53,15 @@ Migrate MlxAdminPage admin guard, unavailable, loaded-model, and security-risk p
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-
+Migrated MlxAdminPage admin guard, temporary-unavailable, active-model, and security-risk product-state UI from AntD Alert/Tag to the design-system Alert/Badge primitives in PR #2158. Added focused regression coverage for all migrated product-state branches, removed the four MlxAdminPage baseline exceptions, and recorded verification evidence. Package-wide TypeScript and the full design-system verifier remain blocked by unrelated current-dev debt outside this slice, documented in Implementation Notes.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->


### PR DESCRIPTION
## Summary

- Migrates `MlxAdminPage` admin guard, temporary-unavailable, active-model, and security-risk product-state UI from AntD `Alert`/`Tag` to design-system `Alert`/`Badge` primitives.
- Adds focused regression coverage for the three Alert branches and trust-remote-code Badge marker.
- Removes the four matching `MlxAdminPage` product-state baseline exceptions and records the slice in Backlog.md.

## Verification

- `bunx vitest run src/components/Option/Admin/__tests__/MlxAdminPage.test.tsx --reporter=dot`
- `bunx vitest run src/design-system/__tests__/product-state-guard.test.ts --reporter=dot`
- `node -e "const fs=require('fs'); const data=JSON.parse(fs.readFileSync('apps/packages/ui/scripts/design-system-product-state-baseline.json','utf8')); console.log(JSON.stringify({total:data.length,mlx:data.filter(e=>e.path==='src/components/Option/Admin/MlxAdminPage.tsx').length,admin:data.filter(e=>e.path?.startsWith('src/components/Option/Admin/')).length}));"` -> `{"total":174,"mlx":0,"admin":16}`
- `git diff --check`
- `env NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit --pretty false` exits 2 from unrelated current-dev TypeScript debt in `src/components/Option/ResearchWorkspace/__tests__/StudioPane.literature-workproducts.test.tsx:684`; no `MlxAdminPage` entries were present in `/tmp/mlx-admin-tsc.log`.
- `bun run verify:design-system-state` exits 1 from unrelated current-dev IntegrationPolicyPanel baseline drift/stale rows; no `MlxAdminPage` findings were present in `/tmp/mlx-admin-design-state.log`.

## Change summary (maintainer-owned)

Maintainer note required before merge: please replace this section with your own summary explaining what changed and why these implementation choices were made.

## UX Audit Checklist

- [x] Existing MLX alert copy is preserved.
- [x] Warning and info urgency semantics are preserved through design-system roles.
- [x] Trust-remote-code warning remains visibly marked as a security risk.
- [x] Provider capability labels remain visible after moving from AntD Tag to design-system Badge.

## Bandit

Not run. This slice touched TypeScript UI, JSON baseline data, and Backlog task markdown only.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrates `MlxAdminPage` product-state UI from AntD to the design system to standardize alerts and badges, with focused tests and baseline cleanup. Backlog closeout has been recorded.

- **Refactors**
  - Replaced AntD `Alert`/`Tag` with design-system `Alert`/`Badge` for admin guard, temporary-unavailable, active-model notice, trust-remote-code warning, and capability labels (Vision/Tools/Audio).
  - Preserved existing copy, urgency semantics (`warning`/`info`), and accessibility roles.
  - Added tests for all three `Alert` branches and the trust-remote-code `Badge`, checking `data-ds-component` anchors and ARIA roles.
  - Removed four `MlxAdminPage` entries from `design-system-product-state-baseline.json` and documented closeout in Backlog tasks.

<sup>Written for commit 938531b5f03132241074ff04d86fff9ee91d4991. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2158?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

