### PR TITLE
Migrate WorkflowEditor alerts to design-system Alert

### DIFF
--- a/apps/packages/ui/scripts/design-system-product-state-baseline.json
+++ b/apps/packages/ui/scripts/design-system-product-state-baseline.json
@@ -900,49 +900,5 @@
     "reason": "Existing AntD Tag product-state UI in src/components/Quiz/tabs/TakeQuizTab.tsx before the guard.",
     "replacement": "tldw design-system state primitive",
     "migrationQueue": "shared-product-state"
-  },
-  {
-    "id": "antd-product-state-import:src/components/WorkflowEditor/ExecutionPanel.tsx:Alert#antd-alert-executionpanel-type-error-execution-error-lin-14y38x7",
-    "path": "src/components/WorkflowEditor/ExecutionPanel.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/WorkflowEditor/ExecutionPanel.tsx before the stable duplicate-id guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
-    "id": "antd-product-state-import:src/components/WorkflowEditor/ExecutionPanel.tsx:Alert#antd-alert-executionpanel-type-warning-diagnostics-unava-tyqo72",
-    "path": "src/components/WorkflowEditor/ExecutionPanel.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/WorkflowEditor/ExecutionPanel.tsx before the stable duplicate-id guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
-    "id": "antd-product-state-import:src/components/WorkflowEditor/NodeConfigPanel.tsx:Alert",
-    "path": "src/components/WorkflowEditor/NodeConfigPanel.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/WorkflowEditor/NodeConfigPanel.tsx before the guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
-    "id": "antd-product-state-import:src/components/WorkflowEditor/NodePalette.tsx:Alert",
-    "path": "src/components/WorkflowEditor/NodePalette.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/WorkflowEditor/NodePalette.tsx before the guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
   }
 ]

--- a/apps/packages/ui/src/components/WorkflowEditor/ExecutionPanel.tsx
+++ b/apps/packages/ui/src/components/WorkflowEditor/ExecutionPanel.tsx
@@ -13,7 +13,6 @@ import {
   Empty,
   Modal,
   Input,
-  Alert,
   Spin,
   Tag
 } from "antd"
@@ -31,6 +30,7 @@ import {
   ChevronRight
 } from "lucide-react"
 import { WorkflowRunInspector } from "@/components/Common/Workflow"
+import { Alert } from "@/components/ui/primitives"
 import type { StepExecutionStatus } from "@/types/workflow-editor"
 import { useWorkflowEditorStore } from "@/store/workflow-editor"
 
