### PR TITLE
docs(chat): reconcile character overlay rail plan

### DIFF
--- a/Docs/superpowers/plans/2026-05-22-chat-character-overlay-and-tracked-identity-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-05-22-chat-character-overlay-and-tracked-identity-implementation-plan.md
@@ -2,9 +2,11 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Preserve existing tracked character/persona chats while adding snapshot-based, non-destructive character/persona personality overlays for normal `/chat` conversations, with the main control surface in a side rail.
+**Status:** Reconciled on 2026-05-30. This plan is historical and should not be executed as written.
 
-**Architecture:** Keep the current tracked chat contract intact and add a separate `assistantOverlay` settings contract for normal chats. Resolve effective assistant mode from tracked chat metadata plus chat settings, route tracked and overlay sends differently, and add a right-rail control surface that reuses the existing picker and chat shell instead of replacing them.
+**Goal:** Preserve existing tracked character/persona chats while adding snapshot-based, non-destructive character/persona personality overlays for normal `/chat` conversations, with the main control surface in the existing cockpit runtime/context rails.
+
+**Architecture:** Keep the current tracked chat contract intact and add a separate `assistantOverlay` settings contract for normal chats. Resolve effective assistant mode from tracked chat metadata plus chat settings, route tracked and overlay sends differently, and use the existing runtime/context cockpit rails as the assistant control surface.
 
 **Tech Stack:** React, TypeScript, Next.js route wrappers, shared `@/components` UI package, Plasmo/local storage utilities, FastAPI, Pydantic validation, pytest, Vitest, Testing Library, Browser plugin or Playwright for final UI verification.
 
@@ -15,6 +17,18 @@
 - Design spec: `Docs/superpowers/specs/2026-05-22-chat-character-overlay-and-tracked-identity-design.md`
 - Design Backlog task: `TASK-444`
 
+## 2026-05-30 Reconciliation
+
+Do not create `CharacterControlRail`, `CharacterControlRailSheet`, or a new `character-control` coordinator panel from this plan. The current `dev` branch already includes the durable parts of this plan:
+
+- `assistantOverlay` typing, normalization, sync, and backend validation;
+- effective assistant-state resolution;
+- snapshot-on-apply overlay helpers;
+- runtime/context rail assistant selection, clear, context-source, tracked-start, and reload proof;
+- real-server tests asserting `character-control-rail` is absent.
+
+Tasks 1-3 below are retained as historical implementation context. Tasks 4-5 are superseded by the current cockpit runtime/context rail implementation and should not be used to reintroduce a standalone rail.
+
 ## Scope Constraints
 
 - Keep existing tracked character chats and tracked persona chats behaviorally unchanged.
@@ -24,7 +38,7 @@
 - No route split for character chat.
 - No removal of the existing composer, left sidebar, knowledge section, or artifacts panel.
 - No backend tracked chat contract rewrite.
-- Extension parity should reuse the same state contract, but desktop rail work lands first.
+- Extension parity should reuse the same state contract, but desktop runtime/context rail work lands first.
 
 ## File Map
 
@@ -50,22 +64,22 @@
   - Inject overlay personality snapshot with deterministic prompt ordering.
 
 - `apps/packages/ui/src/components/Common/AssistantSelect.tsx`
-  - Keep summary picker behavior intact while supporting rail-driven overlay apply.
+  - Keep summary picker behavior intact while supporting runtime/context rail-driven overlay apply.
 
 - `apps/packages/ui/src/components/Option/Playground/Playground.tsx`
-  - Render the desktop character-control rail inside the existing `/chat` shell.
+  - Historical note: the original plan proposed rendering a desktop character-control rail. The reconciled direction keeps this inside the existing cockpit runtime/context rails.
 
 - `apps/packages/ui/src/components/Option/Playground/PlaygroundForm.tsx`
-  - Add rail entry/status wiring where needed without rehoming the composer.
+  - Add runtime/context rail entry/status wiring where needed without rehoming the composer.
 
 - `apps/packages/ui/src/store/chat-surface-coordinator.ts`
-  - Add rail panel state.
+  - Historical note: the original plan proposed rail panel state. The reconciled direction does not add a standalone character panel.
 
 - `apps/packages/ui/src/routes/sidepanel-chat.tsx`
   - Reuse the same effective-mode and overlay settings contract for extension chat flows.
 
 - `apps/packages/ui/src/components/Sidepanel/Chat/form.tsx`
