### PR TITLE
Migrate DataTables alerts to design-system Alert

### DIFF
--- a/apps/packages/ui/scripts/design-system-product-state-baseline.json
+++ b/apps/packages/ui/scripts/design-system-product-state-baseline.json
@@ -363,39 +363,6 @@
     "migrationQueue": "shared-product-state"
   },
   {
-    "id": "antd-product-state-import:src/components/Option/DataTables/CreateTableWizard.tsx:Alert",
-    "path": "src/components/Option/DataTables/CreateTableWizard.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/Option/DataTables/CreateTableWizard.tsx before the guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
-    "id": "antd-product-state-import:src/components/Option/DataTables/SaveTablePanel.tsx:Alert",
-    "path": "src/components/Option/DataTables/SaveTablePanel.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/Option/DataTables/SaveTablePanel.tsx before the guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
-    "id": "antd-product-state-import:src/components/Option/DataTables/TableDetailModal.tsx:Alert",
-    "path": "src/components/Option/DataTables/TableDetailModal.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/Option/DataTables/TableDetailModal.tsx before the guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
     "id": "antd-product-state-import:src/components/Option/Items/ItemsWorkspace.tsx:Empty",
     "path": "src/components/Option/Items/ItemsWorkspace.tsx",
     "rule": "antd-product-state-import",

--- a/apps/packages/ui/src/components/Option/DataTables/CreateTableWizard.tsx
+++ b/apps/packages/ui/src/components/Option/DataTables/CreateTableWizard.tsx
@@ -1,8 +1,9 @@
 import React, { useCallback, useMemo } from "react"
-import { Steps, Card, Button, Alert } from "antd"
+import { Steps, Card, Button } from "antd"
 import { ArrowLeft, ArrowRight, Sparkles } from "lucide-react"
 import { useTranslation } from "react-i18next"
 import { useDataTablesStore } from "@/store/data-tables"
+import { Alert } from "@/components/ui/primitives"
 import { SourceSelector } from "./SourceSelector"
 import { GenerationPanel } from "./GenerationPanel"
 import { TablePreview } from "./TablePreview"
@@ -124,20 +125,16 @@ export const CreateTableWizard: React.FC = () => {
       {/* Intro tip */}
       {wizardStep === "sources" && (
         <Alert
-          title={
-            <span className="flex items-center gap-2">
-              <Sparkles className="h-4 w-4" />
-              {t("dataTables:wizard.tip", "Tip")}
-            </span>
-          }
-          description={t(
+          variant="info"
+          icon={<Sparkles className="size-4" />}
+          title={t("dataTables:wizard.tip", "Tip")}
+          className="mb-4"
+        >
+          {t(
             "dataTables:wizard.tipText",
             "Select chats, documents, or search your knowledge base to extract structured data. The more specific your sources, the better the results."
           )}
-          type="info"
-          showIcon={false}
-          className="mb-4"
-        />
+        </Alert>
       )}
 
       {/* Step content */}

--- a/apps/packages/ui/src/components/Option/DataTables/SaveTablePanel.tsx
+++ b/apps/packages/ui/src/components/Option/DataTables/SaveTablePanel.tsx
@@ -1,11 +1,12 @@
 import React, { useState } from "react"
-import { Alert, Button, Card, Input, message, Result } from "antd"
+import { Button, Card, Input, message, Result } from "antd"
 import { CheckCircle, Download, Save, Table2 } from "lucide-react"
 import { useTranslation } from "react-i18next"
 import { useQueryClient } from "@tanstack/react-query"
 import { useDataTablesStore } from "@/store/data-tables"
 import { tldwClient } from "@/services/tldw/TldwApiClient"
 import { exportAndDownload } from "@/utils/data-table-export"
+import { Alert } from "@/components/ui/primitives"
 import type { ExportFormat } from "@/types/data-tables"
 
 const { TextArea } = Input
@@ -121,14 +122,14 @@ export const SaveTablePanel: React.FC = () => {
   if (!generatedTable) {
     return (
       <Alert
-        type="warning"
+        variant="warning"
         title={t("dataTables:noTableToSave", "No table to save")}
-        description={t(
+      >
+        {t(
           "dataTables:goBackToGenerate",
           "Go back to the previous step to generate a table first."
         )}
-        showIcon
-      />
+      </Alert>
     )
   }
 

--- a/apps/packages/ui/src/components/Option/DataTables/TableDetailModal.tsx
+++ b/apps/packages/ui/src/components/Option/DataTables/TableDetailModal.tsx
@@ -1,6 +1,5 @@
 import React, { useEffect, useRef, useState } from "react"
 import {
-  Alert,
   Button,
   Descriptions,
   Drawer,
@@ -17,6 +16,7 @@ import { tldwClient } from "@/services/tldw/TldwApiClient"
 import { useDataTablesStore } from "@/store/data-tables"
 import { exportAndDownload } from "@/utils/data-table-export"
 import { pollDataTableJob } from "@/utils/data-tables-jobs"
+import { Alert } from "@/components/ui/primitives"
 import type { DataTable, ExportFormat } from "@/types/data-tables"
 import { EditableDataTable } from "./EditableDataTable"
 
@@ -238,11 +238,11 @@ export const TableDetailModal: React.FC<TableDetailModalProps> = ({
       {/* Error */}
       {error && (
         <Alert
-          type="error"
+          variant="error"
           title={t("common:error", "Error")}
-          description={error}
-          showIcon
-        />
+        >
+          {error}
+        </Alert>
       )}
 
       {/* Content */}

--- a/apps/packages/ui/src/components/Option/DataTables/__tests__/CreateTableWizard.design-system-alert.test.tsx
+++ b/apps/packages/ui/src/components/Option/DataTables/__tests__/CreateTableWizard.design-system-alert.test.tsx
@@ -1,6 +1,7 @@
 import React from "react"
 import { render, screen } from "@testing-library/react"
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest"
+import { expectInsideDesignSystemAlert } from "@/test-utils/designSystemAlert"
 import { CreateTableWizard } from "../CreateTableWizard"
 import type { DataTable } from "@/types/data-tables"
 
@@ -52,15 +53,6 @@ vi.mock("../TablePreview", () => ({
 vi.mock("../SaveTablePanel", () => ({
   SaveTablePanel: () => <div data-testid="save-table-panel" />
 }))
-
-const expectInsideDesignSystemAlert = (text: string | RegExp) => {
-  const node = screen.getByText(text)
-  const alert = node.closest('[data-ds-component="Alert"]')
-  expect(alert).not.toBeNull()
-  const alertEl = alert as HTMLElement
-  expect(alertEl).toHaveAttribute("data-ds-component", "Alert")
-  return alertEl
-}
 
 describe("CreateTableWizard design-system alerts", () => {
   beforeAll(() => {

--- a/apps/packages/ui/src/components/Option/DataTables/__tests__/CreateTableWizard.design-system-alert.test.tsx
+++ b/apps/packages/ui/src/components/Option/DataTables/__tests__/CreateTableWizard.design-system-alert.test.tsx
@@ -1,0 +1,105 @@
+import React from "react"
+import { render, screen } from "@testing-library/react"
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest"
+import { CreateTableWizard } from "../CreateTableWizard"
+import type { DataTable } from "@/types/data-tables"
+
+const dataTablesState = {
+  wizardStep: "sources" as "sources" | "prompt" | "preview" | "save",
+  selectedSources: [] as Array<unknown>,
+  tableName: "",
+  prompt: "",
+  generatedTable: null as DataTable | null,
+  isGenerating: false,
+  setWizardStep: vi.fn(),
+  resetWizard: vi.fn()
+}
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (
+      key: string,
+      defaultValueOrOptions?:
+        | string
+        | {
+            defaultValue?: string
+          }
+    ) => {
+      if (typeof defaultValueOrOptions === "string") return defaultValueOrOptions
+      if (defaultValueOrOptions?.defaultValue) return defaultValueOrOptions.defaultValue
+      return key
+    }
+  })
+}))
+
+vi.mock("@/store/data-tables", () => ({
+  useDataTablesStore: (selector: (state: typeof dataTablesState) => unknown) =>
+    selector(dataTablesState)
+}))
+
+vi.mock("../SourceSelector", () => ({
+  SourceSelector: () => <div data-testid="source-selector" />
+}))
+
+vi.mock("../GenerationPanel", () => ({
+  GenerationPanel: () => <div data-testid="generation-panel" />
+}))
+
+vi.mock("../TablePreview", () => ({
+  TablePreview: () => <div data-testid="table-preview" />
+}))
+
+vi.mock("../SaveTablePanel", () => ({
+  SaveTablePanel: () => <div data-testid="save-table-panel" />
+}))
+
+const expectInsideDesignSystemAlert = (text: string | RegExp) => {
+  const node = screen.getByText(text)
+  const alert = node.closest('[data-ds-component="Alert"]')
+  expect(alert).not.toBeNull()
+  const alertEl = alert as HTMLElement
+  expect(alertEl).toHaveAttribute("data-ds-component", "Alert")
+  return alertEl
+}
+
+describe("CreateTableWizard design-system alerts", () => {
+  beforeAll(() => {
+    if (typeof window.matchMedia !== "function") {
+      Object.defineProperty(window, "matchMedia", {
+        writable: true,
+        value: vi.fn().mockImplementation((query: string) => ({
+          matches: false,
+          media: query,
+          onchange: null,
+          addListener: vi.fn(),
+          removeListener: vi.fn(),
+          addEventListener: vi.fn(),
+          removeEventListener: vi.fn(),
+          dispatchEvent: vi.fn()
+        }))
+      })
+    }
+  })
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    dataTablesState.wizardStep = "sources"
+    dataTablesState.selectedSources = []
+    dataTablesState.tableName = ""
+    dataTablesState.prompt = ""
+    dataTablesState.generatedTable = null
+    dataTablesState.isGenerating = false
+  })
+
+  it("renders the source-selection tip through the design-system Alert primitive", () => {
+    render(<CreateTableWizard />)
+
+    const alert = expectInsideDesignSystemAlert("Tip")
+    expect(alert).toHaveAttribute("role", "status")
+    expect(
+      screen.getByText(
+        "Select chats, documents, or search your knowledge base to extract structured data. The more specific your sources, the better the results."
+      )
+    ).toBeInTheDocument()
+  })
+})

--- a/apps/packages/ui/src/components/Option/DataTables/__tests__/SaveTablePanel.design-system-alert.test.tsx
+++ b/apps/packages/ui/src/components/Option/DataTables/__tests__/SaveTablePanel.design-system-alert.test.tsx
@@ -2,6 +2,7 @@ import React from "react"
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import { render, screen } from "@testing-library/react"
 import { beforeEach, describe, expect, it, vi } from "vitest"
+import { expectInsideDesignSystemAlert } from "@/test-utils/designSystemAlert"
 import { SaveTablePanel } from "../SaveTablePanel"
 import type { DataTable } from "@/types/data-tables"
 
@@ -57,15 +58,6 @@ const renderPanel = () => {
       <SaveTablePanel />
     </QueryClientProvider>
   )
-}
-
-const expectInsideDesignSystemAlert = (text: string | RegExp) => {
-  const node = screen.getByText(text)
-  const alert = node.closest('[data-ds-component="Alert"]')
-  expect(alert).not.toBeNull()
-  const alertEl = alert as HTMLElement
-  expect(alertEl).toHaveAttribute("data-ds-component", "Alert")
-  return alertEl
 }
 
 describe("SaveTablePanel design-system alerts", () => {

--- a/apps/packages/ui/src/components/Option/DataTables/__tests__/SaveTablePanel.design-system-alert.test.tsx
+++ b/apps/packages/ui/src/components/Option/DataTables/__tests__/SaveTablePanel.design-system-alert.test.tsx
@@ -1,0 +1,86 @@
+import React from "react"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { render, screen } from "@testing-library/react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { SaveTablePanel } from "../SaveTablePanel"
+import type { DataTable } from "@/types/data-tables"
+
+const dataTablesState = {
+  generatedTable: null as DataTable | null,
+  addTable: vi.fn(),
+  setActiveTab: vi.fn(),
+  resetWizard: vi.fn()
+}
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (
+      key: string,
+      defaultValueOrOptions?:
+        | string
+        | {
+            defaultValue?: string
+          }
+    ) => {
+      if (typeof defaultValueOrOptions === "string") return defaultValueOrOptions
+      if (defaultValueOrOptions?.defaultValue) return defaultValueOrOptions.defaultValue
+      return key
+    }
+  })
+}))
+
+vi.mock("@/store/data-tables", () => ({
+  useDataTablesStore: (selector: (state: typeof dataTablesState) => unknown) =>
+    selector(dataTablesState)
+}))
+
+vi.mock("@/services/tldw/TldwApiClient", () => ({
+  tldwClient: {
+    updateDataTable: vi.fn()
+  }
+}))
+
+vi.mock("@/utils/data-table-export", () => ({
+  exportAndDownload: vi.fn()
+}))
+
+const renderPanel = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false }
+    }
+  })
+
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <SaveTablePanel />
+    </QueryClientProvider>
+  )
+}
+
+const expectInsideDesignSystemAlert = (text: string | RegExp) => {
+  const node = screen.getByText(text)
+  const alert = node.closest('[data-ds-component="Alert"]')
+  expect(alert).not.toBeNull()
+  const alertEl = alert as HTMLElement
+  expect(alertEl).toHaveAttribute("data-ds-component", "Alert")
+  return alertEl
+}
+
+describe("SaveTablePanel design-system alerts", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    dataTablesState.generatedTable = null
+  })
+
+  it("renders the missing-table warning through the design-system Alert primitive", () => {
+    renderPanel()
+
+    const alert = expectInsideDesignSystemAlert("No table to save")
+    expect(alert).toHaveAttribute("role", "alert")
+    expect(
+      screen.getByText("Go back to the previous step to generate a table first.")
+    ).toBeInTheDocument()
+  })
+})

