### PR TITLE
Preserve Research Workspace Deep Research return context

### DIFF
--- a/apps/packages/ui/src/components/Option/ResearchWorkspace/StudioPane/index.tsx
+++ b/apps/packages/ui/src/components/Option/ResearchWorkspace/StudioPane/index.tsx
@@ -2291,7 +2291,9 @@ export const StudioPane: React.FC<StudioPaneProps> = ({
                 const StatusConfig = STATUS_ICONS[artifact.status]
                 const StatusIcon = StatusConfig.icon
                 const deepResearchLaunchHref =
-                  buildLiteratureDeepResearchLaunchPath(artifact)
+                  buildLiteratureDeepResearchLaunchPath(artifact, {
+                    workspaceId
+                  })
                 const failedStatusDeleteLabel = t(
                   "playground:studio.deleteFailedOutput",
                   "Delete failed output"

--- a/apps/packages/ui/src/components/Option/ResearchWorkspace/StudioPane/literature-deep-research-launch.ts
+++ b/apps/packages/ui/src/components/Option/ResearchWorkspace/StudioPane/literature-deep-research-launch.ts
@@ -49,6 +49,10 @@ type ResearchFollowUpSeed = {
   }
 }
 
+type LiteratureDeepResearchLaunchOptions = {
+  workspaceId?: string | null
+}
+
 const truncateForLaunch = (value: string, limit: number): string => {
   const trimmed = value.trim()
   if (limit <= 0) {
@@ -430,7 +434,8 @@ export const buildLiteratureDeepResearchLaunchQuery = (
 }
 
 export const buildLiteratureDeepResearchLaunchPath = (
-  artifact: GeneratedArtifact
+  artifact: GeneratedArtifact,
+  options: LiteratureDeepResearchLaunchOptions = {}
 ): string | null => {
   const query = buildLiteratureDeepResearchLaunchQuery(artifact)
   if (!query) {
@@ -446,6 +451,10 @@ export const buildLiteratureDeepResearchLaunchPath = (
     sourcePolicy: "local_first",
     autonomyMode: "checkpointed",
     from: "research-workspace",
+    sourceWorkspaceId: options.workspaceId,
+    sourceArtifactId: artifact.id,
+    sourceArtifactTemplate: artifact.templateId,
+    sourceArtifactTitle: artifact.title,
     followUp: buildLiteratureDeepResearchFollowUp(artifact, sourceCoverage)
   })
 }

--- a/apps/packages/ui/src/components/Option/ResearchWorkspace/__tests__/StudioPane.literature-workproducts.test.tsx
+++ b/apps/packages/ui/src/components/Option/ResearchWorkspace/__tests__/StudioPane.literature-workproducts.test.tsx
@@ -445,6 +445,46 @@ describe("StudioPane literature work products", () => {
     expect(query.length).toBeLessThanOrEqual(2600)
   })
 
+  it("adds Research Workspace origin metadata to Deep Research launch paths", () => {
+    const href = buildLiteratureDeepResearchLaunchPath(
+      {
+        id: "artifact-gap",
+        type: "data_table",
+        title: "Corpus Gap Finder",
+        status: "completed",
+        templateId: "corpus_gap_finder",
+        content: "| Gap | Evidence Basis |\n| --- | --- |\n| Rural settings | Paper A; Paper B |",
+        sourceCoverage: {
+          selectedSourceIds: ["source-1", "source-2"],
+          usableSources: [
+            { sourceId: "source-1", mediaId: 101, title: "Paper A" },
+            { sourceId: "source-2", mediaId: 202, title: "Paper B" }
+          ],
+          skippedSources: [],
+          truncatedSources: [],
+          minimumUsableSourcesMet: true
+        },
+        createdAt: new Date("2026-02-18T00:00:00.000Z")
+      },
+      { workspaceId: "workspace-literature" }
+    )
+
+    expect(href).not.toBeNull()
+    const parsed = new URL(href!, "https://example.local")
+
+    expect(parsed.searchParams.get("from")).toBe("research-workspace")
+    expect(parsed.searchParams.get("source_workspace_id")).toBe(
+      "workspace-literature"
+    )
+    expect(parsed.searchParams.get("source_artifact_id")).toBe("artifact-gap")
+    expect(parsed.searchParams.get("source_artifact_template")).toBe(
+      "corpus_gap_finder"
+    )
+    expect(parsed.searchParams.get("source_artifact_title")).toBe(
+      "Corpus Gap Finder"
+    )
+  })
+
   it("strictly caps truncated Deep Research launch queries", () => {
     const query = buildLiteratureDeepResearchLaunchQuery({
       id: "artifact-long-query",
@@ -1736,7 +1776,18 @@ Proposal
       within(
         screen.getByTestId("studio-artifact-secondary-actions-artifact-matrix")
       ).getByRole("link", { name: /launch deep research/i })
-    ).toHaveAttribute("href", expect.stringContaining("/research?"))
+    ).toHaveAttribute(
+      "href",
+      expect.stringContaining("source_workspace_id=workspace-literature")
+    )
+    expect(
+      within(
+        screen.getByTestId("studio-artifact-secondary-actions-artifact-matrix")
+      ).getByRole("link", { name: /launch deep research/i })
+    ).toHaveAttribute(
+      "href",
+      expect.stringContaining("source_artifact_id=artifact-matrix")
+    )
     expect(links[0]).toHaveAttribute("target", "_blank")
     expect(links[0]).toHaveAttribute("rel", "noopener noreferrer")
     expect(

--- a/apps/packages/ui/src/routes/__tests__/route-paths.research.test.ts
+++ b/apps/packages/ui/src/routes/__tests__/route-paths.research.test.ts
@@ -2,9 +2,11 @@ import { describe, expect, it } from "vitest"
 import {
   CHAT_PATH,
   RESEARCH_PATH,
+  RESEARCH_WORKSPACE_PATH,
   buildCharacterChatPath,
   buildChatThreadPath,
-  buildResearchLaunchPath
+  buildResearchLaunchPath,
+  buildResearchWorkspaceReturnPath
 } from "../route-paths"
 import { SETTINGS_SERVER_CHAT_ID_PARAM } from "../../utils/settings-return"
 
@@ -117,6 +119,53 @@ describe("route-paths deep research launch", () => {
     expect(parsed.searchParams.get("autonomy_mode")).toBeNull()
     expect(parsed.searchParams.get("autorun")).toBeNull()
     expect(parsed.searchParams.get("from")).toBeNull()
+  })
+
+  it("includes bounded Research Workspace source context on launch paths", () => {
+    const href = buildResearchLaunchPath({
+      query: "Verify matrix gaps",
+      from: "research-workspace",
+      sourceWorkspaceId: " workspace-literature ",
+      sourceArtifactId: " artifact-gap ",
+      sourceArtifactTemplate: " corpus_gap_finder ",
+      sourceArtifactTitle: `${"x".repeat(239)} trailing title text`
+    })
+    const parsed = new URL(href, "https://example.local")
+
+    expect(parsed.searchParams.get("source_workspace_id")).toBe(
+      "workspace-literature"
+    )
+    expect(parsed.searchParams.get("source_artifact_id")).toBe("artifact-gap")
+    expect(parsed.searchParams.get("source_artifact_template")).toBe(
+      "corpus_gap_finder"
+    )
+    const sourceArtifactTitle = parsed.searchParams.get("source_artifact_title")
+    expect(sourceArtifactTitle?.length).toBeLessThanOrEqual(240)
+    expect(sourceArtifactTitle).not.toMatch(/\s$/)
+  })
+
+  it("builds a Research Workspace return path with run context", () => {
+    const href = buildResearchWorkspaceReturnPath({
+      sourceWorkspaceId: "workspace-literature",
+      sourceArtifactId: "artifact-gap",
+      sourceArtifactTemplate: "corpus_gap_finder",
+      sourceArtifactTitle: "Corpus Gap Finder",
+      researchRunId: "rs_new"
+    })
+    const parsed = new URL(href, "https://example.local")
+
+    expect(parsed.pathname).toBe(RESEARCH_WORKSPACE_PATH)
+    expect(parsed.searchParams.get("source_workspace_id")).toBe(
+      "workspace-literature"
+    )
+    expect(parsed.searchParams.get("source_artifact_id")).toBe("artifact-gap")
+    expect(parsed.searchParams.get("source_artifact_template")).toBe(
+      "corpus_gap_finder"
+    )
+    expect(parsed.searchParams.get("source_artifact_title")).toBe(
+      "Corpus Gap Finder"
+    )
+    expect(parsed.searchParams.get("research_run_id")).toBe("rs_new")
   })
 
   it("builds an exact chat-thread path for server-backed return handoff", () => {

--- a/apps/packages/ui/src/routes/route-paths.ts
+++ b/apps/packages/ui/src/routes/route-paths.ts
@@ -66,7 +66,19 @@ type BuildResearchLaunchPathOptions = {
   run?: string | null
   chatId?: string | null
   launchMessageId?: string | null
+  sourceWorkspaceId?: string | null
+  sourceArtifactId?: string | null
+  sourceArtifactTemplate?: string | null
+  sourceArtifactTitle?: string | null
   followUp?: Record<string, unknown> | null
+}
+
+type BuildResearchWorkspaceReturnPathOptions = {
+  sourceWorkspaceId?: string | null
+  sourceArtifactId?: string | null
+  sourceArtifactTemplate?: string | null
+  sourceArtifactTitle?: string | null
+  researchRunId?: string | null
 }
 
 type BuildChatThreadPathOptions = {
@@ -79,6 +91,8 @@ type BuildCharacterChatPathOptions = {
 }
 
 const MAX_RESEARCH_FOLLOW_UP_SEARCH_PARAM_LENGTH = 4096
+const MAX_RESEARCH_SOURCE_ID_SEARCH_PARAM_LENGTH = 128
+const MAX_RESEARCH_SOURCE_TITLE_SEARCH_PARAM_LENGTH = 240
 
 const setTrimmedSearchParam = (
   params: URLSearchParams,
@@ -88,6 +102,24 @@ const setTrimmedSearchParam = (
   const trimmed = value?.trim()
   if (trimmed) {
     params.set(key, trimmed)
+  }
+}
+
+const setBoundedTrimmedSearchParam = (
+  params: URLSearchParams,
+  key: string,
+  value: string | null | undefined,
+  maxLength: number
+) => {
+  if (maxLength <= 0) {
+    return
+  }
+  const trimmed = value?.trim()
+  if (trimmed) {
+    const bounded = trimmed.slice(0, maxLength).trim()
+    if (bounded) {
+      params.set(key, bounded)
+    }
   }
 }
 
@@ -136,6 +168,30 @@ export const buildResearchLaunchPath = (
   setTrimmedSearchParam(params, "run", options.run)
   setTrimmedSearchParam(params, "chat_id", options.chatId)
   setTrimmedSearchParam(params, "launch_message_id", options.launchMessageId)
+  setBoundedTrimmedSearchParam(
+    params,
+    "source_workspace_id",
+    options.sourceWorkspaceId,
+    MAX_RESEARCH_SOURCE_ID_SEARCH_PARAM_LENGTH
+  )
+  setBoundedTrimmedSearchParam(
+    params,
+    "source_artifact_id",
+    options.sourceArtifactId,
+    MAX_RESEARCH_SOURCE_ID_SEARCH_PARAM_LENGTH
+  )
+  setBoundedTrimmedSearchParam(
+    params,
+    "source_artifact_template",
+    options.sourceArtifactTemplate,
+    MAX_RESEARCH_SOURCE_ID_SEARCH_PARAM_LENGTH
+  )
+  setBoundedTrimmedSearchParam(
+    params,
+    "source_artifact_title",
+    options.sourceArtifactTitle,
+    MAX_RESEARCH_SOURCE_TITLE_SEARCH_PARAM_LENGTH
+  )
   setJsonSearchParam(params, "follow_up", options.followUp, {
     maxEncodedLength: MAX_RESEARCH_FOLLOW_UP_SEARCH_PARAM_LENGTH
   })
@@ -144,6 +200,44 @@ export const buildResearchLaunchPath = (
   }
   const encoded = params.toString()
   return encoded ? `${RESEARCH_PATH}?${encoded}` : RESEARCH_PATH
+}
+
+export const buildResearchWorkspaceReturnPath = (
+  options: BuildResearchWorkspaceReturnPathOptions = {}
+): string => {
+  const params = new URLSearchParams()
+  setBoundedTrimmedSearchParam(
+    params,
+    "source_workspace_id",
+    options.sourceWorkspaceId,
+    MAX_RESEARCH_SOURCE_ID_SEARCH_PARAM_LENGTH
+  )
+  setBoundedTrimmedSearchParam(
+    params,
+    "source_artifact_id",
+    options.sourceArtifactId,
+    MAX_RESEARCH_SOURCE_ID_SEARCH_PARAM_LENGTH
+  )
+  setBoundedTrimmedSearchParam(
+    params,
+    "source_artifact_template",
+    options.sourceArtifactTemplate,
+    MAX_RESEARCH_SOURCE_ID_SEARCH_PARAM_LENGTH
+  )
+  setBoundedTrimmedSearchParam(
+    params,
+    "source_artifact_title",
+    options.sourceArtifactTitle,
+    MAX_RESEARCH_SOURCE_TITLE_SEARCH_PARAM_LENGTH
+  )
+  setBoundedTrimmedSearchParam(
+    params,
+    "research_run_id",
+    options.researchRunId,
+    MAX_RESEARCH_SOURCE_ID_SEARCH_PARAM_LENGTH
+  )
+  const encoded = params.toString()
+  return encoded ? `${RESEARCH_WORKSPACE_PATH}?${encoded}` : RESEARCH_WORKSPACE_PATH
 }
 
 export const buildChatThreadPath = (

--- a/apps/tldw-frontend/__tests__/pages/research-run-console.test.tsx
+++ b/apps/tldw-frontend/__tests__/pages/research-run-console.test.tsx
@@ -360,6 +360,51 @@ describe('ResearchRunsPage', () => {
     expect(screen.queryByRole('link', { name: 'Back to Chat' })).not.toBeInTheDocument();
   });
 
+  it('preserves Research Workspace source context after manual run creation', async () => {
+    const user = userEvent.setup();
+    const params = new URLSearchParams({
+      query: 'Verify matrix gaps',
+      source_policy: 'local_first',
+      autonomy_mode: 'checkpointed',
+      from: 'research-workspace',
+      source_workspace_id: 'workspace-literature',
+      source_artifact_id: 'artifact-gap',
+      source_artifact_template: 'corpus_gap_finder',
+      source_artifact_title: 'Corpus Gap Finder',
+    });
+    window.history.replaceState({}, '', `/research?${params.toString()}`);
+
+    renderWithProviders(<ResearchRunsPage />);
+
+    expect(await screen.findByDisplayValue('Verify matrix gaps')).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: 'Start run' }));
+
+    await waitFor(() => {
+      expect(mocks.createResearchRun).toHaveBeenCalledWith({
+        query: 'Verify matrix gaps',
+        source_policy: 'local_first',
+        autonomy_mode: 'checkpointed',
+      });
+    });
+    await waitFor(() => {
+      expect(window.location.search).toContain('run=rs_new');
+      expect(window.location.search).toContain('from=research-workspace');
+      expect(window.location.search).toContain('source_workspace_id=workspace-literature');
+      expect(window.location.search).toContain('source_artifact_id=artifact-gap');
+      expect(window.location.search).toContain('source_artifact_template=corpus_gap_finder');
+      expect(window.location.search).not.toContain('query=');
+    });
+
+    const returnLink = await screen.findByRole('link', {
+      name: 'Back to Research Workspace',
+    });
+    expect(returnLink).toHaveAttribute(
+      'href',
+      '/research-workspace?source_workspace_id=workspace-literature&source_artifact_id=artifact-gap&source_artifact_template=corpus_gap_finder&source_artifact_title=Corpus+Gap+Finder&research_run_id=rs_new'
+    );
+    expect(screen.getByText('Source artifact: Corpus Gap Finder')).toBeInTheDocument();
+  });
+
   it('prefills the research question from launch query params', async () => {
     window.history.replaceState(
       {},

--- a/apps/tldw-frontend/pages/research.tsx
+++ b/apps/tldw-frontend/pages/research.tsx
@@ -1,7 +1,10 @@
 import React, { useEffect, useReducer, useState } from 'react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 
-import { buildChatThreadPath } from '@/routes/route-paths';
+import {
+  buildChatThreadPath,
+  buildResearchWorkspaceReturnPath,
+} from '@/routes/route-paths';
 import { useToast } from '@web/components/ui/ToastProvider';
 import {
   approveResearchCheckpoint,
@@ -42,15 +45,22 @@ const TRUST_ARTIFACT_NAMES = [
 
 const TRUST_READY_PHASES = new Set(['awaiting_outline_review', 'packaging', 'completed']);
 const TRUST_INVALIDATION_PHASES = new Set(['collecting', 'synthesizing']);
+const MAX_RESEARCH_SOURCE_ID_SEARCH_PARAM_LENGTH = 128;
+const MAX_RESEARCH_SOURCE_TITLE_SEARCH_PARAM_LENGTH = 240;
 
 type ResearchLaunchParams = {
   query: string | null;
   sourcePolicy: string | null;
   autonomyMode: string | null;
   autorun: boolean;
+  from: string | null;
   runId: string | null;
   chatId: string | null;
   launchMessageId: string | null;
+  sourceWorkspaceId: string | null;
+  sourceArtifactId: string | null;
+  sourceArtifactTemplate: string | null;
+  sourceArtifactTitle: string | null;
   followUp: ResearchRunCreateRequest['follow_up'] | null;
 };
 
@@ -395,32 +405,69 @@ function deriveTrustView(
   };
 }
 
+function parseBoundedLaunchSearchParam(
+  params: URLSearchParams,
+  key: string,
+  maxLength: number
+): string | null {
+  const trimmed = params.get(key)?.trim();
+  return trimmed ? trimmed.slice(0, maxLength).trim() || null : null;
+}
+
 function parseResearchLaunchParams(search: string): ResearchLaunchParams {
   const params = new URLSearchParams(search);
   const query = params.get('query')?.trim() || null;
   const sourcePolicy = params.get('source_policy')?.trim() || null;
   const autonomyMode = params.get('autonomy_mode')?.trim() || null;
+  const from = params.get('from')?.trim() || null;
   const runId = params.get('run')?.trim() || null;
   const chatId = params.get('chat_id')?.trim() || null;
   const launchMessageId = params.get('launch_message_id')?.trim() || null;
+  const sourceWorkspaceId = parseBoundedLaunchSearchParam(
+    params,
+    'source_workspace_id',
+    MAX_RESEARCH_SOURCE_ID_SEARCH_PARAM_LENGTH
+  );
+  const sourceArtifactId = parseBoundedLaunchSearchParam(
+    params,
+    'source_artifact_id',
+    MAX_RESEARCH_SOURCE_ID_SEARCH_PARAM_LENGTH
+  );
+  const sourceArtifactTemplate = parseBoundedLaunchSearchParam(
+    params,
+    'source_artifact_template',
+    MAX_RESEARCH_SOURCE_ID_SEARCH_PARAM_LENGTH
+  );
+  const sourceArtifactTitle = parseBoundedLaunchSearchParam(
+    params,
+    'source_artifact_title',
+    MAX_RESEARCH_SOURCE_TITLE_SEARCH_PARAM_LENGTH
+  );
   const followUp = parseResearchLaunchFollowUp(params.get('follow_up'));
   return {
     query,
     sourcePolicy,
     autonomyMode,
     autorun: params.get('autorun') === '1',
+    from,
     runId,
     chatId,
     launchMessageId,
+    sourceWorkspaceId,
+    sourceArtifactId,
+    sourceArtifactTemplate,
+    sourceArtifactTitle,
     followUp,
   };
 }
 
-function replaceResearchLaunchUrl(runId: string | null) {
+function replaceResearchLaunchUrl(runId: string | null, launchParams: ResearchLaunchParams | null) {
   if (typeof window === 'undefined') {
     return;
   }
   const nextUrl = new URL(window.location.href);
+  const sourceWorkspaceId =
+    launchParams?.from === 'research-workspace' ? launchParams.sourceWorkspaceId : null;
   nextUrl.searchParams.delete('query');
   nextUrl.searchParams.delete('source_policy');
   nextUrl.searchParams.delete('autonomy_mode');
@@ -429,6 +476,23 @@ function replaceResearchLaunchUrl(runId: string | null) {
   nextUrl.searchParams.delete('chat_id');
   nextUrl.searchParams.delete('launch_message_id');
   nextUrl.searchParams.delete('follow_up');
+  nextUrl.searchParams.delete('source_workspace_id');
+  nextUrl.searchParams.delete('source_artifact_id');
+  nextUrl.searchParams.delete('source_artifact_template');
+  nextUrl.searchParams.delete('source_artifact_title');
+  if (sourceWorkspaceId) {
+    nextUrl.searchParams.set('from', 'research-workspace');
+    nextUrl.searchParams.set('source_workspace_id', sourceWorkspaceId);
+    if (launchParams?.sourceArtifactId) {
+      nextUrl.searchParams.set('source_artifact_id', launchParams.sourceArtifactId);
+    }
+    if (launchParams?.sourceArtifactTemplate) {
+      nextUrl.searchParams.set('source_artifact_template', launchParams.sourceArtifactTemplate);
+    }
+    if (launchParams?.sourceArtifactTitle) {
+      nextUrl.searchParams.set('source_artifact_title', launchParams.sourceArtifactTitle);
+    }
+  }
   if (runId) {
     nextUrl.searchParams.set('run', runId);
   } else {
@@ -998,7 +1062,7 @@ export default function ResearchRunsPage() {
         setSelectedRunId(createdRun.id);
         dispatch({ type: 'replace-run', run: createdRun });
         setQuestion('');
-        replaceResearchLaunchUrl(createdRun.id);
+        replaceResearchLaunchUrl(createdRun.id, launchParams);
         setLaunchParams((current) =>
           current
             ? {
@@ -1076,6 +1140,26 @@ export default function ResearchRunsPage() {
         researchReturnRunId: selectedRun.id,
       })
     : null;
+  const hasResearchWorkspaceReturnContext =
+    launchParams?.from === 'research-workspace' && Boolean(launchParams.sourceWorkspaceId);
+  const researchWorkspaceReturnRunId = selectedRun?.id ?? launchParams?.runId ?? null;
+  const researchWorkspaceReturnHref =
+    hasResearchWorkspaceReturnContext
+      ? buildResearchWorkspaceReturnPath({
+          sourceWorkspaceId: launchParams?.sourceWorkspaceId,
+          sourceArtifactId: launchParams?.sourceArtifactId,
+          sourceArtifactTemplate: launchParams?.sourceArtifactTemplate,
+          sourceArtifactTitle: launchParams?.sourceArtifactTitle,
+          researchRunId: researchWorkspaceReturnRunId,
+        })
+      : null;
+  const researchWorkspaceSourceLabel =
+    hasResearchWorkspaceReturnContext
+      ? launchParams?.sourceArtifactTitle ||
+        launchParams?.sourceArtifactTemplate ||
+        launchParams?.sourceArtifactId ||
+        null
+      : null;
   const trustView = deriveTrustView(state.bundle, state.artifactContents);
   const loadedTrustArtifactNames = TRUST_ARTIFACT_NAMES.filter(
     (artifactName) => state.artifactContents[artifactName] !== undefined
@@ -1129,7 +1213,7 @@ export default function ResearchRunsPage() {
       setSelectedRunId(createdRun.id);
       dispatch({ type: 'replace-run', run: createdRun });
       setQuestion('');
-      replaceResearchLaunchUrl(createdRun.id);
+      replaceResearchLaunchUrl(createdRun.id, launchParams);
       setLaunchParams((current) =>
         current
           ? {
@@ -1480,6 +1564,11 @@ export default function ResearchRunsPage() {
                   {selectedRun.status} · {selectedRun.phase} · {selectedRun.control_state}
                 </p>
               )}
+              {researchWorkspaceSourceLabel && (
+                <p className="mt-1 text-sm text-muted-foreground">
+                  Source artifact: {researchWorkspaceSourceLabel}
+                </p>
+              )}
             </div>
             <div className="flex flex-wrap gap-2">
               {backToChatHref && (
@@ -1488,6 +1577,14 @@ export default function ResearchRunsPage() {
                   href={backToChatHref}
                 >
                   Back to Chat
+                </a>
+              )}
+              {researchWorkspaceReturnHref && (
+                <a
+                  className="rounded-full border border-border px-3 py-2 text-sm hover:bg-muted"
+                  href={researchWorkspaceReturnHref}
+                >
+                  Back to Research Workspace
                 </a>
               )}
               <button

--- a/backlog/tasks/task-567 - Preserve-Research-Workspace-Deep-Research-return-context.md
+++ b/backlog/tasks/task-567 - Preserve-Research-Workspace-Deep-Research-return-context.md
@@ -1,0 +1,47 @@
+---
+id: TASK-567
+title: Preserve Research Workspace Deep Research return context
+status: Done
+documentation:
+- Docs/Product/Research_Workspace_Literature_Workproducts_PRD.md
+- Docs/superpowers/plans/2026-05-30-research-workspace-literature-workproducts-plan.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Add the next narrow Deep Research bridge slice after the literature work-products follow-up: carry Research Workspace origin metadata (workspace/artifact/template/title) through Deep Research launch URLs and /research run creation so later bundle import/display work can target the correct Research Workspace artifact without guessing.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Deep Research launch paths from Research Workspace literature artifacts include bounded origin metadata for workspace ID, artifact ID, artifact template, and artifact title when available.
+- [x] #2 The /research console parses Research Workspace origin metadata, preserves it after manual or autorun run creation, and exposes a return link/context for the selected run.
+- [x] #3 Focused route, Research Workspace launch, and research console tests cover the handoff metadata and pass.
+- [x] #4 Bandit is skipped with rationale if only frontend TypeScript files are touched.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+- Added bounded Research Workspace source metadata to Deep Research launch URLs and return URLs.
+- Passed focused Vitest coverage after rebasing onto latest origin/dev: package route helper, Research Workspace StudioPane literature work products, and /research run console.
+- Addressed Qodo review feedback by trimming bounded route params after slicing so launch/return URL builders match the /research parser normalization.
+- Bandit skipped: touched files are frontend TypeScript/TSX tests and UI code only; no Python execution path changed.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Research Workspace literature artifacts now launch Deep Research with workspace/artifact/template/title origin metadata. The /research console parses that context, preserves it after run creation, and exposes a Back to Research Workspace link with the source artifact label.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## Summary

- What changed: Preserved Research Workspace origin metadata in Deep Research launch URLs and added a Research Workspace return URL helper.
- What changed: Threaded that context through literature artifact launch buttons and the `/research` run console, including post-create URL preservation and a Back to Research Workspace link/source artifact label.
- Why: Later Deep Research bundle import/display work needs a reliable workspace/artifact target instead of guessing from query text.

## Change summary (maintainer-owned)

- [ ] Maintainer to replace this with a human-authored summary of what changed and why before merge.

## Validation

- [x] Tests added/updated for behavior changes
- [x] Relevant unit/integration tests pass locally
- [ ] Docs updated (if behavior, routes, or config changed) - Not required; Backlog TASK-567 records the implementation and verification.
- [x] `cd apps/packages/ui && bun run test -- src/routes/__tests__/route-paths.research.test.ts`
- [x] `cd apps/packages/ui && bun run test -- src/components/Option/ResearchWorkspace/__tests__/StudioPane.literature-workproducts.test.tsx`
- [x] `cd apps/tldw-frontend && bun run test:run -- __tests__/pages/research-run-console.test.tsx`
- [x] `git diff --check HEAD~1..HEAD`
- [x] Bandit skipped: frontend TypeScript/TSX only; no Python execution path changed.

## UX Audit Checklist (v2 Stage 5)

- [ ] `npm run e2e:smoke:stage5` passes - Not run; focused Research Workspace/Deep Research handoff slice.
- [ ] `npx playwright test e2e/smoke/all-pages.spec.ts --reporter=line` passes (or failures documented) - Not run; focused Research Workspace/Deep Research handoff slice.
- [ ] No listed AntD deprecations in console output: `Drawer.width`, `Space.direction`, `Alert.message`, `List` - Not audited in browser.
- [x] No `Maximum update depth exceeded` warnings on audited routes - No browser route audit performed; focused Vitest only.
- [x] No unresolved `{{...}}` placeholders on audited routes - No user-facing template placeholders added.
- [x] WebUI/extension parity validated for shared UI fixes - Shared route helper change is covered by package tests; extension browser parity not run.
- [x] For Flashcards UI changes: tabs remain `Study` / `Manage` / `Transfer` and secondary create CTAs route through manager create-entry path - Not applicable.
- [x] For Flashcards drawer changes: use `FLASHCARDS_DRAWER_WIDTH_PX` and keep footer action order `Cancel -> secondary -> primary` - Not applicable.
- [x] For Flashcards help/copy/import UX changes: update `Docs/User_Guides/WebUI_Extension/Flashcards_Study_Guide.md` and keep in-app help links pointed at guide section anchors - Not applicable.

## Watchlists Accessibility Checklist (Group 09 Stage 5)

- [x] If Watchlists UI behavior changed: `cd apps/packages/ui && bun run test:watchlists:a11y` passes locally - Not applicable.
- [x] If Watchlists UI behavior changed: keyboard-only path still works for Overview -> Feeds -> Monitors -> Activity -> Articles -> Reports - Not applicable.
- [x] If Watchlists UI behavior changed: list/table labels and live-region copy remain localized (no new hardcoded assistive text) - Not applicable.
- [x] If Watchlists UI behavior changed: monitor/feed active state is not color-only (explicit text or icon signal is present) - Not applicable.
- [x] If Watchlists UI behavior changed: known assistive-tech constraints reviewed in `Docs/Plans/WATCHLISTS_ASSISTIVE_TECH_AUDIT_2026_02_24.md` - Not applicable.

## Watchlists Scale Checklist (Group 10 Stage 5)

- [x] If Watchlists UI behavior changed: `cd apps/packages/ui && bun run test:watchlists:scale` passes locally - Not applicable.
- [x] If Watchlists polling/notifications behavior changed: no duplicate terminal notifications during in-flight polling overlap - Not applicable.
- [x] If Watchlists Activity polling changed: auto-refresh is gated to active + visible Activity context (no background tab polling churn) - Not applicable.
- [x] If Watchlists batch triage behavior changed: partial-failure retry path remains available and updates only failed IDs - Not applicable.
- [x] If Watchlists scale behavior changed: constraints/mitigations reviewed in `Docs/Plans/WATCHLISTS_SCALE_READINESS_RUNBOOK_2026_02_24.md` - Not applicable.

## Risk & Rollback

- Risk level: Low
- Rollback plan: Revert this PR to remove the handoff metadata URL params, return helper, and `/research` return-link rendering.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves Research Workspace context across Deep Research launch and run flows, and adds a return link back to the originating workspace. Supports later bundle import/display without guessing and satisfies TASK-567.

- New Features
  - Launch URLs from literature artifacts now include origin params: `source_workspace_id`, `source_artifact_id`, `source_artifact_template`, `source_artifact_title`, plus `from=research-workspace`.
  - `/research` parses and bounds these params, preserves them after manual/autorun run creation, updates the URL, and shows a “Back to Research Workspace” link with a source artifact label; return paths include `research_run_id`.
  - Added `buildResearchWorkspaceReturnPath`; `buildResearchLaunchPath` now accepts bounded source params (IDs 128 chars, title 240). Tests cover route helpers, workspace launch buttons, and run console flows.

<sup>Written for commit f6b3d84a9ed1ea5f55ee89066266f9500fcace80. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2174?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

