### PR TITLE
Show Deep Research verification on Research Workspace proposals

### DIFF
--- a/Docs/superpowers/plans/2026-05-30-research-workspace-deep-research-proposal-verification-plan.md
+++ b/Docs/superpowers/plans/2026-05-30-research-workspace-deep-research-proposal-verification-plan.md
@@ -1,0 +1,65 @@
+# Research Workspace Deep Research Proposal Verification Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Show imported Deep Research verification summaries beside compatible Research Proposal Pack sections without mutating proposal content, source coverage, or review checklist state.
+
+**Architecture:** Add a small pure helper that finds the matching imported Deep Research bundle for a proposal artifact, normalizes bounded verification metadata, and splits proposal markdown into display sections with conservative section annotations. Wire that helper into the generic artifact View modal only for `research_proposal_pack` artifacts, leaving all other artifact viewers unchanged.
+
+**Tech Stack:** TypeScript, React, Vitest, Testing Library, existing Research Workspace StudioPane and artifact metadata contracts.
+
+---
+
+## File Structure
+
+- Create `apps/packages/ui/src/components/Option/ResearchWorkspace/StudioPane/proposal-deep-research-verification.ts`
+  - Pure section parsing and Deep Research import compatibility helpers.
+  - No React imports; safe to unit test directly.
+- Modify `apps/packages/ui/src/components/Option/ResearchWorkspace/StudioPane/ArtifactModalContent.tsx`
+  - Add a proposal-specific viewer component that renders markdown sections with optional verification companions.
+- Modify `apps/packages/ui/src/components/Option/ResearchWorkspace/StudioPane/index.tsx`
+  - Find the matching Deep Research import when viewing proposal artifacts and route the modal through the proposal viewer.
+- Modify `apps/packages/ui/src/components/Option/ResearchWorkspace/__tests__/StudioPane.literature-workproducts.test.tsx`
+  - Add RED helper and UI tests for matching, non-matching, and modal section rendering.
+- Modify `backlog/tasks/task-571 - Show-Deep-Research-verification-in-proposal-sections.md`
+  - Record acceptance criteria, plan link, verification, and final closeout.
+
+## Stage 1: Pure Verification Contract
+
+**Goal:** Define the strict compatibility and bounded summary behavior.
+
+**Success Criteria:** Tests prove only Deep Research bundle imports whose `data.deepResearch.sourceArtifact.id` matches the proposal are considered compatible, and the helper exposes run ID, counts, unresolved questions, contradictions, and source trust.
+
+**Tests:** Focused Vitest helper tests in `StudioPane.literature-workproducts.test.tsx`.
+
+**Status:** Complete
+
+## Stage 2: Proposal Section Mapping
+
+**Goal:** Split proposal markdown into displayable sections and attach conservative verification summaries to relevant sections.
+
+**Success Criteria:** Tests prove proposal sections remain readable, verification appears beside Source Audit/Literature Overview/Proposed Hypothesis/Methodology, and unrelated imports produce no section companions.
+
+**Tests:** Focused Vitest helper tests.
+
+**Status:** Complete
+
+## Stage 3: Modal UI Integration
+
+**Goal:** Display section-level verification companions in the View modal for compatible proposal artifacts.
+
+**Success Criteria:** Testing Library coverage proves the modal shows Deep Research verification beside proposal sections and preserves sourceCoverage/reviewChecklist artifacts unchanged.
+
+**Tests:** Focused StudioPane UI tests.
+
+**Status:** Complete
+
+## Stage 4: Verification And Closeout
+
+**Goal:** Run focused tests, type-check if feasible, diff check, Bandit applicability, and update TASK-571.
+
+**Success Criteria:** Verification results are recorded in the task and the branch is ready for PR.
+
+**Tests:** Focused Vitest suite, TypeScript check, `git diff --check`; Bandit skip rationale for frontend-only TypeScript/backlog changes.
+
+**Status:** Complete

--- a/apps/packages/ui/src/components/Option/ResearchWorkspace/StudioPane/ArtifactModalContent.tsx
+++ b/apps/packages/ui/src/components/Option/ResearchWorkspace/StudioPane/ArtifactModalContent.tsx
@@ -9,6 +9,7 @@ import {
   ZoomOut,
 } from "lucide-react"
 
+import { MarkdownPreview } from "@/components/Common/MarkdownPreview"
 import Mermaid from "@/components/Common/Mermaid"
 import type { GeneratedArtifact } from "@/types/workspace"
 