--- a/apps/packages/ui/src/components/Option/DataTables/__tests__/TableDetailModal.design-system-alert.test.tsx
+++ b/apps/packages/ui/src/components/Option/DataTables/__tests__/TableDetailModal.design-system-alert.test.tsx
@@ -1,0 +1,136 @@
+import React from "react"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { render, screen } from "@testing-library/react"
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest"
+import { TableDetailModal } from "../TableDetailModal"
+import type { DataTable } from "@/types/data-tables"
+
+const { getDataTableMock } = vi.hoisted(() => ({
+  getDataTableMock: vi.fn()
+}))
+
+const dataTablesState = {
+  currentTable: null as DataTable | null,
+  currentTableLoading: false,
+  editingState: {
+    editingCellKey: null as string | null,
+    isDirty: false,
+    pendingChanges: []
+  },
+  setCurrentTable: vi.fn(),
+  setCurrentTableLoading: vi.fn(),
+  stopEditing: vi.fn(),
+  updateTableInList: vi.fn()
+}
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (
+      key: string,
+      defaultValueOrOptions?:
+        | string
+        | {
+            defaultValue?: string
+          }
+    ) => {
+      if (typeof defaultValueOrOptions === "string") return defaultValueOrOptions
+      if (defaultValueOrOptions?.defaultValue) return defaultValueOrOptions.defaultValue
+      return key
+    }
+  })
+}))
+
+vi.mock("@/store/data-tables", () => ({
+  useDataTablesStore: (selector: (state: typeof dataTablesState) => unknown) =>
+    selector(dataTablesState)
+}))
+
+vi.mock("@/services/tldw/TldwApiClient", () => ({
+  tldwClient: {
+    getDataTable: getDataTableMock,
+    getDataTableJob: vi.fn(),
+    regenerateDataTable: vi.fn()
+  }
+}))
+
+vi.mock("@/utils/data-table-export", () => ({
+  exportAndDownload: vi.fn()
+}))
+
+vi.mock("@/utils/data-tables-jobs", () => ({
+  pollDataTableJob: vi.fn()
+}))
+
+vi.mock("../EditableDataTable", () => ({
+  EditableDataTable: () => <div data-testid="editable-data-table" />
+}))
+
+const renderModal = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false }
+    }
+  })
+
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <TableDetailModal open tableId="table-1" onClose={vi.fn()} />
+    </QueryClientProvider>
+  )
+}
+
+const expectInsideDesignSystemAlert = async (text: string | RegExp) => {
+  const node = await screen.findByText(text)
+  const alert = node.closest('[data-ds-component="Alert"]')
+  expect(alert).not.toBeNull()
+  const alertEl = alert as HTMLElement
+  expect(alertEl).toHaveAttribute("data-ds-component", "Alert")
+  return alertEl
+}
+
+describe("TableDetailModal design-system alerts", () => {
+  beforeAll(() => {
+    if (typeof window.matchMedia !== "function") {
+      Object.defineProperty(window, "matchMedia", {
+        writable: true,
+        value: vi.fn().mockImplementation((query: string) => ({
+          matches: false,
+          media: query,
+          onchange: null,
+          addListener: vi.fn(),
+          removeListener: vi.fn(),
+          addEventListener: vi.fn(),
+          removeEventListener: vi.fn(),
+          dispatchEvent: vi.fn()
+        }))
+      })
+    }
+
+    if (!(globalThis as any).ResizeObserver) {
+      ;(globalThis as any).ResizeObserver = class ResizeObserver {
+        observe() {}
+        unobserve() {}
+        disconnect() {}
+      }
+    }
+  })
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    dataTablesState.currentTable = null
+    dataTablesState.currentTableLoading = false
+    dataTablesState.editingState.editingCellKey = null
+    dataTablesState.editingState.isDirty = false
+    dataTablesState.editingState.pendingChanges = []
+    getDataTableMock.mockRejectedValue(new Error("Failed to load table details"))
+  })
+
+  it("renders load failures through the design-system Alert primitive", async () => {
+    renderModal()
+
+    const alert = await expectInsideDesignSystemAlert("Error")
+    expect(alert).toHaveAttribute("role", "alert")
+    expect(screen.getByText("Failed to load table details")).toBeInTheDocument()
+  })
+})

