### PR TITLE
Migrate API key admin alerts to design system

### DIFF
--- a/apps/packages/ui/scripts/design-system-product-state-baseline.json
+++ b/apps/packages/ui/scripts/design-system-product-state-baseline.json
@@ -1,49 +1,5 @@
 [
   {
-    "id": "antd-product-state-import:src/components/Option/Admin/ApiKeyManagementPage.tsx:Alert#antd-alert-apikeymanagementpage-type-error-access-denied-1uep3es",
-    "path": "src/components/Option/Admin/ApiKeyManagementPage.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/Option/Admin/ApiKeyManagementPage.tsx before the stable duplicate-id guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
-    "id": "antd-product-state-import:src/components/Option/Admin/ApiKeyManagementPage.tsx:Alert#antd-alert-apikeymanagementpage-type-error-line-263-xku5ai",
-    "path": "src/components/Option/Admin/ApiKeyManagementPage.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/Option/Admin/ApiKeyManagementPage.tsx before the stable duplicate-id guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
-    "id": "antd-product-state-import:src/components/Option/Admin/ApiKeyManagementPage.tsx:Alert#antd-alert-apikeymanagementpage-type-success-new-api-key-uh4fem",
-    "path": "src/components/Option/Admin/ApiKeyManagementPage.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/Option/Admin/ApiKeyManagementPage.tsx before the stable duplicate-id guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
-    "id": "antd-product-state-import:src/components/Option/Admin/ApiKeyManagementPage.tsx:Alert#antd-alert-apikeymanagementpage-type-warning-not-availab-ijz070",
-    "path": "src/components/Option/Admin/ApiKeyManagementPage.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/Option/Admin/ApiKeyManagementPage.tsx before the stable duplicate-id guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
     "id": "antd-product-state-import:src/components/Option/Admin/MonitoringDashboardPage.tsx:Alert#antd-alert-monitoringdashboardpage-type-error-access-den-19nq744",
     "path": "src/components/Option/Admin/MonitoringDashboardPage.tsx",
     "rule": "antd-product-state-import",

--- a/apps/packages/ui/src/components/Option/Admin/ApiKeyManagementPage.tsx
+++ b/apps/packages/ui/src/components/Option/Admin/ApiKeyManagementPage.tsx
@@ -230,7 +230,7 @@ const ApiKeyManagementPage: React.FC = () => {
         >
           <div>
             <p>Copy this key now -- it will not be shown again:</p>
-            <code style={{ fontSize: 14, padding: "8px 12px", background: "#f5f5f5", display: "block", wordBreak: "break-all" }}>
+            <code className="block break-all rounded border border-border bg-surface2 px-3 py-2 font-mono text-sm text-foreground">
               {newKeyValue}
             </code>
           </div>

--- a/apps/packages/ui/src/components/Option/Admin/ApiKeyManagementPage.tsx
+++ b/apps/packages/ui/src/components/Option/Admin/ApiKeyManagementPage.tsx
@@ -8,7 +8,6 @@ import {
   Form,
   Tag,
   Space,
-  Alert,
   Select,
   Popconfirm,
   message
@@ -17,6 +16,7 @@ import {
   deriveAdminGuardFromError,
   sanitizeAdminErrorMessage
 } from "./admin-error-utils"
+import { Alert } from "@/components/ui/primitives"
 import { tldwClient } from "@/services/tldw/TldwApiClient"
 
 const ApiKeyManagementPage: React.FC = () => {
@@ -201,10 +201,18 @@ const ApiKeyManagementPage: React.FC = () => {
 
   // Render
   if (adminGuard === "forbidden") {
-    return <Alert type="error" message="Access Denied" description="You don't have permission to manage API keys." showIcon />
+    return (
+      <Alert variant="error" title="Access Denied">
+        You don't have permission to manage API keys.
+      </Alert>
+    )
   }
   if (adminGuard === "notFound") {
-    return <Alert type="warning" message="Not Available" description="API key management is not available on this server." showIcon />
+    return (
+      <Alert variant="warning" title="Not Available">
+        API key management is not available on this server.
+      </Alert>
+    )
   }
 
   return (
@@ -214,20 +222,19 @@ const ApiKeyManagementPage: React.FC = () => {
       {/* New key alert */}
       {newKeyValue && (
         <Alert
-          type="success"
-          message="New API Key Created"
-          description={
-            <div>
-              <p>Copy this key now -- it will not be shown again:</p>
-              <code style={{ fontSize: 14, padding: "8px 12px", background: "#f5f5f5", display: "block", wordBreak: "break-all" }}>
-                {newKeyValue}
-              </code>
-            </div>
-          }
-          closable
-          onClose={() => setNewKeyValue(null)}
-          style={{ marginBottom: 16 }}
-        />
+          variant="success"
+          title="New API Key Created"
+          dismissible
+          onDismiss={() => setNewKeyValue(null)}
+          className="mb-4"
+        >
+          <div>
+            <p>Copy this key now -- it will not be shown again:</p>
+            <code style={{ fontSize: 14, padding: "8px 12px", background: "#f5f5f5", display: "block", wordBreak: "break-all" }}>
+              {newKeyValue}
+            </code>
+          </div>
+        </Alert>
       )}
 
       {/* User selector */}
@@ -260,7 +267,11 @@ const ApiKeyManagementPage: React.FC = () => {
             </Button>
           }
         >
-          {keysError && <Alert type="error" message={keysError} style={{ marginBottom: 12 }} />}
+          {keysError && (
+            <Alert variant="error" className="mb-3">
+              {keysError}
+            </Alert>
+          )}
           <Table
             dataSource={keys}
             columns={keyColumns}

--- a/apps/packages/ui/src/components/Option/Admin/__tests__/ApiKeyManagementPage.design-system.test.tsx
+++ b/apps/packages/ui/src/components/Option/Admin/__tests__/ApiKeyManagementPage.design-system.test.tsx
@@ -1,0 +1,192 @@
+// @vitest-environment jsdom
+
+import React from "react"
+import { fireEvent, render, screen, waitFor } from "@testing-library/react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import ApiKeyManagementPage from "../ApiKeyManagementPage"
+
+const apiMock = vi.hoisted(() => ({
+  listAdminUsers: vi.fn(),
+  listUserApiKeys: vi.fn(),
+  createUserApiKey: vi.fn(),
+  revokeUserApiKey: vi.fn(),
+  rotateUserApiKey: vi.fn()
+}))
+
+vi.mock("antd", async () => {
+  const actual = await vi.importActual<typeof import("antd")>("antd")
+
+  const Select = ({
+    options = [],
+    value,
+    onChange,
+    placeholder,
+    loading
+  }: {
+    options?: Array<{ value: number; label: string }>
+    value?: number | null
+    onChange?: (value: number) => void
+    placeholder?: string
+    loading?: boolean
+  }) => (
+    <select
+      aria-label="Select User"
+      disabled={loading}
+      value={value ?? ""}
+      onChange={(event) => onChange?.(Number(event.currentTarget.value))}
+    >
+      <option value="">{placeholder ?? "Select"}</option>
+      {options.map((option) => (
+        <option key={option.value} value={option.value}>
+          {option.label}
+        </option>
+      ))}
+    </select>
+  )
+
+  const Modal = ({
+    children,
+    confirmLoading,
+    onCancel,
+    onOk,
+    open,
+    title
+  }: {
+    children?: React.ReactNode
+    confirmLoading?: boolean
+    onCancel?: () => void
+    onOk?: () => void
+    open?: boolean
+    title?: string
+  }) => {
+    if (!open) return null
+
+    return (
+      <div role="dialog" aria-label={title}>
+        {children}
+        <button type="button" disabled={confirmLoading} onClick={onOk}>
+          OK
+        </button>
+        <button type="button" onClick={onCancel}>
+          Cancel
+        </button>
+      </div>
+    )
+  }
+
+  return {
+    ...actual,
+    Modal,
+    Select
+  }
+})
+
+vi.mock("@/services/tldw/TldwApiClient", () => ({
+  tldwClient: apiMock
+}))
+
+const expectDesignSystemAlertForText = async (text: string) => {
+  const title = await screen.findByText(text)
+  const alert = title.closest('[data-ds-component="Alert"]')
+
+  expect(alert).not.toBeNull()
+  return alert as HTMLElement
+}
+
+const renderWithUser = async () => {
+  render(<ApiKeyManagementPage />)
+
+  await screen.findByText("API Key Management")
+  fireEvent.change(await screen.findByLabelText("Select User"), {
+    target: { value: "11" }
+  })
+}
+
+describe("ApiKeyManagementPage design-system states", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+
+    if (!window.matchMedia) {
+      Object.defineProperty(window, "matchMedia", {
+        writable: true,
+        value: vi.fn().mockImplementation((query: string) => ({
+          matches: false,
+          media: query,
+          onchange: null,
+          addListener: vi.fn(),
+          removeListener: vi.fn(),
+          addEventListener: vi.fn(),
+          removeEventListener: vi.fn(),
+          dispatchEvent: vi.fn()
+        }))
+      })
+    }
+
+    if (!(window as any).ResizeObserver) {
+      ;(window as any).ResizeObserver = class {
+        observe() {}
+        unobserve() {}
+        disconnect() {}
+      }
+    }
+
+    apiMock.listAdminUsers.mockResolvedValue({
+      users: [{ id: 11, username: "admin", email: "admin@example.com" }]
+    })
+    apiMock.listUserApiKeys.mockResolvedValue([])
+    apiMock.createUserApiKey.mockResolvedValue({ key: "sk-test-secret" })
+    apiMock.revokeUserApiKey.mockResolvedValue({})
+    apiMock.rotateUserApiKey.mockResolvedValue({})
+  })
+
+  it("renders forbidden guard feedback through the design-system Alert primitive", async () => {
+    apiMock.listAdminUsers.mockRejectedValueOnce({ status: 403 })
+
+    render(<ApiKeyManagementPage />)
+
+    const alert = await expectDesignSystemAlertForText("Access Denied")
+    expect(alert).toHaveAttribute("role", "alert")
+    expect(alert).toHaveTextContent("You don't have permission to manage API keys.")
+  })
+
+  it("renders missing-endpoint guard feedback through the design-system Alert primitive", async () => {
+    apiMock.listAdminUsers.mockRejectedValueOnce({ status: 404 })
+
+    render(<ApiKeyManagementPage />)
+
+    const alert = await expectDesignSystemAlertForText("Not Available")
+    expect(alert).toHaveAttribute("role", "alert")
+    expect(alert).toHaveTextContent("API key management is not available on this server.")
+  })
+
+  it("renders key-load failures through the design-system Alert primitive", async () => {
+    apiMock.listUserApiKeys.mockRejectedValueOnce(new Error("key API failed"))
+
+    await renderWithUser()
+
+    const alert = await expectDesignSystemAlertForText("key API failed")
+    expect(alert).toHaveAttribute("role", "alert")
+  })
+
+  it("renders created-key success feedback through the design-system Alert primitive", async () => {
+    await renderWithUser()
+
+    fireEvent.click(await screen.findByRole("button", { name: "Create Key" }))
+    fireEvent.change(screen.getByPlaceholderText("e.g. Production Key"), {
+      target: { value: "Production Key" }
+    })
+    fireEvent.click(screen.getByRole("button", { name: "OK" }))
+
+    await waitFor(() => {
+      expect(apiMock.createUserApiKey).toHaveBeenCalledWith(11, {
+        name: "Production Key",
+        rate_limit: undefined
+      })
+    })
+
+    const alert = await expectDesignSystemAlertForText("New API Key Created")
+    expect(alert).toHaveAttribute("role", "status")
+    expect(alert).toHaveTextContent("Copy this key now -- it will not be shown again:")
+    expect(alert).toHaveTextContent("sk-test-secret")
+  })
+})

--- a/backlog/tasks/task-45.44.7 - Migrate-design-system-product-state-Admin-and-health-expansion.md
+++ b/backlog/tasks/task-45.44.7 - Migrate-design-system-product-state-Admin-and-health-expansion.md
@@ -63,26 +63,30 @@ documentation:
   \  - Admin path rows: 25 -> 23\n  - DataOpsPage target rows: 2 -> 0\n\nVerifier\
   \ evidence:\n  - scoped verifier log had no DataOpsPage findings\n  - full verifier\
   \ remains blocked by unrelated current-dev drift outside this slice"
+- "TASK-45.44.7.9 / PR #2156 migrated ServerAdminPage users, roles, and media budget\
+  \ inline error feedback from AntD Alert to the design-system Alert primitive.\n\
+  Baseline file evidence:\n  - total baseline rows: 181 -> 178\n  - Admin path rows:\
+  \ 23 -> 20\n  - ServerAdminPage target rows: 3 -> 0\n\nVerifier evidence:\n  - scoped\
+  \ verifier log had no ServerAdminPage findings\n  - full verifier remains blocked\
+  \ by unrelated current-dev IntegrationPolicyPanel baseline drift/stale rows outside\
+  \ this slice"
+- "TASK-45.44.7.10 / PR #2158 migrated MlxAdminPage admin guard, temporary-unavailable,\
+  \ active-model, and security-risk product-state UI from AntD Alert/Tag to the design-system\
+  \ Alert/Badge primitives.\nBaseline file evidence:\n  - total baseline rows: 178\
+  \ -> 174\n  - Admin path rows: 20 -> 16\n  - MlxAdminPage target rows: 4 -> 0\n\n\
+  Verifier evidence:\n  - scoped verifier log had no MlxAdminPage findings\n  - full\
+  \ verifier remains blocked by unrelated current-dev IntegrationPolicyPanel baseline\
+  \ drift/stale rows outside this slice"
 - |-
-  TASK-45.44.7.9 / PR #2156 migrated ServerAdminPage users, roles, and media budget inline error feedback from AntD Alert to the design-system Alert primitive.
+  TASK-45.44.7.11 / PR #2162 migrated ApiKeyManagementPage access denied, not-available, new-key-created, and key-load error feedback from AntD Alert to the design-system Alert primitive.
   Baseline file evidence:
-    - total baseline rows: 181 -> 178
-    - Admin path rows: 23 -> 20
-    - ServerAdminPage target rows: 3 -> 0
+    - total baseline rows: 174 -> 170
+    - Admin path rows: 16 -> 12
+    - ApiKeyManagementPage target rows: 4 -> 0
 
   Verifier evidence:
-    - scoped verifier log had no ServerAdminPage findings
-    - full verifier remains blocked by unrelated current-dev IntegrationPolicyPanel baseline drift/stale rows outside this slice
-- |-
-  TASK-45.44.7.10 / PR #2158 migrated MlxAdminPage admin guard, temporary-unavailable, active-model, and security-risk product-state UI from AntD Alert/Tag to the design-system Alert/Badge primitives.
-  Baseline file evidence:
-    - total baseline rows: 178 -> 174
-    - Admin path rows: 20 -> 16
-    - MlxAdminPage target rows: 4 -> 0
-
-  Verifier evidence:
-    - scoped verifier log had no MlxAdminPage findings
-    - full verifier remains blocked by unrelated current-dev IntegrationPolicyPanel baseline drift/stale rows outside this slice
+    - scoped verifier log had no ApiKeyManagementPage findings
+    - full verifier remains blocked by unrelated current-dev findings in IntegrationPolicyPanel, WritingActionBar, Notes, and ResearchWorkspace plus stale IntegrationPolicyPanel baseline entries outside this slice
 parent_task_id: TASK-45.44
 priority: medium
 ---

--- a/backlog/tasks/task-45.44.7.11 - Migrate-ApiKeyManagementPage-alerts-to-design-system-Alert.md
+++ b/backlog/tasks/task-45.44.7.11 - Migrate-ApiKeyManagementPage-alerts-to-design-system-Alert.md
@@ -1,0 +1,67 @@
+---
+id: TASK-45.44.7.11
+title: Migrate ApiKeyManagementPage alerts to design-system Alert
+status: In Progress
+priority: Medium
+parent_task_id: TASK-45.44.7
+modified_files:
+- apps/packages/ui/src/components/Option/Admin/ApiKeyManagementPage.tsx
+- apps/packages/ui/src/components/Option/Admin/__tests__/ApiKeyManagementPage.design-system.test.tsx
+- apps/packages/ui/scripts/design-system-product-state-baseline.json
+- backlog/tasks/task-45.44.7 - Migrate-design-system-product-state-Admin-and-health-expansion.md
+labels:
+- design-system
+- webui
+- product-state
+references:
+- https://github.com/rmusser01/tldw_server/issues/1664
+- apps/packages/ui/scripts/design-system-product-state-baseline.json
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Migrate ApiKeyManagementPage access denied, not-available, new-key-created, and key-load error feedback from AntD Alert to the design-system Alert primitive with focused regression coverage and product-state baseline cleanup.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 ApiKeyManagementPage access denied and not-available guard states render through the design-system Alert primitive.
+- [ ] #2 ApiKeyManagementPage new API key success and key-load error feedback render through the design-system Alert primitive.
+- [ ] #3 The product-state baseline no longer contains ApiKeyManagementPage entries.
+- [ ] #4 Focused regression coverage proves the migration and the product-state guard has no ApiKeyManagementPage findings.
+- [ ] #5 Final summary added with verification evidence.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+2026-05-30:
+- Added focused ApiKeyManagementPage design-system regression coverage for forbidden guard, missing-endpoint guard, key-load error, and created-key success feedback.
+- RED evidence: `bunx vitest run src/components/Option/Admin/__tests__/ApiKeyManagementPage.design-system.test.tsx --reporter=dot` failed with 4 expected assertions at missing `data-ds-component="Alert"` ancestors.
+- Migrated the four AntD Alert branches to the design-system Alert primitive while preserving existing user-facing copy.
+- Removed the four ApiKeyManagementPage baseline entries.
+- GREEN evidence: `bunx vitest run src/components/Option/Admin/__tests__/ApiKeyManagementPage.design-system.test.tsx --reporter=dot` passed 1 file / 4 tests.
+- Guard evidence: `bunx vitest run src/design-system/__tests__/product-state-guard.test.ts --reporter=dot` passed 1 file / 54 tests.
+- Baseline count evidence: total rows 174 -> 170; Admin path rows 16 -> 12; ApiKeyManagementPage target rows 4 -> 0.
+- `git diff --check` passed.
+- `env NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit --pretty false` passed.
+- `bun run verify:design-system-state` remains blocked by unrelated current-dev findings in IntegrationPolicyPanel, WritingActionBar, Notes, and ResearchWorkspace plus stale IntegrationPolicyPanel baseline entries; the filtered log contains no ApiKeyManagementPage findings.
+- Bandit skipped because this slice only touches TypeScript, TSX, JSON, and Backlog markdown.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-45.44.7.11 - Migrate-ApiKeyManagementPage-alerts-to-design-system-Alert.md
+++ b/backlog/tasks/task-45.44.7.11 - Migrate-ApiKeyManagementPage-alerts-to-design-system-Alert.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-45.44.7.11
 title: Migrate ApiKeyManagementPage alerts to design-system Alert
-status: In Progress
+status: Done
 priority: Medium
 parent_task_id: TASK-45.44.7
 modified_files:
@@ -16,6 +16,7 @@ labels:
 references:
 - https://github.com/rmusser01/tldw_server/issues/1664
 - apps/packages/ui/scripts/design-system-product-state-baseline.json
+- https://github.com/rmusser01/tldw_server/pull/2162
 ---
 
 ## Description
@@ -26,11 +27,11 @@ Migrate ApiKeyManagementPage access denied, not-available, new-key-created, and 
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 ApiKeyManagementPage access denied and not-available guard states render through the design-system Alert primitive.
-- [ ] #2 ApiKeyManagementPage new API key success and key-load error feedback render through the design-system Alert primitive.
-- [ ] #3 The product-state baseline no longer contains ApiKeyManagementPage entries.
-- [ ] #4 Focused regression coverage proves the migration and the product-state guard has no ApiKeyManagementPage findings.
-- [ ] #5 Final summary added with verification evidence.
+- [x] #1 ApiKeyManagementPage access denied and not-available guard states render through the design-system Alert primitive.
+- [x] #2 ApiKeyManagementPage new API key success and key-load error feedback render through the design-system Alert primitive.
+- [x] #3 The product-state baseline no longer contains ApiKeyManagementPage entries.
+- [x] #4 Focused regression coverage proves the migration and the product-state guard has no ApiKeyManagementPage findings.
+- [x] #5 Final summary added with verification evidence.
 <!-- AC:END -->
 
 ## Implementation Notes
@@ -53,15 +54,15 @@ Migrate ApiKeyManagementPage access denied, not-available, new-key-created, and 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-
+Migrated ApiKeyManagementPage access denied, not-available, new-key-created, and key-load error feedback from AntD Alert to the design-system Alert primitive in PR #2162. Added focused regression coverage for all four migrated feedback branches, removed the four ApiKeyManagementPage baseline exceptions, and recorded verification evidence. Focused Vitest, guard Vitest, package TypeScript, and diff checks passed; the full design-system verifier remains blocked by unrelated current-dev findings outside this slice, documented in Implementation Notes.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->

--- a/backlog/tasks/task-45.44.7.11 - Migrate-ApiKeyManagementPage-alerts-to-design-system-Alert.md
+++ b/backlog/tasks/task-45.44.7.11 - Migrate-ApiKeyManagementPage-alerts-to-design-system-Alert.md
@@ -49,12 +49,14 @@ Migrate ApiKeyManagementPage access denied, not-available, new-key-created, and 
 - `env NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit --pretty false` passed.
 - `bun run verify:design-system-state` remains blocked by unrelated current-dev findings in IntegrationPolicyPanel, WritingActionBar, Notes, and ResearchWorkspace plus stale IntegrationPolicyPanel baseline entries; the filtered log contains no ApiKeyManagementPage findings.
 - Bandit skipped because this slice only touches TypeScript, TSX, JSON, and Backlog markdown.
+- Addressed PR #2162 Gemini review feedback by replacing the one-time API key code block's hardcoded inline colors/padding with tokenized design-system classes.
+- Review-fix verification: `bunx vitest run src/components/Option/Admin/__tests__/ApiKeyManagementPage.design-system.test.tsx --reporter=dot`, `env NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit --pretty false`, and `git diff --check` passed.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Migrated ApiKeyManagementPage access denied, not-available, new-key-created, and key-load error feedback from AntD Alert to the design-system Alert primitive in PR #2162. Added focused regression coverage for all four migrated feedback branches, removed the four ApiKeyManagementPage baseline exceptions, and recorded verification evidence. Focused Vitest, guard Vitest, package TypeScript, and diff checks passed; the full design-system verifier remains blocked by unrelated current-dev findings outside this slice, documented in Implementation Notes.
+Migrated ApiKeyManagementPage access denied, not-available, new-key-created, and key-load error feedback from AntD Alert to the design-system Alert primitive in PR #2162. Added focused regression coverage for all four migrated feedback branches, removed the four ApiKeyManagementPage baseline exceptions, addressed review feedback on tokenized API key code-block styling, and recorded verification evidence. Focused Vitest, guard Vitest, package TypeScript, and diff checks passed; the full design-system verifier remains blocked by unrelated current-dev findings outside this slice, documented in Implementation Notes.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done


### PR DESCRIPTION
## Summary

- Migrates `ApiKeyManagementPage` access denied, not-available, new-key-created, and key-load error feedback from AntD `Alert` to the design-system `Alert` primitive.
- Adds focused regression coverage for all four migrated feedback branches.
- Removes the four matching `ApiKeyManagementPage` product-state baseline exceptions and records the slice in Backlog.md.

## Verification

- `bunx vitest run src/components/Option/Admin/__tests__/ApiKeyManagementPage.design-system.test.tsx --reporter=dot`
- `bunx vitest run src/design-system/__tests__/product-state-guard.test.ts --reporter=dot`
- `node -e "const fs=require('fs'); const data=JSON.parse(fs.readFileSync('apps/packages/ui/scripts/design-system-product-state-baseline.json','utf8')); console.log(JSON.stringify({total:data.length,apiKeys:data.filter(e=>e.path==='src/components/Option/Admin/ApiKeyManagementPage.tsx').length,admin:data.filter(e=>e.path?.startsWith('src/components/Option/Admin/')).length}, null, 2));"` -> `{"total":170,"apiKeys":0,"admin":12}`
- `git diff --check`
- `env NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit --pretty false`
- `bun run verify:design-system-state` exits 1 from unrelated current-dev findings in `IntegrationPolicyPanel`, `WritingActionBar`, Notes, and ResearchWorkspace plus stale `IntegrationPolicyPanel` baseline entries; no `ApiKeyManagementPage` findings were present in `/tmp/api-key-admin-design-state.log`.

## Change summary (maintainer-owned)

Maintainer note required before merge: please replace this section with your own summary explaining what changed and why these implementation choices were made.

## UX Audit Checklist

- [x] Existing API key guard and feedback copy is preserved.
- [x] Error/warning/success urgency semantics are preserved through design-system roles.
- [x] Created-key one-time visibility and dismiss behavior are preserved.
- [x] Key-load failures remain inline with the API Keys table.

## Bandit

Not run. This slice touched TypeScript UI, JSON baseline data, and Backlog task markdown only.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrates API key admin alerts in `ApiKeyManagementPage` from `antd` `Alert` to the design-system `Alert` and tokenizes the created-key code block for consistent styling. Adds focused tests and removes product-state baseline exceptions.

- **Refactors**
  - Replaced four `antd` `Alert` cases (access denied, not available, new key created, key-load error) with design-system `Alert`; preserved copy and roles; success alert is dismissible.
  - Styled the created-key code block with design-system utility classes instead of inline styles.
  - Added tests for these states and removed this page’s entries from `design-system-product-state-baseline.json`.

<sup>Written for commit 20d7323d6c6be469a01e0beb6eaefe369df4986d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2162?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

