### PR TITLE
Resolve Research Workspace task ID collisions

### DIFF
--- a/Docs/superpowers/plans/2026-05-30-research-workspace-deep-research-bundle-import-plan.md
+++ b/Docs/superpowers/plans/2026-05-30-research-workspace-deep-research-bundle-import-plan.md
@@ -34,7 +34,7 @@
 - Modify `apps/packages/ui/src/components/Option/ResearchWorkspace/__tests__/ResearchWorkspace.stage2.responsive.test.tsx`
   - Mock bundle fetch and artifact insertion.
   - Cover successful import and failed/malformed bundle handling.
-- Modify `backlog/tasks/task-570 - Implement-Deep-Research-bundle-import-into-Research-Workspace-artifacts.md`
+- Modify `backlog/tasks/task-573 - Implement-Deep-Research-bundle-import-into-Research-Workspace-artifacts.md`
   - Record implementation notes, verification, and final status at closeout.
 
 ## Task 1: Add Bundle Import Adapter Tests

--- a/Docs/superpowers/plans/2026-05-30-research-workspace-deep-research-bundle-import-plan.md
+++ b/Docs/superpowers/plans/2026-05-30-research-workspace-deep-research-bundle-import-plan.md
@@ -12,7 +12,7 @@
 
 ## Source Requirements
 
-- Backlog: `TASK-570`
+- Backlog: `TASK-573`
 - Existing follow-up: `TASK-572` (`Import Deep Research bundles into Research Workspace artifacts`)
 - PRD: `Docs/Product/Research_Workspace_Literature_Workproducts_PRD.md`
 - Umbrella plan: `Docs/superpowers/plans/2026-05-30-research-workspace-literature-workproducts-plan.md`
@@ -182,4 +182,4 @@ If only frontend TS/TSX/docs/backlog files changed, record Bandit skipped as not
 
 - [x] **Step 5: Update Backlog and commit**
 
-Update TASK-570 with notes, final summary, and DoD status, then commit the task, plan, tests, and implementation.
+Update TASK-573 with notes, final summary, and DoD status, then commit the task, plan, tests, and implementation.

--- a/Docs/superpowers/plans/2026-05-30-research-workspace-deep-research-proposal-verification-plan.md
+++ b/Docs/superpowers/plans/2026-05-30-research-workspace-deep-research-proposal-verification-plan.md
@@ -21,7 +21,7 @@
   - Find the matching Deep Research import when viewing proposal artifacts and route the modal through the proposal viewer.
 - Modify `apps/packages/ui/src/components/Option/ResearchWorkspace/__tests__/StudioPane.literature-workproducts.test.tsx`
   - Add RED helper and UI tests for matching, non-matching, and modal section rendering.
-- Modify `backlog/tasks/task-571 - Show-Deep-Research-verification-in-proposal-sections.md`
+- Modify `backlog/tasks/task-574 - Show-Deep-Research-verification-in-proposal-sections.md`
   - Record acceptance criteria, plan link, verification, and final closeout.
 
 ## Stage 1: Pure Verification Contract

--- a/Docs/superpowers/plans/2026-05-30-research-workspace-deep-research-proposal-verification-plan.md
+++ b/Docs/superpowers/plans/2026-05-30-research-workspace-deep-research-proposal-verification-plan.md
@@ -56,7 +56,7 @@
 
 ## Stage 4: Verification And Closeout
 
-**Goal:** Run focused tests, type-check if feasible, diff check, Bandit applicability, and update TASK-571.
+**Goal:** Run focused tests, type-check if feasible, diff check, Bandit applicability, and update TASK-574.
 
 **Success Criteria:** Verification results are recorded in the task and the branch is ready for PR.
 

--- a/backlog/tasks/task-485 - Implement-Research-Workspace-literature-work-products-MVP.md
+++ b/backlog/tasks/task-485 - Implement-Research-Workspace-literature-work-products-MVP.md
@@ -52,13 +52,13 @@ Stage 4 complete: added Research Proposal Pack RED tests for Source Audit/source
 
 Stage 5 complete: added discoverability, invalid JSON, source-lineage/source-coverage, and export-scope regression coverage; labeled Literature Review templates in the chooser; added JSON export for parsed data-table artifacts while keeping XLSX absent. Verification: `cd apps/packages/ui && bun run test -- src/components/Option/ResearchWorkspace/__tests__/StudioPane.literature-workproducts.test.tsx src/components/Option/ResearchWorkspace/__tests__/StudioPane.stage1.test.tsx src/components/Option/ResearchWorkspace/__tests__/StudioPane.stage2.test.tsx src/workspace-templates/__tests__/work-product-templates.test.ts` passed with 4 files / 74 tests. `bun run verify:design-system-state` failed on existing product-state baseline findings outside touched work-product files; no new touched-file finding was identified in the blocked list.
 