@@ -259,9 +260,11 @@ export const ProposalDeepResearchVerificationViewer: React.FC<{
                 {section.heading}
               </h3>
               {section.body ? (
-                <div className="mt-2 whitespace-pre-wrap text-sm text-text">
-                  {section.body}
-                </div>
+                <MarkdownPreview
+                  className="mt-2 text-text"
+                  content={section.body}
+                  size="sm"
+                />
               ) : (
                 <p className="mt-2 text-sm text-text-muted">No section body.</p>
               )}
@@ -305,8 +308,10 @@ export const ProposalDeepResearchVerificationViewer: React.FC<{
                       <ul className="mt-1 list-disc space-y-1 pl-4 text-text-muted">
                         {section.verification.unresolvedQuestions
                           .slice(0, 3)
-                          .map((question) => (
-                            <li key={question}>{question}</li>
+                          .map((question, questionIndex) => (
+                            <li key={`${question}-${questionIndex}`}>
+                              {question}
+                            </li>
                           ))}
                       </ul>
                     </div>

--- a/apps/packages/ui/src/components/Option/ResearchWorkspace/StudioPane/ArtifactModalContent.tsx
+++ b/apps/packages/ui/src/components/Option/ResearchWorkspace/StudioPane/ArtifactModalContent.tsx
@@ -31,6 +31,8 @@ import {
 } from "../undo-manager"
 import { buildProposalDeepResearchVerificationSections } from "./proposal-deep-research-verification"
 
+const MAX_DISPLAYED_UNRESOLVED_QUESTIONS = 3
+
 export const MindMapArtifactViewer: React.FC<{
   title: string
   content: string
@@ -307,7 +309,7 @@ export const ProposalDeepResearchVerificationViewer: React.FC<{
                       </p>
                       <ul className="mt-1 list-disc space-y-1 pl-4 text-text-muted">
                         {section.verification.unresolvedQuestions
-                          .slice(0, 3)
+                          .slice(0, MAX_DISPLAYED_UNRESOLVED_QUESTIONS)
                           .map((question, questionIndex) => (
                             <li key={`${question}-${questionIndex}`}>
                               {question}

--- a/apps/packages/ui/src/components/Option/ResearchWorkspace/StudioPane/ArtifactModalContent.tsx
+++ b/apps/packages/ui/src/components/Option/ResearchWorkspace/StudioPane/ArtifactModalContent.tsx
@@ -10,6 +10,7 @@ import {
 } from "lucide-react"
 
 import Mermaid from "@/components/Common/Mermaid"
+import type { GeneratedArtifact } from "@/types/workspace"
 
 import {
   extractMermaidCode,
@@ -27,6 +28,7 @@ import {
   scheduleWorkspaceUndoAction,
   undoWorkspaceAction,
 } from "../undo-manager"
+import { buildProposalDeepResearchVerificationSections } from "./proposal-deep-research-verification"
 
 export const MindMapArtifactViewer: React.FC<{
   title: string
@@ -219,6 +221,103 @@ export const DataTableArtifactViewer: React.FC<{
         size="small"
         scroll={{ x: true, y: 420 }}
       />
+    </div>
+  )
+}
+
+export const ProposalDeepResearchVerificationViewer: React.FC<{
+  proposalArtifact: GeneratedArtifact
+  verificationArtifact: GeneratedArtifact
+}> = ({ proposalArtifact, verificationArtifact }) => {
+  const sections = React.useMemo(
+    () =>
+      buildProposalDeepResearchVerificationSections(
+        proposalArtifact,
+        verificationArtifact
+      ),
+    [proposalArtifact, verificationArtifact]
+  )
+
+  return (
+    <div className="flex max-h-[70vh] flex-col gap-3 overflow-y-auto">
+      <div className="rounded border border-border bg-surface2/40 p-3 text-xs text-text-muted">
+        Deep Research verification is shown beside compatible proposal sections
+        as imported run evidence. The original proposal content, source coverage,
+        and review checklist are unchanged.
+      </div>
+      {sections.map((section, index) => {
+        const showDetailedVerification =
+          section.heading.trim().toLowerCase() === "source audit"
+
+        return (
+          <section
+            key={`${section.heading}-${index}`}
+            className="grid gap-3 rounded border border-border bg-surface p-3 md:grid-cols-[minmax(0,1fr)_minmax(16rem,20rem)]"
+          >
+            <div className="min-w-0">
+              <h3 className="text-sm font-semibold text-text">
+                {section.heading}
+              </h3>
+              {section.body ? (
+                <div className="mt-2 whitespace-pre-wrap text-sm text-text">
+                  {section.body}
+                </div>
+              ) : (
+                <p className="mt-2 text-sm text-text-muted">No section body.</p>
+              )}
+            </div>
+            {section.verification ? (
+              <aside
+                aria-label={`Deep Research verification for ${section.heading}`}
+                className="rounded border border-primary/20 bg-primary/5 p-3 text-xs text-text"
+              >
+                <p className="font-semibold text-text">
+                  Deep Research verification
+                </p>
+                <p className="mt-1 text-text-muted">
+                  Run {section.verification.runId}
+                </p>
+                <div className="mt-2 flex flex-wrap gap-1.5">
+                  <span className="rounded bg-success/10 px-2 py-0.5 text-success">
+                    {section.verification.supportedClaimCount} supported
+                  </span>
+                  <span className="rounded bg-warning/10 px-2 py-0.5 text-warning">
+                    {section.verification.unsupportedClaimCount} unsupported
+                  </span>
+                  <span className="rounded bg-error/10 px-2 py-0.5 text-error">
+                    {section.verification.contradictionCount} contradiction
+                    {section.verification.contradictionCount === 1 ? "" : "s"}
+                  </span>
+                </div>
+                {showDetailedVerification &&
+                  section.verification.sourceTrustCount > 0 && (
+                    <p className="mt-2 text-text-muted">
+                      Source trust entries:{" "}
+                      {section.verification.sourceTrustCount}
+                    </p>
+                  )}
+                {showDetailedVerification &&
+                  section.verification.unresolvedQuestions.length > 0 && (
+                    <div className="mt-2">
+                      <p className="font-medium text-text">
+                        Unresolved questions
+                      </p>
+                      <ul className="mt-1 list-disc space-y-1 pl-4 text-text-muted">
+                        {section.verification.unresolvedQuestions
+                          .slice(0, 3)
+                          .map((question) => (
+                            <li key={question}>{question}</li>
+                          ))}
+                      </ul>
+                    </div>
+                  )}
+              </aside>
+            ) : (
+              <div className="hidden md:block" aria-hidden="true" />
+            )}
+          </section>
+        )
+      })}
     </div>
   )
 }

--- a/apps/packages/ui/src/components/Option/ResearchWorkspace/StudioPane/index.tsx
+++ b/apps/packages/ui/src/components/Option/ResearchWorkspace/StudioPane/index.tsx
@@ -105,6 +105,7 @@ import {
   type ResearchWorkspaceCapabilitiesResponse
 } from "../research-workspace-capabilities"
 import { buildLiteratureDeepResearchLaunchPath } from "./literature-deep-research-launch"
+import { findProposalDeepResearchVerificationArtifact } from "./proposal-deep-research-verification"
 
 // Re-export for external consumers
 export { estimateGenerationSeconds, estimateGenerationTokens, estimateGenerationCostUsd } from "./hooks/useArtifactGeneration"
@@ -484,6 +485,12 @@ const FlashcardArtifactEditor = React.lazy(() =>
 const QuizArtifactEditor = React.lazy(() =>
   import("./ArtifactModalContent").then((module) => ({
     default: module.QuizArtifactEditor
+  }))
+)
+
+const ProposalDeepResearchVerificationViewer = React.lazy(() =>
+  import("./ArtifactModalContent").then((module) => ({
+    default: module.ProposalDeepResearchVerificationViewer
   }))
 )
 
@@ -1272,6 +1279,27 @@ export const StudioPane: React.FC<StudioPaneProps> = ({
         ...responsiveModalProps(860),
         footer: null,
         icon: null
+      })
+      return
+    }
+
+    const proposalVerificationArtifact =
+      findProposalDeepResearchVerificationArtifact(artifact, generatedArtifacts)
+    if (artifact.content && proposalVerificationArtifact) {
+      Modal.info({
+        title: artifact.title,
+        content: renderArtifactModalContent(
+          <ProposalDeepResearchVerificationViewer
+            proposalArtifact={artifact}
+            verificationArtifact={proposalVerificationArtifact}
+          />,
+          t(
+            "playground:studio.loadingProposalVerificationViewer",
+            "Loading proposal verification..."
+          )
+        ),
+        ...responsiveModalProps(980),
+        footer: null
       })
       return
     }

--- a/apps/packages/ui/src/components/Option/ResearchWorkspace/StudioPane/proposal-deep-research-verification.ts
+++ b/apps/packages/ui/src/components/Option/ResearchWorkspace/StudioPane/proposal-deep-research-verification.ts
@@ -1,0 +1,194 @@
+import type { GeneratedArtifact } from "@/types/workspace"
+
+const VERIFIED_PROPOSAL_SECTION_HEADINGS = new Set([
+  "literature overview",
+  "proposed hypothesis",
+  "methodology",
+  "source audit"
+])
+
+export interface ProposalDeepResearchVerificationSummary {
+  runId: string
+  question?: string
+  supportedClaimCount: number
+  unsupportedClaimCount: number
+  unresolvedQuestions: string[]
+  contradictionCount: number
+  sourceTrustCount: number
+}
+
+export interface ProposalDeepResearchVerificationSection {
+  heading: string
+  level: number
+  body: string
+  verification?: ProposalDeepResearchVerificationSummary
+}
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value)
+
+const asRecord = (value: unknown): Record<string, unknown> =>
+  isRecord(value) ? value : {}
+
+const readString = (value: unknown): string =>
+  typeof value === "string" ? value.trim() : ""
+
+const readCount = (value: unknown): number =>
+  typeof value === "number" && Number.isFinite(value) ? value : 0
+
+const readRecordList = (value: unknown): Array<Record<string, unknown>> =>
+  Array.isArray(value) ? value.filter(isRecord) : []
+
+const readStringList = (value: unknown): string[] =>
+  Array.isArray(value)
+    ? value.map(readString).filter((entry) => entry.length > 0)
+    : []
+
+const getDeepResearchData = (
+  artifact: GeneratedArtifact
+): Record<string, unknown> | null => {
+  if (
+    artifact.status !== "completed" ||
+    artifact.producerMetadata?.producerType !== "deep_research_bundle_import"
+  ) {
+    return null
+  }
+  const deepResearch = isRecord(artifact.data)
+    ? artifact.data.deepResearch
+    : null
+  return isRecord(deepResearch) ? deepResearch : null
+}
+
+export const findProposalDeepResearchVerificationArtifact = (
+  proposalArtifact: GeneratedArtifact,
+  artifacts: GeneratedArtifact[]
+): GeneratedArtifact | null => {
+  if (
+    proposalArtifact.templateId !== "research_proposal_pack" ||
+    proposalArtifact.status !== "completed"
+  ) {
+    return null
+  }
+
+  for (const artifact of artifacts) {
+    const deepResearch = getDeepResearchData(artifact)
+    if (!deepResearch) continue
+
+    const sourceArtifact = asRecord(deepResearch.sourceArtifact)
+    const sourceTemplate = readString(sourceArtifact.template)
+    if (
+      readString(sourceArtifact.id) === proposalArtifact.id &&
+      (!sourceTemplate || sourceTemplate === "research_proposal_pack")
+    ) {
+      return artifact
+    }
+  }
+
+  return null
+}
+
+const buildVerificationSummary = (
+  verificationArtifact: GeneratedArtifact
+): ProposalDeepResearchVerificationSummary | undefined => {
+  const deepResearch = getDeepResearchData(verificationArtifact)
+  if (!deepResearch) return undefined
+
+  const verificationSummary = asRecord(deepResearch.verificationSummary)
+  const unsupportedClaims = readRecordList(deepResearch.unsupportedClaims)
+  const runId =
+    readString(deepResearch.runId) ||
+    readString(verificationArtifact.producerMetadata?.runId)
+  if (!runId) return undefined
+
+  return {
+    runId,
+    question: readString(deepResearch.question) || undefined,
+    supportedClaimCount: readCount(verificationSummary.supported_claim_count),
+    unsupportedClaimCount:
+      readCount(verificationSummary.unsupported_claim_count) ||
+      unsupportedClaims.length,
+    unresolvedQuestions: readStringList(deepResearch.unresolvedQuestions),
+    contradictionCount: readRecordList(deepResearch.contradictions).length,
+    sourceTrustCount: readRecordList(deepResearch.sourceTrust).length
+  }
+}
+
+const normalizeHeading = (heading: string): string =>
+  heading.trim().toLowerCase()
+
+const shouldShowVerificationForHeading = (heading: string): boolean =>
+  VERIFIED_PROPOSAL_SECTION_HEADINGS.has(normalizeHeading(heading))
+
+const fallbackSection = (content: string): ProposalDeepResearchVerificationSection[] =>
+  content.trim()
+    ? [
+        {
+          heading: "Research Proposal Pack",
+          level: 1,
+          body: content.trim()
+        }
+      ]
+    : []
+
+const parseProposalSections = (
+  content: string
+): ProposalDeepResearchVerificationSection[] => {
+  const lines = content.split(/\r?\n/)
+  const sections: ProposalDeepResearchVerificationSection[] = []
+  let current:
+    | {
+        heading: string
+        level: number
+        body: string[]
+      }
+    | null = null
+
+  const flush = () => {
+    if (!current) return
+    sections.push({
+      heading: current.heading,
+      level: current.level,
+      body: current.body.join("\n").trim()
+    })
+  }
+
+  for (const line of lines) {
+    const headingMatch = line.match(/^(#{1,6})\s+(.+?)\s*$/)
+    if (headingMatch) {
+      flush()
+      current = {
+        heading: headingMatch[2].trim(),
+        level: headingMatch[1].length,
+        body: []
+      }
+      continue
+    }
+
+    if (current) {
+      current.body.push(line)
+    }
+  }
+
+  flush()
+  return sections.length > 0 ? sections : fallbackSection(content)
+}
+
+export const buildProposalDeepResearchVerificationSections = (
+  proposalArtifact: GeneratedArtifact,
+  verificationArtifact?: GeneratedArtifact | null
+): ProposalDeepResearchVerificationSection[] => {
+  const sections = parseProposalSections(proposalArtifact.content ?? "")
+  const verification = verificationArtifact
+    ? buildVerificationSummary(verificationArtifact)
+    : undefined
+
+  if (!verification) {
+    return sections
+  }
+
+  return sections.map((section) =>
+    shouldShowVerificationForHeading(section.heading)
+      ? { ...section, verification }
+      : section
+  )
+}

--- a/apps/packages/ui/src/components/Option/ResearchWorkspace/StudioPane/proposal-deep-research-verification.ts
+++ b/apps/packages/ui/src/components/Option/ResearchWorkspace/StudioPane/proposal-deep-research-verification.ts
@@ -135,20 +135,23 @@ const parseProposalSections = (
 ): ProposalDeepResearchVerificationSection[] => {
   const lines = content.split(/\r?\n/)
   const sections: ProposalDeepResearchVerificationSection[] = []
-  let current:
-    | {
-        heading: string
-        level: number
-        body: string[]
-      }
-    | null = null
+  let current: {
+    heading: string
+    level: number
+    body: string[]
+  } = {
+    heading: "",
+    level: 1,
+    body: []
+  }
 
   const flush = () => {
-    if (!current) return
+    const body = current.body.join("\n").trim()
+    if (!current.heading && !body) return
     sections.push({
-      heading: current.heading,
+      heading: current.heading || "Overview",
       level: current.level,
-      body: current.body.join("\n").trim()
+      body
     })
   }
 
@@ -164,9 +167,7 @@ const parseProposalSections = (
       continue
     }
 
-    if (current) {
-      current.body.push(line)
-    }
+    current.body.push(line)
   }
 
   flush()

--- a/apps/packages/ui/src/components/Option/ResearchWorkspace/__tests__/StudioPane.literature-workproducts.test.tsx
+++ b/apps/packages/ui/src/components/Option/ResearchWorkspace/__tests__/StudioPane.literature-workproducts.test.tsx
@@ -2,7 +2,11 @@ import React from "react"
 import { fireEvent, render, screen, waitFor, within } from "@testing-library/react"
 import { MemoryRouter } from "react-router-dom"
 import { beforeEach, describe, expect, it, vi } from "vitest"
-import type { AudioGenerationSettings, WorkspaceSource } from "@/types/workspace"
+import type {
+  AudioGenerationSettings,
+  GeneratedArtifact,
+  WorkspaceSource
+} from "@/types/workspace"
 import { StudioPane } from "../StudioPane"
 import {
   buildCorpusGapMessages,
@@ -16,6 +20,10 @@ import {
   buildLiteratureDeepResearchLaunchPath,
   isDeepResearchLaunchableLiteratureArtifact
 } from "../StudioPane/literature-deep-research-launch"
+import {
+  buildProposalDeepResearchVerificationSections,
+  findProposalDeepResearchVerificationArtifact
+} from "../StudioPane/proposal-deep-research-verification"
 
 const {
   mockAddArtifact,
@@ -341,7 +349,174 @@ const sourceDetail = (title: string, text: string) => ({
   content: { text }
 })
 
+const proposalArtifact = {
+  id: "artifact-proposal",
+  type: "report",
+  title: "Research Proposal Pack",
+  status: "completed",
+  templateId: "research_proposal_pack",
+  content: [
+    "# Rural Transfer Study",
+    "## Research Question",
+    "How should rural clinics adapt transfer coaching?",
+    "## Literature Overview",
+    "Paper A supports timely coaching. Paper B warns rural clinics differ.",
+    "## Proposed Hypothesis",
+    "Rural clinics need a lower-touch coaching protocol.",
+    "## Methodology",
+    "Run a matched cohort study with retention tracking.",
+    "## Source Audit",
+    "Paper A and Paper B are the selected source base."
+  ].join("\n\n"),
+  sourceCoverage: {
+    selectedSourceIds: ["source-1", "source-2"],
+    usableSources: [
+      { sourceId: "source-1", mediaId: 101, title: "Paper A" },
+      { sourceId: "source-2", mediaId: 202, title: "Paper B" }
+    ],
+    skippedSources: [],
+    truncatedSources: [],
+    minimumUsableSourcesMet: true
+  },
+  reviewChecklist: [
+    {
+      id: "proposal-source-audit",
+      label: "Confirm source audit before reuse",
+      checked: false
+    }
+  ],
+  createdAt: new Date("2026-02-18T00:00:00.000Z")
+} satisfies GeneratedArtifact
+
+const matchingDeepResearchImport = {
+  id: "artifact-deep-research-import",
+  type: "report",
+  title: "Deep Research: Research Proposal Pack",
+  status: "completed",
+  content: "# Deep Research Import",
+  producerMetadata: {
+    producerType: "deep_research_bundle_import",
+    runId: "research-run-7",
+    templateId: "research_proposal_pack"
+  },
+  data: {
+    deepResearch: {
+      runId: "research-run-7",
+      question: "Verify the rural transfer proposal.",
+      sourceArtifact: {
+        id: "artifact-proposal",
+        template: "research_proposal_pack",
+        title: "Research Proposal Pack"
+      },
+      verificationSummary: {
+        supported_claim_count: 2,
+        unsupported_claim_count: 1
+      },
+      unresolvedQuestions: [
+        "Which rural clinic constraints change the intervention?",
+        "Which source contradicts the sampling plan?"
+      ],
+      contradictions: [
+        {
+          claim: "Rural transfer is always stronger than urban transfer.",
+          reason: "Paper B reports mixed rural outcomes."
+        }
+      ],
+      unsupportedClaims: [
+        {
+          text: "The retention tracking cadence is validated in all rural settings."
+        }
+      ],
+      sourceTrust: [
+        { source_id: "source-1", snapshot_policy: "full_artifact" },
+        { source_id: "source-2", snapshot_policy: "excerpt_only" }
+      ]
+    }
+  },
+  createdAt: new Date("2026-02-18T00:03:00.000Z")
+} satisfies GeneratedArtifact
+
 describe("StudioPane literature work products", () => {
+  it("finds only matching Deep Research imports for proposal verification", () => {
+    const unrelatedImport = {
+      ...matchingDeepResearchImport,
+      id: "artifact-unrelated-import",
+      data: {
+        deepResearch: {
+          ...matchingDeepResearchImport.data.deepResearch,
+          sourceArtifact: {
+            id: "other-proposal",
+            template: "research_proposal_pack",
+            title: "Other Proposal"
+          }
+        }
+      }
+    } satisfies GeneratedArtifact
+    const wrongProducerImport = {
+      ...matchingDeepResearchImport,
+      id: "artifact-wrong-producer",
+      producerMetadata: {
+        producerType: "manual_report_import",
+        runId: "research-run-7"
+      }
+    } satisfies GeneratedArtifact
+    const unfinishedImport = {
+      ...matchingDeepResearchImport,
+      id: "artifact-unfinished-import",
+      status: "generating"
+    } satisfies GeneratedArtifact
+
+    expect(
+      findProposalDeepResearchVerificationArtifact(proposalArtifact, [
+        wrongProducerImport,
+        unfinishedImport,
+        unrelatedImport,
+        matchingDeepResearchImport
+      ])
+    ).toBe(matchingDeepResearchImport)
+    expect(
+      findProposalDeepResearchVerificationArtifact(proposalArtifact, [
+        unrelatedImport
+      ])
+    ).toBeNull()
+  })
+
+  it("attaches conservative Deep Research verification to proposal sections", () => {
+    const sections = buildProposalDeepResearchVerificationSections(
+      proposalArtifact,
+      matchingDeepResearchImport
+    )
+
+    expect(sections.map((section) => section.heading)).toEqual([
+      "Rural Transfer Study",
+      "Research Question",
+      "Literature Overview",
+      "Proposed Hypothesis",
+      "Methodology",
+      "Source Audit"
+    ])
+    expect(
+      sections.find((section) => section.heading === "Research Question")
+        ?.verification
+    ).toBeUndefined()
+
+    for (const heading of [
+      "Literature Overview",
+      "Proposed Hypothesis",
+      "Methodology",
+      "Source Audit"
+    ]) {
+      const verification = sections.find((section) => section.heading === heading)
+        ?.verification
+      expect(verification?.runId).toBe("research-run-7")
+      expect(verification?.supportedClaimCount).toBe(2)
+      expect(verification?.unsupportedClaimCount).toBe(1)
+      expect(verification?.unresolvedQuestions).toHaveLength(2)
+      expect(verification?.contradictionCount).toBe(1)
+      expect(verification?.sourceTrustCount).toBe(2)
+    }
+  })
+
   it("rejects array rows instead of treating them as literature matrix records", () => {
     expect(() =>
       normalizeLiteratureMatrixResponse(JSON.stringify({ rows: [["Paper A"]] }))
@@ -1795,5 +1970,38 @@ Proposal
         screen.getByTestId("studio-artifact-secondary-actions-artifact-proposal")
       ).queryByRole("link", { name: /launch deep research/i })
     ).not.toBeInTheDocument()
+  })
+
+  it("shows Deep Research verification beside compatible proposal sections", async () => {
+    const originalSourceCoverage = proposalArtifact.sourceCoverage
+    const originalReviewChecklist = proposalArtifact.reviewChecklist
+    workspaceStoreState.generatedArtifacts = [
+      proposalArtifact,
+      matchingDeepResearchImport
+    ]
+
+    renderStudioPane()
+
+    const proposalActions = screen.getByTestId(
+      "studio-artifact-primary-actions-artifact-proposal"
+    )
+    fireEvent.click(within(proposalActions).getByRole("button", { name: /view/i }))
+
+    await waitFor(() => {
+      expect(screen.getAllByText("Deep Research verification").length).toBeGreaterThan(0)
+    })
+    expect(screen.getAllByText("Literature Overview").length).toBeGreaterThan(0)
+    expect(screen.getAllByText("Methodology").length).toBeGreaterThan(0)
+    expect(screen.getAllByText(/Run research-run-7/i).length).toBeGreaterThan(0)
+    expect(screen.getAllByText(/2 supported/i).length).toBeGreaterThan(0)
+    expect(screen.getAllByText(/1 unsupported/i).length).toBeGreaterThan(0)
+    expect(
+      screen.getAllByText(/1 contradiction/i).length
+    ).toBeGreaterThan(0)
+    expect(
+      screen.getAllByText(/Which rural clinic constraints/i).length
+    ).toBeGreaterThan(0)
+    expect(proposalArtifact.sourceCoverage).toBe(originalSourceCoverage)
+    expect(proposalArtifact.reviewChecklist).toBe(originalReviewChecklist)
   })
 })

--- a/apps/packages/ui/src/components/Option/ResearchWorkspace/__tests__/StudioPane.literature-workproducts.test.tsx
+++ b/apps/packages/ui/src/components/Option/ResearchWorkspace/__tests__/StudioPane.literature-workproducts.test.tsx
@@ -209,6 +209,12 @@ vi.mock("../StudioPane/QuickNotesSection", () => ({
   )
 }))
 
+vi.mock("@/components/Common/MarkdownPreview", () => ({
+  MarkdownPreview: ({ content }: { content: string }) => (
+    <div data-testid="proposal-section-markdown">{content}</div>
+  )
+}))
+
 vi.mock("../source-location-copy", () => ({
   getWorkspaceStudioNoSourcesHint: () => "Select sources to start generating outputs"
 }))
@@ -360,7 +366,8 @@ const proposalArtifact = {
     "## Research Question",
     "How should rural clinics adapt transfer coaching?",
     "## Literature Overview",
-    "Paper A supports timely coaching. Paper B warns rural clinics differ.",
+    "- Paper A **supports** timely coaching.",
+    "- Paper B warns rural clinics differ.",
     "## Proposed Hypothesis",
     "Rural clinics need a lower-touch coaching protocol.",
     "## Methodology",
@@ -515,6 +522,34 @@ describe("StudioPane literature work products", () => {
       expect(verification?.contradictionCount).toBe(1)
       expect(verification?.sourceTrustCount).toBe(2)
     }
+  })
+
+  it("preserves proposal content before the first markdown heading", () => {
+    const sections = buildProposalDeepResearchVerificationSections(
+      {
+        ...proposalArtifact,
+        content: [
+          "Prepared for the rural care review board.",
+          "",
+          "Use this proposal alongside the source audit.",
+          "",
+          "## Literature Overview",
+          "Paper A supports timely coaching."
+        ].join("\n")
+      },
+      matchingDeepResearchImport
+    )
+
+    expect(sections[0]).toMatchObject({
+      heading: "Overview",
+      level: 1,
+      body: [
+        "Prepared for the rural care review board.",
+        "",
+        "Use this proposal alongside the source audit."
+      ].join("\n")
+    })
+    expect(sections[1]?.heading).toBe("Literature Overview")
   })
 
   it("rejects array rows instead of treating them as literature matrix records", () => {
@@ -2000,6 +2035,9 @@ Proposal
     ).toBeGreaterThan(0)
     expect(
       screen.getAllByText(/Which rural clinic constraints/i).length
+    ).toBeGreaterThan(0)
+    expect(
+      screen.getAllByTestId("proposal-section-markdown").length
     ).toBeGreaterThan(0)
     expect(proposalArtifact.sourceCoverage).toBe(originalSourceCoverage)
     expect(proposalArtifact.reviewChecklist).toBe(originalReviewChecklist)

--- a/backlog/tasks/task-571 - Show-Deep-Research-verification-in-proposal-sections.md
+++ b/backlog/tasks/task-571 - Show-Deep-Research-verification-in-proposal-sections.md
@@ -6,6 +6,8 @@ documentation:
 - Docs/Product/Research_Workspace_Literature_Workproducts_PRD.md
 - Docs/superpowers/plans/2026-05-30-research-workspace-literature-workproducts-plan.md
 - Docs/superpowers/plans/2026-05-30-research-workspace-deep-research-proposal-verification-plan.md
+pr_links:
+- https://github.com/rmusser01/tldw_server/pull/2186
 modified_files:
 - Docs/superpowers/plans/2026-05-30-research-workspace-deep-research-proposal-verification-plan.md
 - apps/packages/ui/src/components/Option/ResearchWorkspace/StudioPane/proposal-deep-research-verification.ts

--- a/backlog/tasks/task-571 - Show-Deep-Research-verification-in-proposal-sections.md
+++ b/backlog/tasks/task-571 - Show-Deep-Research-verification-in-proposal-sections.md
@@ -37,6 +37,7 @@ Follow-up after the Research Workspace literature work-products MVP. Display Dee
 - Added `proposal-deep-research-verification.ts` to split proposal markdown sections, find compatible completed Deep Research bundle imports, and normalize bounded bundle-level verification metadata.
 - Added a proposal-specific modal viewer that renders proposal sections with compact Deep Research verification companions beside Literature Overview, Proposed Hypothesis, Methodology, and Source Audit. Source Audit carries the detailed unresolved-question/source-trust summary to avoid repeating long bundle-level detail beside every section.
 - Wired StudioPane artifact View handling to use the proposal verification viewer only when a matching Deep Research import exists; other artifact viewers remain unchanged.
+- PR review follow-up preserved proposal content that appears before the first markdown heading under an Overview section, rendered proposal section bodies through the shared MarkdownPreview component, and made unresolved-question list keys unique when duplicate question text appears.
 - Bandit skipped: touched implementation files are frontend TypeScript/TSX plus docs/backlog only, with no Python execution path changed.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
@@ -46,9 +47,10 @@ Follow-up after the Research Workspace literature work-products MVP. Display Dee
 Implemented TASK-571 by showing imported Deep Research verification beside compatible Research Proposal Pack sections. The matching contract is strict and local to imported bundle artifacts: completed `deep_research_bundle_import` artifacts must point back to the proposal artifact through `data.deepResearch.sourceArtifact.id`. The modal display keeps proposal markdown, source coverage, and review checklist data unchanged while surfacing run ID, supported/unsupported claim counts, contradiction count, source trust count, and unresolved questions from the imported bundle.
 
 Verification:
-- `bunx vitest run src/components/Option/ResearchWorkspace/__tests__/deep-research-bundle-import.test.ts src/components/Option/ResearchWorkspace/__tests__/StudioPane.literature-workproducts.test.tsx --maxWorkers=1 --no-file-parallelism` passed with 2 files / 36 tests.
+- `bunx vitest run src/components/Option/ResearchWorkspace/__tests__/deep-research-bundle-import.test.ts src/components/Option/ResearchWorkspace/__tests__/StudioPane.literature-workproducts.test.tsx --maxWorkers=1 --no-file-parallelism` passed with 2 files / 37 tests after review follow-up.
 - `NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit -p tsconfig.json` passed in `apps/packages/ui`.
 - `bun run verify:design-system-state` passed with allowed legacy product-state exceptions only.
+- `TLDW_E2E_EXTENSION_LAUNCH_TIMEOUT_MS=90000 TLDW_E2E_EXTENSION_TARGET_WAIT_MS=90000 bun run test:e2e:workspace-parity` built the extension locally and exited 0 with the parity test skipped because extension launch is unavailable in this local environment; the prior CI failure was a Playwright timeout on the pre-rebase commit.
 - `git diff --check` passed.
 - Bandit skipped because this slice touched frontend TypeScript/TSX, docs, and Backlog only.
 <!-- SECTION:FINAL_SUMMARY:END -->

--- a/backlog/tasks/task-571 - Show-Deep-Research-verification-in-proposal-sections.md
+++ b/backlog/tasks/task-571 - Show-Deep-Research-verification-in-proposal-sections.md
@@ -1,10 +1,17 @@
 ---
 id: TASK-571
 title: Show Deep Research verification in proposal sections
-status: To Do
+status: Done
 documentation:
 - Docs/Product/Research_Workspace_Literature_Workproducts_PRD.md
 - Docs/superpowers/plans/2026-05-30-research-workspace-literature-workproducts-plan.md
+- Docs/superpowers/plans/2026-05-30-research-workspace-deep-research-proposal-verification-plan.md
+modified_files:
+- Docs/superpowers/plans/2026-05-30-research-workspace-deep-research-proposal-verification-plan.md
+- apps/packages/ui/src/components/Option/ResearchWorkspace/StudioPane/proposal-deep-research-verification.ts
+- apps/packages/ui/src/components/Option/ResearchWorkspace/StudioPane/ArtifactModalContent.tsx
+- apps/packages/ui/src/components/Option/ResearchWorkspace/StudioPane/index.tsx
+- apps/packages/ui/src/components/Option/ResearchWorkspace/__tests__/StudioPane.literature-workproducts.test.tsx
 ---
 
 ## Description
@@ -15,26 +22,41 @@ Follow-up after the Research Workspace literature work-products MVP. Display Dee
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
+- [x] #1 Research Proposal Pack artifacts display Deep Research verification summaries beside compatible proposal sections when a matching imported bundle artifact exists.
+- [x] #2 Compatibility is strict: only completed Deep Research bundle imports whose `sourceArtifact.id` matches the proposal artifact are used; unrelated imports are ignored.
+- [x] #3 Proposal artifact `sourceCoverage` and `reviewChecklist` contracts are preserved unchanged.
+- [x] #4 Focused pure helper and StudioPane UI tests cover matching, non-matching, and section rendering behavior.
 <!-- AC:END -->
 
 ## Implementation Notes
 
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
-
+- Created task-specific implementation plan: `Docs/superpowers/plans/2026-05-30-research-workspace-deep-research-proposal-verification-plan.md`.
+- Added `proposal-deep-research-verification.ts` to split proposal markdown sections, find compatible completed Deep Research bundle imports, and normalize bounded bundle-level verification metadata.
+- Added a proposal-specific modal viewer that renders proposal sections with compact Deep Research verification companions beside Literature Overview, Proposed Hypothesis, Methodology, and Source Audit. Source Audit carries the detailed unresolved-question/source-trust summary to avoid repeating long bundle-level detail beside every section.
+- Wired StudioPane artifact View handling to use the proposal verification viewer only when a matching Deep Research import exists; other artifact viewers remain unchanged.
+- Bandit skipped: touched implementation files are frontend TypeScript/TSX plus docs/backlog only, with no Python execution path changed.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Implemented TASK-571 by showing imported Deep Research verification beside compatible Research Proposal Pack sections. The matching contract is strict and local to imported bundle artifacts: completed `deep_research_bundle_import` artifacts must point back to the proposal artifact through `data.deepResearch.sourceArtifact.id`. The modal display keeps proposal markdown, source coverage, and review checklist data unchanged while surfacing run ID, supported/unsupported claim counts, contradiction count, source trust count, and unresolved questions from the imported bundle.
 
+Verification:
+- `bunx vitest run src/components/Option/ResearchWorkspace/__tests__/deep-research-bundle-import.test.ts src/components/Option/ResearchWorkspace/__tests__/StudioPane.literature-workproducts.test.tsx --maxWorkers=1 --no-file-parallelism` passed with 2 files / 36 tests.
+- `NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit -p tsconfig.json` passed in `apps/packages/ui`.
+- `bun run verify:design-system-state` passed with allowed legacy product-state exceptions only.
+- `git diff --check` passed.
+- Bandit skipped because this slice touched frontend TypeScript/TSX, docs, and Backlog only.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->


### PR DESCRIPTION
## Change summary
- Adds a proposal verification helper that strictly matches completed Deep Research bundle imports back to a Research Proposal Pack artifact by `data.deepResearch.sourceArtifact.id`.
- Adds a proposal-specific modal view that keeps the original proposal markdown, `sourceCoverage`, and `reviewChecklist` intact while showing imported verification evidence beside relevant proposal sections.
- Extends Research Workspace tests for strict matching, section attachment, UI rendering, and preservation of proposal metadata contracts.

## Why this approach
- The proposal artifact remains the source of truth for the MVP work product, and Deep Research evidence is presented as an adjacent imported run record instead of mutating generated proposal content.
- Matching by source artifact ID avoids accidental cross-display when multiple research artifacts or imported bundles exist in the same workspace.
- The UI shows compact counts beside Literature Overview, Proposed Hypothesis, Methodology, and Source Audit, with the longer unresolved-question/source-trust detail concentrated in Source Audit to keep the modal scannable.

## Verification
- `bunx vitest run src/components/Option/ResearchWorkspace/__tests__/deep-research-bundle-import.test.ts src/components/Option/ResearchWorkspace/__tests__/StudioPane.literature-workproducts.test.tsx --maxWorkers=1 --no-file-parallelism` passed after rebasing on latest `origin/dev`: 2 files / 36 tests.
- `NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit -p tsconfig.json` passed after rebase.
- `bun run verify:design-system-state` passed after rebase with the existing allowed legacy product-state exceptions only.
- `git diff --check` passed after rebase.
- Bandit skipped because this slice touches frontend TypeScript/TSX, docs, and Backlog records only.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shows Deep Research verification beside relevant sections of Research Proposal Pack proposals without changing proposal content or metadata. Implements TASK-571 with strict matching to the correct completed `deep_research_bundle_import`.

- **New Features**
  - Matches only completed `deep_research_bundle_import` artifacts whose `data.deepResearch.sourceArtifact.id` equals the proposal ID; opens the viewer only when a match exists.
  - Adds a proposal modal that splits markdown (preserving any pre-heading content as an “Overview”) and shows run ID plus supported/unsupported/contradiction counts on Literature Overview, Proposed Hypothesis, Methodology, and Source Audit. Source Audit also shows truncated unresolved questions and source trust. Original markdown is rendered via `MarkdownPreview`; `sourceCoverage` and `reviewChecklist` remain unchanged.

- **Bug Fixes**
  - Sets and names the unresolved-questions display limit to 3 in Source Audit for clarity.

<sup>Written for commit 49010d5ab1dd7b87de552aa74144219e5a50d6ad. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2186?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