-  - Add sheet/drawer presentation for character controls if the sidepanel requires local UI glue.
+  - Reuse shared assistant state where sidepanel chat exposes assistant controls.
 
 - `tldw_Server_API/app/api/v1/endpoints/character_chat_sessions.py`
   - Validate `assistantOverlay` in chat settings payloads.
@@ -78,11 +92,10 @@
 - `apps/packages/ui/src/utils/assistant-overlay.ts`
   - Build snapshot-on-apply overlay payloads from full character/persona detail.
 
-- `apps/packages/ui/src/components/Option/Playground/CharacterControlRail.tsx`
-  - Main desktop character/persona control surface for `/chat`.
+Do not create these files from this plan:
 
+- `apps/packages/ui/src/components/Option/Playground/CharacterControlRail.tsx`
 - `apps/packages/ui/src/components/Option/Playground/CharacterControlRailSheet.tsx`
-  - Mobile/compact presentation wrapper if `Playground` already uses sheet patterns elsewhere.
 
 ### New Or Modified Tests
 
@@ -91,7 +104,7 @@
 - `apps/packages/ui/src/hooks/chat/__tests__/effective-assistant-state.test.ts`
 - `apps/packages/ui/src/hooks/__tests__/useMessageOption.assistant-overlay.test.tsx`
 - `apps/packages/ui/src/hooks/chat-modes/__tests__/normalChatMode.overlay.test.ts`
-- `apps/packages/ui/src/components/Option/Playground/__tests__/CharacterControlRail.test.tsx`
+- `apps/packages/ui/src/components/Option/Playground/__tests__/PlaygroundRuntimeInspector.first-slice.test.tsx`
 - `apps/packages/ui/src/components/Option/Playground/__tests__/Playground.coordinator.integration.test.tsx`
 - `apps/packages/ui/src/store/__tests__/chat-surface-coordinator.test.ts`
 - `apps/packages/ui/src/components/Common/__tests__/AssistantSelect.behavior.test.tsx`
