### PR TITLE
Close Document and Workspace product-state tracker

### DIFF
--- a/backlog/tasks/task-45.44.10 - Migrate-design-system-product-state-Document-and-Workspace-surfaces.md
+++ b/backlog/tasks/task-45.44.10 - Migrate-design-system-product-state-Document-and-Workspace-surfaces.md
@@ -1,9 +1,10 @@
 ---
 id: TASK-45.44.10
 title: 'Migrate design-system product state: Document and Workspace surfaces'
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-05-14 03:20'
+updated_date: '2026-05-31 18:14'
 labels:
   - design-system
   - webui
@@ -27,9 +28,9 @@ Mirror the linked GitHub product-area migration issue. Closure requires zero cur
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 The linked GitHub issue owns current count and public status.
+- [x] #1 The linked GitHub issue owns current count and public status.
 - [x] #2 Implementation PR tasks are created under this child when the area is too broad for one PR.
-- [ ] #3 Backlog notes record PR links and before/after count evidence.
+- [x] #3 Backlog notes record PR links and before/after count evidence.
 <!-- AC:END -->
 
 ## Implementation Notes
@@ -43,12 +44,20 @@ Mirror the linked GitHub product-area migration issue. Closure requires zero cur
 - Created and completed TASK-45.44.10.6 for the final current Document/Workspace slice: DocumentWorkspaceErrorBoundary Result migration. PR: https://github.com/rmusser01/tldw_server/pull/1961. Verifier evidence after the slice reduces total baseline exceptions from 292 to 291 and removes the Document/Workspace product-area bucket.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Closed after confirming the current design-system product-state baseline no longer contains Document/Workspace-owned entries. `bun run verify:design-system-state` passes from `apps/packages/ui` and reports 82 allowed legacy exceptions in other product areas. A targeted baseline parse reports `{ "total": 82, "documentWorkspaceHits": 0 }` for DocumentWorkspace, Document/Workspace, ResearchWorkspace, Research Workspace, and Workspace labels.
+
+Updated the linked public GitHub issue #1667 with the verified 2026-05-31 status, current zero owned-exception count, and implementation PR links (#1950, #1952, #1955, #1959, #1961). This closeout changes Backlog metadata only, so Bandit is not applicable. Known remaining work is outside this tracker: the shared-product-state baseline still contains 82 allowed exceptions owned by other queues.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->


### PR DESCRIPTION
## Summary

- Closes Backlog `TASK-45.44.10` after the Document/Workspace product-state migration completed across the child PR sequence.
- Records the current zero owned-exception baseline evidence and the remaining out-of-scope shared-product-state baseline count.
- Updated GitHub issue #1667 with the current public status, verified counts, and implementation PR links.

## Change summary (maintainer-owned)

- [ ] Maintainer to confirm the final human-written change summary before merge.

## Verification

- `bun run verify:design-system-state` from `apps/packages/ui` passes; current baseline reports 82 allowed legacy exceptions in other product areas.
- Targeted baseline parse reports `{ "total": 82, "documentWorkspaceHits": 0 }` for DocumentWorkspace, Document/Workspace, ResearchWorkspace, Research Workspace, and Workspace labels.
- `git diff --check` passes.
- Bandit not applicable: this closeout changes Backlog metadata only.

## Risk / Rollback

- Risk is limited to tracker metadata and the public issue body update.
- Rollback is reverting the Backlog task closeout commit and restoring issue #1667 body if needed.

Closes #1667

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Closes the Document/Workspace product-state tracker by marking `TASK-45.44.10` as Done and recording the final baseline (metadata-only).
Verified zero Document/Workspace-owned exceptions via the design-system state check and a targeted parse (82 allowed elsewhere), updated GitHub issue #1667 with the 2026-05-31 status and implementation PR links, and marked all AC/DoD complete; Bandit not applicable.

<sup>Written for commit 0744a397e6ace29e2fe9dfaa8f88f906ca50979b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2196?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

