### PR TITLE
Migrate rate limiting admin alerts to design system

### DIFF
--- a/apps/packages/ui/scripts/design-system-product-state-baseline.json
+++ b/apps/packages/ui/scripts/design-system-product-state-baseline.json
@@ -77,61 +77,6 @@
     "migrationQueue": "shared-product-state"
   },
   {
-    "id": "antd-product-state-import:src/components/Option/Admin/RateLimitingPage.tsx:Alert#antd-alert-ratelimitingpage-type-error-access-denied-you-snzu3t",
-    "path": "src/components/Option/Admin/RateLimitingPage.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/Option/Admin/RateLimitingPage.tsx before the stable duplicate-id guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
-    "id": "antd-product-state-import:src/components/Option/Admin/RateLimitingPage.tsx:Alert#antd-alert-ratelimitingpage-type-info-line-304-1ygiko7",
-    "path": "src/components/Option/Admin/RateLimitingPage.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/Option/Admin/RateLimitingPage.tsx before the stable duplicate-id guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
-    "id": "antd-product-state-import:src/components/Option/Admin/RateLimitingPage.tsx:Alert#antd-alert-ratelimitingpage-type-info-no-coverage-data-l-w560el",
-    "path": "src/components/Option/Admin/RateLimitingPage.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/Option/Admin/RateLimitingPage.tsx before the stable duplicate-id guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
-    "id": "antd-product-state-import:src/components/Option/Admin/RateLimitingPage.tsx:Alert#antd-alert-ratelimitingpage-type-info-no-policy-data-loa-v2yfeq",
-    "path": "src/components/Option/Admin/RateLimitingPage.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/Option/Admin/RateLimitingPage.tsx before the stable duplicate-id guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
-    "id": "antd-product-state-import:src/components/Option/Admin/RateLimitingPage.tsx:Alert#antd-alert-ratelimitingpage-type-warning-not-available-r-nd5eoc",
-    "path": "src/components/Option/Admin/RateLimitingPage.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/Option/Admin/RateLimitingPage.tsx before the stable duplicate-id guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
     "id": "antd-product-state-import:src/components/Option/AudiobookStudio/AudiobookStudioPage.tsx:Tag",
     "path": "src/components/Option/AudiobookStudio/AudiobookStudioPage.tsx",
     "rule": "antd-product-state-import",

--- a/apps/packages/ui/src/components/Option/Admin/RateLimitingPage.tsx
+++ b/apps/packages/ui/src/components/Option/Admin/RateLimitingPage.tsx
@@ -3,7 +3,6 @@ import {
   Card,
   Table,
   Tag,
-  Alert,
   Button,
   Space,
   Progress,
@@ -13,6 +12,7 @@ import {
   deriveAdminGuardFromError,
   sanitizeAdminErrorMessage
 } from "./admin-error-utils"
+import { Alert } from "@/components/ui/primitives"
 import { useCanonicalConnectionConfig } from "@/hooks/useCanonicalConnectionConfig"
 import { tldwClient } from "@/services/tldw/TldwApiClient"
 
@@ -193,10 +193,18 @@ const RateLimitingPage: React.FC = () => {
   // ── Render ──
 
   if (adminGuard === "forbidden") {
-    return <Alert type="error" title="Access Denied" description="You don't have permission to access rate limiting administration." showIcon />
+    return (
+      <Alert variant="error" title="Access Denied">
+        You don't have permission to access rate limiting administration.
+      </Alert>
+    )
   }
   if (adminGuard === "notFound") {
-    return <Alert type="warning" title="Not Available" description="Rate limiting administration is not available on this server." showIcon />
+    return (
+      <Alert variant="warning" title="Not Available">
+        Rate limiting administration is not available on this server.
+      </Alert>
+    )
   }
 
   return (
@@ -241,7 +249,7 @@ const RateLimitingPage: React.FC = () => {
             )}
           </Space>
         ) : (
-          <Alert type="info" title="No policy data loaded yet." showIcon />
+          <Alert title="No policy data loaded yet." />
         )}
       </Card>
 
@@ -286,7 +294,7 @@ const RateLimitingPage: React.FC = () => {
             )}
           </Space>
         ) : (
-          <Alert type="info" title="No coverage data loaded yet." showIcon />
+          <Alert title="No coverage data loaded yet." />
         )}
       </Card>
 
