### PR TITLE
Record chat sidebar tools-first verification

### DIFF
--- a/backlog/tasks/task-567 - Implement-chat-sidebar-tools-first-expansion-behavior.md
+++ b/backlog/tasks/task-567 - Implement-chat-sidebar-tools-first-expansion-behavior.md
@@ -1,0 +1,72 @@
+---
+id: TASK-567
+title: Implement chat sidebar tools-first expansion behavior
+status: Done
+labels:
+- webui
+- extension
+- chat
+- sidebar
+- ux
+priority: high
+references:
+- TASK-401
+- TASK-404
+documentation:
+- Docs/superpowers/specs/2026-05-17-chat-sidebar-tools-first-expansion-design.md
+- Docs/superpowers/plans/2026-05-17-chat-sidebar-tools-first-expansion-implementation-plan.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement the approved shared ChatSidebar tools-first behavior from TASK-401/TASK-404: every sidebar open or foreground should show shortcuts/tools expanded, keep recent conversations collapsed until explicitly expanded or searched, gate lazy history loading and selection controls behind recent visibility, and wire open-reset signals from shared WebUI/extension layout shells.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 ChatSidebar opens shortcuts/tools first and keeps Recent conversations collapsed on direct expanded mount.
+- [x] #2 Collapsed-to-expanded sidebar opens and explicit layout open-reset signals restore the tools-first state.
+- [x] #3 Recent conversations, search, selection controls, history rendering, lazy history loading, and coordinator visibility are gated behind recent visibility or active search.
+- [x] #4 Shared WebUI and package layout shells pass `openResetKey` to desktop and mobile ChatSidebar mounts.
+- [x] #5 Focused sidebar/layout/WebLayout tests and a live browser check verify the current merged behavior; no production UI code changes were needed in this branch because the implementation is already present on `origin/dev`.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Follow Docs/superpowers/plans/2026-05-17-chat-sidebar-tools-first-expansion-implementation-plan.md with TDD slices for ChatSidebar tools-first reset, recent disclosure gating, lazy history/coordinator visibility, layout openResetKey wiring, focused tests, browser verification where practical, and Backlog finalization.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Created this implementation tracker after forking the thread onto sidebar-related work, then verified the current `origin/dev` baseline at merge commit `b91af76404e91bdad8b9b19727c4c2f8d1eefe7a`. The planned sidebar behavior is already implemented in the clean baseline: `ChatSidebar` owns `recentCollapsed`, `recentHistoryVisible`, `openResetKey` reset handling, recent disclosure rendering, history/control gating, and coordinator visibility; `Layout.tsx` and `WebLayout.tsx` both pass `openResetKey` into desktop and mobile ChatSidebar mounts. Because the production and test code already matched the approved plan, this branch only records verification and Backlog closeout.
+
+Verification:
+- `cd apps/packages/ui && bun install` was required in the fresh worktree because initial `bunx vitest`/`bun run test` attempts could not resolve the package-local Vitest install.
+- `cd apps/packages/ui && bun run test src/components/Common/ChatSidebar/__tests__/ChatSidebar.tools-first.test.tsx src/components/Common/ChatSidebar/__tests__/ChatSidebar.lazy-history.test.tsx src/components/Common/__tests__/ChatSidebar.coordinator.test.tsx src/components/Layouts/__tests__/Layout.chat-sidebar-reset-signal.guard.test.ts` passed: 4 files, 14 tests.
+- `cd apps/tldw-frontend && bunx vitest run __tests__/components/layout/WebLayout.chat-scroll-contract.test.tsx` passed: 1 file, 5 tests.
+- Live browser check used `NEXT_PUBLIC_API_URL=http://127.0.0.1:8000 bun run dev -- -H 127.0.0.1 -p 18051` with approved local binding. After setting local `apiKey`, `tldwConfig`, and `__tldw_test_bypass`, `/chat` showed the collapsed chat sidebar. Expanding it showed Shortcuts open and Recent conversations closed; manually expanding Recent exposed search; collapse/reopen reset back to Shortcuts open and Recent closed.
+- The first dev-server attempt failed until `NEXT_PUBLIC_API_URL` was supplied. A sandboxed bind attempt then failed with `EPERM`, so the browser check used approved elevated localhost binding. The server was stopped afterward and `lsof -nP -iTCP:18051 -sTCP:LISTEN` confirmed no listener remained.
+- Browser console showed backend/unreachable-style errors during the local-only check because no FastAPI backend was running on `127.0.0.1:8000`; this did not block verification of the sidebar open/reset behavior.
+- Bandit skipped: this closeout branch changes Backlog Markdown only; no Python files or production source files were touched.
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Verified and closed the sidebar tools-first implementation against latest `origin/dev`. The current baseline already implements the approved behavior: chat sidebar opens tools/shortcuts first, keeps Recent conversations collapsed by default, gates history/search/selection/coordinator work behind recent visibility or active search, and receives reset signals from both shared layout shells. This branch records the focused test and live browser evidence only.
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## Change Summary (Maintainer-Owned)

