### PR TITLE
Close MCP and ACP product-state tracker

### DIFF
--- a/backlog/tasks/task-45.44.4 - Migrate-design-system-product-state-MCP-and-ACP.md
+++ b/backlog/tasks/task-45.44.4 - Migrate-design-system-product-state-MCP-and-ACP.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-45.44.4
 title: 'Migrate design-system product state: MCP and ACP'
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-05-14 03:19'
-updated_date: '2026-05-14 06:35'
+updated_date: '2026-05-31 18:31'
 labels:
   - design-system
   - webui
@@ -28,9 +28,9 @@ Mirror the linked GitHub product-area migration issue. Closure requires zero cur
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 The linked GitHub issue owns current count and public status.
-- [ ] #2 Implementation PR tasks are created under this child when the area is too broad for one PR.
-- [ ] #3 Backlog notes record PR links and before/after count evidence.
+- [x] #1 The linked GitHub issue owns current count and public status.
+- [x] #2 Implementation PR tasks are created under this child when the area is too broad for one PR.
+- [x] #3 Backlog notes record PR links and before/after count evidence.
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -45,14 +45,24 @@ Review-driven unblock from PR #1683: replace the unbaselined WorkspaceACPHistory
 PR #1683 review surfaced a full-verifier blocker in WorkspaceACPHistoryModal. This narrow change is being handled inside the Chat/Playground PR only to restore verifier pass status; it does not complete the broader MCP/ACP migration area.
 
 PR #1683 review unblock completed: after rebasing onto current dev, WorkspaceACPHistoryModal uses the shared design-system Alert primitive for the load-error product state. Full bun run verify:design-system-state exits 0. The broader MCP/ACP baseline migration remains open.
+
+Closeout verification on 2026-05-31: current `apps/packages/ui/scripts/design-system-product-state-baseline.json` contains 82 allowed repo-wide exceptions and 0 MCP/ACP-owned hits for MCP, ACP, AgentTasks, WorkspaceACP, ACPPlayground, MCPHub, `Option/MCP`, and `Option/ACP` labels. The linked GitHub issue #1661 was refreshed with the current public status and zero owned-exception count. No additional implementation child tasks are required for this closeout because the current owned bucket is already zero; the prior implementation path is recorded through PR #1683 and later merged MCP/ACP route-alignment work.
 <!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Closed after confirming the current design-system product-state baseline no longer contains MCP/ACP-owned entries. `bun run verify:design-system-state` passes from `apps/packages/ui` and reports 82 allowed legacy exceptions in other product areas. A targeted baseline parse reports `{ "total": 82, "mcpAcpHits": 0 }` for MCP, ACP, AgentTasks, WorkspaceACP, ACPPlayground, MCPHub, `Option/MCP`, and `Option/ACP` labels.
+
+Updated the linked public GitHub issue #1661 with the verified 2026-05-31 status, current zero owned-exception count, and implementation PR reference (#1683). This closeout changes Backlog metadata only, so Bandit is not applicable. Known remaining work is outside this tracker: the shared-product-state baseline still contains 82 allowed exceptions owned by other queues.
+<!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->


### PR DESCRIPTION
## Summary

- Closes Backlog `TASK-45.44.4` after confirming the MCP/ACP product-state bucket is now zero.
- Records current baseline verification evidence and the remaining out-of-scope shared-product-state count.
- Updates GitHub issue #1661 with the current public status and implementation reference.

## Change summary (maintainer-owned)

- [ ] Maintainer to confirm the final human-written change summary before merge.

## Verification

- `bun run verify:design-system-state` from `apps/packages/ui` passes; current baseline reports 82 allowed legacy exceptions in other product areas.
- Targeted baseline parse reports `{ "total": 82, "mcpAcpHits": 0 }` for MCP, ACP, AgentTasks, WorkspaceACP, ACPPlayground, MCPHub, `Option/MCP`, and `Option/ACP` labels.
- `git diff --check` passes.
- Bandit not applicable: this closeout changes Backlog metadata only.

## Risk / Rollback

- Risk is limited to tracker metadata and the public issue body update.
- Rollback is reverting the Backlog task closeout commit and restoring issue #1661 body if needed.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Closes the MCP/ACP design-system product-state tracker by confirming the owned bucket is zero and marking `TASK-45.44.4` as Done. `bun run verify:design-system-state` passes from `apps/packages/ui`; baseline shows 0 `MCP`/`ACP` hits (82 allowed exceptions elsewhere), and issue #1661 is updated.

<sup>Written for commit 95ea4991b556536e92e68eb2ab0652d5f043a442. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2197?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

