### PR TITLE
Add MCP gateway preset detail CLI

### DIFF
--- a/Docs/superpowers/plans/2026-05-30-mcp-unified-stage4j-preset-details-cli-plan.md
+++ b/Docs/superpowers/plans/2026-05-30-mcp-unified-stage4j-preset-details-cli-plan.md
@@ -1,0 +1,17 @@
+## Stage 1: CLI Contract
+**Goal**: Define the `show-preset` CLI behavior for deterministic full preset inspection.
+**Success Criteria**: Tests cover success output and unknown preset JSON errors.
+**Tests**: Focused CLI tests in `test_gateway_cli_package.py`.
+**Status**: Complete
+
+## Stage 2: Minimal Implementation
+**Goal**: Add the smallest CLI handler and preset lookup needed to satisfy the contract.
+**Success Criteria**: `mcp-unified-gateway show-preset <id>` emits stable JSON containing preset id, version, and full profile data.
+**Tests**: Focused CLI tests pass.
+**Status**: Complete
+
+## Stage 3: Verification
+**Goal**: Validate the package boundary and touched scope.
+**Success Criteria**: Focused MCP tests, lint, diff check, and Bandit touched-scope scan complete with results recorded in TASK-567.
+**Tests**: `pytest`, `ruff`, `bandit`, and `git diff --check`.
+**Status**: Complete

--- a/backlog/tasks/task-567 - Implement-MCP-Unified-Stage-4J-preset-details-CLI.md
+++ b/backlog/tasks/task-567 - Implement-MCP-Unified-Stage-4J-preset-details-CLI.md
@@ -1,0 +1,60 @@
+---
+id: TASK-567
+title: Implement MCP Unified Stage 4J preset details CLI
+status: Done
+assignee: []
+created_date: ''
+updated_date: '2026-05-30 21:32'
+labels:
+  - mcp-unified
+  - stage-4
+  - cli
+  - profiles
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Add a narrow standalone gateway CLI command for deterministic full built-in preset inspection so front-ends can inspect role/profile policy documents before applying a profile.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 mcp-unified-gateway exposes a command to show one built-in preset as deterministic JSON.
+- [x] #2 Unknown preset ids return machine-readable JSON errors without tracebacks.
+- [x] #3 The command output includes the preset id/version and full profile policy data needed by front-ends.
+- [x] #4 Focused CLI tests, extraction contract tests, lint, diff check, and Bandit touched-scope validation are run.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Plan: Docs/superpowers/plans/2026-05-30-mcp-unified-stage4j-preset-details-cli-plan.md
+
+Verification:
+- source .venv/bin/activate && python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_gateway_cli_package.py -q (baseline: 6 passed; initial show-preset red path: 2 failed before implementation; after implementation: 8 passed)
+- source .venv/bin/activate && python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_gateway_cli_package.py tldw_Server_API/app/core/MCP_unified/tests/test_profile_presets.py -q (timestamp determinism red path: 2 failed before fixed template timestamps; after implementation: 19 passed)
+- source .venv/bin/activate && python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_gateway_cli_package.py tldw_Server_API/app/core/MCP_unified/tests/test_profile_presets.py tldw_Server_API/app/core/MCP_unified/tests/test_extraction_contracts.py tldw_Server_API/app/core/MCP_unified/tests/test_http_mapping.py -q (66 passed)
+- source .venv/bin/activate && python -m ruff check mcp_unified/gateway/cli.py mcp_unified/profiles/presets.py tldw_Server_API/app/core/MCP_unified/tests/test_gateway_cli_package.py tldw_Server_API/app/core/MCP_unified/tests/test_profile_presets.py (passed)
+- source .venv/bin/activate && python -m bandit -r mcp_unified/gateway mcp_unified/profiles -f json -o /tmp/bandit_mcp_stage4j_preset_details.json (0 findings)
+- git diff --check (passed)
+
+Skipped/blocked: none.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Implemented the Stage 4J standalone gateway CLI preset detail slice by adding mcp-unified-gateway show-preset <preset_id>. The command emits deterministic JSON with full built-in preset/profile policy data, returns machine-readable unknown-preset errors without tracebacks, and uses fixed built-in preset template timestamps so the output is stable across processes.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-568 - Implement-MCP-Unified-Stage-4J-preset-details-CLI.md
+++ b/backlog/tasks/task-568 - Implement-MCP-Unified-Stage-4J-preset-details-CLI.md
@@ -1,10 +1,10 @@
 ---
