### PR TITLE
Add Stage 4H gateway config file loader

### DIFF
--- a/Docs/superpowers/plans/2026-05-30-mcp-unified-stage4h-gateway-config-loader-plan.md
+++ b/Docs/superpowers/plans/2026-05-30-mcp-unified-stage4h-gateway-config-loader-plan.md
@@ -1,0 +1,138 @@
+# MCP Unified Stage 4H Gateway Config File Loader Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:test-driven-development for behavior changes and keep this slice package-owned.
+
+**Goal:** Add package-owned helpers that load standalone gateway profile bootstrap config from explicit JSON or TOML files.
+
+**Architecture:** Keep the loader in `mcp_unified.gateway.config` so it reuses the Stage 4G dataclass validation and bootstrap seam. Use stdlib `json` and `tomllib` only, infer format from file suffix, and fail fast with clear `ValueError`s for unsupported formats, parse failures, and non-object top-level payloads. This slice deliberately stops before CLI commands, process entrypoints, external MCP lifecycle, and host route integration.
+
+**Tech Stack:** Python 3.11, dataclasses, stdlib JSON/TOML parsers, package-local gateway/profile/storage primitives, pytest, Ruff, Bandit.
+
+---
+
+### Task 1: Config File Loader RED Tests
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py`
+- Modify: `mcp_unified/gateway/config.py`
+- Modify: `mcp_unified/gateway/__init__.py`
+
+- [x] **Step 1: Add failing loader tests**
+
+Add tests that assert:
+- a JSON config file loads into `GatewayProfileBootstrapConfig` and bootstraps a default preset;
+- a TOML config file loads store/default values into the config model;
+- unsupported suffixes, malformed JSON/TOML, and non-object top-level payloads raise clear `ValueError`s;
+- importing `mcp_unified.gateway` exposes the loader without importing `tldw_Server_API`.
+
+- [x] **Step 2: Run RED tests**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/mcp-unified-stage4h-gateway-config-loader/.venv/bin/python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py -q
+```
+
+Expected: new tests fail because the loader/export does not exist.
+
+Result: `7 failed, 51 passed, 4 warnings`; all new failures were expected missing loader/export imports.
+
+### Task 2: Package Config Loader
+
+**Files:**
+- Modify: `mcp_unified/gateway/config.py`
+- Modify: `mcp_unified/gateway/__init__.py`
+
+- [x] **Step 1: Add loader helpers**
+
+Implement:
+- `GatewayConfigFormat = Literal["json", "toml"]`;
+- `load_gateway_profile_bootstrap_config(path: str | Path, *, format: GatewayConfigFormat | None = None) -> GatewayProfileBootstrapConfig`;
+- `_detect_config_format(path, format)` and parser helpers for clear errors.
+
+- [x] **Step 2: Preserve package isolation**
+
+Keep imports stdlib plus package-local only. Do not import FastAPI, `tldw_Server_API`, PyYAML, click/typer, or host config helpers.
+
+- [x] **Step 3: Export public loader APIs**
+
+Export the loader and format alias from `mcp_unified.gateway` and `mcp_unified.gateway.config`.
+
+- [x] **Step 4: Run GREEN tests**
+
+Run the focused gateway package tests and confirm all pass.
+
+Result: `58 passed, 4 warnings`.
+
+### Task 3: Compatibility, Security, And PR Handoff
+
+**Files:**
+- Modify: `Docs/superpowers/plans/2026-05-30-mcp-unified-stage4h-gateway-config-loader-plan.md`
+- Modify: `backlog/tasks/task-565 - Implement-MCP-Unified-Stage-4H-gateway-config-file-loader.md`
+
+- [x] **Step 1: Run host compatibility tests**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/mcp-unified-stage4h-gateway-config-loader/.venv/bin/python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_extraction_contracts.py tldw_Server_API/app/core/MCP_unified/tests/test_http_mapping.py -q
+```
+
+- [x] **Step 2: Run lint, security, and whitespace checks**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/mcp-unified-stage4h-gateway-config-loader/.venv/bin/python -m ruff check mcp_unified/gateway tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/mcp-unified-stage4h-gateway-config-loader/.venv/bin/python -m bandit -r mcp_unified/gateway -f json -o /tmp/bandit_mcp_stage4h_gateway_config_loader.json
+git diff --check
+```
+
+- [x] **Step 3: Update plan and Backlog task**
+
+Record RED/GREEN and final verification evidence. Check off acceptance criteria and Definition of Done.
+
+- [x] **Step 4: Commit, push, and open PR**
+
+Commit the plan, gateway/test changes, and Backlog task update together, push the branch, and open a PR against `dev`.
+
+Result: PR #2161 opened at `https://github.com/rmusser01/tldw_server/pull/2161`.
+
+### Task 4: Review Follow-Up
+
+**Files:**
+- Modify: `mcp_unified/gateway/config.py`
+- Modify: `tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py`
+
+- [x] **Step 1: Verify and reproduce schema/type error feedback**
+
+Gemini review noted that invalid config schema/type cases escaped as raw `TypeError`s. Added regression coverage for unknown top-level keys and invalid `store` value types.
+
+Review RED result: `2 failed, 58 passed, 4 warnings`.
+
+- [x] **Step 2: Wrap schema/type errors as ValueError**
+
+Wrap `GatewayProfileBootstrapConfig(**payload)` `TypeError`s with `ValueError("Invalid gateway config schema or types: ...")`.
+
+Review GREEN result: `60 passed, 4 warnings`.
+
+- [x] **Step 3: Address Qodo docstring and JSON-location feedback**
+
+Qodo review noted that the public loader docstring omitted key behavior and that JSON parse errors dropped line/column context. Added a JSON diagnostic regression and expanded the public loader docstring.
+
+Qodo RED result: `1 failed, 60 passed, 4 warnings`.
+Qodo GREEN result: `61 passed, 4 warnings`.
+
+## Verification
+
+- Baseline: `51 passed, 4 warnings` for `test_gateway_fastapi_package.py` on merged Stage 4G.
+- RED: `7 failed, 51 passed, 4 warnings`; expected missing loader/export failures only.
+- GREEN: `58 passed, 4 warnings` for `test_gateway_fastapi_package.py`.
+- Review RED: `2 failed, 58 passed, 4 warnings` for raw schema/type `TypeError` leakage.
+- Review GREEN: `60 passed, 4 warnings` for `test_gateway_fastapi_package.py`.
+- Qodo RED: `1 failed, 60 passed, 4 warnings` for missing JSON parse location details.
+- Qodo GREEN: `61 passed, 4 warnings` for `test_gateway_fastapi_package.py`.
+- Compatibility: `47 passed, 4 warnings` for `test_extraction_contracts.py` and `test_http_mapping.py`.
+- Ruff: `All checks passed!` for `mcp_unified/gateway` and the focused gateway package tests.
+- Bandit: `0` results and no errors for `mcp_unified/gateway`.
+- Whitespace: `git diff --check` passed.

