### PR TITLE
Import Deep Research bundles into Research Workspace

### DIFF
--- a/Docs/superpowers/plans/2026-05-30-research-workspace-deep-research-bundle-import-plan.md
+++ b/Docs/superpowers/plans/2026-05-30-research-workspace-deep-research-bundle-import-plan.md
@@ -1,0 +1,185 @@
+# Research Workspace Deep Research Bundle Import Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let a matching Deep Research return handoff import a completed `bundle.json` into Research Workspace as a source-backed generated artifact.
+
+**Architecture:** Keep the slice frontend-only and reuse the existing `tldwClient.getResearchBundle(run_id)` API plus the Research Workspace `addArtifact` store action. Add a pure bundle-to-artifact adapter so validation, provenance, source coverage, and bounded content formatting can be tested without rendering the full workspace.
+
+**Tech Stack:** TypeScript, React, Zustand workspace store, Vitest/Testing Library, existing Research Workspace route-state helpers, existing Deep Research bundle API client.
+
+---
+
+## Source Requirements
+
+- Backlog: `TASK-570`
+- Existing follow-up: `TASK-489` (`Import Deep Research bundles into Research Workspace artifacts`)
+- PRD: `Docs/Product/Research_Workspace_Literature_Workproducts_PRD.md`
+- Umbrella plan: `Docs/superpowers/plans/2026-05-30-research-workspace-literature-workproducts-plan.md`
+
+## File Structure
+
+- Create `apps/packages/ui/src/components/Option/ResearchWorkspace/deep-research-bundle-import.ts`
+  - Pure validation and normalization for Deep Research bundle imports.
+  - Builds a `GeneratedArtifact` payload without `id`/`createdAt`.
+  - Preserves run/source artifact provenance in `producerMetadata` and `data.deepResearch`.
+  - Builds bounded markdown content and source coverage from the source artifact when available, otherwise from `bundle.source_inventory`.
+- Create `apps/packages/ui/src/components/Option/ResearchWorkspace/__tests__/deep-research-bundle-import.test.ts`
+  - Covers successful artifact payload construction, malformed bundle rejection, source coverage fallback, and bounded content.
+- Modify `apps/packages/ui/src/components/Option/ResearchWorkspace/index.tsx`
+  - Add explicit Import action to the existing Deep Research return handoff.
+  - Fetch bundle with `tldwClient.getResearchBundle`.
+  - Insert imported artifact through `addArtifact`.
+  - Show importing, imported, and failed states without mutating unrelated workspace state.
+- Modify `apps/packages/ui/src/components/Option/ResearchWorkspace/__tests__/ResearchWorkspace.stage2.responsive.test.tsx`
+  - Mock bundle fetch and artifact insertion.
+  - Cover successful import and failed/malformed bundle handling.
+- Modify `backlog/tasks/task-570 - Implement-Deep-Research-bundle-import-into-Research-Workspace-artifacts.md`
+  - Record implementation notes, verification, and final status at closeout.
+
+## Task 1: Add Bundle Import Adapter Tests
+
+**Goal:** Lock the import contract before production code.
+
+- [x] **Step 1: Write failing adapter tests**
+
+Add tests for:
+
+- valid bundle returns a `report` artifact titled from the source artifact/run;
+- artifact contains `producerMetadata.producerType === "deep_research_bundle_import"`;
+- artifact `data.deepResearch.runId`, `verificationSummary`, `sourceTrust`, `claims`, `unsupportedClaims`, `contradictions`, and `sourceArtifact` are populated;
+- source artifact `sourceCoverage` is preserved when available;
+- fallback coverage is derived from `bundle.source_inventory`;
+- missing `question` or `report_markdown` throws a user-facing import error;
+- long report content is bounded and marked as truncated.
+
+- [x] **Step 2: Run tests and confirm RED**
+
+Run:
+
+```bash
+cd apps/packages/ui
+bun run test -- src/components/Option/ResearchWorkspace/__tests__/deep-research-bundle-import.test.ts
+```
+
+Expected: FAIL because the adapter does not exist.
+
+## Task 2: Implement Bundle Import Adapter
+
+**Goal:** Convert a Deep Research bundle into a safe Research Workspace artifact payload.
+
+- [x] **Step 1: Create `deep-research-bundle-import.ts`**
+
+Implement:
+
+- `DeepResearchBundleImportError`
+- `buildDeepResearchBundleArtifactPayload(options)`
+- internal helpers for bounded strings, string lists, record/list checks, source inventory normalization, provenance metadata, and markdown assembly.
+
+- [x] **Step 2: Preserve source coverage**
+
+Rules:
+
+- If the source artifact has `sourceCoverage`, copy it directly.
+- Otherwise derive `selectedSourceIds` and `usableSources` from `bundle.source_inventory`.
+- `minimumUsableSourcesMet` is true when at least one imported source exists.
+- Do not invent skipped/truncated sources when the bundle does not provide them.
+
+- [x] **Step 3: Run adapter tests and confirm GREEN**
+
+Run:
+
+```bash
+cd apps/packages/ui
+bun run test -- src/components/Option/ResearchWorkspace/__tests__/deep-research-bundle-import.test.ts
+```
+
+Expected: PASS.
+
+## Task 3: Wire Import Action Into Return Handoff
+
+**Goal:** Let the user import a matching returned bundle from the existing banner.
+
+- [x] **Step 1: Add failing Research Workspace UI tests**
+
+In `ResearchWorkspace.stage2.responsive.test.tsx`, add tests that:
+
+- clicking `Import bundle` calls `tldwClient.getResearchBundle("research-run-7")`;
+- `addArtifact` receives the normalized artifact payload;
+- successful import shows a compact imported state;
+- rejected/malformed bundles show an error and do not call `addArtifact`;
+- mismatched workspace return contexts still do not render the handoff.
+
+- [x] **Step 2: Run UI tests and confirm RED**
+
+Run:
+
+```bash
+cd apps/packages/ui
+bun run test -- src/components/Option/ResearchWorkspace/__tests__/ResearchWorkspace.stage2.responsive.test.tsx
+```
+
+Expected: FAIL because the Import action is not wired.
+
+- [x] **Step 3: Implement the Import action**
+
+Modify `ResearchWorkspace/index.tsx`:
+
+- select `addArtifact` from `useWorkspaceStore`;
+- keep local import status/error state scoped to the active return context;
+- find the source artifact by `sourceArtifactId` when present;
+- fetch the bundle through `tldwClient.getResearchBundle`;
+- pass bundle, return context, and source artifact into the adapter;
+- call `addArtifact(payload)`;
+- show loading, success, and error copy in the handoff banner.
+
+- [x] **Step 4: Run UI tests and confirm GREEN**
+
+Run:
+
+```bash
+cd apps/packages/ui
+bun run test -- src/components/Option/ResearchWorkspace/__tests__/ResearchWorkspace.stage2.responsive.test.tsx
+```
+
+Expected: PASS.
+
+## Task 4: Verification And Closeout
+
+**Goal:** Prove the slice and record results.
+
+- [x] **Step 1: Run focused Research Workspace tests**
+
+Run:
+
+```bash
+cd apps/packages/ui
+bun run test -- src/components/Option/ResearchWorkspace/__tests__/deep-research-bundle-import.test.ts \
+  src/components/Option/ResearchWorkspace/__tests__/research-workspace-route-state.test.ts \
+  src/components/Option/ResearchWorkspace/__tests__/ResearchWorkspace.stage2.responsive.test.tsx
+```
+
+- [x] **Step 2: Run TypeScript check**
+
+Run:
+
+```bash
+cd apps/packages/ui
+NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit -p tsconfig.json
+```
+
+- [x] **Step 3: Run diff check**
+
+Run:
+
+```bash
+git diff --check
+```
+
+- [x] **Step 4: Record Bandit applicability**
+
+If only frontend TS/TSX/docs/backlog files changed, record Bandit skipped as not applicable. If Python changes are added, run Bandit on the touched Python scope.
+
+- [x] **Step 5: Update Backlog and commit**
+
+Update TASK-570 with notes, final summary, and DoD status, then commit the task, plan, tests, and implementation.