- [ ] Maintainer to replace this checkbox with a human-owned summary before merge.

## Summary

- What changed: Added Backlog `TASK-567` to record the current sidebar tools-first implementation verification and closeout evidence.
- Why: The approved sidebar behavior is already present on latest `dev`; this PR makes the implementation state explicit and records the focused test/browser evidence in an unambiguous task.

## Validation

- [x] Tests added/updated for behavior changes
- [x] Relevant unit/integration tests pass locally
- [x] Docs updated (if behavior, routes, or config changed)

Focused checks:

- `cd apps/packages/ui && bun run test src/components/Common/ChatSidebar/__tests__/ChatSidebar.tools-first.test.tsx src/components/Common/ChatSidebar/__tests__/ChatSidebar.lazy-history.test.tsx src/components/Common/__tests__/ChatSidebar.coordinator.test.tsx src/components/Layouts/__tests__/Layout.chat-sidebar-reset-signal.guard.test.ts` passed: 4 files, 14 tests.
- `cd apps/tldw-frontend && bunx vitest run __tests__/components/layout/WebLayout.chat-scroll-contract.test.tsx` passed: 1 file, 5 tests.
- `git diff --check origin/dev...HEAD` passed.
- Live browser check against `http://127.0.0.1:18051/chat` verified collapsed sidebar -> expanded tools-first state, manual Recent expansion, and collapse/reopen reset.
- Bandit skipped: Backlog Markdown-only PR; no Python files changed.

## UX Audit Checklist (v2 Stage 5)

- [ ] `npm run e2e:smoke:stage5` passes
- [ ] `npx playwright test e2e/smoke/all-pages.spec.ts --reporter=line` passes (or failures documented)
- [x] No listed AntD deprecations in console output: `Drawer.width`, `Space.direction`, `Alert.message`, `List`
- [x] No `Maximum update depth exceeded` warnings on audited routes
- [x] No unresolved `{{...}}` placeholders on audited routes
- [x] WebUI/extension parity validated for shared UI fixes
- [x] For Flashcards UI changes: tabs remain `Study` / `Manage` / `Transfer` and secondary create CTAs route through manager create-entry path
- [x] For Flashcards drawer changes: use `FLASHCARDS_DRAWER_WIDTH_PX` and keep footer action order `Cancel -> secondary -> primary`
- [x] For Flashcards help/copy/import UX changes: update `Docs/User_Guides/WebUI_Extension/Flashcards_Study_Guide.md` and keep in-app help links pointed at guide section anchors

## Watchlists Accessibility Checklist (Group 09 Stage 5)

- [x] If Watchlists UI behavior changed: `cd apps/packages/ui && bun run test:watchlists:a11y` passes locally
- [x] If Watchlists UI behavior changed: keyboard-only path still works for Overview -> Feeds -> Monitors -> Activity -> Articles -> Reports
- [x] If Watchlists UI behavior changed: list/table labels and live-region copy remain localized (no new hardcoded assistive text)
- [x] If Watchlists UI behavior changed: monitor/feed active state is not color-only (explicit text or icon signal is present)
- [x] If Watchlists UI behavior changed: known assistive-tech constraints reviewed in `Docs/Plans/WATCHLISTS_ASSISTIVE_TECH_AUDIT_2026_02_24.md`

## Watchlists Scale Checklist (Group 10 Stage 5)

- [x] If Watchlists UI behavior changed: `cd apps/packages/ui && bun run test:watchlists:scale` passes locally
- [x] If Watchlists polling/notifications behavior changed: no duplicate terminal notifications during in-flight polling overlap
- [x] If Watchlists Activity polling changed: auto-refresh is gated to active + visible Activity context (no background tab polling churn)
- [x] If Watchlists batch triage behavior changed: partial-failure retry path remains available and updates only failed IDs
- [x] If Watchlists scale behavior changed: constraints/mitigations reviewed in `Docs/Plans/WATCHLISTS_SCALE_READINESS_RUNBOOK_2026_02_24.md`

## Risk & Rollback

- Risk level: Low
- Rollback plan: Revert the Backlog-only commit `docs(chat): record sidebar tools-first verification`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Records and verifies the chat sidebar tools-first behavior already on `dev`, closing Backlog `TASK-567` and aligning with `TASK-401`/`TASK-404`. Adds a verification doc with focused test passes and a browser check confirming tools open first, Recent stays collapsed, history/search/selection are gated, and layout reset signals restore the default; no production code changes.

<sup>Written for commit adffca1e2c8a1ead722a5ad789cdb31b598b8265. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2168?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

