### PR TITLE
Migrate StudySuggestionsPanel product states

### DIFF
--- a/apps/packages/ui/scripts/design-system-product-state-baseline.json
+++ b/apps/packages/ui/scripts/design-system-product-state-baseline.json
@@ -1133,39 +1133,6 @@
     "migrationQueue": "shared-product-state"
   },
   {
-    "id": "antd-product-state-import:src/components/StudySuggestions/StudySuggestionsPanel.tsx:Alert",
-    "path": "src/components/StudySuggestions/StudySuggestionsPanel.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/StudySuggestions/StudySuggestionsPanel.tsx before the guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
-    "id": "antd-product-state-import:src/components/StudySuggestions/StudySuggestionsPanel.tsx:Empty",
-    "path": "src/components/StudySuggestions/StudySuggestionsPanel.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Empty",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Empty product-state UI in src/components/StudySuggestions/StudySuggestionsPanel.tsx before the guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
-    "id": "antd-product-state-import:src/components/StudySuggestions/StudySuggestionsPanel.tsx:Tag",
-    "path": "src/components/StudySuggestions/StudySuggestionsPanel.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Tag",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Tag product-state UI in src/components/StudySuggestions/StudySuggestionsPanel.tsx before the guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
     "id": "antd-product-state-import:src/components/WorkflowEditor/ExecutionPanel.tsx:Alert#antd-alert-executionpanel-type-error-execution-error-lin-14y38x7",
     "path": "src/components/WorkflowEditor/ExecutionPanel.tsx",
     "rule": "antd-product-state-import",

--- a/apps/packages/ui/src/components/StudySuggestions/StudySuggestionsPanel.tsx
+++ b/apps/packages/ui/src/components/StudySuggestions/StudySuggestionsPanel.tsx
@@ -1,9 +1,16 @@
 import React from "react"
-import { Alert, Button, Card, Descriptions, Empty, Space, Tag, Typography } from "antd"
+import { Button, Card, Descriptions, Space, Typography } from "antd"
 import { ReloadOutlined } from "@ant-design/icons"
 
 import { TopicBuilder, type TopicBuilderRankReason, type TopicBuilderTopic } from "./TopicBuilder"
 import { useStudySuggestions } from "./hooks/useStudySuggestions"
+import {
+  Alert,
+  Badge,
+  EmptyState,
+  LoadingState,
+  type BadgeVariant
+} from "@/components/ui"
 import type {
   SuggestionAnchorType,
   StudySuggestionActionRequest,
@@ -14,6 +21,20 @@ import type {
 const { Text } = Typography
 
 const normalizeLabel = (value: string): string => value.trim().replace(/\s+/g, " ")
+
+const getStatusBadgeVariant = (status: string): BadgeVariant => {
+  switch (status) {
+    case "failed":
+      return "danger"
+    case "pending":
+      return "warning"
+    case "ready":
+    case "active":
+      return "success"
+    default:
+      return "secondary"
+  }
+}
 
 const normalizeSelectedLabels = (topics: TopicBuilderTopic[]): string[] => {
   const seen = new Set<string>()
@@ -347,9 +368,10 @@ export const StudySuggestionsPanel: React.FC<StudySuggestionsPanelProps> = ({
   if (!snapshot && isLoading) {
     return (
       <Card size="small" title="Study suggestions">
-        <Empty
-          image={Empty.PRESENTED_IMAGE_SIMPLE}
-          description="Loading study suggestions..."
+        <LoadingState
+          mode="inline"
+          label="Loading study suggestions..."
+          className="w-full justify-center py-4"
         />
       </Card>
     )
@@ -360,12 +382,15 @@ export const StudySuggestionsPanel: React.FC<StudySuggestionsPanelProps> = ({
       <Card
         size="small"
         title="Study suggestions"
-        extra={<Tag color="red">failed</Tag>}
+        extra={
+          <Badge variant="danger" size="sm">
+            failed
+          </Badge>
+        }
       >
         <Space orientation="vertical" size={16} className="w-full">
           <Alert
-            type="error"
-            showIcon
+            variant="error"
             title="Study suggestions are unavailable right now."
           />
           <Button
@@ -385,7 +410,12 @@ export const StudySuggestionsPanel: React.FC<StudySuggestionsPanelProps> = ({
   if (!snapshot) {
     return (
       <Card size="small" title="Study suggestions">
-        <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description="No study suggestions yet." />
+        <EmptyState
+          variant="inline"
+          size="sm"
+          title="No study suggestions yet."
+          className="py-4"
+        />
       </Card>
     )
   }
@@ -394,23 +424,30 @@ export const StudySuggestionsPanel: React.FC<StudySuggestionsPanelProps> = ({
     <Card
       size="small"
       title="Study suggestions"
-      extra={<Tag color={status === "failed" ? "red" : status === "pending" ? "gold" : "green"}>{status}</Tag>}
+      extra={
+        <Badge variant={getStatusBadgeVariant(status)} size="sm">
+          {status}
+        </Badge>
+      }
     >
       <Space orientation="vertical" size={16} className="w-full">
         <div className="space-y-1">
           <Text strong>{sessionCopy}</Text>
           <div className="flex flex-wrap gap-2">
-            <Tag>{snapshot.snapshot.activity_type}</Tag>
+            <Badge variant="secondary" size="sm">
+              {snapshot.snapshot.activity_type}
+            </Badge>
             {snapshot.snapshot.refreshed_from_snapshot_id != null ? (
-              <Tag color="blue">Refreshed</Tag>
+              <Badge variant="info" size="sm">
+                Refreshed
+              </Badge>
             ) : null}
           </div>
         </div>
 
         {lastAction ? (
           <Alert
-            type={lastAction.disposition === "opened_existing" ? "info" : "success"}
-            showIcon
+            variant={lastAction.disposition === "opened_existing" ? "info" : "success"}
             title={lastAction.disposition === "opened_existing" ? "Open existing" : "Generated"}
           />
         ) : null}

--- a/apps/packages/ui/src/components/StudySuggestions/StudySuggestionsPanel.tsx
+++ b/apps/packages/ui/src/components/StudySuggestions/StudySuggestionsPanel.tsx
@@ -13,6 +13,7 @@ import {
 } from "@/components/ui"
 import type {
   SuggestionAnchorType,
+  SuggestionStatus,
   StudySuggestionActionRequest,
   StudySuggestionActionResponse,
   StudySuggestionSnapshotResponse
@@ -22,17 +23,18 @@ const { Text } = Typography
 
 const normalizeLabel = (value: string): string => value.trim().replace(/\s+/g, " ")
 
-const getStatusBadgeVariant = (status: string): BadgeVariant => {
+const getStatusBadgeVariant = (status: SuggestionStatus): BadgeVariant => {
   switch (status) {
     case "failed":
       return "danger"
     case "pending":
       return "warning"
     case "ready":
-    case "active":
       return "success"
-    default:
+    case "none":
       return "secondary"
+    default:
+      return status satisfies never
   }
 }
 
@@ -365,7 +367,7 @@ export const StudySuggestionsPanel: React.FC<StudySuggestionsPanelProps> = ({
     await onActionResult?.(response, request)
   }
 
-  if (!snapshot && isLoading) {
+  if (!snapshot && (isLoading || status === "pending")) {
     return (
       <Card size="small" title="Study suggestions">
         <LoadingState

--- a/apps/packages/ui/src/components/StudySuggestions/components/__tests__/StudySuggestionsPanel.test.tsx
+++ b/apps/packages/ui/src/components/StudySuggestions/components/__tests__/StudySuggestionsPanel.test.tsx
@@ -145,6 +145,25 @@ describe("StudySuggestionsPanel", () => {
     )
   })
 
+  it("keeps pending suggestions without a snapshot in the design-system LoadingState primitive", async () => {
+    vi.mocked(useStudySuggestions).mockReturnValue({
+      status: "pending",
+      snapshot: null,
+      isLoading: false,
+      isRefreshing: false,
+      refresh: mocks.refresh,
+      performAction: mocks.performAction
+    } as never)
+
+    render(<StudySuggestionsPanel anchorType="quiz_attempt" anchorId={101} />)
+
+    await expectDesignSystemComponentForText(
+      "Loading study suggestions...",
+      "LoadingState"
+    )
+    expect(screen.queryByText("No study suggestions yet.")).not.toBeInTheDocument()
+  })
+
   it("renders empty suggestions feedback through the design-system EmptyState primitive", async () => {
     vi.mocked(useStudySuggestions).mockReturnValue({
       status: "ready",

--- a/apps/packages/ui/src/components/StudySuggestions/components/__tests__/StudySuggestionsPanel.test.tsx
+++ b/apps/packages/ui/src/components/StudySuggestions/components/__tests__/StudySuggestionsPanel.test.tsx
@@ -101,6 +101,17 @@ const v2Snapshot = {
   }
 }
 
+const expectDesignSystemComponentForText = async (
+  text: string | RegExp,
+  component: "Alert" | "Badge" | "EmptyState" | "LoadingState"
+) => {
+  const node = await screen.findByText(text)
+  const componentNode = node.closest(`[data-ds-component="${component}"]`)
+
+  expect(componentNode).not.toBeNull()
+  return componentNode as HTMLElement
+}
+
 describe("StudySuggestionsPanel", () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -114,6 +125,92 @@ describe("StudySuggestionsPanel", () => {
       refresh: mocks.refresh,
       performAction: mocks.performAction
     } as never)
+  })
+
+  it("renders loading feedback through the design-system LoadingState primitive", async () => {
+    vi.mocked(useStudySuggestions).mockReturnValue({
+      status: "pending",
+      snapshot: null,
+      isLoading: true,
+      isRefreshing: false,
+      refresh: mocks.refresh,
+      performAction: mocks.performAction
+    } as never)
+
+    render(<StudySuggestionsPanel anchorType="quiz_attempt" anchorId={101} />)
+
+    await expectDesignSystemComponentForText(
+      "Loading study suggestions...",
+      "LoadingState"
+    )
+  })
+
+  it("renders empty suggestions feedback through the design-system EmptyState primitive", async () => {
+    vi.mocked(useStudySuggestions).mockReturnValue({
+      status: "ready",
+      snapshot: null,
+      isLoading: false,
+      isRefreshing: false,
+      refresh: mocks.refresh,
+      performAction: mocks.performAction
+    } as never)
+
+    render(<StudySuggestionsPanel anchorType="quiz_attempt" anchorId={101} />)
+
+    await expectDesignSystemComponentForText(
+      "No study suggestions yet.",
+      "EmptyState"
+    )
+  })
+
+  it("renders failed feedback through the design-system Alert primitive", async () => {
+    vi.mocked(useStudySuggestions).mockReturnValue({
+      status: "failed",
+      snapshot: null,
+      isLoading: false,
+      isRefreshing: false,
+      refresh: mocks.refresh,
+      performAction: mocks.performAction
+    } as never)
+
+    render(<StudySuggestionsPanel anchorType="quiz_attempt" anchorId={101} />)
+
+    const alert = await expectDesignSystemComponentForText(
+      "Study suggestions are unavailable right now.",
+      "Alert"
+    )
+    expect(alert).toHaveAttribute("role", "alert")
+    await expectDesignSystemComponentForText("failed", "Badge")
+    expect(screen.getByRole("button", { name: /Retry/ })).toBeInTheDocument()
+  })
+
+  it("renders study status labels through the design-system Badge primitive", async () => {
+    render(<StudySuggestionsPanel anchorType="quiz_attempt" anchorId={101} />)
+
+    await expectDesignSystemComponentForText("ready", "Badge")
+    await expectDesignSystemComponentForText("quiz_attempt", "Badge")
+  })
+
+  it("renders refreshed labels through the design-system Badge primitive", async () => {
+    vi.mocked(useStudySuggestions).mockReturnValue({
+      status: "ready",
+      snapshot: {
+        ...initialSnapshot,
+        snapshot: {
+          ...initialSnapshot.snapshot,
+          id: 89,
+          refreshed_from_snapshot_id: 88
+        }
+      },
+      isLoading: false,
+      isRefreshing: false,
+      refresh: mocks.refresh,
+      performAction: mocks.performAction
+    } as never)
+
+    render(<StudySuggestionsPanel anchorType="quiz_attempt" anchorId={101} />)
+
+    await expectDesignSystemComponentForText("Refreshed", "Badge")
   })
 
   it("lets users add, rename, remove, and reset topics while showing manual topics as exploratory", async () => {
@@ -247,7 +344,11 @@ describe("StudySuggestionsPanel", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "Create flashcards" }))
 
-    expect(await screen.findByText("Open existing")).toBeInTheDocument()
+    const actionAlert = await expectDesignSystemComponentForText(
+      "Open existing",
+      "Alert"
+    )
+    expect(actionAlert).toHaveAttribute("role", "status")
     expect(mocks.performAction).toHaveBeenCalledWith(
       expect.objectContaining({
         targetService: "flashcards",

--- a/backlog/tasks/task-45.44.9 - Migrate-design-system-product-state-Flashcards-Quiz-and-study-flows.md
+++ b/backlog/tasks/task-45.44.9 - Migrate-design-system-product-state-Flashcards-Quiz-and-study-flows.md
@@ -36,6 +36,13 @@ documentation:
     to the design-system Alert primitive. Baseline evidence: total product-state exceptions
     263 -> 262; Flashcards/Quiz/study-flow exceptions 39 -> 38; ReviewTab target rows
     1 -> 0. Verification recorded in TASK-45.44.9.9.
+  - >-
+    TASK-45.44.9.11 / PR #2172 migrated StudySuggestionsPanel loading, empty,
+    failed, reused-result, and status feedback from AntD Alert/Empty/Tag to design-system
+    Alert, EmptyState, LoadingState, and Badge primitives. Baseline evidence:
+    total product-state exceptions 110 -> 107; Flashcards/Quiz/study-flow exceptions
+    24 -> 21; StudySuggestionsPanel target rows 3 -> 0. Verification recorded
+    in TASK-45.44.9.11.
 ---
 
 ## Description

--- a/backlog/tasks/task-45.44.9 - Migrate-design-system-product-state-Flashcards-Quiz-and-study-flows.md
+++ b/backlog/tasks/task-45.44.9 - Migrate-design-system-product-state-Flashcards-Quiz-and-study-flows.md
@@ -43,6 +43,12 @@ documentation:
     total product-state exceptions 110 -> 107; Flashcards/Quiz/study-flow exceptions
     24 -> 21; StudySuggestionsPanel target rows 3 -> 0. Verification recorded
     in TASK-45.44.9.11.
+  - >-
+    TASK-45.44.9.12 / PR #2172 addressed review findings on StudySuggestionsPanel:
+    pending/no-snapshot status now remains in LoadingState instead of falling through
+    to EmptyState, and status badge variant mapping now uses the SuggestionStatus
+    union with the unreachable active case removed. Verification recorded in
+    TASK-45.44.9.12.
 ---
 
 ## Description

--- a/backlog/tasks/task-45.44.9.11 - Migrate-StudySuggestionsPanel-product-states-to-design-system-primitives.md
+++ b/backlog/tasks/task-45.44.9.11 - Migrate-StudySuggestionsPanel-product-states-to-design-system-primitives.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-45.44.9.11
 title: Migrate StudySuggestionsPanel product states to design-system primitives
-status: In Progress
+status: Done
 assignee: []
 created_date: ''
-updated_date: '2026-05-30 21:44'
+updated_date: '2026-05-30 21:50'
 labels:
   - design-system
   - webui
@@ -15,6 +15,7 @@ references:
   - >-
     apps/packages/ui/src/components/StudySuggestions/components/__tests__/StudySuggestionsPanel.test.tsx
   - apps/packages/ui/scripts/design-system-product-state-baseline.json
+  - 'https://github.com/rmusser01/tldw_server/pull/2172'
 parent_task_id: TASK-45.44.9
 ---
 
@@ -26,10 +27,10 @@ Migrate StudySuggestionsPanel loading, empty, failed, action-result, and status 
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 StudySuggestionsPanel loading and no-suggestions states render through design-system LoadingState/EmptyState primitives while preserving copy.
-- [ ] #2 StudySuggestionsPanel failed and action-result feedback render through the design-system Alert primitive while preserving copy and retry behavior.
-- [ ] #3 StudySuggestionsPanel status, activity, and refreshed indicators render through the design-system Badge primitive.
-- [ ] #4 The StudySuggestionsPanel product-state baseline entries are removed and product-state guard verification remains passing.
+- [x] #1 StudySuggestionsPanel loading and no-suggestions states render through design-system LoadingState/EmptyState primitives while preserving copy.
+- [x] #2 StudySuggestionsPanel failed and action-result feedback render through the design-system Alert primitive while preserving copy and retry behavior.
+- [x] #3 StudySuggestionsPanel status, activity, and refreshed indicators render through the design-system Badge primitive.
+- [x] #4 The StudySuggestionsPanel product-state baseline entries are removed and product-state guard verification remains passing.
 <!-- AC:END -->
 
 ## Implementation Notes
@@ -41,15 +42,16 @@ Added focused StudySuggestionsPanel regression coverage for loading, empty, fail
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Migrated StudySuggestionsPanel loading, empty, failed, reused-result, and status feedback from AntD Alert/Empty/Tag to design-system Alert, EmptyState, LoadingState, and Badge primitives in PR #2172. Added focused regression coverage for loading, empty, failed, ready/activity/refreshed badge, and reused-result states; removed the three StudySuggestionsPanel baseline exceptions; and verified focused Vitest, product-state guard Vitest, full design-system verifier, TypeScript, and diff checks. Bandit was skipped because the slice touched only frontend TypeScript/TSX, JSON baseline, and Backlog markdown.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Tests written and passing
-- [ ] #2 Code follows project conventions
-- [ ] #3 No linter/formatter warnings in touched files
-- [ ] #4 No new security findings introduced in touched code
-- [ ] #5 Implementation matches plan
-- [ ] #6 Final summary added
-- [ ] #7 Known skips or blockers documented
+- [x] #1 Tests written and passing
+- [x] #2 Code follows project conventions
+- [x] #3 No linter/formatter warnings in touched files
+- [x] #4 No new security findings introduced in touched code
+- [x] #5 Implementation matches plan
+- [x] #6 Final summary added
+- [x] #7 Known skips or blockers documented
 <!-- DOD:END -->

--- a/backlog/tasks/task-45.44.9.11 - Migrate-StudySuggestionsPanel-product-states-to-design-system-primitives.md
+++ b/backlog/tasks/task-45.44.9.11 - Migrate-StudySuggestionsPanel-product-states-to-design-system-primitives.md
@@ -1,0 +1,55 @@
+---
+id: TASK-45.44.9.11
+title: Migrate StudySuggestionsPanel product states to design-system primitives
+status: In Progress
+assignee: []
+created_date: ''
+updated_date: '2026-05-30 21:44'
+labels:
+  - design-system
+  - webui
+  - product-state
+dependencies: []
+references:
+  - apps/packages/ui/src/components/StudySuggestions/StudySuggestionsPanel.tsx
+  - >-
+    apps/packages/ui/src/components/StudySuggestions/components/__tests__/StudySuggestionsPanel.test.tsx
+  - apps/packages/ui/scripts/design-system-product-state-baseline.json
+parent_task_id: TASK-45.44.9
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Migrate StudySuggestionsPanel loading, empty, failed, action-result, and status feedback from AntD Alert/Empty/Tag to the shared design-system primitives with focused regression coverage and baseline cleanup.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 StudySuggestionsPanel loading and no-suggestions states render through design-system LoadingState/EmptyState primitives while preserving copy.
+- [ ] #2 StudySuggestionsPanel failed and action-result feedback render through the design-system Alert primitive while preserving copy and retry behavior.
+- [ ] #3 StudySuggestionsPanel status, activity, and refreshed indicators render through the design-system Badge primitive.
+- [ ] #4 The StudySuggestionsPanel product-state baseline entries are removed and product-state guard verification remains passing.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Added focused StudySuggestionsPanel regression coverage for loading, empty, failed, ready/activity/refreshed badges, and reused-result feedback through design-system wrappers. RED evidence: `bunx vitest run src/components/StudySuggestions/components/__tests__/StudySuggestionsPanel.test.tsx --reporter=dot` failed with five expected missing `data-ds-component` ancestor assertions before production code changed. Migrated StudySuggestionsPanel AntD Alert/Empty/Tag product states to design-system Alert, EmptyState, LoadingState, and Badge primitives while preserving visible copy and retry behavior. Removed the three StudySuggestionsPanel product-state baseline exceptions. GREEN evidence: focused Vitest passed 1 file / 9 tests. Guard evidence: product-state guard Vitest passed 1 file / 54 tests. Full verifier evidence: `bun run verify:design-system-state` passed with baseline exceptions 107. TypeScript evidence: `env NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit --pretty false` passed. Whitespace evidence: `git diff --check` passed. Bandit skipped because this slice touched only TypeScript/TSX UI, JSON baseline, and Backlog markdown.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Tests written and passing
+- [ ] #2 Code follows project conventions
+- [ ] #3 No linter/formatter warnings in touched files
+- [ ] #4 No new security findings introduced in touched code
+- [ ] #5 Implementation matches plan
+- [ ] #6 Final summary added
+- [ ] #7 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-45.44.9.12 - Address-PR-2172-StudySuggestionsPanel-review-comments.md
+++ b/backlog/tasks/task-45.44.9.12 - Address-PR-2172-StudySuggestionsPanel-review-comments.md
@@ -1,0 +1,62 @@
+---
+id: TASK-45.44.9.12
+title: Address PR 2172 StudySuggestionsPanel review comments
+status: Done
+assignee: []
+created_date: ''
+updated_date: '2026-05-30 21:55'
+labels:
+  - design-system
+  - webui
+  - product-state
+  - review-fix
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/pull/2172'
+  - apps/packages/ui/src/components/StudySuggestions/StudySuggestionsPanel.tsx
+  - >-
+    apps/packages/ui/src/components/StudySuggestions/components/__tests__/StudySuggestionsPanel.test.tsx
+  - apps/packages/ui/src/services/studySuggestions.ts
+parent_task_id: TASK-45.44.9
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Address the actionable PR #2172 review findings on StudySuggestionsPanel after the initial design-system migration.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Pending StudySuggestionsPanel status without a snapshot renders the design-system LoadingState copy, not EmptyState copy.
+- [x] #2 Status badge variant mapping uses the real SuggestionStatus type and removes unreachable status cases.
+- [x] #3 Focused regression coverage and TypeScript verification cover the review fixes.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Reviewed Qodo feedback on PR #2172. Verified the pending/no-snapshot concern against StudySuggestionsPanel and useStudySuggestions: status can be pending while snapshot is null and isLoading is false, so the panel should continue to show loading feedback instead of the no-suggestions empty state.
+
+Added a RED regression test for status pending, snapshot null, and isLoading false. RED evidence: `bunx vitest run src/components/StudySuggestions/components/__tests__/StudySuggestionsPanel.test.tsx --reporter=dot` failed because LoadingState text was absent and EmptyState rendered instead.
+
+Fixed StudySuggestionsPanel so pending/no-snapshot uses the design-system LoadingState branch, and tightened getStatusBadgeVariant to accept SuggestionStatus with the unreachable active case removed and an exhaustive switch default.
+
+GREEN evidence: `bunx vitest run src/components/StudySuggestions/components/__tests__/StudySuggestionsPanel.test.tsx --reporter=dot` passed 1 file / 10 tests. Type evidence: `env NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit --pretty false` passed. Design-system verifier evidence: `bun run verify:design-system-state` passed with 107 baseline exceptions. Whitespace evidence: `git diff --check` passed before task closeout. Bandit skipped because this review fix touched only frontend TypeScript/TSX and Backlog markdown.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Addressed the two PR #2172 review findings: pending StudySuggestionsPanel status without a snapshot now remains in the design-system LoadingState branch, and the status badge mapping now uses the real SuggestionStatus union with the unreachable active case removed. Added focused regression coverage for the pending/no-snapshot state and verified focused Vitest, TypeScript, the design-system product-state verifier, and diff checks. Bandit was skipped because the touched code is frontend TypeScript/TSX plus Backlog markdown.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## Summary
- Migrate `StudySuggestionsPanel` loading, empty, failed, reused-result, and status feedback from AntD `Alert`/`Empty`/`Tag` to design-system `Alert`, `EmptyState`, `LoadingState`, and `Badge` primitives.
- Add focused regression coverage for the design-system wrappers around loading, empty, failed, ready/activity/refreshed badge, and reused-result states.
- Remove the three `StudySuggestionsPanel` product-state baseline exceptions, reducing total baseline rows from 110 to 107 and Flashcards/Quiz/study-flow rows from 24 to 21.

## Verification
- `bunx vitest run src/components/StudySuggestions/components/__tests__/StudySuggestionsPanel.test.tsx --reporter=dot`
- `bunx vitest run src/design-system/__tests__/product-state-guard.test.ts --reporter=dot`
- `bun run verify:design-system-state` (passes with baseline exceptions 107)
- `env NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit --pretty false`
- `git diff --check`
- `git diff --cached --check`

## Change summary (maintainer-owned)
TODO: Maintainer to replace this before merge with a human-written summary explaining what changed and why these implementation choices were made.

## UX Audit Checklist
- [x] Existing user-facing copy is preserved for migrated states.
- [x] Failed feedback keeps alert urgency; loading/empty/status states use canonical design-system primitives.
- [x] Regression coverage asserts wrapper contracts instead of only text presence.

## Bandit
Skipped: frontend TypeScript/TSX, JSON baseline, and Backlog markdown only; no Python files changed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrated StudySuggestionsPanel product states from `antd` to design-system primitives and refined pending state handling. Satisfies TASK-45.44.9.11, addresses TASK-45.44.9.12, and removes three product-state baseline exceptions.

- **Refactors**
  - Made status-to-badge mapping type-safe with `SuggestionStatus`; switched activity/refreshed labels to design-system `Badge`.
  - Pending with no snapshot now stays in `LoadingState`; empty uses `EmptyState`; errors and action-results use design-system `Alert` with preserved copy and retry.
  - Added focused tests for `data-ds-component` wrappers and the pending/no-snapshot branch.
  - Removed 3 baseline exceptions for StudySuggestionsPanel (110 → 107); product-state guard passing; closeout recorded in TASK-45.44.9.11 and TASK-45.44.9.12.

<sup>Written for commit 15fb43a96a4e4fd8b9b13c11142589473c72c62f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2172?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