-Stage 6 complete: created Deep Research follow-up tasks TASK-487, TASK-488, TASK-572, and TASK-571 covering launch from Matrix/Gap artifacts, follow-up seeding from hypotheses/proposals, bundle import back into Research Workspace, and verification display beside proposal sections.
+Stage 6 complete: created Deep Research follow-up tasks TASK-487, TASK-488, TASK-572, and TASK-574 covering launch from Matrix/Gap artifacts, follow-up seeding from hypotheses/proposals, bundle import back into Research Workspace, and verification display beside proposal sections.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Implemented the Research Workspace literature work-products MVP: actionable Literature Matrix, Corpus Gap Finder, Evidence-Bound Hypotheses, and Research Proposal Pack templates; source coverage/lineage metadata; JSON-first validation for Matrix/Gap/Hypotheses; proposal Source Audit enforcement; Literature Review grouping; CSV/JSON table exports; and Deep Research follow-up tasks TASK-487, TASK-488, TASK-572, and TASK-571. Verification: focused Research Workspace Vitest suite passed with 4 files / 74 tests. `bun run verify:design-system-state` remains blocked by pre-existing product-state baseline findings outside touched work-product files. Bandit skipped because this slice touched UI/docs/backlog files only, with no Python code.
+Implemented the Research Workspace literature work-products MVP: actionable Literature Matrix, Corpus Gap Finder, Evidence-Bound Hypotheses, and Research Proposal Pack templates; source coverage/lineage metadata; JSON-first validation for Matrix/Gap/Hypotheses; proposal Source Audit enforcement; Literature Review grouping; CSV/JSON table exports; and Deep Research follow-up tasks TASK-487, TASK-488, TASK-572, and TASK-574. Verification: focused Research Workspace Vitest suite passed with 4 files / 74 tests. `bun run verify:design-system-state` remains blocked by pre-existing product-state baseline findings outside touched work-product files. Bandit skipped because this slice touched UI/docs/backlog files only, with no Python code.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-572 - Import-Deep-Research-bundles-into-Research-Workspace-artifacts.md
+++ b/backlog/tasks/task-572 - Import-Deep-Research-bundles-into-Research-Workspace-artifacts.md
@@ -17,21 +17,21 @@ Follow-up after the Research Workspace literature work-products MVP. Import Deep
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [x] #1 Bundle import implementation is tracked in the completed TASK-570 record.
-- [x] #2 This follow-up is explicitly closed as fulfilled by TASK-570 / PR #2181, with no new implementation work in this task.
-- [x] #3 Verification and Bandit applicability are recorded in TASK-570 so this tracker shell is no longer ambiguous live work.
+- [x] #1 Bundle import implementation is tracked in the completed TASK-573 record.
+- [x] #2 This follow-up is explicitly closed as fulfilled by TASK-573 / PR #2181, with no new implementation work in this task.
+- [x] #3 Verification and Bandit applicability are recorded in TASK-573 so this tracker shell is no longer ambiguous live work.
 <!-- AC:END -->
 
 ## Implementation Notes
 
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
-Closed as fulfilled by TASK-570, which implemented the Deep Research bundle import path and records the focused tests, TypeScript check, diff check, and frontend-only Bandit skip. This task exists as the original literature-work-products follow-up shell, renumbered from the colliding TASK-489 to TASK-572 for tracker hygiene.
+Closed as fulfilled by TASK-573, which implemented the Deep Research bundle import path and records the focused tests, TypeScript check, diff check, and frontend-only Bandit skip. This task exists as the original literature-work-products follow-up shell, renumbered from the colliding TASK-489 to TASK-572 for tracker hygiene.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-TASK-572 is closed as the uniquely numbered follow-up record for the Deep Research bundle-import scope already completed under TASK-570 / PR #2181. No source changes were made for this closeout; it only removes the stale To Do tracker ambiguity after the earlier ID-collision cleanup.
+TASK-572 is closed as the uniquely numbered follow-up record for the Deep Research bundle-import scope already completed under TASK-573 / PR #2181. No source changes were made for this closeout; it only removes the stale To Do tracker ambiguity after the earlier ID-collision cleanup.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-573 - Implement-Deep-Research-bundle-import-into-Research-Workspace-artifacts.md
+++ b/backlog/tasks/task-573 - Implement-Deep-Research-bundle-import-into-Research-Workspace-artifacts.md
@@ -1,5 +1,5 @@
 ---
-id: TASK-570
+id: TASK-573
 title: Implement Deep Research bundle import into Research Workspace artifacts
 status: Done
 documentation:
@@ -11,6 +11,8 @@ documentation:
 
 <!-- SECTION:DESCRIPTION:BEGIN -->
 Implement the next post-MVP Research Workspace / Deep Research bridge: import a completed Deep Research bundle.json into the active Research Workspace as a generated artifact, preserving run provenance, source coverage, verification summary metadata, and the source artifact return context. This implementation task references the existing follow-up TASK-572, which was originally created as TASK-489 before tracker hygiene renumbered it away from colliding older task files.
+
+Tracker hygiene note: this record was renumbered from TASK-570 to TASK-573 after PR #2186 merged because TASK-570 is the canonical MCP Unified Stage 4K planning task.
 <!-- SECTION:DESCRIPTION:END -->
 
 ## Acceptance Criteria