@@ -301,7 +309,7 @@ const RateLimitingPage: React.FC = () => {
         }
       >
         {rateLimitsError ? (
-          <Alert type="info" title={rateLimitsError} showIcon />
+          <Alert title={rateLimitsError} />
         ) : (
           <Table
             dataSource={rateLimits}

--- a/apps/packages/ui/src/components/Option/Admin/__tests__/RateLimitingPage.test.tsx
+++ b/apps/packages/ui/src/components/Option/Admin/__tests__/RateLimitingPage.test.tsx
@@ -28,6 +28,14 @@ import RateLimitingPage from "../RateLimitingPage"
 const fetchMock = vi.fn()
 vi.stubGlobal("fetch", fetchMock)
 
+const expectDesignSystemAlertForText = async (text: string) => {
+  const title = await screen.findByText(text)
+  const alert = title.closest('[data-ds-component="Alert"]')
+
+  expect(alert).not.toBeNull()
+  return alert as HTMLElement
+}
+
 describe("RateLimitingPage", () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -67,6 +75,52 @@ describe("RateLimitingPage", () => {
       unprotected: [],
       coverage_pct: 100
     })
+    mocks.listAdminRateLimits.mockResolvedValue([])
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        paths: {
+          "/api/v1/admin/rate-limits": {}
+        }
+      })
+    })
+  })
+
+  it("renders forbidden guard feedback through the design-system Alert primitive", async () => {
+    mocks.getGovernorPolicy.mockRejectedValueOnce({ status: 403 })
+
+    render(<RateLimitingPage />)
+
+    const alert = await expectDesignSystemAlertForText("Access Denied")
+    expect(alert).toHaveAttribute("role", "alert")
+    expect(alert).toHaveTextContent(
+      "You don't have permission to access rate limiting administration."
+    )
+  })
+
+  it("renders missing-endpoint guard feedback through the design-system Alert primitive", async () => {
+    mocks.getGovernorPolicy.mockRejectedValueOnce({ status: 404 })
+
+    render(<RateLimitingPage />)
+
+    const alert = await expectDesignSystemAlertForText("Not Available")
+    expect(alert).toHaveAttribute("role", "alert")
+    expect(alert).toHaveTextContent(
+      "Rate limiting administration is not available on this server."
+    )
+  })
+
+  it("renders empty policy and coverage feedback through the design-system Alert primitive", async () => {
+    mocks.getGovernorPolicy.mockResolvedValueOnce(null)
+    mocks.getGovernorCoverage.mockResolvedValueOnce(null)
+
+    render(<RateLimitingPage />)
+
+    const policyAlert = await expectDesignSystemAlertForText("No policy data loaded yet.")
+    expect(policyAlert).toHaveAttribute("role", "status")
+
+    const coverageAlert = await expectDesignSystemAlertForText("No coverage data loaded yet.")
+    expect(coverageAlert).toHaveAttribute("role", "status")
   })
 
   it("shows an unsupported-state message without calling admin rate-limits when the route is absent", async () => {
@@ -82,6 +136,10 @@ describe("RateLimitingPage", () => {
     expect(
       await screen.findByText("Rate limits listing endpoint is not available on this server.")
     ).toBeInTheDocument()
+    const alert = await expectDesignSystemAlertForText(
+      "Rate limits listing endpoint is not available on this server."
+    )
+    expect(alert).toHaveAttribute("role", "status")
     expect(mocks.listAdminRateLimits).not.toHaveBeenCalled()
   })
 })

--- a/backlog/tasks/task-45.44.7 - Migrate-design-system-product-state-Admin-and-health-expansion.md
+++ b/backlog/tasks/task-45.44.7 - Migrate-design-system-product-state-Admin-and-health-expansion.md
@@ -87,6 +87,16 @@ documentation:
   Verifier evidence:
     - scoped verifier log had no ApiKeyManagementPage findings
     - full verifier remains blocked by unrelated current-dev findings in IntegrationPolicyPanel, WritingActionBar, Notes, and ResearchWorkspace plus stale IntegrationPolicyPanel baseline entries outside this slice
+- |-
+  TASK-45.44.7.12 / PR #2165 migrated RateLimitingPage access denied, not-available, empty policy, empty coverage, and rate-limits unavailable feedback from AntD Alert to the design-system Alert primitive.
+  Baseline file evidence:
+    - total baseline rows: 170 -> 165
+    - Admin path rows: 12 -> 7
+    - RateLimitingPage target rows: 5 -> 0
+
+  Verifier evidence:
+    - scoped verifier log had no RateLimitingPage findings
+    - full verifier remains blocked by unrelated current-dev findings in IntegrationPolicyPanel, WritingActionBar, Notes, and ResearchWorkspace plus stale IntegrationPolicyPanel baseline entries outside this slice
 parent_task_id: TASK-45.44
 priority: medium
 ---