@@ -331,12 +331,12 @@ export const ExecutionPanel = ({ className = "" }: ExecutionPanelProps) => {
         {/* Error display */}
         {error && (
           <Alert
-            type="error"
+            variant="error"
             title="Execution Error"
-            description={error}
-            showIcon
             className="mb-3"
-          />
+          >
+            {error}
+          </Alert>
         )}
 
         {status === "failed" && runId && (
@@ -350,16 +350,15 @@ export const ExecutionPanel = ({ className = "" }: ExecutionPanelProps) => {
               </div>
             ) : runInvestigationError ? (
               <Alert
-                type="warning"
+                variant="warning"
                 title="Diagnostics unavailable"
-                description={runInvestigationError}
-                showIcon
-                action={(
-                  <Button size="small" onClick={() => void loadRunInvestigation(runId)}>
-                    Retry diagnostics
-                  </Button>
-                )}
-              />
+                action={{
+                  label: "Retry diagnostics",
+                  onClick: () => void loadRunInvestigation(runId)
+                }}
+              >
+                {runInvestigationError}
+              </Alert>
             ) : runInvestigation ? (
               <WorkflowRunInspector investigation={runInvestigation} />
             ) : null}

--- a/apps/packages/ui/src/components/WorkflowEditor/NodeConfigPanel.tsx
+++ b/apps/packages/ui/src/components/WorkflowEditor/NodeConfigPanel.tsx
@@ -15,8 +15,7 @@ import {
   Button,
   Tooltip,
   Empty,
-  Divider,
-  Alert
+  Divider
 } from "antd"
 import {
   Settings,
@@ -30,6 +29,7 @@ import type {
 } from "@/types/workflow-editor"
 import type { ConfigFieldSchema } from "./step-registry"
 import { useWorkflowEditorStore } from "@/store/workflow-editor"
+import { Alert } from "@/components/ui/primitives"
 import { getStepMetadata } from "./step-registry"
 import { schemaHasProperties, schemaToConfigFields } from "./schema-utils"
 import { useWorkflowDynamicOptions } from "./dynamic-options"
@@ -476,9 +476,8 @@ export const NodeConfigPanel = ({ className = "" }: NodeConfigPanelProps) => {
               />
               {rawConfigError && (
                 <Alert
-                  type="error"
+                  variant="error"
                   title={rawConfigError}
-                  showIcon
                   className="mt-2"
                 />
               )}

--- a/apps/packages/ui/src/components/WorkflowEditor/NodePalette.tsx
+++ b/apps/packages/ui/src/components/WorkflowEditor/NodePalette.tsx
@@ -6,10 +6,11 @@
  */
 
 import { useState, useMemo, useEffect } from "react"
-import { Input, Collapse, Tooltip, Spin, Alert, Button } from "antd"
+import { Input, Collapse, Tooltip, Spin, Button } from "antd"
 import { Search, GripVertical } from "lucide-react"
 import type { WorkflowStepType } from "@/types/workflow-editor"
 import { useWorkflowEditorStore } from "@/store/workflow-editor"
+import { Alert } from "@/components/ui/primitives"
 import { getCategorizedSteps, type StepTypeMetadata } from "./step-registry"
 import { STEP_ICON_COMPONENTS, DEFAULT_STEP_ICON } from "./step-icons"
 
@@ -355,20 +356,17 @@ export const NodePalette = ({ className = "" }: NodePaletteProps) => {
       {stepTypesStatus === "error" && (
         <div className="px-3 pt-2">
           <Alert
-            type="warning"
-            showIcon
+            variant="warning"
             title="Limited node library"
-            description={
-              <span className="text-xs">
-                Could not load server step types. Showing fallback steps.
-              </span>
-            }
-            action={
-              <Button size="small" onClick={handleRetryStepTypes}>
-                Retry
-              </Button>
-            }
-          />
+            action={{
+              label: "Retry",
+              onClick: handleRetryStepTypes
+            }}
+          >
+            <span className="text-xs">
+              Could not load server step types. Showing fallback steps.
+            </span>
+          </Alert>
         </div>
       )}
 

--- a/apps/packages/ui/src/components/WorkflowEditor/__tests__/ExecutionPanel.design-system.test.tsx
+++ b/apps/packages/ui/src/components/WorkflowEditor/__tests__/ExecutionPanel.design-system.test.tsx
@@ -1,0 +1,70 @@
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { cleanup, render, screen, within } from "@testing-library/react"
+import { ExecutionPanel } from "../ExecutionPanel"
+import { useWorkflowEditorStore } from "@/store/workflow-editor"
+
+vi.mock("@/components/Common/Workflow", () => ({
+  WorkflowRunInspector: () => <div data-testid="workflow-run-inspector" />
+}))
+
+const originalLoadRunInvestigation =
+  useWorkflowEditorStore.getState().loadRunInvestigation
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+  useWorkflowEditorStore.setState({
+    nodes: [],
+    edges: [],
+    runId: null,
+    status: "idle",
+    nodeStates: {},
+    pendingApproval: null,
+    error: null,
+    startedAt: null,
+    completedAt: null,
+    runInvestigation: null,
+    runInvestigationLoading: false,
+    runInvestigationError: null,
+    loadRunInvestigation: originalLoadRunInvestigation
+  })
+})
+
+describe("ExecutionPanel design-system alerts", () => {
+  it("renders execution errors through the design-system Alert", () => {
+    useWorkflowEditorStore.setState({
+      status: "failed",
+      error: "Workflow step failed",
+      loadRunInvestigation: vi.fn().mockResolvedValue(undefined)
+    })
+
+    render(<ExecutionPanel />)
+
+    const error = screen.getByText("Workflow step failed")
+    const alert = error.closest('[data-ds-component="Alert"]')
+    expect(alert).not.toBeNull()
+    const alertEl = alert as HTMLElement
+    expect(alertEl).toHaveTextContent("Execution Error")
+    expect(alertEl).toHaveTextContent("Workflow step failed")
+  })
+
+  it("renders diagnostics failures through the design-system Alert", () => {
+    useWorkflowEditorStore.setState({
+      status: "failed",
+      runId: "run-1",
+      runInvestigationError: "Diagnostics service unavailable",
+      loadRunInvestigation: vi.fn().mockResolvedValue(undefined)
+    })
+
+    render(<ExecutionPanel />)
+
+    const error = screen.getByText("Diagnostics service unavailable")
+    const alert = error.closest('[data-ds-component="Alert"]')
+    expect(alert).not.toBeNull()
+    const alertEl = alert as HTMLElement
+    expect(alertEl).toHaveTextContent("Diagnostics unavailable")
+    expect(
+      within(alertEl).getByRole("button", { name: "Retry diagnostics" })
+    ).toBeInTheDocument()
+  })
+})

--- a/apps/packages/ui/src/components/WorkflowEditor/__tests__/NodeConfigPanel.test.tsx
+++ b/apps/packages/ui/src/components/WorkflowEditor/__tests__/NodeConfigPanel.test.tsx
@@ -312,4 +312,46 @@ describe("NodeConfigPanel selectors", () => {
       )
     ).toBeInTheDocument()
   })
+
+  it("renders raw config validation errors through the design-system Alert", () => {
+    setupStore(
+      "custom_raw_step",
+      {
+        type: "object",
+        properties: {}
+      },
+      { enabled: true }
+    )
+    useWorkflowEditorStore.setState({
+      stepRegistry: {
+        custom_raw_step: {
+          type: "custom_raw_step" as any,
+          label: "Custom Raw Step",
+          description: "Custom raw step",
+          category: "utility",
+          icon: "MessageSquare",
+          color: "bg-gray-500",
+          inputs: [],
+          outputs: [],
+          configSchema: []
+        }
+      }
+    })
+
+    vi.mocked(useWorkflowDynamicOptions).mockReturnValue({
+      optionsByKey: {},
+      loadingByKey: {}
+    })
+
+    render(<NodeConfigPanel />)
+
+    fireEvent.change(screen.getByPlaceholderText('{"key": "value"}'), {
+      target: { value: "not-json" }
+    })
+
+    const error = screen.getByText(/Unexpected token|not valid JSON/)
+    const alert = error.closest('[data-ds-component="Alert"]')
+    expect(alert).not.toBeNull()
+    expect(alert).toHaveTextContent(/Unexpected token|not valid JSON/)
+  })
 })