--- a/apps/packages/ui/src/components/Option/DataTables/__tests__/TableDetailModal.design-system-alert.test.tsx
+++ b/apps/packages/ui/src/components/Option/DataTables/__tests__/TableDetailModal.design-system-alert.test.tsx
@@ -2,6 +2,7 @@ import React from "react"
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import { render, screen } from "@testing-library/react"
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest"
+import { expectInsideDesignSystemAlertAsync } from "@/test-utils/designSystemAlert"
 import { TableDetailModal } from "../TableDetailModal"
 import type { DataTable } from "@/types/data-tables"
 
@@ -80,15 +81,6 @@ const renderModal = () => {
   )
 }
 
-const expectInsideDesignSystemAlert = async (text: string | RegExp) => {
-  const node = await screen.findByText(text)
-  const alert = node.closest('[data-ds-component="Alert"]')
-  expect(alert).not.toBeNull()
-  const alertEl = alert as HTMLElement
-  expect(alertEl).toHaveAttribute("data-ds-component", "Alert")
-  return alertEl
-}
-
 describe("TableDetailModal design-system alerts", () => {
   beforeAll(() => {
     if (typeof window.matchMedia !== "function") {
@@ -129,7 +121,7 @@ describe("TableDetailModal design-system alerts", () => {
   it("renders load failures through the design-system Alert primitive", async () => {
     renderModal()
 
-    const alert = await expectInsideDesignSystemAlert("Error")
+    const alert = await expectInsideDesignSystemAlertAsync("Error")
     expect(alert).toHaveAttribute("role", "alert")
     expect(screen.getByText("Failed to load table details")).toBeInTheDocument()
   })

--- a/apps/packages/ui/src/test-utils/designSystemAlert.ts
+++ b/apps/packages/ui/src/test-utils/designSystemAlert.ts
@@ -1,0 +1,20 @@
+import { screen } from "@testing-library/react"
+import { expect } from "vitest"
+
+const expectDesignSystemAlertAncestor = (node: HTMLElement) => {
+  const alert = node.closest('[data-ds-component="Alert"]')
+  expect(alert).not.toBeNull()
+  const alertEl = alert as HTMLElement
+  expect(alertEl).toHaveAttribute("data-ds-component", "Alert")
+  return alertEl
+}
+
+export const expectInsideDesignSystemAlert = (text: string | RegExp) => {
+  return expectDesignSystemAlertAncestor(screen.getByText(text))
+}
+
+export const expectInsideDesignSystemAlertAsync = async (
+  text: string | RegExp
+) => {
+  return expectDesignSystemAlertAncestor(await screen.findByText(text))
+}

--- a/backlog/tasks/task-45.44.2.7 - Migrate-remaining-DataTables-alerts-to-design-system-Alert.md
+++ b/backlog/tasks/task-45.44.2.7 - Migrate-remaining-DataTables-alerts-to-design-system-Alert.md
@@ -1,0 +1,62 @@
+---
+id: TASK-45.44.2.7
+title: Migrate remaining DataTables alerts to design-system Alert
+status: Done
+assignee: []
+created_date: ''
+updated_date: '2026-05-31 16:35'
+labels:
+  - design-system
+  - webui
+  - extension
+  - product-state
+dependencies: []
+references:
+  - apps/packages/ui/src/components/Option/DataTables/CreateTableWizard.tsx
+  - apps/packages/ui/src/components/Option/DataTables/SaveTablePanel.tsx
+  - apps/packages/ui/src/components/Option/DataTables/TableDetailModal.tsx
+  - apps/packages/ui/scripts/design-system-product-state-baseline.json
+  - 'https://github.com/rmusser01/tldw_server/issues/1659'
+parent_task_id: TASK-45.44.2
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Continue the Ingestion/Library/media product-state migration by replacing the remaining DataTables AntD Alert product-state callouts in CreateTableWizard, SaveTablePanel, and TableDetailModal with the shared design-system Alert primitive, then remove the matching baseline exceptions.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 CreateTableWizard, SaveTablePanel, and TableDetailModal product-state callouts render through the shared design-system Alert primitive while preserving user-facing copy/actions.
+- [x] #2 The remaining DataTables AntD Alert product-state baseline entries for the touched files are removed without introducing new unbaselined findings for those paths.
+- [x] #3 Focused regression coverage verifies the design-system Alert marker for the migrated branches.
+- [x] #4 Focused tests, scoped product-state guard verification, TypeScript/touched-scope check, diff whitespace check, and Bandit skip rationale are recorded.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+- Added focused design-system Alert regression tests for the CreateTableWizard source-selection tip, SaveTablePanel missing-table warning, and TableDetailModal load-error state. The initial focused Vitest run failed as expected because the existing AntD Alert markup did not expose data-ds-component="Alert".
+- Replaced the three remaining DataTables AntD Alert product-state callouts with the shared design-system Alert primitive while preserving existing titles, body copy, and state severity.
+- Removed the three matching DataTables baseline exceptions; baseline count moved from 82 to 79 and the touched paths now have zero baseline entries.
+- Verification: focused DataTables Alert tests passed 3/3; product-state guard unit passed 54/54; bun run verify:design-system-state exited 0 with 79 baseline exceptions; node --max-old-space-size=8192 ./node_modules/typescript/bin/tsc --noEmit --pretty false exited 0; git diff --check exited 0.
+- Bandit skipped because this slice touched frontend TSX/test/JSON/Backlog markdown only, with no Python code.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Migrated the remaining DataTables product-state alerts in CreateTableWizard, SaveTablePanel, and TableDetailModal from direct AntD Alert usage to the shared design-system Alert primitive. Added focused DOM coverage for all three migrated branches and removed the obsolete DataTables baseline exceptions, reducing the product-state baseline from 82 to 79 entries.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-45.44.2.7 - Migrate-remaining-DataTables-alerts-to-design-system-Alert.md
+++ b/backlog/tasks/task-45.44.2.7 - Migrate-remaining-DataTables-alerts-to-design-system-Alert.md
@@ -4,7 +4,7 @@ title: Migrate remaining DataTables alerts to design-system Alert
 status: Done
 assignee: []
 created_date: ''
-updated_date: '2026-05-31 16:35'
+updated_date: '2026-05-31 16:46'
 labels:
   - design-system
   - webui
@@ -43,6 +43,9 @@ Continue the Ingestion/Library/media product-state migration by replacing the re
 - Removed the three matching DataTables baseline exceptions; baseline count moved from 82 to 79 and the touched paths now have zero baseline entries.
 - Verification: focused DataTables Alert tests passed 3/3; product-state guard unit passed 54/54; bun run verify:design-system-state exited 0 with 79 baseline exceptions; node --max-old-space-size=8192 ./node_modules/typescript/bin/tsc --noEmit --pretty false exited 0; git diff --check exited 0.
 - Bandit skipped because this slice touched frontend TSX/test/JSON/Backlog markdown only, with no Python code.
+
+- PR review follow-up: extracted the repeated DataTables design-system Alert ancestor assertion into src/test-utils/designSystemAlert.ts with sync and async helpers, then updated the three new DataTables alert tests to import the shared helper without changing assertion semantics.
+- Review-fix verification: focused DataTables Alert tests passed 3/3; node --max-old-space-size=8192 ./node_modules/typescript/bin/tsc --noEmit --pretty false exited 0; git diff --check exited 0.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary


### PR DESCRIPTION
## Summary

- Migrates the remaining DataTables product-state alerts in `CreateTableWizard`, `SaveTablePanel`, and `TableDetailModal` from direct AntD `Alert` usage to the shared design-system `Alert` primitive.
- Adds focused regression coverage for each migrated branch using null-guarded `closest('[data-ds-component="Alert"]')` assertions.
- Removes the three matching DataTables product-state baseline exceptions, reducing the baseline from 82 to 79 entries.
- Closes out `TASK-45.44.2.7`.

## Verification

- RED: `bunx vitest run src/components/Option/DataTables/__tests__/CreateTableWizard.design-system-alert.test.tsx src/components/Option/DataTables/__tests__/SaveTablePanel.design-system-alert.test.tsx src/components/Option/DataTables/__tests__/TableDetailModal.design-system-alert.test.tsx --maxWorkers=1 --no-file-parallelism` failed 3/3 before implementation because the existing AntD Alert markup did not expose `data-ds-component="Alert"`.
- GREEN: `bunx vitest run src/components/Option/DataTables/__tests__/CreateTableWizard.design-system-alert.test.tsx src/components/Option/DataTables/__tests__/SaveTablePanel.design-system-alert.test.tsx src/components/Option/DataTables/__tests__/TableDetailModal.design-system-alert.test.tsx --maxWorkers=1 --no-file-parallelism` passed 3/3.
- `bunx vitest run src/design-system/__tests__/product-state-guard.test.ts --maxWorkers=1 --no-file-parallelism` passed 54/54.
- `bun run verify:design-system-state` exited 0 with 79 allowed baseline exceptions.
- `node --max-old-space-size=8192 ./node_modules/typescript/bin/tsc --noEmit --pretty false` exited 0.
- `git diff --check` exited 0.
- Bandit skipped: frontend TSX/test/JSON/Backlog markdown only, no Python touched.

## UX Audit Checklist

- N/A. This is a primitive migration preserving existing DataTables copy and visibility behavior.

## Watchlists Accessibility Checklist

- N/A. No Watchlists files touched.

## Watchlists Scale Checklist

- N/A. No Watchlists data-path changes.

## Docstring Coverage

- N/A. Frontend-only TypeScript/JSON/Backlog slice.

## Risk / Rollback

- Low risk: isolated to three DataTables alert branches and focused test coverage.
- Rollback: revert this commit to restore the previous AntD Alert usage and baseline entries.

## Change Summary

Maintainer-written summary required before merge: explain what changed and why the design-system Alert primitive is the right migration target for these DataTables product-state callouts.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrated remaining DataTables alerts in CreateTableWizard, SaveTablePanel, and TableDetailModal from `antd` Alert to the design-system `Alert`, unifying product-state UI and removing three baseline exceptions (82 → 79). Added focused tests and a shared test helper to verify the design-system `Alert`.

- **Refactors**
  - Replaced `antd` Alert with design-system `Alert` in the three components.
  - Added focused tests and extracted `expectInsideDesignSystemAlert(Async)` in `@/test-utils/designSystemAlert`.
  - Removed the three matching product-state baseline exceptions.

<sup>Written for commit 076b1432416e3c2bd4704c76cc248b5406b45449. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2192?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

