### PR TITLE
Add MCP Unified gateway CLI

### DIFF
--- a/Docs/superpowers/plans/2026-05-30-mcp-unified-stage4i-gateway-cli-plan.md
+++ b/Docs/superpowers/plans/2026-05-30-mcp-unified-stage4i-gateway-cli-plan.md
@@ -1,0 +1,167 @@
+# MCP Unified Stage 4I Gateway CLI Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a narrow package-owned MCP Unified gateway CLI for validating standalone gateway profile bootstrap config files and listing bundled profile presets.
+
+**Architecture:** The CLI lives in `mcp_unified.gateway.cli`, uses stdlib `argparse`, and delegates all config validation to the existing `load_gateway_profile_bootstrap_config()` helper. Output is deterministic JSON so front ends, setup wizards, and shell scripts can consume it without importing FastAPI or starting any transport.
+
+**Tech Stack:** Python 3.11, stdlib `argparse`/`json`, existing `mcp_unified.gateway.config`, existing `mcp_unified.profiles.presets`, pytest.
+
+---
+
+### Task 1: CLI Contract Tests
+
+**Files:**
+- Create: `tldw_Server_API/app/core/MCP_unified/tests/test_gateway_cli_package.py`
+
+- [x] **Step 1: Write the failing config validation success test**
+
+```python
+def test_gateway_cli_validate_config_reports_success_json(tmp_path, capsys):
+    config_path = tmp_path / "gateway.json"
+    config_path.write_text(json.dumps({"store": {"kind": "memory"}, "default_preset_id": "project-researcher"}))
+
+    exit_code = gateway_cli.main(["validate-config", str(config_path)])
+
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["ok"] is True
+    assert payload["default_preset_id"] == "project-researcher"
+    assert payload["store"]["kind"] == "memory"
+```
+
+- [x] **Step 2: Run test to verify it fails**
+
+Run: `source .venv/bin/activate && python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_gateway_cli_package.py::test_gateway_cli_validate_config_reports_success_json -q`
+
+Expected: FAIL because `mcp_unified.gateway.cli` does not exist.
+
+- [x] **Step 3: Write the failing validation error test**
+
+```python
+def test_gateway_cli_validate_config_reports_error_json(tmp_path, capsys):
+    config_path = tmp_path / "gateway.json"
+    config_path.write_text("{", encoding="utf-8")
+
+    exit_code = gateway_cli.main(["validate-config", str(config_path)])
+
+    assert exit_code == 1
+    captured = capsys.readouterr()
+    payload = json.loads(captured.err)
+    assert payload["ok"] is False
+    assert "Invalid gateway config JSON" in payload["error"]
+    assert "Traceback" not in captured.err
+```
+
+- [x] **Step 4: Run test to verify it fails for the missing CLI**
+
+Run: `source .venv/bin/activate && python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_gateway_cli_package.py::test_gateway_cli_validate_config_reports_error_json -q`
+
+Expected: FAIL because `mcp_unified.gateway.cli` does not exist.
+
+- [x] **Step 5: Write the failing preset listing and entry point tests**
+
+```python
+def test_gateway_cli_list_presets_reports_builtin_summary(capsys):
+    exit_code = gateway_cli.main(["list-presets"])
+
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    preset_ids = {preset["id"] for preset in payload["presets"]}
+    assert "project-researcher" in preset_ids
+    assert all({"id", "name", "description", "version"} <= set(preset) for preset in payload["presets"])
+
+
+def test_gateway_cli_project_script_is_registered():
+    pyproject = Path("pyproject.toml").read_text(encoding="utf-8")
+
+    assert 'mcp-unified-gateway = "mcp_unified.gateway.cli:main"' in pyproject
+```
+
+- [x] **Step 6: Run tests to verify they fail**
+
+Run: `source .venv/bin/activate && python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_gateway_cli_package.py -q`
+
+Expected: FAIL for the missing CLI module and missing project script.
+
+### Task 2: Minimal CLI Implementation
+
+**Files:**
+- Create: `mcp_unified/gateway/cli.py`
+- Modify: `mcp_unified/gateway/__init__.py`
+- Modify: `pyproject.toml`
+
+- [x] **Step 1: Implement `mcp_unified.gateway.cli`**
+
+Implementation requirements:
+- `main(argv: Sequence[str] | None = None) -> int`
+- Subcommand `validate-config PATH [--format json|toml]`
+- Subcommand `list-presets`
+- Success output goes to stdout as sorted-key JSON plus newline.
+- Validation errors go to stderr as sorted-key JSON plus newline and return `1`.
+- Do not import FastAPI, start HTTP/WebSocket/stdio transports, or instantiate external MCP services.
+
+- [x] **Step 2: Export the CLI module public entry**
+
+Add `gateway_cli_main` or a lazy `main` export only if needed by tests or public package ergonomics. Avoid importing the CLI from `mcp_unified.gateway.__init__` if doing so would add avoidable import work.
+
+- [x] **Step 3: Register the project script**
+
+Add:
+
+```toml
+mcp-unified-gateway = "mcp_unified.gateway.cli:main"
+```
+
+- [x] **Step 4: Run the CLI tests**
+
+Run: `source .venv/bin/activate && python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_gateway_cli_package.py -q`
+
+Expected: PASS.
+
+### Task 3: Verification and Closeout
+
+**Files:**
+- Modify: `backlog/tasks/task-566 - Implement-MCP-Unified-Stage-4I-gateway-CLI.md`
+
+- [x] **Step 1: Run focused gateway package tests**
+
+Run: `source .venv/bin/activate && python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_gateway_cli_package.py tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py -q`
+
+Expected: PASS.
+
+- [x] **Step 2: Run extraction and HTTP compatibility tests**
+
+Run: `source .venv/bin/activate && python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_extraction_contracts.py tldw_Server_API/app/core/MCP_unified/tests/test_http_mapping.py -q`
+
+Expected: PASS.
+
+- [x] **Step 3: Run lint and security checks**
+
+Run: `source .venv/bin/activate && python -m ruff check mcp_unified/gateway tldw_Server_API/app/core/MCP_unified/tests/test_gateway_cli_package.py`
+
+Expected: PASS.
+
+Run: `source .venv/bin/activate && python -m bandit -r mcp_unified/gateway -f json -o /tmp/bandit_mcp_stage4i_gateway_cli.json`
+
+Expected: PASS with zero findings in touched package scope.
+
+- [x] **Step 4: Run whitespace and status checks**
+
+Run: `git diff --check`
+
+Expected: no output.
+
+Run: `git status --short`
+
+Expected: only Stage 4I files, plan file, and Backlog task are modified.
+
+- [ ] **Step 5: Update Backlog task and commit**
+
+Record verification in `TASK-566`, then commit with a message like:
+
+```bash
+git add mcp_unified/gateway/cli.py mcp_unified/gateway/__init__.py pyproject.toml tldw_Server_API/app/core/MCP_unified/tests/test_gateway_cli_package.py Docs/superpowers/plans/2026-05-30-mcp-unified-stage4i-gateway-cli-plan.md "backlog/tasks/task-566 - Implement-MCP-Unified-Stage-4I-gateway-CLI.md"
+git commit -m "feat: add MCP Unified gateway CLI"
+```