--- a/backlog/tasks/task-45.44.7.12 - Migrate-RateLimitingPage-alerts-to-design-system-Alert.md
+++ b/backlog/tasks/task-45.44.7.12 - Migrate-RateLimitingPage-alerts-to-design-system-Alert.md
@@ -1,0 +1,67 @@
+---
+id: TASK-45.44.7.12
+title: Migrate RateLimitingPage alerts to design-system Alert
+status: In Progress
+priority: Medium
+parent_task_id: TASK-45.44.7
+modified_files:
+- apps/packages/ui/src/components/Option/Admin/RateLimitingPage.tsx
+- apps/packages/ui/src/components/Option/Admin/__tests__/RateLimitingPage.test.tsx
+- apps/packages/ui/scripts/design-system-product-state-baseline.json
+- backlog/tasks/task-45.44.7 - Migrate-design-system-product-state-Admin-and-health-expansion.md
+labels:
+- design-system
+- webui
+- product-state
+references:
+- https://github.com/rmusser01/tldw_server/issues/1664
+- apps/packages/ui/scripts/design-system-product-state-baseline.json
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Migrate RateLimitingPage access denied, not-available, empty policy, empty coverage, and rate-limits unavailable feedback from AntD Alert to the design-system Alert primitive with focused regression coverage and product-state baseline cleanup.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 RateLimitingPage access denied and not-available guard states render through the design-system Alert primitive.
+- [ ] #2 RateLimitingPage empty policy, empty coverage, and rate-limits unavailable feedback render through the design-system Alert primitive.
+- [ ] #3 The product-state baseline no longer contains RateLimitingPage Alert entries.
+- [ ] #4 Focused regression coverage proves the migration and the product-state guard has no RateLimitingPage findings.
+- [ ] #5 Final summary added with verification evidence.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+2026-05-30:
+- Added focused RateLimitingPage design-system regression coverage for forbidden guard, missing-endpoint guard, empty policy feedback, empty coverage feedback, and rate-limits unavailable feedback.
+- RED evidence: `bunx vitest run src/components/Option/Admin/__tests__/RateLimitingPage.test.tsx --reporter=dot` failed with 4 expected assertions at missing `data-ds-component="Alert"` ancestors.
+- Migrated the five AntD Alert branches to the design-system Alert primitive while preserving existing copy.
+- Removed the five RateLimitingPage Alert baseline entries.
+- GREEN evidence: `bunx vitest run src/components/Option/Admin/__tests__/RateLimitingPage.test.tsx --reporter=dot` passed 1 file / 4 tests.
+- Guard evidence: `bunx vitest run src/design-system/__tests__/product-state-guard.test.ts --reporter=dot` passed 1 file / 54 tests.
+- Baseline count evidence: total rows 170 -> 165; Admin path rows 12 -> 7; RateLimitingPage target rows 5 -> 0.
+- `git diff --check` passed.
+- `env NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit --pretty false` passed.
+- `bun run verify:design-system-state` remains blocked by unrelated current-dev findings in IntegrationPolicyPanel, WritingActionBar, Notes, and ResearchWorkspace plus stale IntegrationPolicyPanel baseline entries; the filtered log contains no RateLimitingPage findings.
+- Bandit skipped because this slice only touches TypeScript, TSX, JSON, and Backlog markdown.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-45.44.7.12 - Migrate-RateLimitingPage-alerts-to-design-system-Alert.md
+++ b/backlog/tasks/task-45.44.7.12 - Migrate-RateLimitingPage-alerts-to-design-system-Alert.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-45.44.7.12
 title: Migrate RateLimitingPage alerts to design-system Alert
-status: In Progress
+status: Done
 priority: Medium
 parent_task_id: TASK-45.44.7
 modified_files:
@@ -16,6 +16,7 @@ labels:
 references:
 - https://github.com/rmusser01/tldw_server/issues/1664
 - apps/packages/ui/scripts/design-system-product-state-baseline.json
+- https://github.com/rmusser01/tldw_server/pull/2165
 ---
 
 ## Description