@@ -42,7 +44,7 @@ Docs/superpowers/plans/2026-05-30-research-workspace-deep-research-bundle-import
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Implemented TASK-570 by adding a frontend-only Deep Research bundle import path for Research Workspace return handoffs. A matching returned run can now fetch the existing `/api/v1/research/runs/{id}/bundle` response through `tldwClient.getResearchBundle`, normalize it into a completed Research Workspace report artifact, preserve source artifact provenance in producer metadata and `data.deepResearch`, carry source lineage/source coverage from the source artifact or fallback bundle source inventory, and show explicit importing/imported/error states in the handoff banner. Imported artifacts intentionally do not set a literature `templateId`, so they are not mistaken for launchable literature work products.
+Implemented TASK-573 by adding a frontend-only Deep Research bundle import path for Research Workspace return handoffs. A matching returned run can now fetch the existing `/api/v1/research/runs/{id}/bundle` response through `tldwClient.getResearchBundle`, normalize it into a completed Research Workspace report artifact, preserve source artifact provenance in producer metadata and `data.deepResearch`, carry source lineage/source coverage from the source artifact or fallback bundle source inventory, and show explicit importing/imported/error states in the handoff banner. Imported artifacts intentionally do not set a literature `templateId`, so they are not mistaken for launchable literature work products.
 
 PR #2181 review remediation also now cancels in-flight imports if the user switches workspaces or unmounts Research Workspace before the bundle fetch completes, and caps imported bundle lists before they are used for source coverage, source lineage, readable content, or persisted Deep Research metadata.
 

--- a/backlog/tasks/task-574 - Show-Deep-Research-verification-in-proposal-sections.md
+++ b/backlog/tasks/task-574 - Show-Deep-Research-verification-in-proposal-sections.md
@@ -1,5 +1,5 @@
 ---
-id: TASK-571
+id: TASK-574
 title: Show Deep Research verification in proposal sections
 status: Done
 documentation:
@@ -20,6 +20,8 @@ modified_files:
 
 <!-- SECTION:DESCRIPTION:BEGIN -->
 Follow-up after the Research Workspace literature work-products MVP. Display Deep Research verification summaries next to compatible Research Proposal Pack sections without replacing the MVP sourceCoverage and review checklist contracts.
+
+Tracker hygiene note: this record was renumbered from TASK-571 to TASK-574 after PR #2186 merged because TASK-571 is the canonical MCP Unified Stage 4K implementation task.
 <!-- SECTION:DESCRIPTION:END -->
 
 ## Acceptance Criteria
@@ -44,7 +46,7 @@ Follow-up after the Research Workspace literature work-products MVP. Display Dee
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Implemented TASK-571 by showing imported Deep Research verification beside compatible Research Proposal Pack sections. The matching contract is strict and local to imported bundle artifacts: completed `deep_research_bundle_import` artifacts must point back to the proposal artifact through `data.deepResearch.sourceArtifact.id`. The modal display keeps proposal markdown, source coverage, and review checklist data unchanged while surfacing run ID, supported/unsupported claim counts, contradiction count, source trust count, and unresolved questions from the imported bundle.
+Implemented TASK-574 by showing imported Deep Research verification beside compatible Research Proposal Pack sections. The matching contract is strict and local to imported bundle artifacts: completed `deep_research_bundle_import` artifacts must point back to the proposal artifact through `data.deepResearch.sourceArtifact.id`. The modal display keeps proposal markdown, source coverage, and review checklist data unchanged while surfacing run ID, supported/unsupported claim counts, contradiction count, source trust count, and unresolved questions from the imported bundle.
 
 Verification:
 - `bunx vitest run src/components/Option/ResearchWorkspace/__tests__/deep-research-bundle-import.test.ts src/components/Option/ResearchWorkspace/__tests__/StudioPane.literature-workproducts.test.tsx --maxWorkers=1 --no-file-parallelism` passed with 2 files / 37 tests after review follow-up.


### PR DESCRIPTION
## Summary
- renumber the Research Workspace Deep Research bundle import implementation record from TASK-570 to TASK-573
- renumber the Research Workspace proposal verification record from TASK-571 to TASK-574
- update related follow-up task and plan references so TASK-570/TASK-571 remain canonical for MCP Unified Stage 4K

## Verification
- `rg -n "^id: TASK-(570|571|572|573|574)$" backlog/tasks backlog/completed` shows one record for each ID
- `git diff --check HEAD~1 HEAD`

## Change summary
This is a backlog hygiene cleanup after PR #2186 merged onto dev with task IDs that collided with the MCP Unified Stage 4K task records. The Research Workspace records are the later arrivals, so they were moved to the next open IDs while preserving their PR links and closeout content.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix task ID collisions by renumbering Research Workspace Deep Research tasks: bundle import from TASK-570 to TASK-573, proposal verification from TASK-571 to TASK-574. Renamed task files and updated plan task paths and follow-up references so TASK-570/571 remain canonical for MCP Unified Stage 4K.

<sup>Written for commit 6fe80d19d672ea6194f4a154fd29be339038d581. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2187?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