--- a/backlog/tasks/task-566 - Implement-MCP-Unified-Stage-4I-gateway-CLI.md
+++ b/backlog/tasks/task-566 - Implement-MCP-Unified-Stage-4I-gateway-CLI.md
@@ -1,0 +1,54 @@
+---
+id: TASK-566
+title: Implement MCP Unified Stage 4I gateway CLI
+status: Done
+labels:
+- mcp-unified
+- stage-4
+- gateway
+- cli
+priority: medium
+modified_files:
+- mcp_unified/gateway/cli.py
+- pyproject.toml
+- tldw_Server_API/app/core/MCP_unified/tests/test_gateway_cli_package.py
+- Docs/superpowers/plans/2026-05-30-mcp-unified-stage4i-gateway-cli-plan.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Add a narrow package-owned CLI for standalone gateway configuration workflows: validate JSON/TOML gateway profile bootstrap config files and list built-in profile presets without starting transports or managing external MCP service lifecycle.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Docs/superpowers/plans/2026-05-30-mcp-unified-stage4i-gateway-cli-plan.md
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Implemented Stage 4I gateway CLI with deterministic JSON commands for config validation and built-in preset listing. Review pass rebased PR #2163 onto origin/dev and addressed all still-valid comments: typed pytest capsys fixtures, added JSON handling for argparse failures, converted loader failures at the CLI boundary to JSON stderr without tracebacks, and replaced brittle script-entry substring testing with semantic TOML parsing. Verified focused gateway, extraction/http compatibility, ruff, Bandit, and diff checks.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/mcp_unified/gateway/cli.py
+++ b/mcp_unified/gateway/cli.py
@@ -1,0 +1,189 @@
+"""Command-line helpers for standalone MCP gateway configuration workflows."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any, NoReturn, TextIO
+
+from mcp_unified.profiles.presets import list_builtin_presets
+
+from .config import (
+    GatewayConfigFormat,
+    GatewayProfileBootstrapConfig,
+    load_gateway_profile_bootstrap_config,
+)
+
+
+class _CliArgumentError(ValueError):
+    """Raised when CLI arguments cannot be parsed into a command."""
+
+
+class _CliHelpRequested(Exception):
+    """Raised after argparse has printed human-readable help output."""
+
+    def __init__(self, status: int) -> None:
+        """Store the intended process exit status."""
+
+        self.status = status
+
+
+class _JsonArgumentParser(argparse.ArgumentParser):
+    """Argument parser that lets `main()` format parse failures as JSON."""
+
+    def error(self, message: str) -> NoReturn:
+        """Raise a normal exception instead of printing usage and exiting."""
+
+        raise _CliArgumentError(message)
+
+    def exit(self, status: int = 0, message: str | None = None) -> NoReturn:
+        """Raise exceptions instead of terminating the Python process."""
+
+        if status == 0:
+            if message:
+                self._print_message(message, sys.stdout)
+            raise _CliHelpRequested(status)
+
+        raise _CliArgumentError(
+            message.strip() if message else f"argument parsing failed with status {status}"
+        )
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Run the standalone MCP gateway CLI and return a process exit code."""
+
+    parser = _build_parser()
+    try:
+        args = parser.parse_args(argv)
+    except _CliHelpRequested as exc:
+        return exc.status
+    except _CliArgumentError as exc:
+        _emit_json(
+            {
+                "error": str(exc),
+                "ok": False,
+            },
+            sys.stderr,
+        )
+        return 2
+    return args.handler(args)
+
+
+def _build_parser() -> _JsonArgumentParser:
+    """Build the CLI argument parser."""
+
+    parser = _JsonArgumentParser(
+        prog="mcp-unified-gateway",
+        description="Standalone MCP Unified gateway configuration utilities.",
+    )
+    subparsers = parser.add_subparsers(
+        dest="command",
+        parser_class=_JsonArgumentParser,
+        required=True,
+    )
+
+    validate_config = subparsers.add_parser(
+        "validate-config",
+        help="Validate a gateway profile bootstrap config file.",
+    )
+    validate_config.add_argument(
+        "path",
+        type=Path,
+        help="Path to a JSON or TOML gateway config file.",
+    )
+    validate_config.add_argument(
+        "--format",
+        choices=("json", "toml"),
+        dest="config_format",
+        help="Config format override when the file suffix is unavailable.",
+    )
+    validate_config.set_defaults(handler=_handle_validate_config)
+
+    list_presets = subparsers.add_parser(
+        "list-presets",
+        help="List bundled MCP profile presets.",
+    )
+    list_presets.set_defaults(handler=_handle_list_presets)
+
+    return parser
+
+
+def _handle_validate_config(args: argparse.Namespace) -> int:
+    """Validate one config file and emit a deterministic JSON result."""
+
+    config_path: Path = args.path
+    config_format: GatewayConfigFormat | str | None = args.config_format
+    try:
+        config = load_gateway_profile_bootstrap_config(
+            config_path,
+            format=config_format,
+        )
+    except Exception as exc:  # noqa: BLE001
+        # CLI boundary: config loader failures should be machine-readable.
+        _emit_json(
+            {
+                "error": str(exc),
+                "ok": False,
+                "path": str(config_path),
+            },
+            sys.stderr,
+        )
+        return 1
+
+    _emit_json(_validated_config_payload(config, config_path), sys.stdout)
+    return 0
+
+
+def _handle_list_presets(_args: argparse.Namespace) -> int:
+    """Emit bundled profile preset summaries as deterministic JSON."""
+
+    presets = sorted(list_builtin_presets(), key=lambda preset: preset.id)
+    _emit_json(
+        {
+            "presets": [
+                {
+                    "description": preset.profile.description,
+                    "id": preset.id,
+                    "name": preset.profile.name,
+                    "version": preset.version,
+                }
+                for preset in presets
+            ]
+        },
+        sys.stdout,
+    )
+    return 0
+
+
+def _validated_config_payload(
+    config: GatewayProfileBootstrapConfig,
+    path: Path,
+) -> dict[str, Any]:
+    """Build the JSON payload for a successfully validated config."""
+
+    sqlite_path = config.store.sqlite_path
+    return {
+        "default_preset_id": config.default_preset_id,
+        "default_profile_id": config.default_profile_id,
+        "ok": True,
+        "path": str(path),
+        "profiles": len(config.profiles),
+        "store": {
+            "kind": config.store.kind,
+            "sqlite_path": str(sqlite_path) if sqlite_path is not None else None,
+        },
+    }
+
+
+def _emit_json(payload: Mapping[str, Any], stream: TextIO) -> None:
+    """Write one JSON object to the selected stream."""
+
+    stream.write(json.dumps(payload, sort_keys=True))
+    stream.write("\n")
+
+
+if __name__ == "__main__":  # pragma: no cover - exercised through console script.
+    raise SystemExit(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -505,6 +505,7 @@ tldw-server = "tldw_Server_API.app.main:run_server"
 # Point tldw-evals to the richer, unified CLI
 tldw-evals = "tldw_Server_API.cli.evals_cli:main"
 tldw-setup = "tldw_Server_API.cli.wizard.cli:main"
+mcp-unified-gateway = "mcp_unified.gateway.cli:main"
 
 ###########################
 # Tools - Package Discovery

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_cli_package.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_cli_package.py
@@ -1,0 +1,148 @@
+"""Package-level tests for the standalone MCP gateway CLI."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from mcp_unified.gateway import cli as gateway_cli
+
+try:
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover - Python 3.10 compatibility.
+    import tomli as tomllib
+
+
+def test_gateway_cli_validate_config_reports_success_json(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Validate a JSON config file and report a deterministic success payload."""
+
+    config_path = tmp_path / "gateway.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "store": {"kind": "memory"},
+                "default_preset_id": "project-researcher",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    exit_code = gateway_cli.main(["validate-config", str(config_path)])
+
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+    assert exit_code == 0
+    assert captured.err == ""
+    assert payload == {
+        "default_preset_id": "project-researcher",
+        "default_profile_id": None,
+        "ok": True,
+        "path": str(config_path),
+        "profiles": 0,
+        "store": {"kind": "memory", "sqlite_path": None},
+    }
+
+
+def test_gateway_cli_validate_config_reports_error_json(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Report validation failures as user-facing JSON without tracebacks."""
+
+    config_path = tmp_path / "gateway.json"
+    config_path.write_text("{", encoding="utf-8")
+
+    exit_code = gateway_cli.main(["validate-config", str(config_path)])
+
+    captured = capsys.readouterr()
+    payload = json.loads(captured.err)
+    assert exit_code == 1
+    assert captured.out == ""
+    assert payload["ok"] is False
+    assert payload["path"] == str(config_path)
+    assert "Invalid gateway config JSON" in payload["error"]
+    assert "Traceback" not in captured.err
+
+
+def test_gateway_cli_validate_config_reports_unexpected_loader_errors_as_json(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Convert non-ValueError loader failures into JSON stderr responses."""
+
+    config_path = tmp_path / "gateway.json"
+    config_path.write_text("{}", encoding="utf-8")
+
+    def _raise_runtime_error(*args: object, **kwargs: object) -> object:
+        raise RuntimeError("loader failed")
+
+    monkeypatch.setattr(
+        gateway_cli,
+        "load_gateway_profile_bootstrap_config",
+        _raise_runtime_error,
+    )
+
+    exit_code = gateway_cli.main(["validate-config", str(config_path)])
+
+    captured = capsys.readouterr()
+    payload = json.loads(captured.err)
+    assert exit_code == 1
+    assert captured.out == ""
+    assert payload == {
+        "error": "loader failed",
+        "ok": False,
+        "path": str(config_path),
+    }
+    assert "Traceback" not in captured.err
+
+
+def test_gateway_cli_argument_errors_are_json(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Report argparse failures as deterministic JSON instead of usage text."""
+
+    exit_code = gateway_cli.main([])
+
+    captured = capsys.readouterr()
+    payload = json.loads(captured.err)
+    assert exit_code == 2
+    assert captured.out == ""
+    assert payload["ok"] is False
+    assert "command" in payload["error"]
+    assert "usage:" not in captured.err
+
+
+def test_gateway_cli_list_presets_reports_builtin_summary(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """List bundled presets as a small JSON summary for front-end discovery."""
+
+    exit_code = gateway_cli.main(["list-presets"])
+
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+    preset_ids = {preset["id"] for preset in payload["presets"]}
+    assert exit_code == 0
+    assert captured.err == ""
+    assert "project-researcher" in preset_ids
+    assert all(
+        {"description", "id", "name", "version"} <= set(preset)
+        for preset in payload["presets"]
+    )
+
+
+def test_gateway_cli_project_script_is_registered() -> None:
+    """Expose the package CLI through the installed project scripts."""
+
+    pyproject_path = Path(__file__).resolve().parents[5] / "pyproject.toml"
+    pyproject = tomllib.loads(pyproject_path.read_text(encoding="utf-8"))
+
+    assert (
+        pyproject["project"]["scripts"]["mcp-unified-gateway"]
+        == "mcp_unified.gateway.cli:main"
+    )


### PR DESCRIPTION
## Summary

- What changed:
  - Added `mcp_unified.gateway.cli` with JSON-emitting `validate-config` and `list-presets` commands.
  - Registered `mcp-unified-gateway = "mcp_unified.gateway.cli:main"` as a project script.
  - Added focused package tests and linked Stage 4I work to Backlog `TASK-566`.
- Why:
  - This gives standalone MCP gateway consumers a package-owned, script-friendly way to validate gateway profile bootstrap config and discover built-in modes without starting HTTP/WebSocket/stdio transports or managing external MCP service lifecycle.

## Validation

- [x] Tests added/updated for behavior changes
- [x] Relevant unit/integration tests pass locally
- [x] Docs updated (if behavior, routes, or config changed)

Commands run:

- `source .venv/bin/activate && python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_gateway_cli_package.py -q`
- `source .venv/bin/activate && python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_gateway_cli_package.py tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py -q`
- `source .venv/bin/activate && python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_extraction_contracts.py tldw_Server_API/app/core/MCP_unified/tests/test_http_mapping.py -q`
- `source .venv/bin/activate && python -m ruff check mcp_unified/gateway tldw_Server_API/app/core/MCP_unified/tests/test_gateway_cli_package.py`
- `source .venv/bin/activate && python -m bandit -r mcp_unified/gateway -f json -o /tmp/bandit_mcp_stage4i_gateway_cli.json`
- `source .venv/bin/activate && python -c 'import json; data=json.load(open("/tmp/bandit_mcp_stage4i_gateway_cli.json")); print({"results": len(data.get("results", [])), "errors": data.get("errors", [])})'`
- `git diff --cached --check`

## UX Audit Checklist (v2 Stage 5)

- [ ] `npm run e2e:smoke:stage5` passes
- [ ] `npx playwright test e2e/smoke/all-pages.spec.ts --reporter=line` passes (or failures documented)
- [x] No listed AntD deprecations in console output: `Drawer.width`, `Space.direction`, `Alert.message`, `List` (not applicable: no WebUI changes)
- [x] No `Maximum update depth exceeded` warnings on audited routes (not applicable: no WebUI changes)
- [x] No unresolved `{{...}}` placeholders on audited routes (not applicable: no WebUI changes)
- [x] WebUI/extension parity validated for shared UI fixes (not applicable: no WebUI changes)
- [x] For Flashcards UI changes: tabs remain `Study` / `Manage` / `Transfer` and secondary create CTAs route through manager create-entry path (not applicable)
- [x] For Flashcards drawer changes: use `FLASHCARDS_DRAWER_WIDTH_PX` and keep footer action order `Cancel -> secondary -> primary` (not applicable)
- [x] For Flashcards help/copy/import UX changes: update `Docs/User_Guides/WebUI_Extension/Flashcards_Study_Guide.md` and keep in-app help links pointed at guide section anchors (not applicable)

## Watchlists Accessibility Checklist (Group 09 Stage 5)

- [x] If Watchlists UI behavior changed: `cd apps/packages/ui && bun run test:watchlists:a11y` passes locally (not applicable)
- [x] If Watchlists UI behavior changed: keyboard-only path still works for Overview -> Feeds -> Monitors -> Activity -> Articles -> Reports (not applicable)
- [x] If Watchlists UI behavior changed: list/table labels and live-region copy remain localized (no new hardcoded assistive text) (not applicable)
- [x] If Watchlists UI behavior changed: monitor/feed active state is not color-only (explicit text or icon signal is present) (not applicable)
- [x] If Watchlists UI behavior changed: known assistive-tech constraints reviewed in `Docs/Plans/WATCHLISTS_ASSISTIVE_TECH_AUDIT_2026_02_24.md` (not applicable)

## Watchlists Scale Checklist (Group 10 Stage 5)

- [x] If Watchlists UI behavior changed: `cd apps/packages/ui && bun run test:watchlists:scale` passes locally (not applicable)
- [x] If Watchlists polling/notifications behavior changed: no duplicate terminal notifications during in-flight polling overlap (not applicable)
- [x] If Watchlists Activity polling changed: auto-refresh is gated to active + visible Activity context (no background tab polling churn) (not applicable)
- [x] If Watchlists batch triage behavior changed: partial-failure retry path remains available and updates only failed IDs (not applicable)
- [x] If Watchlists scale behavior changed: constraints/mitigations reviewed in `Docs/Plans/WATCHLISTS_SCALE_READINESS_RUNBOOK_2026_02_24.md` (not applicable)

## Risk & Rollback

- Risk level: Low
- Rollback plan: Revert this PR to remove the CLI module, script entry point, tests, plan, and Backlog task. Runtime gateway transports are unchanged.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a minimal `mcp_unified.gateway.cli` to validate gateway bootstrap configs and list built‑in presets without starting transports. Outputs deterministic JSON for scripts and setup flows, meeting TASK-566.

- **New Features**
  - Adds `validate-config PATH [--format json|toml]` and `list-presets`; success JSON to stdout, errors to stderr; exit codes: 0 (ok), 1 (validation failure), 2 (argument error). `validate-config` returns fields: ok, path, defaults, profiles count, and store details; `list-presets` returns id, name, description, version for bundled presets.
  - Registers `mcp-unified-gateway` project script (`mcp_unified.gateway.cli:main`). Tests cover success/error payloads, JSON-formatted argparse failures, and converting loader errors to JSON without tracebacks; no runtime transport changes.

<sup>Written for commit 8d2034c1d0c1e592cf9eef5ae954592597203630. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2163?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

