### PR TITLE
Migrate Prompt Studio test case states to design system

### DIFF
--- a/apps/packages/ui/scripts/design-system-product-state-baseline.json
+++ b/apps/packages/ui/scripts/design-system-product-state-baseline.json
@@ -550,61 +550,6 @@
     "migrationQueue": "shared-product-state"
   },
   {
-    "id": "antd-product-state-import:src/components/Option/Prompt/Studio/TestCases/TestCaseBulkPanel.tsx:Alert#antd-alert-testcasebulkpanel-type-info-line-172-50bcsa",
-    "path": "src/components/Option/Prompt/Studio/TestCases/TestCaseBulkPanel.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/Option/Prompt/Studio/TestCases/TestCaseBulkPanel.tsx before the stable duplicate-id guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
-    "id": "antd-product-state-import:src/components/Option/Prompt/Studio/TestCases/TestCaseBulkPanel.tsx:Alert#antd-alert-testcasebulkpanel-type-info-line-239-xqvozm",
-    "path": "src/components/Option/Prompt/Studio/TestCases/TestCaseBulkPanel.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/Option/Prompt/Studio/TestCases/TestCaseBulkPanel.tsx before the stable duplicate-id guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
-    "id": "antd-product-state-import:src/components/Option/Prompt/Studio/TestCases/TestCaseGenerateModal.tsx:Alert",
-    "path": "src/components/Option/Prompt/Studio/TestCases/TestCaseGenerateModal.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/Option/Prompt/Studio/TestCases/TestCaseGenerateModal.tsx before the guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
-    "id": "antd-product-state-import:src/components/Option/Prompt/Studio/TestCases/TestCaseRunModal.tsx:Alert",
-    "path": "src/components/Option/Prompt/Studio/TestCases/TestCaseRunModal.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/Option/Prompt/Studio/TestCases/TestCaseRunModal.tsx before the guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
-    "id": "antd-product-state-import:src/components/Option/Prompt/Studio/TestCases/TestCaseRunModal.tsx:Tag",
-    "path": "src/components/Option/Prompt/Studio/TestCases/TestCaseRunModal.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Tag",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Tag product-state UI in src/components/Option/Prompt/Studio/TestCases/TestCaseRunModal.tsx before the guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
     "id": "antd-product-state-import:src/components/Option/Settings/chatbooks.tsx:Alert",
     "path": "src/components/Option/Settings/chatbooks.tsx",
     "rule": "antd-product-state-import",

--- a/apps/packages/ui/src/components/Option/Prompt/Studio/TestCases/TestCaseBulkPanel.tsx
+++ b/apps/packages/ui/src/components/Option/Prompt/Studio/TestCases/TestCaseBulkPanel.tsx
@@ -1,5 +1,5 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query"
-import { Drawer, Tabs, notification, Alert, Upload, Spin } from "antd"
+import { Drawer, Tabs, notification, Upload, Spin } from "antd"
 import type { UploadProps } from "antd"
 import { Download, Upload as UploadIcon, FileJson, FileSpreadsheet } from "lucide-react"
 import React, { useState } from "react"
@@ -12,6 +12,7 @@ import {
   type TestCaseCreatePayload
 } from "@/services/prompt-studio"
 import { Button } from "@/components/Common/Button"
+import { Alert as DsAlert } from "@/components/ui/primitives"
 
 type TestCaseBulkPanelProps = {
   open: boolean
@@ -169,9 +170,8 @@ export const TestCaseBulkPanel: React.FC<TestCaseBulkPanelProps> = ({
             ),
             children: (
               <div className="space-y-4">
-                <Alert
-                  type="info"
-                  showIcon
+                <DsAlert
+                  variant="info"
                   title={t("managePrompts.studio.testCases.exportInfo", {
                     defaultValue:
                       "Export all test cases from this project to a file."
@@ -236,9 +236,8 @@ export const TestCaseBulkPanel: React.FC<TestCaseBulkPanelProps> = ({
             ),
             children: (
               <div className="space-y-4">
-                <Alert
-                  type="info"
-                  showIcon
+                <DsAlert
+                  variant="info"
                   title={t("managePrompts.studio.testCases.importInfo", {
                     defaultValue:
                       "Import test cases from a JSON or CSV file. New test cases will be added to the project."

--- a/apps/packages/ui/src/components/Option/Prompt/Studio/TestCases/TestCaseGenerateModal.tsx
+++ b/apps/packages/ui/src/components/Option/Prompt/Studio/TestCases/TestCaseGenerateModal.tsx
@@ -1,5 +1,5 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
-import { Modal, Form, InputNumber, Select, notification, Alert, Spin } from "antd"
+import { Modal, Form, InputNumber, Select, notification, Spin } from "antd"
 import { Sparkles } from "lucide-react"
 import React from "react"
 import { useTranslation } from "react-i18next"
@@ -10,6 +10,7 @@ import {
   type Prompt
 } from "@/services/prompt-studio"
 import { Button } from "@/components/Common/Button"
+import { Alert as DsAlert } from "@/components/ui/primitives"
 
 type TestCaseGenerateModalProps = {
   open: boolean
@@ -94,9 +95,8 @@ export const TestCaseGenerateModal: React.FC<TestCaseGenerateModalProps> = ({
       destroyOnHidden
     >
       <div className="mt-4 space-y-4">
-        <Alert
-          type="info"
-          showIcon
+        <DsAlert
+          variant="info"
           title={t("managePrompts.studio.testCases.generateInfo", {
             defaultValue:
               "Use AI to automatically generate test cases based on your prompt structure."

--- a/apps/packages/ui/src/components/Option/Prompt/Studio/TestCases/TestCaseRunModal.tsx
+++ b/apps/packages/ui/src/components/Option/Prompt/Studio/TestCases/TestCaseRunModal.tsx
@@ -1,5 +1,5 @@
 import { useMutation, useQuery } from "@tanstack/react-query"
-import { Modal, Select, notification, Alert, Spin, Table, Tag } from "antd"
+import { Modal, Select, notification, Spin, Table } from "antd"
 import { Play, CheckCircle2, XCircle, Clock } from "lucide-react"
 import React, { useState } from "react"
 import { useTranslation } from "react-i18next"
@@ -10,6 +10,7 @@ import {
   type TestRunResult
 } from "@/services/prompt-studio"
 import { Button } from "@/components/Common/Button"
+import { Alert as DsAlert, Badge } from "@/components/ui/primitives"
 
 type TestCaseRunModalProps = {
   open: boolean
@@ -102,9 +103,8 @@ export const TestCaseRunModal: React.FC<TestCaseRunModalProps> = ({
       <div className="mt-4 space-y-4">
         {!results && (
           <>
-            <Alert
-              type="info"
-              showIcon
+            <DsAlert
+              variant="info"
               title={t("managePrompts.studio.testCases.runInfo", {
                 defaultValue:
                   "Run {{count}} test cases against a prompt to see the outputs.",
@@ -157,13 +157,15 @@ export const TestCaseRunModal: React.FC<TestCaseRunModalProps> = ({
                   defaultValue: "Results"
                 })}
               </span>
-              <Tag color="green" icon={<CheckCircle2 className="size-3" />}>
+              <Badge variant="success" size="sm">
+                <CheckCircle2 className="size-3" aria-hidden="true" />
                 {passCount} passed
-              </Tag>
+              </Badge>
               {failCount > 0 && (
-                <Tag color="red" icon={<XCircle className="size-3" />}>
+                <Badge variant="danger" size="sm">
+                  <XCircle className="size-3" aria-hidden="true" />
                   {failCount} failed
-                </Tag>
+                </Badge>
               )}
             </div>
 
@@ -191,19 +193,24 @@ export const TestCaseRunModal: React.FC<TestCaseRunModalProps> = ({
                   width: 80,
                   render: (_, record) =>
                     record.error ? (
-                      <Tag color="red" icon={<XCircle className="size-3" />}>
+                      <Badge variant="danger" size="sm">
+                        <XCircle className="size-3" aria-hidden="true" />
                         Error
-                      </Tag>
+                      </Badge>
                     ) : record.passed ? (
-                      <Tag color="green" icon={<CheckCircle2 className="size-3" />}>
+                      <Badge variant="success" size="sm">
+                        <CheckCircle2 className="size-3" aria-hidden="true" />
                         Pass
-                      </Tag>
+                      </Badge>
                     ) : record.passed === false ? (
-                      <Tag color="orange" icon={<XCircle className="size-3" />}>
+                      <Badge variant="warning" size="sm">
+                        <XCircle className="size-3" aria-hidden="true" />
                         Fail
-                      </Tag>
+                      </Badge>
                     ) : (
-                      <Tag>Run</Tag>
+                      <Badge variant="secondary" size="sm">
+                        Run
+                      </Badge>
                     )
                 },
                 {

--- a/apps/packages/ui/src/components/Option/Prompt/Studio/TestCases/__tests__/TestCaseDesignSystem.test.tsx
+++ b/apps/packages/ui/src/components/Option/Prompt/Studio/TestCases/__tests__/TestCaseDesignSystem.test.tsx
@@ -1,0 +1,319 @@
+import React from "react"
+import { fireEvent, render, screen, within } from "@testing-library/react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { TestCaseBulkPanel } from "../TestCaseBulkPanel"
+import { TestCaseGenerateModal } from "../TestCaseGenerateModal"
+import { TestCaseRunModal } from "../TestCaseRunModal"
+
+const testRunResults = vi.hoisted(() => [
+  {
+    test_case_id: 88,
+    passed: true,
+    output: "Grounded answer with citations.",
+    execution_time: 1.23
+  },
+  {
+    test_case_id: 89,
+    passed: false,
+    output: "Ungrounded answer.",
+    execution_time: 0.82
+  },
+  {
+    test_case_id: 90,
+    passed: null,
+    error: "Provider timeout",
+    execution_time: 0.45
+  }
+])
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (
+      key: string,
+      fallbackOrOptions?: string | { defaultValue?: string; [key: string]: unknown }
+    ) => {
+      if (typeof fallbackOrOptions === "string") return fallbackOrOptions
+      if (fallbackOrOptions?.defaultValue) {
+        return Object.entries(fallbackOrOptions).reduce(
+          (value, [name, replacement]) =>
+            name === "defaultValue"
+              ? value
+              : value.replace(
+                  new RegExp(`{{${name}}}`, "g"),
+                  String(replacement)
+                ),
+          fallbackOrOptions.defaultValue
+        )
+      }
+      return key
+    }
+  })
+}))
+
+vi.mock("@/components/Common/Button", () => ({
+  Button: ({
+    children,
+    disabled,
+    htmlType,
+    onClick
+  }: {
+    children?: React.ReactNode
+    disabled?: boolean
+    htmlType?: "button" | "submit" | "reset"
+    onClick?: () => void
+  }) => (
+    <button type={htmlType ?? "button"} disabled={disabled} onClick={onClick}>
+      {children}
+    </button>
+  )
+}))
+
+vi.mock("@/services/prompt-studio", () => ({
+  createBulkTestCases: vi.fn(),
+  exportTestCases: vi.fn(),
+  generateTestCases: vi.fn(),
+  importTestCases: vi.fn(),
+  listPrompts: vi.fn(),
+  runTestCases: vi.fn()
+}))
+
+vi.mock("@tanstack/react-query", () => ({
+  useQuery: ({ queryKey }: { queryKey: unknown[] }) => {
+    if (queryKey.includes("prompts")) {
+      return {
+        data: {
+          data: {
+            data: [
+              {
+                id: 55,
+                project_id: 7,
+                name: "Research synthesis",
+                version_number: 2
+              }
+            ]
+          }
+        }
+      }
+    }
+
+    return { data: undefined, isLoading: false }
+  },
+  useMutation: (options: any = {}) => ({
+    isPending: false,
+    mutate: vi.fn((args) => {
+      options.onSuccess?.({ data: { data: testRunResults } }, args)
+    })
+  }),
+  useQueryClient: () => ({ invalidateQueries: vi.fn() })
+}))
+
+vi.mock("antd", () => {
+  const passthrough = ({ children }: { children?: React.ReactNode }) => (
+    <div>{children}</div>
+  )
+  const Form = Object.assign(
+    ({
+      children,
+      onFinish
+    }: {
+      children?: React.ReactNode
+      onFinish?: (values: Record<string, unknown>) => void
+    }) => (
+      <form
+        onSubmit={(event) => {
+          event.preventDefault()
+          onFinish?.({})
+        }}
+      >
+        {children}
+      </form>
+    ),
+    {
+      Item: ({
+        children,
+        label
+      }: {
+        children?: React.ReactNode
+        label?: React.ReactNode
+      }) => (
+        <label>
+          {label}
+          {children}
+        </label>
+      ),
+      useForm: () => [
+        {
+          resetFields: vi.fn()
+        }
+      ]
+    }
+  )
+
+  const Select = ({
+    onChange,
+    options = [],
+    placeholder,
+    value
+  }: {
+    onChange?: (value: unknown) => void
+    options?: Array<{ label: React.ReactNode; value: unknown }>
+    placeholder?: string
+    value?: unknown
+  }) => (
+    <select
+      aria-label={placeholder ?? "Select"}
+      value={value === null || value === undefined ? "" : String(value)}
+      onChange={(event) => {
+        const selected = options.find(
+          (option) => String(option.value) === event.currentTarget.value
+        )
+        onChange?.(selected?.value ?? event.currentTarget.value)
+      }}
+    >
+      <option value="">{placeholder ?? "Select"}</option>
+      {options.map((option) => (
+        <option key={String(option.value)} value={String(option.value)}>
+          {option.label}
+        </option>
+      ))}
+    </select>
+  )
+
+  const Upload = Object.assign(passthrough, {
+    Dragger: passthrough
+  })
+
+  return {
+    Alert: ({ message, title, description }: any) => (
+      <div data-antd-component="Alert">
+        {title ?? message}
+        {description}
+      </div>
+    ),
+    Drawer: ({ open, children, title }: any) =>
+      open ? (
+        <section>
+          <h2>{title}</h2>
+          {children}
+        </section>
+      ) : null,
+    Form,
+    InputNumber: (props: any) => <input type="number" {...props} />,
+    Modal: ({ open, title, children, footer }: any) =>
+      open ? (
+        <section>
+          <h2>{title}</h2>
+          {children}
+          {footer}
+        </section>
+      ) : null,
+    Select,
+    Spin: () => <div>Loading</div>,
+    Table: ({ dataSource = [], columns = [], rowKey }: any) => (
+      <table>
+        <tbody>
+          {dataSource.map((record: any, index: number) => (
+            <tr key={record[rowKey] ?? index}>
+              {columns.map((column: any) => (
+                <td key={column.key ?? column.dataIndex}>
+                  {column.render
+                    ? column.render(record[column.dataIndex], record, index)
+                    : record[column.dataIndex]}
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    ),
+    Tabs: ({ items = [] }: any) => (
+      <div>
+        {items.map((item: any) => (
+          <section key={item.key}>
+            <h3>{item.label}</h3>
+            {item.children}
+          </section>
+        ))}
+      </div>
+    ),
+    Tag: ({ children }: { children?: React.ReactNode }) => (
+      <span data-antd-component="Tag">{children}</span>
+    ),
+    Upload,
+    notification: {
+      error: vi.fn(),
+      success: vi.fn(),
+      warning: vi.fn()
+    }
+  }
+})
+
+const expectDesignSystemAlert = (text: string) => {
+  const nodes = screen.getAllByText(text, { exact: false })
+
+  expect(
+    nodes.some((node) => node.closest('[data-ds-component="Alert"]'))
+  ).toBe(true)
+}
+
+const expectDesignSystemBadge = (
+  text: string | RegExp,
+  scope: { getByText: typeof screen.getByText } = screen
+) => {
+  const node = scope.getByText(text)
+
+  expect(node.closest('[data-ds-component="Badge"]')).toBeTruthy()
+}
+
+describe("Prompt Studio test-case design-system states", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("renders import and export guidance through design-system Alerts", () => {
+    render(<TestCaseBulkPanel open projectId={7} onClose={vi.fn()} />)
+
+    expectDesignSystemAlert("Export all test cases from this project")
+    expectDesignSystemAlert("Import test cases from a JSON or CSV file")
+  })
+
+  it("renders generation and run guidance through design-system Alerts", () => {
+    render(<TestCaseGenerateModal open projectId={7} onClose={vi.fn()} />)
+    expectDesignSystemAlert("Use AI to automatically generate test cases")
+
+    render(
+      <TestCaseRunModal
+        open
+        projectId={7}
+        testCaseIds={[88, 89, 90]}
+        onClose={vi.fn()}
+      />
+    )
+    expectDesignSystemAlert("Run 3 test cases against a prompt")
+  })
+
+  it("renders test run summary and row statuses through design-system Badges", () => {
+    render(
+      <TestCaseRunModal
+        open
+        projectId={7}
+        testCaseIds={[88, 89, 90]}
+        onClose={vi.fn()}
+      />
+    )
+
+    fireEvent.change(screen.getByLabelText("Select a prompt..."), {
+      target: { value: "55" }
+    })
+    fireEvent.click(screen.getByText("Run Tests"))
+
+    expectDesignSystemBadge("1 passed")
+    expectDesignSystemBadge("1 failed")
+
+    const resultsTable = within(screen.getByRole("table"))
+    expectDesignSystemBadge("Pass", resultsTable)
+    expectDesignSystemBadge("Fail", resultsTable)
+    expectDesignSystemBadge("Error", resultsTable)
+  })
+})

--- a/backlog/tasks/task-45.44.8.4 - Migrate-Prompt-Studio-test-case-product-states-to-design-system-primitives.md
+++ b/backlog/tasks/task-45.44.8.4 - Migrate-Prompt-Studio-test-case-product-states-to-design-system-primitives.md
@@ -1,0 +1,58 @@
+---
+id: TASK-45.44.8.4
+title: Migrate Prompt Studio test case product states to design-system primitives
+status: Done
+labels:
+- design-system
+- webui
+- product-state
+- prompt-studio
+parent_task_id: TASK-45.44.8
+references:
+- apps/packages/ui/scripts/design-system-product-state-baseline.json
+- backlog/tasks/task-45.44.8 - Migrate-design-system-product-state-Prompt-and-Prompt-Studio.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Migrate Prompt Studio TestCases product-state exceptions in TestCaseBulkPanel, TestCaseGenerateModal, and TestCaseRunModal from AntD Alert/Tag to design-system Alert/Badge primitives, remove the matching baseline entries, and add focused coverage proving the migrated design-system markers render.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 `TestCaseBulkPanel` uses the design-system `Alert` primitive for import/export guidance instead of AntD `Alert`.
+- [x] #2 `TestCaseGenerateModal` and `TestCaseRunModal` use the design-system `Alert` primitive for guidance instead of AntD `Alert`.
+- [x] #3 `TestCaseRunModal` uses design-system `Badge` primitives for run summaries and row statuses instead of AntD `Tag`.
+- [x] #4 Focused Prompt Studio test-case tests assert the migrated design-system markers render.
+- [x] #5 The product-state baseline removes only the migrated Prompt Studio test-case exceptions, and `verify:design-system-state` passes.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+- Added `TestCaseDesignSystem.test.tsx` with red/green coverage for bulk import/export guidance, AI generation guidance, run guidance, and test-run summary/row status labels.
+- Replaced AntD `Alert` usage in `TestCaseBulkPanel`, `TestCaseGenerateModal`, and `TestCaseRunModal` with the design-system `Alert` primitive.
+- Replaced `TestCaseRunModal` AntD `Tag` status labels with design-system `Badge` variants while preserving existing pass/fail/error/run labels and icons.
+- Removed five baseline entries for the migrated Prompt Studio test-case product-state exceptions.
+- TDD red run reached the intended assertions after dependency install: `TestCaseDesignSystem.test.tsx` failed because content was still rendered under AntD `Alert`/`Tag` instead of DS markers.
+- Review fix: tightened `TestCaseDesignSystem` badge assertions so summary badges are matched exactly and row-status badges are scoped to the rendered results table, preventing `Pass`/`Fail` checks from being satisfied by `passed`/`failed` summary text.
+- Verification after rebase on latest `origin/dev`: focused test-case DS test passed; test-case + evaluation + optimization Prompt Studio DS tests passed; `bun run verify:design-system-state` passed with total baseline exceptions at 97 and Prompt/Prompt Studio at 11; `NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit --pretty false` passed.
+- Bandit not applicable: touched code is frontend TypeScript/TSX, JSON baseline, and Backlog task metadata only.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Migrated Prompt Studio test-case guidance and run-result state labels from AntD product-state primitives to design-system primitives. Added focused render coverage and removed the matching five baseline exceptions.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## Change summary (maintainer-owned)

TODO: Maintainer to summarize why this Prompt Studio test-case state migration is scoped separately and why the DS Alert/Badge primitives are the right replacement for these product states.

## Summary

- Migrates Prompt Studio test-case import/export, generation, and run guidance from AntD `Alert` to the design-system `Alert` primitive.
- Migrates `TestCaseRunModal` summary and row status labels from AntD `Tag` to the design-system `Badge` primitive.
- Adds focused Prompt Studio test-case render coverage for DS `Alert`/`Badge` markers.
- Removes the five matching product-state baseline exceptions.
- Closes `TASK-45.44.8.4`.

## Verification

- [x] `bunx vitest run src/components/Option/Prompt/Studio/TestCases/__tests__/TestCaseDesignSystem.test.tsx --maxWorkers=1 --no-file-parallelism`
- [x] `bunx vitest run src/components/Option/Prompt/Studio/TestCases/__tests__/TestCaseDesignSystem.test.tsx src/components/Option/Prompt/Studio/Evaluations/__tests__/EvaluationDesignSystem.test.tsx src/components/Option/Prompt/Studio/Optimizations/__tests__/OptimizationDesignSystem.test.tsx --maxWorkers=1 --no-file-parallelism`
- [x] `bun run verify:design-system-state`
- [x] `NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit --pretty false`
- [x] `git diff --check`
- [x] baseline JSON parse
- [x] Bandit not applicable: frontend TS/TSX, JSON baseline, and Backlog task metadata only

## UX Audit Checklist

- [x] Preserves existing test-case guidance copy and run-result status labels.
- [x] Uses shared DS state primitives instead of AntD product-state UI.
- [x] Keeps the slice narrow to Prompt Studio test-case surfaces.
- [x] Adds render-level regression coverage for the migrated state primitives.

## Watchlists

- [x] Not applicable; no Watchlists surfaces touched.

## Risk and rollback

Low risk. The change is a primitive swap for existing inline state UI with focused tests and verifier coverage. Rollback is reverting this PR, which restores the prior AntD states and baseline entries.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrates Prompt Studio test-case guidance and run-result labels from `antd` `Alert`/`Tag` to design-system `Alert`/`Badge`. Unifies product-state UI, removes five baseline exceptions, and adds focused tests to satisfy `TASK-45.44.8.4`.

- **Refactors**
  - Replaced AntD state UI with design-system primitives in TestCaseBulkPanel, TestCaseGenerateModal, and TestCaseRunModal.
  - Used `Badge` variants for pass/fail/error/run labels and summary counts.
  - Added `TestCaseDesignSystem.test.tsx` to assert design-system `Alert`/`Badge` render with the same copy.
  - Removed matching entries from `scripts/design-system-product-state-baseline.json`; `verify:design-system-state` passes.

<sup>Written for commit eba56f32ad33364f28bf3a55bae682606ca274ab. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2175?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