@@ -402,185 +415,27 @@ git add apps/packages/ui/src/utils/assistant-overlay.ts apps/packages/ui/src/uti
 git commit -m "feat: add snapshot-based assistant overlay send path"
 ```
 
-## Task 4: Add The Desktop Character Control Rail
+## Task 4: Superseded Standalone Character Control Rail
 
-**Files:**
-- Create: `apps/packages/ui/src/components/Option/Playground/CharacterControlRail.tsx`
-- Modify: `apps/packages/ui/src/components/Option/Playground/Playground.tsx`
-- Modify: `apps/packages/ui/src/components/Option/Playground/PlaygroundForm.tsx`
-- Modify: `apps/packages/ui/src/store/chat-surface-coordinator.ts`
-- Test: `apps/packages/ui/src/components/Option/Playground/__tests__/CharacterControlRail.test.tsx`
-- Test: `apps/packages/ui/src/components/Option/Playground/__tests__/Playground.coordinator.integration.test.tsx`
-- Test: `apps/packages/ui/src/store/__tests__/chat-surface-coordinator.test.ts`
+Do not execute the original desktop-rail slice. Current `dev` intentionally keeps character/persona controls inside `PlaygroundRuntimeInspector`, `PlaygroundContextRail`, and the existing cockpit mobile tabs.
 
-- [ ] **Step 1: Write failing rail panel-state tests**
+Current proof points:
 
-Cover:
-- new `character-control` panel id registers cleanly
-- opening the rail does not break existing panel exclusivity rules
+- `apps/packages/ui/src/components/Option/Playground/__tests__/Playground.cockpit-regression.guard.test.ts` asserts `CharacterControlRail` is absent.
+- `apps/tldw-frontend/e2e/workflows/chat-cockpit.real-server.spec.ts` asserts `character-control-rail` has count `0` while proving runtime-rail character/persona selection, clear, tracked start, and reload.
+- `apps/packages/ui/src/components/Option/Playground/__tests__/PlaygroundRuntimeInspector.first-slice.test.tsx` covers the runtime assistant controls that replaced the standalone rail direction.
 
-Run:
-```bash
-bunx vitest run apps/packages/ui/src/store/__tests__/chat-surface-coordinator.test.ts
-```
+Future assistant UI work should extend those existing cockpit rail components unless a new product decision explicitly reopens a separate panel.
 
-Expected:
-- FAIL because the new panel id does not yet exist.
+## Task 5: Superseded Sidepanel/Mobile Rail Sheet
 
-- [ ] **Step 2: Write failing UI tests for overlay/tracked actions**
+Do not create a `CharacterControlRailSheet`. Mobile `/chat` uses the existing cockpit context/runtime tabs, and the extension sidepanel handoff is currently route-only. Any future sidepanel assistant-state work should start from the shared `assistantOverlay` and effective-assistant-state contract, not from this rail-sheet plan.
 
-Cover:
-- rail shows current mode summary
-- apply overlay action writes overlay
-- clear overlay preserves the thread
-- tracked actions are clearly separate from overlay actions
+Keep these proof gates when touching the assistant workflow:
 
-Run:
-```bash
-bunx vitest run apps/packages/ui/src/components/Option/Playground/__tests__/CharacterControlRail.test.tsx apps/packages/ui/src/components/Option/Playground/__tests__/Playground.coordinator.integration.test.tsx
-```
-
-Expected:
-- FAIL because the rail does not exist.
-
-- [ ] **Step 3: Implement the rail shell and panel wiring**
-
-Implement:
-- new panel id in `chat-surface-coordinator.ts`
-- desktop rail rendering in `Playground.tsx`
-- minimal integration points in `PlaygroundForm.tsx` for status/entry
-
-Keep:
-- left history sidebar unchanged
-- composer available
-- no starter cards or route-level mode split
-
-- [ ] **Step 4: Implement rail actions**
-
-Wire:
-- `Apply overlay`
-- `Change overlay`
-- `Clear overlay`
-- `Start tracked character chat`
-- `Start tracked persona chat`
-- `Open tracked session`
-
-Honor:
-- tracked defaults win on tracked-start actions
-- overlay writes stay in settings only
-
-- [ ] **Step 5: Run targeted tests**
-
-Run:
-```bash
-bunx vitest run apps/packages/ui/src/store/__tests__/chat-surface-coordinator.test.ts apps/packages/ui/src/components/Option/Playground/__tests__/CharacterControlRail.test.tsx apps/packages/ui/src/components/Option/Playground/__tests__/Playground.coordinator.integration.test.tsx
-```
-
-Expected:
-- PASS with no regressions in existing coordinator behavior.
-
-- [ ] **Step 6: Commit the desktop-rail slice**
-
-Run:
-```bash
-git add apps/packages/ui/src/components/Option/Playground/CharacterControlRail.tsx apps/packages/ui/src/components/Option/Playground/Playground.tsx apps/packages/ui/src/components/Option/Playground/PlaygroundForm.tsx apps/packages/ui/src/store/chat-surface-coordinator.ts apps/packages/ui/src/store/__tests__/chat-surface-coordinator.test.ts apps/packages/ui/src/components/Option/Playground/__tests__/CharacterControlRail.test.tsx apps/packages/ui/src/components/Option/Playground/__tests__/Playground.coordinator.integration.test.tsx
-git commit -m "feat: add chat character control rail"
-```
-
-## Task 5: Add Sidepanel/Mobile Parity, Then Verify End-To-End
-
-**Files:**
-- Create if needed: `apps/packages/ui/src/components/Option/Playground/CharacterControlRailSheet.tsx`
-- Modify: `apps/packages/ui/src/routes/sidepanel-chat.tsx`
-- Modify: `apps/packages/ui/src/components/Sidepanel/Chat/form.tsx`
-- Modify as needed: `apps/packages/ui/src/components/Sidepanel/Chat/CharacterSelect.tsx`
-- Test: `apps/packages/ui/src/components/Sidepanel/Chat/__tests__/form.mobile-toolbar.contract.test.ts`
-- Test: `apps/packages/ui/src/routes/__tests__/sidepanel-chat.background-storage-stability.guard.test.ts`
-- Test: `apps/packages/ui/src/routes/__tests__/sidepanel-chat-resume.test.ts`
-
-- [ ] **Step 1: Write failing parity tests**
-
-Cover:
-- sidepanel can read the same effective assistant mode contract
-- overlay state survives sidepanel/local-chat hydration
-- mobile/sheet entry exposes overlay apply/change/clear actions
-
-Run:
-```bash
-bunx vitest run apps/packages/ui/src/components/Sidepanel/Chat/__tests__/form.mobile-toolbar.contract.test.ts apps/packages/ui/src/routes/__tests__/sidepanel-chat.background-storage-stability.guard.test.ts apps/packages/ui/src/routes/__tests__/sidepanel-chat-resume.test.ts
-```
-
-Expected:
-- FAIL because sidepanel does not yet reuse the new contract everywhere it needs to.
-
-- [ ] **Step 2: Implement compact/sheet presentation and shared state wiring**
-
-Implement:
-- sheet/drawer wrapper if required for narrow layouts
-- sidepanel glue that reuses the same resolver and overlay settings contract
-
-Do not:
-- fork the overlay state model for extension
-- invent a separate route mode for character overlay
-
-- [ ] **Step 3: Run targeted frontend regression tests**
-
-Run:
-```bash
-bunx vitest run apps/packages/ui/src/components/Sidepanel/Chat/__tests__/form.mobile-toolbar.contract.test.ts apps/packages/ui/src/routes/__tests__/sidepanel-chat.background-storage-stability.guard.test.ts apps/packages/ui/src/routes/__tests__/sidepanel-chat-resume.test.ts apps/packages/ui/src/components/Option/Playground/__tests__/Playground.responsive-parity.guard.test.ts
-```
-
-Expected:
-- PASS with shared overlay semantics across desktop and sidepanel chat.
-
-- [ ] **Step 4: Run backend and frontend focused verification sweep**
-
-Run:
-```bash
-bunx vitest run apps/packages/ui/src/services/__tests__/chat-settings.overlay.test.ts apps/packages/ui/src/hooks/chat/__tests__/effective-assistant-state.test.ts apps/packages/ui/src/hooks/chat-modes/__tests__/normalChatMode.overlay.test.ts apps/packages/ui/src/components/Option/Playground/__tests__/CharacterControlRail.test.tsx apps/packages/ui/src/components/Sidepanel/Chat/__tests__/form.mobile-toolbar.contract.test.ts
-source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Character_Chat/test_chat_settings_endpoints.py tldw_Server_API/tests/Character_Chat_NEW/unit/test_chat_settings_merge.py -k "assistant_overlay or overlay" -v
-```
-
-Expected:
-- PASS on all targeted suites.
-
-- [ ] **Step 5: Run Bandit on touched backend scope**
-
-Run:
-```bash
-source .venv/bin/activate && python -m bandit -r tldw_Server_API/app/api/v1/endpoints/character_chat_sessions.py -f json -o /tmp/bandit_chat_overlay.json
-```
-
-Expected:
-- No new findings in touched backend code.
-- If findings appear, fix them before moving on.
-
-- [ ] **Step 6: Verify in the browser**
-
-Use Browser plugin or Playwright against the local WebUI:
-
-Desktop checks:
-1. Open `/chat`.
-2. Start a plain chat, apply overlay before first send, reload, verify overlay persists.
-3. Send messages, change overlay mid-thread, verify history/chat id stay stable.
-4. Open a tracked character chat and verify existing tracked behavior is unchanged.
-
-Sidepanel/mobile checks:
-1. Open sidepanel chat.
-2. Apply overlay from compact controls.
-3. Verify no thread reset and correct rehydration.
-
-Expected:
-- Overlay and tracked modes remain clearly distinct.
-- No starter-card dependency appears.
-
-- [ ] **Step 7: Commit parity/hardening**
-
-Run:
-```bash
-git add <CharacterControlRailSheet.tsx if created> apps/packages/ui/src/routes/sidepanel-chat.tsx apps/packages/ui/src/components/Sidepanel/Chat/form.tsx apps/packages/ui/src/components/Sidepanel/Chat/CharacterSelect.tsx apps/packages/ui/src/components/Sidepanel/Chat/__tests__/form.mobile-toolbar.contract.test.ts apps/packages/ui/src/routes/__tests__/sidepanel-chat.background-storage-stability.guard.test.ts apps/packages/ui/src/routes/__tests__/sidepanel-chat-resume.test.ts
-git commit -m "feat: add chat overlay parity and verification coverage"
-```
+- focused overlay/settings tests: `chat-settings.overlay`, `chat-settings.sync`, `effective-assistant-state`, `normalChatMode.overlay`, and `assistant-overlay`;
+- focused cockpit tests: `PlaygroundRuntimeInspector.first-slice`, `Playground.cockpit-regression.guard`, `Playground.cockpit-controls`;
+- real-server proof for runtime rail character/persona selection, clear, tracked start, reload, and absence of `character-control-rail`.
 
 ## Done Checklist
 
@@ -590,7 +445,7 @@ git commit -m "feat: add chat overlay parity and verification coverage"
 - [ ] Overlay changes do not reset thread state.
 - [ ] Overlay is snapshot-on-apply, not live re-resolution.
 - [ ] Tracked-start actions use tracked defaults rather than carrying plain-chat overlay state forward.
-- [ ] Desktop `/chat` exposes the character rail without replacing existing UI.
+- [ ] Desktop `/chat` exposes runtime/context cockpit rails without replacing existing UI.
 - [ ] Sidepanel/mobile surfaces reuse the same state contract.
 - [ ] Targeted frontend and backend tests pass.
 - [ ] Bandit result recorded.

--- a/Docs/superpowers/specs/2026-05-22-chat-character-overlay-and-tracked-identity-design.md
+++ b/Docs/superpowers/specs/2026-05-22-chat-character-overlay-and-tracked-identity-design.md
@@ -2,10 +2,23 @@
 
 **Date:** 2026-05-22
 **Surface:** WebUI `/chat` and extension sidepanel chat flows
-**Status:** Approved in-session
+**Status:** Reconciled on 2026-05-30
 **Backlog:** TASK-444
 
 ---
+
+## 2026-05-30 Reconciliation
+
+This spec's data-model decision remains current: tracked character/persona identity and normal-chat assistant overlay must stay separate.
+
+The original UI direction is superseded. Do not add or reintroduce a standalone `CharacterControlRail`. The current `dev` implementation intentionally routes character/persona controls through the existing `/chat` cockpit rails:
+
+- the runtime rail shows assistant state, selection, clear, Scene Director access, and tracked-start behavior;
+- the context rail shows assistant/context sources and clear affordances;
+- mobile uses the existing cockpit rail tabs rather than a separate character sheet;
+- regression coverage asserts `CharacterControlRail` remains absent from `/chat`.
+
+The implementation plan linked from this task is retained as historical context for the state split and overlay contract, but its standalone rail stage is not executable.
 
 ## Goal
 
@@ -16,7 +29,7 @@ The end state is one chat surface with a clearer contract:
 - tracked character/persona chats still behave as tracked chats;
 - normal chats can borrow character/persona personality without becoming tracked chats;
 - assistant switching in a normal chat does not reset the thread;
-- the main character/persona control surface lives in a side rail, not in starter cards, not in a drawer-first setup flow, and not primarily in the composer.
+- the main character/persona control surface lives in the existing cockpit runtime/context rails, not in starter cards, not in a drawer-first setup flow, not primarily in the composer, and not in a standalone character rail.
 
 ## Product Decision
 
@@ -41,9 +54,9 @@ The implementation must support both of these behaviors at the same time:
 1. Existing character/persona chats continue to be tracked to the selected character/persona exactly as they are today.
 2. A user can add, change, or clear a character/persona on an existing non-character/persona conversation and use it only for assistant personality, without resetting or reclassifying the chat.
 
-## Problem
+## Original Problem
 
-The current `/chat` flow conflates tracked identity with UI selection and send-time routing:
+At original authoring time, `/chat` conflated tracked identity with UI selection and send-time routing:
 
 - assistant selection is stored globally in [useSelectedAssistant.ts](/Users/macbook-dev/Documents/GitHub/tldw_server2/apps/packages/ui/src/hooks/useSelectedAssistant.ts:59);
 - tracked chat hydration writes back into that same global selection in [useSelectServerChat.ts](/Users/macbook-dev/Documents/GitHub/tldw_server2/apps/packages/ui/src/hooks/chat/useSelectServerChat.ts:151);
@@ -98,7 +111,7 @@ Use these terms consistently:
 | Plain chat | A conversation with neither tracked identity nor overlay. |
 | Tracked character chat | A conversation owned by a character. |
 | Tracked persona chat | A conversation owned by a persona. |
-| Character rail | The side-rail control surface for identity, behavior, scene, context, saved setups, and session actions. |
+| Runtime assistant controls | The existing cockpit runtime/context rail controls for assistant identity, selection, clear/change actions, Scene Director access, context visibility, and tracked session actions. |
 
 Do not describe overlay state as "the chat is now a character chat." It is still a normal chat.
 
@@ -166,7 +179,7 @@ assistantOverlay?: {
   id: string
   name: string
   avatar_url?: string | null
-  system_prompt?: string | null
+  system_prompt_snapshot?: string | null
   updatedAt: string
 } | null
 ```