-id: TASK-567
+id: TASK-568
 title: Implement MCP Unified Stage 4J preset details CLI
 status: Done
 assignee: []
 created_date: ''
-updated_date: '2026-05-30 21:32'
+updated_date: '2026-05-30 21:45'
 labels:
   - mcp-unified
   - stage-4
@@ -32,9 +32,16 @@ Add a narrow standalone gateway CLI command for deterministic full built-in pres
 <!-- SECTION:NOTES:BEGIN -->
 Plan: Docs/superpowers/plans/2026-05-30-mcp-unified-stage4j-preset-details-cli-plan.md
 
+Review follow-up:
+- Rebased onto origin/dev at 8b5fca0e68.
+- Renumbered this task from TASK-567 to TASK-568 after the rebase because origin/dev now contains a different TASK-567.
+- Verified Qodo's version/date drift finding against current code and fixed it by deriving PRESET_VERSION and PRESET_CREATED_AT from PRESET_RELEASE_DATE.
+- CodeRabbit had no actionable completed review findings at the time of the fix; its only visible comment was still a processing/status comment. Gemini was quota-limited.
+
 Verification:
 - source .venv/bin/activate && python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_gateway_cli_package.py -q (baseline: 6 passed; initial show-preset red path: 2 failed before implementation; after implementation: 8 passed)
 - source .venv/bin/activate && python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_gateway_cli_package.py tldw_Server_API/app/core/MCP_unified/tests/test_profile_presets.py -q (timestamp determinism red path: 2 failed before fixed template timestamps; after implementation: 19 passed)
+- source .venv/bin/activate && python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_profile_presets.py::test_builtin_preset_template_timestamps_are_version_stable -q (red: failed before PRESET_RELEASE_DATE; green: 1 passed)
 - source .venv/bin/activate && python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_gateway_cli_package.py tldw_Server_API/app/core/MCP_unified/tests/test_profile_presets.py tldw_Server_API/app/core/MCP_unified/tests/test_extraction_contracts.py tldw_Server_API/app/core/MCP_unified/tests/test_http_mapping.py -q (66 passed)
 - source .venv/bin/activate && python -m ruff check mcp_unified/gateway/cli.py mcp_unified/profiles/presets.py tldw_Server_API/app/core/MCP_unified/tests/test_gateway_cli_package.py tldw_Server_API/app/core/MCP_unified/tests/test_profile_presets.py (passed)
 - source .venv/bin/activate && python -m bandit -r mcp_unified/gateway mcp_unified/profiles -f json -o /tmp/bandit_mcp_stage4j_preset_details.json (0 findings)
@@ -46,7 +53,7 @@ Skipped/blocked: none.
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Implemented the Stage 4J standalone gateway CLI preset detail slice by adding mcp-unified-gateway show-preset <preset_id>. The command emits deterministic JSON with full built-in preset/profile policy data, returns machine-readable unknown-preset errors without tracebacks, and uses fixed built-in preset template timestamps so the output is stable across processes.
+Implemented the Stage 4J standalone gateway CLI preset detail slice and PR review follow-up. The CLI exposes mcp-unified-gateway show-preset <preset_id>, emits deterministic full preset/profile policy JSON, returns machine-readable unknown-preset errors, and derives preset version and template timestamps from one PRESET_RELEASE_DATE source so provenance cannot drift silently.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-568 - Implement-MCP-Unified-Stage-4J-preset-details-CLI.md
+++ b/backlog/tasks/task-568 - Implement-MCP-Unified-Stage-4J-preset-details-CLI.md
@@ -36,12 +36,13 @@ Review follow-up:
 - Rebased onto origin/dev at 8b5fca0e68.
 - Renumbered this task from TASK-567 to TASK-568 after the rebase because origin/dev now contains a different TASK-567.
 - Verified Qodo's version/date drift finding against current code and fixed it by deriving PRESET_VERSION and PRESET_CREATED_AT from PRESET_RELEASE_DATE.
