### PR TITLE
Renumber Research Workspace Deep Research bundle import task

### DIFF
--- a/Docs/superpowers/plans/2026-05-30-research-workspace-deep-research-bundle-import-plan.md
+++ b/Docs/superpowers/plans/2026-05-30-research-workspace-deep-research-bundle-import-plan.md
@@ -13,7 +13,7 @@
 ## Source Requirements
 
 - Backlog: `TASK-570`
-- Existing follow-up: `TASK-489` (`Import Deep Research bundles into Research Workspace artifacts`)
+- Existing follow-up: `TASK-572` (`Import Deep Research bundles into Research Workspace artifacts`)
 - PRD: `Docs/Product/Research_Workspace_Literature_Workproducts_PRD.md`
 - Umbrella plan: `Docs/superpowers/plans/2026-05-30-research-workspace-literature-workproducts-plan.md`
 

--- a/backlog/tasks/task-485 - Implement-Research-Workspace-literature-work-products-MVP.md
+++ b/backlog/tasks/task-485 - Implement-Research-Workspace-literature-work-products-MVP.md
@@ -52,13 +52,13 @@ Stage 4 complete: added Research Proposal Pack RED tests for Source Audit/source
 
 Stage 5 complete: added discoverability, invalid JSON, source-lineage/source-coverage, and export-scope regression coverage; labeled Literature Review templates in the chooser; added JSON export for parsed data-table artifacts while keeping XLSX absent. Verification: `cd apps/packages/ui && bun run test -- src/components/Option/ResearchWorkspace/__tests__/StudioPane.literature-workproducts.test.tsx src/components/Option/ResearchWorkspace/__tests__/StudioPane.stage1.test.tsx src/components/Option/ResearchWorkspace/__tests__/StudioPane.stage2.test.tsx src/workspace-templates/__tests__/work-product-templates.test.ts` passed with 4 files / 74 tests. `bun run verify:design-system-state` failed on existing product-state baseline findings outside touched work-product files; no new touched-file finding was identified in the blocked list.
 
-Stage 6 complete: created Deep Research follow-up tasks TASK-487, TASK-488, TASK-489, and TASK-571 covering launch from Matrix/Gap artifacts, follow-up seeding from hypotheses/proposals, bundle import back into Research Workspace, and verification display beside proposal sections.
+Stage 6 complete: created Deep Research follow-up tasks TASK-487, TASK-488, TASK-572, and TASK-571 covering launch from Matrix/Gap artifacts, follow-up seeding from hypotheses/proposals, bundle import back into Research Workspace, and verification display beside proposal sections.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Implemented the Research Workspace literature work-products MVP: actionable Literature Matrix, Corpus Gap Finder, Evidence-Bound Hypotheses, and Research Proposal Pack templates; source coverage/lineage metadata; JSON-first validation for Matrix/Gap/Hypotheses; proposal Source Audit enforcement; Literature Review grouping; CSV/JSON table exports; and Deep Research follow-up tasks TASK-487, TASK-488, TASK-489, and TASK-571. Verification: focused Research Workspace Vitest suite passed with 4 files / 74 tests. `bun run verify:design-system-state` remains blocked by pre-existing product-state baseline findings outside touched work-product files. Bandit skipped because this slice touched UI/docs/backlog files only, with no Python code.
+Implemented the Research Workspace literature work-products MVP: actionable Literature Matrix, Corpus Gap Finder, Evidence-Bound Hypotheses, and Research Proposal Pack templates; source coverage/lineage metadata; JSON-first validation for Matrix/Gap/Hypotheses; proposal Source Audit enforcement; Literature Review grouping; CSV/JSON table exports; and Deep Research follow-up tasks TASK-487, TASK-488, TASK-572, and TASK-571. Verification: focused Research Workspace Vitest suite passed with 4 files / 74 tests. `bun run verify:design-system-state` remains blocked by pre-existing product-state baseline findings outside touched work-product files. Bandit skipped because this slice touched UI/docs/backlog files only, with no Python code.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-570 - Implement-Deep-Research-bundle-import-into-Research-Workspace-artifacts.md
+++ b/backlog/tasks/task-570 - Implement-Deep-Research-bundle-import-into-Research-Workspace-artifacts.md
@@ -10,7 +10,7 @@ documentation:
 ## Description
 
 <!-- SECTION:DESCRIPTION:BEGIN -->
-Implement the next post-MVP Research Workspace / Deep Research bridge: import a completed Deep Research bundle.json into the active Research Workspace as a generated artifact, preserving run provenance, source coverage, verification summary metadata, and the source artifact return context. This implementation task references the existing follow-up TASK-489, whose ID collides with older task files in this checkout and cannot be safely edited through MCP/CLI by task ID.
+Implement the next post-MVP Research Workspace / Deep Research bridge: import a completed Deep Research bundle.json into the active Research Workspace as a generated artifact, preserving run provenance, source coverage, verification summary metadata, and the source artifact return context. This implementation task references the existing follow-up TASK-572, which was originally created as TASK-489 before tracker hygiene renumbered it away from colliding older task files.
 <!-- SECTION:DESCRIPTION:END -->
 
 ## Acceptance Criteria

--- a/backlog/tasks/task-572 - Import-Deep-Research-bundles-into-Research-Workspace-artifacts.md
+++ b/backlog/tasks/task-572 - Import-Deep-Research-bundles-into-Research-Workspace-artifacts.md
@@ -1,5 +1,5 @@
 ---
-id: TASK-489
+id: TASK-572
 title: Import Deep Research bundles into Research Workspace artifacts
 status: To Do
 documentation:


### PR DESCRIPTION
Change summary
- Renumbered the Research Workspace Deep Research bundle-import follow-up from TASK-489 to TASK-572 to avoid colliding with unrelated TASK-489 records.
- Updated the literature MVP closeout, bundle-import implementation plan, and TASK-570 reference to point at TASK-572.

Why
- TASK-489 is reused by unrelated tracker records, so the Research Workspace follow-up could not be looked up unambiguously. TASK-572 was unused on current dev.
- This is a tracker-hygiene-only change; task content and status are otherwise unchanged.

Verification
- rg confirmed the Research Workspace bundle-import task is now TASK-572 and that remaining TASK-489 hits are unrelated tasks.
- git diff --cached --check passed before commit.
- Bandit skipped: backlog/docs-only tracker hygiene change; no Python code touched.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renumbered the Deep Research bundle-import follow-up in Research Workspace from TASK-489 to TASK-572 to avoid ID collisions with unrelated records. Updated all references and renamed the task file; docs-only change with no runtime impact.

- **Refactors**
  - Renamed task file to `backlog/tasks/task-572 - Import-Deep-Research-bundles-into-Research-Workspace-artifacts.md` and set `id: TASK-572`.
  - Updated references in `task-485`, `task-570`, and the bundle-import plan to point to `TASK-572`.

<sup>Written for commit 89cb940463599b0a451a28c8b14f4d365c2622f5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2183?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