@@ -226,29 +239,28 @@ This resolver should replace ad hoc assistant checks in:
 
 The UI must expose the split between tracked identity and overlay directly, rather than hiding it behind one generic assistant picker.
 
-### Character Rail
+### Runtime Assistant Controls
 
-Add a persistent right-side character rail to `/chat`.
+Use the existing `/chat` cockpit rails as the character/persona control plane.
 
 Placement:
 
-- desktop: beside the transcript using the same shell pattern currently used for the artifacts panel in [Playground.tsx](/Users/macbook-dev/Documents/GitHub/tldw_server2/apps/packages/ui/src/components/Option/Playground/Playground.tsx:1813);
-- mobile and narrow sidepanel layouts: sheet/drawer variant with the same state model.
+- desktop: inside the existing runtime and context rails rendered by the cockpit shell;
+- mobile and narrow layouts: inside the existing cockpit context/runtime tabs;
+- extension sidepanel: keep the route-only handoff contract and reuse the shared state model where sidepanel chat exposes assistant controls.
 
-The rail is an additive control plane. It does not replace the existing composer or left sidebar.
+Do not create a separate persistent `CharacterControlRail`, a replacement character workspace, or a drawer-first setup flow for this task.
 
-### Rail Sections
+### Cockpit Sections
 
