### PR TITLE
Stage Deep Research return handoff

### DIFF
--- a/apps/packages/ui/src/components/Option/ResearchWorkspace/__tests__/ResearchWorkspace.stage2.responsive.test.tsx
+++ b/apps/packages/ui/src/components/Option/ResearchWorkspace/__tests__/ResearchWorkspace.stage2.responsive.test.tsx
@@ -318,6 +318,24 @@ describe("ResearchWorkspace Stage 2 drawer responsiveness", () => {
     expect(screen.queryByTestId("workspace-chat-pane")).not.toBeInTheDocument()
   })
 
+  it("opens Studio from HashRouter mobile ?tab=studio route state", () => {
+    testState.isMobile = true
+    window.history.replaceState(
+      null,
+      "",
+      "/options.html#/research-workspace?tab=studio"
+    )
+
+    render(<ResearchWorkspace />)
+
+    expect(screen.getByTestId("workspace-mobile-tabs")).toHaveAttribute(
+      "data-active-key",
+      "studio"
+    )
+    expect(screen.getByTestId("workspace-studio-pane")).toBeInTheDocument()
+    expect(screen.queryByTestId("workspace-chat-pane")).not.toBeInTheDocument()
+  })
+
   it("falls back to Chat for invalid mobile tab route state", () => {
     testState.isMobile = true
     window.history.replaceState(null, "", "/research-workspace?tab=banana")
@@ -431,6 +449,60 @@ describe("ResearchWorkspace Stage 2 drawer responsiveness", () => {
       "data-active-key",
       "studio"
     )
+  })
+
+  it("surfaces matching Deep Research return context and focuses Studio", async () => {
+    window.history.replaceState(
+      null,
+      "",
+      "/research-workspace?source_workspace_id=workspace-1&source_artifact_id=gap-artifact&source_artifact_template=corpus_gap_finder&source_artifact_title=Corpus%20Gap%20Finder&research_run_id=research-run-7"
+    )
+
+    render(<ResearchWorkspace />)
+
+    const handoff = screen.getByTestId("workspace-deep-research-return-handoff")
+    expect(handoff).toHaveTextContent("Deep Research return ready")
+    expect(handoff).toHaveTextContent("Corpus Gap Finder")
+    expect(handoff).toHaveTextContent("research-run-7")
+    await waitFor(() => {
+      expect(testState.setRightPaneCollapsed).toHaveBeenCalledWith(false)
+    })
+    expect(
+      screen.getByRole("complementary", { name: "Studio panel" })
+    ).toBeInTheDocument()
+  })
+
+  it("surfaces matching Deep Research return context from HashRouter search params", async () => {
+    window.history.replaceState(
+      null,
+      "",
+      "/options.html#/research-workspace?source_workspace_id=workspace-1&source_artifact_id=gap-artifact&source_artifact_template=corpus_gap_finder&source_artifact_title=Corpus%20Gap%20Finder&research_run_id=research-run-7"
+    )
+
+    render(<ResearchWorkspace />)
+
+    const handoff = screen.getByTestId("workspace-deep-research-return-handoff")
+    expect(handoff).toHaveTextContent("Deep Research return ready")
+    expect(handoff).toHaveTextContent("Corpus Gap Finder")
+    expect(handoff).toHaveTextContent("research-run-7")
+    await waitFor(() => {
+      expect(testState.setRightPaneCollapsed).toHaveBeenCalledWith(false)
+    })
+  })
+
+  it("ignores Deep Research return context for a different workspace", () => {
+    window.history.replaceState(
+      null,
+      "",
+      "/research-workspace?source_workspace_id=workspace-2&source_artifact_id=gap-artifact&source_artifact_template=corpus_gap_finder&source_artifact_title=Corpus%20Gap%20Finder&research_run_id=research-run-7"
+    )
+
+    render(<ResearchWorkspace />)
+
+    expect(
+      screen.queryByTestId("workspace-deep-research-return-handoff")
+    ).not.toBeInTheDocument()
+    expect(testState.setRightPaneCollapsed).not.toHaveBeenCalledWith(false)
   })
 
   it("opens Sources from the mobile Studio source-readiness CTA", async () => {

--- a/apps/packages/ui/src/components/Option/ResearchWorkspace/__tests__/research-workspace-route-state.test.ts
+++ b/apps/packages/ui/src/components/Option/ResearchWorkspace/__tests__/research-workspace-route-state.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest"
 import {
   RESEARCH_WORKSPACE_LAST_MOBILE_TAB_STORAGE_KEY,
   getInitialResearchWorkspaceTab,
+  getResearchWorkspaceSearchFromLocation,
   getResearchWorkspaceTabFromSearch,
   parseResearchWorkspaceTab,
   readResearchWorkspaceLastMobileTab,
@@ -34,6 +35,27 @@ describe("Research Workspace route state", () => {
       "sources"
     )
     expect(getResearchWorkspaceTabFromSearch("?tab=banana&tab=studio")).toBeNull()
+  })
+
+  it("reads query params from normal and hash-router locations", () => {
+    expect(
+      getResearchWorkspaceSearchFromLocation({
+        search: "?tab=studio",
+        hash: "#/research-workspace?tab=sources"
+      })
+    ).toBe("?tab=studio")
+    expect(
+      getResearchWorkspaceSearchFromLocation({
+        search: "",
+        hash: "#/research-workspace?tab=studio&shared=123"
+      })
+    ).toBe("?tab=studio&shared=123")
+    expect(
+      getResearchWorkspaceSearchFromLocation({
+        search: "",
+        hash: "#/research-workspace"
+      })
+    ).toBe("")
   })
 
   it("falls back to Chat for missing or invalid route state", () => {

--- a/apps/packages/ui/src/components/Option/ResearchWorkspace/index.tsx
+++ b/apps/packages/ui/src/components/Option/ResearchWorkspace/index.tsx
@@ -88,7 +88,10 @@ import {
   type WorkspaceGlobalSearchResult
 } from "./workspace-global-search"
 import {
+  getResearchWorkspaceDeepResearchReturnContext,
+  getResearchWorkspaceSearchFromLocation,
   getResearchWorkspaceTabFromSearch,
+  isResearchWorkspaceDeepResearchReturnForWorkspace,
   parseResearchWorkspaceTab,
   RESEARCH_WORKSPACE_DEFAULT_TAB,
   readResearchWorkspaceLastMobileTab,
@@ -1042,15 +1045,23 @@ const ResearchWorkspaceBody: React.FC = () => {
   const [leftDrawerOpen, setLeftDrawerOpen] = React.useState(false)
   const [rightDrawerOpen, setRightDrawerOpen] = React.useState(false)
 
-  const initialRouteTabRef = React.useRef<WorkspaceTabKey | null>(
-    getResearchWorkspaceTabFromSearch(
-      typeof window === "undefined" ? "" : window.location.search
+  const initialRouteSearchRef = React.useRef(
+    getResearchWorkspaceSearchFromLocation(
+      typeof window === "undefined" ? null : window.location
     )
+  )
+  const initialRouteTabRef = React.useRef<WorkspaceTabKey | null>(
+    getResearchWorkspaceTabFromSearch(initialRouteSearchRef.current)
   )
   const initialStoredMobileTabRef = React.useRef<WorkspaceTabKey | null>(
     initialRouteTabRef.current ? null : readResearchWorkspaceLastMobileTab()
   )
   const initialRouteTabAppliedRef = React.useRef(false)
+  const initialDeepResearchReturnContextRef =
+    React.useRef(
+      getResearchWorkspaceDeepResearchReturnContext(initialRouteSearchRef.current)
+    )
+  const deepResearchReturnAppliedRef = React.useRef(false)
 
   // Mobile tab state
   const [activeTab, setActiveTab] = React.useState<WorkspaceTabKey>(
@@ -1167,7 +1178,9 @@ const ResearchWorkspaceBody: React.FC = () => {
 
   React.useEffect(() => {
     try {
-      const params = new URLSearchParams(window.location.search)
+      const params = new URLSearchParams(
+        getResearchWorkspaceSearchFromLocation(window.location)
+      )
       const shareIdStr = params.get("shared")
       if (shareIdStr) {
         const sid = parseInt(shareIdStr, 10)
@@ -1199,6 +1212,13 @@ const ResearchWorkspaceBody: React.FC = () => {
   // Workspace store
   const workspaceId = useWorkspaceStore((s) => s.workspaceId)
   const workspaceName = useWorkspaceStore((s) => s.workspaceName) || ""
+  const activeDeepResearchReturnContext =
+    isResearchWorkspaceDeepResearchReturnForWorkspace(
+      initialDeepResearchReturnContextRef.current,
+      workspaceId
+    )
+      ? initialDeepResearchReturnContextRef.current
+      : null
   const workspaceBanner = useWorkspaceStore((s) => s.workspaceBanner) || {
     title: "",
     subtitle: "",
@@ -2199,6 +2219,14 @@ const ResearchWorkspaceBody: React.FC = () => {
     focusWorkspacePane(initialRouteTab)
   }, [focusWorkspacePane])
 
+  React.useEffect(() => {
+    if (deepResearchReturnAppliedRef.current) return
+    if (!activeDeepResearchReturnContext) return
+
+    deepResearchReturnAppliedRef.current = true
+    focusWorkspacePane("studio")
+  }, [activeDeepResearchReturnContext, focusWorkspacePane])
+
   const handleOpenSplitWorkspace = React.useCallback(() => {
     if (readyEffectiveSelectedSourceEntries.length === 0) {
       focusWorkspacePane("sources")
@@ -3104,6 +3132,47 @@ const ResearchWorkspaceBody: React.FC = () => {
       </div>
     </div>
   ) : null
+  const deepResearchReturnSourceLabel =
+    activeDeepResearchReturnContext?.sourceArtifactTitle ||
+    activeDeepResearchReturnContext?.sourceArtifactId ||
+    activeDeepResearchReturnContext?.sourceArtifactTemplate ||
+    t("playground:studio.deepResearchReturnFallbackSource", "source artifact")
+  const deepResearchReturnBanner = activeDeepResearchReturnContext ? (
+    <div
+      data-testid="workspace-deep-research-return-handoff"
+      className="mx-3 mt-2 flex flex-wrap items-center justify-between gap-2 rounded border border-primary/30 bg-primary/10 px-3 py-2.5 text-sm text-text"
+      role="status"
+      aria-live="polite"
+    >
+      <span className="min-w-0">
+        <span className="font-medium">
+          {t(
+            "playground:studio.deepResearchReturnReady",
+            "Deep Research return ready"
+          )}
+        </span>
+        <span className="mx-1 text-text-subtle">|</span>
+        <span className="text-text-muted">
+          {t("playground:studio.sourceArtifactLabel", "Source artifact")}:
+        </span>{" "}
+        <span className="font-medium">{deepResearchReturnSourceLabel}</span>
+        <span className="mx-1 text-text-subtle">|</span>
+        <span className="text-text-muted">
+          {t("playground:studio.deepResearchRunLabel", "Run")}:
+        </span>{" "}
+        <span className="font-mono text-xs">
+          {activeDeepResearchReturnContext.researchRunId}
+        </span>
+      </span>
+      <button
+        type="button"
+        className="rounded border border-border px-2 py-1 text-xs font-medium hover:bg-surface2"
+        onClick={() => focusWorkspacePane("studio")}
+      >
+        {t("playground:studio.openStudio", "Open Studio")}
+      </button>
+    </div>
+  ) : null
 
   const focusSkipTarget = (
     event: React.MouseEvent<HTMLAnchorElement>,
@@ -3332,6 +3401,7 @@ const ResearchWorkspaceBody: React.FC = () => {
             isMobile
           />
           <SharedWorkspaceBanner />
+          {deepResearchReturnBanner}
 
           {tutorialPromptBanner}
 
@@ -3383,6 +3453,7 @@ const ResearchWorkspaceBody: React.FC = () => {
             isMobile={false}
           />
           <SharedWorkspaceBanner />
+          {deepResearchReturnBanner}
 
           {tutorialPromptBanner}
 

--- a/apps/packages/ui/src/components/Option/ResearchWorkspace/research-workspace-route-state.ts
+++ b/apps/packages/ui/src/components/Option/ResearchWorkspace/research-workspace-route-state.ts
@@ -3,8 +3,19 @@ export type ResearchWorkspaceTab = "sources" | "chat" | "studio"
 export const RESEARCH_WORKSPACE_DEFAULT_TAB: ResearchWorkspaceTab = "chat"
 export const RESEARCH_WORKSPACE_LAST_MOBILE_TAB_STORAGE_KEY =
   "tldw:research-workspace:last-mobile-tab:v1"
+const DEEP_RESEARCH_RETURN_ID_MAX_LENGTH = 128
+const DEEP_RESEARCH_RETURN_TITLE_MAX_LENGTH = 240
+
+export type ResearchWorkspaceDeepResearchReturnContext = {
+  sourceWorkspaceId: string
+  sourceArtifactId: string | null
+  sourceArtifactTemplate: string | null
+  sourceArtifactTitle: string | null
+  researchRunId: string
+}
 
 type ResearchWorkspaceTabStorage = Pick<Storage, "getItem" | "setItem">
+type ResearchWorkspaceLocation = Pick<Location, "hash" | "search">
 
 const getBrowserStorage = (): ResearchWorkspaceTabStorage | null => {
   if (typeof window === "undefined") return null
@@ -33,11 +44,84 @@ export const getResearchWorkspaceTabFromSearch = (
   return parseResearchWorkspaceTab(params.get("tab"))
 }
 
+export const getResearchWorkspaceSearchFromLocation = (
+  location: ResearchWorkspaceLocation | null | undefined
+): string => {
+  if (!location) return ""
+  if (location.search) return location.search
+
+  const hashQueryIndex = location.hash.indexOf("?")
+  if (hashQueryIndex < 0) return ""
+
+  const hashFragmentIndex = location.hash.indexOf("#", hashQueryIndex + 1)
+  return hashFragmentIndex < 0
+    ? location.hash.slice(hashQueryIndex)
+    : location.hash.slice(hashQueryIndex, hashFragmentIndex)
+}
+
 export const getInitialResearchWorkspaceTab = (
   search: string | URLSearchParams | null | undefined,
   fallback: ResearchWorkspaceTab = RESEARCH_WORKSPACE_DEFAULT_TAB
 ): ResearchWorkspaceTab => {
   return getResearchWorkspaceTabFromSearch(search) ?? fallback
+}
+
+const readBoundedSearchParam = (
+  params: URLSearchParams,
+  key: string,
+  maxLength: number
+): string | null => {
+  const value = params.get(key)?.trim()
+  if (!value) return null
+  return value.slice(0, maxLength)
+}
+
+export const getResearchWorkspaceDeepResearchReturnContext = (
+  search: string | URLSearchParams | null | undefined
+): ResearchWorkspaceDeepResearchReturnContext | null => {
+  if (!search) return null
+  const params =
+    typeof search === "string" ? new URLSearchParams(search) : search
+
+  const sourceWorkspaceId = readBoundedSearchParam(
+    params,
+    "source_workspace_id",
+    DEEP_RESEARCH_RETURN_ID_MAX_LENGTH
+  )
+  const researchRunId = readBoundedSearchParam(
+    params,
+    "research_run_id",
+    DEEP_RESEARCH_RETURN_ID_MAX_LENGTH
+  )
+
+  if (!sourceWorkspaceId || !researchRunId) return null
+
+  return {
+    sourceWorkspaceId,
+    sourceArtifactId: readBoundedSearchParam(
+      params,
+      "source_artifact_id",
+      DEEP_RESEARCH_RETURN_ID_MAX_LENGTH
+    ),
+    sourceArtifactTemplate: readBoundedSearchParam(
+      params,
+      "source_artifact_template",
+      DEEP_RESEARCH_RETURN_ID_MAX_LENGTH
+    ),
+    sourceArtifactTitle: readBoundedSearchParam(
+      params,
+      "source_artifact_title",
+      DEEP_RESEARCH_RETURN_TITLE_MAX_LENGTH
+    ),
+    researchRunId
+  }
+}
+
+export const isResearchWorkspaceDeepResearchReturnForWorkspace = (
+  context: ResearchWorkspaceDeepResearchReturnContext | null,
+  workspaceId: string | null | undefined
+): context is ResearchWorkspaceDeepResearchReturnContext => {
+  return Boolean(context && workspaceId && context.sourceWorkspaceId === workspaceId)
 }
 
 export const readResearchWorkspaceLastMobileTab = (

--- a/backlog/tasks/task-569 - Stage-Deep-Research-return-handoff-in-Research-Workspace.md
+++ b/backlog/tasks/task-569 - Stage-Deep-Research-return-handoff-in-Research-Workspace.md
@@ -1,0 +1,59 @@
+---
+id: TASK-569
+title: Stage Deep Research return handoff in Research Workspace
+status: Done
+assignee: []
+created_date: ''
+updated_date: '2026-05-30 23:55'
+labels:
+  - research-workspace
+  - deep-research
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/pull/2178'
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Parse Deep Research return parameters on /research-workspace and surface a bounded handoff in Research Workspace Studio so completed Deep Research runs have a visible return target before full bundle import lands.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 /research-workspace parses research_run_id and source artifact return parameters without mutating unrelated workspace state.
+- [x] #2 A return URL whose source_workspace_id matches the current workspace opens/focuses Studio and displays the source artifact label plus run ID.
+- [x] #3 Return parameters for a different workspace are ignored so they do not create or display a handoff in the current workspace.
+- [x] #4 Focused route tests cover valid return context and mismatched workspace handling.
+- [x] #5 Verification records focused UI tests and Bandit rationale for frontend-only TypeScript changes.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Review fix: replace Research Workspace URL query reads with React Router location.search so HashRouter URLs are supported. Add regression coverage for a hash-style /research-workspace?... URL before changing production code, then rerun focused tests and TypeScript.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Added bounded Deep Research return URL parsing for Research Workspace, matched return contexts to the active workspace, focused Studio for valid returns, and surfaced a compact handoff banner with the source artifact label and research run ID. Review fix for PR #2178: added HashRouter query extraction so mobile tab state, shared-workspace parsing, and Deep Research return context work when route params live under window.location.hash. Added route-level regression coverage for matching/mismatched returns and HashRouter tab/return URLs. PR: https://github.com/rmusser01/tldw_server/pull/2178. Verification: bunx vitest run src/components/Option/ResearchWorkspace/__tests__/research-workspace-route-state.test.ts src/components/Option/ResearchWorkspace/__tests__/ResearchWorkspace.stage2.responsive.test.tsx (25 tests passed); NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit -p tsconfig.json (passed); git diff --check (passed). Bandit was not run because the touched production/test files are frontend TypeScript/TSX only.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## Change summary (maintainer-owned)

- Maintainer to replace before merge with a human-written summary of what changed and why.

## Summary

- What changed:
  - Parse bounded Deep Research return params on `/research-workspace`.
  - Match return context to the active Research Workspace before surfacing it.
  - Focus Studio and show a compact handoff banner with the source artifact label and research run ID.
  - Support HashRouter-style query params so extension/options URLs like `#/research-workspace?...` work for tab state, shared workspace parsing, and Deep Research return context.
  - Mark `TASK-569` Acceptance Criteria and Definition of Done checklists complete.
- Why:
  - This gives the Deep Research return link from PR #2174 a visible landing point in Research Workspace without implementing full bundle import yet.
  - The HashRouter fix preserves that handoff on Chrome/Edge options surfaces where query params live under `window.location.hash`.

## Validation

- [x] Tests added/updated for behavior changes
- [x] Relevant unit/integration tests pass locally
- [x] Docs updated (Backlog.md `TASK-569` records the implementation, review fix, and verification; user docs not needed for this internal handoff slice)

Commands run:

- `bunx vitest run src/components/Option/ResearchWorkspace/__tests__/research-workspace-route-state.test.ts src/components/Option/ResearchWorkspace/__tests__/ResearchWorkspace.stage2.responsive.test.tsx` - 25 tests passed
- `NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit -p tsconfig.json` - passed
- `git diff --check` - passed

Bandit was not run because the touched files are frontend TypeScript/TSX only.

## UX Audit Checklist (v2 Stage 5)

- [ ] `npm run e2e:smoke:stage5` passes - not run; focused Research Workspace route-shell slice covered by Vitest and TypeScript check
- [ ] `npx playwright test e2e/smoke/all-pages.spec.ts --reporter=line` passes (or failures documented) - not run; no all-pages route coverage required for this narrow slice
- [x] No listed AntD deprecations in console output: `Drawer.width`, `Space.direction`, `Alert.message`, `List` - no AntD API changes in this PR
- [x] No `Maximum update depth exceeded` warnings on audited routes - focused Vitest route render completed without this warning
- [x] No unresolved `{{...}}` placeholders on audited routes - banner text is composed from plain fragments and route values
- [x] WebUI/extension parity validated for shared UI fixes - N/A; Research Workspace package UI shell only
- [x] For Flashcards UI changes: tabs remain `Study` / `Manage` / `Transfer` and secondary create CTAs route through manager create-entry path - N/A
- [x] For Flashcards drawer changes: use `FLASHCARDS_DRAWER_WIDTH_PX` and keep footer action order `Cancel -> secondary -> primary` - N/A
- [x] For Flashcards help/copy/import UX changes: update `Docs/User_Guides/WebUI_Extension/Flashcards_Study_Guide.md` and keep in-app help links pointed at guide section anchors - N/A

## Watchlists Accessibility Checklist (Group 09 Stage 5)

- [x] If Watchlists UI behavior changed: `cd apps/packages/ui && bun run test:watchlists:a11y` passes locally - N/A; no Watchlists changes
- [x] If Watchlists UI behavior changed: keyboard-only path still works for Overview -> Feeds -> Monitors -> Activity -> Articles -> Reports - N/A
- [x] If Watchlists UI behavior changed: list/table labels and live-region copy remain localized (no new hardcoded assistive text) - N/A
- [x] If Watchlists UI behavior changed: monitor/feed active state is not color-only (explicit text or icon signal is present) - N/A
- [x] If Watchlists UI behavior changed: known assistive-tech constraints reviewed in `Docs/Plans/WATCHLISTS_ASSISTIVE_TECH_AUDIT_2026_02_24.md` - N/A

## Watchlists Scale Checklist (Group 10 Stage 5)

- [x] If Watchlists UI behavior changed: `cd apps/packages/ui && bun run test:watchlists:scale` passes locally - N/A; no Watchlists changes
- [x] If Watchlists polling/notifications behavior changed: no duplicate terminal notifications during in-flight polling overlap - N/A
- [x] If Watchlists Activity polling changed: auto-refresh is gated to active + visible Activity context (no background tab polling churn) - N/A
- [x] If Watchlists batch triage behavior changed: partial-failure retry path remains available and updates only failed IDs - N/A
- [x] If Watchlists scale behavior changed: constraints/mitigations reviewed in `Docs/Plans/WATCHLISTS_SCALE_READINESS_RUNBOOK_2026_02_24.md` - N/A

## Risk & Rollback

- Risk level: Low
- Rollback plan: Revert `4ad77cae4a`; the prior Deep Research return URL behavior will still navigate back to Research Workspace without the handoff banner or HashRouter return-param support.
