### PR TITLE
Close chat sidebar tools-first planning tasks

### DIFF
--- a/backlog/tasks/task-401 - Design-chat-sidebar-tools-first-expansion-behavior.md
+++ b/backlog/tasks/task-401 - Design-chat-sidebar-tools-first-expansion-behavior.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-401
 title: Design chat sidebar tools-first expansion behavior
-status: In Progress
+status: Done
 labels:
 - webui
 - extension
@@ -20,30 +20,36 @@ Design the shared WebUI/extension chat sidebar behavior so every sidebar open/ex
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Spec captures the approved tools-first sidebar open behavior.
-- [ ] #2 Spec identifies shared ChatSidebar state ownership and boundaries.
-- [ ] #3 Spec covers lazy recent-history loading and regression tests.
-- [ ] #4 Backlog task links the resulting design artifact.
+- [x] #1 Spec captures the approved tools-first sidebar open behavior.
+- [x] #2 Spec identifies shared ChatSidebar state ownership and boundaries.
+- [x] #3 Spec covers lazy recent-history loading and regression tests.
+- [x] #4 Backlog task links the resulting design artifact.
 <!-- AC:END -->
 
 ## Implementation Notes
 
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Closed after implementation verification was recorded in TASK-567 and merged through PR #2168.
+
+- Design artifact: `Docs/superpowers/specs/2026-05-17-chat-sidebar-tools-first-expansion-design.md`.
+- The spec captures the shared ChatSidebar ownership boundary, the tools-first reset behavior, recent-history lazy loading, and regression coverage expectations.
+- Verification evidence now lives in TASK-567, including focused ChatSidebar unit tests, the WebLayout chat scroll contract test, and a browser smoke pass on `/chat`.
+- This closeout changes only Backlog Markdown task records. Bandit is not applicable to this non-code closeout.
 
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Design spec written, spec-review approved, and critique-hardened before implementation planning. Awaiting transition to implementation plan.
+Closed the sidebar tools-first design task. The approved spec defines the shared ChatSidebar ownership and boundaries, tools-first reset behavior, recent-history lazy loading, and regression coverage. Implementation and verification are now recorded in TASK-567 and PR #2168.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->

--- a/backlog/tasks/task-404 - Plan-chat-sidebar-tools-first-expansion-implementation.md
+++ b/backlog/tasks/task-404 - Plan-chat-sidebar-tools-first-expansion-implementation.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-404
 title: Plan chat sidebar tools-first expansion implementation
-status: In Progress
+status: Done
 labels:
 - webui
 - extension
@@ -23,29 +23,35 @@ Create an execution-ready implementation plan for the shared ChatSidebar tools-f
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Implementation plan is saved under Docs/superpowers/plans.
-- [ ] #2 Plan decomposes ChatSidebar, layout reset signal, lazy-history gating, and tests into reviewable TDD tasks.
-- [ ] #3 Plan records exact files and verification commands.
+- [x] #1 Implementation plan is saved under Docs/superpowers/plans.
+- [x] #2 Plan decomposes ChatSidebar, layout reset signal, lazy-history gating, and tests into reviewable TDD tasks.
+- [x] #3 Plan records exact files and verification commands.
 <!-- AC:END -->
 
 ## Implementation Notes
 
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Closed after implementation verification was recorded in TASK-567 and merged through PR #2168.
+
+- Implementation plan: `Docs/superpowers/plans/2026-05-17-chat-sidebar-tools-first-expansion-implementation-plan.md`.
+- The plan decomposes ChatSidebar reset behavior, recent disclosure/history gating, coordinator visibility wiring, layout `openResetKey` behavior, and focused regression tests.
+- Verification evidence now lives in TASK-567, including focused ChatSidebar unit tests, the WebLayout chat scroll contract test, and a browser smoke pass on `/chat`.
+- This closeout changes only Backlog Markdown task records. Bandit is not applicable to this non-code closeout.
 
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Implementation plan written and self-reviewed against the current ChatSidebar, layout, settings, and coordinator code. The plan includes TDD tasks for tools-first reset, recent disclosure gating, lazy history, layout reset signals, and final verification.
+Closed the sidebar tools-first planning task. The execution plan is saved and has been validated by the merged implementation and verification recorded in TASK-567 and PR #2168.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->


### PR DESCRIPTION
## Summary

- What changed: closed TASK-401 and TASK-404 by marking their acceptance criteria and Definition of Done complete, adding the TASK-567 / PR #2168 verification trail, and replacing stale "awaiting transition" wording.
- Why: the sidebar tools-first implementation and verification have already merged, so the older design and planning records should reflect the current project state.

## Change summary (maintainer-owned)

- [ ] Maintainer has reviewed and owns the change summary and rationale before merge.

## Validation

- [x] Tests added/updated for behavior changes: not applicable, Markdown-only Backlog closeout.
- [x] Relevant unit/integration tests pass locally: not applicable to this Markdown-only closeout; prior implementation tests are recorded in TASK-567.
- [x] Docs updated: Backlog task records updated.
- [x] `git diff --check origin/dev..HEAD`

## UX Audit Checklist (v2 Stage 5)

- [x] Not applicable: no WebUI or extension behavior changed in this PR.

## Watchlists Accessibility Checklist (Group 09 Stage 5)

- [x] Not applicable: no Watchlists UI behavior changed in this PR.

## Watchlists Scale Checklist (Group 10 Stage 5)

- [x] Not applicable: no Watchlists polling, notification, Activity, batch triage, or scale behavior changed in this PR.

## Risk & Rollback

- Risk level: Low.
- Rollback plan: revert the single Backlog Markdown closeout commit.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Closes TASK-401 and TASK-404 by marking acceptance criteria and Definition of Done complete and linking to the merged tools-first chat sidebar work. Adds the TASK-567 / PR #2168 verification trail and removes stale “awaiting transition” text; docs-only, no code changes.

<sup>Written for commit 6a4079337baf87662aa4158ce96442ffe23407fd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2173?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