-- CodeRabbit had no actionable completed review findings at the time of the fix; its only visible comment was still a processing/status comment. Gemini was quota-limited.
+- Verified CodeRabbit's timestamp string-literal test finding against current code and fixed it by parsing CLI timestamps into aware datetimes before asserting equality. Gemini was quota-limited.
 
 Verification:
 - source .venv/bin/activate && python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_gateway_cli_package.py -q (baseline: 6 passed; initial show-preset red path: 2 failed before implementation; after implementation: 8 passed)
 - source .venv/bin/activate && python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_gateway_cli_package.py tldw_Server_API/app/core/MCP_unified/tests/test_profile_presets.py -q (timestamp determinism red path: 2 failed before fixed template timestamps; after implementation: 19 passed)
 - source .venv/bin/activate && python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_profile_presets.py::test_builtin_preset_template_timestamps_are_version_stable -q (red: failed before PRESET_RELEASE_DATE; green: 1 passed)
+- source .venv/bin/activate && python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_gateway_cli_package.py::test_gateway_cli_show_preset_reports_full_builtin_profile -q (passes with timestamp parsing)
 - source .venv/bin/activate && python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_gateway_cli_package.py tldw_Server_API/app/core/MCP_unified/tests/test_profile_presets.py tldw_Server_API/app/core/MCP_unified/tests/test_extraction_contracts.py tldw_Server_API/app/core/MCP_unified/tests/test_http_mapping.py -q (66 passed)
 - source .venv/bin/activate && python -m ruff check mcp_unified/gateway/cli.py mcp_unified/profiles/presets.py tldw_Server_API/app/core/MCP_unified/tests/test_gateway_cli_package.py tldw_Server_API/app/core/MCP_unified/tests/test_profile_presets.py (passed)
 - source .venv/bin/activate && python -m bandit -r mcp_unified/gateway mcp_unified/profiles -f json -o /tmp/bandit_mcp_stage4j_preset_details.json (0 findings)

--- a/backlog/tasks/task-568 - Implement-MCP-Unified-Stage-4J-preset-details-CLI.md
+++ b/backlog/tasks/task-568 - Implement-MCP-Unified-Stage-4J-preset-details-CLI.md
@@ -66,3 +66,19 @@ Implemented the Stage 4J standalone gateway CLI preset detail slice and PR revie
 - [x] #5 Final summary added
 - [x] #6 Known skips or blockers documented
 <!-- DOD:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Review follow-up:
+- Verified CodeRabbit's touched-scope docstring coverage warning against current code and added a docstring for the nested CLI loader failure helper.
+
+Verification:
+- source .venv/bin/activate && python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_gateway_cli_package.py -q (8 passed)
+- local AST docstring scan for new/changed Python functions in this PR (clean)
+- git diff --check (passed)
+Review follow-up:
+- Added a docstring to the new preset timestamp stability test so all newly added Python functions in this PR have docstrings.
+Review follow-up:
+- Rebased again onto origin/dev at b3f0465bc14f8d02532dc61153e78c5619ebdbaf after dev advanced.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->

--- a/mcp_unified/gateway/cli.py
+++ b/mcp_unified/gateway/cli.py
@@ -9,7 +9,7 @@ from collections.abc import Mapping, Sequence
 from pathlib import Path
 from typing import Any, NoReturn, TextIO
 
