### PR TITLE
Migrate Prompt Studio test run states to design system

### DIFF
--- a/apps/packages/ui/src/components/Option/Prompt/Studio/TestCases/TestCaseRunModal.tsx
+++ b/apps/packages/ui/src/components/Option/Prompt/Studio/TestCases/TestCaseRunModal.tsx
@@ -10,7 +10,7 @@ import {
   type TestRunResult
 } from "@/services/prompt-studio"
 import { Button } from "@/components/Common/Button"
-import { Alert as DsAlert, Badge } from "@/components/ui/primitives"
+import { Alert, Badge } from "@/components/ui/primitives"
 
 type TestCaseRunModalProps = {
   open: boolean
@@ -84,6 +84,49 @@ export const TestCaseRunModal: React.FC<TestCaseRunModalProps> = ({
   const passCount = results?.filter((r) => r.passed).length ?? 0
   const failCount = results?.filter((r) => r.passed === false).length ?? 0
 
+  const renderResultStatusBadge = (record: TestRunResult) => {
+    if (record.error) {
+      return (
+        <Badge variant="danger" size="sm">
+          <XCircle className="size-3" aria-hidden="true" />
+          {t("managePrompts.studio.testCases.results.error", {
+            defaultValue: "Error"
+          })}
+        </Badge>
+      )
+    }
+
+    if (record.passed) {
+      return (
+        <Badge variant="success" size="sm">
+          <CheckCircle2 className="size-3" aria-hidden="true" />
+          {t("managePrompts.studio.testCases.results.pass", {
+            defaultValue: "Pass"
+          })}
+        </Badge>
+      )
+    }
+
+    if (record.passed === false) {
+      return (
+        <Badge variant="warning" size="sm">
+          <XCircle className="size-3" aria-hidden="true" />
+          {t("managePrompts.studio.testCases.results.fail", {
+            defaultValue: "Fail"
+          })}
+        </Badge>
+      )
+    }
+
+    return (
+      <Badge size="sm">
+        {t("managePrompts.studio.testCases.results.run", {
+          defaultValue: "Run"
+        })}
+      </Badge>
+    )
+  }
+
   return (
     <Modal
       open={open}
@@ -103,7 +146,7 @@ export const TestCaseRunModal: React.FC<TestCaseRunModalProps> = ({
       <div className="mt-4 space-y-4">
         {!results && (
           <>
-            <DsAlert
+            <Alert
               variant="info"
               title={t("managePrompts.studio.testCases.runInfo", {
                 defaultValue:
@@ -159,12 +202,18 @@ export const TestCaseRunModal: React.FC<TestCaseRunModalProps> = ({
               </span>
               <Badge variant="success" size="sm">
                 <CheckCircle2 className="size-3" aria-hidden="true" />
-                {passCount} passed
+                {t("managePrompts.studio.testCases.results.passedCount", {
+                  defaultValue: "{{count}} passed",
+                  count: passCount
+                })}
               </Badge>
               {failCount > 0 && (
                 <Badge variant="danger" size="sm">
                   <XCircle className="size-3" aria-hidden="true" />
-                  {failCount} failed
+                  {t("managePrompts.studio.testCases.results.failedCount", {
+                    defaultValue: "{{count}} failed",
+                    count: failCount
+                  })}
                 </Badge>
               )}
             </div>
@@ -191,27 +240,7 @@ export const TestCaseRunModal: React.FC<TestCaseRunModalProps> = ({
                   }),
                   key: "status",
                   width: 80,
-                  render: (_, record) =>
-                    record.error ? (
-                      <Badge variant="danger" size="sm">
-                        <XCircle className="size-3" aria-hidden="true" />
-                        Error
-                      </Badge>
-                    ) : record.passed ? (
-                      <Badge variant="success" size="sm">
-                        <CheckCircle2 className="size-3" aria-hidden="true" />
-                        Pass
-                      </Badge>
-                    ) : record.passed === false ? (
-                      <Badge variant="warning" size="sm">
-                        <XCircle className="size-3" aria-hidden="true" />
-                        Fail
-                      </Badge>
-                    ) : (
-                      <Badge variant="secondary" size="sm">
-                        Run
-                      </Badge>
-                    )
+                  render: (_, record) => renderResultStatusBadge(record)
                 },
                 {
                   title: t("managePrompts.studio.testCases.columns.output", {

--- a/apps/packages/ui/src/components/Option/Prompt/Studio/TestCases/__tests__/TestCaseRunModal.design-system.test.tsx
+++ b/apps/packages/ui/src/components/Option/Prompt/Studio/TestCases/__tests__/TestCaseRunModal.design-system.test.tsx
@@ -1,0 +1,243 @@
+import React from "react"
+import { fireEvent, render, screen, within } from "@testing-library/react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { TestCaseRunModal } from "../TestCaseRunModal"
+
+const runResults = vi.hoisted(() => ({
+  results: [
+    {
+      test_case_id: 101,
+      passed: true,
+      output: "The answer cited the required source.",
+      execution_time: 0.42
+    },
+    {
+      test_case_id: 102,
+      passed: false,
+      output: "The answer omitted the required evidence.",
+      execution_time: 0.67
+    },
+    {
+      test_case_id: 103,
+      passed: null,
+      output: "",
+      error: "Provider timed out",
+      execution_time: 1.25
+    }
+  ]
+}))
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (
+      _key: string,
+      fallbackOrOptions?: string | { defaultValue?: string; [key: string]: unknown }
+    ) => {
+      if (typeof fallbackOrOptions === "string") return fallbackOrOptions
+      if (fallbackOrOptions?.defaultValue) {
+        return Object.entries(fallbackOrOptions).reduce(
+          (value, [name, replacement]) =>
+            name === "defaultValue"
+              ? value
+              : value.replace(
+                  new RegExp(`{{${name}}}`, "g"),
+                  String(replacement)
+                ),
+          fallbackOrOptions.defaultValue
+        )
+      }
+      return _key
+    }
+  })
+}))
+
+vi.mock("@/services/prompt-studio", () => ({
+  listPrompts: vi.fn(),
+  runTestCases: vi.fn()
+}))
+
+vi.mock("@tanstack/react-query", () => ({
+  useQuery: () => ({
+    data: {
+      data: {
+        data: [
+          {
+            id: 55,
+            project_id: 7,
+            name: "Research synthesis",
+            version_number: 2
+          }
+        ]
+      }
+    }
+  }),
+  useMutation: (config: { onSuccess?: (response: unknown) => void }) => ({
+    isPending: false,
+    mutate: vi.fn(() =>
+      config.onSuccess?.({
+        data: {
+          data: runResults.results
+        }
+      })
+    )
+  })
+}))
+
+vi.mock("antd", () => ({
+  Alert: ({
+    message,
+    title,
+    description
+  }: {
+    message?: React.ReactNode
+    title?: React.ReactNode
+    description?: React.ReactNode
+  }) => (
+    <div data-antd-component="Alert">
+      {title ?? message}
+      {description}
+    </div>
+  ),
+  Modal: ({
+    open,
+    title,
+    children
+  }: {
+    open?: boolean
+    title?: React.ReactNode
+    children?: React.ReactNode
+  }) =>
+    open ? (
+      <section role="dialog">
+        <h2>{title}</h2>
+        {children}
+      </section>
+    ) : null,
+  notification: {
+    error: vi.fn(),
+    success: vi.fn(),
+    warning: vi.fn()
+  },
+  Select: ({
+    onChange,
+    options,
+    placeholder,
+    value
+  }: {
+    onChange?: (value: number) => void
+    options?: Array<{ label: string; value: number }>
+    placeholder?: string
+    value?: number | null
+  }) => (
+    <select
+      aria-label="Select Prompt to Run Against"
+      value={value ?? ""}
+      onChange={(event) => onChange?.(Number(event.currentTarget.value))}
+    >
+      <option value="">{placeholder}</option>
+      {options?.map((option) => (
+        <option key={option.value} value={option.value}>
+          {option.label}
+        </option>
+      ))}
+    </select>
+  ),
+  Spin: () => <div data-testid="loading-spinner" />,
+  Table: ({
+    columns,
+    dataSource
+  }: {
+    columns: Array<{
+      key?: string
+      dataIndex?: string
+      render?: (value: unknown, record: (typeof runResults.results)[number]) => React.ReactNode
+    }>
+    dataSource: typeof runResults.results
+  }) => (
+    <table>
+      <tbody>
+        {dataSource.map((record) => (
+          <tr key={record.test_case_id}>
+            {columns.map((column, index) => {
+              const value = column.dataIndex
+                ? record[column.dataIndex as keyof typeof record]
+                : undefined
+              return (
+                <td key={column.key ?? column.dataIndex ?? index}>
+                  {column.render ? column.render(value, record) : String(value ?? "")}
+                </td>
+              )
+            })}
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  ),
+  Tag: ({ children }: { children?: React.ReactNode }) => (
+    <span data-antd-component="Tag">{children}</span>
+  )
+}))
+
+function renderModal() {
+  return render(
+    <TestCaseRunModal
+      open
+      projectId={7}
+      testCaseIds={[101, 102, 103]}
+      onClose={vi.fn()}
+    />
+  )
+}
+
+function expectClosestDsComponent(text: string | RegExp, component: string) {
+  const node = screen.getByText(text)
+  const element = node.closest(`[data-ds-component="${component}"]`)
+  expect(element).not.toBeNull()
+  return element as HTMLElement
+}
+
+describe("TestCaseRunModal design-system product states", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("renders the run guidance through the design-system Alert primitive", () => {
+    renderModal()
+
+    const alert = expectClosestDsComponent(
+      "Run 3 test cases against a prompt to see the outputs.",
+      "Alert"
+    )
+
+    expect(alert).toHaveAttribute("role", "status")
+  })
+
+  it("renders run result summary and status labels through design-system Badge", async () => {
+    renderModal()
+
+    fireEvent.change(screen.getByRole("combobox"), {
+      target: { value: "55" }
+    })
+    fireEvent.click(screen.getByRole("button", { name: /Run Tests/i }))
+
+    const summary = await screen.findByText("Results")
+    const summaryRegion = summary.closest("div")
+    expect(summaryRegion).not.toBeNull()
+
+    expect(
+      within(summaryRegion as HTMLElement)
+        .getByText("1 passed")
+        .closest('[data-ds-component="Badge"]')
+    ).not.toBeNull()
+    expect(
+      within(summaryRegion as HTMLElement)
+        .getByText("1 failed")
+        .closest('[data-ds-component="Badge"]')
+    ).not.toBeNull()
+
+    expectClosestDsComponent("Pass", "Badge")
+    expectClosestDsComponent("Fail", "Badge")
+    expectClosestDsComponent("Error", "Badge")
+  })
+})

--- a/backlog/tasks/task-45.44.8 - Migrate-design-system-product-state-Prompt-and-Prompt-Studio.md
+++ b/backlog/tasks/task-45.44.8 - Migrate-design-system-product-state-Prompt-and-Prompt-Studio.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-45.44.8
 title: 'Migrate design-system product state: Prompt and Prompt Studio'
-status: To Do
+status: In Progress
 assignee: []
 created_date: '2026-05-14 03:19'
 labels:

--- a/backlog/tasks/task-45.44.8.4 - Migrate-TestCaseRunModal-product-states-to-design-system-primitives.md
+++ b/backlog/tasks/task-45.44.8.4 - Migrate-TestCaseRunModal-product-states-to-design-system-primitives.md
@@ -1,0 +1,58 @@
+---
+id: TASK-45.44.8.4
+title: Migrate TestCaseRunModal product states to design-system primitives
+status: Done
+labels:
+- design-system
+- webui
+- product-state
+- prompt-studio
+priority: medium
+parent_task_id: TASK-45.44.8
+references:
+- apps/packages/ui/src/components/Option/Prompt/Studio/TestCases/TestCaseRunModal.tsx
+- apps/packages/ui/scripts/design-system-product-state-baseline.json
+- backlog/tasks/task-45.44.8 - Migrate-design-system-product-state-Prompt-and-Prompt-Studio.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Migrate TestCaseRunModal run guidance and result status labels from AntD product-state primitives to the shared design-system Alert and Badge primitives, keeping the product-state guard baseline free of TestCaseRunModal entries.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 TestCaseRunModal no longer imports or renders AntD Alert/Tag for product-state messaging.
+- [x] #2 Focused Prompt Studio test-case modal coverage asserts the migrated design-system Alert and Badge markers render.
+- [x] #3 The product-state baseline contains no TestCaseRunModal Alert/Tag exceptions, and `verify:design-system-state` passes.
+- [x] #4 Verification, known skips, and Bandit disposition are recorded.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+- Added focused design-system coverage for the run guidance alert and run result status badges.
+- Replaced TestCaseRunModal AntD Alert/Tag product-state rendering with design-system Alert/Badge primitives while preserving existing Modal, Select, Spin, Table, Button, labels, and result summary behavior.
+- Confirmed the rebased product-state baseline contains no TestCaseRunModal product-state entries.
+- TDD red check: `bunx vitest run src/components/Option/Prompt/Studio/TestCases/__tests__/TestCaseRunModal.design-system.test.tsx --reporter=dot` failed because the run guidance and result labels were not rendered inside design-system markers.
+- Verification: `bunx vitest run src/components/Option/Prompt/Studio/TestCases/__tests__/TestCaseRunModal.design-system.test.tsx --reporter=dot` passed 2 tests; Prompt Studio DS combined suite passed 3 files / 7 tests; `bun run verify:design-system-state` passed with no TestCaseRunModal baseline entries; `git diff --check` passed; `NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit --pretty false` passed.
+- PR review follow-up rebased onto latest `origin/dev`, removed the no-longer-needed design-system Alert import alias, and routed the run result status/summary labels through the existing `t()` translator while preserving default visible copy.
+- Bandit not applicable: touched code is frontend TypeScript/TSX, JSON baseline, and Backlog task metadata only.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Migrated TestCaseRunModal run guidance and result status labels from AntD Alert/Tag to the design-system Alert/Badge primitives. Added focused render coverage, kept the rebased product-state baseline free of TestCaseRunModal entries, addressed PR feedback for import clarity and localized result labels, and verified focused tests, Prompt Studio DS tests, the product-state verifier, diff check, and package TypeScript.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## Summary
- migrate TestCaseRunModal run guidance from AntD Alert to the design-system Alert primitive
- migrate run summary and table status labels from AntD Tag to design-system Badge
- remove the two matching product-state baseline exceptions and close TASK-45.44.8.4

## Verification
- bunx vitest run src/components/Option/Prompt/Studio/TestCases/__tests__/TestCaseRunModal.design-system.test.tsx --reporter=dot
- bunx vitest run src/components/Option/Prompt/Studio/TestCases/__tests__/TestCaseRunModal.design-system.test.tsx src/components/Option/Prompt/Studio/Evaluations/__tests__/EvaluationDesignSystem.test.tsx src/components/Option/Prompt/Studio/Optimizations/__tests__/OptimizationDesignSystem.test.tsx --reporter=dot
- bun run verify:design-system-state
- git diff --check
- NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit --pretty false

Bandit not applicable: frontend TypeScript/TSX, JSON baseline, and Backlog metadata only.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrates Prompt Studio TestCaseRunModal product-state UI from `antd` to design-system `Alert`/`Badge` for consistent states and styling. Localizes result messages and clears product-state baseline exceptions to complete TASK-45.44.8.4.

- **Refactors**
  - Replaced `antd` `Alert`/`Tag` with design-system `Alert`/`Badge` for run guidance, result summary, and per-row status.
  - Routed result status and pass/fail counts through `t()` with default strings.
  - Extracted `renderResultStatusBadge` and removed the `Alert` import alias; added focused tests for alert guidance and status badges.

<sup>Written for commit b3ea939c6d01634cbd0190c382b03dc7c2002e10. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2180?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

