### PR TITLE
Fix chat cockpit rail restore layout

### DIFF
--- a/apps/packages/ui/src/components/Option/Playground/Playground.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/Playground.tsx
@@ -574,23 +574,9 @@ export const Playground = () => {
     : "max-w-[64rem]";
   const handleChatLayoutModeChange = React.useCallback(
     (mode: PlaygroundCockpitMode) => {
-      if (
-        mode === "cockpit" &&
-        !normalizedCockpitContextRailVisible &&
-        !normalizedCockpitRuntimeRailVisible
-      ) {
-        void setCockpitContextRailVisible(true);
-        void setCockpitRuntimeRailVisible(true);
-      }
       void setChatLayoutMode(mode);
     },
-    [
-      normalizedCockpitContextRailVisible,
-      normalizedCockpitRuntimeRailVisible,
-      setChatLayoutMode,
-      setCockpitContextRailVisible,
-      setCockpitRuntimeRailVisible,
-    ],
+    [setChatLayoutMode],
   );
 
   React.useEffect(() => {

--- a/apps/packages/ui/src/components/Option/Playground/Playground.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/Playground.tsx
@@ -565,6 +565,13 @@ export const Playground = () => {
     cockpitRuntimeRailVisible !== false;
   const mobileCockpitComposerConstrained =
     isMobileViewport && normalizedChatLayoutMode === "cockpit";
+  const cockpitRailCollapsedWideContent =
+    normalizedChatLayoutMode === "cockpit" &&
+    (!normalizedCockpitContextRailVisible ||
+      !normalizedCockpitRuntimeRailVisible);
+  const chatContentWidthClassName = cockpitRailCollapsedWideContent
+    ? "max-w-none"
+    : "max-w-[64rem]";
   const handleChatLayoutModeChange = React.useCallback(
     (mode: PlaygroundCockpitMode) => {
       if (
@@ -2988,7 +2995,7 @@ export const Playground = () => {
     <div
       ref={drop}
       data-is-dragging={dropState === "dragging"}
-      className="relative flex h-full min-h-0 flex-col items-center bg-bg text-text data-[is-dragging=true]:bg-surface2"
+      className="relative flex h-full min-h-0 w-full flex-col items-center bg-bg text-text data-[is-dragging=true]:bg-surface2"
       style={
         chatBackgroundImage
           ? {
@@ -3098,7 +3105,9 @@ export const Playground = () => {
               </div>
             )}
             <div className="px-4 pt-2">
-              <div className="mx-auto flex w-full max-w-[64rem] items-center justify-between text-[11px] text-text-muted">
+              <div
+                className={`mx-auto flex w-full ${chatContentWidthClassName} items-center justify-between text-[11px] text-text-muted`}
+              >
                 <div className="flex min-w-0 flex-wrap items-center gap-1.5">
                   <span
                     data-testid="playground-active-chat-mode"
@@ -3228,7 +3237,7 @@ export const Playground = () => {
                   role="dialog"
                   aria-modal="false"
                   aria-label={t("playground:shortcuts.title", "Shortcuts")}
-                  className="mx-auto mt-1 w-full max-w-[64rem] rounded-md border border-border bg-surface2 px-2 py-1.5 text-[11px] text-text"
+                  className={`mx-auto mt-1 w-full ${chatContentWidthClassName} rounded-md border border-border bg-surface2 px-2 py-1.5 text-[11px] text-text`}
                 >
                   <div className="mb-1 flex items-center justify-between gap-2">
                     <span className="font-semibold">
@@ -3314,7 +3323,9 @@ export const Playground = () => {
                 </div>
               )}
               {threadSearchOpen && (
-                <div className="mx-auto mt-1 flex w-full max-w-[64rem] flex-wrap items-center gap-2 rounded-md border border-border bg-surface2 px-2 py-1">
+                <div
+                  className={`mx-auto mt-1 flex w-full ${chatContentWidthClassName} flex-wrap items-center gap-2 rounded-md border border-border bg-surface2 px-2 py-1`}
+                >
                   <div className="relative min-w-[200px] flex-1">
                     <Search
                       className="pointer-events-none absolute left-2 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-text-subtle"
@@ -3398,7 +3409,7 @@ export const Playground = () => {
               {compactFeatureNoticeVisible && (
                 <div
                   data-testid="playground-mobile-parity-notice"
-                  className="mx-auto mt-1 w-full max-w-[64rem] rounded-md border border-warn/30 bg-warn/10 px-2 py-1 text-[10px] text-warn"
+                  className={`mx-auto mt-1 w-full ${chatContentWidthClassName} rounded-md border border-warn/30 bg-warn/10 px-2 py-1 text-[10px] text-warn`}
                 >
                   {t(
                     "playground:regions.compactFeatureNotice",
@@ -3428,7 +3439,7 @@ export const Playground = () => {
               aria-label={t("playground:aria.chatTranscript", "Chat messages")}
               className="custom-scrollbar flex-1 min-h-0 w-full overflow-x-hidden overflow-y-auto px-4"
             >
-              <div className="mx-auto w-full max-w-[64rem] pb-6">
+              <div className={`mx-auto w-full ${chatContentWidthClassName} pb-6`}>
                 <ChatErrorBoundary>
                   <PlaygroundChat
                     showStarterDeck={showStarterDeck}
@@ -3466,7 +3477,9 @@ export const Playground = () => {
                   : ""
               }`}
             >
-              <div className="mx-auto w-full max-w-[64rem] px-4 pt-2 text-[11px] text-text-muted">
+              <div
+                className={`mx-auto w-full ${chatContentWidthClassName} px-4 pt-2 text-[11px] text-text-muted`}
+              >
                 <span className="inline-flex items-center rounded-full border border-border bg-surface2 px-2 py-0.5">
                   {t("playground:regions.composer", "Composer")}
                 </span>
@@ -3498,6 +3511,7 @@ export const Playground = () => {
                 droppedFiles={droppedFiles}
                 stickyDockEnabled={stickyChatInput}
                 mobileCockpitModeActive={mobileCockpitComposerConstrained}
+                forceWideMode={cockpitRailCollapsedWideContent}
                 onComposerLayoutChange={
                   stickyChatInput ? handleComposerLayoutChange : undefined
                 }

--- a/apps/packages/ui/src/components/Option/Playground/PlaygroundCockpitShell.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/PlaygroundCockpitShell.tsx
@@ -61,8 +61,12 @@ const CockpitTooltipButton = ({
       ? `${describedBy} ${tooltipId}`
       : tooltipId;
 
+  const resolvedWrapperClassName = wrapperClassName
+    ? `group inline-flex ${wrapperClassName}`
+    : "group relative inline-flex";
+
   return (
-    <span className={`group relative inline-flex ${wrapperClassName ?? ""}`}>
+    <span className={resolvedWrapperClassName}>
       <button
         {...buttonProps}
         aria-describedby={ariaDescribedBy}
@@ -198,6 +202,8 @@ export const PlaygroundCockpitShell = ({
     "cockpit.restoreRuntimeSidechannel",
     "Restore runtime sidechannel",
   );
+  const contextRailTabLabel = t("cockpit.contextRailTab", "Context rail");
+  const runtimeRailTabLabel = t("cockpit.runtimeRailTab", "Runtime rail");
   const modeSummaryKey = buildModeSummaryKey(
     focusMode,
     leftRailVisible,
@@ -229,14 +235,20 @@ export const PlaygroundCockpitShell = ({
                 "Cockpit rails hidden. Status remains visible.",
               );
   const bodyClassName = focusMode
-    ? "flex min-h-0 flex-1 justify-center overflow-hidden"
-    : showLeftRail && showRightRail
-      ? "grid min-h-0 flex-1 grid-cols-1 overflow-hidden lg:grid-cols-[minmax(220px,280px)_minmax(0,1fr)_minmax(240px,300px)]"
-      : showLeftRail
-        ? "grid min-h-0 flex-1 grid-cols-1 overflow-hidden lg:grid-cols-[minmax(220px,280px)_minmax(0,1fr)]"
-        : showRightRail
-          ? "grid min-h-0 flex-1 grid-cols-1 overflow-hidden lg:grid-cols-[minmax(0,1fr)_minmax(240px,300px)]"
-          : "grid min-h-0 flex-1 grid-cols-1 overflow-hidden";
+    ? "flex min-h-0 w-full min-w-0 flex-1 justify-center overflow-hidden"
+    : "grid min-h-0 w-full min-w-0 flex-1 grid-cols-1 overflow-hidden lg:[grid-template-columns:var(--cockpit-grid-columns)]";
+  const cockpitGridColumns = showLeftRail
+    ? showRightRail
+      ? "minmax(220px,280px) minmax(0,1fr) minmax(240px,300px)"
+      : "minmax(220px,280px) minmax(0,1fr)"
+    : showRightRail
+      ? "minmax(0,1fr) minmax(240px,300px)"
+      : "minmax(0,1fr)";
+  const cockpitGridStyle = focusMode
+    ? undefined
+    : ({
+        "--cockpit-grid-columns": cockpitGridColumns,
+      } as React.CSSProperties);
 
   return (
     <div
@@ -244,7 +256,7 @@ export const PlaygroundCockpitShell = ({
       data-mode={mode}
       data-left-rail={showLeftRail ? "visible" : "hidden"}
       data-right-rail={showRightRail ? "visible" : "hidden"}
-      className="flex h-full min-h-0 min-w-0 flex-1 flex-col overflow-hidden bg-bg text-text"
+      className="flex h-full min-h-0 w-full min-w-0 flex-1 flex-col overflow-hidden bg-bg text-text"
     >
       <header
         aria-label={t("cockpit.layoutControls", "Chat layout controls")}
@@ -427,43 +439,7 @@ export const PlaygroundCockpitShell = ({
         </div>
       )}
 
-      <div className={`${bodyClassName} relative`}>
-        {!focusMode && !leftRailVisible ? (
-          <CockpitTooltipButton
-            type="button"
-            data-testid="playground-cockpit-left-rail-restore"
-            aria-label={restoreContextSidechannelLabel}
-            aria-controls="playground-cockpit-left-rail"
-            aria-expanded="false"
-            onClick={() => onLeftRailVisibleChange?.(true)}
-            tooltip={restoreContextSidechannelLabel}
-            tooltipPlacement="right"
-            wrapperClassName="absolute left-2 top-2 z-20 hidden lg:inline-flex"
-            className="inline-flex min-h-[32px] items-center gap-1 rounded-md border border-border bg-surface2 px-2 py-1 text-xs font-medium text-text shadow-sm hover:bg-surface focus:outline-none focus-visible:ring-2 focus-visible:ring-focus"
-          >
-            <PanelLeftOpen className="h-3.5 w-3.5" aria-hidden="true" />
-            <span>{t("cockpit.context", "Context")}</span>
-          </CockpitTooltipButton>
-        ) : null}
-
-        {!focusMode && !rightRailVisible ? (
-          <CockpitTooltipButton
-            type="button"
-            data-testid="playground-cockpit-right-rail-restore"
-            aria-label={restoreRuntimeSidechannelLabel}
-            aria-controls="playground-cockpit-right-rail"
-            aria-expanded="false"
-            onClick={() => onRightRailVisibleChange?.(true)}
-            tooltip={restoreRuntimeSidechannelLabel}
-            tooltipPlacement="left"
-            wrapperClassName="absolute right-2 top-2 z-20 hidden lg:inline-flex"
-            className="inline-flex min-h-[32px] items-center gap-1 rounded-md border border-border bg-surface2 px-2 py-1 text-xs font-medium text-text shadow-sm hover:bg-surface focus:outline-none focus-visible:ring-2 focus-visible:ring-focus"
-          >
-            <span>{t("cockpit.runtime", "Runtime")}</span>
-            <PanelRightOpen className="h-3.5 w-3.5" aria-hidden="true" />
-          </CockpitTooltipButton>
-        ) : null}
-
+      <div className={`${bodyClassName} relative`} style={cockpitGridStyle}>
         {showLeftRail && (
           <aside
             id="playground-cockpit-left-rail"
@@ -495,9 +471,11 @@ export const PlaygroundCockpitShell = ({
         <main
           data-testid="playground-cockpit-main"
           className={`min-h-0 min-w-0 overflow-hidden bg-bg ${
-            focusMode || (!showLeftRail && !showRightRail)
+            focusMode
               ? "w-full max-w-[72rem]"
-              : ""
+              : !showLeftRail && !showRightRail
+                ? "w-full"
+                : ""
           }`}
         >
           {children}
@@ -530,6 +508,46 @@ export const PlaygroundCockpitShell = ({
             <div className="min-w-0">{rightRail}</div>
           </aside>
         )}
+
+        {!focusMode && !leftRailVisible ? (
+          <CockpitTooltipButton
+            type="button"
+            data-testid="playground-cockpit-left-rail-restore"
+            aria-label={restoreContextSidechannelLabel}
+            aria-controls="playground-cockpit-left-rail"
+            aria-expanded="false"
+            onClick={() => onLeftRailVisibleChange?.(true)}
+            tooltip={restoreContextSidechannelLabel}
+            tooltipPlacement="right"
+            wrapperClassName="absolute left-0 top-1/2 z-20 hidden -translate-y-1/2 lg:inline-flex"
+            className="inline-flex h-32 w-9 flex-col items-center justify-center gap-2 rounded-r-md border-y border-r border-border bg-surface2/95 py-2 text-[11px] font-semibold text-text shadow-md backdrop-blur-sm hover:bg-surface focus:outline-none focus-visible:ring-2 focus-visible:ring-focus"
+          >
+            <PanelLeftOpen className="h-3.5 w-3.5" aria-hidden="true" />
+            <span className="rotate-180 whitespace-nowrap leading-none [writing-mode:vertical-rl]">
+              {contextRailTabLabel}
+            </span>
+          </CockpitTooltipButton>
+        ) : null}
+
+        {!focusMode && !rightRailVisible ? (
+          <CockpitTooltipButton
+            type="button"
+            data-testid="playground-cockpit-right-rail-restore"
+            aria-label={restoreRuntimeSidechannelLabel}
+            aria-controls="playground-cockpit-right-rail"
+            aria-expanded="false"
+            onClick={() => onRightRailVisibleChange?.(true)}
+            tooltip={restoreRuntimeSidechannelLabel}
+            tooltipPlacement="left"
+            wrapperClassName="absolute right-0 top-1/2 z-20 hidden -translate-y-1/2 lg:inline-flex"
+            className="inline-flex h-32 w-9 flex-col items-center justify-center gap-2 rounded-l-md border-y border-l border-border bg-surface2/95 py-2 text-[11px] font-semibold text-text shadow-md backdrop-blur-sm hover:bg-surface focus:outline-none focus-visible:ring-2 focus-visible:ring-focus"
+          >
+            <span className="whitespace-nowrap leading-none [writing-mode:vertical-rl]">
+              {runtimeRailTabLabel}
+            </span>
+            <PanelRightOpen className="h-3.5 w-3.5" aria-hidden="true" />
+          </CockpitTooltipButton>
+        ) : null}
       </div>
 
       <div data-testid="playground-cockpit-status-strip">{statusStrip}</div>

--- a/apps/packages/ui/src/components/Option/Playground/PlaygroundEmpty.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/PlaygroundEmpty.tsx
@@ -11,7 +11,6 @@ import {
   Microscope,
 } from "lucide-react";
 import { useDemoMode } from "@/context/demo-mode";
-import { useIsConnected } from "@/hooks/useConnectionState";
 import { useHelpModal } from "@/store/tutorials";
 import { buildResearchLaunchPath } from "@/routes/route-paths";
 import { requestQuickIngestOpen } from "@/utils/quick-ingest-open";
@@ -23,7 +22,6 @@ const actionButtonFocusClassName =
 export const PlaygroundEmpty = () => {
   const { t } = useTranslation(["playground", "common", "option"]);
   const { demoEnabled } = useDemoMode();
-  const isConnected = useIsConnected();
   const { open: openHelpModal } = useHelpModal();
   const navigate = useNavigate();
   const [modesExpanded, setModesExpanded] = React.useState(false);
@@ -133,29 +131,11 @@ export const PlaygroundEmpty = () => {
     [dispatchStarter, handleOpenDeepResearch, t],
   );
 
-  const isDisconnected = !demoEnabled && !isConnected;
   const description = demoEnabled ? (
     t("playground:empty.demoDescription", {
       defaultValue:
         "You're in demo mode — try asking a question to see how the assistant responds. You can connect your own tldw server later.",
     })
-  ) : isDisconnected ? (
-    <div className="mx-auto flex max-w-2xl flex-col items-center gap-2 sm:text-base">
-      <span>
-        {t("playground:empty.disconnectedDescription", {
-          defaultValue: "Connect to a tldw server to start chatting.",
-        })}
-      </span>
-      <button
-        type="button"
-        onClick={() => navigate("/settings/tldw")}
-        className={`inline-flex items-center text-sm font-medium text-primary transition hover:underline ${actionButtonFocusClassName}`}
-      >
-        {t("playground:empty.openSettings", {
-          defaultValue: "Open Settings",
-        })}
-      </button>
-    </div>
   ) : (
     t("playground:empty.description", {
       defaultValue:

--- a/apps/packages/ui/src/components/Option/Playground/PlaygroundForm.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/PlaygroundForm.tsx
@@ -265,6 +265,7 @@ type Props = {
   onPrepareResearchFollowUp?: (target: ResearchFollowUpTarget) => void;
   stickyDockEnabled?: boolean;
   mobileCockpitModeActive?: boolean;
+  forceWideMode?: boolean;
   onComposerLayoutChange?: (metrics: ComposerDockLayoutMetrics) => void;
   onDraftPresenceChange?: (hasDraft: boolean) => void;
   characterChatSendBlocker?: PlaygroundSendBlocker | null;
@@ -460,6 +461,7 @@ export const PlaygroundForm = ({
   onPrepareResearchFollowUp,
   stickyDockEnabled = false,
   mobileCockpitModeActive = false,
+  forceWideMode = false,
   onComposerLayoutChange,
   onDraftPresenceChange,
   characterChatSendBlocker = null,
@@ -495,6 +497,7 @@ export const PlaygroundForm = ({
   const voiceChatSubmitFormRef = React.useRef<() => void>(() => undefined);
 
   const [checkWideMode] = useStorage("checkWideMode", false);
+  const effectiveWideMode = checkWideMode || forceWideMode;
   const [allowExternalImages, setAllowExternalImages] = useStorage(
     "allowExternalImages",
     DEFAULT_CHAT_SETTINGS.allowExternalImages,
@@ -934,9 +937,6 @@ export const PlaygroundForm = ({
       });
     },
   });
-  const [hasShownConnectBanner, setHasShownConnectBanner] =
-    React.useState(false);
-  const [showConnectBanner, setShowConnectBanner] = React.useState(false);
   const [documentGeneratorOpen, setDocumentGeneratorOpen] =
     React.useState(false);
   const [voiceModeSelectorOpen, setVoiceModeSelectorOpen] =
@@ -2467,12 +2467,6 @@ export const PlaygroundForm = ({
     }
   }, [defaultInternetSearchOn, setWebSearch]);
 
-  React.useEffect(() => {
-    if (isConnectionReady) {
-      setShowConnectBanner(false);
-    }
-  }, [isConnectionReady]);
-
   const notifyImageAttachmentDisabled = React.useCallback(() => {
     notificationApi.warning({
       message: t(
@@ -2644,13 +2638,6 @@ export const PlaygroundForm = ({
       textareaRef,
     ],
   );
-  const handleDisconnectedFocus = React.useCallback(() => {
-    if (!isConnectionReady && !hasShownConnectBanner) {
-      setShowConnectBanner(true);
-      setHasShownConnectBanner(true);
-    }
-  }, [hasShownConnectBanner, isConnectionReady]);
-
   const handleTextareaKeyDown = (
     e: React.KeyboardEvent<HTMLTextAreaElement>,
   ) => {
@@ -2659,7 +2646,6 @@ export const PlaygroundForm = ({
   };
 
   const handleTextareaFocus = React.useCallback(() => {
-    handleDisconnectedFocus();
     if (!isMessageCollapsed) return;
     const wasPointer = pointerDownRef.current;
     pointerDownRef.current = false;
@@ -2673,7 +2659,6 @@ export const PlaygroundForm = ({
     }
     syncCollapsedCaret();
   }, [
-    handleDisconnectedFocus,
     isMessageCollapsed,
     syncCollapsedCaret,
     textareaRef,
@@ -4128,6 +4113,7 @@ export const PlaygroundForm = ({
   const contextItems = usePlaygroundContextItems({
     selectedModel,
     modelSummaryLabel,
+    isConnectionReady,
     isSessionDegraded,
     connectionStatusLabel,
     compareModeActive,
@@ -4805,9 +4791,11 @@ export const PlaygroundForm = ({
     >
       <div className="flex w-full flex-col items-center px-4 pb-6">
         <div
-          data-checkwidemode={checkWideMode}
+          data-checkwidemode={effectiveWideMode}
           data-ui-mode={uiMode}
-          className="relative z-10 flex w-full max-w-[64rem] flex-col items-center justify-center gap-2 text-base data-[checkwidemode='true']:max-w-none"
+          className={`relative z-10 flex w-full ${
+            effectiveWideMode ? "max-w-none" : "max-w-[64rem]"
+          } flex-col items-center justify-center gap-2 text-base`}
         >
           <div className="relative flex w-full flex-row justify-center">
             <div
@@ -5449,17 +5437,10 @@ export const PlaygroundForm = ({
                                     onCompositionEnd={handleCompositionEnd}
                                     onMouseDown={handleTextareaMouseDown}
                                     onMouseUp={handleTextareaMouseUp}
-                                    placeholder={
-                                      isConnectionReady
-                                        ? t(
-                                            "playground:composer.placeholderWithMentions",
-                                            "Type a message... (/ commands, @ mentions)",
-                                          )
-                                        : t(
-                                            "playground:composer.connectionPlaceholder",
-                                            "Connect to tldw to start chatting.",
-                                          )
-                                    }
+                                    placeholder={t(
+                                      "playground:composer.placeholderWithMentions",
+                                      "Type a message... (/ commands, @ mentions)",
+                                    )}
                                     isProMode={isProMode}
                                     isMobile={isMobileViewport}
                                     isConnectionReady={isConnectionReady}
@@ -5954,42 +5935,6 @@ export const PlaygroundForm = ({
                           </>
                         );
                       })()}
-                      {showConnectBanner && !isConnectionReady && (
-                        <div className="mt-2 flex flex-wrap items-center justify-between gap-2 rounded-md border border-warn/30 bg-warn/10 px-3 py-2 text-xs text-warn">
-                          <p className="max-w-xs text-left">
-                            {t(
-                              "playground:composer.connectNotice",
-                              "Connect to your tldw server in Settings to send messages.",
-                            )}
-                          </p>
-                          <div className="flex flex-wrap items-center gap-2">
-                            <Link
-                              to="/settings/tldw"
-                              className="text-xs font-medium text-warn underline hover:text-warn"
-                            >
-                              {t("settings:tldw.setupLink", "Set up server")}
-                            </Link>
-                            <Link
-                              to="/settings/health"
-                              className="text-xs font-medium text-warn underline hover:text-warn"
-                            >
-                              {t(
-                                "settings:healthSummary.diagnostics",
-                                "Health & diagnostics",
-                              )}
-                            </Link>
-                            <button
-                              type="button"
-                              onClick={() => setShowConnectBanner(false)}
-                              className="inline-flex items-center rounded-full p-1 text-warn hover:bg-warn/10"
-                              aria-label={t("common:close", "Dismiss")}
-                              title={t("common:close", "Dismiss") as string}
-                            >
-                              <X className="h-3 w-3" />
-                            </button>
-                          </div>
-                        </div>
-                      )}
                       <ChatQueuePanel
                         queue={queuedMessages}
                         isConnectionReady={isConnectionReady}

--- a/apps/packages/ui/src/components/Option/Playground/__tests__/Playground.cockpit-rail-restore.test.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/__tests__/Playground.cockpit-rail-restore.test.tsx
@@ -1,0 +1,148 @@
+// @vitest-environment jsdom
+import React from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { PlaygroundCockpitShell } from "../PlaygroundCockpitShell";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (_key: string, fallback: string) => fallback,
+  }),
+}));
+
+const renderShell = ({
+  leftRailVisible,
+  rightRailVisible,
+  onLeftRailVisibleChange = vi.fn(),
+  onRightRailVisibleChange = vi.fn(),
+}: {
+  leftRailVisible: boolean;
+  rightRailVisible: boolean;
+  onLeftRailVisibleChange?: (visible: boolean) => void;
+  onRightRailVisibleChange?: (visible: boolean) => void;
+}) => {
+  render(
+    <PlaygroundCockpitShell
+      mode="cockpit"
+      onModeChange={vi.fn()}
+      leftRailVisible={leftRailVisible}
+      rightRailVisible={rightRailVisible}
+      onLeftRailVisibleChange={onLeftRailVisibleChange}
+      onRightRailVisibleChange={onRightRailVisibleChange}
+      leftRail={<div>Context tools</div>}
+      rightRail={<div>Runtime tools</div>}
+      statusStrip={<div>Ready</div>}
+    >
+      <div>Chat transcript</div>
+    </PlaygroundCockpitShell>,
+  );
+
+  return { onLeftRailVisibleChange, onRightRailVisibleChange };
+};
+
+describe("Playground cockpit rail restore tabs", () => {
+  it("mounts the context restore control on the left edge while runtime stays expanded", () => {
+    const { onLeftRailVisibleChange } = renderShell({
+      leftRailVisible: false,
+      rightRailVisible: true,
+    });
+
+    expect(
+      screen.queryByTestId("playground-cockpit-left-rail"),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByTestId("playground-cockpit-right-rail"),
+    ).toBeInTheDocument();
+
+    const contextRestore = screen.getByTestId(
+      "playground-cockpit-left-rail-restore",
+    );
+    expect(contextRestore).toHaveTextContent("Context rail");
+    expect(contextRestore.parentElement).toHaveClass(
+      "absolute",
+      "left-0",
+      "top-1/2",
+      "-translate-y-1/2",
+    );
+    expect(contextRestore.parentElement).not.toHaveClass("relative");
+    expect(
+      screen
+        .getByTestId("playground-cockpit-main")
+        .parentElement?.style.getPropertyValue("--cockpit-grid-columns"),
+    ).toBe("minmax(0,1fr) minmax(240px,300px)");
+
+    fireEvent.click(contextRestore);
+    expect(onLeftRailVisibleChange).toHaveBeenCalledWith(true);
+  });
+
+  it("mounts the runtime restore control on the right edge while context stays expanded", () => {
+    const { onRightRailVisibleChange } = renderShell({
+      leftRailVisible: true,
+      rightRailVisible: false,
+    });
+
+    expect(
+      screen.getByTestId("playground-cockpit-left-rail"),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByTestId("playground-cockpit-right-rail"),
+    ).not.toBeInTheDocument();
+
+    const runtimeRestore = screen.getByTestId(
+      "playground-cockpit-right-rail-restore",
+    );
+    expect(runtimeRestore).toHaveTextContent("Runtime rail");
+    expect(runtimeRestore.parentElement).toHaveClass(
+      "absolute",
+      "right-0",
+      "top-1/2",
+      "-translate-y-1/2",
+    );
+    expect(runtimeRestore.parentElement).not.toHaveClass("relative");
+    expect(
+      screen
+        .getByTestId("playground-cockpit-main")
+        .parentElement?.style.getPropertyValue("--cockpit-grid-columns"),
+    ).toBe("minmax(220px,280px) minmax(0,1fr)");
+
+    fireEvent.click(runtimeRestore);
+    expect(onRightRailVisibleChange).toHaveBeenCalledWith(true);
+  });
+
+  it("keeps both collapsed rail restore tabs visible without adding an in-flow collapsed panel", () => {
+    const { onLeftRailVisibleChange, onRightRailVisibleChange } = renderShell({
+      leftRailVisible: false,
+      rightRailVisible: false,
+    });
+
+    const contextRestore = screen.getByTestId(
+      "playground-cockpit-left-rail-restore",
+    );
+    const runtimeRestore = screen.getByTestId(
+      "playground-cockpit-right-rail-restore",
+    );
+
+    expect(contextRestore).toHaveTextContent("Context rail");
+    expect(runtimeRestore).toHaveTextContent("Runtime rail");
+    expect(
+      screen.queryByTestId("playground-collapsed-composition-summary"),
+    ).not.toBeInTheDocument();
+    expect(
+      screen
+        .getByTestId("playground-cockpit-main")
+        .parentElement?.style.getPropertyValue("--cockpit-grid-columns"),
+    ).toBe("minmax(0,1fr)");
+    expect(screen.getByTestId("playground-cockpit-main")).toHaveClass(
+      "w-full",
+    );
+    expect(screen.getByTestId("playground-cockpit-main")).not.toHaveClass(
+      "max-w-[72rem]",
+    );
+
+    fireEvent.click(contextRestore);
+    fireEvent.click(runtimeRestore);
+    expect(onLeftRailVisibleChange).toHaveBeenCalledWith(true);
+    expect(onRightRailVisibleChange).toHaveBeenCalledWith(true);
+  });
+});

--- a/apps/packages/ui/src/components/Option/Playground/__tests__/Playground.cockpit-shell.test.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/__tests__/Playground.cockpit-shell.test.tsx
@@ -1084,6 +1084,62 @@ describe("Playground cockpit shell", () => {
     ).toBeInTheDocument();
   });
 
+  it("preserves both intentionally collapsed rails across focus and cockpit mode toggles", async () => {
+    render(<Playground />);
+
+    expect(
+      await screen.findByTestId("playground-cockpit-shell"),
+    ).toHaveAttribute("data-mode", "cockpit");
+
+    fireEvent.click(screen.getByRole("button", { name: /hide context rail/i }));
+    fireEvent.click(screen.getByRole("button", { name: /hide runtime rail/i }));
+
+    await waitFor(() => {
+      expect(screen.queryByTestId("playground-cockpit-left-rail")).toBeNull();
+      expect(screen.queryByTestId("playground-cockpit-right-rail")).toBeNull();
+    });
+    expect(storageState.values.get("playgroundChatContextRailVisible")).toBe(
+      false,
+    );
+    expect(storageState.values.get("playgroundChatRuntimeRailVisible")).toBe(
+      false,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /enter focus chat/i }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("playground-cockpit-shell")).toHaveAttribute(
+        "data-mode",
+        "focus",
+      );
+    });
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /show cockpit panels/i }),
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("playground-cockpit-shell")).toHaveAttribute(
+        "data-mode",
+        "cockpit",
+      );
+    });
+    expect(screen.queryByTestId("playground-cockpit-left-rail")).toBeNull();
+    expect(screen.queryByTestId("playground-cockpit-right-rail")).toBeNull();
+    expect(
+      screen.getByTestId("playground-cockpit-left-rail-restore"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId("playground-cockpit-right-rail-restore"),
+    ).toBeInTheDocument();
+    expect(storageState.values.get("playgroundChatContextRailVisible")).toBe(
+      false,
+    );
+    expect(storageState.values.get("playgroundChatRuntimeRailVisible")).toBe(
+      false,
+    );
+  });
+
   it("persists independent context and runtime rail visibility in cockpit mode", async () => {
     render(<Playground />);
 

--- a/apps/packages/ui/src/components/Option/Playground/__tests__/Playground.sticky-composer-layout.integration.test.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/__tests__/Playground.sticky-composer-layout.integration.test.tsx
@@ -74,6 +74,9 @@ const storeOptionState = vi.hoisted(() => ({
 const storageState = vi.hoisted(() => ({
   value: {
     stickyChatInput: true,
+    chatLayoutMode: "cockpit",
+    cockpitContextRailVisible: true,
+    cockpitRuntimeRailVisible: true,
   },
 }));
 
@@ -96,7 +99,14 @@ vi.mock("react-i18next", () => ({
 }));
 
 vi.mock("@/components/Option/Playground/PlaygroundForm", () => ({
-  PlaygroundForm: () => <div data-testid="playground-form">Mock composer</div>,
+  PlaygroundForm: ({ forceWideMode = false }: { forceWideMode?: boolean }) => (
+    <div
+      data-testid="playground-form"
+      data-force-wide-mode={String(forceWideMode)}
+    >
+      Mock composer
+    </div>
+  ),
 }));
 
 vi.mock("@/components/Option/Playground/PlaygroundChat", () => ({
@@ -168,6 +178,15 @@ vi.mock("@plasmohq/storage/hook", () => ({
     if (key === "stickyChatInput") {
       return [storageState.value.stickyChatInput];
     }
+    if (key === "playgroundChatLayoutMode") {
+      return [storageState.value.chatLayoutMode];
+    }
+    if (key === "playgroundChatContextRailVisible") {
+      return [storageState.value.cockpitContextRailVisible];
+    }
+    if (key === "playgroundChatRuntimeRailVisible") {
+      return [storageState.value.cockpitRuntimeRailVisible];
+    }
     return [defaultValue];
   },
 }));
@@ -230,6 +249,9 @@ describe("Playground sticky composer layout integration", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     storageState.value.stickyChatInput = true;
+    storageState.value.chatLayoutMode = "cockpit";
+    storageState.value.cockpitContextRailVisible = true;
+    storageState.value.cockpitRuntimeRailVisible = true;
     storeOptionState.value.setSelectedQuickPrompt = vi.fn();
   });
 
@@ -248,6 +270,23 @@ describe("Playground sticky composer layout integration", () => {
         Node.DOCUMENT_POSITION_FOLLOWING,
     ).toBeTruthy();
     expect(findCenteredWidthContract(dock)).toBeDefined();
+  });
+
+  it("removes centered chat width constraints when cockpit rails are collapsed", () => {
+    storageState.value.cockpitContextRailVisible = false;
+    storageState.value.cockpitRuntimeRailVisible = false;
+
+    render(<Playground />);
+
+    const transcript = screen.getByTestId("playground-chat-transcript");
+    const dock = screen.getByTestId("playground-chat-composer-dock");
+
+    expect(findCenteredWidthContract(transcript)).toBeUndefined();
+    expect(findCenteredWidthContract(dock)).toBeUndefined();
+    expect(screen.getByTestId("playground-form")).toHaveAttribute(
+      "data-force-wide-mode",
+      "true",
+    );
   });
 
   it("keeps the legacy non-docked composer branch when sticky chat input is disabled", () => {

--- a/apps/packages/ui/src/components/Option/Playground/__tests__/PlaygroundEmpty.disconnected.test.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/__tests__/PlaygroundEmpty.disconnected.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { fireEvent, render, screen, within } from "@testing-library/react";
+import { render, screen, within } from "@testing-library/react";
 import { describe, expect, it, vi, beforeEach } from "vitest";
 import { PlaygroundEmpty } from "../PlaygroundEmpty";
 
@@ -38,25 +38,22 @@ describe("PlaygroundEmpty – disconnected state", () => {
     vi.clearAllMocks();
   });
 
-  it("renders an Open Settings button inside the unified onboarding shell when disconnected", () => {
+  it("keeps the blank chat shell neutral when disconnected", () => {
     render(<PlaygroundEmpty />);
 
     const shell = screen.getByTestId("playground-empty-shell");
-    const settingsButton = within(shell).getByRole("button", {
-      name: /open settings/i,
-    });
-    expect(settingsButton).toBeInTheDocument();
-  });
 
-  it("navigates to /settings/tldw when Open Settings is clicked", () => {
-    render(<PlaygroundEmpty />);
-
-    const shell = screen.getByTestId("playground-empty-shell");
-    const settingsButton = within(shell).getByRole("button", {
-      name: /open settings/i,
-    });
-    fireEvent.click(settingsButton);
-
-    expect(navigate).toHaveBeenCalledWith("/settings/tldw");
+    expect(
+      within(shell).getByText(
+        "Experiment with different models, prompts, and knowledge sources here.",
+      ),
+    ).toBeInTheDocument();
+    expect(
+      within(shell).queryByText("Connect to a tldw server to start chatting."),
+    ).not.toBeInTheDocument();
+    expect(
+      within(shell).queryByRole("button", { name: /open settings/i }),
+    ).not.toBeInTheDocument();
+    expect(navigate).not.toHaveBeenCalled();
   });
 });

--- a/apps/packages/ui/src/components/Option/Playground/__tests__/PlaygroundForm.pinned-fallback.test.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/__tests__/PlaygroundForm.pinned-fallback.test.tsx
@@ -3,6 +3,7 @@ import React from "react"
 import { render, screen, within } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import { beforeEach, describe, expect, it, vi } from "vitest"
+import { MemoryRouter } from "react-router-dom"
 
 import { PlaygroundForm } from "../PlaygroundForm"
 
@@ -320,11 +321,19 @@ vi.mock("@plasmohq/storage/hook", () => ({
 }))
 
 vi.mock("react-router-dom", () => ({
+  MemoryRouter: ({ children }: { children: React.ReactNode }) => <>{children}</>,
   Link: ({ children, to, ...rest }: any) => (
     <a href={typeof to === "string" ? to : "#"} {...rest}>
       {children}
     </a>
   ),
+  useLocation: () => ({
+    pathname: "/chat",
+    search: "",
+    hash: "",
+    state: null,
+    key: "test-location"
+  }),
   useNavigate: () => vi.fn()
 }))
 
@@ -365,6 +374,7 @@ vi.mock("@/store/model", () => ({
       extraBody: "",
       jsonMode: false,
       numCtx: 8192,
+      setActiveSettingsScope: vi.fn(),
       updateSetting: vi.fn(),
       updateSettings: vi.fn()
     })
@@ -402,6 +412,9 @@ vi.mock("@/hooks/useMcpTools", () => ({
   useMcpTools: () => ({
     hasMcp: false,
     healthState: "ready",
+    discoveredTools: [],
+    chatTools: [],
+    toolCounts: { enabled: 0, available: 0 },
     tools: [],
     toolsLoading: false,
     catalogs: [],
@@ -518,17 +531,23 @@ vi.mock("../MentionsDropdown", () => ({
 
 vi.mock("../ComposerTextarea", () => ({
   ComposerTextarea: ({
+    textareaRef,
     value,
     onChange,
+    onFocus,
     placeholder
   }: {
+    textareaRef?: React.RefObject<HTMLTextAreaElement | null>
     value: string
     onChange: (event: React.ChangeEvent<HTMLTextAreaElement>) => void
+    onFocus?: () => void
     placeholder?: string
   }) => (
     <textarea
+      ref={textareaRef}
       value={value}
       onChange={onChange}
+      onFocus={onFocus}
       placeholder={placeholder}
       data-testid="composer-textarea"
     />
@@ -866,6 +885,36 @@ beforeEach(() => {
 })
 
 describe("PlaygroundForm pinned fallback", () => {
+  it("uses one shared disconnected recovery notice without duplicate composer copy", async () => {
+    const user = userEvent.setup()
+    playgroundFormConnectionState.phase = "disconnected"
+    playgroundFormConnectionState.isConnected = false
+
+    render(
+      <MemoryRouter>
+        <PlaygroundForm droppedFiles={[]} />
+      </MemoryRouter>
+    )
+
+    const textarea = screen.getByTestId("composer-textarea")
+
+    expect(textarea).toHaveAttribute(
+      "placeholder",
+      "Type a message... (/ commands, @ mentions)"
+    )
+    expect(
+      screen.getByTestId("playground-composer-disconnected-notice")
+    ).toBeInTheDocument()
+
+    await user.click(textarea)
+
+    expect(
+      screen.queryByText(
+        "Connect to your tldw server in Settings to send messages."
+      )
+    ).not.toBeInTheDocument()
+  })
+
   it("renders a dedicated pinned-only fallback card and separate recent history block", () => {
     render(
       <PlaygroundForm

--- a/apps/packages/ui/src/components/Option/Playground/__tests__/usePlaygroundContextItems.role-play.test.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/__tests__/usePlaygroundContextItems.role-play.test.tsx
@@ -35,6 +35,7 @@ const createDeps = (
   modelSummaryLabel: "GPT-4.1",
   isSessionDegraded: false,
   connectionStatusLabel: "Connected",
+  isConnectionReady: true,
   compareModeActive: false,
   compareSelectedModels: [],
   currentPreset: null,
@@ -72,6 +73,44 @@ const createDeps = (
 });
 
 describe("usePlaygroundContextItems role-play state", () => {
+  it("does not add a duplicate offline session status chip", () => {
+    const { result } = renderHook(() =>
+      usePlaygroundContextItems(
+        createDeps({
+          isSessionDegraded: true,
+          connectionStatusLabel: "Offline",
+          isConnectionReady: false,
+        }),
+      ),
+    );
+
+    expect(
+      result.current.find((item) => item.id === "sessionStatus"),
+    ).toBeUndefined();
+  });
+
+  it("keeps the session status chip for connected degraded sessions", () => {
+    const { result } = renderHook(() =>
+      usePlaygroundContextItems(
+        createDeps({
+          isSessionDegraded: true,
+          connectionStatusLabel: "Degraded",
+          isConnectionReady: true,
+        }),
+      ),
+    );
+
+    expect(result.current).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: "sessionStatus",
+          value: "Degraded",
+          tone: "warning",
+        }),
+      ]),
+    );
+  });
+
   it("labels applied behavior templates by name instead of as anonymous prompt state", () => {
     const { result } = renderHook(() =>
       usePlaygroundContextItems(

--- a/apps/packages/ui/src/components/Option/Playground/hooks/usePlaygroundContextItems.ts
+++ b/apps/packages/ui/src/components/Option/Playground/hooks/usePlaygroundContextItems.ts
@@ -8,6 +8,7 @@ import type { RolePlayCompatibility } from "../role-play-compatibility";
 export type UsePlaygroundContextItemsDeps = {
   selectedModel: string | null | undefined;
   modelSummaryLabel: string;
+  isConnectionReady: boolean;
   isSessionDegraded: boolean;
   connectionStatusLabel: string;
   compareModeActive: boolean;
@@ -58,6 +59,7 @@ export function usePlaygroundContextItems(
   const {
     selectedModel,
     modelSummaryLabel,
+    isConnectionReady,
     isSessionDegraded,
     connectionStatusLabel,
     compareModeActive,
@@ -112,7 +114,7 @@ export function usePlaygroundContextItems(
       tone: selectedModel ? "active" : "warning",
       onClick: openModelApiSelector,
     });
-    if (isSessionDegraded) {
+    if (isConnectionReady && isSessionDegraded) {
       items.push({
         id: "sessionStatus",
         label: t("playground:composer.context.sessionStatus", "Session status"),
@@ -508,6 +510,7 @@ export function usePlaygroundContextItems(
     jsonMode,
     focusConnectionCard,
     handleToggleWebSearch,
+    isConnectionReady,
     isSessionDegraded,
     modelSummaryLabel,
     openModelApiSelector,

--- a/backlog/tasks/task-578 - Fix-chat-cockpit-collapsed-rail-edge-restore-affordances.md
+++ b/backlog/tasks/task-578 - Fix-chat-cockpit-collapsed-rail-edge-restore-affordances.md
@@ -1,0 +1,68 @@
+---
+id: TASK-578
+title: Fix chat cockpit collapsed rail edge restore affordances
+status: Done
+labels:
+- chat
+- frontend
+- ux
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement the fresh-worktree /chat cockpit rail collapse fix: when either in-page cockpit rail is collapsed, show a same-side edge-mounted restore tab that clearly identifies Context or Runtime, keep the opposite rail expanded, and let the chat main area widen without vertical displacement. Scope is the actual Playground cockpit rails, not the global sidebar or sidepanel route.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Collapsing the left Context rail removes only that rail, keeps the Runtime rail visible, and shows a left edge-mounted restore tab identifying Context.
+- [x] #2 Collapsing the right Runtime rail removes only that rail, keeps the Context rail visible, and shows a right edge-mounted restore tab identifying Runtime.
+- [x] #3 If both rails are collapsed, both edge-mounted restore tabs remain visible and independently restore their rail.
+- [x] #4 The cockpit main area occupies the freed grid column width without adding an in-flow collapsed banner or pushing the chat/composer downward.
+- [x] #5 Focused tests cover the actual PlaygroundCockpitShell behavior and labels.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+- Updated the actual Playground cockpit shell rails, not the app sidebar or sidepanel route.
+- Added full-width constraints to the Playground root and cockpit body so collapsed rail states do not shrink-wrap the chat surface.
+- Replaced state-specific Tailwind grid-template classes with an explicit `--cockpit-grid-columns` style value for the four cockpit rail states.
+- Converted collapsed rail restore controls into same-side vertical edge tabs labelled `Context rail` and `Runtime rail`.
+- Fixed the tooltip button wrapper so absolute-positioned restore tabs are not also forced to `relative`.
+- Added focused regression coverage for left-collapsed, right-collapsed, and both-collapsed restore behavior.
+- Follow-up from screenshot review: both-collapsed mode still inherited the focus-mode max-width, leaving dead horizontal space despite both restore tabs being visible.
+- Removed the inner chat/transcript/composer `max-w-[64rem]` constraint when any cockpit rail is collapsed, and force the composer form into its wide layout for those states.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Implemented the /chat cockpit rail collapse behavior in a fresh worktree. The remaining rail now stays expanded, the chat surface and inner composer/transcript stack widen into the freed grid column without vertical displacement, and collapsed rails are represented by same-side edge-mounted restore tabs. Rendered Playwright verification captured updated left-collapsed, right-collapsed, and both-collapsed screenshots under `/private/tmp/tldw-chat-rails-fresh-20260531`.
+Additional verification after the offline-readiness cleanup: the combined cockpit/rail/offline Vitest suite passed, `git diff --check` passed, and `NODE_OPTIONS=--max-old-space-size=8192 ../../tldw-frontend/node_modules/.bin/tsc --noEmit -p tsconfig.json` passed from `apps/packages/ui`. The same TypeScript command without the heap override hit Node's default heap limit before producing diagnostics.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+
+Verification recorded:
+- `bunx vitest run src/components/Option/Playground/__tests__/Playground.cockpit-rail-restore.test.tsx --reporter=verbose` passed: 1 file, 3 tests.
+- `bunx vitest run src/components/Option/Playground/__tests__/Playground.cockpit-shell.test.tsx src/components/Option/Playground/__tests__/Playground.cockpit-rail-restore.test.tsx --reporter=verbose` passed: 2 files, 34 tests.
+- `bunx vitest run src/components/Option/Playground/__tests__/Playground.cockpit-shell.test.tsx src/components/Option/Playground/__tests__/Playground.cockpit-rail-restore.test.tsx src/components/Option/Playground/__tests__/Playground.sticky-composer-layout.integration.test.tsx --reporter=verbose` passed: 3 files, 37 tests.
+- `git diff --check` passed.
+- Terminal-driven Playwright check against `http://127.0.0.1:18083/chat` passed for context-collapsed, runtime-collapsed, and both-collapsed geometry. It confirmed no collapsed in-flow summary, main `y=91` in each collapsed state, left restore tab at `x=32`, right restore tab at `x=1372`, and widened main widths of `1076px` and `1096px` for one-rail-collapsed states.
+- Follow-up terminal-driven Playwright check also confirmed both-collapsed main width `1376px` on a `1376px` shell, no inner `max-w-[64rem]` constraints, and composer wide mode enabled.
+- The earlier screenshots lacked the app header/sidebar because the route was loaded in an unauthenticated state and `_app.tsx` sets `hideShellNav` when auth is unresolved or missing. A follow-up authenticated Playwright run confirmed the full app chrome is present: app header `x=48 y=0 h=51`, collapsed app chat sidebar `x=0 w=48`, cockpit shell `x=48 y=51 w=1392`, and both rail restore tabs visible.
+
+Known skips:
+- Bandit not run because the fresh worktree has no `.venv` and the touched implementation is TypeScript/React only.
+- Rendered console output still includes expected local setup noise for missing API key/CORS to the backend on `127.0.0.1:8000`; it is unrelated to cockpit rail layout.
+<!-- DOD:END -->

--- a/backlog/tasks/task-579 - Reduce-duplicate-chat-offline-readiness-indicators.md
+++ b/backlog/tasks/task-579 - Reduce-duplicate-chat-offline-readiness-indicators.md
@@ -1,0 +1,53 @@
+---
+id: TASK-579
+title: Reduce duplicate chat offline readiness indicators
+status: Done
+labels:
+- frontend
+- chat
+- ux
+priority: High
+modified_files:
+- apps/packages/ui/src/components/Option/Playground/PlaygroundEmpty.tsx
+- apps/packages/ui/src/components/Option/Playground/PlaygroundForm.tsx
+- apps/packages/ui/src/components/Option/Playground/hooks/usePlaygroundContextItems.ts
+- apps/packages/ui/src/components/Option/Playground/__tests__/PlaygroundEmpty.disconnected.test.tsx
+- apps/packages/ui/src/components/Option/Playground/__tests__/PlaygroundForm.pinned-fallback.test.tsx
+- apps/packages/ui/src/components/Option/Playground/__tests__/usePlaygroundContextItems.role-play.test.tsx
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+The chat cockpit currently surfaces offline/readiness state from multiple widgets at once, producing four or more visible offline indicators. Deduplicate the offline state so users see one primary recovery message and at most one compact status indicator.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 When the chat page is offline, visible offline/readiness messaging is limited to one primary message plus at most one compact status indicator.
+- [x] #2 Composer, empty state, and status strip do not repeat the same server-connection failure copy simultaneously.
+- [x] #3 Behavior is covered by a regression test.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+['Root-cause investigation started from the authenticated full-shell verification screenshot where the empty state, composer placeholder/notice, status chips, and connection callouts all reported offline independently.']
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Reduced duplicate chat offline/readiness messaging. The blank chat empty state now stays neutral while offline, the composer textarea keeps its normal drafting placeholder, the focus-triggered duplicate connect banner was removed, and the session status context chip is suppressed while the connection itself is offline but remains available for connected degraded sessions. Verification: targeted vitest suite passed, combined cockpit/rail/offline suite passed, git diff --check passed, and terminal Playwright confirmed exactly two visible offline indicators with no legacy duplicate connection strings. Bandit skipped because this task touched TypeScript/TSX and Backlog metadata only; the fresh worktree also has no project .venv.
+Additional verification: `NODE_OPTIONS=--max-old-space-size=8192 ../../tldw-frontend/node_modules/.bin/tsc --noEmit -p tsconfig.json` passed from `apps/packages/ui`. The same command without the heap override hit Node's default heap limit before producing diagnostics.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-581 - Address-PR-2201-cockpit-rail-mode-switch-review-feedback.md
+++ b/backlog/tasks/task-581 - Address-PR-2201-cockpit-rail-mode-switch-review-feedback.md
@@ -1,0 +1,53 @@
+---
+id: TASK-581
+title: Address PR 2201 cockpit rail mode-switch review feedback
+status: Done
+assignee: []
+created_date: ''
+updated_date: 2026-06-01 00:24
+labels:
+- frontend
+- chat
+- ux
+- review-feedback
+dependencies: []
+references:
+- https://github.com/rmusser01/tldw_server/pull/2201
+- TASK-578
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Fix PR #2201 review feedback: preserve intentionally collapsed cockpit rail visibility across focus-to-cockpit mode switches now that both-collapsed cockpit state is supported by edge-mounted restore tabs. Remove or relax the legacy auto-restore branch in handleChatLayoutModeChange and add regression coverage for both rails collapsed across focus/cockpit toggles.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Switching from focus mode back to cockpit preserves intentionally collapsed Context and Runtime rails when both are hidden.
+- [x] #2 Legacy auto-restore no longer reopens both rails solely because cockpit mode is selected.
+- [x] #3 Regression coverage proves both edge restore tabs remain available after focus-to-cockpit toggling.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Verified the issue against `handleChatLayoutModeChange`: storage already normalizes unset rail visibility to visible, so the legacy both-hidden auto-restore was only overriding explicit user intent.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Removed the legacy cockpit-mode auto-restore from `handleChatLayoutModeChange` so explicit `false` rail visibility persists across focus/cockpit mode toggles. Added a red/green regression in `Playground.cockpit-shell.test.tsx` covering both rails collapsed, focus mode, return to cockpit, and both edge restore tabs still visible. Verification: focused test file failed before the handler change, then passed after; combined cockpit/rail/offline suite passed with 54 tests; shared UI TypeScript passed with the heap override; `git diff --check` passed; targeted ESLint `--quiet` exited 0 with the existing Next pages-directory warning. Bandit skipped because touched code is TypeScript/TSX plus Backlog metadata only.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## Summary
- Add same-side edge-mounted restore tabs for collapsed /chat cockpit Context and Runtime rails.
- Let the chat transcript and composer widen into freed rail space instead of shifting downward.
- Deduplicate offline/readiness messaging so offline chat shows one recovery notice plus one compact indicator.

## Test Plan
- bunx vitest run src/components/Option/Playground/__tests__/Playground.cockpit-shell.test.tsx src/components/Option/Playground/__tests__/Playground.cockpit-rail-restore.test.tsx src/components/Option/Playground/__tests__/Playground.sticky-composer-layout.integration.test.tsx src/components/Option/Playground/__tests__/PlaygroundEmpty.disconnected.test.tsx src/components/Option/Playground/__tests__/PlaygroundForm.pinned-fallback.test.tsx src/components/Option/Playground/__tests__/usePlaygroundContextItems.role-play.test.tsx --reporter=verbose
- NODE_OPTIONS=--max-old-space-size=8192 ../../tldw-frontend/node_modules/.bin/tsc --noEmit -p tsconfig.json
- git diff --check

## Notes
- Terminal Playwright was used during development for visual verification; the in-app browser was not used.
- Bandit was not run because this change touches TypeScript/TSX and Backlog metadata only.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the /chat cockpit rail collapse UX with edge-mounted restore tabs, wider chat when rails are collapsed, and cleaner offline messaging. Preserves intentionally collapsed rails across focus↔cockpit mode toggles.

- New Features
  - Same-side vertical edge restore tabs for collapsed Context/Runtime rails, labeled “Context rail” and “Runtime rail”; when both are collapsed, both tabs remain visible.
  - Chat transcript and composer widen into freed space; composer auto-switches to wide mode when any rail is collapsed; stable grid via `--cockpit-grid-columns` to prevent layout shifts.
  - Removes the inner 64rem width cap when rails are collapsed so the cockpit main can use full width.

- Bug Fixes
  - Preserves user-collapsed rails across focus/cockpit toggles; removes the legacy cockpit auto-restore.
  - Deduplicates offline/readiness messages: neutral empty state, standard composer placeholder, and at most one compact indicator.
  - Fixes tooltip wrapper so absolute-positioned restore tabs sit at screen edges.
  - Adds focused tests for edge restore behavior (left/right/both), mode-toggle persistence, wide-mode composer, and offline copy.

<sup>Written for commit 19cd9fcb026ef8aba5d10ca9347ae5561a43970c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2201?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

