### PR TITLE
Add MCP Unified editable profile CRUD

### DIFF
--- a/Docs/superpowers/plans/2026-05-31-mcp-unified-stage4l-editable-profile-crud-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-05-31-mcp-unified-stage4l-editable-profile-crud-implementation-plan.md
@@ -1,0 +1,1001 @@
+# MCP Unified Stage 4L Editable Profile CRUD Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add manager-owned editable gateway profile create, limited patch, and guarded delete operations with matching FastAPI and CLI surfaces.
+
+**Architecture:** Extend `GatewayProfileManager` as the only mutation boundary, then keep FastAPI and CLI thin over that manager. Add a narrow guarded-delete capability for persistent stores so profile assignment checks and profile deletion cannot race. Preserve Stage 4K response envelopes, compact audit posture, package boundaries, and persistent-store-only CLI mutations.
+
+**Tech Stack:** Python 3.11, FastAPI, Pydantic v2, package-local MCP profile/storage protocols, SQLAlchemy-backed SQLite store, pytest, Bandit.
+
+---
+
+## Source Design
+
+- Spec: `Docs/superpowers/specs/2026-05-31-mcp-unified-stage4l-editable-profile-crud-design.md`
+- Backlog: `TASK-574`
+- Prior stage to preserve:
+  - `Docs/superpowers/specs/2026-05-30-mcp-unified-stage4k-gateway-profile-management-design.md`
+  - `Docs/superpowers/plans/2026-05-31-mcp-unified-stage4k-gateway-profile-management-implementation-plan.md`
+
+## Scope Boundaries
+
+Build only:
+
+- Full-document stored profile create.
+- Limited safe profile patch.
+- Guarded hard delete.
+- Manager-owned validation, default safety checks, assignment checks, and compact audit events.
+- FastAPI endpoints for `POST /profiles`, `PATCH /profiles/{profile_id}`, and `DELETE /profiles/{profile_id}`.
+- CLI commands for `create-profile`, `patch-profile`, and `delete-profile`.
+
+Do not build:
+
+- Profile assignment CRUD.
+- Workspace or principal binding management.
+- Approval policy editing.
+- Path scope editing.
+- External server grants.
+- Credential grants.
+- Storage schema migrations.
+- Audit viewer APIs.
+- Front-end UI changes.
+
+## File Map
+
+- Modify: `mcp_unified/gateway/profiles.py`
+  - Add `create_profile()`, `patch_profile()`, and `delete_profile()`.
+  - Add patch-shape validation helpers, effective-default helper, assignment guard helper, compact changed-field audit payloads, and guarded-delete dispatch.
+- Modify: `mcp_unified/interfaces/storage.py`
+  - Add a narrow optional protocol/capability for guarded profile deletion, for example `GuardedProfileDeleteStore`.
+- Modify: `mcp_unified/profiles/store.py`
+  - Add process-local locking or a guarded-delete method for `InMemoryProfileStore`/assignment-store combinations if the implementation chooses a shared memory helper.
+- Modify: `mcp_unified/storage/sqlite.py`
+  - Implement atomic persistent guarded delete using the existing SQLAlchemy backend and current tables, without schema migration.
+- Modify: `mcp_unified/gateway/fastapi.py`
+  - Add request/response models and management routes for create, patch, delete.
+  - Extend `_PROFILE_MANAGEMENT_STATUS_CODES`.
+- Modify: `mcp_unified/gateway/cli.py`
+  - Add parser commands, JSON file/stdin loading helpers, manager adapters, and persistent-store enforcement for new mutations.
+- Test: `tldw_Server_API/app/core/MCP_unified/tests/test_gateway_profile_management.py`
+  - Manager CRUD, audit, default safety, assignment safety, and persistent guarded-delete tests.
+- Test: `tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py`
+  - HTTP route contracts and status mappings.
+- Test: `tldw_Server_API/app/core/MCP_unified/tests/test_gateway_cli_package.py`
+  - CLI command contracts, stdin/file handling, malformed JSON, and memory-store mutation rejection.
+
+## Public Contracts To Preserve
+
+- Stage 4K profile management routes and CLI commands keep their current response shapes.
+- Profile mutations remain manager-owned; FastAPI and CLI do not call stores directly.
+- Package code in `mcp_unified` does not import `tldw_Server_API`.
+- CLI mutating profile-management commands reject nonpersistent memory-store configs.
+- Audit failures stay best effort and do not fail successful profile mutations.
+- Full profile create may preserve valid `created_at`, but must set `updated_at` to the mutation time.
+- Patch preserves omitted fields, rejects unsupported fields, and rejects no-op patch documents.
+- Delete refuses current effective default and any assigned profile.
+
+## Domain Shapes
+
+Extend the FastAPI reason-code map with:
+
+```python
+_PROFILE_MANAGEMENT_STATUS_CODES = {
+    "profile_not_found": 404,
+    "preset_not_found": 404,
+    "default_profile_not_configured": 404,
+    "profile_disabled": 409,
+    "profile_already_exists": 409,
+    "invalid_profile_request": 422,
+    "profile_store_unavailable": 503,
+    "assignment_store_unavailable": 503,
+    "profile_is_default": 409,
+    "profile_has_assignments": 409,
+    "invalid_profile_patch": 422,
+}
+```
+
+Use reason codes consistently:
+
+- `profile_already_exists`: create target already exists.
+- `profile_is_default`: create, patch, or delete would make the effective gateway default missing or disabled.
+- `profile_has_assignments`: delete target has non-default assignments or any assignment references.
+- `invalid_profile_patch`: unsupported patch field, unsupported nested policy key, malformed patch shape after JSON parsing, or no-op patch.
+- `invalid_profile_request`: malformed full-create request after JSON parsing or missing required text arguments.
+
+Allowed patch fields:
+
+```python
+PROFILE_PATCH_FIELDS = {"name", "description", "enabled", "metadata", "policy_document"}
+POLICY_PATCH_FIELDS = {
+    "allowed_tools",
+    "denied_tools",
+    "capabilities",
+    "denied_capabilities",
+    "tool_patterns",
+    "module_patterns",
+    "risk_classes",
+    "resource_constraints",
+}
+```
+
+---
+
+### Task 1: Manager RED Tests For Create, Patch, And Delete
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/MCP_unified/tests/test_gateway_profile_management.py`
+
+- [ ] **Step 1: Add create success and duplicate RED tests**
+
+Append manager tests near the existing `duplicate_preset` tests:
+
+```python
+@pytest.mark.asyncio
+async def test_create_profile_persists_valid_profile_and_audits_success() -> None:
+    created_at = datetime(2026, 5, 31, 12, 0, tzinfo=UTC)
+    audit_store = InMemoryAuditStore()
+    store = InMemoryProfileStore()
+    manager = _manager(store, audit_store=audit_store)
+
+    payload = await manager.create_profile(
+        {
+            "id": "custom-reviewer",
+            "name": "Custom Reviewer",
+            "metadata": {"owner": "qa"},
+            "created_at": created_at.isoformat(),
+            "updated_at": created_at.isoformat(),
+        }
+    )
+
+    assert payload["ok"] is True
+    assert payload["profile"]["id"] == "custom-reviewer"
+    assert payload["profile"]["metadata"] == {"owner": "qa"}
+    assert payload["profile"]["created_at"] == created_at.isoformat()
+    assert payload["profile"]["updated_at"] != created_at.isoformat()
+    assert await store.get_profile("custom-reviewer") is not None
+    assert [event.event_type for event in audit_store.events] == ["profile.created"]
+```
+
+Add a duplicate test:
+
+```python
+@pytest.mark.asyncio
+async def test_create_profile_rejects_duplicate_id() -> None:
+    manager = _manager(InMemoryProfileStore([MCPProfile(id="existing", name="Existing")]))
+
+    with pytest.raises(GatewayProfileManagementError) as exc_info:
+        await manager.create_profile({"id": "existing", "name": "Duplicate"})
+
+    assert exc_info.value.reason_code == "profile_already_exists"
+    assert exc_info.value.to_payload()["profile_id"] == "existing"
+```
+
+- [ ] **Step 2: Add effective-default disabled create RED tests**
+
+Cover assignment-first resolution and fallback-only behavior:
+
+```python
+@pytest.mark.asyncio
+async def test_create_profile_rejects_disabled_effective_default_assignment_id() -> None:
+    assignment_store = InMemoryProfileAssignmentStore(
+        [ProfileAssignment(id="gateway-default", profile_id="default", is_default=True)]
+    )
+    manager = _manager(InMemoryProfileStore(), assignment_store)
+
+    with pytest.raises(GatewayProfileManagementError) as exc_info:
+        await manager.create_profile({"id": "default", "name": "Default", "enabled": False})
+
+    assert exc_info.value.reason_code == "profile_is_default"
+```
+
+```python
+@pytest.mark.asyncio
+async def test_create_profile_allows_disabled_fallback_id_when_assignment_overrides_it() -> None:
+    assignment_store = InMemoryProfileAssignmentStore(
+        [ProfileAssignment(id="gateway-default", profile_id="assigned", is_default=True)]
+    )
+    manager = _manager(
+        InMemoryProfileStore([MCPProfile(id="assigned", name="Assigned")]),
+        assignment_store,
+        fallback_default_profile_id="fallback",
+    )
+
+    payload = await manager.create_profile(
+        {"id": "fallback", "name": "Fallback", "enabled": False}
+    )
+
+    assert payload["profile"]["id"] == "fallback"
+    assert payload["profile"]["enabled"] is False
+```
+
+Also add a fallback-only rejection test:
+
+```python
+@pytest.mark.asyncio
+async def test_create_profile_rejects_disabled_fallback_default_without_assignment() -> None:
+    manager = _manager(
+        InMemoryProfileStore(),
+        fallback_default_profile_id="fallback",
+    )
+
+    with pytest.raises(GatewayProfileManagementError) as exc_info:
+        await manager.create_profile(
+            {"id": "fallback", "name": "Fallback", "enabled": False}
+        )
+
+    assert exc_info.value.reason_code == "profile_is_default"
+```
+
+- [ ] **Step 3: Add patch allowed-field RED tests**
+
+Add a test that patches `name`, `description`, `enabled`, `metadata`, and two `policy_document` fields while preserving omitted fields:
+
+```python
+@pytest.mark.asyncio
+async def test_patch_profile_replaces_allowed_fields_and_preserves_omitted_fields() -> None:
+    original = MCPProfile(
+        id="reviewer",
+        name="Reviewer",
+        description="old",
+        metadata={"old": True},
+        policy_document={"allowed_tools": ["old.tool"], "denied_tools": ["old.deny"]},
+    )
+    manager = _manager(InMemoryProfileStore([original]))
+
+    payload = await manager.patch_profile(
+        "reviewer",
+        {
+            "name": "Senior Reviewer",
+            "description": "new",
+            "metadata": {"new": True},
+            "policy_document": {"allowed_tools": ["new.tool"]},
+        },
+    )
+
+    profile = payload["profile"]
+    assert profile["name"] == "Senior Reviewer"
+    assert profile["description"] == "new"
+    assert profile["metadata"] == {"new": True}
+    assert profile["policy_document"]["allowed_tools"] == ["new.tool"]
+    assert profile["policy_document"]["denied_tools"] == ["old.deny"]
+```
+
+- [ ] **Step 4: Add patch rejection RED tests**
+
+Cover:
+
+- unsupported top-level field;
+- unknown nested policy field;
+- empty `{}`;
+- `{"policy_document": {}}`;
+- semantic no-op patch such as `{"name": existing_name}`;
+- default-profile disable.
+
+Expected assertion:
+
+```python
+with pytest.raises(GatewayProfileManagementError) as exc_info:
+    await manager.patch_profile("reviewer", {"approval_policy": {"mode": "auto"}})
+assert exc_info.value.reason_code == "invalid_profile_patch"
+```
+
+For semantic no-op, assert the manager does not update `updated_at`:
+
+```python
+before = (await store.get_profile("reviewer")).updated_at
+with pytest.raises(GatewayProfileManagementError) as exc_info:
+    await manager.patch_profile("reviewer", {"name": "Reviewer"})
+after = (await store.get_profile("reviewer")).updated_at
+assert exc_info.value.reason_code == "invalid_profile_patch"
+assert after == before
+```
+
+- [ ] **Step 5: Add delete RED tests**
+
+Cover:
+
+- deleting a non-default unassigned profile returns `{"ok": True, "profile_id": "temporary"}`;
+- missing profile returns `profile_not_found`;
+- effective default deletion returns `profile_is_default`;
+- assigned profile deletion returns `profile_has_assignments`;
+- failure audit payloads remain compact and omit `policy_document`.
+- expected failure audit events are emitted for unsupported patch fields,
+  semantic no-op patches, default disable, default delete, and assignment delete
+  protection.
+
+- [ ] **Step 6: Add persistent guarded-delete RED test**
+
+Use `SQLiteMCPStore` in a temp DB. Seed a profile and assignment, call the manager delete path, and assert it fails before cascade removes the assignment:
+
+Add imports if they are not already present:
+
+```python
+from pathlib import Path
+
+from mcp_unified.storage.sqlite import SQLiteMCPStore
+```
+
+```python
+@pytest.mark.asyncio
+async def test_delete_profile_sqlite_guard_preserves_assigned_profile(tmp_path: Path) -> None:
+    store = SQLiteMCPStore(tmp_path / "mcp.db")
+    await store.upsert_profile(MCPProfile(id="assigned", name="Assigned"))
+    await store.upsert_assignment(
+        ProfileAssignment(id="workspace-assignment", profile_id="assigned", workspace_id="ws")
+    )
+    manager = GatewayProfileManager(
+        profile_store=store,
+        assignment_store=store,
+        store_metadata=GatewayProfileStoreMetadata(kind="sqlite", persistent=True),
+    )
+
+    with pytest.raises(GatewayProfileManagementError) as exc_info:
+        await manager.delete_profile("assigned")
+
+    assert exc_info.value.reason_code == "profile_has_assignments"
+    assert await store.get_profile("assigned") is not None
+    assert await store.get_assignment("workspace-assignment") is not None
+    await store.aclose()
+```
+
+- [ ] **Step 7: Run RED manager tests**
+
+Run:
+
+```bash
+source .venv/bin/activate
+python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_gateway_profile_management.py -q
+```
+
+Expected: new tests fail because `GatewayProfileManager` does not yet expose `create_profile`, `patch_profile`, or `delete_profile`.
+
+### Task 2: Manager, Patch Validation, And Guarded Delete Implementation
+
+**Files:**
+- Modify: `mcp_unified/interfaces/storage.py`
+- Modify: `mcp_unified/gateway/profiles.py`
+- Modify: `mcp_unified/storage/sqlite.py`
+- Modify: `mcp_unified/profiles/store.py` if needed for an in-memory guarded-delete helper
+- Test: `tldw_Server_API/app/core/MCP_unified/tests/test_gateway_profile_management.py`
+
+- [ ] **Step 1: Add optional guarded-delete protocol**
+
+In `mcp_unified/interfaces/storage.py`, add a focused protocol without changing the existing `ProfileStore` contract:
+
+```python
+class GuardedProfileDeleteStore(Protocol):
+    """Store capability for atomically deleting unassigned non-default profiles."""
+
+    async def delete_profile_if_unassigned(
+        self,
+        profile_id: str,
+        *,
+        effective_default_profile_id: str | None,
+    ) -> str:
+        """Return deleted, not_found, is_default, or has_assignments."""
+        raise NotImplementedError
+```
+
+Use return strings for simple manager mapping:
+
+- `"deleted"`
+- `"not_found"`
+- `"is_default"`
+- `"has_assignments"`
+
+- [ ] **Step 2: Implement SQLite guarded delete atomically**
+
+In `SQLiteMCPStore`, add async wrapper and sync implementation:
+
+```python
+async def delete_profile_if_unassigned(
+    self,
+    profile_id: str,
+    *,
+    effective_default_profile_id: str | None,
+) -> str:
+    return await self._run_db(
+        self._delete_profile_if_unassigned_sync,
+        profile_id,
+        effective_default_profile_id=effective_default_profile_id,
+    )
+```
+
+Inside the sync method, use one transaction on `self._engine.begin()` and SQLAlchemy table objects:
+
+1. if `profile_id == effective_default_profile_id`, return `"is_default"`;
+2. select profile row by id; if absent return `"not_found"`;
+3. select one assignment row with `profile_id`; if present return `"has_assignments"`;
+4. delete profile row;
+5. return `"deleted"` if rowcount is truthy, otherwise `"not_found"`.
+
+Do not add tables or migrations.
+
+- [ ] **Step 3: Add manager helper constants and validators**
+
+In `mcp_unified/gateway/profiles.py`, add module constants:
+
+```python
+_PROFILE_PATCH_FIELDS = frozenset({"name", "description", "enabled", "metadata", "policy_document"})
+_POLICY_PATCH_FIELDS = frozenset(
+    {
+        "allowed_tools",
+        "denied_tools",
+        "capabilities",
+        "denied_capabilities",
+        "tool_patterns",
+        "module_patterns",
+        "risk_classes",
+        "resource_constraints",
+    }
+)
+```
+
+Add helpers:
+
+```python
+async def _effective_default_profile_id(self) -> str | None:
+    assignment = await self._load_default_assignment()
+    if assignment is not None:
+        return assignment.profile_id
+    return self.fallback_default_profile_id
+
+def _validate_patch_document(self, patch: Mapping[str, Any]) -> dict[str, Any]:
+    normalized = dict(patch)
+    # Validate keys and no-op shape here; see the tests in Task 1.
+    return normalized
+
+def _apply_profile_patch(
+    self,
+    profile: MCPProfile,
+    patch: Mapping[str, Any],
+) -> tuple[MCPProfile, tuple[str, ...]]:
+    # Copy existing profile, replace only supplied allowed fields, validate model,
+    # and compare the JSON-safe before/after payloads while ignoring updated_at.
+    # If no semantic field changed, raise invalid_profile_patch.
+    return profile.model_copy(deep=True), tuple(sorted(patch))
+```
+
+The validator must reject non-mapping input, unsupported top-level keys, unsupported nested policy keys, empty patch, and empty policy-only patch using `invalid_profile_patch`. `_apply_profile_patch()` must reject semantic no-ops using `invalid_profile_patch` after comparing the pre-patch and post-patch model dumps with `updated_at` excluded.
+
+- [ ] **Step 4: Implement `create_profile()`**
+
+Implementation shape:
+
+```python
+async def create_profile(self, profile_document: MCPProfile | Mapping[str, Any]) -> dict[str, Any]:
+    try:
+        profile = profile_document.model_copy(deep=True) if isinstance(profile_document, MCPProfile) else MCPProfile.model_validate(profile_document)
+    except Exception as exc:
+        raise self._error("Invalid profile request", reason_code="invalid_profile_request") from exc
+
+    if await self._get_profile(profile.id) is not None:
+        await self._audit_expected_failure(
+            "profile.create_failed",
+            reason_code="profile_already_exists",
+            profile_id=profile.id,
+            target_type="profile",
+            target_id=profile.id,
+        )
+        raise self._error(
+            f"Profile already exists: {profile.id}",
+            reason_code="profile_already_exists",
+            profile_id=profile.id,
+        )
+
+    effective_default_id = await self._effective_default_profile_id()
+    if not profile.enabled and profile.id == effective_default_id:
+        await self._audit_expected_failure(
+            "profile.create_failed",
+            reason_code="profile_is_default",
+            profile_id=profile.id,
+            target_type="profile",
+            target_id=profile.id,
+        )
+        raise self._error(
+            f"Profile is the effective default: {profile.id}",
+            reason_code="profile_is_default",
+            profile_id=profile.id,
+        )
+
+    now = datetime.now(timezone.utc)
+    profile = profile.model_copy(update={"updated_at": now}, deep=True)
+    stored = await self.profile_store.upsert_profile(profile)
+    await self._append_audit_event(
+        "profile.created",
+        profile_id=stored.id,
+        target_type="profile",
+        target_id=stored.id,
+        payload={"profile_id": stored.id},
+    )
+    return {"ok": True, "profile": self._dump_profile(stored), "store": self.store_metadata.to_payload()}
+```
+
+- [ ] **Step 5: Implement `patch_profile()`**
+
+Implementation shape:
+
+```python
+async def patch_profile(self, profile_id: str, patch_document: Mapping[str, Any]) -> dict[str, Any]:
+    normalized_profile_id = self._require_text(profile_id, field="profile_id")
+    try:
+        patch = self._validate_patch_document(patch_document)
+    except GatewayProfileManagementError:
+        await self._audit_expected_failure(
+            "profile.patch_failed",
+            reason_code="invalid_profile_patch",
+            profile_id=normalized_profile_id,
+            target_type="profile",
+            target_id=normalized_profile_id,
+        )
+        raise
+    profile = await self._get_profile(normalized_profile_id)
+    if profile is None:
+        await self._audit_expected_failure(
+            "profile.patch_failed",
+            reason_code="profile_not_found",
+            profile_id=normalized_profile_id,
+            target_type="profile",
+            target_id=normalized_profile_id,
+        )
+        raise self._error(
+            f"Profile not found: {normalized_profile_id}",
+            reason_code="profile_not_found",
+            profile_id=normalized_profile_id,
+        )
+    if patch.get("enabled") is False and normalized_profile_id == await self._effective_default_profile_id():
+        await self._audit_expected_failure(
+            "profile.patch_failed",
+            reason_code="profile_is_default",
+            profile_id=normalized_profile_id,
+            target_type="profile",
+            target_id=normalized_profile_id,
+        )
+        raise self._error(
+            f"Profile is the effective default: {normalized_profile_id}",
+            reason_code="profile_is_default",
+            profile_id=normalized_profile_id,
+        )
+    try:
+        updated, changed_fields = self._apply_profile_patch(profile, patch)
+    except GatewayProfileManagementError:
+        await self._audit_expected_failure(
+            "profile.patch_failed",
+            reason_code="invalid_profile_patch",
+            profile_id=normalized_profile_id,
+            target_type="profile",
+            target_id=normalized_profile_id,
+        )
+        raise
+    updated = updated.model_copy(update={"updated_at": datetime.now(timezone.utc)}, deep=True)
+    stored = await self.profile_store.upsert_profile(updated)
+    await self._append_audit_event(
+        "profile.patched",
+        profile_id=stored.id,
+        target_type="profile",
+        target_id=stored.id,
+        payload={"profile_id": stored.id, "changed_fields": list(changed_fields)},
+    )
+    return {"ok": True, "profile": self._dump_profile(stored), "store": self.store_metadata.to_payload()}
+```
+
+- [ ] **Step 6: Implement `delete_profile()`**
+
+Implementation shape:
+
+```python
+async def delete_profile(self, profile_id: str) -> dict[str, Any]:
+    normalized_profile_id = self._require_text(profile_id, field="profile_id")
+    effective_default_id = await self._effective_default_profile_id()
+    if normalized_profile_id == effective_default_id:
+        await self._audit_expected_failure(
+            "profile.delete_failed",
+            reason_code="profile_is_default",
+            profile_id=normalized_profile_id,
+            target_type="profile",
+            target_id=normalized_profile_id,
+        )
+        raise self._error(
+            f"Profile is the effective default: {normalized_profile_id}",
+            reason_code="profile_is_default",
+            profile_id=normalized_profile_id,
+        )
+
+    guarded_delete = getattr(self.profile_store, "delete_profile_if_unassigned", None)
+    if callable(guarded_delete):
+        result = await guarded_delete(
+            normalized_profile_id,
+            effective_default_profile_id=effective_default_id,
+        )
+    elif not self.store_metadata.persistent:
+        result = await self._manager_guarded_delete(normalized_profile_id)
+    else:
+        raise self._error("Profile store unavailable", reason_code="profile_store_unavailable")
+
+    if result == "deleted":
+        await self._append_audit_event(
+            "profile.deleted",
+            profile_id=normalized_profile_id,
+            target_type="profile",
+            target_id=normalized_profile_id,
+            payload={"profile_id": normalized_profile_id},
+        )
+        return {"ok": True, "profile_id": normalized_profile_id, "store": self.store_metadata.to_payload()}
+    if result == "not_found":
+        await self._audit_expected_failure(
+            "profile.delete_failed",
+            reason_code="profile_not_found",
+            profile_id=normalized_profile_id,
+            target_type="profile",
+            target_id=normalized_profile_id,
+        )
+        raise self._error(
+            f"Profile not found: {normalized_profile_id}",
+            reason_code="profile_not_found",
+            profile_id=normalized_profile_id,
+        )
+    if result == "has_assignments":
+        await self._audit_expected_failure(
+            "profile.delete_failed",
+            reason_code="profile_has_assignments",
+            profile_id=normalized_profile_id,
+            target_type="profile",
+            target_id=normalized_profile_id,
+        )
+        raise self._error(
+            f"Profile has assignments: {normalized_profile_id}",
+            reason_code="profile_has_assignments",
+            profile_id=normalized_profile_id,
+        )
+    raise self._error(
+        f"Profile is the effective default: {normalized_profile_id}",
+        reason_code="profile_is_default",
+        profile_id=normalized_profile_id,
+    )
+```
+
+For result mapping:
+
+- `"not_found"` -> `profile_not_found`
+- `"is_default"` -> `profile_is_default`
+- `"has_assignments"` -> `profile_has_assignments`
+
+- [ ] **Step 7: Run manager tests to GREEN**
+
+Run:
+
+```bash
+source .venv/bin/activate
+python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_gateway_profile_management.py -q
+```
+
+Expected: all tests in this file pass.
+
+- [ ] **Step 8: Commit manager/storage slice**
+
+```bash
+git add mcp_unified/interfaces/storage.py mcp_unified/gateway/profiles.py mcp_unified/storage/sqlite.py mcp_unified/profiles/store.py tldw_Server_API/app/core/MCP_unified/tests/test_gateway_profile_management.py
+git commit -m "feat: add gateway profile CRUD manager"
+```
+
+### Task 3: FastAPI CRUD Routes
+
+**Files:**
+- Modify: `mcp_unified/gateway/fastapi.py`
+- Modify: `tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py`
+
+- [ ] **Step 1: Extend manager double in FastAPI tests**
+
+Add methods to `_ProfileManagementManagerDouble`:
+
+```python
+async def create_profile(self, profile: dict[str, Any]) -> dict[str, Any]:
+    self.calls.append(("create_profile", (profile,), {}))
+    return {
+        "ok": True,
+        "profile": {"id": profile["id"], "name": profile["name"]},
+        "store": {"kind": "memory", "persistent": False},
+    }
+
+async def patch_profile(self, profile_id: str, patch: dict[str, Any]) -> dict[str, Any]:
+    self.calls.append(("patch_profile", (profile_id, patch), {}))
+    return {
+        "ok": True,
+        "profile": {"id": profile_id, "name": patch.get("name", f"Profile {profile_id}")},
+        "store": {"kind": "memory", "persistent": False},
+    }
+
+async def delete_profile(self, profile_id: str) -> dict[str, Any]:
+    self.calls.append(("delete_profile", (profile_id,), {}))
+    return {
+        "ok": True,
+        "profile_id": profile_id,
+        "store": {"kind": "memory", "persistent": False},
+    }
+```
+
+Record calls in `self.calls` and return Stage 4L success envelopes.
+
+- [ ] **Step 2: Add RED route tests**
+
+Add tests for:
+
+- `POST /mcp/profiles` forwards full body to `manager.create_profile()`;
+- `PATCH /mcp/profiles/{profile_id}` forwards body to `manager.patch_profile()`;
+- `DELETE /mcp/profiles/{profile_id}` forwards to `manager.delete_profile()`;
+- `GatewayProfileManagementError` reason codes map as specified;
+- malformed `POST /profiles` body returns FastAPI/Pydantic validation response;
+- empty patch response from manager maps `invalid_profile_patch` to 422.
+
+Expected route assertion:
+
+```python
+def test_gateway_profile_management_create_profile_route() -> None:
+    runtime = _FakeGatewayRuntime()
+    manager = _ProfileManagementManagerDouble()
+    app = create_gateway_app(runtime, profile_manager=manager)
+    client = TestClient(app)
+
+    response = client.post("/mcp/profiles", json={"id": "custom", "name": "Custom"})
+
+    assert response.status_code == 200
+    assert response.json()["profile"]["id"] == "custom"
+    assert manager.calls == [("create_profile", ({"id": "custom", "name": "Custom"},), {})]
+```
+
+- [ ] **Step 3: Implement FastAPI models and routes**
+
+Add models near existing management models:
+
+```python
+from pydantic import BaseModel, ConfigDict
+
+class CreateProfileRequest(BaseModel):
+    model_config = ConfigDict(extra="allow")
+    id: str
+    name: str
+
+class PatchProfileRequest(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+class DeleteProfileResponse(BaseModel):
+    ok: bool
+    profile_id: str
+    store: StoreMetadataResponse
+```
+
+Prefer route-level `request.model_dump(exclude_unset=True)` for patch so omitted fields stay omitted. For create, pass the full model dump to the manager.
+
+Add:
+
+```python
+@router.post("/profiles", response_model=ProfileResponse)
+async def create_profile(request: CreateProfileRequest) -> ProfileResponse | JSONResponse:
+    try:
+        return await manager.create_profile(request.model_dump(mode="json"))
+    except GatewayProfileManagementError as exc:
+        return _profile_management_error_response(exc)
+
+@router.patch("/profiles/{profile_id}", response_model=ProfileResponse)
+async def patch_profile(profile_id: str, request: PatchProfileRequest) -> ProfileResponse | JSONResponse:
+    try:
+        return await manager.patch_profile(
+            profile_id,
+            request.model_dump(mode="json", exclude_unset=True),
+        )
+    except GatewayProfileManagementError as exc:
+        return _profile_management_error_response(exc)
+
+@router.delete("/profiles/{profile_id}", response_model=DeleteProfileResponse)
+async def delete_profile(profile_id: str) -> DeleteProfileResponse | JSONResponse:
+    try:
+        return await manager.delete_profile(profile_id)
+    except GatewayProfileManagementError as exc:
+        return _profile_management_error_response(exc)
+```
+
+Extend `_PROFILE_MANAGEMENT_STATUS_CODES` with Stage 4L codes.
+
+- [ ] **Step 4: Run FastAPI tests**
+
+Run:
+
+```bash
+source .venv/bin/activate
+python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py -q
+```
+
+Expected: file passes.
+
+- [ ] **Step 5: Commit FastAPI slice**
+
+```bash
+git add mcp_unified/gateway/fastapi.py tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py
+git commit -m "feat: expose gateway profile CRUD routes"
+```
+
+### Task 4: CLI CRUD Commands
+
+**Files:**
+- Modify: `mcp_unified/gateway/cli.py`
+- Modify: `tldw_Server_API/app/core/MCP_unified/tests/test_gateway_cli_package.py`
+
+- [ ] **Step 1: Add CLI RED tests for create and patch file input**
+
+Use existing `_write_gateway_config()` and `_profile_payload()` helpers. Add tests for:
+
+- `create-profile --profile-file profile.json --config gateway.json`;
+- `create-profile --profile-file - --config gateway.json` using `monkeypatch.setattr(gateway_cli.sys, "stdin", io.StringIO(json.dumps(profile_payload)))`;
+- `patch-profile reviewer --patch-file patch.json --config gateway.json`;
+- `patch-profile reviewer --patch-file - --config gateway.json`;
+- malformed JSON in profile/patch file returns exit code `2` and JSON stderr;
+- memory-store create/patch/delete rejects with exit code `1`.
+
+Add `import io` at the top of the test file.
+
+- [ ] **Step 2: Add CLI RED tests for delete**
+
+Cover:
+
+- deleting an unassigned SQLite-backed profile succeeds and emits compact payload;
+- deleting the effective default exits `1` with `profile_is_default`;
+- deleting assigned profile exits `1` with `profile_has_assignments`.
+
+- [ ] **Step 3: Implement parser commands**
+
+In `_build_parser()`, add:
+
+```python
+create_profile = subparsers.add_parser(
+    "create-profile",
+    help="Create a profile from a JSON document in a persistent gateway profile store.",
+)
+create_profile.add_argument("--profile-file", required=True, type=Path)
+_add_profile_config_argument(create_profile)
+create_profile.set_defaults(handler=_handle_create_profile)
+
+patch_profile = subparsers.add_parser(
+    "patch-profile",
+    help="Patch safe editable fields on a profile in a persistent gateway profile store.",
+)
+patch_profile.add_argument("profile_id")
+patch_profile.add_argument("--patch-file", required=True, type=Path)
+_add_profile_config_argument(patch_profile)
+patch_profile.set_defaults(handler=_handle_patch_profile)
+
+delete_profile = subparsers.add_parser(
+    "delete-profile",
+    help="Delete an unassigned non-default profile from a persistent gateway profile store.",
+)
+delete_profile.add_argument("profile_id")
+_add_profile_config_argument(delete_profile)
+delete_profile.set_defaults(handler=_handle_delete_profile)
+```
+
+- [ ] **Step 4: Implement JSON file/stdin helpers**
+
+Add:
+
+```python
+def _load_json_argument_file(path: Path, *, label: str) -> dict[str, Any]:
+    raw = sys.stdin.read() if str(path) == "-" else path.read_text(encoding="utf-8")
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise _CliArgumentError(f"Invalid {label} JSON: {exc.msg}") from exc
+    if not isinstance(payload, dict):
+        raise _CliArgumentError(f"{label} JSON must be an object")
+    return payload
+```
+
+Use `_CliArgumentError` so malformed input exits `2`.
+
+- [ ] **Step 5: Implement handlers**
+
+Handlers:
+
+```python
+def _handle_create_profile(args: argparse.Namespace) -> int:
+    profile = _load_json_argument_file(args.profile_file, label="profile")
+    return _handle_profile_management_command(
+        args,
+        lambda manager: manager.create_profile(profile),
+        require_persistent=True,
+    )
+```
+
+Similarly implement patch and delete. Use `_require_cli_text()` for `profile_id`.
+
+- [ ] **Step 6: Run CLI tests**
+
+Run:
+
+```bash
+source .venv/bin/activate
+python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_gateway_cli_package.py -q
+```
+
+Expected: file passes.
+
+- [ ] **Step 7: Commit CLI slice**
+
+```bash
+git add mcp_unified/gateway/cli.py tldw_Server_API/app/core/MCP_unified/tests/test_gateway_cli_package.py
+git commit -m "feat: add gateway profile CRUD CLI"
+```
+
+### Task 5: Integration Verification And Backlog Closeout
+
+**Files:**
+- Modify: `backlog/tasks/task-574 - Plan-MCP-Unified-Stage-4L-editable-profile-CRUD-implementation.md`
+- Modify or create implementation task if execution starts from this plan.
+
+- [ ] **Step 1: Run focused MCP Unified tests**
+
+Run:
+
+```bash
+source .venv/bin/activate
+python -m pytest \
+  tldw_Server_API/app/core/MCP_unified/tests/test_gateway_profile_management.py \
+  tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py \
+  tldw_Server_API/app/core/MCP_unified/tests/test_gateway_cli_package.py \
+  tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py \
+  -q
+```
+
+Expected: all selected tests pass.
+
+- [ ] **Step 2: Run package import boundary check**
+
+Run:
+
+```bash
+source .venv/bin/activate
+python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py -q
+```
+
+Expected: package boundary tests pass and no `mcp_unified` package file imports `tldw_Server_API`.
+
+- [ ] **Step 3: Run Bandit on touched package files**
+
+Run:
+
+```bash
+source .venv/bin/activate
+python -m bandit -r \
+  mcp_unified/gateway/profiles.py \
+  mcp_unified/gateway/fastapi.py \
+  mcp_unified/gateway/cli.py \
+  mcp_unified/interfaces/storage.py \
+  mcp_unified/storage/sqlite.py \
+  mcp_unified/profiles/store.py \
+  -f json -o /tmp/bandit_mcp_stage4l_profile_crud.json
+```
+
+Expected: no new security findings in touched code.
+
+- [ ] **Step 4: Run diff hygiene checks**
+
+Run:
+
+```bash
+git diff --check
+git status --short
+```
+
+Expected: no whitespace errors; only intended implementation files are modified before final staging.
+
+- [ ] **Step 5: Update Backlog task records**
+
+If this plan-only task is still open, update `TASK-574` with final plan-review status and mark it done. If implementation begins, create a separate implementation task before code edits or update the approved implementation task with modified files and verification results.
+
+- [ ] **Step 6: Commit final verification/backlog updates**
+
+```bash
+git add 'backlog/tasks/task-574 - Plan-MCP-Unified-Stage-4L-editable-profile-CRUD-implementation.md'
+git commit -m "chore: close profile CRUD planning"
+```
+
+Only run this commit if the plan task is being finalized separately from implementation.

--- a/Docs/superpowers/specs/2026-05-31-mcp-unified-stage4l-editable-profile-crud-design.md
+++ b/Docs/superpowers/specs/2026-05-31-mcp-unified-stage4l-editable-profile-crud-design.md
@@ -82,9 +82,14 @@ The manager continues to depend on the same package-owned protocols:
 - `ProfileAssignmentStore` for gateway default and future assignment lookup.
 - Optional `AuditStore` for profile lifecycle audit events.
 
-No new storage protocol is required. `ProfileStore` already exposes
+No storage schema migration is required. `ProfileStore` already exposes
 `get_profile`, `list_profiles`, `upsert_profile`, and `delete_profile`.
 `ProfileAssignmentStore` already supports listing assignments by `profile_id`.
+Because guarded deletion must not race assignment creation in persistent stores,
+Stage 4L may add a narrow package-owned guarded-delete capability for stores
+that can perform the assignment check and profile delete atomically. Generic
+check-then-delete fallback is acceptable only for nonpersistent in-memory stores
+used by tests and local development.
 
 ## Manager Contract
 
@@ -98,8 +103,9 @@ compact audit event.
 Create is not an upsert. If a profile with the requested ID already exists, the
 operation fails with a deterministic `profile_already_exists` reason.
 
-Creating disabled profiles is allowed except when the new profile ID is already
-selected by the current gateway default assignment or bootstrap fallback default.
+Creating disabled profiles is allowed except when the new profile ID matches the
+effective gateway default profile ID. Effective default resolution is
+assignment-first, then bootstrap fallback only when no assignment is configured.
 In that case, creating the disabled profile would make the effective gateway
 default disabled, so the manager must reject it. Callers should either create an
 enabled profile for that ID or move the default first.
@@ -135,10 +141,16 @@ Omitted fields are preserved. Provided list and dict fields replace that
 specific field; they are not merged. Providing `metadata` replaces the entire
 metadata object.
 
+Patch bodies must contain at least one supported change. Empty patch documents,
+empty `policy_document` objects with no other changes, and requests that would
+only refresh `updated_at` fail with `invalid_profile_patch`.
+
 Out-of-scope fields must be rejected rather than silently ignored. This includes
 `id`, `schema_version`, `preset_id`, `preset_version`, `approval_policy`,
 `path_scopes`, `external_server_grants`, `credential_grants`, `provenance`,
-`created_at`, and `updated_at`.
+`created_at`, and `updated_at`. Unknown nested `policy_document` keys are also
+rejected even though `ProfilePolicy` accepts extension fields in full profile
+documents.
 
 If the patch sets `enabled=false` for the current gateway default profile, the
 operation fails. Callers must move the default first.
@@ -160,7 +172,11 @@ Delete fails when:
 
 The manager should not rely on SQLite foreign-key cascade behavior for safety.
 The user-visible contract is that the control plane refuses unsafe deletion
-before storage mutation.
+before storage mutation. For persistent stores, the assignment check and profile
+delete must be serialized or atomic at the storage capability used by the
+manager. This prevents a concurrent default or assignment write from slipping
+between the guard and the delete. The nonpersistent in-memory fallback may use a
+manager-level lock because it is process-local and development-only.
 
 Deletion safety is scoped to the current Stage 4L ownership boundary: default
 profile resolution and profile assignments. SQLite may cascade future-owned rows
@@ -228,6 +244,12 @@ New reason codes should extend Stage 4K's deterministic mapping:
 - `profile_is_default`
 - `profile_has_assignments`
 - `invalid_profile_patch`
+
+Use `profile_is_default` for any create, patch, or delete operation blocked
+because it would make the effective gateway default missing or disabled. Use
+`profile_has_assignments` only when deletion is blocked by non-default
+assignments. Use `invalid_profile_patch` for unsupported patch fields,
+malformed patch shape after JSON parsing, and no-op patch documents.
 
 Existing reason codes should be reused where they already fit, including
 `profile_not_found`, `profile_already_exists`, `invalid_profile_request`,
@@ -313,6 +335,8 @@ Expected failure audit examples:
 
 - Duplicate ID during create.
 - Unsupported patch field.
+- No-op patch document.
+- Disabled profile create for the effective default ID.
 - Default-profile disable protection.
 - Default-profile delete protection.
 - Assignment delete protection.
@@ -331,10 +355,13 @@ Manager tests should cover:
 - Patching allowed fields and preserving omitted fields.
 - Replacing `metadata` and individual policy fields rather than merging them.
 - Rejecting unsupported patch fields.
+- Rejecting unknown nested `policy_document` patch fields.
+- Rejecting empty or no-op patch documents.
 - Rejecting `enabled=false` when the profile is the current gateway default.
 - Deleting a non-default unassigned profile.
 - Rejecting deletion of the current default profile.
 - Rejecting deletion of a profile with assignments.
+- Using an atomic or serialized guarded delete path for persistent stores.
 - Compact audit events for expected failures.
 
 FastAPI tests should cover:
@@ -343,6 +370,8 @@ FastAPI tests should cover:
 - Malformed JSON or invalid Pydantic body handling for `POST /profiles`.
 - `PATCH /profiles/{profile_id}` success.
 - Blocked default disable through `PATCH /profiles/{profile_id}`.
+- Empty patch and unsupported nested policy-key handling for
+  `PATCH /profiles/{profile_id}`.
 - `DELETE /profiles/{profile_id}` success.
 - Blocked delete for default and assigned profiles.
 - Deterministic reason-code to HTTP-status mapping.
@@ -354,6 +383,8 @@ CLI tests should cover:
 - Malformed JSON handling for `--profile-file` and `--patch-file` input.
 - `patch-profile <profile_id> --patch-file`.
 - `patch-profile <profile_id> --patch-file -`.
+- Empty patch and unsupported nested policy-key handling through
+  `patch-profile`.
 - `delete-profile <profile_id>`.
 - Guarded delete and default-disable domain errors.
 - Persistent-store requirement for all mutating commands.
@@ -370,8 +401,9 @@ Implementation should stay close to the Stage 4K patterns:
 - Prefer manager-level helper methods for default detection and assignment
   checks so FastAPI and CLI do not duplicate safety rules.
 - Preserve copy isolation when returning profile documents.
-- Avoid storage-layer migrations unless tests reveal a current store contract
-  mismatch.
+- Avoid storage-layer migrations. A narrow guarded-delete storage capability is
+  acceptable if needed to make persistent-store deletion atomic without changing
+  table shape.
 
 ## Acceptance Criteria
 

--- a/Docs/superpowers/specs/2026-05-31-mcp-unified-stage4l-editable-profile-crud-design.md
+++ b/Docs/superpowers/specs/2026-05-31-mcp-unified-stage4l-editable-profile-crud-design.md
@@ -98,6 +98,12 @@ compact audit event.
 Create is not an upsert. If a profile with the requested ID already exists, the
 operation fails with a deterministic `profile_already_exists` reason.
 
+Creating disabled profiles is allowed except when the new profile ID is already
+selected by the current gateway default assignment or bootstrap fallback default.
+In that case, creating the disabled profile would make the effective gateway
+default disabled, so the manager must reject it. Callers should either create an
+enabled profile for that ID or move the default first.
+
 The manager should preserve a valid provided `created_at` value. `updated_at`
 should be set to the current time during create so the stored document reflects
 the mutation time.
@@ -155,6 +161,12 @@ Delete fails when:
 The manager should not rely on SQLite foreign-key cascade behavior for safety.
 The user-visible contract is that the control plane refuses unsafe deletion
 before storage mutation.
+
+Deletion safety is scoped to the current Stage 4L ownership boundary: default
+profile resolution and profile assignments. SQLite may cascade future-owned rows
+such as approval policy or credential grant records, but Stage 4L does not expose
+or inspect those surfaces. Those references should be handled by the later
+approval/grant lifecycle slice.
 
 ## FastAPI Contract
 
@@ -314,6 +326,8 @@ Manager tests should cover:
 
 - Creating a valid profile and auditing success.
 - Rejecting duplicate profile IDs.
+- Rejecting creation of a disabled profile whose ID matches the current default
+  assignment or fallback default.
 - Patching allowed fields and preserving omitted fields.
 - Replacing `metadata` and individual policy fields rather than merging them.
 - Rejecting unsupported patch fields.
@@ -326,6 +340,7 @@ Manager tests should cover:
 FastAPI tests should cover:
 
 - `POST /profiles` success and duplicate failure.
+- Malformed JSON or invalid Pydantic body handling for `POST /profiles`.
 - `PATCH /profiles/{profile_id}` success.
 - Blocked default disable through `PATCH /profiles/{profile_id}`.
 - `DELETE /profiles/{profile_id}` success.
@@ -336,6 +351,7 @@ CLI tests should cover:
 
 - `create-profile --profile-file`.
 - `create-profile --profile-file -`.
+- Malformed JSON handling for `--profile-file` and `--patch-file` input.
 - `patch-profile <profile_id> --patch-file`.
 - `patch-profile <profile_id> --patch-file -`.
 - `delete-profile <profile_id>`.

--- a/Docs/superpowers/specs/2026-05-31-mcp-unified-stage4l-editable-profile-crud-design.md
+++ b/Docs/superpowers/specs/2026-05-31-mcp-unified-stage4l-editable-profile-crud-design.md
@@ -1,0 +1,369 @@
+# MCP Unified Stage 4L Editable Profile CRUD Design
+
+## Summary
+
+Stage 4L adds controlled profile create, patch, and delete operations to the
+standalone MCP gateway profile-management surface. It builds directly on Stage
+4K's stored profile listing, inspection, preset duplication, and default-profile
+selection work.
+
+The slice stays intentionally narrow. Full profile documents may be created, but
+updates are limited to safe profile metadata, enablement, and basic policy
+filter fields. Deletion is a guarded hard delete that refuses to remove profiles
+that are still the gateway default or have assignments.
+
+## Current Context
+
+The merged Stage 4K gateway profile-management work provides:
+
+- `GatewayProfileManager` in `mcp_unified.gateway.profiles`.
+- FastAPI profile-management endpoints for listing profiles, showing a profile,
+  duplicating a built-in preset, reading the gateway default profile, and setting
+  the gateway default profile.
+- CLI commands for the same management operations.
+- `ProfileStore` and `ProfileAssignmentStore` protocols with create/update and
+  delete primitives already available.
+- `InMemoryProfileStore`, `InMemoryProfileAssignmentStore`, and
+  `SQLiteMCPStore` implementations that already support the needed profile and
+  assignment storage operations.
+- Profile-aware runtime resolution that can use a stored gateway default
+  profile assignment.
+
+Stage 4K deliberately did not add arbitrary profile mutation, workspace binding
+management, approval policy editing, external server grants, credential grants,
+or UI changes. Stage 4L fills the next smallest product gap: editable stored
+profiles for front ends that need to create and maintain gateway modes.
+
+## Goals
+
+- Add manager-owned create, limited patch, and guarded delete operations for
+  stored gateway profiles.
+- Keep the manager as the only business-logic mutation boundary for CLI and
+  FastAPI.
+- Accept full validated `MCPProfile` documents for create.
+- Accept only approved safe fields for patch.
+- Reject operations that would leave the gateway default pointing at a missing
+  or disabled profile.
+- Reject deletion of profiles that still have assignments.
+- Preserve compact audit behavior without logging full policy documents or
+  grant-like material.
+- Keep package boundaries intact: package code must not import
+  `tldw_Server_API`.
+
+## Non-Goals
+
+- Profile assignment CRUD.
+- Workspace or principal binding management.
+- Approval policy editing.
+- Path scope editing.
+- External MCP server grant editing.
+- Credential grant editing.
+- Storage schema migrations.
+- Audit viewer APIs.
+- Front-end UI changes.
+- Changing legacy `tldw_server` MCP behavior outside the standalone gateway
+  package.
+
+## Architecture
+
+Extend `mcp_unified.gateway.profiles.GatewayProfileManager` with three methods:
+
+- `create_profile(profile_document)`
+- `patch_profile(profile_id, patch_document)`
+- `delete_profile(profile_id)`
+
+FastAPI endpoints and CLI commands call these manager methods only. They do not
+mutate profile stores directly and do not duplicate default-profile, assignment,
+validation, or audit rules.
+
+The manager continues to depend on the same package-owned protocols:
+
+- `ProfileStore` for stored profile documents.
+- `ProfileAssignmentStore` for gateway default and future assignment lookup.
+- Optional `AuditStore` for profile lifecycle audit events.
+
+No new storage protocol is required. `ProfileStore` already exposes
+`get_profile`, `list_profiles`, `upsert_profile`, and `delete_profile`.
+`ProfileAssignmentStore` already supports listing assignments by `profile_id`.
+
+## Manager Contract
+
+### `create_profile(profile_document)`
+
+Create accepts a full `MCPProfile` document. The manager validates the input
+against the existing `MCPProfile` model, rejects duplicate profile IDs, updates
+timestamps, persists through `ProfileStore.upsert_profile()`, and emits a
+compact audit event.
+
+Create is not an upsert. If a profile with the requested ID already exists, the
+operation fails with a deterministic `profile_already_exists` reason.
+
+The manager should preserve a valid provided `created_at` value. `updated_at`
+should be set to the current time during create so the stored document reflects
+the mutation time.
+
+### `patch_profile(profile_id, patch_document)`
+
+Patch loads the existing profile, applies only approved fields, validates the
+resulting `MCPProfile`, persists it, and emits a compact audit event.
+
+Allowed top-level patch fields:
+
+- `name`
+- `description`
+- `enabled`
+- `metadata`
+
+Allowed `policy_document` patch fields:
+
+- `allowed_tools`
+- `denied_tools`
+- `capabilities`
+- `denied_capabilities`
+- `tool_patterns`
+- `module_patterns`
+- `risk_classes`
+- `resource_constraints`
+
+Omitted fields are preserved. Provided list and dict fields replace that
+specific field; they are not merged. Providing `metadata` replaces the entire
+metadata object.
+
+Out-of-scope fields must be rejected rather than silently ignored. This includes
+`id`, `schema_version`, `preset_id`, `preset_version`, `approval_policy`,
+`path_scopes`, `external_server_grants`, `credential_grants`, `provenance`,
+`created_at`, and `updated_at`.
+
+If the patch sets `enabled=false` for the current gateway default profile, the
+operation fails. Callers must move the default first.
+
+On success, `created_at` is preserved and `updated_at` is set to the current
+time.
+
+### `delete_profile(profile_id)`
+
+Delete is a guarded hard delete. The manager loads the profile, checks whether
+it is the current gateway default, checks for any assignments referencing the
+profile, then calls `ProfileStore.delete_profile()` only when safe.
+
+Delete fails when:
+
+- The profile does not exist.
+- The profile is the current gateway default.
+- Any assignment exists for the profile.
+
+The manager should not rely on SQLite foreign-key cascade behavior for safety.
+The user-visible contract is that the control plane refuses unsafe deletion
+before storage mutation.
+
+## FastAPI Contract
+
+Add package-owned endpoints under the existing gateway management router:
+
+- `POST /profiles`
+- `PATCH /profiles/{profile_id}`
+- `DELETE /profiles/{profile_id}`
+
+`POST /profiles` accepts a full `MCPProfile` document. The success response
+matches the existing profile response shape:
+
+```json
+{
+  "ok": true,
+  "profile": {},
+  "store": {"kind": "sqlite", "persistent": true}
+}
+```
+
+`PATCH /profiles/{profile_id}` accepts a constrained patch body:
+
+```json
+{
+  "name": "Researcher",
+  "enabled": true,
+  "metadata": {"owner": "workspace-a"},
+  "policy_document": {
+    "allowed_tools": ["search.*"],
+    "denied_tools": ["shell.exec"]
+  }
+}
+```
+
+The `profile_id` path parameter is authoritative. The body must not include a
+profile ID.
+
+`DELETE /profiles/{profile_id}` returns a small success payload:
+
+```json
+{
+  "ok": true,
+  "profile_id": "workspace-researcher",
+  "store": {"kind": "sqlite", "persistent": true}
+}
+```
+
+Expected HTTP status mapping:
+
+- `200`: successful read or write.
+- `404`: profile not found.
+- `409`: duplicate profile ID, current default protection, or assignment
+  protection.
+- `422`: malformed request body or unsupported patch field.
+- `503`: required profile or assignment store unavailable.
+
+New reason codes should extend Stage 4K's deterministic mapping:
+
+- `profile_is_default`
+- `profile_has_assignments`
+- `invalid_profile_patch`
+
+Existing reason codes should be reused where they already fit, including
+`profile_not_found`, `profile_already_exists`, `invalid_profile_request`,
+`profile_store_unavailable`, and `assignment_store_unavailable`.
+
+## CLI Contract
+
+Add these commands to `mcp-unified-gateway`:
+
+- `create-profile --profile-file <path|->`
+- `patch-profile <profile_id> --patch-file <path|->`
+- `delete-profile <profile_id>`
+
+`-` means stdin for `--profile-file` and `--patch-file`.
+
+All commands emit one JSON object. Success payloads include store metadata, as
+in Stage 4K:
+
+```json
+{"kind": "sqlite", "persistent": true}
+{"kind": "memory", "persistent": false}
+```
+
+Mutating commands remain persistent-store-only. They must reject nonpersistent
+memory-store configs unless a future implementation plan explicitly adds and
+tests a development-only override. This keeps the CLI consistent with Stage 4K:
+read-only memory inspection may be useful in tests, but mutation should not
+pretend to persist.
+
+Expected success payloads:
+
+```json
+{"ok": true, "profile": {}, "store": {"kind": "sqlite", "persistent": true}}
+{"ok": true, "profile": {}, "store": {"kind": "sqlite", "persistent": true}}
+{"ok": true, "profile_id": "workspace-researcher", "store": {"kind": "sqlite", "persistent": true}}
+```
+
+CLI exit codes remain:
+
+- `0`: success.
+- `1`: domain error.
+- `2`: argument parsing or request-shape error.
+
+## Validation And Data Flow
+
+Create flow:
+
+1. FastAPI or CLI parses JSON input.
+2. The manager validates the input as `MCPProfile`.
+3. The manager checks for duplicate profile IDs.
+4. The manager normalizes mutation timestamps.
+5. The manager persists through `ProfileStore.upsert_profile()`.
+6. The manager writes a compact audit event.
+
+Patch flow:
+
+1. FastAPI or CLI parses a constrained patch request.
+2. The manager loads the existing profile.
+3. The manager rejects unsupported fields.
+4. The manager rejects `enabled=false` for the current gateway default profile.
+5. The manager applies provided field replacements only.
+6. The manager validates the resulting `MCPProfile`.
+7. The manager persists and audits.
+
+Delete flow:
+
+1. The manager loads the profile.
+2. The manager checks whether it is the current gateway default.
+3. The manager calls `ProfileAssignmentStore.list_assignments(profile_id=...)`.
+4. If any assignment exists, deletion is rejected.
+5. Otherwise, the manager calls `ProfileStore.delete_profile()`.
+6. The manager writes a compact audit event.
+
+## Audit Behavior
+
+Audit remains best effort and compact. Success and expected failure events should
+include operation type, profile ID, result, reason code when applicable, and a
+small set of changed field names. They should not include full profile policy
+documents, resource constraints, grants, approval policies, or credential-like
+material.
+
+Expected failure audit examples:
+
+- Duplicate ID during create.
+- Unsupported patch field.
+- Default-profile disable protection.
+- Default-profile delete protection.
+- Assignment delete protection.
+
+Unexpected audit-store failures should be logged but should not make successful
+profile mutations fail, preserving the Stage 4K audit posture.
+
+## Testing Plan
+
+Manager tests should cover:
+
+- Creating a valid profile and auditing success.
+- Rejecting duplicate profile IDs.
+- Patching allowed fields and preserving omitted fields.
+- Replacing `metadata` and individual policy fields rather than merging them.
+- Rejecting unsupported patch fields.
+- Rejecting `enabled=false` when the profile is the current gateway default.
+- Deleting a non-default unassigned profile.
+- Rejecting deletion of the current default profile.
+- Rejecting deletion of a profile with assignments.
+- Compact audit events for expected failures.
+
+FastAPI tests should cover:
+
+- `POST /profiles` success and duplicate failure.
+- `PATCH /profiles/{profile_id}` success.
+- Blocked default disable through `PATCH /profiles/{profile_id}`.
+- `DELETE /profiles/{profile_id}` success.
+- Blocked delete for default and assigned profiles.
+- Deterministic reason-code to HTTP-status mapping.
+
+CLI tests should cover:
+
+- `create-profile --profile-file`.
+- `create-profile --profile-file -`.
+- `patch-profile <profile_id> --patch-file`.
+- `patch-profile <profile_id> --patch-file -`.
+- `delete-profile <profile_id>`.
+- Guarded delete and default-disable domain errors.
+- Persistent-store requirement for all mutating commands.
+
+## Implementation Notes
+
+Implementation should stay close to the Stage 4K patterns:
+
+- Add request/response models near the existing FastAPI management models.
+- Extend `_PROFILE_MANAGEMENT_STATUS_CODES` rather than introducing a second
+  error mapper.
+- Keep CLI JSON rendering and domain-error rendering consistent with current
+  profile commands.
+- Prefer manager-level helper methods for default detection and assignment
+  checks so FastAPI and CLI do not duplicate safety rules.
+- Preserve copy isolation when returning profile documents.
+- Avoid storage-layer migrations unless tests reveal a current store contract
+  mismatch.
+
+## Acceptance Criteria
+
+- The design is tracked by Backlog task `TASK-573`.
+- A reviewed Stage 4L implementation plan can be written from this spec without
+  reopening CRUD scope questions.
+- The planned implementation keeps all profile mutations behind
+  `GatewayProfileManager`.
+- The planned implementation does not include assignment CRUD, approval policy
+  editing, path scope editing, external server grants, credential grants, or UI
+  changes.

--- a/backlog/tasks/task-573 - MCP-Unified-Stage-4L-editable-profile-CRUD-design.md
+++ b/backlog/tasks/task-573 - MCP-Unified-Stage-4L-editable-profile-CRUD-design.md
@@ -1,0 +1,56 @@
+---
+id: TASK-573
+title: MCP Unified Stage 4L editable profile CRUD design
+status: In Progress
+assignee: []
+created_date: ''
+updated_date: '2026-05-31 15:32'
+labels:
+  - mcp-unified
+  - design
+  - stage-4l
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Write and review the Stage 4L design spec for manager-first editable profile CRUD, covering create, limited patch, guarded delete, FastAPI/CLI surfaces, validation, audit behavior, and test scope.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Stage 4L design spec captures manager-first editable profile CRUD scope.
+- [ ] #2 Spec covers FastAPI and CLI contracts for create, limited patch, and guarded delete.
+- [ ] #3 Spec documents safety rules for duplicate create, unsupported patch fields, default disable, default delete, and assigned-profile delete.
+- [ ] #4 Spec documents non-goals for assignment CRUD, approval policy editing, path scopes, grants, and UI changes.
+- [ ] #5 Spec review loop is completed and results are recorded.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Design-only task. After human and reviewer approval, invoke the writing-plans skill to create the Stage 4L implementation plan in a separate plan artifact.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Spec drafted at Docs/superpowers/specs/2026-05-31-mcp-unified-stage4l-editable-profile-crud-design.md. Awaiting reviewer loop.
+<!-- SECTION:NOTES:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/backlog/tasks/task-573 - MCP-Unified-Stage-4L-editable-profile-CRUD-design.md
+++ b/backlog/tasks/task-573 - MCP-Unified-Stage-4L-editable-profile-CRUD-design.md
@@ -4,7 +4,7 @@ title: MCP Unified Stage 4L editable profile CRUD design
 status: In Progress
 assignee: []
 created_date: ''
-updated_date: '2026-05-31 15:32'
+updated_date: '2026-05-31 15:36'
 labels:
   - mcp-unified
   - design
@@ -36,8 +36,13 @@ Design-only task. After human and reviewer approval, invoke the writing-plans sk
 ## Implementation Notes
 
 <!-- SECTION:NOTES:BEGIN -->
-Spec drafted at Docs/superpowers/specs/2026-05-31-mcp-unified-stage4l-editable-profile-crud-design.md. Awaiting reviewer loop.
+Spec drafted at Docs/superpowers/specs/2026-05-31-mcp-unified-stage4l-editable-profile-crud-design.md. Spec reviewer approved with no blocking issues; advisory clarifications for disabled default create, scoped delete guards, malformed JSON tests, and the disabled-default-create manager test were incorporated.
 <!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+<!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
@@ -48,9 +53,3 @@ Spec drafted at Docs/superpowers/specs/2026-05-31-mcp-unified-stage4l-editable-p
 - [ ] #5 Final summary added
 - [ ] #6 Known skips or blockers documented
 <!-- DOD:END -->
-
-## Final Summary
-
-<!-- SECTION:FINAL_SUMMARY:BEGIN -->
-
-<!-- SECTION:FINAL_SUMMARY:END -->

--- a/backlog/tasks/task-573 - MCP-Unified-Stage-4L-editable-profile-CRUD-design.md
+++ b/backlog/tasks/task-573 - MCP-Unified-Stage-4L-editable-profile-CRUD-design.md
@@ -36,7 +36,7 @@ Design-only task. After human and reviewer approval, invoke the writing-plans sk
 ## Implementation Notes
 
 <!-- SECTION:NOTES:BEGIN -->
-Spec drafted at Docs/superpowers/specs/2026-05-31-mcp-unified-stage4l-editable-profile-crud-design.md. Spec reviewer approved with no blocking issues; advisory clarifications for disabled default create, scoped delete guards, malformed JSON tests, and the disabled-default-create manager test were incorporated.
+Spec drafted at Docs/superpowers/specs/2026-05-31-mcp-unified-stage4l-editable-profile-crud-design.md. Spec reviewer approved with no blocking issues; advisory clarifications for disabled default create, scoped delete guards, malformed JSON tests, and the disabled-default-create manager test were incorporated. A follow-up self-review tightened effective-default wording, no-op patch handling, nested policy patch rejection, reason-code specificity, and persistent-store guarded delete requirements.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-573 - MCP-Unified-Stage-4L-editable-profile-CRUD-design.md
+++ b/backlog/tasks/task-573 - MCP-Unified-Stage-4L-editable-profile-CRUD-design.md
@@ -1,15 +1,18 @@
 ---
 id: TASK-573
 title: MCP Unified Stage 4L editable profile CRUD design
-status: In Progress
+status: Done
 assignee: []
 created_date: ''
-updated_date: '2026-05-31 15:36'
+updated_date: 2026-05-31 15:36
 labels:
-  - mcp-unified
-  - design
-  - stage-4l
+- mcp-unified
+- design
+- stage-4l
 dependencies: []
+modified_files:
+- Docs/superpowers/specs/2026-05-31-mcp-unified-stage4l-editable-profile-crud-design.md
+- backlog/tasks/task-573 - MCP-Unified-Stage-4L-editable-profile-CRUD-design.md
 ---
 
 ## Description
@@ -20,11 +23,11 @@ Write and review the Stage 4L design spec for manager-first editable profile CRU
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Stage 4L design spec captures manager-first editable profile CRUD scope.
-- [ ] #2 Spec covers FastAPI and CLI contracts for create, limited patch, and guarded delete.
-- [ ] #3 Spec documents safety rules for duplicate create, unsupported patch fields, default disable, default delete, and assigned-profile delete.
-- [ ] #4 Spec documents non-goals for assignment CRUD, approval policy editing, path scopes, grants, and UI changes.
-- [ ] #5 Spec review loop is completed and results are recorded.
+- [x] #1 Stage 4L design spec captures manager-first editable profile CRUD scope.
+- [x] #2 Spec covers FastAPI and CLI contracts for create, limited patch, and guarded delete.
+- [x] #3 Spec documents safety rules for duplicate create, unsupported patch fields, default disable, default delete, and assigned-profile delete.
+- [x] #4 Spec documents non-goals for assignment CRUD, approval policy editing, path scopes, grants, and UI changes.
+- [x] #5 Spec review loop is completed and results are recorded.
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -42,14 +45,15 @@ Spec drafted at Docs/superpowers/specs/2026-05-31-mcp-unified-stage4l-editable-p
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Stage 4L design spec was written and reviewed. It captures manager-first editable profile CRUD scope, FastAPI and CLI contracts, safety rules for duplicate create, unsupported/no-op patch, default protections, assigned-profile delete protection, compact audit posture, persistent-store guarded delete requirements, and explicit non-goals. Follow-up implementation planning and execution are tracked in TASK-574 and TASK-575. Known skips/blockers: Bandit not applicable for design-only task; no blockers.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->

--- a/backlog/tasks/task-574 - Plan-MCP-Unified-Stage-4L-editable-profile-CRUD-implementation.md
+++ b/backlog/tasks/task-574 - Plan-MCP-Unified-Stage-4L-editable-profile-CRUD-implementation.md
@@ -1,0 +1,48 @@
+---
+id: TASK-574
+title: Plan MCP Unified Stage 4L editable profile CRUD implementation
+status: In Progress
+labels:
+- mcp-unified
+- planning
+- stage-4l
+modified_files:
+- Docs/superpowers/plans/2026-05-31-mcp-unified-stage4l-editable-profile-crud-implementation-plan.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Write and review the Stage 4L implementation plan for manager-first editable profile create, limited patch, guarded delete, FastAPI/CLI surfaces, and focused tests.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Implementation plan is written under `Docs/superpowers/plans/`.
+- [ ] #2 Plan maps exact files for manager, storage, FastAPI, CLI, and tests.
+- [ ] #3 Plan follows TDD with RED/GREEN test commands and expected outcomes.
+- [ ] #4 Plan covers persistent-store guarded delete requirements from the approved spec.
+- [ ] #5 Plan review loop is completed and results are recorded.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Plan drafted at Docs/superpowers/plans/2026-05-31-mcp-unified-stage4l-editable-profile-crud-implementation-plan.md. First plan review found gaps in semantic no-op patch handling and expected-failure audit coverage; the plan was revised to cover those cases plus explicit delete response and fallback-default create tests. Second plan review approved with no blocking issues; advisory FastAPI `ConfigDict` import note was incorporated.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-574 - Plan-MCP-Unified-Stage-4L-editable-profile-CRUD-implementation.md
+++ b/backlog/tasks/task-574 - Plan-MCP-Unified-Stage-4L-editable-profile-CRUD-implementation.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-574
 title: Plan MCP Unified Stage 4L editable profile CRUD implementation
-status: In Progress
+status: Done
 labels:
 - mcp-unified
 - planning
@@ -18,11 +18,11 @@ Write and review the Stage 4L implementation plan for manager-first editable pro
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Implementation plan is written under `Docs/superpowers/plans/`.
-- [ ] #2 Plan maps exact files for manager, storage, FastAPI, CLI, and tests.
-- [ ] #3 Plan follows TDD with RED/GREEN test commands and expected outcomes.
-- [ ] #4 Plan covers persistent-store guarded delete requirements from the approved spec.
-- [ ] #5 Plan review loop is completed and results are recorded.
+- [x] #1 Implementation plan is written under `Docs/superpowers/plans/`.
+- [x] #2 Plan maps exact files for manager, storage, FastAPI, CLI, and tests.
+- [x] #3 Plan follows TDD with RED/GREEN test commands and expected outcomes.
+- [x] #4 Plan covers persistent-store guarded delete requirements from the approved spec.
+- [x] #5 Plan review loop is completed and results are recorded.
 <!-- AC:END -->
 
 ## Implementation Notes
@@ -34,15 +34,15 @@ Plan drafted at Docs/superpowers/plans/2026-05-31-mcp-unified-stage4l-editable-p
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-
+Implementation plan was written, reviewed, revised for semantic no-op patch/audit coverage and FastAPI model import details, and then executed through Stage 4L implementation task TASK-575. The plan remained the governing checklist for manager/storage, FastAPI, CLI, verification, and Backlog closeout. Verification is recorded on TASK-575. Known skips/blockers: none for the planning slice.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->

--- a/backlog/tasks/task-575 - Implement-MCP-Unified-Stage-4L-editable-profile-CRUD.md
+++ b/backlog/tasks/task-575 - Implement-MCP-Unified-Stage-4L-editable-profile-CRUD.md
@@ -6,6 +6,10 @@ labels:
 - mcp-unified
 - implementation
 - stage-4l
+modified_files:
+- mcp_unified/interfaces/storage.py
+- mcp_unified/gateway/profiles.py
+- mcp_unified/storage/sqlite.py
 ---
 
 ## Description

--- a/backlog/tasks/task-575 - Implement-MCP-Unified-Stage-4L-editable-profile-CRUD.md
+++ b/backlog/tasks/task-575 - Implement-MCP-Unified-Stage-4L-editable-profile-CRUD.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-575
 title: Implement MCP Unified Stage 4L editable profile CRUD
-status: In Progress
+status: Done
 labels:
 - mcp-unified
 - implementation
@@ -12,8 +12,10 @@ modified_files:
 - mcp_unified/storage/sqlite.py
 - mcp_unified/gateway/fastapi.py
 - mcp_unified/gateway/cli.py
+- tldw_Server_API/app/core/MCP_unified/tests/test_gateway_profile_management.py
 - tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py
 - tldw_Server_API/app/core/MCP_unified/tests/test_gateway_cli_package.py
+- backlog/tasks/task-575 - Implement-MCP-Unified-Stage-4L-editable-profile-CRUD.md
 ---
 
 ## Description
@@ -24,11 +26,11 @@ Implement the approved Stage 4L plan for manager-owned editable profile create, 
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Manager-owned create, limited patch, and guarded delete are implemented.
-- [ ] #2 Persistent-store delete uses an atomic or serialized guarded-delete path.
-- [ ] #3 FastAPI exposes `POST /profiles`, `PATCH /profiles/{profile_id}`, and `DELETE /profiles/{profile_id}` with deterministic reason-code mapping.
-- [ ] #4 CLI exposes `create-profile`, `patch-profile`, and `delete-profile` with file/stdin JSON input where applicable.
-- [ ] #5 Focused manager, FastAPI, CLI, boundary, and Bandit verification is recorded.
+- [x] #1 Manager-owned create, limited patch, and guarded delete are implemented.
+- [x] #2 Persistent-store delete uses an atomic or serialized guarded-delete path.
+- [x] #3 FastAPI exposes `POST /profiles`, `PATCH /profiles/{profile_id}`, and `DELETE /profiles/{profile_id}` with deterministic reason-code mapping.
+- [x] #4 CLI exposes `create-profile`, `patch-profile`, and `delete-profile` with file/stdin JSON input where applicable.
+- [x] #5 Focused manager, FastAPI, CLI, boundary, and Bandit verification is recorded.
 <!-- AC:END -->
 
 ## Implementation Notes
@@ -40,15 +42,15 @@ Implementation follows `Docs/superpowers/plans/2026-05-31-mcp-unified-stage4l-ed
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-
+Implemented MCP Unified Stage 4L editable profile CRUD end to end. Added manager-owned full profile create, limited semantic patch, and guarded hard delete; added persistent SQLite guarded delete via SQLAlchemy Core and async offload; exposed FastAPI POST/PATCH/DELETE profile routes; and added CLI create-profile, patch-profile, and delete-profile commands with persistent-store enforcement and file/stdin JSON handling. Verification: focused MCP Unified suite passed (190 passed, 4 warnings); package boundary suite passed (9 passed, 3 warnings); Bandit on touched package files reported 0 results and 0 errors; git diff --check was clean. Known skips/blockers: full repository suite not run; no blockers.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->

--- a/backlog/tasks/task-575 - Implement-MCP-Unified-Stage-4L-editable-profile-CRUD.md
+++ b/backlog/tasks/task-575 - Implement-MCP-Unified-Stage-4L-editable-profile-CRUD.md
@@ -10,6 +10,8 @@ modified_files:
 - mcp_unified/interfaces/storage.py
 - mcp_unified/gateway/profiles.py
 - mcp_unified/storage/sqlite.py
+- mcp_unified/gateway/fastapi.py
+- tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py
 ---
 
 ## Description

--- a/backlog/tasks/task-575 - Implement-MCP-Unified-Stage-4L-editable-profile-CRUD.md
+++ b/backlog/tasks/task-575 - Implement-MCP-Unified-Stage-4L-editable-profile-CRUD.md
@@ -11,7 +11,9 @@ modified_files:
 - mcp_unified/gateway/profiles.py
 - mcp_unified/storage/sqlite.py
 - mcp_unified/gateway/fastapi.py
+- mcp_unified/gateway/cli.py
 - tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py
+- tldw_Server_API/app/core/MCP_unified/tests/test_gateway_cli_package.py
 ---
 
 ## Description

--- a/backlog/tasks/task-575 - Implement-MCP-Unified-Stage-4L-editable-profile-CRUD.md
+++ b/backlog/tasks/task-575 - Implement-MCP-Unified-Stage-4L-editable-profile-CRUD.md
@@ -1,0 +1,46 @@
+---
+id: TASK-575
+title: Implement MCP Unified Stage 4L editable profile CRUD
+status: In Progress
+labels:
+- mcp-unified
+- implementation
+- stage-4l
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement the approved Stage 4L plan for manager-owned editable profile create, limited patch, guarded delete, FastAPI routes, CLI commands, focused tests, and verification.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Manager-owned create, limited patch, and guarded delete are implemented.
+- [ ] #2 Persistent-store delete uses an atomic or serialized guarded-delete path.
+- [ ] #3 FastAPI exposes `POST /profiles`, `PATCH /profiles/{profile_id}`, and `DELETE /profiles/{profile_id}` with deterministic reason-code mapping.
+- [ ] #4 CLI exposes `create-profile`, `patch-profile`, and `delete-profile` with file/stdin JSON input where applicable.
+- [ ] #5 Focused manager, FastAPI, CLI, boundary, and Bandit verification is recorded.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Implementation follows `Docs/superpowers/plans/2026-05-31-mcp-unified-stage4l-editable-profile-crud-implementation-plan.md`.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-576 - Address-MCP-Stage-4L-PR-review-findings.md
+++ b/backlog/tasks/task-576 - Address-MCP-Stage-4L-PR-review-findings.md
@@ -1,0 +1,53 @@
+---
+id: TASK-576
+title: Address MCP Stage 4L PR review findings
+status: Done
+assignee: []
+created_date: ''
+updated_date: '2026-05-31 18:42'
+labels:
+  - mcp-unified
+  - stage-4l
+  - pr-review
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Fix still-valid PR #2195 review findings for Stage 4L editable profile CRUD: narrow Pydantic validation exception handling, normalize create id/name inputs, make create duplicate handling atomic at the store boundary, harden guarded delete error/status handling, and handle patching profiles with no policy_document. Keep changes minimal and validate focused MCP tests plus Bandit.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Broad except Exception handlers in create/patch validation are narrowed to expected validation/payload exceptions.
+- [x] #2 Profile create rejects or consistently normalizes whitespace id/name values so unaddressable profiles cannot be created.
+- [x] #3 Create duplicate detection uses a store-level create-if-absent path rather than read-then-upsert.
+- [x] #4 Guarded delete translates store failures and unknown statuses to domain errors with audit events instead of misclassifying as default profile.
+- [x] #5 Policy document patch handles profiles whose policy_document is None without crashing.
+- [x] #6 Focused MCP profile/FastAPI/CLI tests pass and touched-scope Bandit is clean.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Verified current PR review findings against rebased branch after syncing with origin/dev. All five reported code-level issues remain valid: broad Pydantic catches, whitespace create id/name behavior, create read-then-upsert TOCTOU, guarded delete unknown/status failure handling, and policy_document None patch crash.
+
+Implemented PR review fixes after rebasing on origin/dev: create now uses store-level create_profile conflict handling; create id/name are normalized; validation catches are narrowed; guarded delete translates store failures and unknown results; policy_document patches handle missing stored policies.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Addressed all current PR #2195 review findings from Qodo, CodeRabbit, and Gemini. Added store-level atomic create support for memory and SQLite stores, manager validation/normalization/error handling hardening, explicit unexpected delete status mapping, and regression coverage. Verification: 223 focused MCP tests passed, Ruff touched-file check passed, Bandit touched-scope scan reported 0 results/0 errors, and git diff --check was clean.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-577 - Address-MCP-Stage-4L-PR-closeout-metadata-and-docstrings.md
+++ b/backlog/tasks/task-577 - Address-MCP-Stage-4L-PR-closeout-metadata-and-docstrings.md
@@ -1,0 +1,51 @@
+---
+id: TASK-577
+title: Address MCP Stage 4L PR closeout metadata and docstrings
+status: Done
+assignee: []
+created_date: ''
+updated_date: '2026-05-31 19:07'
+labels:
+  - mcp-unified
+  - stage-4l
+  - pr-review
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Address remaining PR #2195 closeout comments after code review fixes: complete PR description validation/risk/rollback metadata, resolve stale review threads with evidence, and add concise docstrings to touched public MCP gateway/storage protocol surfaces so the PR does not worsen docstring coverage warnings.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 PR body includes validation checklist, UX/Watchlists applicability, risk level, rollback plan, and AI-authored PR note.
+- [x] #2 Unresolved stale review threads are replied to or resolved with fix evidence.
+- [x] #3 Touched public FastAPI route handlers and storage protocol methods have concise docstrings where missing.
+- [x] #4 Focused MCP tests, Ruff touched-file check, Bandit touched-scope scan, and git diff --check are clean.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Verified current PR state after commit 733392167e. Remaining items are closeout/metadata: CodeRabbit PR description checklist, repo-wide docstring warning, and stale unresolved review threads whose findings are already fixed in current code.
+
+Added concise docstrings to touched public FastAPI route handlers and storage protocol methods. Prepared a complete PR body with validation, UX/Watchlists applicability, risk, rollback, and docstring coverage context. Review-thread resolution will reference the fixed current code after push.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Addressed remaining PR closeout comments: completed PR metadata, documented touched public MCP gateway/storage surfaces, and prepared stale review-thread replies/resolution. Verification: 223 focused MCP tests passed, Ruff touched-file check passed, Bandit touched-scope scan reported 0 results/0 errors, git diff --check was clean, and an AST public-docstring audit reported 0 gaps for touched MCP files.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/mcp_unified/gateway/cli.py
+++ b/mcp_unified/gateway/cli.py
@@ -169,6 +169,47 @@ def _build_parser() -> _JsonArgumentParser:
     _add_profile_config_argument(duplicate_preset)
     duplicate_preset.set_defaults(handler=_handle_duplicate_preset)
 
+    create_profile = subparsers.add_parser(
+        "create-profile",
+        help="Create a user-editable profile in a persistent gateway store.",
+    )
+    create_profile.add_argument(
+        "--profile-file",
+        type=Path,
+        required=True,
+        help="Path to a JSON profile object, or '-' to read from stdin.",
+    )
+    _add_profile_config_argument(create_profile)
+    create_profile.set_defaults(handler=_handle_create_profile)
+
+    patch_profile = subparsers.add_parser(
+        "patch-profile",
+        help="Patch a stored profile in a persistent gateway store.",
+    )
+    patch_profile.add_argument(
+        "profile_id",
+        help="Profile id to patch.",
+    )
+    patch_profile.add_argument(
+        "--patch-file",
+        type=Path,
+        required=True,
+        help="Path to a JSON patch object, or '-' to read from stdin.",
+    )
+    _add_profile_config_argument(patch_profile)
+    patch_profile.set_defaults(handler=_handle_patch_profile)
+
+    delete_profile = subparsers.add_parser(
+        "delete-profile",
+        help="Delete an unassigned non-default profile in a persistent gateway store.",
+    )
+    delete_profile.add_argument(
+        "profile_id",
+        help="Profile id to delete.",
+    )
+    _add_profile_config_argument(delete_profile)
+    delete_profile.set_defaults(handler=_handle_delete_profile)
+
     get_default_profile = subparsers.add_parser(
         "get-default-profile",
         help="Show the active gateway default profile.",
@@ -264,6 +305,43 @@ def _handle_duplicate_preset(args: argparse.Namespace) -> int:
             profile_id=profile_id,
             name=name,
         ),
+        require_persistent=True,
+    )
+
+
+def _handle_create_profile(args: argparse.Namespace) -> int:
+    """Create one user-editable profile from a JSON file or stdin payload."""
+
+    return _handle_profile_management_command(
+        args,
+        lambda manager: manager.create_profile(
+            _load_json_argument_file(args.profile_file, label="profile"),
+        ),
+        require_persistent=True,
+    )
+
+
+def _handle_patch_profile(args: argparse.Namespace) -> int:
+    """Patch one stored profile using a JSON file or stdin payload."""
+
+    profile_id = _require_cli_text(args.profile_id, field="profile_id")
+    return _handle_profile_management_command(
+        args,
+        lambda manager: manager.patch_profile(
+            profile_id,
+            _load_json_argument_file(args.patch_file, label="patch"),
+        ),
+        require_persistent=True,
+    )
+
+
+def _handle_delete_profile(args: argparse.Namespace) -> int:
+    """Delete one stored profile from a persistent gateway store."""
+
+    profile_id = _require_cli_text(args.profile_id, field="profile_id")
+    return _handle_profile_management_command(
+        args,
+        lambda manager: manager.delete_profile(profile_id),
         require_persistent=True,
     )
 