--- a/apps/packages/ui/src/components/Option/ResearchWorkspace/__tests__/ResearchWorkspace.stage2.responsive.test.tsx
+++ b/apps/packages/ui/src/components/Option/ResearchWorkspace/__tests__/ResearchWorkspace.stage2.responsive.test.tsx
@@ -9,6 +9,7 @@ const {
   mockWorkspaceStorageGetItem,
   mockWorkspaceStorageSetItem,
   mockGetResearchWorkspaceCapabilities,
+  mockGetResearchBundle,
   mockChatPaneProps,
   mockStudioPaneProps
 } = vi.hoisted(() => ({
@@ -30,6 +31,7 @@ const {
       }
     }
   })),
+  mockGetResearchBundle: vi.fn(),
   mockChatPaneProps: [] as any[],
   mockStudioPaneProps: [] as any[]
 }))
@@ -55,6 +57,7 @@ const testState = {
   captureToCurrentNote: vi.fn(),
   clearCurrentNote: vi.fn(),
   loadNote: vi.fn(),
+  addArtifact: vi.fn(),
   selectedSourceIds: [] as string[],
   generatedArtifacts: [] as Array<{ id: string }>,
   setLeftPaneCollapsed: vi.fn(),
@@ -124,6 +127,7 @@ vi.mock("@/store/workspace", () => ({
 vi.mock("@/services/tldw/TldwApiClient", () => ({
   tldwClient: {
     getMediaDetails: vi.fn().mockResolvedValue({}),
+    getResearchBundle: mockGetResearchBundle,
     getResearchWorkspaceCapabilities: mockGetResearchWorkspaceCapabilities
   }
 }))
@@ -233,7 +237,9 @@ describe("ResearchWorkspace Stage 2 drawer responsiveness", () => {
     testState.createNewWorkspace = vi.fn()
     testState.clearCurrentNote = vi.fn()
     testState.loadNote = vi.fn()
+    testState.addArtifact = vi.fn()
     mockGetResearchWorkspaceCapabilities.mockClear()
+    mockGetResearchBundle.mockReset()
     mockChatPaneProps.length = 0
     mockStudioPaneProps.length = 0
     window.localStorage.removeItem(RESEARCH_WORKSPACE_LAST_MOBILE_TAB_STORAGE_KEY)
@@ -470,6 +476,105 @@ describe("ResearchWorkspace Stage 2 drawer responsiveness", () => {
     expect(
       screen.getByRole("complementary", { name: "Studio panel" })
     ).toBeInTheDocument()
+  })
+
+  it("imports a completed Deep Research bundle from the return handoff", async () => {
+    testState.generatedArtifacts = [
+      {
+        id: "gap-artifact",
+        type: "data_table",
+        title: "Corpus Gap Finder",
+        status: "completed",
+        templateId: "corpus_gap_finder",
+        sourceCoverage: {
+          selectedSourceIds: ["source-a", "source-b"],
+          usableSources: [
+            { sourceId: "source-a", mediaId: 101, title: "Paper A" },
+            { sourceId: "source-b", mediaId: 102, title: "Paper B" }
+          ],
+          skippedSources: [],
+          truncatedSources: [],
+          minimumUsableSourcesMet: true
+        },
+        sourceLineage: [
+          { sourceId: "source-a", mediaId: 101, title: "Paper A" },
+          { sourceId: "source-b", mediaId: 102, title: "Paper B" }
+        ],
+        createdAt: new Date()
+      }
+    ] as any[]
+    mockGetResearchBundle.mockResolvedValueOnce({
+      question: "Which intervention gaps remain?",
+      report_markdown: "# Deep Report\n\nThe evidence supports follow-up work.",
+      claims: [
+        {
+          text: "Claim one",
+          citations: [{ source_id: "src_1", title: "Paper A" }]
+        }
+      ],
+      source_inventory: [{ source_id: "src_1", title: "Paper A" }],
+      verification_summary: {
+        supported_claim_count: 1,
+        unsupported_claim_count: 0
+      },
+      source_trust: [{ source_id: "src_1", snapshot_policy: "full_artifact" }]
+    })
+    window.history.replaceState(
+      null,
+      "",
+      "/research-workspace?source_workspace_id=workspace-1&source_artifact_id=gap-artifact&source_artifact_template=corpus_gap_finder&source_artifact_title=Corpus%20Gap%20Finder&research_run_id=research-run-7"
+    )
+
+    render(<ResearchWorkspace />)
+
+    fireEvent.click(screen.getByRole("button", { name: /import bundle/i }))
+
+    await waitFor(() => {
+      expect(mockGetResearchBundle).toHaveBeenCalledWith("research-run-7")
+    })
+    expect(testState.addArtifact).toHaveBeenCalledTimes(1)
+    const artifactPayload = testState.addArtifact.mock.calls[0]?.[0]
+    expect(artifactPayload).toMatchObject({
+      type: "report",
+      status: "completed",
+      title: "Deep Research: Corpus Gap Finder",
+      producerMetadata: {
+        producerType: "deep_research_bundle_import",
+        runId: "research-run-7",
+        templateId: "corpus_gap_finder"
+      }
+    })
+    expect(artifactPayload.data.deepResearch.runId).toBe("research-run-7")
+    expect(artifactPayload.sourceCoverage.selectedSourceIds).toEqual([
+      "source-a",
+      "source-b"
+    ])
+    expect(
+      screen.getByTestId("workspace-deep-research-return-handoff")
+    ).toHaveTextContent("Bundle imported")
+  })
+
+  it("shows a bundle import error without adding an artifact", async () => {
+    mockGetResearchBundle.mockResolvedValueOnce({
+      question: "Which intervention gaps remain?"
+    })
+    window.history.replaceState(
+      null,
+      "",
+      "/research-workspace?source_workspace_id=workspace-1&source_artifact_id=gap-artifact&source_artifact_template=corpus_gap_finder&source_artifact_title=Corpus%20Gap%20Finder&research_run_id=research-run-7"
+    )
+
+    render(<ResearchWorkspace />)
+
+    fireEvent.click(screen.getByRole("button", { name: /import bundle/i }))
+
+    await waitFor(() => {
+      expect(mockGetResearchBundle).toHaveBeenCalledWith("research-run-7")
+    })
+    expect(testState.addArtifact).not.toHaveBeenCalled()
+    expect(
+      screen.getByTestId("workspace-deep-research-return-handoff")
+    ).toHaveTextContent("could not be imported")
   })
 
   it("surfaces matching Deep Research return context from HashRouter search params", async () => {

--- a/apps/packages/ui/src/components/Option/ResearchWorkspace/__tests__/ResearchWorkspace.stage2.responsive.test.tsx
+++ b/apps/packages/ui/src/components/Option/ResearchWorkspace/__tests__/ResearchWorkspace.stage2.responsive.test.tsx
@@ -1,4 +1,11 @@
-import { fireEvent, render, screen, waitFor, within } from "@testing-library/react"
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within
+} from "@testing-library/react"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 import { ResearchWorkspace } from "../index"
 import { RESEARCH_WORKSPACE_LAST_MOBILE_TAB_STORAGE_KEY } from "../research-workspace-route-state"
@@ -103,26 +110,30 @@ vi.mock("@/hooks/useMediaQuery", () => ({
   useMobile: () => testState.isMobile
 }))
 
-vi.mock("@/store/workspace", () => ({
-  useWorkspaceStore: (
-    selector: (state: typeof testState) => unknown
-  ) => selector(testState),
-  createWorkspaceStorage: () => ({
-    getItem: (key: string) => {
-      mockWorkspaceStorageGetItem.mockImplementationOnce(async (requestedKey: string) =>
-        requestedKey === ONBOARDING_KEY ? onboardingStorageState.value ?? null : null
-      )
-      return mockWorkspaceStorageGetItem(key)
-    },
-    setItem: (key: string, value: string) => {
-      if (key === ONBOARDING_KEY) {
-        onboardingStorageState.value = value
-      }
-      return mockWorkspaceStorageSetItem(key, value)
-    },
-    removeItem: vi.fn()
-  })
-}))
+vi.mock("@/store/workspace", () => {
+  const useWorkspaceStore = (selector: (state: typeof testState) => unknown) =>
+    selector(testState)
+  useWorkspaceStore.getState = () => testState
+
+  return {
+    useWorkspaceStore,
+    createWorkspaceStorage: () => ({
+      getItem: (key: string) => {
+        mockWorkspaceStorageGetItem.mockImplementationOnce(async (requestedKey: string) =>
+          requestedKey === ONBOARDING_KEY ? onboardingStorageState.value ?? null : null
+        )
+        return mockWorkspaceStorageGetItem(key)
+      },
+      setItem: (key: string, value: string) => {
+        if (key === ONBOARDING_KEY) {
+          onboardingStorageState.value = value
+        }
+        return mockWorkspaceStorageSetItem(key, value)
+      },
+      removeItem: vi.fn()
+    })
+  }
+})
 
 vi.mock("@/services/tldw/TldwApiClient", () => ({
   tldwClient: {
@@ -230,6 +241,7 @@ describe("ResearchWorkspace Stage 2 drawer responsiveness", () => {
     testState.storeHydrated = true
     testState.leftPaneCollapsed = false
     testState.rightPaneCollapsed = false
+    testState.workspaceId = "workspace-1"
     testState.workspaceTag = ""
     testState.selectedSourceIds = []
     testState.generatedArtifacts = []
@@ -244,6 +256,23 @@ describe("ResearchWorkspace Stage 2 drawer responsiveness", () => {
     mockStudioPaneProps.length = 0
     window.localStorage.removeItem(RESEARCH_WORKSPACE_LAST_MOBILE_TAB_STORAGE_KEY)
     window.history.replaceState(null, "", "/research-workspace")
+  })
+
+  const createCompletedDeepResearchBundle = () => ({
+    question: "Which intervention gaps remain?",
+    report_markdown: "# Deep Report\n\nThe evidence supports follow-up work.",
+    claims: [
+      {
+        text: "Claim one",
+        citations: [{ source_id: "src_1", title: "Paper A" }]
+      }
+    ],
+    source_inventory: [{ source_id: "src_1", title: "Paper A" }],
+    verification_summary: {
+      supported_claim_count: 1,
+      unsupported_claim_count: 0
+    },
+    source_trust: [{ source_id: "src_1", snapshot_policy: "full_artifact" }]
   })
 
   it("uses non-masked tablet drawers so chat remains visible", () => {
@@ -503,22 +532,7 @@ describe("ResearchWorkspace Stage 2 drawer responsiveness", () => {
         createdAt: new Date()
       }
     ] as any[]
-    mockGetResearchBundle.mockResolvedValueOnce({
-      question: "Which intervention gaps remain?",
-      report_markdown: "# Deep Report\n\nThe evidence supports follow-up work.",
-      claims: [
-        {
-          text: "Claim one",
-          citations: [{ source_id: "src_1", title: "Paper A" }]
-        }
-      ],
-      source_inventory: [{ source_id: "src_1", title: "Paper A" }],
-      verification_summary: {
-        supported_claim_count: 1,
-        unsupported_claim_count: 0
-      },
-      source_trust: [{ source_id: "src_1", snapshot_policy: "full_artifact" }]
-    })
+    mockGetResearchBundle.mockResolvedValueOnce(createCompletedDeepResearchBundle())
     window.history.replaceState(
       null,
       "",
@@ -552,6 +566,67 @@ describe("ResearchWorkspace Stage 2 drawer responsiveness", () => {
     expect(
       screen.getByTestId("workspace-deep-research-return-handoff")
     ).toHaveTextContent("Bundle imported")
+  })
+
+  it("cancels a bundle import when the active workspace changes during fetch", async () => {
+    let resolveBundle!: (bundle: unknown) => void
+    const bundlePromise = new Promise<unknown>((resolve) => {
+      resolveBundle = resolve
+    })
+    mockGetResearchBundle.mockReturnValueOnce(bundlePromise)
+    window.history.replaceState(
+      null,
+      "",
+      "/research-workspace?source_workspace_id=workspace-1&source_artifact_id=gap-artifact&source_artifact_template=corpus_gap_finder&source_artifact_title=Corpus%20Gap%20Finder&research_run_id=research-run-7"
+    )
+
+    render(<ResearchWorkspace />)
+
+    fireEvent.click(screen.getByRole("button", { name: /import bundle/i }))
+
+    await waitFor(() => {
+      expect(mockGetResearchBundle).toHaveBeenCalledWith("research-run-7")
+    })
+    testState.workspaceId = "workspace-2"
+
+    await act(async () => {
+      resolveBundle(createCompletedDeepResearchBundle())
+      await bundlePromise
+    })
+
+    expect(testState.addArtifact).not.toHaveBeenCalled()
+    expect(
+      screen.getByTestId("workspace-deep-research-return-handoff")
+    ).not.toHaveTextContent("Bundle imported")
+  })
+
+  it("cancels a bundle import after the Research Workspace unmounts", async () => {
+    let resolveBundle!: (bundle: unknown) => void
+    const bundlePromise = new Promise<unknown>((resolve) => {
+      resolveBundle = resolve
+    })
+    mockGetResearchBundle.mockReturnValueOnce(bundlePromise)
+    window.history.replaceState(
+      null,
+      "",
+      "/research-workspace?source_workspace_id=workspace-1&source_artifact_id=gap-artifact&source_artifact_template=corpus_gap_finder&source_artifact_title=Corpus%20Gap%20Finder&research_run_id=research-run-7"
+    )
+
+    const { unmount } = render(<ResearchWorkspace />)
+
+    fireEvent.click(screen.getByRole("button", { name: /import bundle/i }))
+
+    await waitFor(() => {
+      expect(mockGetResearchBundle).toHaveBeenCalledWith("research-run-7")
+    })
+    unmount()
+
+    await act(async () => {
+      resolveBundle(createCompletedDeepResearchBundle())
+      await bundlePromise
+    })
+
+    expect(testState.addArtifact).not.toHaveBeenCalled()
   })
 
   it("shows a bundle import error without adding an artifact", async () => {

--- a/apps/packages/ui/src/components/Option/ResearchWorkspace/__tests__/deep-research-bundle-import.test.ts
+++ b/apps/packages/ui/src/components/Option/ResearchWorkspace/__tests__/deep-research-bundle-import.test.ts
@@ -5,6 +5,7 @@ import type {
 } from "@/types/workspace"
 import {
   DeepResearchBundleImportError,
+  MAX_IMPORT_LIST_ITEMS,
   buildDeepResearchBundleArtifactPayload
 } from "../deep-research-bundle-import"
 
@@ -151,5 +152,50 @@ describe("Deep Research bundle import", () => {
     expect(artifact.content).toContain(
       "[Deep Research report truncated for workspace import.]"
     )
+  })
+
+  it("bounds imported bundle lists before persisting artifact metadata", () => {
+    const unboundedList = Array.from({ length: MAX_IMPORT_LIST_ITEMS + 10 }, (_, index) => ({
+      source_id: `src_${index}`,
+      title: `Paper ${index}`,
+      citations: [{ source_id: `src_${index}` }]
+    }))
+    const longBundle = {
+      ...bundle,
+      claims: unboundedList,
+      source_inventory: unboundedList,
+      unresolved_questions: Array.from(
+        { length: MAX_IMPORT_LIST_ITEMS + 10 },
+        (_, index) => `Question ${index}`
+      ),
+      unsupported_claims: unboundedList,
+      contradictions: unboundedList,
+      source_trust: unboundedList
+    }
+
+    const artifact = buildDeepResearchBundleArtifactPayload({
+      bundle: longBundle,
+      returnContext
+    })
+    const deepResearch = artifact.data?.deepResearch as {
+      claims: unknown[]
+      sourceInventory: unknown[]
+      unresolvedQuestions: unknown[]
+      unsupportedClaims: unknown[]
+      contradictions: unknown[]
+      sourceTrust: unknown[]
+    }
+
+    expect(deepResearch.claims).toHaveLength(MAX_IMPORT_LIST_ITEMS)
+    expect(deepResearch.sourceInventory).toHaveLength(MAX_IMPORT_LIST_ITEMS)
+    expect(deepResearch.unresolvedQuestions).toHaveLength(MAX_IMPORT_LIST_ITEMS)
+    expect(deepResearch.unsupportedClaims).toHaveLength(MAX_IMPORT_LIST_ITEMS)
+    expect(deepResearch.contradictions).toHaveLength(MAX_IMPORT_LIST_ITEMS)
+    expect(deepResearch.sourceTrust).toHaveLength(MAX_IMPORT_LIST_ITEMS)
+    expect(artifact.sourceCoverage.selectedSourceIds).toHaveLength(
+      MAX_IMPORT_LIST_ITEMS
+    )
+    expect(artifact.sourceLineage).toHaveLength(MAX_IMPORT_LIST_ITEMS)
+    expect(artifact.content).toContain(`Source inventory: ${MAX_IMPORT_LIST_ITEMS}`)
   })
 })

--- a/apps/packages/ui/src/components/Option/ResearchWorkspace/__tests__/deep-research-bundle-import.test.ts
+++ b/apps/packages/ui/src/components/Option/ResearchWorkspace/__tests__/deep-research-bundle-import.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, it } from "vitest"
+import type {
+  ArtifactSourceCoverage,
+  GeneratedArtifact
+} from "@/types/workspace"
+import {
+  DeepResearchBundleImportError,
+  buildDeepResearchBundleArtifactPayload
+} from "../deep-research-bundle-import"
+
+const returnContext = {
+  sourceWorkspaceId: "workspace-1",
+  sourceArtifactId: "gap-artifact",
+  sourceArtifactTemplate: "corpus_gap_finder",
+  sourceArtifactTitle: "Corpus Gap Finder",
+  researchRunId: "research-run-7"
+}
+
+const sourceCoverage: ArtifactSourceCoverage = {
+  selectedSourceIds: ["source-a", "source-b"],
+  usableSources: [
+    { sourceId: "source-a", mediaId: 101, title: "Paper A" },
+    { sourceId: "source-b", mediaId: 102, title: "Paper B" }
+  ],
+  skippedSources: [],
+  truncatedSources: [],
+  sourceContextCharLimit: { perSource: 6000, total: 18000 },
+  minimumUsableSourcesMet: true
+}
+
+const sourceArtifact = {
+  id: "gap-artifact",
+  type: "data_table",
+  title: "Corpus Gap Finder",
+  status: "completed",
+  templateId: "corpus_gap_finder",
+  sourceCoverage,
+  sourceLineage: [
+    { sourceId: "source-a", mediaId: 101, title: "Paper A", citationCount: 2 },
+    { sourceId: "source-b", mediaId: 102, title: "Paper B", citationCount: 1 }
+  ],
+  content: "Gap artifact content",
+  createdAt: new Date("2026-05-30T12:00:00.000Z"),
+  completedAt: new Date("2026-05-30T12:01:00.000Z")
+} satisfies GeneratedArtifact
+
+const bundle = {
+  question: "Which intervention gaps remain?",
+  report_markdown: "# Deep Report\n\nThe evidence supports follow-up work.",
+  claims: [
+    {
+      text: "Claim one",
+      citations: [{ source_id: "src_1", title: "Paper A" }],
+      support_level: "strong"
+    }
+  ],
+  source_inventory: [
+    { source_id: "src_1", title: "Paper A" },
+    { source_id: "src_2", title: "Paper B" }
+  ],
+  unresolved_questions: ["What changes in field settings?"],
+  verification_summary: {
+    supported_claim_count: 1,
+    unsupported_claim_count: 0
+  },
+  unsupported_claims: [],
+  contradictions: [],
+  source_trust: [{ source_id: "src_1", snapshot_policy: "full_artifact" }]
+}
+
+describe("Deep Research bundle import", () => {
+  it("builds a completed Research Workspace artifact from a bundle", () => {
+    const artifact = buildDeepResearchBundleArtifactPayload({
+      bundle,
+      returnContext,
+      sourceArtifact
+    })
+
+    expect(artifact.type).toBe("report")
+    expect(artifact.status).toBe("completed")
+    expect(artifact.title).toBe("Deep Research: Corpus Gap Finder")
+    expect(artifact.templateId).toBeUndefined()
+    expect(artifact.content).toContain("# Deep Report")
+    expect(artifact.content).toContain("Imported from Deep Research run")
+    expect(artifact.sourceCoverage).toEqual(sourceCoverage)
+    expect(artifact.sourceLineage).toEqual(sourceArtifact.sourceLineage)
+    expect(artifact.producerMetadata).toMatchObject({
+      producerType: "deep_research_bundle_import",
+      runId: "research-run-7",
+      templateId: "corpus_gap_finder"
+    })
+    expect(artifact.data?.deepResearch).toMatchObject({
+      runId: "research-run-7",
+      question: "Which intervention gaps remain?",
+      sourceArtifact: {
+        id: "gap-artifact",
+        template: "corpus_gap_finder",
+        title: "Corpus Gap Finder"
+      },
+      verificationSummary: {
+        supported_claim_count: 1,
+        unsupported_claim_count: 0
+      },
+      sourceTrust: [{ source_id: "src_1", snapshot_policy: "full_artifact" }]
+    })
+  })
+
+  it("derives fallback source coverage from the bundle source inventory", () => {
+    const artifact = buildDeepResearchBundleArtifactPayload({
+      bundle,
+      returnContext
+    })
+
+    expect(artifact.sourceCoverage).toEqual({
+      selectedSourceIds: ["src_1", "src_2"],
+      usableSources: [
+        { sourceId: "src_1", title: "Paper A" },
+        { sourceId: "src_2", title: "Paper B" }
+      ],
+      skippedSources: [],
+      truncatedSources: [],
+      minimumUsableSourcesMet: true
+    })
+    expect(artifact.sourceLineage).toEqual([
+      { sourceId: "src_1", title: "Paper A", citationCount: 1 },
+      { sourceId: "src_2", title: "Paper B", citationCount: 0 }
+    ])
+  })
+
+  it("rejects malformed bundles without a usable report", () => {
+    expect(() =>
+      buildDeepResearchBundleArtifactPayload({
+        bundle: { question: "Question only" },
+        returnContext
+      })
+    ).toThrow(DeepResearchBundleImportError)
+  })
+
+  it("bounds imported readable content", () => {
+    const longBundle = {
+      ...bundle,
+      report_markdown: `# Deep Report\n\n${"Long finding. ".repeat(2000)}`
+    }
+
+    const artifact = buildDeepResearchBundleArtifactPayload({
+      bundle: longBundle,
+      returnContext
+    })
+
+    expect(artifact.content?.length).toBeLessThan(9000)
+    expect(artifact.content).toContain(
+      "[Deep Research report truncated for workspace import.]"
+    )
+  })
+})

--- a/apps/packages/ui/src/components/Option/ResearchWorkspace/deep-research-bundle-import.ts
+++ b/apps/packages/ui/src/components/Option/ResearchWorkspace/deep-research-bundle-import.ts
@@ -1,0 +1,279 @@
+import type {
+  ArtifactSourceCoverage,
+  ArtifactSourceCoverageEntry,
+  ArtifactSourceLineage,
+  GeneratedArtifact
+} from "@/types/workspace"
+import type { ResearchWorkspaceDeepResearchReturnContext } from "./research-workspace-route-state"
+
+const IMPORTED_REPORT_LIMIT = 7_600
+const PREVIEW_LIMIT = 280
+const IMPORT_TRUNCATION_SUFFIX =
+  "\n\n[Deep Research report truncated for workspace import.]"
+
+type DeepResearchBundleImportOptions = {
+  bundle: unknown
+  returnContext: ResearchWorkspaceDeepResearchReturnContext
+  sourceArtifact?: GeneratedArtifact | null
+}
+
+type GeneratedArtifactPayload = Omit<GeneratedArtifact, "id" | "createdAt">
+
+export class DeepResearchBundleImportError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = "DeepResearchBundleImportError"
+  }
+}
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value)
+
+const asRecord = (value: unknown): Record<string, unknown> =>
+  isRecord(value) ? value : {}
+
+const readString = (value: unknown): string =>
+  typeof value === "string" ? value.trim() : ""
+
+const readRecordList = (value: unknown): Array<Record<string, unknown>> =>
+  Array.isArray(value) ? value.filter(isRecord) : []
+
+const readStringList = (value: unknown): string[] =>
+  Array.isArray(value) ? value.map(readString).filter(Boolean) : []
+
+const readQuestion = (bundle: Record<string, unknown>): string => {
+  const directQuestion = readString(bundle.question)
+  if (directQuestion) return directQuestion
+
+  return readString(asRecord(bundle.brief).query)
+}
+
+const truncateForImport = (value: string, limit: number): string => {
+  const trimmed = value.trim()
+  if (trimmed.length <= limit) return trimmed
+  if (limit <= IMPORT_TRUNCATION_SUFFIX.length) {
+    return IMPORT_TRUNCATION_SUFFIX.slice(0, limit)
+  }
+
+  return `${trimmed
+    .slice(0, limit - IMPORT_TRUNCATION_SUFFIX.length)
+    .trimEnd()}${IMPORT_TRUNCATION_SUFFIX}`
+}
+
+const formatCount = (label: string, value: unknown): string | null =>
+  typeof value === "number" && Number.isFinite(value)
+    ? `${label}: ${value}`
+    : null
+
+const normalizeSourceInventory = (
+  bundle: Record<string, unknown>
+): ArtifactSourceCoverageEntry[] =>
+  readRecordList(bundle.source_inventory)
+    .map((entry): ArtifactSourceCoverageEntry | null => {
+      const sourceId = readString(entry.source_id ?? entry.id)
+      if (!sourceId) return null
+
+      const title = readString(entry.title ?? entry.label)
+      return {
+        sourceId,
+        ...(title ? { title } : {})
+      }
+    })
+    .filter((entry): entry is ArtifactSourceCoverageEntry => Boolean(entry))
+
+const buildFallbackSourceCoverage = (
+  sources: ArtifactSourceCoverageEntry[]
+): ArtifactSourceCoverage => ({
+  selectedSourceIds: sources.map((source) => source.sourceId),
+  usableSources: sources,
+  skippedSources: [],
+  truncatedSources: [],
+  minimumUsableSourcesMet: sources.length > 0
+})
+
+const buildCitationCounts = (
+  claims: Array<Record<string, unknown>>
+): Map<string, number> => {
+  const counts = new Map<string, number>()
+  for (const claim of claims) {
+    for (const citation of readRecordList(claim.citations)) {
+      const sourceId = readString(citation.source_id ?? citation.id)
+      if (!sourceId) continue
+      counts.set(sourceId, (counts.get(sourceId) ?? 0) + 1)
+    }
+  }
+  return counts
+}
+
+const buildFallbackSourceLineage = (
+  sources: ArtifactSourceCoverageEntry[],
+  claims: Array<Record<string, unknown>>
+): ArtifactSourceLineage[] => {
+  const citationCounts = buildCitationCounts(claims)
+  return sources.map((source) => ({
+    sourceId: source.sourceId,
+    ...(source.mediaId !== undefined ? { mediaId: source.mediaId } : {}),
+    ...(source.title ? { title: source.title } : {}),
+    citationCount: citationCounts.get(source.sourceId) ?? 0
+  }))
+}
+
+const buildSourceArtifactMetadata = (
+  returnContext: ResearchWorkspaceDeepResearchReturnContext,
+  sourceArtifact?: GeneratedArtifact | null
+) => ({
+  id: sourceArtifact?.id ?? returnContext.sourceArtifactId,
+  template: sourceArtifact?.templateId ?? returnContext.sourceArtifactTemplate,
+  title: sourceArtifact?.title ?? returnContext.sourceArtifactTitle
+})
+
+const buildImportedContent = (options: {
+  question: string
+  reportMarkdown: string
+  returnContext: ResearchWorkspaceDeepResearchReturnContext
+  sourceTitle: string
+  sourceCount: number
+  verificationSummary: Record<string, unknown>
+  unresolvedQuestions: string[]
+}): string => {
+  const verificationBits = [
+    formatCount(
+      "supported claims",
+      options.verificationSummary.supported_claim_count
+    ),
+    formatCount(
+      "unsupported claims",
+      options.verificationSummary.unsupported_claim_count
+    )
+  ].filter(Boolean)
+  const unresolvedQuestions = options.unresolvedQuestions.length
+    ? [
+        "",
+        "## Unresolved Questions",
+        "",
+        ...options.unresolvedQuestions.map((question) => `- ${question}`)
+      ]
+    : []
+
+  return [
+    `# Deep Research Import: ${options.sourceTitle}`,
+    "",
+    `Imported from Deep Research run ${options.returnContext.researchRunId}.`,
+    `Source artifact: ${options.sourceTitle}`,
+    `Question: ${options.question}`,
+    `Source inventory: ${options.sourceCount}`,
+    verificationBits.length ? `Verification: ${verificationBits.join(", ")}` : "",
+    "",
+    "## Report",
+    "",
+    truncateForImport(options.reportMarkdown, IMPORTED_REPORT_LIMIT),
+    ...unresolvedQuestions
+  ]
+    .filter((line) => line !== "")
+    .join("\n")
+}
+
+export const buildDeepResearchBundleArtifactPayload = ({
+  bundle,
+  returnContext,
+  sourceArtifact = null
+}: DeepResearchBundleImportOptions): GeneratedArtifactPayload => {
+  if (!isRecord(bundle)) {
+    throw new DeepResearchBundleImportError(
+      "Deep Research bundle could not be imported because it was not valid JSON."
+    )
+  }
+
+  const question = readQuestion(bundle)
+  const reportMarkdown = readString(bundle.report_markdown)
+  if (!question) {
+    throw new DeepResearchBundleImportError(
+      "Deep Research bundle could not be imported because it is missing a question."
+    )
+  }
+  if (!reportMarkdown) {
+    throw new DeepResearchBundleImportError(
+      "Deep Research bundle could not be imported because it is missing report markdown."
+    )
+  }
+
+  const claims = readRecordList(bundle.claims)
+  const sourceInventory = normalizeSourceInventory(bundle)
+  const sourceCoverage =
+    sourceArtifact?.sourceCoverage ?? buildFallbackSourceCoverage(sourceInventory)
+  const sourceLineage =
+    sourceArtifact?.sourceLineage ??
+    buildFallbackSourceLineage(sourceInventory, claims)
+  const sourceArtifactMetadata = buildSourceArtifactMetadata(
+    returnContext,
+    sourceArtifact
+  )
+  const sourceTitle =
+    sourceArtifactMetadata.title ||
+    sourceArtifactMetadata.id ||
+    returnContext.researchRunId
+  const verificationSummary = asRecord(bundle.verification_summary)
+  const unresolvedQuestions = readStringList(bundle.unresolved_questions)
+  const content = buildImportedContent({
+    question,
+    reportMarkdown,
+    returnContext,
+    sourceTitle,
+    sourceCount: sourceInventory.length,
+    verificationSummary,
+    unresolvedQuestions
+  })
+
+  return {
+    type: "report",
+    title: `Deep Research: ${sourceTitle}`,
+    status: "completed",
+    reviewStatus: "draft",
+    sourceLineage,
+    sourceCoverage,
+    reviewChecklist: [
+      {
+        id: "deep-research-source-inventory",
+        label: "Review imported source inventory against workspace sources",
+        checked: false
+      },
+      {
+        id: "deep-research-unsupported-claims",
+        label: "Check unsupported claims and contradictions before reuse",
+        checked: false
+      },
+      {
+        id: "deep-research-provenance",
+        label: "Confirm Deep Research run provenance matches the source artifact",
+        checked: false
+      }
+    ],
+    exportTargets: ["markdown"],
+    schemaVersion: 1,
+    producerMetadata: {
+      producerType: "deep_research_bundle_import",
+      producerId: "deep_research",
+      runId: returnContext.researchRunId,
+      templateId: sourceArtifactMetadata.template ?? undefined
+    },
+    contentType: "text/markdown",
+    previewText: truncateForImport(reportMarkdown, PREVIEW_LIMIT),
+    summary: `Imported Deep Research bundle for: ${question}`,
+    content,
+    data: {
+      deepResearch: {
+        runId: returnContext.researchRunId,
+        question,
+        sourceArtifact: sourceArtifactMetadata,
+        claims,
+        sourceInventory: readRecordList(bundle.source_inventory),
+        unresolvedQuestions,
+        verificationSummary,
+        unsupportedClaims: readRecordList(bundle.unsupported_claims),
+        contradictions: readRecordList(bundle.contradictions),
+        sourceTrust: readRecordList(bundle.source_trust)
+      }
+    },
+    completedAt: new Date()
+  }
+}

--- a/apps/packages/ui/src/components/Option/ResearchWorkspace/deep-research-bundle-import.ts
+++ b/apps/packages/ui/src/components/Option/ResearchWorkspace/deep-research-bundle-import.ts
@@ -8,6 +8,7 @@ import type { ResearchWorkspaceDeepResearchReturnContext } from "./research-work
 
 const IMPORTED_REPORT_LIMIT = 7_600
 const PREVIEW_LIMIT = 280
+export const MAX_IMPORT_LIST_ITEMS = 50
 const IMPORT_TRUNCATION_SUFFIX =
   "\n\n[Deep Research report truncated for workspace import.]"
 
@@ -35,11 +36,14 @@ const asRecord = (value: unknown): Record<string, unknown> =>
 const readString = (value: unknown): string =>
   typeof value === "string" ? value.trim() : ""
 
+const capImportList = <T,>(items: T[]): T[] =>
+  items.slice(0, MAX_IMPORT_LIST_ITEMS)
+
 const readRecordList = (value: unknown): Array<Record<string, unknown>> =>
-  Array.isArray(value) ? value.filter(isRecord) : []
+  Array.isArray(value) ? capImportList(value.filter(isRecord)) : []
 
 const readStringList = (value: unknown): string[] =>
-  Array.isArray(value) ? value.map(readString).filter(Boolean) : []
+  Array.isArray(value) ? capImportList(value.map(readString).filter(Boolean)) : []
 
 const readQuestion = (bundle: Record<string, unknown>): string => {
   const directQuestion = readString(bundle.question)

--- a/apps/packages/ui/src/components/Option/ResearchWorkspace/index.tsx
+++ b/apps/packages/ui/src/components/Option/ResearchWorkspace/index.tsx
@@ -46,6 +46,7 @@ import type {
   WorkspaceSourceStatusListResponse
 } from "@/services/tldw/domains/workspace-api"
 import type {
+  GeneratedArtifact,
   WorkspaceSourceStatus,
   WorkspaceSourceStatusDetails
 } from "@/types/workspace"
@@ -96,6 +97,7 @@ import {
   RESEARCH_WORKSPACE_DEFAULT_TAB,
   readResearchWorkspaceLastMobileTab,
   writeResearchWorkspaceLastMobileTab,
+  type ResearchWorkspaceDeepResearchReturnContext,
   type ResearchWorkspaceTab
 } from "./research-workspace-route-state"
 import {
@@ -112,6 +114,10 @@ import {
   buildResearchWorkspaceServerSourceSignature,
   reconcileResearchWorkspaceServerState
 } from "./workspace-server-reconcile"
+import {
+  DeepResearchBundleImportError,
+  buildDeepResearchBundleArtifactPayload
+} from "./deep-research-bundle-import"
 
 const SourcesPane = React.lazy(() =>
   import("./SourcesPane").then((module) => ({ default: module.SourcesPane }))
@@ -162,6 +168,21 @@ const WORKSPACE_CONFLICT_FIELD_LABELS: Record<string, string> = {
 }
 const WORKSPACE_CHAT_OFFLOAD_POINTER_KIND = "workspace_chat_session_v1"
 const WORKSPACE_ARTIFACT_OFFLOAD_POINTER_KIND = "workspace_artifact_payload_v1"
+
+type DeepResearchBundleImportState = {
+  contextKey: string
+  status: "importing" | "imported" | "failed"
+  message?: string
+}
+
+const buildDeepResearchBundleImportContextKey = (
+  context: ResearchWorkspaceDeepResearchReturnContext
+): string =>
+  [
+    context.sourceWorkspaceId,
+    context.sourceArtifactId ?? "",
+    context.researchRunId
+  ].join(":")
 
 const collectResearchWorkspaceLegacyLocalStorageKeys = (): string[] => {
   if (typeof window === "undefined") return []
@@ -1239,6 +1260,7 @@ const ResearchWorkspaceBody: React.FC = () => {
     (s) => s.selectedSourceFolderIds
   )
   const generatedArtifacts = useWorkspaceStore((s) => s.generatedArtifacts)
+  const addArtifact = useWorkspaceStore((s) => s.addArtifact)
   const leftPaneCollapsed = useWorkspaceStore((s) => s.leftPaneCollapsed)
   const rightPaneCollapsed = useWorkspaceStore((s) => s.rightPaneCollapsed)
   const setLeftPaneCollapsed = useWorkspaceStore((s) => s.setLeftPaneCollapsed)
@@ -1266,6 +1288,15 @@ const ResearchWorkspaceBody: React.FC = () => {
   const workspaceStatusRequestSeqRef = React.useRef(0)
   const workspaceStatusInFlightRef = React.useRef(false)
   const workspaceServerReconcileSignatureRef = React.useRef<string | null>(null)
+  const [deepResearchBundleImportState, setDeepResearchBundleImportState] =
+    React.useState<DeepResearchBundleImportState | null>(null)
+  const activeDeepResearchReturnKey = activeDeepResearchReturnContext
+    ? buildDeepResearchBundleImportContextKey(activeDeepResearchReturnContext)
+    : null
+  const activeDeepResearchBundleImportState =
+    deepResearchBundleImportState?.contextKey === activeDeepResearchReturnKey
+      ? deepResearchBundleImportState
+      : null
   const workspaceProjectedSourceStatusByMediaIdRef = React.useRef<{
     workspaceId: string | null
     fallbackReady: boolean
@@ -2227,6 +2258,63 @@ const ResearchWorkspaceBody: React.FC = () => {
     focusWorkspacePane("studio")
   }, [activeDeepResearchReturnContext, focusWorkspacePane])
 
+  const handleImportDeepResearchBundle = React.useCallback(async () => {
+    if (!activeDeepResearchReturnContext || !activeDeepResearchReturnKey) return
+
+    setDeepResearchBundleImportState({
+      contextKey: activeDeepResearchReturnKey,
+      status: "importing"
+    })
+
+    try {
+      const bundle = await tldwClient.getResearchBundle(
+        activeDeepResearchReturnContext.researchRunId
+      )
+      const sourceArtifact = activeDeepResearchReturnContext.sourceArtifactId
+        ? (generatedArtifacts.find(
+            (artifact: GeneratedArtifact) =>
+              artifact.id === activeDeepResearchReturnContext.sourceArtifactId
+          ) ?? null)
+        : null
+      const artifactPayload = buildDeepResearchBundleArtifactPayload({
+        bundle,
+        returnContext: activeDeepResearchReturnContext,
+        sourceArtifact
+      })
+
+      addArtifact(artifactPayload)
+      setDeepResearchBundleImportState({
+        contextKey: activeDeepResearchReturnKey,
+        status: "imported",
+        message: t(
+          "playground:studio.deepResearchBundleImported",
+          "Bundle imported"
+        )
+      })
+      focusWorkspacePane("studio")
+    } catch (error) {
+      const message =
+        error instanceof DeepResearchBundleImportError || error instanceof Error
+          ? error.message
+          : t(
+              "playground:studio.deepResearchBundleImportFailed",
+              "Deep Research bundle could not be imported."
+            )
+      setDeepResearchBundleImportState({
+        contextKey: activeDeepResearchReturnKey,
+        status: "failed",
+        message
+      })
+    }
+  }, [
+    activeDeepResearchReturnContext,
+    activeDeepResearchReturnKey,
+    addArtifact,
+    focusWorkspacePane,
+    generatedArtifacts,
+    t
+  ])
+
   const handleOpenSplitWorkspace = React.useCallback(() => {
     if (readyEffectiveSelectedSourceEntries.length === 0) {
       focusWorkspacePane("sources")
@@ -3163,14 +3251,58 @@ const ResearchWorkspaceBody: React.FC = () => {
         <span className="font-mono text-xs">
           {activeDeepResearchReturnContext.researchRunId}
         </span>
+        {activeDeepResearchBundleImportState ? (
+          <>
+            <span className="mx-1 text-text-subtle">|</span>
+            <span
+              className={
+                activeDeepResearchBundleImportState.status === "failed"
+                  ? "text-danger"
+                  : "text-text-muted"
+              }
+            >
+              {activeDeepResearchBundleImportState.status === "failed"
+                ? t(
+                    "playground:studio.deepResearchBundleImportFailedInline",
+                    "Bundle could not be imported"
+                  )
+                : activeDeepResearchBundleImportState.message ||
+                  t(
+                    "playground:studio.deepResearchBundleImporting",
+                    "Importing bundle"
+                  )}
+              {activeDeepResearchBundleImportState.status === "failed" &&
+              activeDeepResearchBundleImportState.message
+                ? `: ${activeDeepResearchBundleImportState.message}`
+                : ""}
+            </span>
+          </>
+        ) : null}
       </span>
-      <button
-        type="button"
-        className="rounded border border-border px-2 py-1 text-xs font-medium hover:bg-surface2"
-        onClick={() => focusWorkspacePane("studio")}
-      >
-        {t("playground:studio.openStudio", "Open Studio")}
-      </button>
+      <div className="flex flex-wrap items-center gap-2">
+        <button
+          type="button"
+          className="rounded border border-border px-2 py-1 text-xs font-medium hover:bg-surface2 disabled:cursor-not-allowed disabled:opacity-60"
+          disabled={
+            activeDeepResearchBundleImportState?.status === "importing" ||
+            activeDeepResearchBundleImportState?.status === "imported"
+          }
+          onClick={handleImportDeepResearchBundle}
+        >
+          {activeDeepResearchBundleImportState?.status === "importing"
+            ? t("playground:studio.importingBundle", "Importing")
+            : activeDeepResearchBundleImportState?.status === "imported"
+              ? t("playground:studio.bundleImported", "Imported")
+              : t("playground:studio.importBundle", "Import bundle")}
+        </button>
+        <button
+          type="button"
+          className="rounded border border-border px-2 py-1 text-xs font-medium hover:bg-surface2"
+          onClick={() => focusWorkspacePane("studio")}
+        >
+          {t("playground:studio.openStudio", "Open Studio")}
+        </button>
+      </div>
     </div>
   ) : null
 

--- a/apps/packages/ui/src/components/Option/ResearchWorkspace/index.tsx
+++ b/apps/packages/ui/src/components/Option/ResearchWorkspace/index.tsx
@@ -1288,6 +1288,8 @@ const ResearchWorkspaceBody: React.FC = () => {
   const workspaceStatusRequestSeqRef = React.useRef(0)
   const workspaceStatusInFlightRef = React.useRef(false)
   const workspaceServerReconcileSignatureRef = React.useRef<string | null>(null)
+  const isMountedRef = React.useRef(false)
+  const deepResearchBundleImportRequestSeqRef = React.useRef(0)
   const [deepResearchBundleImportState, setDeepResearchBundleImportState] =
     React.useState<DeepResearchBundleImportState | null>(null)
   const activeDeepResearchReturnKey = activeDeepResearchReturnContext
@@ -1330,6 +1332,14 @@ const ResearchWorkspaceBody: React.FC = () => {
     [selectedSourceIds]
   )
   const workspaceServerSourcesRef = React.useRef(sources)
+  React.useEffect(() => {
+    isMountedRef.current = true
+    return () => {
+      isMountedRef.current = false
+      deepResearchBundleImportRequestSeqRef.current += 1
+    }
+  }, [])
+
   React.useEffect(() => {
     workspaceServerSourcesRef.current = sources
   }, [sources])
@@ -2261,30 +2271,45 @@ const ResearchWorkspaceBody: React.FC = () => {
   const handleImportDeepResearchBundle = React.useCallback(async () => {
     if (!activeDeepResearchReturnContext || !activeDeepResearchReturnKey) return
 
+    const importRequestId = deepResearchBundleImportRequestSeqRef.current + 1
+    deepResearchBundleImportRequestSeqRef.current = importRequestId
+    const returnContext = activeDeepResearchReturnContext
+    const returnContextKey = activeDeepResearchReturnKey
+    const originWorkspaceId = returnContext.sourceWorkspaceId
+    const canContinueImport = () =>
+      isMountedRef.current &&
+      deepResearchBundleImportRequestSeqRef.current === importRequestId &&
+      useWorkspaceStore.getState().workspaceId === originWorkspaceId
+
     setDeepResearchBundleImportState({
-      contextKey: activeDeepResearchReturnKey,
+      contextKey: returnContextKey,
       status: "importing"
     })
 
     try {
       const bundle = await tldwClient.getResearchBundle(
-        activeDeepResearchReturnContext.researchRunId
+        returnContext.researchRunId
       )
-      const sourceArtifact = activeDeepResearchReturnContext.sourceArtifactId
-        ? (generatedArtifacts.find(
+      if (!canContinueImport()) return
+
+      const currentArtifacts = useWorkspaceStore.getState().generatedArtifacts
+      const sourceArtifact = returnContext.sourceArtifactId
+        ? (currentArtifacts.find(
             (artifact: GeneratedArtifact) =>
-              artifact.id === activeDeepResearchReturnContext.sourceArtifactId
+              artifact.id === returnContext.sourceArtifactId
           ) ?? null)
         : null
       const artifactPayload = buildDeepResearchBundleArtifactPayload({
         bundle,
-        returnContext: activeDeepResearchReturnContext,
+        returnContext,
         sourceArtifact
       })
 
+      if (!canContinueImport()) return
       addArtifact(artifactPayload)
+      if (!canContinueImport()) return
       setDeepResearchBundleImportState({
-        contextKey: activeDeepResearchReturnKey,
+        contextKey: returnContextKey,
         status: "imported",
         message: t(
           "playground:studio.deepResearchBundleImported",
@@ -2293,6 +2318,7 @@ const ResearchWorkspaceBody: React.FC = () => {
       })
       focusWorkspacePane("studio")
     } catch (error) {
+      if (!canContinueImport()) return
       const message =
         error instanceof DeepResearchBundleImportError || error instanceof Error
           ? error.message
@@ -2301,7 +2327,7 @@ const ResearchWorkspaceBody: React.FC = () => {
               "Deep Research bundle could not be imported."
             )
       setDeepResearchBundleImportState({
-        contextKey: activeDeepResearchReturnKey,
+        contextKey: returnContextKey,
         status: "failed",
         message
       })
@@ -2311,7 +2337,6 @@ const ResearchWorkspaceBody: React.FC = () => {
     activeDeepResearchReturnKey,
     addArtifact,
     focusWorkspacePane,
-    generatedArtifacts,
     t
   ])
 

--- a/backlog/tasks/task-570 - Implement-Deep-Research-bundle-import-into-Research-Workspace-artifacts.md
+++ b/backlog/tasks/task-570 - Implement-Deep-Research-bundle-import-into-Research-Workspace-artifacts.md
@@ -1,0 +1,62 @@
+---
+id: TASK-570
+title: Implement Deep Research bundle import into Research Workspace artifacts
+status: Done
+documentation:
+- Docs/Product/Research_Workspace_Literature_Workproducts_PRD.md
+- Docs/superpowers/plans/2026-05-30-research-workspace-literature-workproducts-plan.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement the next post-MVP Research Workspace / Deep Research bridge: import a completed Deep Research bundle.json into the active Research Workspace as a generated artifact, preserving run provenance, source coverage, verification summary metadata, and the source artifact return context. This implementation task references the existing follow-up TASK-489, whose ID collides with older task files in this checkout and cannot be safely edited through MCP/CLI by task ID.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 A matching Deep Research return handoff can fetch a completed run bundle through the existing research run bundle API.
+- [x] #2 The imported bundle becomes a Research Workspace generated artifact with a stable template/type, bounded readable content, source lineage, source coverage, and Deep Research run provenance.
+- [x] #3 Unavailable, incomplete, malformed, or mismatched bundles fail visibly without mutating unrelated workspace state.
+- [x] #4 Focused Research Workspace tests cover successful import, failure handling, and provenance/source coverage metadata.
+- [x] #5 Verification, Bandit applicability, and any known skips are recorded before closeout.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Docs/superpowers/plans/2026-05-30-research-workspace-deep-research-bundle-import-plan.md
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+- Created task-specific implementation plan: Docs/superpowers/plans/2026-05-30-research-workspace-deep-research-bundle-import-plan.md
+- Verified PR #2178 is merged into origin/dev at 759b373f4ab990416f972257a495ade79dd3da94 and created a fresh worktree from that commit.
+- Baseline handoff tests passed: `bun run test -- src/components/Option/ResearchWorkspace/__tests__/research-workspace-route-state.test.ts src/components/Option/ResearchWorkspace/__tests__/ResearchWorkspace.stage2.responsive.test.tsx` (25 tests).
+- Added RED adapter and UI tests before implementation; adapter tests first failed on the missing module, and UI tests failed on the missing Import bundle action.
+- Implemented a frontend-only Deep Research bundle import adapter and an explicit import action in the Research Workspace return handoff banner.
+- Bandit skipped: touched production/test files are frontend TypeScript/TSX plus docs/backlog only; no Python code changed.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Implemented TASK-570 by adding a frontend-only Deep Research bundle import path for Research Workspace return handoffs. A matching returned run can now fetch the existing `/api/v1/research/runs/{id}/bundle` response through `tldwClient.getResearchBundle`, normalize it into a completed Research Workspace report artifact, preserve source artifact provenance in producer metadata and `data.deepResearch`, carry source lineage/source coverage from the source artifact or fallback bundle source inventory, and show explicit importing/imported/error states in the handoff banner. Imported artifacts intentionally do not set a literature `templateId`, so they are not mistaken for launchable literature work products.
+
+Verification:
+- `bun run test -- src/components/Option/ResearchWorkspace/__tests__/deep-research-bundle-import.test.ts src/components/Option/ResearchWorkspace/__tests__/research-workspace-route-state.test.ts src/components/Option/ResearchWorkspace/__tests__/ResearchWorkspace.stage2.responsive.test.tsx` passed with 31 tests.
+- `NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit -p tsconfig.json` passed.
+- `git diff --check` passed.
+- Bandit skipped because this slice changed frontend TypeScript/TSX, docs, and Backlog only.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-570 - Implement-Deep-Research-bundle-import-into-Research-Workspace-artifacts.md
+++ b/backlog/tasks/task-570 - Implement-Deep-Research-bundle-import-into-Research-Workspace-artifacts.md
@@ -44,8 +44,10 @@ Docs/superpowers/plans/2026-05-30-research-workspace-deep-research-bundle-import
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
 Implemented TASK-570 by adding a frontend-only Deep Research bundle import path for Research Workspace return handoffs. A matching returned run can now fetch the existing `/api/v1/research/runs/{id}/bundle` response through `tldwClient.getResearchBundle`, normalize it into a completed Research Workspace report artifact, preserve source artifact provenance in producer metadata and `data.deepResearch`, carry source lineage/source coverage from the source artifact or fallback bundle source inventory, and show explicit importing/imported/error states in the handoff banner. Imported artifacts intentionally do not set a literature `templateId`, so they are not mistaken for launchable literature work products.
 
+PR #2181 review remediation also now cancels in-flight imports if the user switches workspaces or unmounts Research Workspace before the bundle fetch completes, and caps imported bundle lists before they are used for source coverage, source lineage, readable content, or persisted Deep Research metadata.
+
 Verification:
-- `bun run test -- src/components/Option/ResearchWorkspace/__tests__/deep-research-bundle-import.test.ts src/components/Option/ResearchWorkspace/__tests__/research-workspace-route-state.test.ts src/components/Option/ResearchWorkspace/__tests__/ResearchWorkspace.stage2.responsive.test.tsx` passed with 31 tests.
+- `bunx vitest run src/components/Option/ResearchWorkspace/__tests__/deep-research-bundle-import.test.ts src/components/Option/ResearchWorkspace/__tests__/research-workspace-route-state.test.ts src/components/Option/ResearchWorkspace/__tests__/ResearchWorkspace.stage2.responsive.test.tsx --maxWorkers=1 --no-file-parallelism` passed with 34 tests.
 - `NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit -p tsconfig.json` passed.
 - `git diff --check` passed.
 - Bandit skipped because this slice changed frontend TypeScript/TSX, docs, and Backlog only.


### PR DESCRIPTION
## Summary

- What changed:
  - Added a Deep Research bundle import adapter for Research Workspace return handoffs.
  - Added an explicit `Import bundle` action to the Deep Research return banner.
  - Imported bundles become completed Research Workspace report artifacts with run provenance, source coverage/lineage, verification summary metadata, and bounded readable markdown content.
  - Added focused adapter and Research Workspace UI regression tests.
- Why:
  - This completes the next dependency for the post-MVP Deep Research bridge: completed `bundle.json` output can come back into the originating Research Workspace before later proposal-section verification UI work.

## Change summary (maintainer-owned)

Maintainer to replace this section before merge with a human-owned summary of what changed and why these implementation choices are appropriate.

## Validation

- [x] Tests added/updated for behavior changes
- [x] Relevant unit/integration tests pass locally
- [x] Docs updated (if behavior, routes, or config changed)

Commands run:

- `bun run test -- src/components/Option/ResearchWorkspace/__tests__/deep-research-bundle-import.test.ts src/components/Option/ResearchWorkspace/__tests__/research-workspace-route-state.test.ts src/components/Option/ResearchWorkspace/__tests__/ResearchWorkspace.stage2.responsive.test.tsx` passed with 31 tests.
- `NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit -p tsconfig.json` passed.
- `git diff --check` passed.
- Bandit skipped: touched production/test files are frontend TypeScript/TSX plus docs/backlog only.

## UX Audit Checklist (v2 Stage 5)

- [ ] `npm run e2e:smoke:stage5` passes
- [ ] `npx playwright test e2e/smoke/all-pages.spec.ts --reporter=line` passes (or failures documented)
- [ ] No listed AntD deprecations in console output: `Drawer.width`, `Space.direction`, `Alert.message`, `List`
- [x] No `Maximum update depth exceeded` warnings on audited routes
- [x] No unresolved `{{...}}` placeholders on audited routes
- [ ] WebUI/extension parity validated for shared UI fixes
- [ ] For Flashcards UI changes: tabs remain `Study` / `Manage` / `Transfer` and secondary create CTAs route through manager create-entry path
- [ ] For Flashcards drawer changes: use `FLASHCARDS_DRAWER_WIDTH_PX` and keep footer action order `Cancel -> secondary -> primary`
- [ ] For Flashcards help/copy/import UX changes: update `Docs/User_Guides/WebUI_Extension/Flashcards_Study_Guide.md` and keep in-app help links pointed at guide section anchors

Notes: focused Research Workspace Vitest coverage and TypeScript were run. Broader smoke/Playwright checks were not run for this narrow banner/import slice.

## Watchlists Accessibility Checklist (Group 09 Stage 5)

- [ ] If Watchlists UI behavior changed: `cd apps/packages/ui && bun run test:watchlists:a11y` passes locally
- [ ] If Watchlists UI behavior changed: keyboard-only path still works for Overview -> Feeds -> Monitors -> Activity -> Articles -> Reports
- [ ] If Watchlists UI behavior changed: list/table labels and live-region copy remain localized (no new hardcoded assistive text)
- [ ] If Watchlists UI behavior changed: monitor/feed active state is not color-only (explicit text or icon signal is present)
- [ ] If Watchlists UI behavior changed: known assistive-tech constraints reviewed in `Docs/Plans/WATCHLISTS_ASSISTIVE_TECH_AUDIT_2026_02_24.md`

Not applicable: this PR does not change Watchlists.

## Watchlists Scale Checklist (Group 10 Stage 5)

- [ ] If Watchlists UI behavior changed: `cd apps/packages/ui && bun run test:watchlists:scale` passes locally
- [ ] If Watchlists polling/notifications behavior changed: no duplicate terminal notifications during in-flight polling overlap
- [ ] If Watchlists Activity polling changed: auto-refresh is gated to active + visible Activity context (no background tab polling churn)
- [ ] If Watchlists batch triage behavior changed: partial-failure retry path remains available and updates only failed IDs
- [ ] If Watchlists scale behavior changed: constraints/mitigations reviewed in `Docs/Plans/WATCHLISTS_SCALE_READINESS_RUNBOOK_2026_02_24.md`

Not applicable: this PR does not change Watchlists.

## Risk & Rollback

- Risk level: Low
- Rollback plan: Revert this PR. The change is frontend-only and only adds an explicit import action after a matching Deep Research return handoff; existing return banner parsing and Studio behavior remain covered.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Deep Research bundle import to Research Workspace so returned runs can be imported as completed report artifacts with provenance and source coverage. Also hardens the flow with scoped state, cancellation on workspace change/unmount, and bounded list sizes; addresses TASK-570.

- **New Features**
  - Added `Import bundle` in the Deep Research return banner with importing/imported/error states.
  - Pure adapter converts a run’s `bundle.json` into a completed `report` via `addArtifact`.
  - Preserves run provenance and verification; stores claims, contradictions, and `source_trust` in `data.deepResearch`.
  - Reuses source coverage/lineage from the source artifact when available; otherwise derives from bundle `source_inventory`.
  - Bounds markdown and preview; truncates with a clear note.
  - Hooked up `tldwClient.getResearchBundle` and added focused adapter/UI tests.

- **Bug Fixes**
  - Cancel in‑flight imports if the workspace changes or the view unmounts; state is scoped to the active return context.
  - Cap imported bundle lists before use to prevent oversized artifacts and misleading coverage/lineage.
  - Stricter validation with clear inline errors; no artifact is added on malformed bundles.

<sup>Written for commit d19042c6c09ba116411e09fe95827bd984124a7e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2181?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