--- a/apps/packages/ui/src/components/WorkflowEditor/__tests__/NodePalette.test.tsx
+++ b/apps/packages/ui/src/components/WorkflowEditor/__tests__/NodePalette.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, afterEach } from "vitest"
-import { cleanup, fireEvent, render, screen } from "@testing-library/react"
+import { cleanup, fireEvent, render, screen, within } from "@testing-library/react"
 import NodePalette from "../NodePalette"
 import { useWorkflowEditorStore } from "@/store/workflow-editor"
 import { buildStepRegistry } from "../step-registry"
@@ -31,8 +31,15 @@ describe("NodePalette step-type loading UX", () => {
 
     render(<NodePalette />)
 
-    expect(screen.getByText("Limited node library")).toBeInTheDocument()
-    fireEvent.click(screen.getByRole("button", { name: "Retry" }))
+    const title = screen.getByText("Limited node library")
+    expect(title).toBeInTheDocument()
+    const alert = title.closest('[data-ds-component="Alert"]')
+    expect(alert).not.toBeNull()
+    const alertEl = alert as HTMLElement
+    expect(alertEl).toHaveTextContent(
+      "Could not load server step types. Showing fallback steps."
+    )
+    fireEvent.click(within(alertEl).getByRole("button", { name: "Retry" }))
     expect(retryMock).toHaveBeenCalledWith(true)
   })
 