@@ -503,6 +581,27 @@ def _optional_cli_text(value: str | None, *, field: str) -> str | None:
     if not normalized:
         raise _CliArgumentError(f"{field} cannot be empty")
     return normalized
+
+
+def _load_json_argument_file(path: Path, *, label: str) -> dict[str, Any]:
+    """Load one JSON object payload from a file path or stdin marker '-'."""
+
+    try:
+        if str(path) == "-":
+            payload_text = sys.stdin.read()
+        else:
+            payload_text = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise _CliArgumentError(f"Unable to read {label} JSON: {exc}") from exc
+
+    try:
+        payload = json.loads(payload_text)
+    except json.JSONDecodeError as exc:
+        raise _CliArgumentError(f"Invalid {label} JSON: {exc.msg}") from exc
+
+    if not isinstance(payload, dict):
+        raise _CliArgumentError(f"{label} JSON must be an object")
+    return payload
 
 
 def _handle_list_presets(_args: argparse.Namespace) -> int:

--- a/mcp_unified/gateway/fastapi.py
+++ b/mcp_unified/gateway/fastapi.py
@@ -272,6 +272,7 @@ def _mount_profile_management_routes(
 
     @router.get("/profiles", response_model=ProfileListResponse)
     async def list_profiles() -> ProfileListResponse | JSONResponse:
+        """Return editable MCP profiles from the configured profile manager."""
         try:
             return await manager.list_profiles()
         except GatewayProfileManagementError as exc:
@@ -281,6 +282,7 @@ def _mount_profile_management_routes(
     async def create_profile(
         request: CreateProfileRequest,
     ) -> ProfileResponse | JSONResponse:
+        """Create a user-editable MCP profile."""
         try:
             return await manager.create_profile(request.model_dump(mode="json"))
         except GatewayProfileManagementError as exc:
@@ -291,6 +293,7 @@ def _mount_profile_management_routes(
         profile_id: str,
         request: PatchProfileRequest,
     ) -> ProfileResponse | JSONResponse:
+        """Apply an allowed semantic patch to an editable MCP profile."""
         try:
             return await manager.patch_profile(
                 profile_id,
@@ -301,6 +304,7 @@ def _mount_profile_management_routes(
 
     @router.delete("/profiles/{profile_id}", response_model=DeleteProfileResponse)
     async def delete_profile(profile_id: str) -> DeleteProfileResponse | JSONResponse:
+        """Delete an unassigned, non-default editable MCP profile."""
         try:
             return await manager.delete_profile(profile_id)
         except GatewayProfileManagementError as exc:
@@ -310,6 +314,7 @@ def _mount_profile_management_routes(
     async def duplicate_preset(
         request: DuplicatePresetRequest,
     ) -> DuplicatePresetResponse | JSONResponse:
+        """Duplicate a built-in profile preset into editable profile storage."""
         try:
             payload = await manager.duplicate_preset(
                 request.preset_id,
@@ -322,6 +327,7 @@ def _mount_profile_management_routes(
 
     @router.get("/profiles/default", response_model=DefaultProfileResponse)
     async def get_default_profile() -> DefaultProfileResponse | JSONResponse:
+        """Return the currently effective default MCP profile."""
         try:
             return await manager.get_default_profile()
         except GatewayProfileManagementError as exc:
@@ -331,6 +337,7 @@ def _mount_profile_management_routes(
     async def set_default_profile(
         request: SetDefaultProfileRequest,
     ) -> DefaultProfileResponse | JSONResponse:
+        """Set the gateway default MCP profile assignment."""
         try:
             return await manager.set_default_profile(request.profile_id)
         except GatewayProfileManagementError as exc:
@@ -338,6 +345,7 @@ def _mount_profile_management_routes(
 
     @router.get("/profiles/{profile_id}", response_model=ProfileResponse)
     async def show_profile(profile_id: str) -> ProfileResponse | JSONResponse:
+        """Return a single editable MCP profile by id."""
         try:
             return await manager.show_profile(profile_id)
         except GatewayProfileManagementError as exc:

--- a/mcp_unified/gateway/fastapi.py
+++ b/mcp_unified/gateway/fastapi.py
@@ -7,7 +7,7 @@ from typing import Any, Literal
 
 from fastapi import APIRouter, FastAPI, Request, Response, WebSocket, WebSocketDisconnect
 from fastapi.responses import JSONResponse
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 
 from .bootstrap import GatewayProfileBootstrap
 from .jsonrpc import (
@@ -47,8 +47,11 @@ _PROFILE_MANAGEMENT_STATUS_CODES = {
     "preset_not_found": 404,
     "default_profile_not_configured": 404,
     "profile_disabled": 409,
+    "profile_is_default": 409,
+    "profile_has_assignments": 409,
     "profile_already_exists": 409,
     "invalid_profile_request": 422,
+    "invalid_profile_patch": 422,
     "profile_store_unavailable": 503,
     "assignment_store_unavailable": 503,
 }
@@ -66,6 +69,21 @@ class SetDefaultProfileRequest(BaseModel):
     """Request body for changing the gateway default profile."""
 
     profile_id: str
+
+
+class CreateProfileRequest(BaseModel):
+    """Request body for creating a user-editable gateway profile."""
+
+    model_config = ConfigDict(extra="allow")
+
+    id: str
+    name: str
+
+
+class PatchProfileRequest(BaseModel):
+    """Request body for patching a user-editable gateway profile."""
+
+    model_config = ConfigDict(extra="allow")
 
 
 class StoreMetadataResponse(BaseModel):
@@ -108,6 +126,14 @@ class DefaultProfileResponse(BaseModel):
     profile: dict[str, Any]
     assignment: dict[str, Any] | None
     default: dict[str, Any]
+    store: StoreMetadataResponse
+
+
+class DeleteProfileResponse(BaseModel):
+    """Response body for deleting one stored gateway profile."""
+
+    ok: bool
+    profile_id: str
     store: StoreMetadataResponse
 
 
@@ -247,6 +273,35 @@ def _mount_profile_management_routes(
     async def list_profiles() -> ProfileListResponse | JSONResponse:
         try:
             return await manager.list_profiles()
+        except GatewayProfileManagementError as exc:
+            return _profile_management_error_response(exc)
+
+    @router.post("/profiles", response_model=ProfileResponse)
+    async def create_profile(
+        request: CreateProfileRequest,
+    ) -> ProfileResponse | JSONResponse:
+        try:
+            return await manager.create_profile(request.model_dump(mode="json"))
+        except GatewayProfileManagementError as exc:
+            return _profile_management_error_response(exc)
+
+    @router.patch("/profiles/{profile_id}", response_model=ProfileResponse)
+    async def patch_profile(
+        profile_id: str,
+        request: PatchProfileRequest,
+    ) -> ProfileResponse | JSONResponse:
+        try:
+            return await manager.patch_profile(
+                profile_id,
+                request.model_dump(mode="json", exclude_unset=True),
+            )
+        except GatewayProfileManagementError as exc:
+            return _profile_management_error_response(exc)
+
+    @router.delete("/profiles/{profile_id}", response_model=DeleteProfileResponse)
+    async def delete_profile(profile_id: str) -> DeleteProfileResponse | JSONResponse:
+        try:
+            return await manager.delete_profile(profile_id)
         except GatewayProfileManagementError as exc:
             return _profile_management_error_response(exc)
 

--- a/mcp_unified/gateway/fastapi.py
+++ b/mcp_unified/gateway/fastapi.py
@@ -54,6 +54,7 @@ _PROFILE_MANAGEMENT_STATUS_CODES = {
     "invalid_profile_patch": 422,
     "profile_store_unavailable": 503,
     "assignment_store_unavailable": 503,
+    "unexpected_delete_result": 500,
 }
 
 

--- a/mcp_unified/gateway/profiles.py
+++ b/mcp_unified/gateway/profiles.py
@@ -22,6 +22,7 @@ from mcp_unified.profiles.defaults import (
 from mcp_unified.profiles.models import MCPProfile
 from mcp_unified.profiles.presets import duplicate_builtin_preset, get_builtin_preset
 from mcp_unified.profiles.store import (
+    ProfileAlreadyExistsError,
     ProfileAssignmentStoreUnavailableError,
     ProfileStoreUnavailableError,
 )
@@ -230,25 +231,18 @@ class GatewayProfileManager:
                 if isinstance(profile_document, MCPProfile)
                 else MCPProfile.model_validate(profile_document)
             )
-        except Exception as exc:
+        except (TypeError, ValueError) as exc:
             raise self._error(
                 "Invalid profile request",
                 reason_code="invalid_profile_request",
             ) from exc
 
-        if await self._get_profile(profile.id) is not None:
-            await self._audit_expected_failure(
-                "profile.create_failed",
-                reason_code="profile_already_exists",
-                profile_id=profile.id,
-                target_type="profile",
-                target_id=profile.id,
-            )
-            raise self._error(
-                f"Profile already exists: {profile.id}",
-                reason_code="profile_already_exists",
-                profile_id=profile.id,
-            )
+        normalized_profile_id = self._require_text(profile.id, field="profile_id")
+        normalized_name = self._require_text(profile.name, field="name")
+        profile = profile.model_copy(
+            update={"id": normalized_profile_id, "name": normalized_name},
+            deep=True,
+        )
 
         effective_default_id = await self._effective_default_profile_id()
         if not profile.enabled and profile.id == effective_default_id:
@@ -268,7 +262,20 @@ class GatewayProfileManager:
         now = datetime.now(timezone.utc)
         profile = profile.model_copy(update={"updated_at": now}, deep=True)
         try:
-            stored = await self.profile_store.upsert_profile(profile)
+            stored = await self.profile_store.create_profile(profile)
+        except ProfileAlreadyExistsError as exc:
+            await self._audit_expected_failure(
+                "profile.create_failed",
+                reason_code="profile_already_exists",
+                profile_id=exc.profile_id,
+                target_type="profile",
+                target_id=exc.profile_id,
+            )
+            raise self._error(
+                f"Profile already exists: {exc.profile_id}",
+                reason_code="profile_already_exists",
+                profile_id=exc.profile_id,
+            ) from exc
         except ProfileStoreUnavailableError as exc:
             raise self._error(
                 "Profile store unavailable",
@@ -408,16 +415,51 @@ class GatewayProfileManager:
             None,
         )
         if callable(guarded_delete):
-            result = await guarded_delete(
-                normalized_profile_id,
-                effective_default_profile_id=effective_default_id,
-            )
+            try:
+                result = await guarded_delete(
+                    normalized_profile_id,
+                    effective_default_profile_id=effective_default_id,
+                )
+            except ProfileStoreUnavailableError as exc:
+                await self._audit_expected_failure(
+                    "profile.delete_failed",
+                    reason_code="profile_store_unavailable",
+                    profile_id=normalized_profile_id,
+                    target_type="profile",
+                    target_id=normalized_profile_id,
+                )
+                raise self._error(
+                    "Profile store unavailable",
+                    reason_code="profile_store_unavailable",
+                    profile_id=normalized_profile_id,
+                ) from exc
+            except RuntimeError as exc:
+                await self._audit_expected_failure(
+                    "profile.delete_failed",
+                    reason_code="profile_store_unavailable",
+                    profile_id=normalized_profile_id,
+                    target_type="profile",
+                    target_id=normalized_profile_id,
+                )
+                raise self._error(
+                    "Profile store unavailable",
+                    reason_code="profile_store_unavailable",
+                    profile_id=normalized_profile_id,
+                ) from exc
         elif not self.store_metadata.persistent:
             result = await self._manager_guarded_delete(normalized_profile_id)
         else:
+            await self._audit_expected_failure(
+                "profile.delete_failed",
+                reason_code="profile_store_unavailable",
+                profile_id=normalized_profile_id,
+                target_type="profile",
+                target_id=normalized_profile_id,
+            )
             raise self._error(
                 "Profile store unavailable",
                 reason_code="profile_store_unavailable",
+                profile_id=normalized_profile_id,
             )
 
         if result == "deleted":
@@ -459,17 +501,31 @@ class GatewayProfileManager:
                 reason_code="profile_has_assignments",
                 profile_id=normalized_profile_id,
             )
+        if result == "is_default":
+            await self._audit_expected_failure(
+                "profile.delete_failed",
+                reason_code="profile_is_default",
+                profile_id=normalized_profile_id,
+                target_type="profile",
+                target_id=normalized_profile_id,
+            )
+            raise self._error(
+                f"Profile is the effective default: {normalized_profile_id}",
+                reason_code="profile_is_default",
+                profile_id=normalized_profile_id,
+            )
 
         await self._audit_expected_failure(
             "profile.delete_failed",
-            reason_code="profile_is_default",
+            reason_code="unexpected_delete_result",
             profile_id=normalized_profile_id,
             target_type="profile",
             target_id=normalized_profile_id,
+            details={"delete_result": result},
         )
         raise self._error(
-            f"Profile is the effective default: {normalized_profile_id}",
-            reason_code="profile_is_default",
+            f"Unexpected guarded delete status {result!r} for profile {normalized_profile_id}",
+            reason_code="unexpected_delete_result",
             profile_id=normalized_profile_id,
         )
 
@@ -654,6 +710,7 @@ class GatewayProfileManager:
         assignment_id: str | None = None,
         target_type: str | None = None,
         target_id: str | None = None,
+        details: Mapping[str, Any] | None = None,
     ) -> None:
         payload: dict[str, Any] = {"reason_code": reason_code}
         if profile_id is not None:
@@ -662,6 +719,8 @@ class GatewayProfileManager:
             payload["preset_id"] = preset_id
         if assignment_id is not None:
             payload["assignment_id"] = assignment_id
+        if details:
+            payload.update(details)
         await self._append_audit_event(
             event_type,
             profile_id=profile_id,
@@ -770,6 +829,14 @@ class GatewayProfileManager:
                     reason_code="invalid_profile_patch",
                 )
             normalized["policy_document"] = policy_patch
+        if "name" in normalized:
+            name = normalized["name"]
+            if not isinstance(name, str) or not name.strip():
+                raise self._error(
+                    "Invalid profile patch",
+                    reason_code="invalid_profile_patch",
+                )
+            normalized["name"] = name.strip()
         return normalized
 
     def _apply_profile_patch(
@@ -781,14 +848,18 @@ class GatewayProfileManager:
         profile_payload = profile.model_dump(mode="python")
         for field, value in patch.items():
             if field == "policy_document":
-                policy_payload = profile.policy_document.model_dump(mode="python")
+                policy_payload = (
+                    profile.policy_document.model_dump(mode="python")
+                    if profile.policy_document is not None
+                    else {}
+                )
                 policy_payload.update(dict(value))
                 profile_payload["policy_document"] = policy_payload
             else:
                 profile_payload[field] = value
         try:
             updated = MCPProfile.model_validate(profile_payload)
-        except Exception as exc:
+        except (TypeError, ValueError) as exc:
             raise self._error(
                 "Invalid profile patch",
                 reason_code="invalid_profile_patch",
@@ -825,10 +896,14 @@ class GatewayProfileManager:
         return normalized
 
     @staticmethod
-    def _optional_text(value: str | None, *, field: str) -> str | None:
-        del field
+    def _optional_text(value: object | None, *, field: str) -> str | None:
         if value is None:
             return None
+        if not isinstance(value, str):
+            raise GatewayProfileManagementError(
+                f"Invalid profile request: {field} must be text",
+                reason_code="invalid_profile_request",
+            )
         normalized = value.strip()
         if not normalized:
             raise GatewayProfileManagementError(

--- a/mcp_unified/gateway/profiles.py
+++ b/mcp_unified/gateway/profiles.py
@@ -27,6 +27,22 @@ from mcp_unified.profiles.store import (
 )
 from mcp_unified.storage.models import AuditEvent, ProfileAssignment
 
+_PROFILE_PATCH_FIELDS = frozenset(
+    {"name", "description", "enabled", "metadata", "policy_document"}
+)
+_POLICY_PATCH_FIELDS = frozenset(
+    {
+        "allowed_tools",
+        "denied_tools",
+        "capabilities",
+        "denied_capabilities",
+        "tool_patterns",
+        "module_patterns",
+        "risk_classes",
+        "resource_constraints",
+    }
+)
+
 
 @dataclass(frozen=True, slots=True)
 class GatewayProfileStoreMetadata:
@@ -202,6 +218,260 @@ class GatewayProfileManager:
             "profile": self._dump_profile(stored),
             "store": self.store_metadata.to_payload(),
         }
+
+    async def create_profile(
+        self,
+        profile_document: MCPProfile | Mapping[str, Any],
+    ) -> dict[str, Any]:
+        """Create a user-editable gateway profile."""
+        try:
+            profile = (
+                profile_document.model_copy(deep=True)
+                if isinstance(profile_document, MCPProfile)
+                else MCPProfile.model_validate(profile_document)
+            )
+        except Exception as exc:
+            raise self._error(
+                "Invalid profile request",
+                reason_code="invalid_profile_request",
+            ) from exc
+
+        if await self._get_profile(profile.id) is not None:
+            await self._audit_expected_failure(
+                "profile.create_failed",
+                reason_code="profile_already_exists",
+                profile_id=profile.id,
+                target_type="profile",
+                target_id=profile.id,
+            )
+            raise self._error(
+                f"Profile already exists: {profile.id}",
+                reason_code="profile_already_exists",
+                profile_id=profile.id,
+            )
+
+        effective_default_id = await self._effective_default_profile_id()
+        if not profile.enabled and profile.id == effective_default_id:
+            await self._audit_expected_failure(
+                "profile.create_failed",
+                reason_code="profile_is_default",
+                profile_id=profile.id,
+                target_type="profile",
+                target_id=profile.id,
+            )
+            raise self._error(
+                f"Profile is the effective default: {profile.id}",
+                reason_code="profile_is_default",
+                profile_id=profile.id,
+            )
+
+        now = datetime.now(timezone.utc)
+        profile = profile.model_copy(update={"updated_at": now}, deep=True)
+        try:
+            stored = await self.profile_store.upsert_profile(profile)
+        except ProfileStoreUnavailableError as exc:
+            raise self._error(
+                "Profile store unavailable",
+                reason_code="profile_store_unavailable",
+                profile_id=profile.id,
+            ) from exc
+
+        await self._append_audit_event(
+            "profile.created",
+            profile_id=stored.id,
+            target_type="profile",
+            target_id=stored.id,
+            payload={"profile_id": stored.id},
+        )
+        profile_payload = self._dump_profile(stored)
+        profile_payload["created_at"] = stored.created_at.isoformat()
+        profile_payload["updated_at"] = stored.updated_at.isoformat()
+        return {
+            "ok": True,
+            "profile": profile_payload,
+            "store": self.store_metadata.to_payload(),
+        }
+
+    async def patch_profile(
+        self,
+        profile_id: str,
+        patch_document: Mapping[str, Any],
+    ) -> dict[str, Any]:
+        """Apply a limited semantic patch to a stored gateway profile."""
+        normalized_profile_id = self._require_text(profile_id, field="profile_id")
+        try:
+            patch = self._validate_patch_document(patch_document)
+        except GatewayProfileManagementError:
+            await self._audit_expected_failure(
+                "profile.patch_failed",
+                reason_code="invalid_profile_patch",
+                profile_id=normalized_profile_id,
+                target_type="profile",
+                target_id=normalized_profile_id,
+            )
+            raise
+
+        profile = await self._get_profile(normalized_profile_id)
+        if profile is None:
+            await self._audit_expected_failure(
+                "profile.patch_failed",
+                reason_code="profile_not_found",
+                profile_id=normalized_profile_id,
+                target_type="profile",
+                target_id=normalized_profile_id,
+            )
+            raise self._error(
+                f"Profile not found: {normalized_profile_id}",
+                reason_code="profile_not_found",
+                profile_id=normalized_profile_id,
+            )
+
+        if (
+            patch.get("enabled") is False
+            and normalized_profile_id == await self._effective_default_profile_id()
+        ):
+            await self._audit_expected_failure(
+                "profile.patch_failed",
+                reason_code="profile_is_default",
+                profile_id=normalized_profile_id,
+                target_type="profile",
+                target_id=normalized_profile_id,
+            )
+            raise self._error(
+                f"Profile is the effective default: {normalized_profile_id}",
+                reason_code="profile_is_default",
+                profile_id=normalized_profile_id,
+            )
+
+        try:
+            updated, changed_fields = self._apply_profile_patch(profile, patch)
+        except GatewayProfileManagementError:
+            await self._audit_expected_failure(
+                "profile.patch_failed",
+                reason_code="invalid_profile_patch",
+                profile_id=normalized_profile_id,
+                target_type="profile",
+                target_id=normalized_profile_id,
+            )
+            raise
+
+        updated = updated.model_copy(
+            update={"updated_at": datetime.now(timezone.utc)},
+            deep=True,
+        )
+        try:
+            stored = await self.profile_store.upsert_profile(updated)
+        except ProfileStoreUnavailableError as exc:
+            raise self._error(
+                "Profile store unavailable",
+                reason_code="profile_store_unavailable",
+                profile_id=normalized_profile_id,
+            ) from exc
+
+        await self._append_audit_event(
+            "profile.patched",
+            profile_id=stored.id,
+            target_type="profile",
+            target_id=stored.id,
+            payload={"profile_id": stored.id, "changed_fields": list(changed_fields)},
+        )
+        profile_payload = self._dump_profile(stored)
+        profile_payload["created_at"] = stored.created_at.isoformat()
+        profile_payload["updated_at"] = stored.updated_at.isoformat()
+        return {
+            "ok": True,
+            "profile": profile_payload,
+            "store": self.store_metadata.to_payload(),
+        }
+
+    async def delete_profile(self, profile_id: str) -> dict[str, Any]:
+        """Delete an unassigned non-default profile."""
+        normalized_profile_id = self._require_text(profile_id, field="profile_id")
+        effective_default_id = await self._effective_default_profile_id()
+        if normalized_profile_id == effective_default_id:
+            await self._audit_expected_failure(
+                "profile.delete_failed",
+                reason_code="profile_is_default",
+                profile_id=normalized_profile_id,
+                target_type="profile",
+                target_id=normalized_profile_id,
+            )
+            raise self._error(
+                f"Profile is the effective default: {normalized_profile_id}",
+                reason_code="profile_is_default",
+                profile_id=normalized_profile_id,
+            )
+
+        guarded_delete = getattr(
+            self.profile_store,
+            "delete_profile_if_unassigned",
+            None,
+        )
+        if callable(guarded_delete):
+            result = await guarded_delete(
+                normalized_profile_id,
+                effective_default_profile_id=effective_default_id,
+            )
+        elif not self.store_metadata.persistent:
+            result = await self._manager_guarded_delete(normalized_profile_id)
+        else:
+            raise self._error(
+                "Profile store unavailable",
+                reason_code="profile_store_unavailable",
+            )
+
+        if result == "deleted":
+            await self._append_audit_event(
+                "profile.deleted",
+                profile_id=normalized_profile_id,
+                target_type="profile",
+                target_id=normalized_profile_id,
+                payload={"profile_id": normalized_profile_id},
+            )
+            return {
+                "ok": True,
+                "profile_id": normalized_profile_id,
+                "store": self.store_metadata.to_payload(),
+            }
+        if result == "not_found":
+            await self._audit_expected_failure(
+                "profile.delete_failed",
+                reason_code="profile_not_found",
+                profile_id=normalized_profile_id,
+                target_type="profile",
+                target_id=normalized_profile_id,
+            )
+            raise self._error(
+                f"Profile not found: {normalized_profile_id}",
+                reason_code="profile_not_found",
+                profile_id=normalized_profile_id,
+            )
+        if result == "has_assignments":
+            await self._audit_expected_failure(
+                "profile.delete_failed",
+                reason_code="profile_has_assignments",
+                profile_id=normalized_profile_id,
+                target_type="profile",
+                target_id=normalized_profile_id,
+            )
+            raise self._error(
+                f"Profile has assignments: {normalized_profile_id}",
+                reason_code="profile_has_assignments",
+                profile_id=normalized_profile_id,
+            )
+
+        await self._audit_expected_failure(
+            "profile.delete_failed",
+            reason_code="profile_is_default",
+            profile_id=normalized_profile_id,
+            target_type="profile",
+            target_id=normalized_profile_id,
+        )
+        raise self._error(
+            f"Profile is the effective default: {normalized_profile_id}",
+            reason_code="profile_is_default",
+            profile_id=normalized_profile_id,
+        )
 
     async def get_default_profile(self) -> dict[str, Any]:
         """Return the active gateway default profile."""
@@ -430,6 +700,107 @@ class GatewayProfileManager:
                 "Profile assignment store unavailable",
                 reason_code="assignment_store_unavailable",
             ) from exc
+
+    async def _effective_default_profile_id(self) -> str | None:
+        assignment = await self._load_default_assignment()
+        if assignment is not None:
+            return assignment.profile_id
+        return self.fallback_default_profile_id
+
+    async def _manager_guarded_delete(self, profile_id: str) -> str:
+        profile = await self._get_profile(profile_id)
+        if profile is None:
+            return "not_found"
+        try:
+            assignments = await self.assignment_store.list_assignments(
+                profile_id=profile_id,
+            )
+        except ProfileAssignmentStoreUnavailableError as exc:
+            raise self._error(
+                "Profile assignment store unavailable",
+                reason_code="assignment_store_unavailable",
+            ) from exc
+        if assignments:
+            return "has_assignments"
+        try:
+            deleted = await self.profile_store.delete_profile(profile_id)
+        except ProfileStoreUnavailableError as exc:
+            raise self._error(
+                "Profile store unavailable",
+                reason_code="profile_store_unavailable",
+                profile_id=profile_id,
+            ) from exc
+        return "deleted" if deleted else "not_found"
+
+    def _validate_patch_document(self, patch: Mapping[str, Any]) -> dict[str, Any]:
+        if not isinstance(patch, Mapping):
+            raise self._error(
+                "Invalid profile patch",
+                reason_code="invalid_profile_patch",
+            )
+        normalized = dict(patch)
+        if not normalized:
+            raise self._error(
+                "Invalid profile patch",
+                reason_code="invalid_profile_patch",
+            )
+        unsupported_fields = set(normalized) - _PROFILE_PATCH_FIELDS
+        if unsupported_fields:
+            raise self._error(
+                "Invalid profile patch",
+                reason_code="invalid_profile_patch",
+            )
+        policy_patch = normalized.get("policy_document")
+        if "policy_document" in normalized:
+            if not isinstance(policy_patch, Mapping):
+                raise self._error(
+                    "Invalid profile patch",
+                    reason_code="invalid_profile_patch",
+                )
+            policy_patch = dict(policy_patch)
+            unsupported_policy_fields = set(policy_patch) - _POLICY_PATCH_FIELDS
+            if unsupported_policy_fields:
+                raise self._error(
+                    "Invalid profile patch",
+                    reason_code="invalid_profile_patch",
+                )
+            if not policy_patch and set(normalized) == {"policy_document"}:
+                raise self._error(
+                    "Invalid profile patch",
+                    reason_code="invalid_profile_patch",
+                )
+            normalized["policy_document"] = policy_patch
+        return normalized
+
+    def _apply_profile_patch(
+        self,
+        profile: MCPProfile,
+        patch: Mapping[str, Any],
+    ) -> tuple[MCPProfile, tuple[str, ...]]:
+        before = profile.model_dump(mode="json", exclude={"updated_at"})
+        profile_payload = profile.model_dump(mode="python")
+        for field, value in patch.items():
+            if field == "policy_document":
+                policy_payload = profile.policy_document.model_dump(mode="python")
+                policy_payload.update(dict(value))
+                profile_payload["policy_document"] = policy_payload
+            else:
+                profile_payload[field] = value
+        try:
+            updated = MCPProfile.model_validate(profile_payload)
+        except Exception as exc:
+            raise self._error(
+                "Invalid profile patch",
+                reason_code="invalid_profile_patch",
+            ) from exc
+
+        after = updated.model_dump(mode="json", exclude={"updated_at"})
+        if after == before:
+            raise self._error(
+                "Invalid profile patch",
+                reason_code="invalid_profile_patch",
+            )
+        return updated, tuple(sorted(patch))
 
     @staticmethod
     def _dump_profile(profile: MCPProfile) -> dict[str, Any]:

--- a/mcp_unified/interfaces/storage.py
+++ b/mcp_unified/interfaces/storage.py
@@ -31,6 +31,11 @@ class ProfileStore(Protocol):
         profile: MCPProfile,
     ) -> MCPProfile: ...
 
+    async def create_profile(
+        self,
+        profile: MCPProfile,
+    ) -> MCPProfile: ...
+
     async def delete_profile(self, profile_id: str) -> bool: ...
 
 

--- a/mcp_unified/interfaces/storage.py
+++ b/mcp_unified/interfaces/storage.py
@@ -34,6 +34,19 @@ class ProfileStore(Protocol):
     async def delete_profile(self, profile_id: str) -> bool: ...
 
 
+class GuardedProfileDeleteStore(Protocol):
+    """Store capability for atomically deleting unassigned non-default profiles."""
+
+    async def delete_profile_if_unassigned(
+        self,
+        profile_id: str,
+        *,
+        effective_default_profile_id: str | None,
+    ) -> str:
+        """Return deleted, not_found, is_default, or has_assignments."""
+        raise NotImplementedError
+
+
 class ProfileAssignmentStore(Protocol):
     """Store for principal, workspace, and default-profile assignments."""
 

--- a/mcp_unified/interfaces/storage.py
+++ b/mcp_unified/interfaces/storage.py
@@ -22,21 +22,31 @@ class ProfileStore(Protocol):
     inspect or mutate returned models without changing persisted state.
     """
 
-    async def get_profile(self, profile_id: str) -> MCPProfile | None: ...
+    async def get_profile(self, profile_id: str) -> MCPProfile | None:
+        """Return a profile by id when present."""
+        ...
 
-    async def list_profiles(self) -> list[MCPProfile]: ...
+    async def list_profiles(self) -> list[MCPProfile]:
+        """Return all stored profiles."""
+        ...
 
     async def upsert_profile(
         self,
         profile: MCPProfile,
-    ) -> MCPProfile: ...
+    ) -> MCPProfile:
+        """Create or replace a profile document."""
+        ...
 
     async def create_profile(
         self,
         profile: MCPProfile,
-    ) -> MCPProfile: ...
+    ) -> MCPProfile:
+        """Create a profile and reject existing ids."""
+        ...
 
-    async def delete_profile(self, profile_id: str) -> bool: ...
+    async def delete_profile(self, profile_id: str) -> bool:
+        """Delete a profile by id and report whether it existed."""
+        ...
 
 
 class GuardedProfileDeleteStore(Protocol):
@@ -55,7 +65,12 @@ class GuardedProfileDeleteStore(Protocol):
 class ProfileAssignmentStore(Protocol):
     """Store for principal, workspace, and default-profile assignments."""
 
-    async def get_assignment(self, assignment_id: str) -> ProfileAssignment | None: ...
+    async def get_assignment(
+        self,
+        assignment_id: str,
+    ) -> ProfileAssignment | None:
+        """Return a profile assignment by id when present."""
+        ...
 
     async def list_assignments(
         self,
@@ -63,50 +78,75 @@ class ProfileAssignmentStore(Protocol):
         profile_id: str | None = None,
         principal_id: str | None = None,
         workspace_id: str | None = None,
-    ) -> list[ProfileAssignment]: ...
+    ) -> list[ProfileAssignment]:
+        """Return profile assignments matching optional filters."""
+        ...
 
     async def upsert_assignment(
         self,
         assignment: ProfileAssignment,
-    ) -> ProfileAssignment: ...
+    ) -> ProfileAssignment:
+        """Create or replace a profile assignment."""
+        ...
 
-    async def delete_assignment(self, assignment_id: str) -> bool: ...
+    async def delete_assignment(self, assignment_id: str) -> bool:
+        """Delete a profile assignment and report whether it existed."""
+        ...
 
 
 class ApprovalPolicyStore(Protocol):
     """Store for reusable approval policy documents and profile bindings."""
 
-    async def get_policy(self, policy_id: str) -> ApprovalPolicyDocument | None: ...
+    async def get_policy(
+        self,
+        policy_id: str,
+    ) -> ApprovalPolicyDocument | None:
+        """Return an approval policy by id when present."""
+        ...
 
     async def list_policies(
         self,
         *,
         profile_id: str | None = None,
-    ) -> list[ApprovalPolicyDocument]: ...
+    ) -> list[ApprovalPolicyDocument]:
+        """Return approval policies matching optional filters."""
+        ...
 
     async def upsert_policy(
         self,
         policy: ApprovalPolicyDocument,
-    ) -> ApprovalPolicyDocument: ...
+    ) -> ApprovalPolicyDocument:
+        """Create or replace an approval policy document."""
+        ...
 
-    async def delete_policy(self, policy_id: str) -> bool: ...
+    async def delete_policy(self, policy_id: str) -> bool:
+        """Delete an approval policy and report whether it existed."""
+        ...
 
 
 class CredentialGrantStore(Protocol):
     """Store for credential broker grant metadata, never secret values."""
 
-    async def get_grant(self, grant_id: str) -> CredentialGrant | None: ...
+    async def get_grant(self, grant_id: str) -> CredentialGrant | None:
+        """Return a credential grant by id when present."""
+        ...
 
     async def list_grants(
         self,
         *,
         profile_id: str | None = None,
         external_server_id: str | None = None,
-    ) -> list[CredentialGrant]: ...
+    ) -> list[CredentialGrant]:
+        """Return credential grants matching optional filters."""
+        ...
 
-    async def upsert_grant(self, grant: CredentialGrant) -> CredentialGrant: ...
+    async def upsert_grant(self, grant: CredentialGrant) -> CredentialGrant:
+        """Create or replace credential grant metadata."""
+        ...
 
-    async def delete_grant(self, grant_id: str) -> bool: ...
+    async def delete_grant(self, grant_id: str) -> bool:
+        """Delete credential grant metadata and report whether it existed."""
+        ...
 
 
 class ExternalRegistryStore(Protocol):
@@ -117,28 +157,45 @@ class ExternalRegistryStore(Protocol):
     expose ``list_server_definitions`` for model-based persistence queries.
     """
 
-    async def get_server(self, server_id: str) -> ExternalServerDefinition | None: ...
+    async def get_server(
+        self,
+        server_id: str,
+    ) -> ExternalServerDefinition | None:
+        """Return an external server definition by id when present."""
+        ...
 
-    async def list_servers(self) -> list[ExternalServerDefinition] | list[dict[str, Any]]: ...
+    async def list_servers(
+        self,
+    ) -> list[ExternalServerDefinition] | list[dict[str, Any]]:
+        """Return external servers in the runtime manager-compatible shape."""
+        ...
 
     async def list_server_definitions(
         self,
         *,
         enabled: bool | None = None,
-    ) -> list[ExternalServerDefinition]: ...
+    ) -> list[ExternalServerDefinition]:
+        """Return typed external server definitions matching filters."""
+        ...
 
     async def upsert_server(
         self,
         server: ExternalServerDefinition,
-    ) -> ExternalServerDefinition: ...
+    ) -> ExternalServerDefinition:
+        """Create or replace an external server definition."""
+        ...
 
-    async def delete_server(self, server_id: str) -> bool: ...
+    async def delete_server(self, server_id: str) -> bool:
+        """Delete an external server and report whether it existed."""
+        ...
 
 
 class AuditStore(Protocol):
     """Append-only audit sink for MCP policy and tool events."""
 
-    async def append_event(self, event: AuditEvent) -> AuditEvent: ...
+    async def append_event(self, event: AuditEvent) -> AuditEvent:
+        """Append an audit event and return the stored event."""
+        ...
 
     async def query_events(
         self,
@@ -147,4 +204,6 @@ class AuditStore(Protocol):
         profile_id: str | None = None,
         event_type: str | None = None,
         limit: int | None = None,
-    ) -> list[AuditEvent]: ...
+    ) -> list[AuditEvent]:
+        """Return audit events matching optional filters."""
+        ...

--- a/mcp_unified/profiles/__init__.py
+++ b/mcp_unified/profiles/__init__.py
@@ -17,7 +17,11 @@ from .resolution import (
     build_effective_policy_result,
 )
 from .resolver import ProfileResolver, StoreBackedProfileResolver
-from .store import InMemoryProfileStore, ProfileStoreUnavailableError
+from .store import (
+    InMemoryProfileStore,
+    ProfileAlreadyExistsError,
+    ProfileStoreUnavailableError,
+)
 
 __all__ = [
     "EffectivePolicy",
@@ -25,6 +29,7 @@ __all__ = [
     "EffectivePolicyStatus",
     "InMemoryProfileStore",
     "MCPProfile",
+    "ProfileAlreadyExistsError",
     "ProfilePolicy",
     "ProfilePreset",
     "ProfileResolver",

--- a/mcp_unified/profiles/store.py
+++ b/mcp_unified/profiles/store.py
@@ -14,6 +14,14 @@ class ProfileStoreUnavailableError(RuntimeError):
     """Raised when a profile store cannot serve requests."""
 
 
+class ProfileAlreadyExistsError(RuntimeError):
+    """Raised when an atomic profile create conflicts with an existing id."""
+
+    def __init__(self, profile_id: str) -> None:
+        super().__init__(f"Profile already exists: {profile_id}")
+        self.profile_id = profile_id
+
+
 class ProfileAssignmentStoreUnavailableError(RuntimeError):
     """Raised when a profile-assignment store cannot serve requests."""
 
@@ -47,6 +55,17 @@ class InMemoryProfileStore:
     ) -> MCPProfile:
         """Store a profile document and return a copy-isolated stored value."""
         validated = self._validate_profile(profile)
+        self._profiles[validated.id] = validated
+        return validated.model_copy(deep=True)
+
+    async def create_profile(
+        self,
+        profile: MCPProfile | Mapping[str, Any],
+    ) -> MCPProfile:
+        """Create a profile only when its id is absent."""
+        validated = self._validate_profile(profile)
+        if validated.id in self._profiles:
+            raise ProfileAlreadyExistsError(validated.id)
         self._profiles[validated.id] = validated
         return validated.model_copy(deep=True)
 

--- a/mcp_unified/storage/sqlite.py
+++ b/mcp_unified/storage/sqlite.py
@@ -297,6 +297,17 @@ class SQLiteMCPStore:
         profiles_table = self._table("mcp_profiles")
         assignments_table = self._table("mcp_profile_assignments")
         with self._engine.begin() as connection:
+            result = connection.execute(
+                delete(profiles_table).where(
+                    profiles_table.c.id == profile_id,
+                    ~select(assignments_table.c.id)
+                    .where(assignments_table.c.profile_id == profile_id)
+                    .exists(),
+                )
+            )
+            if result.rowcount and result.rowcount > 0:
+                return "deleted"
+
             profile_row = connection.execute(
                 select(profiles_table.c.id).where(profiles_table.c.id == profile_id)
             ).mappings().first()
@@ -310,11 +321,7 @@ class SQLiteMCPStore:
             ).mappings().first()
             if assignment_row is not None:
                 return "has_assignments"
-
-            result = connection.execute(
-                delete(profiles_table).where(profiles_table.c.id == profile_id)
-            )
-        return "deleted" if result.rowcount and result.rowcount > 0 else "not_found"
+        return "not_found"
 
     def _get_assignment_sync(self, assignment_id: str) -> ProfileAssignment | None:
         return self._get_model(

--- a/mcp_unified/storage/sqlite.py
+++ b/mcp_unified/storage/sqlite.py
@@ -31,9 +31,11 @@ from sqlalchemy import (
     select,
 )
 from sqlalchemy.dialects.sqlite import insert as sqlite_insert
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.pool import StaticPool
 
 from mcp_unified.profiles.models import MCPProfile
+from mcp_unified.profiles.store import ProfileAlreadyExistsError
 from mcp_unified.storage.models import (
     ApprovalPolicyDocument,
     AuditEvent,
@@ -102,6 +104,13 @@ class SQLiteMCPStore:
     ) -> MCPProfile:
         """Store a profile document and return the persisted model."""
         return await self._run_db(self._upsert_profile_sync, profile)
+
+    async def create_profile(
+        self,
+        profile: MCPProfile | Mapping[str, Any],
+    ) -> MCPProfile:
+        """Create a profile only when its id is absent."""
+        return await self._run_db(self._create_profile_sync, profile)
 
     async def delete_profile(self, profile_id: str) -> bool:
         """Delete a profile by id and return whether it existed."""
@@ -280,6 +289,32 @@ class SQLiteMCPStore:
             },
             update_columns=("enabled", "updated_at", "payload"),
         )
+        return self._load_model(payload, MCPProfile)
+
+    def _create_profile_sync(
+        self,
+        profile: MCPProfile | Mapping[str, Any],
+    ) -> MCPProfile:
+        validated = self._validate_profile(profile)
+        payload = self._dump_model(validated)
+        profiles_table = self._table("mcp_profiles")
+        statement = sqlite_insert(profiles_table).values(
+            id=validated.id,
+            enabled=int(validated.enabled),
+            updated_at=validated.updated_at.isoformat(),
+            payload=payload,
+        )
+        try:
+            with self._engine.begin() as connection:
+                result = connection.execute(
+                    statement.on_conflict_do_nothing(
+                        index_elements=[profiles_table.c.id],
+                    )
+                )
+        except IntegrityError as exc:
+            raise ProfileAlreadyExistsError(validated.id) from exc
+        if not result.rowcount:
+            raise ProfileAlreadyExistsError(validated.id)
         return self._load_model(payload, MCPProfile)
 
     def _delete_profile_sync(self, profile_id: str) -> bool:

--- a/mcp_unified/storage/sqlite.py
+++ b/mcp_unified/storage/sqlite.py
@@ -107,6 +107,19 @@ class SQLiteMCPStore:
         """Delete a profile by id and return whether it existed."""
         return await self._run_db(self._delete_profile_sync, profile_id)
 
+    async def delete_profile_if_unassigned(
+        self,
+        profile_id: str,
+        *,
+        effective_default_profile_id: str | None,
+    ) -> str:
+        """Atomically delete a profile only when it is not default or assigned."""
+        return await self._run_db(
+            self._delete_profile_if_unassigned_sync,
+            profile_id,
+            effective_default_profile_id=effective_default_profile_id,
+        )
+
     async def get_assignment(self, assignment_id: str) -> ProfileAssignment | None:
         """Return a profile assignment by id."""
         return await self._run_db(self._get_assignment_sync, assignment_id)
@@ -271,6 +284,37 @@ class SQLiteMCPStore:
 
     def _delete_profile_sync(self, profile_id: str) -> bool:
         return self._delete_by_id("mcp_profiles", profile_id)
+
+    def _delete_profile_if_unassigned_sync(
+        self,
+        profile_id: str,
+        *,
+        effective_default_profile_id: str | None,
+    ) -> str:
+        if profile_id == effective_default_profile_id:
+            return "is_default"
+
+        profiles_table = self._table("mcp_profiles")
+        assignments_table = self._table("mcp_profile_assignments")
+        with self._engine.begin() as connection:
+            profile_row = connection.execute(
+                select(profiles_table.c.id).where(profiles_table.c.id == profile_id)
+            ).mappings().first()
+            if profile_row is None:
+                return "not_found"
+
+            assignment_row = connection.execute(
+                select(assignments_table.c.id)
+                .where(assignments_table.c.profile_id == profile_id)
+                .limit(1)
+            ).mappings().first()
+            if assignment_row is not None:
+                return "has_assignments"
+
+            result = connection.execute(
+                delete(profiles_table).where(profiles_table.c.id == profile_id)
+            )
+        return "deleted" if result.rowcount and result.rowcount > 0 else "not_found"
 
     def _get_assignment_sync(self, assignment_id: str) -> ProfileAssignment | None:
         return self._get_model(

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_cli_package.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_cli_package.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import io
 import json
 from datetime import datetime, timezone
 from pathlib import Path
@@ -12,6 +13,7 @@ from mcp_unified.gateway import cli as gateway_cli
 from mcp_unified.gateway.config import build_gateway_profile_storage
 from mcp_unified.gateway.profiles import GatewayProfileManager
 from mcp_unified.profiles.models import MCPProfile
+from mcp_unified.storage.models import ProfileAssignment
 
 try:
     import tomllib
@@ -194,6 +196,9 @@ def test_gateway_cli_show_preset_reports_unknown_id_as_json(
     [
         ["list-profiles"],
         ["show-profile", "reviewer"],
+        ["create-profile", "--profile-file", "profile.json"],
+        ["patch-profile", "reviewer", "--patch-file", "patch.json"],
+        ["delete-profile", "reviewer"],
         ["duplicate-preset", "project-researcher"],
         ["get-default-profile"],
         ["set-default-profile", "reviewer"],
@@ -201,15 +206,28 @@ def test_gateway_cli_show_preset_reports_unknown_id_as_json(
 )
 def test_gateway_cli_profile_management_commands_require_config_or_env(
     argv: list[str],
+    tmp_path: Path,
     capsys: pytest.CaptureFixture[str],
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Require an explicit or environment-provided config for store-backed commands."""
 
+    (tmp_path / "profile.json").write_text(
+        json.dumps(_profile_payload("reviewer", "Reviewer")),
+        encoding="utf-8",
+    )
+    (tmp_path / "patch.json").write_text(
+        json.dumps({"description": "Updated reviewer description"}),
+        encoding="utf-8",
+    )
+    resolved_argv = [
+        str(tmp_path / token) if token in {"profile.json", "patch.json"} else token
+        for token in argv
+    ]
     monkeypatch.delenv("MCP_UNIFIED_GATEWAY_CONFIG", raising=False)
     monkeypatch.delenv("MCP_GATEWAY_CONFIG", raising=False)
 
-    exit_code = gateway_cli.main(argv)
+    exit_code = gateway_cli.main(resolved_argv)
 
     captured = capsys.readouterr()
     payload = json.loads(captured.err)
@@ -571,6 +589,292 @@ def test_gateway_cli_duplicate_preset_accepts_custom_id_and_name(
     assert payload["store"] == {"kind": "sqlite", "persistent": True}
 
 
+def test_gateway_cli_create_profile_persists_to_sqlite_store(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Create a user profile from JSON file input and persist to SQLite."""
+
+    sqlite_path = tmp_path / "gateway.db"
+    profile_path = tmp_path / "profile.json"
+    profile = _profile_payload("reviewer", "Reviewer")
+    profile_path.write_text(json.dumps(profile), encoding="utf-8")
+    config_path = _write_gateway_config(
+        tmp_path,
+        {"store": {"kind": "sqlite", "sqlite_path": str(sqlite_path)}},
+    )
+
+    exit_code = gateway_cli.main(
+        [
+            "create-profile",
+            "--profile-file",
+            str(profile_path),
+            "--config",
+            str(config_path),
+        ]
+    )
+
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+    assert exit_code == 0
+    assert captured.err == ""
+    assert payload["ok"] is True
+    assert payload["profile"]["id"] == "reviewer"
+    assert payload["profile"]["name"] == "Reviewer"
+    assert payload["store"] == {"kind": "sqlite", "persistent": True}
+
+    show_exit_code = gateway_cli.main(
+        ["show-profile", "reviewer", "--config", str(config_path)]
+    )
+    show_payload = json.loads(capsys.readouterr().out)
+    assert show_exit_code == 0
+    assert show_payload["profile"]["id"] == "reviewer"
+
+
+def test_gateway_cli_create_profile_accepts_stdin_json(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Create a user profile from stdin JSON when --profile-file=-."""
+
+    sqlite_path = tmp_path / "gateway.db"
+    profile_payload = _profile_payload("stdin-profile", "Stdin Profile")
+    config_path = _write_gateway_config(
+        tmp_path,
+        {"store": {"kind": "sqlite", "sqlite_path": str(sqlite_path)}},
+    )
+    monkeypatch.setattr(
+        gateway_cli.sys,
+        "stdin",
+        io.StringIO(json.dumps(profile_payload)),
+    )
+
+    exit_code = gateway_cli.main(
+        ["create-profile", "--profile-file", "-", "--config", str(config_path)]
+    )
+
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+    assert exit_code == 0
+    assert captured.err == ""
+    assert payload["profile"]["id"] == "stdin-profile"
+    assert payload["store"] == {"kind": "sqlite", "persistent": True}
+
+
+def test_gateway_cli_patch_profile_updates_sqlite_profile(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Patch safe mutable profile fields from a JSON file payload."""
+
+    sqlite_path = tmp_path / "gateway.db"
+    patch_path = tmp_path / "patch.json"
+    patch_payload = {"description": "Updated reviewer description", "enabled": False}
+    patch_path.write_text(json.dumps(patch_payload), encoding="utf-8")
+    config_path = _write_gateway_config(
+        tmp_path,
+        {"store": {"kind": "sqlite", "sqlite_path": str(sqlite_path)}},
+    )
+    _seed_sqlite_profile(sqlite_path, "reviewer", "Reviewer")
+
+    exit_code = gateway_cli.main(
+        [
+            "patch-profile",
+            "reviewer",
+            "--patch-file",
+            str(patch_path),
+            "--config",
+            str(config_path),
+        ]
+    )
+
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+    assert exit_code == 0
+    assert captured.err == ""
+    assert payload["ok"] is True
+    assert payload["profile"]["id"] == "reviewer"
+    assert payload["profile"]["description"] == "Updated reviewer description"
+    assert payload["profile"]["enabled"] is False
+    assert payload["store"] == {"kind": "sqlite", "persistent": True}
+
+
+def test_gateway_cli_patch_profile_accepts_stdin_json(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Patch a stored profile from stdin JSON when --patch-file=-."""
+
+    sqlite_path = tmp_path / "gateway.db"
+    patch_payload = {"description": "Updated via stdin"}
+    config_path = _write_gateway_config(
+        tmp_path,
+        {"store": {"kind": "sqlite", "sqlite_path": str(sqlite_path)}},
+    )
+    _seed_sqlite_profile(sqlite_path, "reviewer", "Reviewer")
+    monkeypatch.setattr(gateway_cli.sys, "stdin", io.StringIO(json.dumps(patch_payload)))
+
+    exit_code = gateway_cli.main(
+        ["patch-profile", "reviewer", "--patch-file", "-", "--config", str(config_path)]
+    )
+
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+    assert exit_code == 0
+    assert captured.err == ""
+    assert payload["profile"]["id"] == "reviewer"
+    assert payload["profile"]["description"] == "Updated via stdin"
+    assert payload["store"] == {"kind": "sqlite", "persistent": True}
+
+
+@pytest.mark.parametrize(
+    ("argv", "label"),
+    [
+        (["create-profile", "--profile-file"], "profile"),
+        (["patch-profile", "reviewer", "--patch-file"], "patch"),
+    ],
+)
+def test_gateway_cli_profile_json_argument_rejects_malformed_json(
+    argv: list[str],
+    label: str,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Reject malformed profile/patch JSON payload files with exit code 2."""
+
+    payload_path = tmp_path / f"{label}.json"
+    payload_path.write_text("{", encoding="utf-8")
+    config_path = _write_gateway_config(
+        tmp_path,
+        {"store": {"kind": "sqlite", "sqlite_path": str(tmp_path / 'gateway.db')}},
+    )
+
+    exit_code = gateway_cli.main([*argv, str(payload_path), "--config", str(config_path)])
+
+    captured = capsys.readouterr()
+    payload = json.loads(captured.err)
+    assert exit_code == 2
+    assert captured.out == ""
+    assert payload["ok"] is False
+    assert payload["error"].startswith(f"Invalid {label} JSON:")
+    assert "Traceback" not in captured.err
+
+
+@pytest.mark.parametrize(
+    ("argv", "label"),
+    [
+        (["create-profile", "--profile-file"], "profile"),
+        (["patch-profile", "reviewer", "--patch-file"], "patch"),
+    ],
+)
+def test_gateway_cli_profile_json_argument_rejects_non_object_payload(
+    argv: list[str],
+    label: str,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Reject profile/patch JSON payloads that are not JSON objects."""
+
+    payload_path = tmp_path / f"{label}.json"
+    payload_path.write_text(json.dumps(["invalid"]), encoding="utf-8")
+    config_path = _write_gateway_config(
+        tmp_path,
+        {"store": {"kind": "sqlite", "sqlite_path": str(tmp_path / 'gateway.db')}},
+    )
+
+    exit_code = gateway_cli.main([*argv, str(payload_path), "--config", str(config_path)])
+
+    captured = capsys.readouterr()
+    payload = json.loads(captured.err)
+    assert exit_code == 2
+    assert captured.out == ""
+    assert payload == {"error": f"{label} JSON must be an object", "ok": False}
+    assert "Traceback" not in captured.err
+
+
+def test_gateway_cli_delete_profile_deletes_unassigned_sqlite_profile(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Delete an unassigned profile from a persistent SQLite store."""
+
+    sqlite_path = tmp_path / "gateway.db"
+    config_path = _write_gateway_config(
+        tmp_path,
+        {"store": {"kind": "sqlite", "sqlite_path": str(sqlite_path)}},
+    )
+    _seed_sqlite_profile(sqlite_path, "temporary", "Temporary")
+
+    exit_code = gateway_cli.main(
+        ["delete-profile", "temporary", "--config", str(config_path)]
+    )
+
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+    assert exit_code == 0
+    assert captured.err == ""
+    assert payload == {
+        "ok": True,
+        "profile_id": "temporary",
+        "store": {"kind": "sqlite", "persistent": True},
+    }
+
+
+def test_gateway_cli_delete_profile_rejects_effective_default_profile(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Reject deleting the effective default profile."""
+
+    sqlite_path = tmp_path / "gateway.db"
+    config_path = _write_gateway_config(
+        tmp_path,
+        {"store": {"kind": "sqlite", "sqlite_path": str(sqlite_path)}},
+    )
+    _seed_sqlite_default_profile(sqlite_path, "project-researcher")
+
+    exit_code = gateway_cli.main(
+        ["delete-profile", "project-researcher", "--config", str(config_path)]
+    )
+
+    captured = capsys.readouterr()
+    payload = json.loads(captured.err)
+    assert exit_code == 1
+    assert captured.out == ""
+    assert payload["reason_code"] == "profile_is_default"
+    assert payload["ok"] is False
+    assert "Traceback" not in captured.err
+
+
+def test_gateway_cli_delete_profile_rejects_assigned_profile(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Reject deleting a profile with active assignments."""
+
+    sqlite_path = tmp_path / "gateway.db"
+    config_path = _write_gateway_config(
+        tmp_path,
+        {"store": {"kind": "sqlite", "sqlite_path": str(sqlite_path)}},
+    )
+    _seed_sqlite_profile(sqlite_path, "assigned", "Assigned")
+    _seed_sqlite_profile_assignment(sqlite_path, "workspace-assignment", "assigned")
+
+    exit_code = gateway_cli.main(
+        ["delete-profile", "assigned", "--config", str(config_path)]
+    )
+
+    captured = capsys.readouterr()
+    payload = json.loads(captured.err)
+    assert exit_code == 1
+    assert captured.out == ""
+    assert payload["reason_code"] == "profile_has_assignments"
+    assert payload["ok"] is False
+    assert "Traceback" not in captured.err
+
+
 def test_gateway_cli_set_default_profile_persists_sqlite_assignment(
     tmp_path: Path,
     capsys: pytest.CaptureFixture[str],
@@ -603,6 +907,9 @@ def test_gateway_cli_set_default_profile_persists_sqlite_assignment(
 @pytest.mark.parametrize(
     "argv",
     [
+        ["create-profile", "--profile-file", "profile.json"],
+        ["patch-profile", "reviewer", "--patch-file", "patch.json"],
+        ["delete-profile", "reviewer"],
         ["duplicate-preset", "project-researcher"],
         ["set-default-profile", "reviewer"],
     ],
@@ -614,6 +921,18 @@ def test_gateway_cli_memory_store_mutations_are_rejected(
 ) -> None:
     """Reject mutating profile-management commands for transient memory stores."""
 
+    (tmp_path / "profile.json").write_text(
+        json.dumps(_profile_payload("reviewer", "Reviewer")),
+        encoding="utf-8",
+    )
+    (tmp_path / "patch.json").write_text(
+        json.dumps({"description": "Updated description"}),
+        encoding="utf-8",
+    )
+    resolved_argv = [
+        str(tmp_path / token) if token in {"profile.json", "patch.json"} else token
+        for token in argv
+    ]
     config_path = _write_gateway_config(
         tmp_path,
         {
@@ -622,7 +941,7 @@ def test_gateway_cli_memory_store_mutations_are_rejected(
         },
     )
 
-    exit_code = gateway_cli.main([*argv, "--config", str(config_path)])
+    exit_code = gateway_cli.main([*resolved_argv, "--config", str(config_path)])
 
     captured = capsys.readouterr()
     payload = json.loads(captured.err)
@@ -631,6 +950,47 @@ def test_gateway_cli_memory_store_mutations_are_rejected(
     assert payload["ok"] is False
     assert payload["reason_code"] == "profile_store_unavailable"
     assert "persistent gateway store" in payload["error"]
+    assert "Traceback" not in captured.err
+
+
+@pytest.mark.parametrize(
+    "argv",
+    [
+        ["create-profile", "--profile-file", "missing-profile.json"],
+        ["patch-profile", "reviewer", "--patch-file", "missing-patch.json"],
+    ],
+)
+def test_gateway_cli_memory_store_rejects_mutations_before_reading_payload_files(
+    argv: list[str],
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Reject transient-store writes before attempting profile or patch file reads."""
+
+    config_path = _write_gateway_config(
+        tmp_path,
+        {
+            "store": {"kind": "memory"},
+            "profiles": [_profile_payload("reviewer", "Reviewer")],
+        },
+    )
+    resolved_argv = [
+        str(tmp_path / token)
+        if token in {"missing-profile.json", "missing-patch.json"}
+        else token
+        for token in argv
+    ]
+
+    exit_code = gateway_cli.main([*resolved_argv, "--config", str(config_path)])
+
+    captured = capsys.readouterr()
+    payload = json.loads(captured.err)
+    assert exit_code == 1
+    assert captured.out == ""
+    assert payload["ok"] is False
+    assert payload["reason_code"] == "profile_store_unavailable"
+    assert "persistent gateway store" in payload["error"]
+    assert "Unable to read" not in payload["error"]
     assert "Traceback" not in captured.err
 
 
@@ -702,3 +1062,27 @@ def _seed_sqlite_default_profile(sqlite_path: Path, preset_id: str) -> None:
             await bundle.profile_store.aclose()
 
     asyncio.run(_seed_default())
+
+
+def _seed_sqlite_profile_assignment(
+    sqlite_path: Path,
+    assignment_id: str,
+    profile_id: str,
+) -> None:
+    bundle = build_gateway_profile_storage(
+        {"kind": "sqlite", "sqlite_path": str(sqlite_path)}
+    )
+
+    async def _seed_assignment() -> None:
+        try:
+            await bundle.assignment_store.upsert_assignment(
+                ProfileAssignment(
+                    id=assignment_id,
+                    profile_id=profile_id,
+                    workspace_id="workspace",
+                )
+            )
+        finally:
+            await bundle.assignment_store.aclose()
+
+    asyncio.run(_seed_assignment())

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py
@@ -322,6 +322,34 @@ class _ProfileManagementManagerDouble:
             "store": {"kind": "memory", "persistent": False},
         }
 
+    async def create_profile(self, profile_payload: dict[str, Any]) -> dict[str, Any]:
+        self.calls.append(("create_profile", (profile_payload,), {}))
+        return {
+            "ok": True,
+            "profile": profile_payload,
+            "store": {"kind": "memory", "persistent": False},
+        }
+
+    async def patch_profile(
+        self,
+        profile_id: str,
+        patch_payload: dict[str, Any],
+    ) -> dict[str, Any]:
+        self.calls.append(("patch_profile", (profile_id, patch_payload), {}))
+        return {
+            "ok": True,
+            "profile": {"id": profile_id, "name": f"Profile {profile_id}", **patch_payload},
+            "store": {"kind": "memory", "persistent": False},
+        }
+
+    async def delete_profile(self, profile_id: str) -> dict[str, Any]:
+        self.calls.append(("delete_profile", (profile_id,), {}))
+        return {
+            "ok": True,
+            "profile_id": profile_id,
+            "store": {"kind": "memory", "persistent": False},
+        }
+
 
 class _ProfileManagementBootstrapDouble:
     def __init__(self, manager: _ProfileManagementManagerDouble) -> None:
@@ -374,6 +402,22 @@ class _ProfileManagementErrorManagerDouble(_ProfileManagementManagerDouble):
     async def set_default_profile(self, profile_id: str) -> dict[str, Any]:
         await self._raise_if_targeted("set_default_profile")
         return await super().set_default_profile(profile_id)
+
+    async def create_profile(self, profile_payload: dict[str, Any]) -> dict[str, Any]:
+        await self._raise_if_targeted("create_profile")
+        return await super().create_profile(profile_payload)
+
+    async def patch_profile(
+        self,
+        profile_id: str,
+        patch_payload: dict[str, Any],
+    ) -> dict[str, Any]:
+        await self._raise_if_targeted("patch_profile")
+        return await super().patch_profile(profile_id, patch_payload)
+
+    async def delete_profile(self, profile_id: str) -> dict[str, Any]:
+        await self._raise_if_targeted("delete_profile")
+        return await super().delete_profile(profile_id)
 
 
 def test_gateway_package_does_not_import_tldw_server_api() -> None:
@@ -537,6 +581,22 @@ def test_gateway_profile_management_success_envelopes() -> None:
             "/mcp/profiles/default",
             json={"profile_id": "architect"},
         )
+        created = client.post(
+            "/mcp/profiles",
+            json={
+                "id": "custom-reviewer",
+                "name": "Custom Reviewer",
+                "policy_document": {"allowed_tools": ["echo.search"]},
+            },
+        )
+        patched = client.patch(
+            "/mcp/profiles/custom-reviewer",
+            json={
+                "name": "Custom Reviewer v2",
+                "description": "updated",
+            },
+        )
+        deleted = client.delete("/mcp/profiles/custom-reviewer")
 
     assert listed.json() == {
         "ok": True,
@@ -598,6 +658,29 @@ def test_gateway_profile_management_success_envelopes() -> None:
         },
         "store": {"kind": "memory", "persistent": False},
     }
+    assert created.json() == {
+        "ok": True,
+        "profile": {
+            "id": "custom-reviewer",
+            "name": "Custom Reviewer",
+            "policy_document": {"allowed_tools": ["echo.search"]},
+        },
+        "store": {"kind": "memory", "persistent": False},
+    }
+    assert patched.json() == {
+        "ok": True,
+        "profile": {
+            "id": "custom-reviewer",
+            "name": "Custom Reviewer v2",
+            "description": "updated",
+        },
+        "store": {"kind": "memory", "persistent": False},
+    }
+    assert deleted.json() == {
+        "ok": True,
+        "profile_id": "custom-reviewer",
+        "store": {"kind": "memory", "persistent": False},
+    }
     assert manager.calls == [
         ("list_profiles", (), {}),
         ("show_profile", ("reviewer",), {}),
@@ -613,6 +696,26 @@ def test_gateway_profile_management_success_envelopes() -> None:
         ),
         ("get_default_profile", (), {}),
         ("set_default_profile", ("architect",), {}),
+        (
+            "create_profile",
+            (
+                {
+                    "id": "custom-reviewer",
+                    "name": "Custom Reviewer",
+                    "policy_document": {"allowed_tools": ["echo.search"]},
+                },
+            ),
+            {},
+        ),
+        (
+            "patch_profile",
+            (
+                "custom-reviewer",
+                {"name": "Custom Reviewer v2", "description": "updated"},
+            ),
+            {},
+        ),
+        ("delete_profile", ("custom-reviewer",), {}),
     ]
 
 
@@ -626,7 +729,10 @@ def test_gateway_profile_management_routes_have_pydantic_response_models() -> No
     paths = app.openapi()["paths"]
     expected_refs = {
         ("/mcp/profiles", "get"): "#/components/schemas/ProfileListResponse",
+        ("/mcp/profiles", "post"): "#/components/schemas/ProfileResponse",
         ("/mcp/profiles/{profile_id}", "get"): "#/components/schemas/ProfileResponse",
+        ("/mcp/profiles/{profile_id}", "patch"): "#/components/schemas/ProfileResponse",
+        ("/mcp/profiles/{profile_id}", "delete"): "#/components/schemas/DeleteProfileResponse",
         ("/mcp/profiles/from-preset", "post"): "#/components/schemas/DuplicatePresetResponse",
         ("/mcp/profiles/default", "get"): "#/components/schemas/DefaultProfileResponse",
         ("/mcp/profiles/default", "put"): "#/components/schemas/DefaultProfileResponse",
@@ -671,6 +777,30 @@ def test_gateway_profile_management_routes_have_pydantic_response_models() -> No
             {"preset_id": "project-researcher"},
             "duplicate_preset",
             "profile_already_exists",
+            409,
+        ),
+        (
+            "PATCH",
+            "/mcp/profiles/reviewer",
+            {"name": "Reviewer"},
+            "patch_profile",
+            "invalid_profile_patch",
+            422,
+        ),
+        (
+            "DELETE",
+            "/mcp/profiles/reviewer",
+            None,
+            "delete_profile",
+            "profile_is_default",
+            409,
+        ),
+        (
+            "DELETE",
+            "/mcp/profiles/reviewer",
+            None,
+            "delete_profile",
+            "profile_has_assignments",
             409,
         ),
         ("GET", "/mcp/profiles", None, "list_profiles", "profile_store_unavailable", 503),
@@ -731,11 +861,19 @@ def test_gateway_profile_management_malformed_or_missing_bodies_return_422() -> 
             content="{",
             headers={"content-type": "application/json"},
         )
+        missing_create = client.post("/mcp/profiles", json={})
+        malformed_create = client.post(
+            "/mcp/profiles",
+            content="{",
+            headers={"content-type": "application/json"},
+        )
 
     assert missing_duplicate.status_code == 422
     assert malformed_duplicate.status_code == 422
     assert missing_default.status_code == 422
     assert malformed_default.status_code == 422
+    assert missing_create.status_code == 422
+    assert malformed_create.status_code == 422
 
 
 def test_gateway_profile_runtime_requires_profile_for_tool_execution() -> None:

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_profile_management.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_profile_management.py
@@ -16,6 +16,8 @@ from mcp_unified.profiles.models import MCPProfile
 from mcp_unified.profiles.store import (
     InMemoryProfileAssignmentStore,
     InMemoryProfileStore,
+    ProfileAlreadyExistsError,
+    ProfileStoreUnavailableError,
 )
 from mcp_unified.storage.models import AuditEvent, ProfileAssignment
 from mcp_unified.storage.sqlite import SQLiteMCPStore
@@ -59,6 +61,37 @@ class FailingAuditStore(InMemoryAuditStore):
 
     async def append_event(self, event: AuditEvent) -> AuditEvent:
         raise RuntimeError(f"audit unavailable for {event.event_type}")
+
+
+class ConflictingCreateProfileStore(InMemoryProfileStore):
+    """Profile store double that reports an atomic create conflict."""
+
+    async def create_profile(self, profile: MCPProfile) -> MCPProfile:
+        raise ProfileAlreadyExistsError(profile.id)
+
+
+class UnavailableGuardedDeleteProfileStore(InMemoryProfileStore):
+    """Profile store double whose guarded delete backend is unavailable."""
+
+    async def delete_profile_if_unassigned(
+        self,
+        profile_id: str,
+        *,
+        effective_default_profile_id: str | None,
+    ) -> str:
+        raise ProfileStoreUnavailableError(f"guarded delete unavailable: {profile_id}")
+
+
+class UnknownGuardedDeleteProfileStore(InMemoryProfileStore):
+    """Profile store double that violates the guarded-delete status contract."""
+
+    async def delete_profile_if_unassigned(
+        self,
+        profile_id: str,
+        *,
+        effective_default_profile_id: str | None,
+    ) -> str:
+        return "surprise"
 
 
 def _manager(
@@ -255,6 +288,43 @@ async def test_create_profile_rejects_duplicate_id() -> None:
     assert stored is not None
     assert stored.name == "Existing"
     assert stored.metadata == {"owner": "original"}
+
+
+@pytest.mark.asyncio
+async def test_create_profile_normalizes_profile_id_and_name() -> None:
+    store = InMemoryProfileStore()
+    manager = _manager(store)
+
+    payload = await manager.create_profile(
+        {"id": " reviewer ", "name": "  Reviewer  "}
+    )
+
+    assert payload["profile"]["id"] == "reviewer"
+    assert payload["profile"]["name"] == "Reviewer"
+    assert await store.get_profile(" reviewer ") is None
+    stored = await store.get_profile("reviewer")
+    assert stored is not None
+    assert stored.name == "Reviewer"
+
+
+@pytest.mark.asyncio
+async def test_create_profile_duplicate_detection_uses_store_create_conflict() -> None:
+    audit_store = InMemoryAuditStore()
+    manager = _manager(
+        ConflictingCreateProfileStore(),
+        audit_store=audit_store,
+    )
+
+    with pytest.raises(GatewayProfileManagementError) as exc_info:
+        await manager.create_profile({"id": "existing", "name": "Existing"})
+
+    assert exc_info.value.reason_code == "profile_already_exists"
+    assert exc_info.value.to_payload()["profile_id"] == "existing"
+    assert [event.event_type for event in audit_store.events] == ["profile.create_failed"]
+    assert audit_store.events[0].payload == {
+        "profile_id": "existing",
+        "reason_code": "profile_already_exists",
+    }
 
 
 @pytest.mark.asyncio
@@ -714,6 +784,25 @@ async def test_patch_profile_preserves_omitted_policy_document_field() -> None:
 
 
 @pytest.mark.asyncio
+async def test_patch_profile_policy_document_handles_missing_stored_policy() -> None:
+    original = MCPProfile(id="reviewer", name="Reviewer").model_copy(
+        update={"policy_document": None},
+    )
+    store = InMemoryProfileStore([original])
+    manager = _manager(store)
+
+    payload = await manager.patch_profile(
+        "reviewer",
+        {"policy_document": {"allowed_tools": ["review.run"]}},
+    )
+
+    assert payload["profile"]["policy_document"]["allowed_tools"] == ["review.run"]
+    stored = await store.get_profile("reviewer")
+    assert stored is not None
+    assert stored.policy_document.allowed_tools == ["review.run"]
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "patch_document",
     [
@@ -729,6 +818,7 @@ async def test_patch_profile_preserves_omitted_policy_document_field() -> None:
         {"created_at": "2026-05-31T12:00:00+00:00"},
         {"updated_at": "2026-05-31T12:00:00+00:00"},
         {"policy_document": {"unknown_policy_field": True}},
+        {"name": "   "},
         {},
         {"policy_document": {}},
     ],
@@ -917,6 +1007,48 @@ async def test_delete_profile_rejects_assigned_profile() -> None:
 
 
 @pytest.mark.asyncio
+async def test_delete_profile_translates_guarded_delete_store_unavailable() -> None:
+    audit_store = InMemoryAuditStore()
+    manager = _manager(
+        UnavailableGuardedDeleteProfileStore([MCPProfile(id="temporary", name="Temporary")]),
+        audit_store=audit_store,
+    )
+
+    with pytest.raises(GatewayProfileManagementError) as exc_info:
+        await manager.delete_profile("temporary")
+
+    assert exc_info.value.reason_code == "profile_store_unavailable"
+    assert exc_info.value.to_payload()["profile_id"] == "temporary"
+    assert [event.event_type for event in audit_store.events] == ["profile.delete_failed"]
+    assert audit_store.events[0].payload == {
+        "profile_id": "temporary",
+        "reason_code": "profile_store_unavailable",
+    }
+
+
+@pytest.mark.asyncio
+async def test_delete_profile_rejects_unknown_guarded_delete_status() -> None:
+    audit_store = InMemoryAuditStore()
+    manager = _manager(
+        UnknownGuardedDeleteProfileStore([MCPProfile(id="temporary", name="Temporary")]),
+        audit_store=audit_store,
+    )
+
+    with pytest.raises(GatewayProfileManagementError) as exc_info:
+        await manager.delete_profile("temporary")
+
+    assert exc_info.value.reason_code == "unexpected_delete_result"
+    assert exc_info.value.to_payload()["profile_id"] == "temporary"
+    assert "surprise" in str(exc_info.value)
+    assert [event.event_type for event in audit_store.events] == ["profile.delete_failed"]
+    assert audit_store.events[0].payload == {
+        "delete_result": "surprise",
+        "profile_id": "temporary",
+        "reason_code": "unexpected_delete_result",
+    }
+
+
+@pytest.mark.asyncio
 async def test_profile_crud_failure_audits_are_compact_and_expected() -> None:
     audit_store = InMemoryAuditStore()
     assignment_store = InMemoryProfileAssignmentStore(
@@ -1024,6 +1156,28 @@ async def test_delete_profile_sqlite_guard_preserves_assigned_profile(tmp_path: 
         assert exc_info.value.reason_code == "profile_has_assignments"
         assert await store.get_profile("assigned") is not None
         assert await store.get_assignment("workspace-assignment") is not None
+    finally:
+        await store.aclose()
+
+
+@pytest.mark.asyncio
+async def test_create_profile_sqlite_reports_atomic_duplicate_conflict(tmp_path: Path) -> None:
+    store = SQLiteMCPStore(tmp_path / "mcp.db")
+    try:
+        await store.upsert_profile(MCPProfile(id="existing", name="Existing"))
+        manager = GatewayProfileManager(
+            profile_store=store,
+            assignment_store=store,
+            store_metadata=GatewayProfileStoreMetadata(kind="sqlite", persistent=True),
+        )
+
+        with pytest.raises(GatewayProfileManagementError) as exc_info:
+            await manager.create_profile({"id": "existing", "name": "Duplicate"})
+
+        assert exc_info.value.reason_code == "profile_already_exists"
+        stored = await store.get_profile("existing")
+        assert stored is not None
+        assert stored.name == "Existing"
     finally:
         await store.aclose()
 

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_profile_management.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_profile_management.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 from datetime import datetime, timedelta, timezone
+from pathlib import Path
 
 import pytest
 from mcp_unified.gateway.profiles import (
@@ -17,6 +18,7 @@ from mcp_unified.profiles.store import (
     InMemoryProfileStore,
 )
 from mcp_unified.storage.models import AuditEvent, ProfileAssignment
+from mcp_unified.storage.sqlite import SQLiteMCPStore
 
 UTC = timezone.utc
 
@@ -201,6 +203,109 @@ async def test_duplicate_preset_rejects_profile_id_collision() -> None:
 
     assert exc_info.value.reason_code == "profile_already_exists"
     assert exc_info.value.to_payload()["profile_id"] == "project-researcher"
+
+
+@pytest.mark.asyncio
+async def test_create_profile_persists_valid_profile_and_audits_success() -> None:
+    created_at = datetime(2020, 1, 1, 12, 0, tzinfo=UTC)
+    audit_store = InMemoryAuditStore()
+    store = InMemoryProfileStore()
+    manager = _manager(store, audit_store=audit_store)
+
+    payload = await manager.create_profile(
+        {
+            "id": "custom-reviewer",
+            "name": "Custom Reviewer",
+            "metadata": {"owner": "qa"},
+            "created_at": created_at.isoformat(),
+            "updated_at": created_at.isoformat(),
+        }
+    )
+
+    assert payload["ok"] is True
+    assert payload["store"] == {"kind": "memory", "persistent": False}
+    assert payload["profile"]["id"] == "custom-reviewer"
+    assert payload["profile"]["metadata"] == {"owner": "qa"}
+    assert payload["profile"]["created_at"] == created_at.isoformat()
+    assert payload["profile"]["updated_at"] != created_at.isoformat()
+    stored = await store.get_profile("custom-reviewer")
+    assert stored is not None
+    assert stored.name == "Custom Reviewer"
+    assert stored.metadata == {"owner": "qa"}
+    assert stored.created_at == created_at
+    assert stored.updated_at > created_at
+    assert stored.updated_at.isoformat() == payload["profile"]["updated_at"]
+    assert stored.enabled is True
+    assert [event.event_type for event in audit_store.events] == ["profile.created"]
+
+
+@pytest.mark.asyncio
+async def test_create_profile_rejects_duplicate_id() -> None:
+    store = InMemoryProfileStore(
+        [MCPProfile(id="existing", name="Existing", metadata={"owner": "original"})]
+    )
+    manager = _manager(store)
+
+    with pytest.raises(GatewayProfileManagementError) as exc_info:
+        await manager.create_profile({"id": "existing", "name": "Duplicate"})
+
+    assert exc_info.value.reason_code == "profile_already_exists"
+    assert exc_info.value.to_payload()["profile_id"] == "existing"
+    stored = await store.get_profile("existing")
+    assert stored is not None
+    assert stored.name == "Existing"
+    assert stored.metadata == {"owner": "original"}
+
+
+@pytest.mark.asyncio
+async def test_create_profile_rejects_disabled_effective_default_assignment_id() -> None:
+    assignment_store = InMemoryProfileAssignmentStore(
+        [ProfileAssignment(id="gateway-default", profile_id="default", is_default=True)]
+    )
+    store = InMemoryProfileStore()
+    manager = _manager(store, assignment_store)
+
+    with pytest.raises(GatewayProfileManagementError) as exc_info:
+        await manager.create_profile({"id": "default", "name": "Default", "enabled": False})
+
+    assert exc_info.value.reason_code == "profile_is_default"
+    assert await store.get_profile("default") is None
+
+
+@pytest.mark.asyncio
+async def test_create_profile_allows_disabled_fallback_id_when_assignment_overrides_it() -> None:
+    assignment_store = InMemoryProfileAssignmentStore(
+        [ProfileAssignment(id="gateway-default", profile_id="assigned", is_default=True)]
+    )
+    manager = _manager(
+        InMemoryProfileStore([MCPProfile(id="assigned", name="Assigned")]),
+        assignment_store,
+        fallback_default_profile_id="fallback",
+    )
+
+    payload = await manager.create_profile(
+        {"id": "fallback", "name": "Fallback", "enabled": False}
+    )
+
+    assert payload["profile"]["id"] == "fallback"
+    assert payload["profile"]["enabled"] is False
+
+
+@pytest.mark.asyncio
+async def test_create_profile_rejects_disabled_fallback_default_without_assignment() -> None:
+    store = InMemoryProfileStore()
+    manager = _manager(
+        store,
+        fallback_default_profile_id="fallback",
+    )
+
+    with pytest.raises(GatewayProfileManagementError) as exc_info:
+        await manager.create_profile(
+            {"id": "fallback", "name": "Fallback", "enabled": False}
+        )
+
+    assert exc_info.value.reason_code == "profile_is_default"
+    assert await store.get_profile("fallback") is None
 
 
 @pytest.mark.asyncio
@@ -486,6 +591,441 @@ async def test_get_default_profile_chooses_newest_legacy_default_with_id_tie_bre
 
     assert payload["profile"]["id"] == "new-a"
     assert payload["assignment"]["id"] == "a-new"
+
+
+@pytest.mark.asyncio
+async def test_patch_profile_replaces_all_allowed_policy_fields() -> None:
+    original_updated_at = datetime(2020, 1, 1, 12, 0, tzinfo=UTC)
+    original = MCPProfile(
+        id="reviewer",
+        name="Reviewer",
+        description="old",
+        enabled=True,
+        metadata={"old": True},
+        policy_document={
+            "allowed_tools": ["old.tool"],
+            "denied_tools": ["old.deny"],
+            "capabilities": ["old-capability"],
+            "denied_capabilities": ["old-denied-capability"],
+            "tool_patterns": ["old.*"],
+            "module_patterns": ["old.module.*"],
+            "risk_classes": ["old-risk"],
+            "resource_constraints": {"max_runtime_seconds": 30},
+        },
+        updated_at=original_updated_at,
+    )
+    store = InMemoryProfileStore([original])
+    manager = _manager(store)
+
+    stored_before = await store.get_profile("reviewer")
+    assert stored_before is not None
+    before_updated_at = stored_before.updated_at
+
+    payload = await manager.patch_profile(
+        "reviewer",
+        {
+            "name": "Senior Reviewer",
+            "description": "new",
+            "enabled": False,
+            "metadata": {"new": True},
+            "policy_document": {
+                "allowed_tools": ["new.tool"],
+                "denied_tools": ["new.deny"],
+                "capabilities": ["new-capability"],
+                "denied_capabilities": ["new-denied-capability"],
+                "tool_patterns": ["new.*"],
+                "module_patterns": ["new.module.*"],
+                "risk_classes": ["new-risk"],
+                "resource_constraints": {"max_runtime_seconds": 120},
+            },
+        },
+    )
+
+    profile = payload["profile"]
+    assert payload["ok"] is True
+    assert payload["store"] == {"kind": "memory", "persistent": False}
+    assert profile["name"] == "Senior Reviewer"
+    assert profile["description"] == "new"
+    assert profile["enabled"] is False
+    assert profile["metadata"] == {"new": True}
+    assert profile["policy_document"]["allowed_tools"] == ["new.tool"]
+    assert profile["policy_document"]["denied_tools"] == ["new.deny"]
+    assert profile["policy_document"]["capabilities"] == ["new-capability"]
+    assert profile["policy_document"]["denied_capabilities"] == ["new-denied-capability"]
+    assert profile["policy_document"]["tool_patterns"] == ["new.*"]
+    assert profile["policy_document"]["module_patterns"] == ["new.module.*"]
+    assert profile["policy_document"]["risk_classes"] == ["new-risk"]
+    assert profile["policy_document"]["resource_constraints"] == {"max_runtime_seconds": 120}
+
+    stored = await store.get_profile("reviewer")
+    assert stored is not None
+    assert stored.name == "Senior Reviewer"
+    assert stored.description == "new"
+    assert stored.enabled is False
+    assert stored.metadata == {"new": True}
+    assert stored.policy_document.allowed_tools == ["new.tool"]
+    assert stored.policy_document.denied_tools == ["new.deny"]
+    assert stored.policy_document.capabilities == ["new-capability"]
+    assert stored.policy_document.denied_capabilities == ["new-denied-capability"]
+    assert stored.policy_document.tool_patterns == ["new.*"]
+    assert stored.policy_document.module_patterns == ["new.module.*"]
+    assert stored.policy_document.risk_classes == ["new-risk"]
+    assert stored.policy_document.resource_constraints == {"max_runtime_seconds": 120}
+    assert stored.updated_at > before_updated_at
+    assert stored.updated_at.isoformat() == payload["profile"]["updated_at"]
+
+
+@pytest.mark.asyncio
+async def test_patch_profile_preserves_omitted_policy_document_field() -> None:
+    original_updated_at = datetime(2020, 1, 1, 12, 0, tzinfo=UTC)
+    original = MCPProfile(
+        id="reviewer",
+        name="Reviewer",
+        policy_document={
+            "allowed_tools": ["old.tool"],
+            "denied_tools": ["old.deny"],
+        },
+        updated_at=original_updated_at,
+    )
+    store = InMemoryProfileStore([original])
+    manager = _manager(store)
+
+    stored_before = await store.get_profile("reviewer")
+    assert stored_before is not None
+    before_updated_at = stored_before.updated_at
+
+    payload = await manager.patch_profile(
+        "reviewer",
+        {"policy_document": {"allowed_tools": ["new.tool"]}},
+    )
+
+    profile = payload["profile"]
+    assert payload["ok"] is True
+    assert payload["store"] == {"kind": "memory", "persistent": False}
+    assert profile["policy_document"]["allowed_tools"] == ["new.tool"]
+    assert profile["policy_document"]["denied_tools"] == ["old.deny"]
+
+    stored = await store.get_profile("reviewer")
+    assert stored is not None
+    assert stored.policy_document.allowed_tools == ["new.tool"]
+    assert stored.policy_document.denied_tools == ["old.deny"]
+    assert stored.updated_at > before_updated_at
+    assert stored.updated_at.isoformat() == payload["profile"]["updated_at"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "patch_document",
+    [
+        {"id": "renamed"},
+        {"schema_version": "2026-05-31"},
+        {"preset_id": "code-reviewer"},
+        {"preset_version": "2026.05.27"},
+        {"approval_policy": {"mode": "auto"}},
+        {"path_scopes": [{"path": "/tmp"}]},
+        {"external_server_grants": [{"server_id": "external"}]},
+        {"credential_grants": [{"credential_id": "credential"}]},
+        {"provenance": {"source": "manual"}},
+        {"created_at": "2026-05-31T12:00:00+00:00"},
+        {"updated_at": "2026-05-31T12:00:00+00:00"},
+        {"policy_document": {"unknown_policy_field": True}},
+        {},
+        {"policy_document": {}},
+    ],
+)
+async def test_patch_profile_rejects_invalid_patch_shapes(
+    patch_document: dict[str, object],
+) -> None:
+    created_at = datetime(2026, 5, 31, 12, 0, tzinfo=UTC)
+    updated_at = datetime(2026, 5, 31, 12, 30, tzinfo=UTC)
+    store = InMemoryProfileStore(
+        [
+            MCPProfile(
+                id="reviewer",
+                name="Reviewer",
+                schema_version=7,
+                preset_id="preset-original",
+                preset_version="v-original",
+                approval_policy={"mode": "manual"},
+                path_scopes=[{"path": "/allowed"}],
+                external_server_grants=[{"server_id": "existing"}],
+                credential_grants=[{"slot": "existing"}],
+                provenance={"source": "original"},
+                created_at=created_at,
+                updated_at=updated_at,
+            )
+        ]
+    )
+    manager = _manager(store)
+
+    stored_before = await store.get_profile("reviewer")
+    assert stored_before is not None
+    before_dump = stored_before.model_dump(mode="json")
+
+    with pytest.raises(GatewayProfileManagementError) as exc_info:
+        await manager.patch_profile("reviewer", patch_document)
+
+    stored_after = await store.get_profile("reviewer")
+    assert stored_after is not None
+    assert exc_info.value.reason_code == "invalid_profile_patch"
+    assert stored_after.model_dump(mode="json") == before_dump
+
+
+@pytest.mark.asyncio
+async def test_patch_profile_rejects_semantic_noop_without_touching_updated_at() -> None:
+    created_at = datetime(2026, 5, 31, 12, 0, tzinfo=UTC)
+    updated_at = datetime(2026, 5, 31, 12, 30, tzinfo=UTC)
+    store = InMemoryProfileStore(
+        [
+            MCPProfile(
+                id="reviewer",
+                name="Reviewer",
+                schema_version=7,
+                preset_id="preset-original",
+                preset_version="v-original",
+                approval_policy={"mode": "manual"},
+                path_scopes=[{"path": "/allowed"}],
+                external_server_grants=[{"server_id": "existing"}],
+                credential_grants=[{"slot": "existing"}],
+                provenance={"source": "original"},
+                created_at=created_at,
+                updated_at=updated_at,
+            )
+        ]
+    )
+    manager = _manager(store)
+
+    stored_before = await store.get_profile("reviewer")
+    assert stored_before is not None
+    before_dump = stored_before.model_dump(mode="json")
+
+    with pytest.raises(GatewayProfileManagementError) as exc_info:
+        await manager.patch_profile("reviewer", {"name": "Reviewer"})
+
+    stored_after = await store.get_profile("reviewer")
+    assert stored_after is not None
+    assert exc_info.value.reason_code == "invalid_profile_patch"
+    assert stored_after.model_dump(mode="json") == before_dump
+
+
+@pytest.mark.asyncio
+async def test_patch_profile_rejects_default_profile_disable() -> None:
+    assignment_store = InMemoryProfileAssignmentStore(
+        [ProfileAssignment(id="gateway-default", profile_id="reviewer", is_default=True)]
+    )
+    created_at = datetime(2026, 5, 31, 12, 0, tzinfo=UTC)
+    updated_at = datetime(2026, 5, 31, 12, 30, tzinfo=UTC)
+    store = InMemoryProfileStore(
+        [
+            MCPProfile(
+                id="reviewer",
+                name="Reviewer",
+                schema_version=7,
+                preset_id="preset-original",
+                preset_version="v-original",
+                enabled=True,
+                approval_policy={"mode": "manual"},
+                path_scopes=[{"path": "/allowed"}],
+                external_server_grants=[{"server_id": "existing"}],
+                credential_grants=[{"slot": "existing"}],
+                provenance={"source": "original"},
+                created_at=created_at,
+                updated_at=updated_at,
+            )
+        ]
+    )
+    manager = _manager(
+        store,
+        assignment_store,
+    )
+
+    stored_before = await store.get_profile("reviewer")
+    assert stored_before is not None
+    before_dump = stored_before.model_dump(mode="json")
+
+    with pytest.raises(GatewayProfileManagementError) as exc_info:
+        await manager.patch_profile("reviewer", {"enabled": False})
+
+    assert exc_info.value.reason_code == "profile_is_default"
+    stored = await store.get_profile("reviewer")
+    assert stored is not None
+    assert stored.enabled is True
+    assert stored.model_dump(mode="json") == before_dump
+
+
+@pytest.mark.asyncio
+async def test_delete_profile_removes_unassigned_non_default_profile() -> None:
+    store = InMemoryProfileStore([MCPProfile(id="temporary", name="Temporary")])
+    manager = _manager(store)
+
+    payload = await manager.delete_profile("temporary")
+
+    assert payload == {
+        "ok": True,
+        "profile_id": "temporary",
+        "store": {"kind": "memory", "persistent": False},
+    }
+    assert await store.get_profile("temporary") is None
+
+
+@pytest.mark.asyncio
+async def test_delete_profile_rejects_missing_profile() -> None:
+    manager = _manager(InMemoryProfileStore())
+
+    with pytest.raises(GatewayProfileManagementError) as exc_info:
+        await manager.delete_profile("missing")
+
+    assert exc_info.value.reason_code == "profile_not_found"
+    assert exc_info.value.to_payload()["profile_id"] == "missing"
+
+
+@pytest.mark.asyncio
+async def test_delete_profile_rejects_effective_default_profile() -> None:
+    assignment_store = InMemoryProfileAssignmentStore(
+        [ProfileAssignment(id="gateway-default", profile_id="default", is_default=True)]
+    )
+    store = InMemoryProfileStore([MCPProfile(id="default", name="Default")])
+    manager = _manager(
+        store,
+        assignment_store,
+    )
+
+    with pytest.raises(GatewayProfileManagementError) as exc_info:
+        await manager.delete_profile("default")
+
+    assert exc_info.value.reason_code == "profile_is_default"
+    assert await store.get_profile("default") is not None
+
+
+@pytest.mark.asyncio
+async def test_delete_profile_rejects_assigned_profile() -> None:
+    assignment_store = InMemoryProfileAssignmentStore(
+        [ProfileAssignment(id="workspace-assignment", profile_id="assigned", workspace_id="ws")]
+    )
+    store = InMemoryProfileStore([MCPProfile(id="assigned", name="Assigned")])
+    manager = _manager(
+        store,
+        assignment_store,
+    )
+
+    with pytest.raises(GatewayProfileManagementError) as exc_info:
+        await manager.delete_profile("assigned")
+
+    assert exc_info.value.reason_code == "profile_has_assignments"
+    assert await store.get_profile("assigned") is not None
+    assert await assignment_store.get_assignment("workspace-assignment") is not None
+
+
+@pytest.mark.asyncio
+async def test_profile_crud_failure_audits_are_compact_and_expected() -> None:
+    audit_store = InMemoryAuditStore()
+    assignment_store = InMemoryProfileAssignmentStore(
+        [
+            ProfileAssignment(id="gateway-default", profile_id="default", is_default=True),
+            ProfileAssignment(
+                id="workspace-assignment",
+                profile_id="assigned",
+                workspace_id="ws",
+            ),
+        ]
+    )
+    manager = _manager(
+        InMemoryProfileStore(
+            [
+                MCPProfile(id="reviewer", name="Reviewer"),
+                MCPProfile(id="default", name="Default"),
+                MCPProfile(id="assigned", name="Assigned"),
+            ]
+        ),
+        assignment_store,
+        audit_store=audit_store,
+    )
+
+    future_owned_invalid_patches = [
+        {"approval_policy": {"mode": "auto"}},
+        {"path_scopes": [{"path": "/tmp"}]},
+        {"external_server_grants": [{"server_id": "external"}]},
+        {"credential_grants": [{"slot": "token"}]},
+        {"provenance": {"source": "bad"}},
+        {"created_at": "2026-05-31T12:00:00+00:00"},
+        {"updated_at": "2026-05-31T12:00:00+00:00"},
+    ]
+    for patch_document in future_owned_invalid_patches:
+        with pytest.raises(GatewayProfileManagementError):
+            await manager.patch_profile("reviewer", patch_document)
+
+    with pytest.raises(GatewayProfileManagementError):
+        await manager.patch_profile("reviewer", {"name": "Reviewer"})
+    with pytest.raises(GatewayProfileManagementError):
+        await manager.patch_profile("default", {"enabled": False})
+    with pytest.raises(GatewayProfileManagementError):
+        await manager.delete_profile("default")
+    with pytest.raises(GatewayProfileManagementError):
+        await manager.delete_profile("assigned")
+
+    assert [event.event_type for event in audit_store.events] == [
+        "profile.patch_failed",
+        "profile.patch_failed",
+        "profile.patch_failed",
+        "profile.patch_failed",
+        "profile.patch_failed",
+        "profile.patch_failed",
+        "profile.patch_failed",
+        "profile.patch_failed",
+        "profile.patch_failed",
+        "profile.delete_failed",
+        "profile.delete_failed",
+    ]
+    assert [event.payload["reason_code"] for event in audit_store.events] == [
+        "invalid_profile_patch",
+        "invalid_profile_patch",
+        "invalid_profile_patch",
+        "invalid_profile_patch",
+        "invalid_profile_patch",
+        "invalid_profile_patch",
+        "invalid_profile_patch",
+        "invalid_profile_patch",
+        "profile_is_default",
+        "profile_is_default",
+        "profile_has_assignments",
+    ]
+
+    serialized_payloads = json.dumps(
+        [event.payload for event in audit_store.events],
+        sort_keys=True,
+    )
+    assert "policy_document" not in serialized_payloads
+    assert "approval_policy" not in serialized_payloads
+    assert "path_scopes" not in serialized_payloads
+    assert "external_server_grants" not in serialized_payloads
+    assert "credential_grants" not in serialized_payloads
+    assert "provenance" not in serialized_payloads
+    assert "created_at" not in serialized_payloads
+    assert "updated_at" not in serialized_payloads
+
+
+@pytest.mark.asyncio
+async def test_delete_profile_sqlite_guard_preserves_assigned_profile(tmp_path: Path) -> None:
+    store = SQLiteMCPStore(tmp_path / "mcp.db")
+    try:
+        await store.upsert_profile(MCPProfile(id="assigned", name="Assigned"))
+        await store.upsert_assignment(
+            ProfileAssignment(id="workspace-assignment", profile_id="assigned", workspace_id="ws")
+        )
+        manager = GatewayProfileManager(
+            profile_store=store,
+            assignment_store=store,
+            store_metadata=GatewayProfileStoreMetadata(kind="sqlite", persistent=True),
+        )
+
+        with pytest.raises(GatewayProfileManagementError) as exc_info:
+            await manager.delete_profile("assigned")
+
+        assert exc_info.value.reason_code == "profile_has_assignments"
+        assert await store.get_profile("assigned") is not None
+        assert await store.get_assignment("workspace-assignment") is not None
+    finally:
+        await store.aclose()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Adds manager-owned MCP Unified profile create, limited patch, and guarded delete flows with compact audit events.
- Exposes editable profile CRUD through standalone FastAPI gateway routes and CLI commands.
- Adds SQLite guarded-delete and create-if-absent storage support plus focused manager, FastAPI, CLI, runtime-boundary, and storage coverage.

## Change Summary
- Implemented editable profile CRUD at the manager boundary so FastAPI and CLI callers share one validation, safety, and audit contract.
- Kept persistent-store mutation safety in the storage layer: SQLite guarded delete is atomic, and profile create now uses insert-if-absent semantics to avoid read-then-upsert races.
- Hardened review findings by normalizing create id/name inputs, narrowing validation exception handling, handling missing policy documents during patch, and mapping unexpected guarded-delete statuses explicitly.

## Validation Checklist
- [x] Focused MCP CRUD/runtime/storage tests: `223 passed, 4 warnings`.
- [x] Ruff touched-file check passed.
- [x] Bandit touched-scope scan reported `0 results`, `0 errors`.
- [x] `git diff --check` clean.
- [x] Remote CI was triggered for the latest pushed head; checks are still pending at the time of this update.

## UX Checklist
- [x] Not applicable. This PR changes standalone MCP gateway/API/CLI/storage behavior and does not modify frontend UX surfaces.

## Watchlists Checklist
- [x] Not applicable. This PR does not modify Watchlists, schedulers, or recurring job behavior.

## Risk Level
- Medium. The PR adds mutating profile-management APIs and storage semantics, but the changes are bounded to MCP Unified profile CRUD and covered by focused manager, route, CLI, and storage contract tests.

## Rollback Plan
- Revert this PR or the Stage 4L commits to remove the new create/patch/delete endpoints, CLI commands, and storage create/delete additions. Existing profile read/list/default flows remain isolated from the new mutation entrypoints.

## Docstring Coverage Note
- CodeRabbit reported the repository-wide docstring coverage baseline as below threshold. This PR does not attempt a repo-wide docstring sweep; touched public MCP gateway/storage surfaces have been documented so this branch does not add avoidable public-docstring gaps.

## Maintainer Note
- AI-authored PR: final merge requires a human-written Change summary per repo policy.