@@ -26,11 +27,11 @@ Migrate RateLimitingPage access denied, not-available, empty policy, empty cover
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 RateLimitingPage access denied and not-available guard states render through the design-system Alert primitive.
-- [ ] #2 RateLimitingPage empty policy, empty coverage, and rate-limits unavailable feedback render through the design-system Alert primitive.
-- [ ] #3 The product-state baseline no longer contains RateLimitingPage Alert entries.
-- [ ] #4 Focused regression coverage proves the migration and the product-state guard has no RateLimitingPage findings.
-- [ ] #5 Final summary added with verification evidence.
+- [x] #1 RateLimitingPage access denied and not-available guard states render through the design-system Alert primitive.
+- [x] #2 RateLimitingPage empty policy, empty coverage, and rate-limits unavailable feedback render through the design-system Alert primitive.
+- [x] #3 The product-state baseline no longer contains RateLimitingPage Alert entries.
+- [x] #4 Focused regression coverage proves the migration and the product-state guard has no RateLimitingPage findings.
+- [x] #5 Final summary added with verification evidence.
 <!-- AC:END -->
 
 ## Implementation Notes
@@ -53,15 +54,15 @@ Migrate RateLimitingPage access denied, not-available, empty policy, empty cover
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-
+Migrated RateLimitingPage access denied, not-available, empty policy, empty coverage, and rate-limits unavailable feedback from AntD Alert to the design-system Alert primitive in PR #2165. Added focused regression coverage for all migrated feedback branches, removed the five RateLimitingPage baseline exceptions, and recorded verification evidence. Focused Vitest, guard Vitest, package TypeScript, and diff checks passed; the full design-system verifier remains blocked by unrelated current-dev findings outside this slice, documented in Implementation Notes.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->


### PR DESCRIPTION
## Summary

- Migrates `RateLimitingPage` access denied, not-available, empty policy, empty coverage, and rate-limits unavailable feedback from AntD `Alert` to the design-system `Alert` primitive.
- Extends focused `RateLimitingPage` regression coverage for all migrated feedback states.
- Removes the five matching `RateLimitingPage` product-state baseline exceptions and records the slice in Backlog.md.

## Verification

- `bunx vitest run src/components/Option/Admin/__tests__/RateLimitingPage.test.tsx --reporter=dot`
- `bunx vitest run src/design-system/__tests__/product-state-guard.test.ts --reporter=dot`
- `node -e "const fs=require('fs'); const data=JSON.parse(fs.readFileSync('apps/packages/ui/scripts/design-system-product-state-baseline.json','utf8')); console.log(JSON.stringify({total:data.length,rateLimiting:data.filter(e=>e.path==='src/components/Option/Admin/RateLimitingPage.tsx').length,admin:data.filter(e=>e.path?.startsWith('src/components/Option/Admin/')).length}, null, 2));"` -> `{"total":165,"rateLimiting":0,"admin":7}`
- `git diff --check`
- `env NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit --pretty false`
- `bun run verify:design-system-state` exits 1 from unrelated current-dev findings in `IntegrationPolicyPanel`, `WritingActionBar`, Notes, and ResearchWorkspace plus stale `IntegrationPolicyPanel` baseline entries; no `RateLimitingPage` findings were present in `/tmp/rate-limiting-design-state.log`.

## Change summary (maintainer-owned)

Maintainer note required before merge: please replace this section with your own summary explaining what changed and why these implementation choices were made.

## UX Audit Checklist

- [x] Existing rate-limiting guard and feedback copy is preserved.
- [x] Error/warning/info urgency semantics are preserved through design-system roles.
- [x] Empty policy and empty coverage messages remain in their original cards.
- [x] Rate-limits unavailable feedback remains inline with the Admin Rate Limits card.

## Bandit

Not run. This slice touched TypeScript UI, JSON baseline data, and Backlog task markdown only.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrated `RateLimitingPage` admin alerts from AntD to the design-system `Alert` to standardize UI and remove legacy exceptions. Added focused tests, cleared the product-state baseline, and recorded the migration in backlog tasks; no copy or behavior changes.

- **Refactors**
  - Replaced AntD `Alert` with `Alert` from `@/components/ui/primitives` for forbidden, not-available, empty policy, empty coverage, and rate-limits unavailable states.
  - Updated tests to assert design-system alerts via `data-ds-component="Alert"` and correct ARIA roles (`alert`, `status`).
  - Removed five `RateLimitingPage` entries from `design-system-product-state-baseline.json`.

<sup>Written for commit 7aa2c75f9dc9ec58eb64920b501debdf9047d883. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2165?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

