### PR TITLE
Close first-time readiness setup design task

### DIFF
--- a/Docs/superpowers/specs/2026-05-18-first-time-model-readiness-setup-design.md
+++ b/Docs/superpowers/specs/2026-05-18-first-time-model-readiness-setup-design.md
@@ -2,7 +2,7 @@
 
 Date: 2026-05-18
 Owner: Codex brainstorming session
-Status: Ready for user review
+Status: Design complete; implementation deferred
 Backlog: TASK-426
 
 ## Summary

--- a/backlog/tasks/task-426 - Design-first-time-model-readiness-setup-flow.md
+++ b/backlog/tasks/task-426 - Design-first-time-model-readiness-setup-flow.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-426
 title: Design first-time model readiness setup flow
-status: In Progress
+status: Done
 labels:
 - design
 - setup
@@ -22,6 +22,10 @@ Create a design spec for a first-time setup/readiness flow that exposes curated 
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
+- [x] #1 Spec captures the unified first-time model readiness setup architecture across backend `/setup` and native WebUI setup.
+- [x] #2 Spec covers chat, embeddings/RAG, speech readiness lanes, and secondary TTS readiness semantics.
+- [x] #3 Spec records provisioning consent, permissions, error handling, secret handling, admin/local setup boundaries, and trusted custom-model safeguards.
+- [x] #4 Verification and the implementation-deferred boundary are recorded.
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -33,21 +37,26 @@ Design-only task. Spec captures the approved first-time model readiness setup ar
 ## Implementation Notes
 
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Closed this design-only task after confirming the spec and task summary already captured the approved first-time readiness setup direction.
+
+- Design artifact: `Docs/superpowers/specs/2026-05-18-first-time-model-readiness-setup-design.md`.
+- Updated the spec status from review-ready to design complete with implementation deferred.
+- This closeout changes only Markdown documentation and Backlog task metadata. Bandit is not applicable.
 
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Created Docs/superpowers/specs/2026-05-18-first-time-model-readiness-setup-design.md as a design-only spec for first-time model readiness setup. The spec records the approved unified readiness wizard direction, native WebUI backed by setup APIs, curated profiles, explicit Provision now gating, lane readiness semantics, permission boundaries, error handling, and test strategy. A follow-up critique pass hardened the design by making restart/admin/remote-blocked states overlays instead of lane statuses, treating TTS as secondary metadata inside the speech lane, requiring WebUI fallback when the backend local setup guard blocks native first-run setup, requiring pollable provisioning instead of long-held HTTP requests, clarifying secret handling, and gating trusted custom HF models behind advanced acknowledgement. Verification: rg found no TODO/TBD/FIXME markers; git diff checks passed for touched docs/task metadata. Bandit skipped because this task changes documentation/task metadata only.
+Closed the first-time model readiness setup design task. The design spec records the approved unified readiness wizard direction, native WebUI backed by setup APIs, curated profiles, explicit Provision now gating, lane readiness semantics, permission boundaries, error handling, and test strategy. A follow-up critique pass hardened restart/admin/remote-blocked overlays, secondary TTS handling, WebUI fallback, pollable provisioning, secret handling, and trusted custom-model acknowledgement. Runtime implementation remains deferred to follow-up implementation tasks.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->


### PR DESCRIPTION
## Summary

- What changed: closed `TASK-426`, added explicit acceptance criteria, checked its Definition of Done, and updated the linked spec status to `Design complete; implementation deferred`.
- Why: the design work was already captured and summarized, but the Backlog record still looked in-progress with no acceptance criteria.

## Change summary (maintainer-owned)

- [ ] Maintainer has reviewed and owns the change summary and rationale before merge.

## Validation

- [x] Tests added/updated for behavior changes: not applicable, docs/Backlog-only closeout.
- [x] Relevant unit/integration tests pass locally: not applicable, no runtime behavior changed.
- [x] Docs updated: `Docs/superpowers/specs/2026-05-18-first-time-model-readiness-setup-design.md`
- [x] `git diff --check origin/dev..HEAD`
- [x] `rg -n "TODO|TBD|FIXME|Open question|open question" Docs/superpowers/specs/2026-05-18-first-time-model-readiness-setup-design.md` returned no matches.

## UX Audit Checklist (v2 Stage 5)

- [x] Not applicable: no WebUI or extension behavior changed in this PR.

## Watchlists Accessibility Checklist (Group 09 Stage 5)

- [x] Not applicable: no Watchlists UI behavior changed in this PR.

## Watchlists Scale Checklist (Group 10 Stage 5)

- [x] Not applicable: no Watchlists polling, notification, Activity, batch triage, or scale behavior changed in this PR.

## Risk & Rollback

- Risk level: Low.
- Rollback plan: revert the single docs/Backlog closeout commit.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Closed TASK-426 by finalizing the first-time model readiness setup design: added acceptance criteria, checked the Definition of Done, and set the spec to "Design complete; implementation deferred". This clarifies the backlog and defers implementation to follow-up work; no runtime changes.

<sup>Written for commit b14e202b0049d92ccccaf3d4a09e515c27f56568. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2176?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