-The rail should own:
+The existing cockpit rails should own:
 
 1. current assistant mode and summary;
 2. identity picker and clear/change actions;
-3. behavior prompt summary;
-4. style/preset summary;
-5. scene summary;
-6. context summary;
-7. saved setups;
-8. tracked recent sessions.
+3. Scene Director entry when a character-backed mode supports it;
+4. context source summary and assistant context sources;
+5. runtime/provider/model state;
+6. tracked recent/session entry points where currently exposed.
 
 ### Existing UI Preservation
 
@@ -261,13 +273,13 @@ Keep:
 
 But change their role:
 
-- the rail becomes the main character/persona control surface;
+- the runtime/context cockpit rails become the main character/persona control surface;
 - the composer remains usable but secondary for identity control;
-- `AssistantSelect` becomes the picker the rail invokes, not the workflow container.
+- `AssistantSelect` becomes the picker the runtime rail invokes, not the workflow container.
 
-## Rail Actions
+## Runtime/Context Rail Actions
 
-Each rail action must map to one write path.
+Each assistant action must map to one write path.
 
 ### Apply Overlay
 
@@ -374,11 +386,9 @@ The assistant-switch reset block in [useMessageOption.tsx](/Users/macbook-dev/Do
 
 [useSelectServerChat.ts](/Users/macbook-dev/Documents/GitHub/tldw_server2/apps/packages/ui/src/hooks/chat/useSelectServerChat.ts:151) should continue to hydrate tracked chat metadata, but it should not make global assistant selection the active source of truth for the loaded chat.
 
-### 4. Add New Rail Panel State
+### 4. Do Not Add Standalone Character Rail Panel State
 
-Extend [chat-surface-coordinator.ts](/Users/macbook-dev/Documents/GitHub/tldw_server2/apps/packages/ui/src/store/chat-surface-coordinator.ts:6) with a new optional panel id for the character rail.
-
-This keeps the new rail within the same panel-ownership model already used for server history, model catalog, and artifacts-adjacent layout.
+The reconciled direction does not require a new `character-control` panel id. Keep assistant controls inside the existing cockpit runtime/context rail ownership model unless a future product decision explicitly reopens a separate panel.
 
 ## Backend Architecture Changes
 
@@ -396,7 +406,7 @@ Extend [_validate_chat_settings_payload](/Users/macbook-dev/Documents/GitHub/tld
 - `assistantOverlay.id`
 - `assistantOverlay.name`
 - optional `assistantOverlay.avatar_url`
-- optional `assistantOverlay.system_prompt`
+- optional `assistantOverlay.system_prompt_snapshot`
 - `assistantOverlay.updatedAt`
 
 The settings merge path in [update_chat_settings](/Users/macbook-dev/Documents/GitHub/tldw_server2/tldw_Server_API/app/api/v1/endpoints/character_chat_sessions.py:5787) should remain the persistence mechanism.
@@ -443,7 +453,7 @@ This keeps:
 
 - character/persona session history accurate;
 - plain chat history accurate;
-- rail actions understandable.
+- runtime/context rail actions understandable.
 
 ## Extension And Sidepanel Parity
 
@@ -453,8 +463,8 @@ Requirements:
 
 - tracked chat metadata keeps working in extension handoff;
 - `assistantOverlay` persists through shared chat settings flows;
-- desktop WebUI can use a persistent right rail;
-- extension sidepanel and mobile surfaces can render the same controls in a sheet/drawer form;
+- desktop WebUI can use the persistent runtime/context rails;
+- extension sidepanel and mobile surfaces can render the same controls through their existing compact rail/tab patterns;
 - neither surface should rely on starter cards or route-level character mode.
 
 ## Risks
@@ -506,19 +516,18 @@ The frontend currently attempts persona memory mode updates from [ConversationTa
 - overlay chats use current conversation id and history;
 - overlay visibly changes assistant behavior.
 
-## Stage 3: Character Rail
+## Stage 3: Cockpit Runtime/Context Rail Integration
 
-**Goal:** Add the main character/persona control surface without replacing existing chat UI.
+**Goal:** Keep the main character/persona control surface in the existing cockpit rails without replacing existing chat UI.
 
 **Scope:**
 
-- add new right-rail panel component;
-- wire rail actions to overlay writes and tracked session actions;
+- wire runtime/context rail actions to overlay writes and tracked session actions;
 - keep composer and sidebar intact.
 
 **Success Criteria:**
 
-- desktop `/chat` exposes a persistent rail for identity controls;
+- desktop `/chat` exposes persistent runtime/context rails for identity controls;
 - users can apply/change/clear overlay from the rail;
 - users can start or open tracked sessions from the rail.
 
@@ -529,7 +538,7 @@ The frontend currently attempts persona memory mode updates from [ConversationTa
 **Scope:**
 
 - reload restoration for tracked and overlay states;
-- mobile/sidepanel sheet version of the rail;
+- mobile/sidepanel presentation through existing compact cockpit controls;
 - recent-session and saved-setup classification fixes.
 
 **Success Criteria:**
@@ -556,7 +565,7 @@ The frontend currently attempts persona memory mode updates from [ConversationTa
 
 ### UI
 
-- rail apply/change/clear flows
+- runtime/context rail apply/change/clear flows
 - tracked-session open flows
 - saved setup apply-in-place vs tracked-open behavior
 - desktop and mobile layout coverage
@@ -576,4 +585,4 @@ The frontend currently attempts persona memory mode updates from [ConversationTa
 - Clearing overlay mid-chat does not reset the conversation.
 - Overlay state persists through chat settings and reload.
 - Overlay chats are not reclassified as tracked character/persona sessions.
-- The main character/persona control surface is a side rail, while the existing `/chat` UI remains in place.
+- The main character/persona control surface is the existing runtime/context cockpit rails, while the rest of the `/chat` UI remains in place.

--- a/backlog/tasks/task-444 - Design-chat-character-overlay-and-tracked-identity-rail-model.md
+++ b/backlog/tasks/task-444 - Design-chat-character-overlay-and-tracked-identity-rail-model.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-444
 title: Design /chat character overlay and tracked identity rail model
-status: In Progress
+status: Done
 labels:
 - design
 - chat
@@ -12,38 +12,55 @@ labels:
 priority: high
 documentation:
 - Docs/superpowers/specs/2026-05-22-chat-character-overlay-and-tracked-identity-design.md
+- Docs/superpowers/plans/2026-05-22-chat-character-overlay-and-tracked-identity-implementation-plan.md
 modified_files:
 - Docs/superpowers/specs/2026-05-22-chat-character-overlay-and-tracked-identity-design.md
+- Docs/superpowers/plans/2026-05-22-chat-character-overlay-and-tracked-identity-implementation-plan.md
 ---
 
 ## Description
 
 <!-- SECTION:DESCRIPTION:BEGIN -->
-Write a design spec for /chat that preserves tracked character/persona chats while adding non-destructive character/persona personality overlays for normal conversations, with a side-rail control surface and no thread resets.
+Reconcile the /chat character/persona overlay design against the current restored cockpit rails. Preserve the tracked identity versus assistant overlay state split, but supersede the original standalone side-rail control surface in favor of the existing runtime/context cockpit rails.
 <!-- SECTION:DESCRIPTION:END -->
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
+- [x] #1 Spec records the 2026-05-30 reconciliation that tracked identity and assistantOverlay remain separate while a standalone CharacterControlRail is superseded.
+- [x] #2 Implementation plan is marked historical and explicitly tells future workers not to create CharacterControlRail, CharacterControlRailSheet, or a new character-control coordinator panel.
+- [x] #3 Current cockpit runtime/context rails are identified as the canonical assistant control surface, with existing guard/e2e proof references recorded.
+- [x] #4 Verification and Bandit applicability are recorded.
 <!-- AC:END -->
 
 ## Implementation Notes
 
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Reconciled TASK-444 against current `origin/dev`. The durable architecture already exists in dev: `ChatAssistantOverlay` typing/normalization, backend `AssistantOverlaySettings` validation, effective-assistant-state resolver, assistant-overlay snapshot helpers, runtime/context rail assistant controls, and real-server proofs for runtime-rail character/persona select/clear/tracked start/reload.
+
+The stale part was the original standalone `CharacterControlRail` / `CharacterControlRailSheet` direction. Updated the spec and implementation plan to prohibit reintroducing that rail and to treat the existing cockpit runtime/context rails as the canonical assistant control surface.
+
+Verification:
+- Inspected current source/tests with `rg` and `sed`.
+- Confirmed `apps/packages/ui/src/components/Option/Playground/__tests__/Playground.cockpit-regression.guard.test.ts` asserts `CharacterControlRail` remains absent.
+- Confirmed `apps/tldw-frontend/e2e/workflows/chat-cockpit.real-server.spec.ts` asserts `character-control-rail` count `0` while proving runtime-rail character/persona select, clear, tracked start, and reload.
+- Ran `rg` over the reconciled spec/plan to verify remaining `CharacterControlRail` mentions are warnings or historical notes rather than executable instructions.
+- Bandit skipped because this reconciliation touched Markdown/Backlog only; no Python source changed.
 
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
+TASK-444 is reconciled and closed. The state split and overlay contract remain valid/current, but the standalone character rail work is superseded by the restored /chat cockpit runtime/context rails. Future assistant UX work should extend `PlaygroundRuntimeInspector`, `PlaygroundContextRail`, and the existing mobile cockpit tabs unless a new product decision explicitly reopens a separate panel.
 
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->


### PR DESCRIPTION
## Change summary (maintainer-owned)

Maintainer: please replace this placeholder with your own summary before merge to satisfy the AI-generated PR merge gate.

## Summary

- Reconciles TASK-444 with current `/chat` cockpit rails: tracked identity and `assistantOverlay` remain separate, but the standalone `CharacterControlRail` direction is superseded.
- Marks the old implementation plan as historical and warns future workers not to create `CharacterControlRail`, `CharacterControlRailSheet`, or a new `character-control` coordinator panel.
- Closes the matching Backlog task with evidence that current guard/e2e coverage expects assistant controls in existing runtime/context rails.

## Verification

- `git diff --check origin/dev..HEAD`
- `rg -n "Do not create|should not be executed|superseded|canonical assistant control|character-control-rail|CharacterControlRail" Docs/superpowers/specs/2026-05-22-chat-character-overlay-and-tracked-identity-design.md Docs/superpowers/plans/2026-05-22-chat-character-overlay-and-tracked-identity-implementation-plan.md "backlog/tasks/task-444 - Design-chat-character-overlay-and-tracked-identity-rail-model.md"`

Bandit: skipped; this PR changes Markdown/Backlog documentation only and no Python source.

## UX Audit Checklist

- [x] Scope limited to `/chat` character/persona overlay planning and directly related current cockpit rail guidance.
- [x] No UI implementation changes.
- [x] Explicitly prevents reintroducing the removed standalone character rail.

## Risk and rollback

Risk is low: documentation/backlog reconciliation only. Rollback by reverting this commit if the product decision changes and a standalone assistant panel is intentionally reopened.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reconciled the `/chat` character/persona overlay docs with the current cockpit rails and closed TASK-444. Tracked identity and `assistantOverlay` stay separate; the standalone `CharacterControlRail` plan is deprecated and marked historical.

- **Migration**
  - Use the existing cockpit runtime/context rails (`PlaygroundRuntimeInspector`, `PlaygroundContextRail`) for assistant controls; do not create `CharacterControlRail`, `CharacterControlRailSheet`, or a `character-control` panel.
  - Added guard/e2e references that assert `character-control-rail` is absent and prove runtime-rail select, clear, tracked start, and reload.
  - No code changes; specs and implementation plan updated to reflect this direction.

<sup>Written for commit 7c3f626c5d249ada079ce32f2448dbc22460752e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2169?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