--- a/backlog/tasks/task-565 - Implement-MCP-Unified-Stage-4H-gateway-config-file-loader.md
+++ b/backlog/tasks/task-565 - Implement-MCP-Unified-Stage-4H-gateway-config-file-loader.md
@@ -1,0 +1,61 @@
+---
+id: TASK-565
+title: Implement MCP Unified Stage 4H gateway config file loader
+status: Done
+labels:
+- mcp-unified
+- standalone-extraction
+- gateway
+priority: medium
+references:
+- Docs/superpowers/specs/2026-05-26-mcp-unified-standalone-library-gateway-design.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Add the next narrow Stage 4 standalone gateway slice after Stage 4G: package-owned config file loading helpers that parse explicit JSON/TOML config files into GatewayProfileBootstrapConfig while preserving the existing dataclass bootstrap seam. This slice intentionally avoids CLI commands, process entrypoints, external MCP spawning/lifecycle, host route integration, and broad settings frameworks.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Gateway package exposes a config-file loader without importing `tldw_Server_API`.
+- [x] #2 Loader accepts explicit JSON and TOML files and returns `GatewayProfileBootstrapConfig`.
+- [x] #3 Loader can feed `bootstrap_profile_gateway_from_config()` for a default preset flow.
+- [x] #4 Unsupported formats, malformed files, and non-object top-level payloads fail fast with clear `ValueError`s.
+- [x] #5 Focused gateway tests, host extraction/http compatibility tests, Ruff, Bandit, and whitespace checks are recorded before PR handoff.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+- Started from merged Stage 4G baseline on `origin/dev` `f3a3f3a64f1c44e4325002895633a7c812a800b0`.
+- Plan: `Docs/superpowers/plans/2026-05-30-mcp-unified-stage4h-gateway-config-loader-plan.md`.
+- Added `load_gateway_profile_bootstrap_config()` with JSON/TOML parsing, suffix or explicit-format detection, non-object payload validation, and parser-specific `ValueError` messages.
+- Exported `GatewayConfigFormat` and the loader through `mcp_unified.gateway` without adding host imports or new third-party dependencies.
+- RED evidence: `7 failed, 51 passed, 4 warnings` for the focused gateway package tests; all new failures were expected missing loader/export imports.
+- GREEN evidence: `58 passed, 4 warnings` for `test_gateway_fastapi_package.py`.
+- Review follow-up verified Gemini's schema/type error comment as valid. RED evidence: `2 failed, 58 passed, 4 warnings`; invalid config schema/type cases escaped as raw `TypeError`s.
+- Review follow-up wraps config dataclass construction `TypeError`s as clear `ValueError`s. GREEN evidence: `60 passed, 4 warnings` for `test_gateway_fastapi_package.py`.
+- Qodo follow-up verified the JSON error location and loader docstring comments as valid. RED evidence: `1 failed, 60 passed, 4 warnings`; malformed JSON messages omitted line/column context.
+- Qodo follow-up includes full JSON parser context in the `ValueError` message and expands the public loader docstring. GREEN evidence: `61 passed, 4 warnings` for `test_gateway_fastapi_package.py`.
+- Compatibility evidence: `47 passed, 4 warnings` for `test_extraction_contracts.py` and `test_http_mapping.py`.
+- Quality evidence: Ruff passed, Bandit reported `0` results and no errors for `mcp_unified/gateway`, and `git diff --check` passed.
+- PR: https://github.com/rmusser01/tldw_server/pull/2161
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Stage 4H adds a package-owned gateway config file loader. Standalone callers can now load explicit JSON or TOML config files into the Stage 4G bootstrap dataclasses, then pass them to `bootstrap_profile_gateway_from_config()` for profile-aware runtime construction. Review follow-up also wraps invalid config schema/type failures as clear `ValueError`s, preserves JSON parser location details, and documents the public loader contract. The slice keeps config validation deterministic and remains intentionally below CLI commands, process entrypoints, external MCP lifecycle, and host route integration.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/mcp_unified/gateway/__init__.py
+++ b/mcp_unified/gateway/__init__.py
@@ -8,10 +8,12 @@ from .bootstrap import (
     build_profile_gateway_runtime,
 )
 from .config import (
+    GatewayConfigFormat,
     GatewayProfileBootstrapConfig,
     GatewayProfileStoreConfig,
     GatewayProfileStoreKind,
     bootstrap_profile_gateway_from_config,
+    load_gateway_profile_bootstrap_config,
 )
 from .profile_runtime import ProfileAwareGatewayRuntime
 from .runtime import GatewayPolicyDenied, GatewayRequestContext, GatewayRuntime
