### PR TITLE
Seed Deep Research follow-ups from hypotheses and proposals

### DIFF
--- a/apps/packages/ui/src/components/Option/ResearchWorkspace/StudioPane/literature-deep-research-launch.ts
+++ b/apps/packages/ui/src/components/Option/ResearchWorkspace/StudioPane/literature-deep-research-launch.ts
@@ -132,8 +132,10 @@ const normalizeHypotheses = (
     .filter((entry) => entry.hypothesis.length > 0)
 }
 
-const makeClaimId = (artifact: GeneratedArtifact, suffix: string): string =>
-  truncateForLaunch(`${artifact.id}:${suffix}`, 128)
+const makeClaimId = (artifact: GeneratedArtifact, suffix: string): string => {
+  const rawId = `${artifact.id}:${suffix}`
+  return rawId.length <= 128 ? rawId : rawId.slice(0, 128)
+}
 
 const buildCommonUnresolvedQuestions = (subject: string): string[] => [
   `Which parts of the ${subject} are evidence-supported versus proposed work?`,
@@ -225,15 +227,22 @@ const buildHypothesesFollowUp = (
 const extractMarkdownSection = (content: string, headings: RegExp[]): string => {
   const lines = content.split(/\r?\n/)
   let collecting = false
+  let startLevel = 0
   const collected: string[] = []
 
   for (const line of lines) {
-    if (/^#{1,6}\s+/.test(line)) {
+    const headingMatch = line.match(/^(#{1,6})\s+/)
+    if (headingMatch) {
+      const headingLevel = headingMatch[1].length
       if (collecting) {
-        break
+        if (headingLevel <= startLevel) {
+          break
+        }
+      } else if (headings.some((heading) => heading.test(line))) {
+        collecting = true
+        startLevel = headingLevel
+        continue
       }
-      collecting = headings.some((heading) => heading.test(line))
-      continue
     }
     if (collecting) {
       collected.push(line)

--- a/apps/packages/ui/src/components/Option/ResearchWorkspace/StudioPane/literature-deep-research-launch.ts
+++ b/apps/packages/ui/src/components/Option/ResearchWorkspace/StudioPane/literature-deep-research-launch.ts
@@ -5,15 +5,49 @@ import type {
   ArtifactSkippedSource,
   GeneratedArtifact
 } from "@/types/workspace"
+import type { NormalizedEvidenceBoundHypothesis } from "./literature-workproducts"
 
 const LITERATURE_DEEP_RESEARCH_TEMPLATE_IDS = new Set([
   "literature_matrix",
-  "corpus_gap_finder"
+  "corpus_gap_finder",
+  "evidence_bound_hypotheses",
+  "research_proposal_pack"
+])
+
+const LITERATURE_DEEP_RESEARCH_FOLLOW_UP_TEMPLATE_IDS = new Set([
+  "evidence_bound_hypotheses",
+  "research_proposal_pack"
 ])
 
 const ARTIFACT_EXCERPT_LIMIT = 1400
 const RESEARCH_QUERY_LIMIT = 2600
 const TRUNCATION_SUFFIX = "\n\n[Truncated for Deep Research launch context.]"
+const FOLLOW_UP_CLAIM_LIMIT = 900
+const FOLLOW_UP_QUESTION_LIMIT = 1800
+
+type ResearchFollowUpSeed = {
+  question: string
+  background: {
+    question: string
+    outline: Array<{
+      title: string
+      focus_area?: string | null
+    }>
+    key_claims: Array<{
+      claim_id: string
+      text: string
+    }>
+    unresolved_questions: string[]
+    verification_summary: {
+      supported_claim_count: number
+      unsupported_claim_count: number
+    }
+    source_trust_summary: {
+      high_trust_count: number
+      low_trust_count: number
+    }
+  }
+}
 
 const truncateForLaunch = (value: string, limit: number): string => {
   const trimmed = value.trim()
@@ -35,22 +69,258 @@ const formatCoverageEntry = (source: ArtifactSourceCoverageEntry): string =>
 const formatSkippedSource = (source: ArtifactSkippedSource): string =>
   `${formatCoverageEntry(source)} (${source.reason})`
 
+const formatCoverageEntryList = (
+  sources: ArtifactSourceCoverageEntry[] | undefined
+): string => sources?.map(formatCoverageEntry).join(", ") || "none"
+
+const formatSkippedSourceList = (
+  sources: ArtifactSkippedSource[] | undefined
+): string => sources?.map(formatSkippedSource).join(", ") || "none"
+
+const formatSourceCoverageClaim = (
+  sourceCoverage: ArtifactSourceCoverage
+): string =>
+  [
+    "Source coverage from Research Workspace artifact:",
+    `selected IDs: ${(sourceCoverage.selectedSourceIds ?? []).join(", ") || "none"}`,
+    `usable sources: ${formatCoverageEntryList(sourceCoverage.usableSources)}`,
+    `skipped sources: ${formatSkippedSourceList(sourceCoverage.skippedSources)}`,
+    `truncated sources: ${formatCoverageEntryList(sourceCoverage.truncatedSources)}`
+  ].join(" ")
+
 const formatSourceCoverage = (sourceCoverage: ArtifactSourceCoverage): string =>
   [
     `Selected source IDs: ${(sourceCoverage.selectedSourceIds ?? []).join(", ") || "none"}`,
-    `Usable sources: ${
-      (sourceCoverage.usableSources ?? []).map(formatCoverageEntry).join(", ") ||
-      "none"
-    }`,
-    `Skipped sources: ${
-      (sourceCoverage.skippedSources ?? []).map(formatSkippedSource).join(", ") ||
-      "none"
-    }`,
-    `Truncated sources: ${
-      (sourceCoverage.truncatedSources ?? []).map(formatCoverageEntry).join(", ") ||
-      "none"
-    }`
+    `Usable sources: ${formatCoverageEntryList(sourceCoverage.usableSources)}`,
+    `Skipped sources: ${formatSkippedSourceList(sourceCoverage.skippedSources)}`,
+    `Truncated sources: ${formatCoverageEntryList(sourceCoverage.truncatedSources)}`
   ].join("\n")
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value)
+
+const readStringList = (value: unknown): string[] =>
+  Array.isArray(value)
+    ? value
+        .map((entry) => String(entry ?? "").trim())
+        .filter(
+          (entry, index, all) =>
+            entry.length > 0 && all.indexOf(entry) === index
+        )
+    : []
+
+const normalizeHypotheses = (
+  artifact: GeneratedArtifact
+): NormalizedEvidenceBoundHypothesis[] => {
+  const rawHypotheses = isRecord(artifact.data) ? artifact.data.hypotheses : null
+  if (!Array.isArray(rawHypotheses)) {
+    return []
+  }
+
+  return rawHypotheses
+    .filter(isRecord)
+    .map((entry) => ({
+      hypothesis: String(entry.hypothesis ?? "").trim(),
+      supportingFindings: readStringList(entry.supportingFindings),
+      supportingSources: readStringList(entry.supportingSources),
+      prediction: String(entry.prediction ?? "").trim(),
+      suggestedMethodology: String(entry.suggestedMethodology ?? "").trim(),
+      threatsToValidity: readStringList(entry.threatsToValidity),
+      whatWouldFalsifyIt: String(entry.whatWouldFalsifyIt ?? "").trim(),
+      confidence: String(entry.confidence ?? "").trim()
+    }))
+    .filter((entry) => entry.hypothesis.length > 0)
+}
+
+const makeClaimId = (artifact: GeneratedArtifact, suffix: string): string =>
+  truncateForLaunch(`${artifact.id}:${suffix}`, 128)
+
+const buildCommonUnresolvedQuestions = (subject: string): string[] => [
+  `Which parts of the ${subject} are evidence-supported versus proposed work?`,
+  "Which selected sources confirm, weaken, or contradict the proposed work?",
+  "Which skipped or truncated sources need review before trusting this follow-up?"
+]
+
+const buildSourceTrustSummary = (sourceCoverage: ArtifactSourceCoverage) => ({
+  high_trust_count: sourceCoverage.usableSources?.length ?? 0,
+  low_trust_count:
+    (sourceCoverage.skippedSources?.length ?? 0) +
+    (sourceCoverage.truncatedSources?.length ?? 0)
+})
+
+const buildCoverageClaim = (
+  artifact: GeneratedArtifact,
+  sourceCoverage: ArtifactSourceCoverage,
+  suffix = "source-coverage"
+) => ({
+  claim_id: makeClaimId(artifact, suffix),
+  text: truncateForLaunch(formatSourceCoverageClaim(sourceCoverage), FOLLOW_UP_CLAIM_LIMIT)
+})
+
+const buildHypothesesFollowUp = (
+  artifact: GeneratedArtifact,
+  sourceCoverage: ArtifactSourceCoverage
+): ResearchFollowUpSeed | null => {
+  const hypotheses = normalizeHypotheses(artifact)
+  if (hypotheses.length === 0) {
+    return null
+  }
+
+  const headline = hypotheses
+    .slice(0, 2)
+    .map((entry) => entry.hypothesis)
+    .join(" ")
+  const question = truncateForLaunch(
+    `Verify and expand these Research Workspace evidence-bound hypotheses: ${headline}`,
+    FOLLOW_UP_QUESTION_LIMIT
+  )
+  const hypothesisClaims = hypotheses.slice(0, 4).map((entry, index) => {
+    const finding = entry.supportingFindings[0] || "No supporting finding listed."
+    const sources = entry.supportingSources.join(", ") || "unknown sources"
+    const proposedWork = [
+      entry.prediction ? `Prediction: ${entry.prediction}` : "",
+      entry.suggestedMethodology
+        ? `Proposed method: ${entry.suggestedMethodology}`
+        : ""
+    ]
+      .filter(Boolean)
+      .join(" ")
+    return {
+      claim_id: makeClaimId(artifact, `hypothesis-${index + 1}`),
+      text: truncateForLaunch(
+        [
+          `Evidence-supported finding for hypothesis ${index + 1}: ${finding}`,
+          `Sources: ${sources}.`,
+          proposedWork
+        ]
+          .filter(Boolean)
+          .join(" "),
+        FOLLOW_UP_CLAIM_LIMIT
+      )
+    }
+  })
+
+  return {
+    question,
+    background: {
+      question,
+      outline: hypotheses.slice(0, 7).map((_entry, index) => ({
+        title: `Hypothesis ${index + 1}`,
+        focus_area: `hypothesis_${index + 1}`
+      })),
+      key_claims: [
+        ...hypothesisClaims.slice(0, 4),
+        buildCoverageClaim(artifact, sourceCoverage)
+      ].slice(0, 5),
+      unresolved_questions: buildCommonUnresolvedQuestions("hypothesis"),
+      verification_summary: {
+        supported_claim_count: Math.min(hypotheses.length, 4),
+        unsupported_claim_count: 1
+      },
+      source_trust_summary: buildSourceTrustSummary(sourceCoverage)
+    }
+  }
+}
+
+const extractMarkdownSection = (content: string, headings: RegExp[]): string => {
+  const lines = content.split(/\r?\n/)
+  let collecting = false
+  const collected: string[] = []
+
+  for (const line of lines) {
+    if (/^#{1,6}\s+/.test(line)) {
+      if (collecting) {
+        break
+      }
+      collecting = headings.some((heading) => heading.test(line))
+      continue
+    }
+    if (collecting) {
+      collected.push(line)
+    }
+  }
+
+  return collected.join("\n").trim()
+}
+
+const buildProposalFollowUp = (
+  artifact: GeneratedArtifact,
+  sourceCoverage: ArtifactSourceCoverage
+): ResearchFollowUpSeed | null => {
+  const content = artifact.content?.trim()
+  if (!content) {
+    return null
+  }
+
+  const evidenceExcerpt =
+    extractMarkdownSection(content, [/^#{1,6}\s+Literature Overview\b/i]) ||
+    extractMarkdownSection(content, [/^#{1,6}\s+Source Audit\b/i]) ||
+    content
+  const proposedHypothesis = extractMarkdownSection(content, [
+    /^#{1,6}\s+Proposed Hypothesis\b/i
+  ])
+  const methodology = extractMarkdownSection(content, [/^#{1,6}\s+Methodology\b/i])
+  const proposedExcerpt = [proposedHypothesis, methodology]
+    .filter(Boolean)
+    .join("\n\n")
+  const question = truncateForLaunch(
+    `Verify and expand this Research Workspace proposal, separating evidence-supported claims from proposed work: ${artifact.title}`,
+    FOLLOW_UP_QUESTION_LIMIT
+  )
+
+  return {
+    question,
+    background: {
+      question,
+      outline: [
+        {
+          title: "Literature evidence",
+          focus_area: "evidence_supported_claims"
+        },
+        {
+          title: "Proposed work",
+          focus_area: "proposed_work"
+        }
+      ],
+      key_claims: [
+        {
+          claim_id: makeClaimId(artifact, "evidence-supported-excerpt"),
+          text: truncateForLaunch(
+            `Evidence-supported proposal excerpt: ${evidenceExcerpt}`,
+            FOLLOW_UP_CLAIM_LIMIT
+          )
+        },
+        {
+          claim_id: makeClaimId(artifact, "proposed-work-excerpt"),
+          text: truncateForLaunch(
+            `Proposed-work excerpt: ${proposedExcerpt || content}`,
+            FOLLOW_UP_CLAIM_LIMIT
+          )
+        },
+        buildCoverageClaim(artifact, sourceCoverage)
+      ],
+      unresolved_questions: buildCommonUnresolvedQuestions("proposal"),
+      verification_summary: {
+        supported_claim_count: evidenceExcerpt ? 1 : 0,
+        unsupported_claim_count: proposedExcerpt ? 1 : 0
+      },
+      source_trust_summary: buildSourceTrustSummary(sourceCoverage)
+    }
+  }
+}
+
+const buildLiteratureDeepResearchFollowUp = (
+  artifact: GeneratedArtifact,
+  sourceCoverage: ArtifactSourceCoverage
+): ResearchFollowUpSeed | null => {
+  if (artifact.templateId === "evidence_bound_hypotheses") {
+    return buildHypothesesFollowUp(artifact, sourceCoverage)
+  }
+  if (artifact.templateId === "research_proposal_pack") {
+    return buildProposalFollowUp(artifact, sourceCoverage)
+  }
+  return null
+}
 
 export const isDeepResearchLaunchableLiteratureArtifact = (
   artifact: GeneratedArtifact
@@ -70,6 +340,14 @@ export const isDeepResearchLaunchableLiteratureArtifact = (
   if ((artifact.sourceCoverage.usableSources?.length ?? 0) < 2) {
     return false
   }
+  if (
+    artifact.templateId &&
+    LITERATURE_DEEP_RESEARCH_FOLLOW_UP_TEMPLATE_IDS.has(artifact.templateId)
+  ) {
+    return (
+      buildLiteratureDeepResearchFollowUp(artifact, artifact.sourceCoverage) !== null
+    )
+  }
   return typeof artifact.content === "string" && artifact.content.trim().length > 0
 }
 
@@ -83,6 +361,34 @@ export const buildLiteratureDeepResearchLaunchQuery = (
   const sourceCoverage = artifact.sourceCoverage
   if (!sourceCoverage) {
     return null
+  }
+  const followUp = buildLiteratureDeepResearchFollowUp(artifact, sourceCoverage)
+  if (
+    artifact.templateId &&
+    LITERATURE_DEEP_RESEARCH_FOLLOW_UP_TEMPLATE_IDS.has(artifact.templateId)
+  ) {
+    if (!followUp) {
+      return null
+    }
+    const artifactExcerpt = truncateForLaunch(
+      artifact.content || "",
+      ARTIFACT_EXCERPT_LIMIT
+    )
+    return truncateForLaunch(
+      [
+        followUp.question,
+        "",
+        `Artifact: ${artifact.title}`,
+        `Artifact template: ${artifact.templateId}`,
+        "",
+        "Source coverage from the artifact:",
+        formatSourceCoverage(sourceCoverage),
+        "",
+        "Artifact excerpt:",
+        artifactExcerpt
+      ].join("\n"),
+      RESEARCH_QUERY_LIMIT
+    )
   }
 
   const artifactKind =
@@ -121,11 +427,16 @@ export const buildLiteratureDeepResearchLaunchPath = (
   if (!query) {
     return null
   }
+  const sourceCoverage = artifact.sourceCoverage
+  if (!sourceCoverage) {
+    return null
+  }
 
   return buildResearchLaunchPath({
     query,
     sourcePolicy: "local_first",
     autonomyMode: "checkpointed",
-    from: "research-workspace"
+    from: "research-workspace",
+    followUp: buildLiteratureDeepResearchFollowUp(artifact, sourceCoverage)
   })
 }

--- a/apps/packages/ui/src/components/Option/ResearchWorkspace/__tests__/StudioPane.literature-workproducts.test.tsx
+++ b/apps/packages/ui/src/components/Option/ResearchWorkspace/__tests__/StudioPane.literature-workproducts.test.tsx
@@ -470,6 +470,140 @@ describe("StudioPane literature work products", () => {
     expect(query?.length).toBeLessThanOrEqual(2600)
   })
 
+  it("seeds Deep Research follow-up context from evidence-bound hypotheses", () => {
+    const href = buildLiteratureDeepResearchLaunchPath({
+      id: "artifact-hypotheses",
+      type: "report",
+      title: "Evidence-Bound Hypotheses",
+      status: "completed",
+      templateId: "evidence_bound_hypotheses",
+      content: "## Evidence-Bound Hypotheses\n\n### Hypothesis 1\n\nPeer coaching improves retention.",
+      data: {
+        hypotheses: [
+          {
+            hypothesis: "Peer coaching improves retention for adult learners.",
+            supportingFindings: [
+              "Paper A reports higher weekly practice completion.",
+              "Paper B identifies social accountability as a retention factor."
+            ],
+            supportingSources: ["Paper A", "Paper B"],
+            prediction: "Cohorts with peer coaching retain more learners after 8 weeks.",
+            suggestedMethodology: "Matched cohort study",
+            threatsToValidity: ["Self-selection into coaching groups"],
+            whatWouldFalsifyIt: "No retention difference after controlling for prior motivation.",
+            confidence: "medium"
+          }
+        ]
+      },
+      sourceCoverage: {
+        selectedSourceIds: ["source-1", "source-2", "source-3"],
+        usableSources: [
+          { sourceId: "source-1", mediaId: 101, title: "Paper A" },
+          { sourceId: "source-2", mediaId: 202, title: "Paper B" }
+        ],
+        skippedSources: [
+          {
+            sourceId: "source-3",
+            mediaId: 303,
+            title: "Paper C",
+            reason: "missing_text"
+          }
+        ],
+        truncatedSources: [],
+        minimumUsableSourcesMet: true
+      },
+      createdAt: new Date("2026-02-18T00:00:00.000Z")
+    })
+
+    expect(href).not.toBeNull()
+    const parsed = new URL(href!, "https://example.local")
+    const followUp = JSON.parse(parsed.searchParams.get("follow_up") || "{}")
+
+    expect(parsed.pathname).toBe("/research")
+    expect(parsed.searchParams.get("from")).toBe("research-workspace")
+    expect(parsed.searchParams.get("query")).toContain("Peer coaching")
+    expect(followUp.question).toContain("Peer coaching improves retention")
+    expect(followUp.background.outline).toEqual([
+      {
+        title: "Hypothesis 1",
+        focus_area: "hypothesis_1"
+      }
+    ])
+    expect(followUp.background.key_claims[0].text).toContain(
+      "Paper A reports higher weekly practice completion."
+    )
+    expect(followUp.background.key_claims[1].text).toContain(
+      "usable sources: Paper A, Paper B"
+    )
+    expect(followUp.background.key_claims[1].text).toContain(
+      "skipped sources: Paper C (missing_text)"
+    )
+    expect(followUp.background.unresolved_questions).toContain(
+      "Which parts of the hypothesis are evidence-supported versus proposed work?"
+    )
+  })
+
+  it("seeds Deep Research follow-up context from proposal packs", () => {
+    const href = buildLiteratureDeepResearchLaunchPath({
+      id: "artifact-proposal",
+      type: "report",
+      title: "Research Proposal Pack",
+      status: "completed",
+      templateId: "research_proposal_pack",
+      content: [
+        "## Source Audit",
+        "All cited claims are derived from Paper A and Paper B.",
+        "",
+        "## Literature Overview",
+        "Peer coaching appears related to adult learner retention.",
+        "",
+        "## Proposed Hypothesis",
+        "Peer coaching will improve eight-week retention.",
+        "",
+        "## Methodology",
+        "Run a matched cohort study with retention tracking."
+      ].join("\n"),
+      sourceCoverage: {
+        selectedSourceIds: ["source-1", "source-2"],
+        usableSources: [
+          { sourceId: "source-1", mediaId: 101, title: "Paper A" },
+          { sourceId: "source-2", mediaId: 202, title: "Paper B" }
+        ],
+        skippedSources: [],
+        truncatedSources: [{ sourceId: "source-2", mediaId: 202, title: "Paper B" }],
+        minimumUsableSourcesMet: true
+      },
+      createdAt: new Date("2026-02-18T00:00:00.000Z")
+    })
+
+    expect(href).not.toBeNull()
+    const parsed = new URL(href!, "https://example.local")
+    const followUp = JSON.parse(parsed.searchParams.get("follow_up") || "{}")
+
+    expect(parsed.searchParams.get("query")).toContain(
+      "Verify and expand this Research Workspace proposal"
+    )
+    expect(followUp.background.outline).toEqual([
+      {
+        title: "Literature evidence",
+        focus_area: "evidence_supported_claims"
+      },
+      {
+        title: "Proposed work",
+        focus_area: "proposed_work"
+      }
+    ])
+    expect(followUp.background.key_claims[0].text).toContain(
+      "Evidence-supported proposal excerpt"
+    )
+    expect(followUp.background.key_claims[1].text).toContain(
+      "Proposed-work excerpt"
+    )
+    expect(followUp.background.key_claims[2].text).toContain(
+      "truncated sources: Paper B"
+    )
+  })
+
   it("requires completed matrix or gap artifacts with source coverage for Deep Research launch", () => {
     expect(
       isDeepResearchLaunchableLiteratureArtifact({

--- a/apps/packages/ui/src/components/Option/ResearchWorkspace/__tests__/StudioPane.literature-workproducts.test.tsx
+++ b/apps/packages/ui/src/components/Option/ResearchWorkspace/__tests__/StudioPane.literature-workproducts.test.tsx
@@ -604,6 +604,101 @@ describe("StudioPane literature work products", () => {
     )
   })
 
+  it("preserves nested proposal section content in Deep Research follow-up seeds", () => {
+    const href = buildLiteratureDeepResearchLaunchPath({
+      id: "artifact-proposal-nested",
+      type: "report",
+      title: "Research Proposal Pack",
+      status: "completed",
+      templateId: "research_proposal_pack",
+      content: [
+        "## Literature Overview",
+        "Adult learner retention improves when support is timely.",
+        "",
+        "### Mechanism",
+        "Peer coaching adds accountability beyond reminder emails.",
+        "",
+        "## Proposed Hypothesis",
+        "Peer coaching will improve eight-week retention.",
+        "",
+        "### Prediction",
+        "Retention will increase for learners with matched peer coaches.",
+        "",
+        "## Methodology",
+        "Run a matched cohort study."
+      ].join("\n"),
+      sourceCoverage: {
+        selectedSourceIds: ["source-1", "source-2"],
+        usableSources: [
+          { sourceId: "source-1", mediaId: 101, title: "Paper A" },
+          { sourceId: "source-2", mediaId: 202, title: "Paper B" }
+        ],
+        skippedSources: [],
+        truncatedSources: [],
+        minimumUsableSourcesMet: true
+      },
+      createdAt: new Date("2026-02-18T00:00:00.000Z")
+    })
+
+    const parsed = new URL(href!, "https://example.local")
+    const followUp = JSON.parse(parsed.searchParams.get("follow_up") || "{}")
+
+    expect(followUp.background.key_claims[0].text).toContain(
+      "Peer coaching adds accountability beyond reminder emails."
+    )
+    expect(followUp.background.key_claims[1].text).toContain(
+      "Retention will increase for learners with matched peer coaches."
+    )
+  })
+
+  it("keeps generated Deep Research follow-up claim IDs clean when artifact IDs are long", () => {
+    const href = buildLiteratureDeepResearchLaunchPath({
+      id: `artifact-${"long-id-segment-".repeat(20)}`,
+      type: "report",
+      title: "Evidence-Bound Hypotheses",
+      status: "completed",
+      templateId: "evidence_bound_hypotheses",
+      content: "## Evidence-Bound Hypotheses\n\n### Hypothesis 1\n\nPeer coaching improves retention.",
+      data: {
+        hypotheses: [
+          {
+            hypothesis: "Peer coaching improves retention for adult learners.",
+            supportingFindings: ["Paper A reports higher weekly practice completion."],
+            supportingSources: ["Paper A"],
+            prediction: "Retention improves after 8 weeks.",
+            suggestedMethodology: "Matched cohort study",
+            threatsToValidity: [],
+            whatWouldFalsifyIt: "No retention difference.",
+            confidence: "medium"
+          }
+        ]
+      },
+      sourceCoverage: {
+        selectedSourceIds: ["source-1", "source-2"],
+        usableSources: [
+          { sourceId: "source-1", mediaId: 101, title: "Paper A" },
+          { sourceId: "source-2", mediaId: 202, title: "Paper B" }
+        ],
+        skippedSources: [],
+        truncatedSources: [],
+        minimumUsableSourcesMet: true
+      },
+      createdAt: new Date("2026-02-18T00:00:00.000Z")
+    })
+
+    const parsed = new URL(href!, "https://example.local")
+    const followUp = JSON.parse(parsed.searchParams.get("follow_up") || "{}")
+    const claimIds = followUp.background.key_claims.map(
+      (claim: { claim_id: string }) => claim.claim_id
+    )
+
+    for (const claimId of claimIds) {
+      expect(claimId).toHaveLength(128)
+      expect(claimId).not.toContain("\n")
+      expect(claimId).not.toContain("Truncated for Deep Research")
+    }
+  })
+
   it("requires completed matrix or gap artifacts with source coverage for Deep Research launch", () => {
     expect(
       isDeepResearchLaunchableLiteratureArtifact({

--- a/apps/packages/ui/src/routes/__tests__/route-paths.research.test.ts
+++ b/apps/packages/ui/src/routes/__tests__/route-paths.research.test.ts
@@ -35,6 +35,72 @@ describe("route-paths deep research launch", () => {
     expect(parsed.searchParams.get("chat_id")).toBe("chat_123")
   })
 
+  it("includes bounded follow-up context for research launches", () => {
+    const followUp = {
+      question: "Verify the peer coaching retention hypothesis.",
+      background: {
+        question: "Verify the peer coaching retention hypothesis.",
+        outline: [{ title: "Hypothesis 1", focus_area: "hypothesis_1" }],
+        key_claims: [
+          {
+            claim_id: "artifact-hypotheses:finding-1",
+            text: "Evidence-supported finding: Paper A reports higher completion."
+          }
+        ],
+        unresolved_questions: [
+          "Which parts are evidence-supported versus proposed work?"
+        ],
+        verification_summary: {
+          supported_claim_count: 1,
+          unsupported_claim_count: 1
+        },
+        source_trust_summary: {
+          high_trust_count: 2,
+          low_trust_count: 1
+        }
+      }
+    }
+    const href = buildResearchLaunchPath({
+      query: "Verify the peer coaching retention hypothesis.",
+      followUp
+    })
+    const parsed = new URL(href, "https://example.local")
+
+    expect(parsed.searchParams.get("follow_up")).toBe(JSON.stringify(followUp))
+  })
+
+  it("drops oversized follow-up context instead of building an unsafe URL", () => {
+    const href = buildResearchLaunchPath({
+      query: "Verify a large proposal seed.",
+      followUp: {
+        question: "Verify a large proposal seed.",
+        background: {
+          question: "Verify a large proposal seed.",
+          outline: [{ title: "Proposal", focus_area: "proposal" }],
+          key_claims: [
+            {
+              claim_id: "oversized-proposal-excerpt",
+              text: "x".repeat(12000)
+            }
+          ],
+          unresolved_questions: ["Which claims still need verification?"],
+          verification_summary: {
+            supported_claim_count: 1,
+            unsupported_claim_count: 1
+          },
+          source_trust_summary: {
+            high_trust_count: 1,
+            low_trust_count: 0
+          }
+        }
+      }
+    })
+    const parsed = new URL(href, "https://example.local")
+
+    expect(parsed.searchParams.get("query")).toBe("Verify a large proposal seed.")
+    expect(parsed.searchParams.get("follow_up")).toBeNull()
+  })
+
   it("omits empty launch fields", () => {
     const href = buildResearchLaunchPath({
       query: "   ",

--- a/apps/packages/ui/src/routes/route-paths.ts
+++ b/apps/packages/ui/src/routes/route-paths.ts
@@ -78,6 +78,8 @@ type BuildCharacterChatPathOptions = {
   characterId?: string | number | null
 }
 
+const MAX_RESEARCH_FOLLOW_UP_SEARCH_PARAM_LENGTH = 4096
+
 const setTrimmedSearchParam = (
   params: URLSearchParams,
   key: string,
@@ -92,15 +94,24 @@ const setTrimmedSearchParam = (
 const setJsonSearchParam = (
   params: URLSearchParams,
   key: string,
-  value: Record<string, unknown> | null | undefined
+  value: Record<string, unknown> | null | undefined,
+  options: { maxEncodedLength?: number } = {}
 ) => {
   if (!value) {
     return
   }
   const serialized = JSON.stringify(value)
-  if (serialized !== "{}") {
-    params.set(key, serialized)
+  if (serialized === "{}") {
+    return
   }
+  const encodedLength = new URLSearchParams({ [key]: serialized }).toString().length
+  if (
+    options.maxEncodedLength !== undefined &&
+    encodedLength > options.maxEncodedLength
+  ) {
+    return
+  }
+  params.set(key, serialized)
 }
 
 export const buildSourcesNewPath = (
@@ -125,7 +136,9 @@ export const buildResearchLaunchPath = (
   setTrimmedSearchParam(params, "run", options.run)
   setTrimmedSearchParam(params, "chat_id", options.chatId)
   setTrimmedSearchParam(params, "launch_message_id", options.launchMessageId)
-  setJsonSearchParam(params, "follow_up", options.followUp)
+  setJsonSearchParam(params, "follow_up", options.followUp, {
+    maxEncodedLength: MAX_RESEARCH_FOLLOW_UP_SEARCH_PARAM_LENGTH
+  })
   if (options.autorun) {
     params.set("autorun", "1")
   }

--- a/apps/packages/ui/src/routes/route-paths.ts
+++ b/apps/packages/ui/src/routes/route-paths.ts
@@ -66,6 +66,7 @@ type BuildResearchLaunchPathOptions = {
   run?: string | null
   chatId?: string | null
   launchMessageId?: string | null
+  followUp?: Record<string, unknown> | null
 }
 
 type BuildChatThreadPathOptions = {
@@ -85,6 +86,20 @@ const setTrimmedSearchParam = (
   const trimmed = value?.trim()
   if (trimmed) {
     params.set(key, trimmed)
+  }
+}
+
+const setJsonSearchParam = (
+  params: URLSearchParams,
+  key: string,
+  value: Record<string, unknown> | null | undefined
+) => {
+  if (!value) {
+    return
+  }
+  const serialized = JSON.stringify(value)
+  if (serialized !== "{}") {
+    params.set(key, serialized)
   }
 }
 
@@ -110,6 +125,7 @@ export const buildResearchLaunchPath = (
   setTrimmedSearchParam(params, "run", options.run)
   setTrimmedSearchParam(params, "chat_id", options.chatId)
   setTrimmedSearchParam(params, "launch_message_id", options.launchMessageId)
+  setJsonSearchParam(params, "follow_up", options.followUp)
   if (options.autorun) {
     params.set("autorun", "1")
   }

--- a/apps/tldw-frontend/__tests__/pages/research-run-console.test.tsx
+++ b/apps/tldw-frontend/__tests__/pages/research-run-console.test.tsx
@@ -425,6 +425,65 @@ describe('ResearchRunsPage', () => {
     });
   });
 
+  it('keeps launch follow-up background question aligned when the query is edited', async () => {
+    const user = userEvent.setup();
+    const followUp = {
+      question: 'Verify the peer coaching retention hypothesis.',
+      background: {
+        question: 'Verify the peer coaching retention hypothesis.',
+        outline: [{ title: 'Hypothesis 1', focus_area: 'hypothesis_1' }],
+        key_claims: [
+          {
+            claim_id: 'artifact-hypotheses:finding-1',
+            text: 'Evidence-supported finding: Paper A reports higher completion.'
+          }
+        ],
+        unresolved_questions: [
+          'Which parts of the hypothesis are evidence-supported versus proposed work?'
+        ],
+        verification_summary: {
+          supported_claim_count: 1,
+          unsupported_claim_count: 1
+        },
+        source_trust_summary: {
+          high_trust_count: 2,
+          low_trust_count: 1
+        }
+      }
+    };
+    const params = new URLSearchParams({
+      query: 'Verify the peer coaching retention hypothesis.',
+      source_policy: 'local_first',
+      autonomy_mode: 'checkpointed',
+      follow_up: JSON.stringify(followUp),
+      from: 'research-workspace'
+    });
+    window.history.replaceState({}, '', `/research?${params.toString()}`);
+
+    renderWithProviders(<ResearchRunsPage />);
+
+    const questionField = await screen.findByLabelText('Research question');
+    await user.clear(questionField);
+    await user.type(questionField, 'Refined peer coaching retention question.');
+    await user.click(screen.getByRole('button', { name: 'Start run' }));
+
+    await waitFor(() => {
+      expect(mocks.createResearchRun).toHaveBeenCalledWith({
+        query: 'Refined peer coaching retention question.',
+        source_policy: 'local_first',
+        autonomy_mode: 'checkpointed',
+        follow_up: {
+          ...followUp,
+          question: 'Refined peer coaching retention question.',
+          background: {
+            ...followUp.background,
+            question: 'Refined peer coaching retention question.',
+          },
+        },
+      });
+    });
+  });
+
   it('auto-creates a run from launch params when autorun is enabled', async () => {
     mocks.createResearchRun.mockResolvedValue(
       makeRun({

--- a/apps/tldw-frontend/__tests__/pages/research-run-console.test.tsx
+++ b/apps/tldw-frontend/__tests__/pages/research-run-console.test.tsx
@@ -373,6 +373,58 @@ describe('ResearchRunsPage', () => {
     expect(mocks.createResearchRun).not.toHaveBeenCalled();
   });
 
+  it('carries launch follow-up context into manual run creation', async () => {
+    const user = userEvent.setup();
+    const followUp = {
+      question: 'Verify the peer coaching retention hypothesis.',
+      background: {
+        question: 'Verify the peer coaching retention hypothesis.',
+        outline: [{ title: 'Hypothesis 1', focus_area: 'hypothesis_1' }],
+        key_claims: [
+          {
+            claim_id: 'artifact-hypotheses:finding-1',
+            text: 'Evidence-supported finding: Paper A reports higher completion.'
+          }
+        ],
+        unresolved_questions: [
+          'Which parts of the hypothesis are evidence-supported versus proposed work?'
+        ],
+        verification_summary: {
+          supported_claim_count: 1,
+          unsupported_claim_count: 1
+        },
+        source_trust_summary: {
+          high_trust_count: 2,
+          low_trust_count: 1
+        }
+      }
+    };
+    const params = new URLSearchParams({
+      query: 'Verify the peer coaching retention hypothesis.',
+      source_policy: 'local_first',
+      autonomy_mode: 'checkpointed',
+      follow_up: JSON.stringify(followUp),
+      from: 'research-workspace'
+    });
+    window.history.replaceState({}, '', `/research?${params.toString()}`);
+
+    renderWithProviders(<ResearchRunsPage />);
+
+    expect(
+      await screen.findByDisplayValue('Verify the peer coaching retention hypothesis.')
+    ).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: 'Start run' }));
+
+    await waitFor(() => {
+      expect(mocks.createResearchRun).toHaveBeenCalledWith({
+        query: 'Verify the peer coaching retention hypothesis.',
+        source_policy: 'local_first',
+        autonomy_mode: 'checkpointed',
+        follow_up: followUp,
+      });
+    });
+  });
+
   it('auto-creates a run from launch params when autorun is enabled', async () => {
     mocks.createResearchRun.mockResolvedValue(
       makeRun({

--- a/apps/tldw-frontend/__tests__/pages/research-run-console.test.tsx
+++ b/apps/tldw-frontend/__tests__/pages/research-run-console.test.tsx
@@ -484,6 +484,67 @@ describe('ResearchRunsPage', () => {
     });
   });
 
+  it('bounds unresolved question entries parsed from launch follow-up context', async () => {
+    const user = userEvent.setup();
+    const oversizedQuestion = 'x'.repeat(2200);
+    const followUp = {
+      question: 'Verify bounded unresolved questions.',
+      background: {
+        question: 'Verify bounded unresolved questions.',
+        outline: [{ title: 'Hypothesis 1', focus_area: 'hypothesis_1' }],
+        key_claims: [
+          {
+            claim_id: 'artifact-hypotheses:finding-1',
+            text: 'Evidence-supported finding: Paper A reports higher completion.'
+          }
+        ],
+        unresolved_questions: [
+          oversizedQuestion,
+          'Which claims still need a primary source?',
+          oversizedQuestion
+        ],
+        verification_summary: {
+          supported_claim_count: 1,
+          unsupported_claim_count: 1
+        },
+        source_trust_summary: {
+          high_trust_count: 2,
+          low_trust_count: 1
+        }
+      }
+    };
+    const params = new URLSearchParams({
+      query: 'Verify bounded unresolved questions.',
+      source_policy: 'local_first',
+      autonomy_mode: 'checkpointed',
+      follow_up: JSON.stringify(followUp),
+      from: 'research-workspace'
+    });
+    window.history.replaceState({}, '', `/research?${params.toString()}`);
+
+    renderWithProviders(<ResearchRunsPage />);
+
+    expect(
+      await screen.findByDisplayValue('Verify bounded unresolved questions.')
+    ).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: 'Start run' }));
+
+    await waitFor(() => {
+      expect(mocks.createResearchRun).toHaveBeenCalledWith(
+        expect.objectContaining({
+          follow_up: expect.objectContaining({
+            background: expect.objectContaining({
+              unresolved_questions: [
+                'x'.repeat(1800),
+                'Which claims still need a primary source?',
+              ],
+            }),
+          }),
+        })
+      );
+    });
+  });
+
   it('auto-creates a run from launch params when autorun is enabled', async () => {
     mocks.createResearchRun.mockResolvedValue(
       makeRun({

--- a/apps/tldw-frontend/pages/research.tsx
+++ b/apps/tldw-frontend/pages/research.tsx
@@ -489,6 +489,20 @@ function normalizeLaunchClaims(value: unknown): NonNullable<
     .slice(0, 5);
 }
 
+function normalizeLaunchUnresolvedQuestions(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  const normalized: string[] = [];
+  value.forEach((item) => {
+    const candidate = normalizeLaunchString(item, 1800);
+    if (candidate && !normalized.includes(candidate)) {
+      normalized.push(candidate);
+    }
+  });
+  return normalized.slice(0, 5);
+}
+
 function parseResearchLaunchFollowUp(raw: string | null): ResearchRunCreateRequest['follow_up'] | null {
   if (!raw) {
     return null;
@@ -519,7 +533,7 @@ function parseResearchLaunchFollowUp(raw: string | null): ResearchRunCreateReque
       question: normalizeLaunchString(backgroundRecord.question, 4000) || question,
       outline: normalizeLaunchOutline(backgroundRecord.outline),
       key_claims: normalizeLaunchClaims(backgroundRecord.key_claims),
-      unresolved_questions: normalizeStringList(backgroundRecord.unresolved_questions).slice(0, 5),
+      unresolved_questions: normalizeLaunchUnresolvedQuestions(backgroundRecord.unresolved_questions),
       verification_summary: {
         supported_claim_count: normalizeLaunchCount(verificationSummary?.supported_claim_count),
         unsupported_claim_count: normalizeLaunchCount(verificationSummary?.unsupported_claim_count),

--- a/apps/tldw-frontend/pages/research.tsx
+++ b/apps/tldw-frontend/pages/research.tsx
@@ -536,6 +536,21 @@ function buildResearchRunCreatePayload(
   query: string,
   launchParams: ResearchLaunchParams | null
 ): ResearchRunCreateRequest {
+  const followUp = launchParams?.followUp
+    ? {
+        ...launchParams.followUp,
+        question: query,
+        ...(launchParams.followUp.background
+          ? {
+              background: {
+                ...launchParams.followUp.background,
+                question: query,
+              },
+            }
+          : {}),
+      }
+    : null;
+
   return {
     query,
     source_policy: launchParams?.sourcePolicy ?? 'balanced',
@@ -548,12 +563,9 @@ function buildResearchRunCreatePayload(
           },
         }
       : {}),
-    ...(launchParams?.followUp
+    ...(followUp
       ? {
-          follow_up: {
-            ...launchParams.followUp,
-            question: query,
-          },
+          follow_up: followUp,
         }
       : {}),
   };

--- a/apps/tldw-frontend/pages/research.tsx
+++ b/apps/tldw-frontend/pages/research.tsx
@@ -18,6 +18,7 @@ import {
   type ResearchBundle,
   type ResearchCheckpointSummary,
   type ResearchContradiction,
+  type ResearchRunCreateRequest,
   type ResearchOutlineCheckpointPayload,
   type ResearchOutlineSeedSection,
   type ResearchPlanCheckpointPayload,
@@ -50,6 +51,7 @@ type ResearchLaunchParams = {
   runId: string | null;
   chatId: string | null;
   launchMessageId: string | null;
+  followUp: ResearchRunCreateRequest['follow_up'] | null;
 };
 
 type ConsoleState = {
@@ -401,6 +403,7 @@ function parseResearchLaunchParams(search: string): ResearchLaunchParams {
   const runId = params.get('run')?.trim() || null;
   const chatId = params.get('chat_id')?.trim() || null;
   const launchMessageId = params.get('launch_message_id')?.trim() || null;
+  const followUp = parseResearchLaunchFollowUp(params.get('follow_up'));
   return {
     query,
     sourcePolicy,
@@ -409,6 +412,7 @@ function parseResearchLaunchParams(search: string): ResearchLaunchParams {
     runId,
     chatId,
     launchMessageId,
+    followUp,
   };
 }
 
@@ -424,6 +428,7 @@ function replaceResearchLaunchUrl(runId: string | null) {
   nextUrl.searchParams.delete('from');
   nextUrl.searchParams.delete('chat_id');
   nextUrl.searchParams.delete('launch_message_id');
+  nextUrl.searchParams.delete('follow_up');
   if (runId) {
     nextUrl.searchParams.set('run', runId);
   } else {
@@ -431,6 +436,127 @@ function replaceResearchLaunchUrl(runId: string | null) {
   }
   const search = nextUrl.searchParams.toString();
   window.history.replaceState({}, '', `${nextUrl.pathname}${search ? `?${search}` : ''}${nextUrl.hash}`);
+}
+
+function normalizeLaunchString(value: unknown, maxLength: number): string {
+  return String(value ?? '').trim().slice(0, maxLength).trim();
+}
+
+function normalizeLaunchCount(value: unknown): number {
+  return typeof value === 'number' && Number.isFinite(value) && value > 0
+    ? Math.floor(value)
+    : 0;
+}
+
+function normalizeLaunchOutline(value: unknown): NonNullable<
+  NonNullable<ResearchRunCreateRequest['follow_up']>['background']
+>['outline'] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value
+    .filter((item): item is Record<string, unknown> => Boolean(asObjectRecord(item)))
+    .map((item) => {
+      const title = normalizeLaunchString(item.title, 500);
+      const focusArea = normalizeLaunchString(item.focus_area, 200);
+      return {
+        title,
+        ...(focusArea ? { focus_area: focusArea } : {}),
+      };
+    })
+    .filter((item) => item.title.length > 0)
+    .slice(0, 7);
+}
+
+function normalizeLaunchClaims(value: unknown): NonNullable<
+  NonNullable<ResearchRunCreateRequest['follow_up']>['background']
+>['key_claims'] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value
+    .filter((item): item is Record<string, unknown> => Boolean(asObjectRecord(item)))
+    .map((item, index) => {
+      const claimId =
+        normalizeLaunchString(item.claim_id, 128) || `launch-follow-up-claim-${index + 1}`;
+      const text = normalizeLaunchString(item.text, 4000);
+      return {
+        claim_id: claimId,
+        text,
+      };
+    })
+    .filter((item) => item.text.length > 0)
+    .slice(0, 5);
+}
+
+function parseResearchLaunchFollowUp(raw: string | null): ResearchRunCreateRequest['follow_up'] | null {
+  if (!raw) {
+    return null;
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+  const record = asObjectRecord(parsed);
+  if (!record) {
+    return null;
+  }
+  const question = normalizeLaunchString(record.question, 4000);
+  if (!question) {
+    return null;
+  }
+  const backgroundRecord = asObjectRecord(record.background);
+  if (!backgroundRecord) {
+    return { question };
+  }
+  const verificationSummary = asObjectRecord(backgroundRecord.verification_summary);
+  const sourceTrustSummary = asObjectRecord(backgroundRecord.source_trust_summary);
+  return {
+    question,
+    background: {
+      question: normalizeLaunchString(backgroundRecord.question, 4000) || question,
+      outline: normalizeLaunchOutline(backgroundRecord.outline),
+      key_claims: normalizeLaunchClaims(backgroundRecord.key_claims),
+      unresolved_questions: normalizeStringList(backgroundRecord.unresolved_questions).slice(0, 5),
+      verification_summary: {
+        supported_claim_count: normalizeLaunchCount(verificationSummary?.supported_claim_count),
+        unsupported_claim_count: normalizeLaunchCount(verificationSummary?.unsupported_claim_count),
+      },
+      source_trust_summary: {
+        high_trust_count: normalizeLaunchCount(sourceTrustSummary?.high_trust_count),
+        low_trust_count: normalizeLaunchCount(sourceTrustSummary?.low_trust_count),
+      },
+    },
+  };
+}
+
+function buildResearchRunCreatePayload(
+  query: string,
+  launchParams: ResearchLaunchParams | null
+): ResearchRunCreateRequest {
+  return {
+    query,
+    source_policy: launchParams?.sourcePolicy ?? 'balanced',
+    autonomy_mode: launchParams?.autonomyMode ?? 'checkpointed',
+    ...(launchParams?.chatId
+      ? {
+          chat_handoff: {
+            chat_id: launchParams.chatId,
+            ...(launchParams.launchMessageId ? { launch_message_id: launchParams.launchMessageId } : {}),
+          },
+        }
+      : {}),
+    ...(launchParams?.followUp
+      ? {
+          follow_up: {
+            ...launchParams.followUp,
+            question: query,
+          },
+        }
+      : {}),
+  };
 }
 
 type PlanCheckpointEditorState = {
@@ -834,21 +960,9 @@ export default function ResearchRunsPage() {
     let cancelled = false;
     void (async () => {
       try {
-        const createdRun = await createResearchRun({
-          query: launchParams.query!,
-          source_policy: launchParams.sourcePolicy ?? 'balanced',
-          autonomy_mode: launchParams.autonomyMode ?? 'checkpointed',
-          ...(launchParams.chatId
-            ? {
-                chat_handoff: {
-                  chat_id: launchParams.chatId,
-                  ...(launchParams.launchMessageId
-                    ? { launch_message_id: launchParams.launchMessageId }
-                    : {}),
-                },
-              }
-            : {}),
-        });
+        const createdRun = await createResearchRun(
+          buildResearchRunCreatePayload(launchParams.query!, launchParams)
+        );
         if (cancelled) {
           return;
         }
@@ -868,6 +982,7 @@ export default function ResearchRunsPage() {
                 runId: createdRun.id,
                 chatId: null,
                 launchMessageId: null,
+                followUp: null,
               }
             : current
         );
@@ -979,17 +1094,29 @@ export default function ResearchRunsPage() {
       return;
     }
     try {
-      const createdRun = await createResearchRun({
-        query: trimmed,
-        source_policy: 'balanced',
-        autonomy_mode: 'checkpointed',
-      });
+      const createdRun = await createResearchRun(
+        buildResearchRunCreatePayload(trimmed, launchParams)
+      );
       queryClient.setQueryData<ResearchRunListItem[]>(['research-runs'], (current) =>
         upsertListItem(current, createdRun, trimmed)
       );
       setSelectedRunId(createdRun.id);
       dispatch({ type: 'replace-run', run: createdRun });
       setQuestion('');
+      replaceResearchLaunchUrl(createdRun.id);
+      setLaunchParams((current) =>
+        current
+          ? {
+              ...current,
+              autorun: false,
+              query: null,
+              runId: createdRun.id,
+              chatId: null,
+              launchMessageId: null,
+              followUp: null,
+            }
+          : current
+      );
     } catch (error) {
       show({
         title: 'Run creation failed',

--- a/backlog/tasks/task-488 - Seed-Deep-Research-follow-ups-from-hypotheses-and-proposals.md
+++ b/backlog/tasks/task-488 - Seed-Deep-Research-follow-ups-from-hypotheses-and-proposals.md
@@ -28,6 +28,7 @@ Follow-up after the Research Workspace literature work-products MVP. Seed Deep R
 - Added bounded follow_up seed construction for hypothesis/proposal artifacts using ResearchRunCreateRequest-compatible fields only: question, outline, key_claims, unresolved_questions, verification_summary, and source_trust_summary.
 - Added source-coverage claims and explicit evidence-supported versus proposed-work follow-up questions so Deep Research starts with the right separation instead of treating proposal text as verified fact.
 - Added follow_up query-param support to shared research launch paths and taught /research to parse, sanitize, and forward that seed during manual and autorun create-run flows.
+- Addressed PR review comments by preserving nested markdown subheading content inside proposal follow-up sections and replacing launch-context truncation for claim_id values with a clean 128-character slice.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary
@@ -38,6 +39,8 @@ Implemented TASK-488 by seeding Deep Research follow_up payloads from Research W
 Verification:
 - `bunx vitest run src/components/Option/ResearchWorkspace/__tests__/StudioPane.literature-workproducts.test.tsx src/routes/__tests__/route-paths.research.test.ts` passed with 30 tests.
 - `bunx vitest run __tests__/pages/research-run-console.test.tsx` passed with 16 tests.
+- After review fixes, `bunx vitest run src/components/Option/ResearchWorkspace/__tests__/StudioPane.literature-workproducts.test.tsx src/routes/__tests__/route-paths.research.test.ts` passed with 32 tests.
+- After review fixes, `bunx vitest run __tests__/pages/research-run-console.test.tsx` passed with 16 tests.
 - `NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit --pretty false` passed in `apps/packages/ui`.
 - `git diff --check` passed.
 - `bunx tsc --noEmit --pretty false` in `apps/tldw-frontend` still fails on existing e2e/admin baseline type errors outside the touched research page.

--- a/backlog/tasks/task-488 - Seed-Deep-Research-follow-ups-from-hypotheses-and-proposals.md
+++ b/backlog/tasks/task-488 - Seed-Deep-Research-follow-ups-from-hypotheses-and-proposals.md
@@ -29,6 +29,7 @@ Follow-up after the Research Workspace literature work-products MVP. Seed Deep R
 - Added source-coverage claims and explicit evidence-supported versus proposed-work follow-up questions so Deep Research starts with the right separation instead of treating proposal text as verified fact.
 - Added follow_up query-param support to shared research launch paths and taught /research to parse, sanitize, and forward that seed during manual and autorun create-run flows.
 - Addressed PR review comments by preserving nested markdown subheading content inside proposal follow-up sections and replacing launch-context truncation for claim_id values with a clean 128-character slice.
+- Addressed follow-up PR review comments by keeping edited launch queries aligned across follow_up.question and follow_up.background.question, and by dropping oversized follow_up URL params before building /research launch paths.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary
@@ -41,6 +42,8 @@ Verification:
 - `bunx vitest run __tests__/pages/research-run-console.test.tsx` passed with 16 tests.
 - After review fixes, `bunx vitest run src/components/Option/ResearchWorkspace/__tests__/StudioPane.literature-workproducts.test.tsx src/routes/__tests__/route-paths.research.test.ts` passed with 32 tests.
 - After review fixes, `bunx vitest run __tests__/pages/research-run-console.test.tsx` passed with 16 tests.
+- After Qodo review fixes, `bunx vitest run src/components/Option/ResearchWorkspace/__tests__/StudioPane.literature-workproducts.test.tsx src/routes/__tests__/route-paths.research.test.ts` passed with 34 tests.
+- After Qodo review fixes, `bunx vitest run __tests__/pages/research-run-console.test.tsx` passed with 17 tests.
 - `NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit --pretty false` passed in `apps/packages/ui`.
 - `git diff --check` passed.
 - `bunx tsc --noEmit --pretty false` in `apps/tldw-frontend` still fails on existing e2e/admin baseline type errors outside the touched research page.

--- a/backlog/tasks/task-488 - Seed-Deep-Research-follow-ups-from-hypotheses-and-proposals.md
+++ b/backlog/tasks/task-488 - Seed-Deep-Research-follow-ups-from-hypotheses-and-proposals.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-488
 title: Seed Deep Research follow-ups from hypotheses and proposals
-status: To Do
+status: Done
 documentation:
 - Docs/Product/Research_Workspace_Literature_Workproducts_PRD.md
 - Docs/superpowers/plans/2026-05-30-research-workspace-literature-workproducts-plan.md
@@ -15,26 +15,41 @@ Follow-up after the Research Workspace literature work-products MVP. Seed Deep R
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
+- [x] #1 Evidence-Bound Hypotheses artifacts can launch Deep Research with a bounded follow_up payload that carries hypothesis outline, evidence-backed claims, source coverage, and evidence/proposed-work separation questions.
+- [x] #2 Research Proposal Pack artifacts can launch Deep Research with a bounded follow_up payload that separates literature evidence from proposed work and carries source coverage.
+- [x] #3 The /research console parses follow_up launch params and includes them in ResearchRunCreateRequest for manual and autorun launches.
+- [x] #4 Focused route, Research Workspace, and research console tests pass; package-wide type-check limitations are documented.
 <!-- AC:END -->
 
 ## Implementation Notes
 
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
-
+- Extended the Research Workspace Deep Research launch helper to support Evidence-Bound Hypotheses and Research Proposal Pack artifacts in addition to Matrix and Gap Finder artifacts.
+- Added bounded follow_up seed construction for hypothesis/proposal artifacts using ResearchRunCreateRequest-compatible fields only: question, outline, key_claims, unresolved_questions, verification_summary, and source_trust_summary.
+- Added source-coverage claims and explicit evidence-supported versus proposed-work follow-up questions so Deep Research starts with the right separation instead of treating proposal text as verified fact.
+- Added follow_up query-param support to shared research launch paths and taught /research to parse, sanitize, and forward that seed during manual and autorun create-run flows.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Implemented TASK-488 by seeding Deep Research follow_up payloads from Research Workspace Evidence-Bound Hypotheses and Research Proposal Pack artifacts. Hypothesis launches now carry hypothesis outline entries, evidence-backed key claims, source coverage, and unresolved questions that separate evidence from proposed work. Proposal launches now carry literature-evidence and proposed-work outline entries, bounded excerpts, source coverage, and the same verification-oriented unresolved questions. The /research console now parses follow_up launch params, forwards them into ResearchRunCreateRequest for manual and autorun launches, applies launch source_policy/autonomy_mode during manual creation, and clears launch context after creating a run.
 
+Verification:
+- `bunx vitest run src/components/Option/ResearchWorkspace/__tests__/StudioPane.literature-workproducts.test.tsx src/routes/__tests__/route-paths.research.test.ts` passed with 30 tests.
+- `bunx vitest run __tests__/pages/research-run-console.test.tsx` passed with 16 tests.
+- `NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit --pretty false` passed in `apps/packages/ui`.
+- `git diff --check` passed.
+- `bunx tsc --noEmit --pretty false` in `apps/tldw-frontend` still fails on existing e2e/admin baseline type errors outside the touched research page.
+- Bandit skipped because this slice touched only TypeScript/TSX frontend code.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->

--- a/backlog/tasks/task-488 - Seed-Deep-Research-follow-ups-from-hypotheses-and-proposals.md
+++ b/backlog/tasks/task-488 - Seed-Deep-Research-follow-ups-from-hypotheses-and-proposals.md
@@ -30,6 +30,7 @@ Follow-up after the Research Workspace literature work-products MVP. Seed Deep R
 - Added follow_up query-param support to shared research launch paths and taught /research to parse, sanitize, and forward that seed during manual and autorun create-run flows.
 - Addressed PR review comments by preserving nested markdown subheading content inside proposal follow-up sections and replacing launch-context truncation for claim_id values with a clean 128-character slice.
 - Addressed follow-up PR review comments by keeping edited launch queries aligned across follow_up.question and follow_up.background.question, and by dropping oversized follow_up URL params before building /research launch paths.
+- Addressed Qodo advisory by truncating and deduping unresolved-question entries parsed from launch follow_up URL payloads before create-run submission.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary
@@ -44,6 +45,8 @@ Verification:
 - After review fixes, `bunx vitest run __tests__/pages/research-run-console.test.tsx` passed with 16 tests.
 - After Qodo review fixes, `bunx vitest run src/components/Option/ResearchWorkspace/__tests__/StudioPane.literature-workproducts.test.tsx src/routes/__tests__/route-paths.research.test.ts` passed with 34 tests.
 - After Qodo review fixes, `bunx vitest run __tests__/pages/research-run-console.test.tsx` passed with 17 tests.
+- After the unresolved-question advisory fix, `bunx vitest run src/components/Option/ResearchWorkspace/__tests__/StudioPane.literature-workproducts.test.tsx src/routes/__tests__/route-paths.research.test.ts` passed with 34 tests.
+- After the unresolved-question advisory fix, `bunx vitest run __tests__/pages/research-run-console.test.tsx` passed with 18 tests.
 - `NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit --pretty false` passed in `apps/packages/ui`.
 - `git diff --check` passed.
 - `bunx tsc --noEmit --pretty false` in `apps/tldw-frontend` still fails on existing e2e/admin baseline type errors outside the touched research page.


### PR DESCRIPTION
## Change summary (maintainer-owned)

Maintainer to fill before merge per AI-generated PR policy.

## AI implementation summary

- Added Research Workspace Deep Research launch seeds for Evidence-Bound Hypotheses and Research Proposal Pack artifacts.
- Added bounded `follow_up` query-param support in shared research launch paths and `/research` create-run handling.
- Preserved the MVP Research Workspace boundary while using the existing `/research` run console as the later-stage handoff target.
- Updated TASK-488 with acceptance criteria, implementation notes, verification, and frontend-only Bandit skip rationale.

## Verification

- `bunx vitest run src/components/Option/ResearchWorkspace/__tests__/StudioPane.literature-workproducts.test.tsx src/routes/__tests__/route-paths.research.test.ts` passed with 30 tests.
- `bunx vitest run __tests__/pages/research-run-console.test.tsx` passed with 16 tests.
- `NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit --pretty false` passed in `apps/packages/ui`.
- `git diff --check` passed.

## Known baseline

- `bunx tsc --noEmit --pretty false` in `apps/tldw-frontend` still fails on existing e2e/admin type errors outside the touched research page.
- Bandit skipped because this slice touched only TypeScript/TSX frontend code.

## UX Audit Checklist

- [x] Keeps Research Workspace and Deep Research as distinct surfaces.
- [x] Uses existing icon-only Deep Research action affordance.
- [x] Does not introduce new visible in-app explanatory copy.
- [x] Keeps launch payloads bounded and source-coverage aware.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Seeds Deep Research launches from Evidence-Bound Hypotheses and Research Proposal Pack artifacts with a bounded follow_up payload. Updates the /research launch paths and console to accept, sanitize, and forward it for manual and autorun runs with safe URL handling and size limits (TASK-488).

- **New Features**
  - Hypotheses: build follow_up with outline, evidence-backed key_claims plus a source-coverage claim, unresolved questions, and verification/source-trust summaries; normalize hypothesis data; cap claim_id at 128 chars.
  - Proposals: separate evidence vs proposed work via markdown sections (e.g., Literature Overview, Proposed Hypothesis, Methodology), preserve nested subheadings, add bounded excerpts and a source-coverage claim.
  - Routing: add a JSON follow_up query param to research launch URLs with a 4KB encoded cap; drop it if oversized; require a seedable follow_up for hypothesis/proposal artifacts; keep query within existing bounds.
  - Console: parse and sanitize follow_up; bound/dedupe unresolved_questions (1.8k chars each, max 5); keep edited queries synced to follow_up.question and background.question; include follow_up in manual and autorun create requests; clear launch params after run creation; enforce minimum usable sources.

<sup>Written for commit 76d0647c64b23e286db17aa81b0817779edcb781. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2164?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