-from mcp_unified.profiles.presets import list_builtin_presets
+from mcp_unified.profiles.presets import get_builtin_preset, list_builtin_presets
 
 from .config import (
     GatewayConfigFormat,
@@ -108,6 +108,16 @@ def _build_parser() -> _JsonArgumentParser:
     )
     list_presets.set_defaults(handler=_handle_list_presets)
 
+    show_preset = subparsers.add_parser(
+        "show-preset",
+        help="Show one bundled MCP profile preset.",
+    )
+    show_preset.add_argument(
+        "preset_id",
+        help="Bundled preset id to inspect.",
+    )
+    show_preset.set_defaults(handler=_handle_show_preset)
+
     return parser
 
 
@@ -152,6 +162,32 @@ def _handle_list_presets(_args: argparse.Namespace) -> int:
                 }
                 for preset in presets
             ]
+        },
+        sys.stdout,
+    )
+    return 0
+
+
+def _handle_show_preset(args: argparse.Namespace) -> int:
+    """Emit one bundled profile preset with its full profile policy."""
+
+    preset_id: str = args.preset_id
+    preset = get_builtin_preset(preset_id)
+    if preset is None:
+        _emit_json(
+            {
+                "error": f"Unknown MCP profile preset: {preset_id}",
+                "ok": False,
+                "preset_id": preset_id,
+            },
+            sys.stderr,
+        )
+        return 1
+
+    _emit_json(
+        {
+            "ok": True,
+            "preset": preset.model_dump(mode="json"),
         },
         sys.stdout,
     )

--- a/mcp_unified/profiles/presets.py
+++ b/mcp_unified/profiles/presets.py
@@ -11,6 +11,7 @@ from pydantic import BaseModel, ConfigDict
 from .models import MCPProfile, ProfilePolicy
 
 PRESET_VERSION = "2026.05.27"
+PRESET_CREATED_AT = datetime(2026, 5, 27, tzinfo=timezone.utc)
 
 _PROCESS_CAPABILITIES = {
     "command.run",
@@ -110,6 +111,8 @@ def _profile(
             "preset_version": PRESET_VERSION,
             **(provenance or {}),
         },
+        created_at=PRESET_CREATED_AT,
+        updated_at=PRESET_CREATED_AT,
     )
 
 

--- a/mcp_unified/profiles/presets.py
+++ b/mcp_unified/profiles/presets.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import date, datetime, timezone
 from typing import Any
 from uuid import uuid4
 
@@ -10,8 +10,14 @@ from pydantic import BaseModel, ConfigDict
 
 from .models import MCPProfile, ProfilePolicy
 