--- a/backlog/tasks/task-45.44.8.6 - Migrate-WorkflowEditor-alerts-to-design-system-Alert.md
+++ b/backlog/tasks/task-45.44.8.6 - Migrate-WorkflowEditor-alerts-to-design-system-Alert.md
@@ -1,0 +1,58 @@
+---
+id: TASK-45.44.8.6
+title: Migrate WorkflowEditor alerts to design-system Alert
+status: Done
+labels:
+- design-system
+- webui
+- product-state
+priority: medium
+parent_task_id: TASK-45.44.8
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Remove WorkflowEditor AntD Alert product-state exceptions from the design-system baseline by migrating ExecutionPanel, NodeConfigPanel, and NodePalette alert surfaces to the shared design-system Alert primitive.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 ExecutionPanel, NodeConfigPanel, and NodePalette render the design-system Alert primitive instead of AntD Alert for product-state alert surfaces.
+- [x] #2 The product-state baseline contains no WorkflowEditor Alert exceptions touched by this slice.
+- [x] #3 Focused regression coverage verifies the migrated WorkflowEditor alert surfaces expose the design-system Alert marker and preserve user-facing copy.
+- [x] #4 Relevant verification commands are recorded, with Bandit skipped only if the touched scope remains TypeScript/UI-only.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Started from latest origin/dev after PR #2188 merged. Scope selected from live design-system baseline: WorkflowEditor ExecutionPanel, NodeConfigPanel, and NodePalette AntD Alert product-state exceptions.
+
+Migrated WorkflowEditor ExecutionPanel, NodeConfigPanel, and NodePalette from AntD Alert to the shared design-system Alert primitive. Preserved alert copy and actions, including diagnostics retry and node-library retry controls.
+
+Removed 4 WorkflowEditor Alert entries from the product-state baseline, reducing live baseline exceptions from 86 to 82 and leaving no WorkflowEditor baseline entries.
+
+Verification recorded:
+- `bunx vitest run src/components/WorkflowEditor/__tests__/ExecutionPanel.design-system.test.tsx src/components/WorkflowEditor/__tests__/NodeConfigPanel.test.tsx src/components/WorkflowEditor/__tests__/NodePalette.test.tsx --reporter=dot`
+- `bun run verify:design-system-state`
+- `NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit --pretty false`
+
+Bandit skipped because this is TypeScript/UI-only work.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+WorkflowEditor AntD Alert product-state exceptions were migrated to the design-system Alert primitive in ExecutionPanel, NodeConfigPanel, and NodePalette. Focused regression coverage now asserts DS Alert markers and preserved copy/actions. Verification passed for the focused WorkflowEditor Vitest suite, design-system product-state guard with 82 remaining exceptions and zero WorkflowEditor entries, and TypeScript with the larger Node heap. Bandit skipped because this is TypeScript/UI-only work.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## Summary
- Migrates WorkflowEditor `ExecutionPanel`, `NodeConfigPanel`, and `NodePalette` product-state alerts from AntD `Alert` to the shared design-system `Alert` primitive.
- Adds focused DS marker regression coverage for execution errors, diagnostics failures, raw config validation errors, and degraded node-library loading.
- Removes the 4 WorkflowEditor Alert baseline exceptions, reducing total product-state baseline debt from 86 to 82.

## Verification
- [x] Red check before runtime migration: focused WorkflowEditor suite failed on missing `data-ds-component="Alert"` markers.
- [x] `bunx vitest run src/components/WorkflowEditor/__tests__/ExecutionPanel.design-system.test.tsx src/components/WorkflowEditor/__tests__/NodeConfigPanel.test.tsx src/components/WorkflowEditor/__tests__/NodePalette.test.tsx --reporter=dot`
- [x] `bun run verify:design-system-state`
- [x] `NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit --pretty false`
- [x] `git diff --check`

## UX Audit Checklist
- [x] Not applicable: this PR preserves existing WorkflowEditor alert copy/actions while swapping Alert primitives.

## Watchlists Accessibility Checklist
- [x] Not applicable: no Watchlists routes or components are changed.

## Watchlists Scale Checklist
- [x] Not applicable: no Watchlists data flows, list rendering, or scale-sensitive queries are changed.

## Docstring Coverage
- [x] Not applicable: this PR only changes TypeScript/TSX UI code, focused UI tests, the design-system baseline JSON, and a Backlog task record; no Python functions or classes are touched.

## Risk / Rollback
- Risk is limited to WorkflowEditor alert rendering; user-facing copy and retry actions are preserved.
- Roll back by reverting this PR, which restores the AntD Alert imports and baseline entries.

## Change Summary (maintainer-owned)
TODO: Maintainer to replace this section with a human-written summary before merge, per AI-generated PR policy.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrates WorkflowEditor alerts in `ExecutionPanel`, `NodeConfigPanel`, and `NodePalette` from `antd` `Alert` to the shared design-system `Alert`. This standardizes alert UI and removes 4 baseline exceptions (86 → 82).

- **Refactors**
  - Swapped `antd` `Alert` for design-system `Alert`, using `variant`, `title`, children, and `action` props.
  - Preserved copy and behaviors for execution errors, diagnostics retry, raw config validation, and node library retry.
  - Added focused tests to assert `data-ds-component="Alert"` markers and preserved copy/actions; removed related baseline exceptions.

<sup>Written for commit d76442ea872ea0f3a18e3d1eb57d22ae6e22d9c8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2191?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

