### PR TITLE
Renumber Research Workspace Deep Research follow-up task

### DIFF
--- a/backlog/tasks/task-485 - Implement-Research-Workspace-literature-work-products-MVP.md
+++ b/backlog/tasks/task-485 - Implement-Research-Workspace-literature-work-products-MVP.md
@@ -52,13 +52,13 @@ Stage 4 complete: added Research Proposal Pack RED tests for Source Audit/source
 
 Stage 5 complete: added discoverability, invalid JSON, source-lineage/source-coverage, and export-scope regression coverage; labeled Literature Review templates in the chooser; added JSON export for parsed data-table artifacts while keeping XLSX absent. Verification: `cd apps/packages/ui && bun run test -- src/components/Option/ResearchWorkspace/__tests__/StudioPane.literature-workproducts.test.tsx src/components/Option/ResearchWorkspace/__tests__/StudioPane.stage1.test.tsx src/components/Option/ResearchWorkspace/__tests__/StudioPane.stage2.test.tsx src/workspace-templates/__tests__/work-product-templates.test.ts` passed with 4 files / 74 tests. `bun run verify:design-system-state` failed on existing product-state baseline findings outside touched work-product files; no new touched-file finding was identified in the blocked list.
 
-Stage 6 complete: created Deep Research follow-up tasks TASK-487, TASK-488, TASK-489, and TASK-490 covering launch from Matrix/Gap artifacts, follow-up seeding from hypotheses/proposals, bundle import back into Research Workspace, and verification display beside proposal sections.
+Stage 6 complete: created Deep Research follow-up tasks TASK-487, TASK-488, TASK-489, and TASK-571 covering launch from Matrix/Gap artifacts, follow-up seeding from hypotheses/proposals, bundle import back into Research Workspace, and verification display beside proposal sections.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Implemented the Research Workspace literature work-products MVP: actionable Literature Matrix, Corpus Gap Finder, Evidence-Bound Hypotheses, and Research Proposal Pack templates; source coverage/lineage metadata; JSON-first validation for Matrix/Gap/Hypotheses; proposal Source Audit enforcement; Literature Review grouping; CSV/JSON table exports; and Deep Research follow-up tasks TASK-487 through TASK-490. Verification: focused Research Workspace Vitest suite passed with 4 files / 74 tests. `bun run verify:design-system-state` remains blocked by pre-existing product-state baseline findings outside touched work-product files. Bandit skipped because this slice touched UI/docs/backlog files only, with no Python code.
+Implemented the Research Workspace literature work-products MVP: actionable Literature Matrix, Corpus Gap Finder, Evidence-Bound Hypotheses, and Research Proposal Pack templates; source coverage/lineage metadata; JSON-first validation for Matrix/Gap/Hypotheses; proposal Source Audit enforcement; Literature Review grouping; CSV/JSON table exports; and Deep Research follow-up tasks TASK-487, TASK-488, TASK-489, and TASK-571. Verification: focused Research Workspace Vitest suite passed with 4 files / 74 tests. `bun run verify:design-system-state` remains blocked by pre-existing product-state baseline findings outside touched work-product files. Bandit skipped because this slice touched UI/docs/backlog files only, with no Python code.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-571 - Show-Deep-Research-verification-in-proposal-sections.md
+++ b/backlog/tasks/task-571 - Show-Deep-Research-verification-in-proposal-sections.md
@@ -1,5 +1,5 @@
 ---
-id: TASK-490
+id: TASK-571
 title: Show Deep Research verification in proposal sections
 status: To Do
 documentation:


### PR DESCRIPTION
Change summary
- Renumbered the Research Workspace Deep Research verification follow-up from TASK-490 to TASK-571 to avoid colliding with existing TASK-490 records.
- Updated the TASK-485 closeout references so the follow-up list names TASK-487, TASK-488, TASK-489, and TASK-571 explicitly.

Why
- TASK-490 is already used by unrelated active tracker records, including Sync v2 and prototype-signoff work. Assigning this Research Workspace follow-up a free ID removes ambiguity without changing its scope.

Verification
- rg confirmed TASK-571 is present and no Research Workspace Show-Deep-Research task remains under task-490.
- git diff --cached --check passed before commit.
- Bandit skipped: backlog/docs-only tracker hygiene change; no Python code touched.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renumbered the Deep Research verification follow-up task from TASK-490 to TASK-571 to avoid an ID collision with existing records. Updated the `task-485` follow-up list to reference TASK-487, TASK-488, TASK-489, and TASK-571.

<sup>Written for commit 7d454efefa0b69b7cb5d33dfcf13562a1e722472. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2182?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