@@ -22,6 +24,7 @@ if TYPE_CHECKING:
 
 __all__ = [
     "GatewayPolicyDenied",
+    "GatewayConfigFormat",
     "GatewayProfileBootstrap",
     "GatewayProfileBootstrapConfig",
     "GatewayRequestContext",
@@ -36,6 +39,7 @@ __all__ = [
     "create_gateway_app",
     "create_gateway_router",
     "handle_stdio_line",
+    "load_gateway_profile_bootstrap_config",
 ]
 
 

--- a/mcp_unified/gateway/config.py
+++ b/mcp_unified/gateway/config.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
+import json
 from collections.abc import Iterable, Mapping
 from dataclasses import dataclass, field
+from json import JSONDecodeError
 from pathlib import Path
-from typing import Any, Literal
+from typing import Any, Literal, cast
 
 from mcp_unified.interfaces.storage import ProfileStore
 from mcp_unified.profiles.models import MCPProfile
@@ -14,6 +16,12 @@ from mcp_unified.profiles.store import InMemoryProfileStore
 from .bootstrap import GatewayProfileBootstrap, bootstrap_profile_gateway
 from .runtime import GatewayRuntime
 
+try:  # pragma: no cover - Python <3.11 fallback is exercised only on older runtimes.
+    import tomllib as _tomllib
+except ModuleNotFoundError:  # pragma: no cover - defensive for unsupported runtimes.
+    _tomllib = None
+
+GatewayConfigFormat = Literal["json", "toml"]
 GatewayProfileStoreKind = Literal["memory", "sqlite"]
 
 
@@ -93,6 +101,36 @@ async def bootstrap_profile_gateway_from_config(
     )
 
 
+def load_gateway_profile_bootstrap_config(
+    path: str | Path,
+    *,
+    format: GatewayConfigFormat | str | None = None,
+) -> GatewayProfileBootstrapConfig:
+    """Load gateway profile bootstrap config from a JSON or TOML file.
+
+    The file format is inferred from `.json` or `.toml` suffixes unless an
+    explicit `format` is supplied. The parsed payload must be a top-level
+    object accepted by `GatewayProfileBootstrapConfig`. Invalid formats,
+    unreadable files, malformed payloads, non-object payloads, and config
+    schema/type errors raise `ValueError` with user-facing context.
+    """
+
+    config_path = Path(path)
+    config_format = _detect_config_format(config_path, format)
+    try:
+        raw_payload = config_path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise ValueError(f"Unable to read gateway config file: {config_path}") from exc
+
+    payload = _parse_config_payload(raw_payload, config_format)
+    if not isinstance(payload, Mapping):
+        raise ValueError("Gateway config file must contain an object")
+    try:
+        return GatewayProfileBootstrapConfig(**payload)
+    except TypeError as exc:
+        raise ValueError(f"Invalid gateway config schema or types: {exc}") from exc
+
+
 def _validate_bootstrap_config(
     config: GatewayProfileBootstrapConfig | Mapping[str, Any] | None,
 ) -> GatewayProfileBootstrapConfig:
@@ -103,6 +141,50 @@ def _validate_bootstrap_config(
     if isinstance(config, GatewayProfileBootstrapConfig):
         return config
     return GatewayProfileBootstrapConfig(**config)
+
+
+def _detect_config_format(
+    path: Path,
+    explicit_format: GatewayConfigFormat | str | None,
+) -> GatewayConfigFormat:
+    """Infer or validate the gateway config file format."""
+
+    if explicit_format is not None:
+        normalized_format = str(explicit_format).strip().lower()
+        if normalized_format in {"json", "toml"}:
+            return cast(GatewayConfigFormat, normalized_format)
+        raise ValueError(
+            f"Unsupported gateway config format: {explicit_format!r}"
+        )
+
+    suffix = path.suffix.lower()
+    if suffix == ".json":
+        return "json"
+    if suffix == ".toml":
+        return "toml"
+    raise ValueError(
+        f"Unsupported gateway config format for path: {path}"
+    )
+
+
+def _parse_config_payload(raw_payload: str, config_format: GatewayConfigFormat) -> Any:
+    """Parse one gateway config payload by validated format."""
+
+    if config_format == "json":
+        try:
+            return json.loads(raw_payload)
+        except JSONDecodeError as exc:
+            raise ValueError(f"Invalid gateway config JSON: {exc}") from exc
+
+    if config_format == "toml":
+        if _tomllib is None:
+            raise ValueError("Gateway TOML config loading requires Python 3.11 tomllib")
+        try:
+            return _tomllib.loads(raw_payload)
+        except ValueError as exc:
+            raise ValueError(f"Invalid gateway config TOML: {exc}") from exc
+
+    raise ValueError(f"Unsupported gateway config format: {config_format!r}")
 
 
 def _build_profile_store(store_config: GatewayProfileStoreConfig) -> ProfileStore:
@@ -131,8 +213,10 @@ def _copy_profile(profile: MCPProfile | Mapping[str, Any]) -> MCPProfile:
 
 
 __all__ = [
+    "GatewayConfigFormat",
     "GatewayProfileBootstrapConfig",
     "GatewayProfileStoreConfig",
     "GatewayProfileStoreKind",
     "bootstrap_profile_gateway_from_config",
+    "load_gateway_profile_bootstrap_config",
 ]

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py
@@ -728,6 +728,153 @@ def test_gateway_config_bootstrap_copies_profile_mapping_inputs() -> None:
     assert [tool["name"] for tool in listed.json()["result"]["tools"]] == ["echo.search"]
 
 
+def test_gateway_config_loader_reads_json_and_bootstraps_default_preset(tmp_path: Path) -> None:
+    """Load JSON gateway config and feed it into the config bootstrap helper."""
+
+    from mcp_unified.gateway import load_gateway_profile_bootstrap_config
+    from mcp_unified.gateway.config import bootstrap_profile_gateway_from_config
+
+    config_path = tmp_path / "gateway.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "store": {"kind": "memory"},
+                "default_preset_id": "project-researcher",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    config = load_gateway_profile_bootstrap_config(config_path)
+    bootstrap = asyncio.run(
+        bootstrap_profile_gateway_from_config(_MultiToolGatewayRuntime(), config)
+    )
+    app = create_gateway_app(bootstrap.runtime, prefix="/mcp")
+
+    with TestClient(app) as client:
+        listed = client.post(
+            "/mcp/request",
+            json={"jsonrpc": "2.0", "method": "tools/list", "params": {}, "id": "tools-config-json"},
+        )
+
+    assert bootstrap.default_profile_id == "project-researcher"
+    assert [tool["name"] for tool in listed.json()["result"]["tools"]] == ["echo.search"]
+
+
+def test_gateway_config_loader_reads_toml_store_config(tmp_path: Path) -> None:
+    """Load TOML gateway config into validated profile bootstrap config."""
+
+    from mcp_unified.gateway.config import (
+        GatewayProfileStoreConfig,
+        load_gateway_profile_bootstrap_config,
+    )
+
+    sqlite_path = tmp_path / "gateway.db"
+    config_path = tmp_path / "gateway.toml"
+    config_path.write_text(
+        "\n".join(
+            [
+                'default_profile_id = "reviewer"',
+                "",
+                "[store]",
+                'kind = "sqlite"',
+                f'sqlite_path = "{sqlite_path}"',
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    config = load_gateway_profile_bootstrap_config(config_path)
+
+    assert isinstance(config.store, GatewayProfileStoreConfig)
+    assert config.store.kind == "sqlite"
+    assert config.store.sqlite_path == str(sqlite_path)
+    assert config.default_profile_id == "reviewer"
+
+
+@pytest.mark.parametrize("suffix", [".yaml", ".txt"])
+def test_gateway_config_loader_rejects_unsupported_suffix(tmp_path: Path, suffix: str) -> None:
+    """Reject config files whose format cannot be inferred safely."""
+
+    from mcp_unified.gateway.config import load_gateway_profile_bootstrap_config
+
+    config_path = tmp_path / f"gateway{suffix}"
+    config_path.write_text("{}", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="Unsupported gateway config format"):
+        load_gateway_profile_bootstrap_config(config_path)
+
+
+@pytest.mark.parametrize(
+    ("suffix", "content", "message"),
+    [
+        (".json", "{", "Invalid gateway config JSON"),
+        (".toml", "[store", "Invalid gateway config TOML"),
+    ],
+)
+def test_gateway_config_loader_rejects_malformed_files(
+    tmp_path: Path,
+    suffix: str,
+    content: str,
+    message: str,
+) -> None:
+    """Reject malformed config files with parser-specific error context."""
+
+    from mcp_unified.gateway.config import load_gateway_profile_bootstrap_config
+
+    config_path = tmp_path / f"gateway{suffix}"
+    config_path.write_text(content, encoding="utf-8")
+
+    with pytest.raises(ValueError, match=message):
+        load_gateway_profile_bootstrap_config(config_path)
+
+
+def test_gateway_config_loader_json_parse_error_reports_location(tmp_path: Path) -> None:
+    """Include JSON parser location details in malformed config errors."""
+
+    from mcp_unified.gateway.config import load_gateway_profile_bootstrap_config
+
+    config_path = tmp_path / "gateway.json"
+    config_path.write_text("{", encoding="utf-8")
+
+    with pytest.raises(ValueError) as exc_info:
+        load_gateway_profile_bootstrap_config(config_path)
+
+    assert "Invalid gateway config JSON" in str(exc_info.value)
+    assert "line 1 column" in str(exc_info.value)
+
+
+def test_gateway_config_loader_rejects_non_object_top_level_payload(tmp_path: Path) -> None:
+    """Reject JSON config payloads that are not top-level objects."""
+
+    from mcp_unified.gateway.config import load_gateway_profile_bootstrap_config
+
+    config_path = tmp_path / "gateway.json"
+    config_path.write_text(json.dumps([{"store": {"kind": "memory"}}]), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="Gateway config file must contain an object"):
+        load_gateway_profile_bootstrap_config(config_path)
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"unexpected": True},
+        {"store": []},
+    ],
+)
+def test_gateway_config_loader_wraps_schema_type_errors(tmp_path: Path, payload: dict[str, Any]) -> None:
+    """Report config schema/type failures as deterministic ValueErrors."""
+
+    from mcp_unified.gateway.config import load_gateway_profile_bootstrap_config
+
+    config_path = tmp_path / "gateway.json"
+    config_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="Invalid gateway config schema or types"):
+        load_gateway_profile_bootstrap_config(config_path)
+
+
 def test_gateway_transport_profile_selector_handles_missing_request_attributes() -> None:
     class _BareRequest:
         """Request double without FastAPI transport attributes."""


### PR DESCRIPTION
## Change summary (maintainer-owned)

- Maintainer to replace this section with a human-authored summary before merge.

## Summary

- What changed:
  - Added `load_gateway_profile_bootstrap_config()` for JSON/TOML config-file loading into `GatewayProfileBootstrapConfig`.
  - Added `GatewayConfigFormat` and exported the loader from `mcp_unified.gateway`.
  - Added fail-fast validation for unsupported formats, malformed files, unreadable files, and non-object top-level payloads.
  - Addressed review feedback by wrapping config schema/type construction failures as clear `ValueError`s.
  - Addressed Qodo feedback by preserving JSON parser line/column diagnostics and expanding the public loader docstring.
  - Added focused tests covering JSON bootstrap, TOML store config loading, and invalid config cases.
- Why:
  - Stage 4H adds the file-backed config seam needed before standalone gateway CLI/config commands, while staying package-owned and host-neutral.

## Validation

- [x] Tests added/updated for behavior changes
- [x] Relevant unit/integration tests pass locally
- [x] Docs updated (if behavior, routes, or config changed)

Commands:

- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/mcp-unified-stage4h-gateway-config-loader/.venv/bin/python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py -q` -> `61 passed, 4 warnings`
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/mcp-unified-stage4h-gateway-config-loader/.venv/bin/python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_extraction_contracts.py tldw_Server_API/app/core/MCP_unified/tests/test_http_mapping.py -q` -> `47 passed, 4 warnings`
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/mcp-unified-stage4h-gateway-config-loader/.venv/bin/python -m ruff check mcp_unified/gateway tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py` -> `All checks passed!`
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/mcp-unified-stage4h-gateway-config-loader/.venv/bin/python -m bandit -r mcp_unified/gateway -f json -o /tmp/bandit_mcp_stage4h_gateway_config_loader.json` -> `0` findings, no errors
- `git diff --check` -> passed

## UX Audit Checklist (v2 Stage 5)

- [x] N/A - MCP package-only backend/library change; no WebUI or extension UI behavior changed.

## Watchlists Accessibility Checklist (Group 09 Stage 5)

- [x] N/A - no Watchlists UI behavior changed.

## Watchlists Scale Checklist (Group 10 Stage 5)

- [x] N/A - no Watchlists polling, notification, Activity, batch triage, or scale behavior changed.

## Risk & Rollback

- Risk level: Low
- Rollback plan: Revert this single commit to remove the config loader/export and associated focused tests.