-PRESET_VERSION = "2026.05.27"
-PRESET_CREATED_AT = datetime(2026, 5, 27, tzinfo=timezone.utc)
+PRESET_RELEASE_DATE = date(2026, 5, 27)
+PRESET_VERSION = PRESET_RELEASE_DATE.strftime("%Y.%m.%d")
+PRESET_CREATED_AT = datetime(
+    PRESET_RELEASE_DATE.year,
+    PRESET_RELEASE_DATE.month,
+    PRESET_RELEASE_DATE.day,
+    tzinfo=timezone.utc,
+)
 
 _PROCESS_CAPABILITIES = {
     "command.run",

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_cli_package.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_cli_package.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from datetime import datetime, timezone
 from pathlib import Path
 
 import pytest
@@ -155,8 +156,9 @@ def test_gateway_cli_show_preset_reports_full_builtin_profile(
     assert preset["version"] == profile["preset_version"]
     assert profile["id"] == "project-researcher"
     assert profile["name"] == "Project Researcher"
-    assert profile["created_at"] == "2026-05-27T00:00:00Z"
-    assert profile["updated_at"] == "2026-05-27T00:00:00Z"
+    expected_timestamp = datetime(2026, 5, 27, tzinfo=timezone.utc)
+    assert _parse_cli_timestamp(profile["created_at"]) == expected_timestamp
+    assert _parse_cli_timestamp(profile["updated_at"]) == expected_timestamp
     assert policy["capabilities"] == ["code_search", "filesystem.read", "docs.read"]
     assert policy["resource_constraints"] == {}
     assert profile["provenance"]["source"] == "builtin_preset"
@@ -191,3 +193,9 @@ def test_gateway_cli_project_script_is_registered() -> None:
         pyproject["project"]["scripts"]["mcp-unified-gateway"]
         == "mcp_unified.gateway.cli:main"
     )
+
+
+def _parse_cli_timestamp(value: str) -> datetime:
+    """Parse a JSON timestamp without depending on a specific UTC suffix."""
+
+    return datetime.fromisoformat(value.replace("Z", "+00:00"))

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_cli_package.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_cli_package.py
@@ -136,6 +136,51 @@ def test_gateway_cli_list_presets_reports_builtin_summary(
     )
 
 
+def test_gateway_cli_show_preset_reports_full_builtin_profile(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Show one bundled preset with its full profile policy document."""
+
+    exit_code = gateway_cli.main(["show-preset", "project-researcher"])
+
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+    preset = payload["preset"]
+    profile = preset["profile"]
+    policy = profile["policy_document"]
+    assert exit_code == 0
+    assert captured.err == ""
+    assert payload["ok"] is True
+    assert preset["id"] == "project-researcher"
+    assert preset["version"] == profile["preset_version"]
+    assert profile["id"] == "project-researcher"
+    assert profile["name"] == "Project Researcher"
+    assert profile["created_at"] == "2026-05-27T00:00:00Z"
+    assert profile["updated_at"] == "2026-05-27T00:00:00Z"
+    assert policy["capabilities"] == ["code_search", "filesystem.read", "docs.read"]
+    assert policy["resource_constraints"] == {}
+    assert profile["provenance"]["source"] == "builtin_preset"
+
+
+def test_gateway_cli_show_preset_reports_unknown_id_as_json(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Report unknown preset ids as JSON errors without tracebacks."""
+
+    exit_code = gateway_cli.main(["show-preset", "unknown-mode"])
+
+    captured = capsys.readouterr()
+    payload = json.loads(captured.err)
+    assert exit_code == 1
+    assert captured.out == ""
+    assert payload == {
+        "error": "Unknown MCP profile preset: unknown-mode",
+        "ok": False,
+        "preset_id": "unknown-mode",
+    }
+    assert "Traceback" not in captured.err
+
+
 def test_gateway_cli_project_script_is_registered() -> None:
     """Expose the package CLI through the installed project scripts."""
 

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_cli_package.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_cli_package.py
@@ -80,6 +80,8 @@ def test_gateway_cli_validate_config_reports_unexpected_loader_errors_as_json(
     config_path.write_text("{}", encoding="utf-8")
 
     def _raise_runtime_error(*args: object, **kwargs: object) -> object:
+        """Simulate an unexpected loader failure from the config boundary."""
+
         raise RuntimeError("loader failed")
 
     monkeypatch.setattr(

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_profile_presets.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_profile_presets.py
@@ -115,6 +115,19 @@ def test_get_builtin_preset_returns_stable_profile_template() -> None:
     assert preset.profile.credential_grants == []
 
 
+def test_builtin_preset_template_timestamps_are_version_stable() -> None:
+    bundled = presets.list_builtin_presets()
+
+    assert all(
+        preset.profile.created_at == datetime(2026, 5, 27, tzinfo=timezone.utc)
+        for preset in bundled
+    )
+    assert all(
+        preset.profile.updated_at == datetime(2026, 5, 27, tzinfo=timezone.utc)
+        for preset in bundled
+    )
+
+
 def test_duplicate_builtin_preset_returns_editable_profile_with_provenance() -> None:
     profile = presets.duplicate_builtin_preset(
         "architect",

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_profile_presets.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_profile_presets.py
@@ -118,12 +118,14 @@ def test_get_builtin_preset_returns_stable_profile_template() -> None:
 def test_builtin_preset_template_timestamps_are_version_stable() -> None:
     bundled = presets.list_builtin_presets()
 
+    assert presets.PRESET_RELEASE_DATE.strftime("%Y.%m.%d") == presets.PRESET_VERSION
+    assert presets.PRESET_CREATED_AT.date() == presets.PRESET_RELEASE_DATE
     assert all(
-        preset.profile.created_at == datetime(2026, 5, 27, tzinfo=timezone.utc)
+        preset.profile.created_at == presets.PRESET_CREATED_AT
         for preset in bundled
     )
     assert all(
-        preset.profile.updated_at == datetime(2026, 5, 27, tzinfo=timezone.utc)
+        preset.profile.updated_at == presets.PRESET_CREATED_AT
         for preset in bundled
     )
 

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_profile_presets.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_profile_presets.py
@@ -116,6 +116,8 @@ def test_get_builtin_preset_returns_stable_profile_template() -> None:
 
 
 def test_builtin_preset_template_timestamps_are_version_stable() -> None:
+    """Keep built-in preset provenance timestamps tied to the release date."""
+
     bundled = presets.list_builtin_presets()
 
     assert presets.PRESET_RELEASE_DATE.strftime("%Y.%m.%d") == presets.PRESET_VERSION


### PR DESCRIPTION
## Summary

- What changed: added `mcp-unified-gateway show-preset <preset_id>` so front-ends can inspect one bundled MCP profile preset as full deterministic JSON; derives preset version and timestamps from one `PRESET_RELEASE_DATE`; parses CLI timestamp assertions as datetimes; added docstrings for the new/changed Python functions called out by review; recorded `TASK-568` after the rebase task-id collision.
- Why: `list-presets` is enough for mode pickers, but front-ends also need a small package-owned way to inspect the exact role/profile policy before applying or locking available actions. The review fixes keep deterministic provenance from drifting, avoid brittle timestamp string assertions, and keep the PR docstring coverage warning addressed in changed code.

## Change summary (maintainer-owned)

Pending requester-owned summary before merge.

## Review Follow-up

- Rebased onto latest `origin/dev` at `b3f0465bc14f8d02532dc61153e78c5619ebdbaf`.
- Addressed Qodo: `PRESET_VERSION` and `PRESET_CREATED_AT` now derive from one `PRESET_RELEASE_DATE` source, with regression coverage.
- Addressed CodeRabbit inline review: CLI timestamp assertions now parse returned ISO strings into aware datetimes instead of comparing the literal `Z` suffix.
- Addressed CodeRabbit pre-merge docstring warning in changed code: newly added/changed Python functions in this PR now have docstrings.
- Gemini was quota-limited and did not provide actionable findings.

## Validation

- [x] Tests added/updated for behavior changes
- [x] Relevant unit/integration tests pass locally
- [x] Docs updated (if behavior, routes, or config changed)

Commands run:
- `source .venv/bin/activate && python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_gateway_cli_package.py -q` (baseline: 6 passed; red path: 2 failed before implementation; after implementation: 8 passed)
- `source .venv/bin/activate && python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_gateway_cli_package.py tldw_Server_API/app/core/MCP_unified/tests/test_profile_presets.py -q` (timestamp determinism red path: 2 failed before fixed template timestamps; after implementation: 19 passed)
- `source .venv/bin/activate && python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_profile_presets.py::test_builtin_preset_template_timestamps_are_version_stable -q` (red: failed before `PRESET_RELEASE_DATE`; green: 1 passed)
- `source .venv/bin/activate && python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_gateway_cli_package.py::test_gateway_cli_show_preset_reports_full_builtin_profile -q` (1 passed)
- `source .venv/bin/activate && python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_gateway_cli_package.py tldw_Server_API/app/core/MCP_unified/tests/test_profile_presets.py tldw_Server_API/app/core/MCP_unified/tests/test_extraction_contracts.py tldw_Server_API/app/core/MCP_unified/tests/test_http_mapping.py -q` (66 passed, 4 warnings)
- `source .venv/bin/activate && python -m ruff check mcp_unified/gateway/cli.py mcp_unified/profiles/presets.py tldw_Server_API/app/core/MCP_unified/tests/test_gateway_cli_package.py tldw_Server_API/app/core/MCP_unified/tests/test_profile_presets.py` (passed)
- Targeted AST docstring scan for the new/changed Python functions in this PR (passed)
- `source .venv/bin/activate && python -m bandit -r mcp_unified/gateway mcp_unified/profiles -f json -o /tmp/bandit_mcp_stage4j_preset_details.json` (0 findings)
- `git diff --check` (passed)

## UX Audit Checklist (v2 Stage 5)

- [ ] `npm run e2e:smoke:stage5` passes
- [ ] `npx playwright test e2e/smoke/all-pages.spec.ts --reporter=line` passes (or failures documented)
- [x] No listed AntD deprecations in console output: `Drawer.width`, `Space.direction`, `Alert.message`, `List` (not applicable; no UI touched)
- [x] No `Maximum update depth exceeded` warnings on audited routes (not applicable; no UI touched)
- [x] No unresolved `{{...}}` placeholders on audited routes (not applicable; no UI touched)
- [x] WebUI/extension parity validated for shared UI fixes (not applicable; no UI touched)
- [x] For Flashcards UI changes: tabs remain `Study` / `Manage` / `Transfer` and secondary create CTAs route through manager create-entry path (not applicable)
- [x] For Flashcards drawer changes: use `FLASHCARDS_DRAWER_WIDTH_PX` and keep footer action order `Cancel -> secondary -> primary` (not applicable)
- [x] For Flashcards help/copy/import UX changes: update `Docs/User_Guides/WebUI_Extension/Flashcards_Study_Guide.md` and keep in-app help links pointed at guide section anchors (not applicable)

## Watchlists Accessibility Checklist (Group 09 Stage 5)

- [x] If Watchlists UI behavior changed: `cd apps/packages/ui && bun run test:watchlists:a11y` passes locally (not applicable; no Watchlists UI touched)
- [x] If Watchlists UI behavior changed: keyboard-only path still works for Overview -> Feeds -> Monitors -> Activity -> Articles -> Reports (not applicable)
- [x] If Watchlists UI behavior changed: list/table labels and live-region copy remain localized (not applicable)
- [x] If Watchlists UI behavior changed: monitor/feed active state is not color-only (not applicable)
- [x] If Watchlists UI behavior changed: known assistive-tech constraints reviewed in `Docs/Plans/WATCHLISTS_ASSISTIVE_TECH_AUDIT_2026_02_24.md` (not applicable)

## Watchlists Scale Checklist (Group 10 Stage 5)

- [x] If Watchlists UI behavior changed: `cd apps/packages/ui && bun run test:watchlists:scale` passes locally (not applicable; no Watchlists UI touched)
- [x] If Watchlists polling/notifications behavior changed: no duplicate terminal notifications during in-flight polling overlap (not applicable)
- [x] If Watchlists Activity polling changed: auto-refresh is gated to active + visible Activity context (not applicable)
- [x] If Watchlists batch triage behavior changed: partial-failure retry path remains available and updates only failed IDs (not applicable)
- [x] If Watchlists scale behavior changed: constraints/mitigations reviewed in `Docs/Plans/WATCHLISTS_SCALE_READINESS_RUNBOOK_2026_02_24.md` (not applicable)

## Risk & Rollback

- Risk level: Low
- Rollback plan: revert this PR branch to remove the `show-preset` CLI command, deterministic preset release-date coupling, TASK-568, and tests.