### PR TITLE
fix(chat): show web search progress in status strip

### DIFF
--- a/apps/packages/ui/src/components/Option/Playground/Playground.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/Playground.tsx
@@ -350,6 +350,7 @@ export const Playground = () => {
     createChatBranch,
     streaming,
     isProcessing,
+    isSearchingInternet,
     selectedCharacter,
     setSelectedCharacter,
     compareMode,
@@ -2964,6 +2965,7 @@ export const Playground = () => {
       contextSummary={statusContextSummary}
       temporaryChat={temporaryChat}
       characterChatActive={characterWorkflowActive}
+      webSearchInProgress={isSearchingInternet}
       degraded={serverReadinessState === "degraded"}
       degradedChecks={serverDegradedChecks}
       errorMessage={null}

--- a/apps/packages/ui/src/components/Option/Playground/PlaygroundStatusStrip.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/PlaygroundStatusStrip.tsx
@@ -30,6 +30,7 @@ type PlaygroundStatusStripRuntimeState =
   | "error"
   | "server-blocked"
   | "streaming"
+  | "web-searching"
   | "loading"
   | "model-loading"
   | "missing-model"
@@ -60,6 +61,7 @@ export type PlaygroundStatusStripProps = {
   contextSummary?: string[] | null;
   temporaryChat?: boolean;
   characterChatActive?: boolean;
+  webSearchInProgress?: boolean;
   degraded?: boolean;
   degradedChecks?: string[];
   errorMessage?: string | null;
@@ -95,6 +97,7 @@ export const PlaygroundStatusStrip = ({
   contextSummary = [],
   temporaryChat,
   characterChatActive = false,
+  webSearchInProgress = false,
   degraded = false,
   degradedChecks = [],
   errorMessage,
@@ -142,17 +145,19 @@ export const PlaygroundStatusStrip = ({
       ? "server-blocked"
       : streaming
         ? "streaming"
-        : isContextLoading
-          ? "loading"
-          : blockingModelUsabilityState
-            ? blockingModelUsabilityState
-            : modelUnavailable
-              ? "model-unavailable"
-              : !hasSelectedModel
-                ? "missing-model"
-                : isDegraded
-                  ? "degraded"
-                  : "ready";
+        : webSearchInProgress
+          ? "web-searching"
+          : isContextLoading
+            ? "loading"
+            : blockingModelUsabilityState
+              ? blockingModelUsabilityState
+              : modelUnavailable
+                ? "model-unavailable"
+                : !hasSelectedModel
+                  ? "missing-model"
+                  : isDegraded
+                    ? "degraded"
+                    : "ready";
   const routeLabel =
     selectedProvider && hasSelectedModel
       ? `${selectedProvider}:${selectedModel}`
@@ -166,6 +171,8 @@ export const PlaygroundStatusStrip = ({
         ? t("cockpit.serverUnavailable", "Server unavailable")
         : runtimeState === "streaming"
           ? t("cockpit.streaming", "Streaming")
+          : runtimeState === "web-searching"
+            ? t("cockpit.searchingWeb", "Searching web")
           : runtimeState === "loading"
             ? t("cockpit.loadingContext", `${LOADING_STATE_LABEL} context`)
             : runtimeState === "model-loading"
@@ -236,6 +243,13 @@ export const PlaygroundStatusStrip = ({
           "Context preview is loading.",
         )
       : null;
+  const webSearchReason =
+    runtimeState === "web-searching"
+      ? t(
+          "cockpit.webSearchInProgress",
+          "Gathering web results before the model responds.",
+        )
+      : null;
   const normalizedSessionTitle = sessionTitle?.trim() || null;
   const normalizedSessionStatusLabel = sessionStatusLabel?.trim() || null;
   const normalizedSessionDetail = sessionDetail?.trim() || null;
@@ -303,6 +317,7 @@ export const PlaygroundStatusStrip = ({
                   runtimeState === "model-unavailable"
                 ? "border-warning/40 bg-warning/10 text-warning"
                 : runtimeState === "streaming" ||
+                    runtimeState === "web-searching" ||
                     runtimeState === "loading" ||
                     runtimeState === "model-loading"
                   ? "border-info/40 bg-info/10 text-info"
@@ -316,6 +331,7 @@ export const PlaygroundStatusStrip = ({
           runtimeState === "model-unavailable" ? (
             <AlertTriangle className="h-3.5 w-3.5" aria-hidden="true" />
           ) : runtimeState === "streaming" ||
+            runtimeState === "web-searching" ||
             runtimeState === "loading" ||
             runtimeState === "model-loading" ? (
             <Loader2 className="h-3.5 w-3.5" aria-hidden="true" />
@@ -384,6 +400,9 @@ export const PlaygroundStatusStrip = ({
             ) : null}
             {contextLoadingReason ? (
               <span className={pillClass}>{contextLoadingReason}</span>
+            ) : null}
+            {webSearchReason ? (
+              <span className={pillClass}>{webSearchReason}</span>
             ) : null}
             {!serverBlocked
               ? degradedChecks.map((check, index) => (

--- a/apps/packages/ui/src/components/Option/Playground/__tests__/Playground.cockpit-controls.test.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/__tests__/Playground.cockpit-controls.test.tsx
@@ -58,6 +58,7 @@ const messageOptionState = vi.hoisted(() => ({
     setContextFiles: vi.fn(),
     createChatBranch: vi.fn(),
     streaming: true,
+    isSearchingInternet: false,
     selectedCharacter: { id: "character-1", name: "Mira Vale" },
     setSelectedCharacter: vi.fn(),
     selectedAssistant: {
@@ -407,6 +408,7 @@ describe("Playground cockpit controls", () => {
     messageOptionState.value.setHistory = vi.fn();
     messageOptionState.value.setMessages = vi.fn();
     messageOptionState.value.streaming = true;
+    messageOptionState.value.isSearchingInternet = false;
     messageOptionState.value.selectedSystemPrompt = "";
     messageOptionState.value.setSelectedSystemPrompt = vi.fn();
     messageOptionState.value.selectedQuickPrompt = null;
@@ -704,6 +706,22 @@ describe("Playground cockpit controls", () => {
       window.removeEventListener(SET_TEMPORARY_CHAT_EVENT, setTemporaryChat);
     }
   }, 15000);
+
+  it("surfaces active web search progress in the cockpit status strip", async () => {
+    messageOptionState.value.streaming = false;
+    messageOptionState.value.isSearchingInternet = true;
+    messageOptionState.value.selectedAssistant = null;
+    messageOptionState.value.selectedCharacter = null;
+
+    render(<Playground />);
+
+    const statusStrip = await screen.findByRole("status", {
+      name: "Chat status",
+    });
+    expect(statusStrip).toHaveTextContent("Searching web");
+    expect(statusStrip).toHaveTextContent("Web search on");
+    expect(statusStrip).not.toHaveTextContent("Ready");
+  });
 
   it("logs selected prompt lookup failures while keeping the prompt unavailable state visible", async () => {
     const promptLookupWarning = vi

--- a/apps/packages/ui/src/components/Option/Playground/__tests__/PlaygroundStatusStrip.first-slice.test.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/__tests__/PlaygroundStatusStrip.first-slice.test.tsx
@@ -63,6 +63,31 @@ describe("PlaygroundStatusStrip first-slice state", () => {
     expect(status).toHaveTextContent("2 files");
   });
 
+  it("shows web search progress instead of ready while search context is being gathered", () => {
+    render(
+      <PlaygroundStatusStrip
+        mode="cockpit"
+        streaming={false}
+        webSearchInProgress
+        selectedProvider="openai"
+        selectedModel="gpt-4.1-mini"
+        messageCount={3}
+        sessionLabel="Server chat"
+        hasContext
+        contextSummary={["Web search on"]}
+        temporaryChat={false}
+        degradedChecks={[]}
+        errorMessage={null}
+      />,
+    );
+
+    const status = screen.getByRole("status", { name: "Chat status" });
+    expect(status).toHaveTextContent("Searching web");
+    expect(status).toHaveTextContent("Gathering web results before the model responds.");
+    expect(status).toHaveTextContent("Web search on");
+    expect(status).not.toHaveTextContent("Ready");
+  });
+
   it("handles explicit null context summaries without throwing", () => {
     render(
       <PlaygroundStatusStrip

--- a/backlog/tasks/task-568 - Prove-live-Web-search-context-status-in-chat.md
+++ b/backlog/tasks/task-568 - Prove-live-Web-search-context-status-in-chat.md
@@ -1,0 +1,55 @@
+---
+id: TASK-568
+title: Prove live Web search context status in /chat
+status: Done
+labels:
+- chat
+- ux
+- proof
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Run a focused /chat live-browser proof for Web search/context activation. Pre-send status-strip/context rail feedback must reflect active Web search/context state, and the send flow must complete or show a recoverable provider/search error without a misleading ready state. Scope is limited to /chat WebUI context/status proof; do not redesign Web search provider settings, extension handoff, long-session, context-limit, compare/export/share.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Inspect existing /chat Web search/context status-strip and context rail coverage on latest dev.
+- [x] #2 Run focused automated coverage or add the smallest missing regression first if live status feedback is not covered.
+- [x] #3 Attempt real-server /chat proof for Web search/context activation in the available local environment and record any environment limits separately from product issues.
+- [x] #4 Document verification evidence and any remaining follow-up scope in the task.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Existing real-server cockpit proof toggles Web search/context source status and validates live send flows, but did not cover the active `isSearchingInternet` pre-response status. Added a focused status-strip regression and a Playground integration regression so active Web search now overrides `Ready` while search context is being gathered.
+
+Environment note: local backend and mock OpenAI server required escalated loopback binds/probes in this sandbox. The real-server proof itself passed once those local services were available.
+
+Verification:
+- Red: `bun run test src/components/Option/Playground/__tests__/PlaygroundStatusStrip.first-slice.test.tsx src/components/Option/Playground/__tests__/Playground.cockpit-controls.test.tsx --maxWorkers=1` failed before implementation because the status strip still rendered `Ready` while `isSearchingInternet`/`webSearchInProgress` was true.
+- Green: same focused unit command passed, 48 tests.
+- Green: `TLDW_WEB_URL=http://localhost:18024 TLDW_WEB_CMD='env NEXT_DISABLE_MEM_OVERRIDE=1 NODE_OPTIONS=--max-old-space-size=4096 bun run dev -- --webpack -p 18024' TLDW_SERVER_URL=http://127.0.0.1:18023 TLDW_E2E_SERVER_URL=http://127.0.0.1:18023 TLDW_API_KEY=smoke-ci-key-12345 TLDW_E2E_API_KEY=smoke-ci-key-12345 SINGLE_USER_API_KEY=smoke-ci-key-12345 NEXT_PUBLIC_API_URL=http://127.0.0.1:18023 bun run e2e:chat-cockpit:real:focused` passed, 5 tests, no skips.
+- Green: `git diff --check`.
+- Bandit: not applicable; touched frontend TypeScript/tests only.
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Live /chat Web search/context proof is now covered by the existing focused real-server cockpit suite plus a new narrow regression for the previously misleading active Web search status. The cockpit status strip now shows Searching web with a short reason while Web search context is being gathered instead of presenting the chat as Ready.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## Summary

- What changed: `/chat` now surfaces active Web search gathering as a first-class status-strip runtime state instead of showing `Ready` while `isSearchingInternet` is true.
- What changed: Added focused status-strip and full `Playground` regression coverage, plus Backlog task evidence for the live-server proof.
- Why: The UX audit follow-up identified a misleading pre-response state for Web search/context activation; users need clear feedback that the app is gathering Web results before the model responds.

## Change Summary (maintainer-owned)

- [ ] Maintainer: replace this checkbox with your own human-written summary before merge, per the AI-generated PR merge gate.

## Validation

- [x] Tests added/updated for behavior changes
- [x] Relevant unit/integration tests pass locally
- [x] Docs updated (if behavior, routes, or config changed)

Commands run:

- `cd apps/packages/ui && bun run test src/components/Option/Playground/__tests__/PlaygroundStatusStrip.first-slice.test.tsx src/components/Option/Playground/__tests__/Playground.cockpit-controls.test.tsx --maxWorkers=1`
- `cd apps/tldw-frontend && TLDW_WEB_URL=http://localhost:18024 TLDW_WEB_CMD='env NEXT_DISABLE_MEM_OVERRIDE=1 NODE_OPTIONS=--max-old-space-size=4096 bun run dev -- --webpack -p 18024' TLDW_SERVER_URL=http://127.0.0.1:18023 TLDW_E2E_SERVER_URL=http://127.0.0.1:18023 TLDW_API_KEY=smoke-ci-key-12345 TLDW_E2E_API_KEY=smoke-ci-key-12345 SINGLE_USER_API_KEY=smoke-ci-key-12345 NEXT_PUBLIC_API_URL=http://127.0.0.1:18023 bun run e2e:chat-cockpit:real:focused`
- `git diff --check`

Post-rebase note:

- Rebasing onto latest `origin/dev` was clean. The second `origin/dev` move only touched Research Workspace files, not `/chat`.
- Focused unit regressions were rerun after the final rebase and passed: 48 tests.
- The focused real-server `/chat` cockpit proof passed before the final research-only rebase: 5 tests, no skips.

Bandit:

- Not applicable; touched frontend TypeScript/test files and a Backlog task only.

## UX Audit Checklist (v2 Stage 5)

- [ ] `npm run e2e:smoke:stage5` passes
- [ ] `npx playwright test e2e/smoke/all-pages.spec.ts --reporter=line` passes (or failures documented)
- [ ] No listed AntD deprecations in console output: `Drawer.width`, `Space.direction`, `Alert.message`, `List`
- [ ] No `Maximum update depth exceeded` warnings on audited routes
- [ ] No unresolved `{{...}}` placeholders on audited routes
- [ ] WebUI/extension parity validated for shared UI fixes
- [ ] For Flashcards UI changes: tabs remain `Study` / `Manage` / `Transfer` and secondary create CTAs route through manager create-entry path
- [ ] For Flashcards drawer changes: use `FLASHCARDS_DRAWER_WIDTH_PX` and keep footer action order `Cancel -> secondary -> primary`
- [ ] For Flashcards help/copy/import UX changes: update `Docs/User_Guides/WebUI_Extension/Flashcards_Study_Guide.md` and keep in-app help links pointed at guide section anchors

Notes:

- Scoped `/chat` fix only; broad Stage 5 smoke and unrelated Flashcards checklist items were not run.
- Extension code was not changed. Existing shared `/chat` cockpit proof covers the WebUI behavior this slice changes.

## Watchlists Accessibility Checklist (Group 09 Stage 5)

- [ ] If Watchlists UI behavior changed: `cd apps/packages/ui && bun run test:watchlists:a11y` passes locally
- [ ] If Watchlists UI behavior changed: keyboard-only path still works for Overview -> Feeds -> Monitors -> Activity -> Articles -> Reports
- [ ] If Watchlists UI behavior changed: list/table labels and live-region copy remain localized (no new hardcoded assistive text)
- [ ] If Watchlists UI behavior changed: monitor/feed active state is not color-only (explicit text or icon signal is present)
- [ ] If Watchlists UI behavior changed: known assistive-tech constraints reviewed in `Docs/Plans/WATCHLISTS_ASSISTIVE_TECH_AUDIT_2026_02_24.md`

Notes:

- Not applicable; no Watchlists UI behavior changed.

## Watchlists Scale Checklist (Group 10 Stage 5)

- [ ] If Watchlists UI behavior changed: `cd apps/packages/ui && bun run test:watchlists:scale` passes locally
- [ ] If Watchlists polling/notifications behavior changed: no duplicate terminal notifications during in-flight polling overlap
- [ ] If Watchlists Activity polling changed: auto-refresh is gated to active + visible Activity context (no background tab polling churn)
- [ ] If Watchlists batch triage behavior changed: partial-failure retry path remains available and updates only failed IDs
- [ ] If Watchlists scale behavior changed: constraints/mitigations reviewed in `Docs/Plans/WATCHLISTS_SCALE_READINESS_RUNBOOK_2026_02_24.md`

Notes:

- Not applicable; no Watchlists behavior changed.

## Risk & Rollback

- Risk level: Low
- Rollback plan: Revert this PR to return the status strip to the previous runtime-state precedence.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the chat status strip to show active web search progress instead of “Ready” while search context is being gathered. This clarifies the pre-response state and avoids misleading feedback.

- **Bug Fixes**
  - Added a `web-searching` runtime state to `PlaygroundStatusStrip`; when `isSearchingInternet` is true (and not streaming), show “Searching web” with a short reason.
  - Passed `webSearchInProgress` from `Playground` to `PlaygroundStatusStrip`, and used the info icon/color for this state.
  - Added focused unit and cockpit integration tests to verify the new state and that “Ready” is not shown during web search.
  - Included a brief proof doc for backlog task `TASK-568`.

<sup>Written for commit ea4114cf523dae96deb777f5ff4179118144b18c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2177?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

