### PR TITLE
Launch Deep Research from literature artifacts

### DIFF
--- a/apps/packages/ui/src/components/Option/ResearchWorkspace/StudioPane/index.tsx
+++ b/apps/packages/ui/src/components/Option/ResearchWorkspace/StudioPane/index.tsx
@@ -1,5 +1,6 @@
 import React, { Suspense, useState, useEffect, useRef } from "react"
 import { useTranslation } from "react-i18next"
+import { Link } from "react-router-dom"
 import {
   Headphones,
   FileText,
@@ -2533,11 +2534,13 @@ export const StudioPane: React.FC<StudioPaneProps> = ({
                             <Tooltip
                               title={t(
                                 "playground:studio.launchDeepResearch",
-                                "Launch Deep Research"
+                              "Launch Deep Research"
                               )}
                             >
-                              <a
-                                href={deepResearchLaunchHref}
+                              <Link
+                                to={deepResearchLaunchHref}
+                                target="_blank"
+                                rel="noopener noreferrer"
                                 className="rounded p-1 text-text-muted hover:bg-surface hover:text-text"
                                 aria-label={t(
                                   "playground:studio.launchDeepResearch",
@@ -2546,7 +2549,7 @@ export const StudioPane: React.FC<StudioPaneProps> = ({
                                 data-testid={`studio-artifact-deep-research-${artifact.id}`}
                               >
                                 <Microscope className="h-4 w-4" />
-                              </a>
+                              </Link>
                             </Tooltip>
                           )}
                           {artifact.content && (

--- a/apps/packages/ui/src/components/Option/ResearchWorkspace/StudioPane/index.tsx
+++ b/apps/packages/ui/src/components/Option/ResearchWorkspace/StudioPane/index.tsx
@@ -19,6 +19,7 @@ import {
   RefreshCw,
   Square,
   MessageCircle,
+  Microscope,
   StickyNote,
   Pencil,
   Trash2,
@@ -102,6 +103,7 @@ import {
   type ResearchWorkspaceCapabilityMode,
   type ResearchWorkspaceCapabilitiesResponse
 } from "../research-workspace-capabilities"
+import { buildLiteratureDeepResearchLaunchPath } from "./literature-deep-research-launch"
 
 // Re-export for external consumers
 export { estimateGenerationSeconds, estimateGenerationTokens, estimateGenerationCostUsd } from "./hooks/useArtifactGeneration"
@@ -2287,6 +2289,8 @@ export const StudioPane: React.FC<StudioPaneProps> = ({
                 const Icon = ARTIFACT_TYPE_ICONS[artifact.type] || FileText
                 const StatusConfig = STATUS_ICONS[artifact.status]
                 const StatusIcon = StatusConfig.icon
+                const deepResearchLaunchHref =
+                  buildLiteratureDeepResearchLaunchPath(artifact)
                 const failedStatusDeleteLabel = t(
                   "playground:studio.deleteFailedOutput",
                   "Delete failed output"
@@ -2525,6 +2529,26 @@ export const StudioPane: React.FC<StudioPaneProps> = ({
                               <MessageCircle className="h-4 w-4" />
                             </button>
                           </Tooltip>
+                          {deepResearchLaunchHref && (
+                            <Tooltip
+                              title={t(
+                                "playground:studio.launchDeepResearch",
+                                "Launch Deep Research"
+                              )}
+                            >
+                              <a
+                                href={deepResearchLaunchHref}
+                                className="rounded p-1 text-text-muted hover:bg-surface hover:text-text"
+                                aria-label={t(
+                                  "playground:studio.launchDeepResearch",
+                                  "Launch Deep Research"
+                                )}
+                                data-testid={`studio-artifact-deep-research-${artifact.id}`}
+                              >
+                                <Microscope className="h-4 w-4" />
+                              </a>
+                            </Tooltip>
+                          )}
                           {artifact.content && (
                             <Dropdown
                               trigger={["click"]}

--- a/apps/packages/ui/src/components/Option/ResearchWorkspace/StudioPane/literature-deep-research-launch.ts
+++ b/apps/packages/ui/src/components/Option/ResearchWorkspace/StudioPane/literature-deep-research-launch.ts
@@ -13,13 +13,20 @@ const LITERATURE_DEEP_RESEARCH_TEMPLATE_IDS = new Set([
 
 const ARTIFACT_EXCERPT_LIMIT = 1400
 const RESEARCH_QUERY_LIMIT = 2600
+const TRUNCATION_SUFFIX = "\n\n[Truncated for Deep Research launch context.]"
 
 const truncateForLaunch = (value: string, limit: number): string => {
   const trimmed = value.trim()
+  if (limit <= 0) {
+    return ""
+  }
   if (trimmed.length <= limit) {
     return trimmed
   }
-  return `${trimmed.slice(0, limit).trimEnd()}\n\n[Truncated for Deep Research launch context.]`
+  if (limit <= TRUNCATION_SUFFIX.length) {
+    return TRUNCATION_SUFFIX.slice(0, limit)
+  }
+  return `${trimmed.slice(0, limit - TRUNCATION_SUFFIX.length).trimEnd()}${TRUNCATION_SUFFIX}`
 }
 
 const formatCoverageEntry = (source: ArtifactSourceCoverageEntry): string =>
@@ -30,15 +37,17 @@ const formatSkippedSource = (source: ArtifactSkippedSource): string =>
 
 const formatSourceCoverage = (sourceCoverage: ArtifactSourceCoverage): string =>
   [
-    `Selected source IDs: ${sourceCoverage.selectedSourceIds.join(", ") || "none"}`,
+    `Selected source IDs: ${(sourceCoverage.selectedSourceIds ?? []).join(", ") || "none"}`,
     `Usable sources: ${
-      sourceCoverage.usableSources.map(formatCoverageEntry).join(", ") || "none"
+      (sourceCoverage.usableSources ?? []).map(formatCoverageEntry).join(", ") ||
+      "none"
     }`,
     `Skipped sources: ${
-      sourceCoverage.skippedSources.map(formatSkippedSource).join(", ") || "none"
+      (sourceCoverage.skippedSources ?? []).map(formatSkippedSource).join(", ") ||
+      "none"
     }`,
     `Truncated sources: ${
-      sourceCoverage.truncatedSources.map(formatCoverageEntry).join(", ") ||
+      (sourceCoverage.truncatedSources ?? []).map(formatCoverageEntry).join(", ") ||
       "none"
     }`
   ].join("\n")
@@ -58,7 +67,7 @@ export const isDeepResearchLaunchableLiteratureArtifact = (
   if (!artifact.sourceCoverage?.minimumUsableSourcesMet) {
     return false
   }
-  if (artifact.sourceCoverage.usableSources.length < 2) {
+  if ((artifact.sourceCoverage.usableSources?.length ?? 0) < 2) {
     return false
   }
   return typeof artifact.content === "string" && artifact.content.trim().length > 0

--- a/apps/packages/ui/src/components/Option/ResearchWorkspace/StudioPane/literature-deep-research-launch.ts
+++ b/apps/packages/ui/src/components/Option/ResearchWorkspace/StudioPane/literature-deep-research-launch.ts
@@ -1,0 +1,122 @@
+import { buildResearchLaunchPath } from "@/routes/route-paths"
+import type {
+  ArtifactSourceCoverage,
+  ArtifactSourceCoverageEntry,
+  ArtifactSkippedSource,
+  GeneratedArtifact
+} from "@/types/workspace"
+
+const LITERATURE_DEEP_RESEARCH_TEMPLATE_IDS = new Set([
+  "literature_matrix",
+  "corpus_gap_finder"
+])
+
+const ARTIFACT_EXCERPT_LIMIT = 1400
+const RESEARCH_QUERY_LIMIT = 2600
+
+const truncateForLaunch = (value: string, limit: number): string => {
+  const trimmed = value.trim()
+  if (trimmed.length <= limit) {
+    return trimmed
+  }
+  return `${trimmed.slice(0, limit).trimEnd()}\n\n[Truncated for Deep Research launch context.]`
+}
+
+const formatCoverageEntry = (source: ArtifactSourceCoverageEntry): string =>
+  source.title || source.sourceId
+
+const formatSkippedSource = (source: ArtifactSkippedSource): string =>
+  `${formatCoverageEntry(source)} (${source.reason})`
+
+const formatSourceCoverage = (sourceCoverage: ArtifactSourceCoverage): string =>
+  [
+    `Selected source IDs: ${sourceCoverage.selectedSourceIds.join(", ") || "none"}`,
+    `Usable sources: ${
+      sourceCoverage.usableSources.map(formatCoverageEntry).join(", ") || "none"
+    }`,
+    `Skipped sources: ${
+      sourceCoverage.skippedSources.map(formatSkippedSource).join(", ") || "none"
+    }`,
+    `Truncated sources: ${
+      sourceCoverage.truncatedSources.map(formatCoverageEntry).join(", ") ||
+      "none"
+    }`
+  ].join("\n")
+
+export const isDeepResearchLaunchableLiteratureArtifact = (
+  artifact: GeneratedArtifact
+): boolean => {
+  if (artifact.status !== "completed") {
+    return false
+  }
+  if (
+    !artifact.templateId ||
+    !LITERATURE_DEEP_RESEARCH_TEMPLATE_IDS.has(artifact.templateId)
+  ) {
+    return false
+  }
+  if (!artifact.sourceCoverage?.minimumUsableSourcesMet) {
+    return false
+  }
+  if (artifact.sourceCoverage.usableSources.length < 2) {
+    return false
+  }
+  return typeof artifact.content === "string" && artifact.content.trim().length > 0
+}
+
+export const buildLiteratureDeepResearchLaunchQuery = (
+  artifact: GeneratedArtifact
+): string | null => {
+  if (!isDeepResearchLaunchableLiteratureArtifact(artifact)) {
+    return null
+  }
+
+  const sourceCoverage = artifact.sourceCoverage
+  if (!sourceCoverage) {
+    return null
+  }
+
+  const artifactKind =
+    artifact.templateId === "corpus_gap_finder"
+      ? "Corpus Gap Finder"
+      : "Literature Matrix"
+  const artifactExcerpt = truncateForLaunch(
+    artifact.content || "",
+    ARTIFACT_EXCERPT_LIMIT
+  )
+  const query = [
+    `Run Deep Research from this Research Workspace ${artifactKind} artifact.`,
+    "",
+    `Artifact: ${artifact.title}`,
+    `Artifact template: ${artifact.templateId}`,
+    "",
+    "Source coverage from the artifact:",
+    formatSourceCoverage(sourceCoverage),
+    "",
+    "Research task:",
+    artifact.templateId === "corpus_gap_finder"
+      ? "Verify, expand, and prioritize the identified corpus gaps. Look for additional evidence, counterexamples, and practical follow-up research questions."
+      : "Verify, expand, and stress-test the matrix findings. Look for missing evidence, contradictions, and follow-up questions across the source set.",
+    "",
+    "Artifact excerpt:",
+    artifactExcerpt
+  ].join("\n")
+
+  return truncateForLaunch(query, RESEARCH_QUERY_LIMIT)
+}
+
+export const buildLiteratureDeepResearchLaunchPath = (
+  artifact: GeneratedArtifact
+): string | null => {
+  const query = buildLiteratureDeepResearchLaunchQuery(artifact)
+  if (!query) {
+    return null
+  }
+
+  return buildResearchLaunchPath({
+    query,
+    sourcePolicy: "local_first",
+    autonomyMode: "checkpointed",
+    from: "research-workspace"
+  })
+}

--- a/apps/packages/ui/src/components/Option/ResearchWorkspace/__tests__/StudioPane.literature-workproducts.test.tsx
+++ b/apps/packages/ui/src/components/Option/ResearchWorkspace/__tests__/StudioPane.literature-workproducts.test.tsx
@@ -1,7 +1,7 @@
 import React from "react"
-import { fireEvent, render, screen, waitFor } from "@testing-library/react"
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react"
 import { beforeEach, describe, expect, it, vi } from "vitest"
-import type { AudioGenerationSettings } from "@/types/workspace"
+import type { AudioGenerationSettings, WorkspaceSource } from "@/types/workspace"
 import { StudioPane } from "../StudioPane"
 import {
   buildCorpusGapMessages,
@@ -10,6 +10,10 @@ import {
   normalizeLiteratureMatrixResponse,
   normalizeResearchProposalMarkdown
 } from "../StudioPane/literature-workproducts"
+import {
+  buildLiteratureDeepResearchLaunchPath,
+  isDeepResearchLaunchableLiteratureArtifact
+} from "../StudioPane/literature-deep-research-launch"
 
 const {
   mockAddArtifact,
@@ -61,7 +65,7 @@ const {
     speed: 1,
     format: "mp3"
   }
-  const defaultSources = [
+  const defaultSources: WorkspaceSource[] = [
     {
       id: "source-1",
       mediaId: 101,
@@ -387,6 +391,75 @@ describe("StudioPane literature work products", () => {
       expect(prompt).toContain("truncated for context budget")
       expect(prompt).not.toContain(longArtifactContent)
     }
+  })
+
+  it("builds a bounded Deep Research launch path from traceable matrix artifacts", () => {
+    const href = buildLiteratureDeepResearchLaunchPath({
+      id: "artifact-matrix",
+      type: "data_table",
+      title: "Literature Matrix",
+      status: "completed",
+      templateId: "literature_matrix",
+      content: "| Source | Finding |\n| --- | --- |\n| Paper A | Matrix row |",
+      sourceCoverage: {
+        selectedSourceIds: ["source-1", "source-2", "source-3"],
+        usableSources: [
+          { sourceId: "source-1", mediaId: 101, title: "Paper A" },
+          { sourceId: "source-2", mediaId: 202, title: "Paper B" }
+        ],
+        skippedSources: [
+          {
+            sourceId: "source-3",
+            mediaId: 303,
+            title: "Paper C",
+            reason: "missing_text"
+          }
+        ],
+        truncatedSources: [],
+        minimumUsableSourcesMet: true
+      },
+      createdAt: new Date("2026-02-18T00:00:00.000Z")
+    })
+
+    expect(href).not.toBeNull()
+    const parsed = new URL(href!, "https://example.local")
+    const query = parsed.searchParams.get("query") || ""
+
+    expect(parsed.pathname).toBe("/research")
+    expect(parsed.searchParams.get("source_policy")).toBe("local_first")
+    expect(parsed.searchParams.get("autonomy_mode")).toBe("checkpointed")
+    expect(parsed.searchParams.get("from")).toBe("research-workspace")
+    expect(query).toContain("Literature Matrix")
+    expect(query).toContain("Paper A")
+    expect(query).toContain("Paper C (missing_text)")
+    expect(query).toContain("Matrix row")
+    expect(query.length).toBeLessThanOrEqual(2600)
+  })
+
+  it("requires completed matrix or gap artifacts with source coverage for Deep Research launch", () => {
+    expect(
+      isDeepResearchLaunchableLiteratureArtifact({
+        id: "artifact-proposal",
+        type: "report",
+        title: "Research Proposal Pack",
+        status: "completed",
+        templateId: "research_proposal_pack",
+        content: "Proposal",
+        createdAt: new Date("2026-02-18T00:00:00.000Z")
+      })
+    ).toBe(false)
+
+    expect(
+      buildLiteratureDeepResearchLaunchPath({
+        id: "artifact-gap",
+        type: "data_table",
+        title: "Corpus Gap Finder",
+        status: "completed",
+        templateId: "corpus_gap_finder",
+        content: "Gap content without coverage",
+        createdAt: new Date("2026-02-18T00:00:00.000Z")
+      })
+    ).toBeNull()
   })
 
   beforeEach(() => {
@@ -1299,5 +1372,74 @@ Proposal
     createObjectUrlSpy.mockRestore()
     revokeObjectUrlSpy.mockRestore()
     anchorClickSpy.mockRestore()
+  })
+
+  it("surfaces Deep Research launch links for completed traceable matrix and gap artifacts", () => {
+    workspaceStoreState.generatedArtifacts = [
+      {
+        id: "artifact-matrix",
+        type: "data_table",
+        title: "Literature Matrix",
+        status: "completed",
+        templateId: "literature_matrix",
+        content: "| Source | Finding |\n| --- | --- |\n| Paper A | Finding A |",
+        sourceCoverage: {
+          selectedSourceIds: ["source-1", "source-2"],
+          usableSources: [
+            { sourceId: "source-1", mediaId: 101, title: "Paper A" },
+            { sourceId: "source-2", mediaId: 202, title: "Paper B" }
+          ],
+          skippedSources: [],
+          truncatedSources: [],
+          minimumUsableSourcesMet: true
+        },
+        createdAt: new Date("2026-02-18T00:00:00.000Z")
+      },
+      {
+        id: "artifact-gap",
+        type: "data_table",
+        title: "Corpus Gap Finder",
+        status: "completed",
+        templateId: "corpus_gap_finder",
+        content: "| Gap | Evidence Basis |\n| --- | --- |\n| Rural settings | Paper A; Paper B |",
+        sourceCoverage: {
+          selectedSourceIds: ["source-1", "source-2"],
+          usableSources: [
+            { sourceId: "source-1", mediaId: 101, title: "Paper A" },
+            { sourceId: "source-2", mediaId: 202, title: "Paper B" }
+          ],
+          skippedSources: [],
+          truncatedSources: [],
+          minimumUsableSourcesMet: true
+        },
+        createdAt: new Date("2026-02-18T00:00:00.000Z")
+      },
+      {
+        id: "artifact-proposal",
+        type: "report",
+        title: "Research Proposal Pack",
+        status: "completed",
+        templateId: "research_proposal_pack",
+        content: "Proposal",
+        createdAt: new Date("2026-02-18T00:00:00.000Z")
+      }
+    ]
+
+    renderStudioPane()
+
+    const links = screen.getAllByRole("link", {
+      name: /launch deep research/i
+    })
+    expect(links).toHaveLength(2)
+    expect(
+      within(
+        screen.getByTestId("studio-artifact-secondary-actions-artifact-matrix")
+      ).getByRole("link", { name: /launch deep research/i })
+    ).toHaveAttribute("href", expect.stringContaining("/research?"))
+    expect(
+      within(
+        screen.getByTestId("studio-artifact-secondary-actions-artifact-proposal")
+      ).queryByRole("link", { name: /launch deep research/i })
+    ).not.toBeInTheDocument()
   })
 })

--- a/apps/packages/ui/src/components/Option/ResearchWorkspace/__tests__/StudioPane.literature-workproducts.test.tsx
+++ b/apps/packages/ui/src/components/Option/ResearchWorkspace/__tests__/StudioPane.literature-workproducts.test.tsx
@@ -1,5 +1,6 @@
 import React from "react"
 import { fireEvent, render, screen, waitFor, within } from "@testing-library/react"
+import { MemoryRouter } from "react-router-dom"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 import type { AudioGenerationSettings, WorkspaceSource } from "@/types/workspace"
 import { StudioPane } from "../StudioPane"
@@ -11,6 +12,7 @@ import {
   normalizeResearchProposalMarkdown
 } from "../StudioPane/literature-workproducts"
 import {
+  buildLiteratureDeepResearchLaunchQuery,
   buildLiteratureDeepResearchLaunchPath,
   isDeepResearchLaunchableLiteratureArtifact
 } from "../StudioPane/literature-deep-research-launch"
@@ -325,7 +327,11 @@ const expandOutputTypesSection = () => {
 }
 
 const renderStudioPane = () => {
-  const renderResult = render(<StudioPane />)
+  const renderResult = render(
+    <MemoryRouter>
+      <StudioPane />
+    </MemoryRouter>
+  )
   expandOutputTypesSection()
   return renderResult
 }
@@ -400,7 +406,9 @@ describe("StudioPane literature work products", () => {
       title: "Literature Matrix",
       status: "completed",
       templateId: "literature_matrix",
-      content: "| Source | Finding |\n| --- | --- |\n| Paper A | Matrix row |",
+      content: "| Source | Finding |\n| --- | --- |\n| Paper A | Matrix row |\n".repeat(
+        200
+      ),
       sourceCoverage: {
         selectedSourceIds: ["source-1", "source-2", "source-3"],
         usableSources: [
@@ -433,7 +441,33 @@ describe("StudioPane literature work products", () => {
     expect(query).toContain("Paper A")
     expect(query).toContain("Paper C (missing_text)")
     expect(query).toContain("Matrix row")
+    expect(query).toContain("[Truncated for Deep Research launch context.]")
     expect(query.length).toBeLessThanOrEqual(2600)
+  })
+
+  it("strictly caps truncated Deep Research launch queries", () => {
+    const query = buildLiteratureDeepResearchLaunchQuery({
+      id: "artifact-long-query",
+      type: "data_table",
+      title: `Literature Matrix ${"long title segment ".repeat(300)}`,
+      status: "completed",
+      templateId: "literature_matrix",
+      content: "Matrix row",
+      sourceCoverage: {
+        selectedSourceIds: ["source-1", "source-2"],
+        usableSources: [
+          { sourceId: "source-1", mediaId: 101, title: "Paper A" },
+          { sourceId: "source-2", mediaId: 202, title: "Paper B" }
+        ],
+        skippedSources: [],
+        truncatedSources: [],
+        minimumUsableSourcesMet: true
+      },
+      createdAt: new Date("2026-02-18T00:00:00.000Z")
+    })
+
+    expect(query).toContain("[Truncated for Deep Research launch context.]")
+    expect(query?.length).toBeLessThanOrEqual(2600)
   })
 
   it("requires completed matrix or gap artifacts with source coverage for Deep Research launch", () => {
@@ -460,6 +494,44 @@ describe("StudioPane literature work products", () => {
         createdAt: new Date("2026-02-18T00:00:00.000Z")
       })
     ).toBeNull()
+
+    expect(
+      isDeepResearchLaunchableLiteratureArtifact({
+        id: "artifact-partial-coverage",
+        type: "data_table",
+        title: "Literature Matrix",
+        status: "completed",
+        templateId: "literature_matrix",
+        content: "Matrix content",
+        sourceCoverage: {
+          minimumUsableSourcesMet: true
+        } as any,
+        createdAt: new Date("2026-02-18T00:00:00.000Z")
+      })
+    ).toBe(false)
+  })
+
+  it("tolerates legacy source coverage objects when building Deep Research launch context", () => {
+    const query = buildLiteratureDeepResearchLaunchQuery({
+      id: "artifact-legacy-coverage",
+      type: "data_table",
+      title: "Literature Matrix",
+      status: "completed",
+      templateId: "literature_matrix",
+      content: "Matrix content",
+      sourceCoverage: {
+        usableSources: [
+          { sourceId: "source-1", mediaId: 101, title: "Paper A" },
+          { sourceId: "source-2", mediaId: 202, title: "Paper B" }
+        ],
+        minimumUsableSourcesMet: true
+      } as any,
+      createdAt: new Date("2026-02-18T00:00:00.000Z")
+    })
+
+    expect(query).toContain("Selected source IDs: none")
+    expect(query).toContain("Skipped sources: none")
+    expect(query).toContain("Truncated sources: none")
   })
 
   beforeEach(() => {
@@ -1436,6 +1508,8 @@ Proposal
         screen.getByTestId("studio-artifact-secondary-actions-artifact-matrix")
       ).getByRole("link", { name: /launch deep research/i })
     ).toHaveAttribute("href", expect.stringContaining("/research?"))
+    expect(links[0]).toHaveAttribute("target", "_blank")
+    expect(links[0]).toHaveAttribute("rel", "noopener noreferrer")
     expect(
       within(
         screen.getByTestId("studio-artifact-secondary-actions-artifact-proposal")

--- a/backlog/tasks/task-487 - Deep-Research-launch-from-literature-work-products.md
+++ b/backlog/tasks/task-487 - Deep-Research-launch-from-literature-work-products.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-487
 title: Deep Research launch from literature work products
-status: To Do
+status: Done
 documentation:
 - Docs/Product/Research_Workspace_Literature_Workproducts_PRD.md
 - Docs/superpowers/plans/2026-05-30-research-workspace-literature-workproducts-plan.md
@@ -15,26 +15,42 @@ Follow-up after the Research Workspace literature work-products MVP. Add a Deep 
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
+- [x] #1 Literature Matrix and Corpus Gap Finder completed artifacts expose a Deep Research launch path without changing MVP generation.
+- [x] #2 Launch seed preserves selected-source coverage and source compatibility from the source artifact.
+- [x] #3 Launch uses the existing Deep Research route/request contract and does not create a parallel runtime.
+- [x] #4 Focused UI tests cover launch visibility, seed content, and incompatible artifact handling.
 <!-- AC:END -->
 
 ## Implementation Notes
 
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Starting post-MVP Deep Research launch follow-up from merged PR #2151. Scope is the first later-stage bridge only: launch from compatible Literature Matrix and Corpus Gap Finder artifacts. Bundle import, hypothesis/proposal follow-up seeding, and proposal verification display remain separate follow-up tasks.
 
+Implemented a frontend-only Deep Research launch bridge for completed, traceable Literature Matrix and Corpus Gap Finder artifacts. The launch helper builds a bounded `/research` launch URL using the existing route contract, local-first source policy, checkpointed autonomy, artifact title/template, source coverage, skipped/truncated source notes, and a capped artifact excerpt. Studio now shows a secondary icon action only for launchable matrix/gap artifacts with at least two usable sources and source coverage.
+
+PR: https://github.com/rmusser01/tldw_server/pull/2159
+
+Verification:
+- `bun run test -- src/components/Option/ResearchWorkspace/__tests__/StudioPane.literature-workproducts.test.tsx` passed: 21 tests.
+- `bun run test -- src/components/Option/ResearchWorkspace/__tests__/StudioPane.literature-workproducts.test.tsx src/components/Option/ResearchWorkspace/__tests__/StudioPane.stage1.test.tsx src/components/Option/ResearchWorkspace/__tests__/StudioPane.stage2.test.tsx src/workspace-templates/__tests__/work-product-templates.test.ts src/routes/__tests__/route-paths.research.test.ts` passed: 5 files / 94 tests.
+- `env NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit --project tsconfig.json` passed. The first default-heap TypeScript run OOMed before this larger-heap pass.
+- `git diff --check` passed.
+- `bun run verify:design-system-state` failed on existing product-state baseline findings outside the new launch helper/action.
+- Bandit skipped because this slice touched TypeScript/UI tests and Backlog metadata only.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-
+Added the first post-MVP Deep Research bridge for Research Workspace literature artifacts. Completed Literature Matrix and Corpus Gap Finder artifacts with source coverage now expose a Launch Deep Research action that opens the existing `/research` console with a bounded, source-coverage-aware seed query. The implementation stays frontend-only, does not alter MVP generation, and leaves bundle import, hypothesis/proposal follow-up seeding, and proposal verification display to their separate follow-up tasks.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->

--- a/backlog/tasks/task-487 - Deep-Research-launch-from-literature-work-products.md
+++ b/backlog/tasks/task-487 - Deep-Research-launch-from-literature-work-products.md
@@ -30,12 +30,14 @@ Implemented a frontend-only Deep Research launch bridge for completed, traceable
 
 PR: https://github.com/rmusser01/tldw_server/pull/2159
 
+Review follow-up: addressed PR feedback by reserving truncation suffix space so raw launch queries strictly respect their caps, tolerating partial legacy source-coverage objects without runtime errors, and rendering the Deep Research launch as a React Router `Link` that opens in a separate tab to preserve the current workspace session.
+
 Verification:
-- `bun run test -- src/components/Option/ResearchWorkspace/__tests__/StudioPane.literature-workproducts.test.tsx` passed: 21 tests.
-- `bun run test -- src/components/Option/ResearchWorkspace/__tests__/StudioPane.literature-workproducts.test.tsx src/components/Option/ResearchWorkspace/__tests__/StudioPane.stage1.test.tsx src/components/Option/ResearchWorkspace/__tests__/StudioPane.stage2.test.tsx src/workspace-templates/__tests__/work-product-templates.test.ts src/routes/__tests__/route-paths.research.test.ts` passed: 5 files / 94 tests.
-- `env NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit --project tsconfig.json` passed. The first default-heap TypeScript run OOMed before this larger-heap pass.
+- `bun run test -- src/components/Option/ResearchWorkspace/__tests__/StudioPane.literature-workproducts.test.tsx` passed: 23 tests.
+- `bun run test -- src/components/Option/ResearchWorkspace/__tests__/StudioPane.literature-workproducts.test.tsx src/components/Option/ResearchWorkspace/__tests__/StudioPane.stage1.test.tsx src/components/Option/ResearchWorkspace/__tests__/StudioPane.stage2.test.tsx src/workspace-templates/__tests__/work-product-templates.test.ts src/routes/__tests__/route-paths.research.test.ts` passed: 5 files / 96 tests.
+- `env NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit --project tsconfig.json` passed.
 - `git diff --check` passed.
-- `bun run verify:design-system-state` failed on existing product-state baseline findings outside the new launch helper/action.
+- `bun run verify:design-system-state` failed on existing product-state baseline findings outside the launch helper/action review fixes.
 - Bandit skipped because this slice touched TypeScript/UI tests and Backlog metadata only.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 


### PR DESCRIPTION
## Change summary (maintainer-owned)

Maintainer: please replace this section with your own summary before merge. AI-authored PRs in this repo require a human-written summary explaining what changed and why these implementation choices were made.

## Summary

- Adds a Research Workspace launch affordance for completed Literature Matrix and Corpus Gap Finder artifacts that have usable source coverage.
- Builds a bounded `/research` launch URL with local-first, checkpointed Deep Research context seeded from the artifact title, template, coverage metadata, and a capped artifact excerpt.
- Covers the helper contract and Studio Pane UI behavior, including the rule that Proposal Pack artifacts do not launch Deep Research directly in this slice.

## Verification

- `bun run test -- src/components/Option/ResearchWorkspace/__tests__/StudioPane.literature-workproducts.test.tsx`
- `bun run test -- src/components/Option/ResearchWorkspace/__tests__/StudioPane.literature-workproducts.test.tsx src/components/Option/ResearchWorkspace/__tests__/StudioPane.stage1.test.tsx src/components/Option/ResearchWorkspace/__tests__/StudioPane.stage2.test.tsx src/workspace-templates/__tests__/work-product-templates.test.ts src/routes/__tests__/route-paths.research.test.ts`
- `env NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit --project tsconfig.json`
- `git diff --check origin/dev..HEAD`

## Known skips / baseline findings

- `bun run verify:design-system-state` was run and still reports existing product-state baseline findings outside this slice. The new literature Deep Research launch helper/action was not part of the reported findings.
- Bandit was skipped because this slice only changes TypeScript UI code, UI tests, and Backlog metadata.

## Risk / rollback

- Risk is limited to the Studio Pane artifact card actions and the generated Research launch query. Rollback is removing the launch helper import/action and its tests.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Launch Deep Research from completed Literature Matrix and Corpus Gap Finder artifacts with sufficient source coverage, opening the `/research` console in a new tab with a bounded, coverage‑aware seed query. Fulfills TASK-487 without changing generation behavior.

- New Features
  - Adds a “Launch Deep Research” action (microscope icon) in the Studio Pane for eligible Literature Matrix and Corpus Gap Finder artifacts.
  - Seeds `/research` with a capped query built from artifact title/template, source coverage (selected IDs/usable/skipped+reasons/truncated), and a trimmed excerpt; uses `local_first`, `checkpointed`, and `from=research-workspace`.
  - Gating: requires status `completed`, `minimumUsableSourcesMet`, at least 2 usable sources, and non‑empty content; Proposal Pack artifacts are excluded.
  - Adds tests for URL construction, visibility, gating, strict query bounds, and legacy coverage objects.

- Bug Fixes
  - Enforces a strict 2600‑char query cap by reserving truncation‑suffix space.
  - Handles partial/legacy `sourceCoverage` objects without errors.
  - Renders the launch as a Router `Link` that opens in a new tab with `noopener noreferrer`.

<sup>Written for commit bc402ca523dfeed41469b19fb0f8912b1da467d4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2159?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

