### PR TITLE
Add MCP external runtime lifecycle integration

### DIFF
--- a/Docs/superpowers/plans/2026-05-31-mcp-unified-stage4n-external-lifecycle-runtime-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-05-31-mcp-unified-stage4n-external-lifecycle-runtime-implementation-plan.md
@@ -347,7 +347,7 @@ python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_gateway_externa
 
 Expected: all runtime and credential tests pass.
 
-- [ ] **Step 6: Commit credential handling**
+- [x] **Step 6: Commit credential handling**
 
 ```bash
 git add mcp_unified/gateway/external_runtime.py mcp_unified/federation/transports.py tldw_Server_API/app/core/MCP_unified/tests/test_gateway_external_runtime.py
@@ -362,7 +362,7 @@ git commit -m "feat: add external runtime credential brokering"
 - Modify: `mcp_unified/gateway/external_runtime.py`
 - Modify: `tldw_Server_API/app/core/MCP_unified/tests/test_gateway_external_runtime.py`
 
-- [ ] **Step 1: Add red tests for default install/update responses**
+- [x] **Step 1: Add red tests for default install/update responses**
 
 Assert:
 
@@ -374,14 +374,14 @@ assert install["reason_code"] == "external_server_install_not_configured"
 assert update["reason_code"] == "external_server_update_not_configured"
 ```
 
-- [ ] **Step 2: Add red tests for unsupported injected installer**
+- [x] **Step 2: Add red tests for unsupported injected installer**
 
 Create a test installer that returns unsupported for the server and assert the
 manager returns `external_server_install_unsupported` and
 `external_server_update_unsupported` without mutating registry or active
 transport state.
 
-- [ ] **Step 3: Implement installer protocol**
+- [x] **Step 3: Implement installer protocol**
 
 Create:
 
@@ -395,13 +395,13 @@ class ExternalServerInstaller(Protocol):
 Create `NullExternalServerInstaller` that returns not-configured responses and
 `available: False` status.
 
-- [ ] **Step 4: Wire manager methods**
+- [x] **Step 4: Wire manager methods**
 
 `install_server()` and `update_server()` should load the registry definition and
 delegate to the configured installer. Unknown/disabled semantics should match
 lifecycle methods unless tests prove update should work for disabled drafts.
 
-- [ ] **Step 5: Run installer tests**
+- [x] **Step 5: Run installer tests**
 
 Run:
 

--- a/Docs/superpowers/plans/2026-05-31-mcp-unified-stage4n-external-lifecycle-runtime-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-05-31-mcp-unified-stage4n-external-lifecycle-runtime-implementation-plan.md
@@ -265,7 +265,7 @@ python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_gateway_externa
 
 Expected: all runtime manager lifecycle/reconcile tests pass.
 
-- [ ] **Step 6: Commit refresh/reconcile**
+- [x] **Step 6: Commit refresh/reconcile**
 
 ```bash
 git add mcp_unified/gateway/external_runtime.py tldw_Server_API/app/core/MCP_unified/tests/test_gateway_external_runtime.py
@@ -279,7 +279,7 @@ git commit -m "feat: reconcile external runtime lifecycle"
 - Modify: `mcp_unified/federation/transports.py`
 - Modify: `tldw_Server_API/app/core/MCP_unified/tests/test_gateway_external_runtime.py`
 
-- [ ] **Step 1: Add red credential-injection test**
+- [x] **Step 1: Add red credential-injection test**
 
 Use sentinel values:
 
@@ -309,14 +309,14 @@ Assert:
 - result metadata and audit payload do not contain sentinel secret values
 - active server definitions are unchanged
 
-- [ ] **Step 2: Add red missing credential tests**
+- [x] **Step 2: Add red missing credential tests**
 
 For a server with `credential_slots=["api_key"]`:
 
 - no broker and no effective grant denies with `credential_broker_unavailable`
 - broker returns `None` denies with `required_credential_grant_missing`
 
-- [ ] **Step 3: Implement credential broker protocol and summary helpers**
+- [x] **Step 3: Implement credential broker protocol and summary helpers**
 
 Define a local protocol in `external_runtime.py` unless it is clearer to add
 `mcp_unified/interfaces/credentials.py`:
@@ -329,14 +329,14 @@ class ExternalCredentialBroker(Protocol):
 Implement `_public_runtime_auth_metadata()` and `_summarize_runtime_auth()` so
 only key names are exposed.
 
-- [ ] **Step 4: Pass runtime_auth through fake transport**
+- [x] **Step 4: Pass runtime_auth through fake transport**
 
 Update `ExternalFederationTransport` and `FakeExternalTransport.call_tool()` to
 accept `runtime_auth: BrokeredExternalCredential | None = None`. Store a copied
 credential in the fake for assertions; never include secret values in default
 metadata.
 
-- [ ] **Step 5: Run credential tests**
+- [x] **Step 5: Run credential tests**
 
 Run:
 

--- a/Docs/superpowers/plans/2026-05-31-mcp-unified-stage4n-external-lifecycle-runtime-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-05-31-mcp-unified-stage4n-external-lifecycle-runtime-implementation-plan.md
@@ -56,7 +56,7 @@ Keep all `mcp_unified` files free of `tldw_Server_API` imports.
 **Files:**
 - Create: `tldw_Server_API/app/core/MCP_unified/tests/test_gateway_external_runtime.py`
 
-- [ ] **Step 1: Write test doubles**
+- [x] **Step 1: Write test doubles**
 
 Create copy-isolated test doubles:
 
@@ -82,7 +82,7 @@ class InMemoryExternalRegistryStore:
 
 Add `RecordingAuditStore` and fake transport classes that record `connect_count`, `close_count`, `calls`, `runtime_auth`, and configurable discovery/call failures.
 
-- [ ] **Step 2: Write red tests for start/status/stop**
+- [x] **Step 2: Write red tests for start/status/stop**
 
 Tests:
 
@@ -118,7 +118,7 @@ async def test_external_runtime_stop_is_idempotent_and_clears_tools():
     assert await manager.list_virtual_tools() == []
 ```
 
-- [ ] **Step 3: Verify red**
+- [x] **Step 3: Verify red**
 
 Run:
 
@@ -136,7 +136,7 @@ Expected: import failure for missing `mcp_unified.gateway.external_runtime`.
 - Modify: `mcp_unified/federation/transports.py`
 - Modify: `mcp_unified/gateway/__init__.py`
 
-- [ ] **Step 1: Add runtime manager skeleton**
+- [x] **Step 1: Add runtime manager skeleton**
 
 Implement:
 
@@ -167,7 +167,7 @@ class GatewayExternalRuntimeManager:
     ) -> None: ...
 ```
 
-- [ ] **Step 2: Implement start/status/stop**
+- [x] **Step 2: Implement start/status/stop**
 
 Use one `asyncio.Lock`. Store active transports in `self._transports`, loaded definitions in `self._servers`, virtual tools in `self._virtual_tools`, and error strings in `self._last_errors`.
 
@@ -188,11 +188,11 @@ Use one `asyncio.Lock`. Store active transports in `self._transports`, loaded de
 - clear tools and state
 - return `external_server_already_stopped` for inactive known servers
 
-- [ ] **Step 3: Implement virtual tool discovery**
+- [x] **Step 3: Implement virtual tool discovery**
 
 Reuse the `ext.<server_id>.<tool>` naming pattern and write classification from `ExternalFederationManager` if possible. Return caller-owned `VirtualExternalTool.copy()` values.
 
-- [ ] **Step 4: Run lifecycle tests**
+- [x] **Step 4: Run lifecycle tests**
 
 Run:
 

--- a/Docs/superpowers/plans/2026-05-31-mcp-unified-stage4n-external-lifecycle-runtime-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-05-31-mcp-unified-stage4n-external-lifecycle-runtime-implementation-plan.md
@@ -412,7 +412,7 @@ python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_gateway_externa
 
 Expected: all runtime, credential, and install/update tests pass.
 
-- [ ] **Step 6: Commit install/update contracts**
+- [x] **Step 6: Commit install/update contracts**
 
 ```bash
 git add mcp_unified/federation/installers.py mcp_unified/federation/__init__.py mcp_unified/gateway/external_runtime.py tldw_Server_API/app/core/MCP_unified/tests/test_gateway_external_runtime.py
@@ -426,7 +426,7 @@ git commit -m "feat: add external runtime install contracts"
 - Modify: `mcp_unified/gateway/fastapi.py`
 - Modify: `tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py`
 
-- [ ] **Step 1: Add red FastAPI tests**
+- [x] **Step 1: Add red FastAPI tests**
 
 In `test_gateway_fastapi_package.py`, add tests that create a fake runtime
 manager and mount:
@@ -448,7 +448,7 @@ Assert:
 - `POST /mcp/external-servers/research/refresh` calls manager with server id
 - expected manager errors map to HTTP status codes
 
-- [ ] **Step 2: Extend bootstrap dataclass**
+- [x] **Step 2: Extend bootstrap dataclass**
 
 Add:
 
@@ -458,14 +458,14 @@ external_runtime_manager: GatewayExternalRuntimeManager | None = None
 
 Keep existing bootstrap call sites compatible by defaulting to `None`.
 
-- [ ] **Step 3: Add FastAPI resolver and route mount**
+- [x] **Step 3: Add FastAPI resolver and route mount**
 
 Add `external_runtime_manager` and `enable_external_runtime_management` params
 to `create_gateway_router()` and `create_gateway_app()`.
 
 Fail fast when explicit enable is true without a manager.
 
-- [ ] **Step 4: Add route handlers**
+- [x] **Step 4: Add route handlers**
 
 Implement the routes from the spec except durable CLI control. Use manager
 methods directly and map `GatewayExternalRuntimeError.to_payload()` to status
@@ -477,7 +477,7 @@ codes:
 - invalid request: 422
 - otherwise: 500
 
-- [ ] **Step 5: Run FastAPI tests**
+- [x] **Step 5: Run FastAPI tests**
 
 Run:
 

--- a/Docs/superpowers/plans/2026-05-31-mcp-unified-stage4n-external-lifecycle-runtime-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-05-31-mcp-unified-stage4n-external-lifecycle-runtime-implementation-plan.md
@@ -1,0 +1,603 @@
+# MCP Unified Stage 4N External Lifecycle Runtime Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add package-owned external MCP server lifecycle runtime controls, credential-secret handling contracts, and safe install/update foundations for the standalone gateway.
+
+**Architecture:** Create a package-local `GatewayExternalRuntimeManager` that is separate from registry CRUD. The manager reads `ExternalServerDefinition` rows from `ExternalRegistryStore`, manages active injected transport instances, emits audit events, resolves brokered credentials only at execution time, and exposes disabled-by-default install/update adapter hooks. FastAPI can mount runtime routes for the in-process gateway; CLI durable lifecycle control is intentionally deferred until a daemon-control client exists.
+
+**Tech Stack:** Python 3.11, Pydantic v2, FastAPI, package-local MCP Unified federation/storage contracts, pytest, Bandit.
+
+---
+
+## Scope And Constraints
+
+Spec: `Docs/superpowers/specs/2026-05-31-mcp-unified-stage4n-external-lifecycle-runtime-design.md`
+
+Backlog: `TASK-581`
+
+Do not move host stdio/WebSocket adapters into `mcp_unified` in this slice. The stdio adapter still depends on `tldw_Server_API.app.core.Agent_Client_Protocol.stdio_client`; importing that from package code would violate the package boundary.
+
+Do not add package-manager execution, network download, shell execution, or marketplace behavior. Install/update methods return deterministic not-configured or unsupported responses unless a test-injected installer adapter is supplied.
+
+Do not add durable lifecycle CLI commands that pretend to control a separate running gateway process. FastAPI/in-process manager routes are the lifecycle control surface for this slice.
+
+Keep all `mcp_unified` files free of `tldw_Server_API` imports.
+
+## File Structure
+
+- Create: `mcp_unified/gateway/external_runtime.py`
+  - `GatewayExternalRuntimeError`
+  - `GatewayExternalRuntimeManager`
+  - lifecycle/status/credential summary helpers
+- Create: `mcp_unified/federation/installers.py`
+  - installer protocol and disabled-by-default implementation
+- Modify: `mcp_unified/federation/transports.py`
+  - allow runtime-auth-aware transport protocol and fake transport behavior
+- Modify: `mcp_unified/federation/__init__.py`
+  - export installer contracts if needed
+- Modify: `mcp_unified/gateway/bootstrap.py`
+  - carry optional `external_runtime_manager`
+- Modify: `mcp_unified/gateway/fastapi.py`
+  - mount runtime lifecycle routes when configured
+- Modify: `mcp_unified/gateway/__init__.py`
+  - lazily export external runtime manager/error if useful
+- Test: `tldw_Server_API/app/core/MCP_unified/tests/test_gateway_external_runtime.py`
+  - manager lifecycle, credential, install/update contract coverage
+- Modify: `tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py`
+  - route mounting/error mapping coverage
+- Modify: `tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py`
+  - export/import-boundary coverage
+- Modify: `backlog/tasks/task-581 - Implement-MCP-external-server-lifecycle-runtime-integration.md`
+  - task notes, verification, final summary
+
+## Task 1: Runtime Test Harness And Lifecycle Red Tests
+
+**Files:**
+- Create: `tldw_Server_API/app/core/MCP_unified/tests/test_gateway_external_runtime.py`
+
+- [ ] **Step 1: Write test doubles**
+
+Create copy-isolated test doubles:
+
+```python
+class InMemoryExternalRegistryStore:
+    def __init__(self, servers=None) -> None:
+        self.servers = {server.id: server.model_copy(deep=True) for server in servers or ()}
+
+    async def get_server(self, server_id: str):
+        server = self.servers.get(server_id)
+        return None if server is None else server.model_copy(deep=True)
+
+    async def list_servers(self):
+        return await self.list_server_definitions()
+
+    async def list_server_definitions(self, *, enabled=None):
+        rows = [
+            server for server in self.servers.values()
+            if enabled is None or server.enabled is enabled
+        ]
+        return [server.model_copy(deep=True) for server in sorted(rows, key=lambda item: item.id)]
+```
+
+Add `RecordingAuditStore` and fake transport classes that record `connect_count`, `close_count`, `calls`, `runtime_auth`, and configurable discovery/call failures.
+
+- [ ] **Step 2: Write red tests for start/status/stop**
+
+Tests:
+
+```python
+async def test_external_runtime_start_discovers_tools_and_reports_healthy_status():
+    ...
+    manager = GatewayExternalRuntimeManager(
+        external_registry_store=store,
+        transport_factory=lambda server: transport,
+        audit_store=audit,
+    )
+
+    payload = await manager.start_server("research")
+    rows = await manager.list_runtime_servers()
+    tools = await manager.list_virtual_tools()
+
+    assert payload["ok"] is True
+    assert payload["reason_code"] == "external_server_started"
+    assert rows["servers"][0]["status"] == "healthy"
+    assert [tool.virtual_name for tool in tools] == ["ext.research.search"]
+    assert transport.connect_count == 1
+```
+
+```python
+async def test_external_runtime_stop_is_idempotent_and_clears_tools():
+    ...
+    await manager.start_server("research")
+    first = await manager.stop_server("research")
+    second = await manager.stop_server("research")
+
+    assert first["reason_code"] == "external_server_stopped"
+    assert second["reason_code"] == "external_server_already_stopped"
+    assert await manager.list_virtual_tools() == []
+```
+
+- [ ] **Step 3: Verify red**
+
+Run:
+
+```bash
+source ../../.venv/bin/activate
+python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_gateway_external_runtime.py -q
+```
+
+Expected: import failure for missing `mcp_unified.gateway.external_runtime`.
+
+## Task 2: Package Runtime Manager Lifecycle
+
+**Files:**
+- Create: `mcp_unified/gateway/external_runtime.py`
+- Modify: `mcp_unified/federation/transports.py`
+- Modify: `mcp_unified/gateway/__init__.py`
+
+- [ ] **Step 1: Add runtime manager skeleton**
+
+Implement:
+
+```python
+class GatewayExternalRuntimeError(RuntimeError):
+    def __init__(self, message: str, *, reason_code: str, server_id: str | None = None) -> None:
+        super().__init__(message)
+        self.reason_code = reason_code
+        self.server_id = server_id
+
+    def to_payload(self) -> dict[str, Any]:
+        payload = {"ok": False, "error": str(self), "reason_code": self.reason_code}
+        if self.server_id is not None:
+            payload["server_id"] = self.server_id
+        return payload
+```
+
+```python
+class GatewayExternalRuntimeManager:
+    def __init__(
+        self,
+        *,
+        external_registry_store: ExternalRegistryStore,
+        transport_factory: Callable[[ExternalServerDefinition], ExternalFederationTransport],
+        audit_store: AuditStore | None = None,
+        credential_broker: ExternalCredentialBroker | None = None,
+        installer: ExternalServerInstaller | None = None,
+    ) -> None: ...
+```
+
+- [ ] **Step 2: Implement start/status/stop**
+
+Use one `asyncio.Lock`. Store active transports in `self._transports`, loaded definitions in `self._servers`, virtual tools in `self._virtual_tools`, and error strings in `self._last_errors`.
+
+`start_server()` should:
+
+- load server with `get_server`
+- reject unknown with `external_server_not_found`
+- reject disabled with `external_server_disabled`
+- stop an already active runtime before replacing it
+- build/connect/discover with a temporary transport first
+- commit active state only after successful discovery
+- close the temporary transport on failure
+
+`stop_server()` should:
+
+- load the server if needed to distinguish unknown from known stopped
+- close active transport if present
+- clear tools and state
+- return `external_server_already_stopped` for inactive known servers
+
+- [ ] **Step 3: Implement virtual tool discovery**
+
+Reuse the `ext.<server_id>.<tool>` naming pattern and write classification from `ExternalFederationManager` if possible. Return caller-owned `VirtualExternalTool.copy()` values.
+
+- [ ] **Step 4: Run lifecycle tests**
+
+Run:
+
+```bash
+source ../../.venv/bin/activate
+python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_gateway_external_runtime.py -q
+```
+
+Expected: new start/stop tests pass; future red tests may still fail as they are added.
+
+- [ ] **Step 5: Commit lifecycle core**
+
+```bash
+git add mcp_unified/gateway/external_runtime.py mcp_unified/federation/transports.py mcp_unified/gateway/__init__.py tldw_Server_API/app/core/MCP_unified/tests/test_gateway_external_runtime.py
+git commit -m "feat: add gateway external runtime lifecycle"
+```
+
+## Task 3: Refresh, Restart, And Reconcile
+
+**Files:**
+- Modify: `mcp_unified/gateway/external_runtime.py`
+- Modify: `tldw_Server_API/app/core/MCP_unified/tests/test_gateway_external_runtime.py`
+
+- [ ] **Step 1: Add red tests for refresh failure isolation**
+
+Test that discovery failure on one server clears only that server's tools, marks
+its status degraded/unhealthy, and preserves other active servers.
+
+- [ ] **Step 2: Add red tests for restart reload**
+
+Update the in-memory store between start and restart. Assert the old transport
+closed, a new transport connected, and discovered tool metadata reflects the
+updated server definition.
+
+- [ ] **Step 3: Add red tests for reconcile**
+
+Tests:
+
+- newly enabled `auto_start=True` server starts
+- disabled active server stops
+- deleted active server stops
+- changed active definition is replaced
+- unchanged active server is refreshed
+
+- [ ] **Step 4: Implement `refresh_server`, `restart_server`, and `reconcile`**
+
+Keep partial failures per-server. Response envelopes should include:
+
+```python
+{
+    "ok": True,
+    "reason_code": "external_server_reconciled",
+    "server_id": server_id,
+    "started_servers": int,
+    "stopped_servers": int,
+    "refreshed_servers": int,
+    "total_servers": int,
+    "errors": {...},
+}
+```
+
+- [ ] **Step 5: Run focused runtime tests**
+
+Run:
+
+```bash
+source ../../.venv/bin/activate
+python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_gateway_external_runtime.py -q
+```
+
+Expected: all runtime manager lifecycle/reconcile tests pass.
+
+- [ ] **Step 6: Commit refresh/reconcile**
+
+```bash
+git add mcp_unified/gateway/external_runtime.py tldw_Server_API/app/core/MCP_unified/tests/test_gateway_external_runtime.py
+git commit -m "feat: reconcile external runtime lifecycle"
+```
+
+## Task 4: Credential Broker Secret Handling
+
+**Files:**
+- Modify: `mcp_unified/gateway/external_runtime.py`
+- Modify: `mcp_unified/federation/transports.py`
+- Modify: `tldw_Server_API/app/core/MCP_unified/tests/test_gateway_external_runtime.py`
+
+- [ ] **Step 1: Add red credential-injection test**
+
+Use sentinel values:
+
+```python
+SECRET_HEADER = "Bearer do-not-leak-header"
+SECRET_ENV = "do-not-leak-env"
+```
+
+Execute a virtual tool through a broker that returns:
+
+```python
+BrokeredExternalCredential(
+    headers={"Authorization": SECRET_HEADER},
+    env={"TOKEN": SECRET_ENV},
+    metadata={
+        "credential_mode": "brokered_ephemeral",
+        "credential_source": "test",
+        "unsafe_note": SECRET_ENV,
+    },
+)
+```
+
+Assert:
+
+- fake transport receives the credential for the call
+- result metadata includes `credential_mode`, `credential_source`, and injected key names
+- result metadata and audit payload do not contain sentinel secret values
+- active server definitions are unchanged
+
+- [ ] **Step 2: Add red missing credential tests**
+
+For a server with `credential_slots=["api_key"]`:
+
+- no broker and no effective grant denies with `credential_broker_unavailable`
+- broker returns `None` denies with `required_credential_grant_missing`
+
+- [ ] **Step 3: Implement credential broker protocol and summary helpers**
+
+Define a local protocol in `external_runtime.py` unless it is clearer to add
+`mcp_unified/interfaces/credentials.py`:
+
+```python
+class ExternalCredentialBroker(Protocol):
+    async def resolve_external_credential(...) -> BrokeredExternalCredential | None: ...
+```
+
+Implement `_public_runtime_auth_metadata()` and `_summarize_runtime_auth()` so
+only key names are exposed.
+
+- [ ] **Step 4: Pass runtime_auth through fake transport**
+
+Update `ExternalFederationTransport` and `FakeExternalTransport.call_tool()` to
+accept `runtime_auth: BrokeredExternalCredential | None = None`. Store a copied
+credential in the fake for assertions; never include secret values in default
+metadata.
+
+- [ ] **Step 5: Run credential tests**
+
+Run:
+
+```bash
+source ../../.venv/bin/activate
+python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_gateway_external_runtime.py -q
+```
+
+Expected: all runtime and credential tests pass.
+
+- [ ] **Step 6: Commit credential handling**
+
+```bash
+git add mcp_unified/gateway/external_runtime.py mcp_unified/federation/transports.py tldw_Server_API/app/core/MCP_unified/tests/test_gateway_external_runtime.py
+git commit -m "feat: add external runtime credential brokering"
+```
+
+## Task 5: Install And Update Contracts
+
+**Files:**
+- Create: `mcp_unified/federation/installers.py`
+- Modify: `mcp_unified/federation/__init__.py`
+- Modify: `mcp_unified/gateway/external_runtime.py`
+- Modify: `tldw_Server_API/app/core/MCP_unified/tests/test_gateway_external_runtime.py`
+
+- [ ] **Step 1: Add red tests for default install/update responses**
+
+Assert:
+
+```python
+install = await manager.install_server("research")
+update = await manager.update_server("research")
+
+assert install["reason_code"] == "external_server_install_not_configured"
+assert update["reason_code"] == "external_server_update_not_configured"
+```
+
+- [ ] **Step 2: Add red tests for unsupported injected installer**
+
+Create a test installer that returns unsupported for the server and assert the
+manager returns `external_server_install_unsupported` and
+`external_server_update_unsupported` without mutating registry or active
+transport state.
+
+- [ ] **Step 3: Implement installer protocol**
+
+Create:
+
+```python
+class ExternalServerInstaller(Protocol):
+    async def install_server(self, server: ExternalServerDefinition, *, context: Any = None) -> dict[str, Any]: ...
+    async def update_server(self, server: ExternalServerDefinition, *, context: Any = None) -> dict[str, Any]: ...
+    async def get_status(self, server: ExternalServerDefinition) -> dict[str, Any]: ...
+```
+
+Create `NullExternalServerInstaller` that returns not-configured responses and
+`available: False` status.
+
+- [ ] **Step 4: Wire manager methods**
+
+`install_server()` and `update_server()` should load the registry definition and
+delegate to the configured installer. Unknown/disabled semantics should match
+lifecycle methods unless tests prove update should work for disabled drafts.
+
+- [ ] **Step 5: Run installer tests**
+
+Run:
+
+```bash
+source ../../.venv/bin/activate
+python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_gateway_external_runtime.py -q
+```
+
+Expected: all runtime, credential, and install/update tests pass.
+
+- [ ] **Step 6: Commit install/update contracts**
+
+```bash
+git add mcp_unified/federation/installers.py mcp_unified/federation/__init__.py mcp_unified/gateway/external_runtime.py tldw_Server_API/app/core/MCP_unified/tests/test_gateway_external_runtime.py
+git commit -m "feat: add external runtime install contracts"
+```
+
+## Task 6: FastAPI Runtime Routes
+
+**Files:**
+- Modify: `mcp_unified/gateway/bootstrap.py`
+- Modify: `mcp_unified/gateway/fastapi.py`
+- Modify: `tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py`
+
+- [ ] **Step 1: Add red FastAPI tests**
+
+In `test_gateway_fastapi_package.py`, add tests that create a fake runtime
+manager and mount:
+
+```python
+app = create_gateway_app(
+    runtime,
+    prefix="/mcp",
+    external_runtime_manager=manager,
+)
+```
+
+Assert:
+
+- `GET /mcp/external-servers/runtime` returns status rows
+- `POST /mcp/external-servers/research/start` calls manager and returns payload
+- `POST /mcp/external-servers/research/stop` calls manager
+- `POST /mcp/external-servers/refresh` calls manager with `None`
+- `POST /mcp/external-servers/research/refresh` calls manager with server id
+- expected manager errors map to HTTP status codes
+
+- [ ] **Step 2: Extend bootstrap dataclass**
+
+Add:
+
+```python
+external_runtime_manager: GatewayExternalRuntimeManager | None = None
+```
+
+Keep existing bootstrap call sites compatible by defaulting to `None`.
+
+- [ ] **Step 3: Add FastAPI resolver and route mount**
+
+Add `external_runtime_manager` and `enable_external_runtime_management` params
+to `create_gateway_router()` and `create_gateway_app()`.
+
+Fail fast when explicit enable is true without a manager.
+
+- [ ] **Step 4: Add route handlers**
+
+Implement the routes from the spec except durable CLI control. Use manager
+methods directly and map `GatewayExternalRuntimeError.to_payload()` to status
+codes:
+
+- not found: 404
+- disabled/conflict: 409
+- transport/credential unavailable: 503
+- invalid request: 422
+- otherwise: 500
+
+- [ ] **Step 5: Run FastAPI tests**
+
+Run:
+
+```bash
+source ../../.venv/bin/activate
+python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py tldw_Server_API/app/core/MCP_unified/tests/test_gateway_external_runtime.py -q
+```
+
+Expected: runtime manager and FastAPI route tests pass.
+
+- [ ] **Step 6: Commit FastAPI routes**
+
+```bash
+git add mcp_unified/gateway/bootstrap.py mcp_unified/gateway/fastapi.py tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py
+git commit -m "feat: expose external runtime gateway routes"
+```
+
+## Task 7: Boundary, Exports, And Compatibility Verification
+
+**Files:**
+- Modify: `mcp_unified/gateway/__init__.py`
+- Modify: `tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py`
+- Modify: `backlog/tasks/task-581 - Implement-MCP-external-server-lifecycle-runtime-integration.md`
+- Modify: this plan file
+
+- [ ] **Step 1: Add boundary/export tests**
+
+Assert:
+
+- `mcp_unified.gateway.GatewayExternalRuntimeManager` resolves lazily or imports
+  without FastAPI-only side effects
+- `mcp_unified.federation.NullExternalServerInstaller` and
+  `ExternalServerInstaller` export if they are public
+- package import-boundary test still finds no `tldw_Server_API` imports
+
+- [ ] **Step 2: Run focused compatibility suite**
+
+Run:
+
+```bash
+source ../../.venv/bin/activate
+python -m pytest \
+  tldw_Server_API/app/core/MCP_unified/tests/test_gateway_external_runtime.py \
+  tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py \
+  tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py \
+  tldw_Server_API/app/core/MCP_unified/tests/test_federation_shell_contracts.py \
+  tldw_Server_API/app/core/MCP_unified/tests/test_external_server_manager.py \
+  tldw_Server_API/app/core/MCP_unified/tests/test_external_credential_broker_runtime.py \
+  -q
+```
+
+Expected: all focused tests pass.
+
+- [ ] **Step 3: Run lint/security/whitespace checks**
+
+Run:
+
+```bash
+source ../../.venv/bin/activate
+python -m ruff check mcp_unified/gateway mcp_unified/federation tldw_Server_API/app/core/MCP_unified/tests/test_gateway_external_runtime.py
+python -m bandit -r mcp_unified/gateway mcp_unified/federation -f json -o /tmp/bandit_mcp_stage4n_external_runtime.json
+git diff --check
+```
+
+Expected: Ruff passes, Bandit reports no new findings in touched package code,
+and diff check passes.
+
+- [ ] **Step 4: Update Backlog and plan status**
+
+Record:
+
+- tests run and results
+- Bandit output path
+- known skips, especially no durable CLI lifecycle commands by design
+- final summary
+
+- [ ] **Step 5: Commit final validation**
+
+```bash
+git add mcp_unified/gateway/__init__.py tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py Docs/superpowers/plans/2026-05-31-mcp-unified-stage4n-external-lifecycle-runtime-implementation-plan.md backlog/tasks/task-581\ -\ Implement-MCP-external-server-lifecycle-runtime-integration.md
+git commit -m "chore: validate external runtime integration"
+```
+
+## Final Verification Before PR
+
+Run:
+
+```bash
+source ../../.venv/bin/activate
+python -m pytest \
+  tldw_Server_API/app/core/MCP_unified/tests/test_gateway_external_runtime.py \
+  tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py \
+  tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py \
+  tldw_Server_API/app/core/MCP_unified/tests/test_federation_shell_contracts.py \
+  tldw_Server_API/app/core/MCP_unified/tests/test_external_server_manager.py \
+  tldw_Server_API/app/core/MCP_unified/tests/test_external_credential_broker_runtime.py \
+  tldw_Server_API/app/core/MCP_unified/tests/test_gateway_external_registry_management.py \
+  tldw_Server_API/app/core/MCP_unified/tests/test_sqlite_storage_contracts.py \
+  -q
+python -m ruff check mcp_unified/gateway mcp_unified/federation tldw_Server_API/app/core/MCP_unified/tests/test_gateway_external_runtime.py
+python -m bandit -r mcp_unified/gateway mcp_unified/federation -f json -o /tmp/bandit_mcp_stage4n_external_runtime.json
+git diff --check
+git status --short --branch
+```
+
+Expected:
+
+- focused pytest suite passes
+- Ruff passes
+- Bandit JSON reports no new findings for touched package code
+- `git diff --check` passes
+- branch is clean after final commit
+
+## Deliberate Deferrals
+
+- Durable lifecycle CLI commands are deferred until there is a daemon-control
+  client. A short-lived CLI process cannot truthfully start/stop transports in a
+  separate running gateway.
+- Real package-owned stdio process spawning remains deferred until executable
+  allowlists, cwd validation, minimal environment construction, resource limits,
+  and process audit policy are implemented in package code.
+- Third-party server install/update execution is deferred; this slice only adds
+  adapter contracts and deterministic disabled/unsupported responses.

--- a/Docs/superpowers/plans/2026-05-31-mcp-unified-stage4n-external-lifecycle-runtime-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-05-31-mcp-unified-stage4n-external-lifecycle-runtime-implementation-plan.md
@@ -203,7 +203,7 @@ python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_gateway_externa
 
 Expected: new start/stop tests pass; future red tests may still fail as they are added.
 
-- [ ] **Step 5: Commit lifecycle core**
+- [x] **Step 5: Commit lifecycle core**
 
 ```bash
 git add mcp_unified/gateway/external_runtime.py mcp_unified/federation/transports.py mcp_unified/gateway/__init__.py tldw_Server_API/app/core/MCP_unified/tests/test_gateway_external_runtime.py
@@ -216,18 +216,18 @@ git commit -m "feat: add gateway external runtime lifecycle"
 - Modify: `mcp_unified/gateway/external_runtime.py`
 - Modify: `tldw_Server_API/app/core/MCP_unified/tests/test_gateway_external_runtime.py`
 
-- [ ] **Step 1: Add red tests for refresh failure isolation**
+- [x] **Step 1: Add red tests for refresh failure isolation**
 
 Test that discovery failure on one server clears only that server's tools, marks
 its status degraded/unhealthy, and preserves other active servers.
 
-- [ ] **Step 2: Add red tests for restart reload**
+- [x] **Step 2: Add red tests for restart reload**
 
 Update the in-memory store between start and restart. Assert the old transport
 closed, a new transport connected, and discovered tool metadata reflects the
 updated server definition.
 
-- [ ] **Step 3: Add red tests for reconcile**
+- [x] **Step 3: Add red tests for reconcile**
 
 Tests:
 
@@ -237,7 +237,7 @@ Tests:
 - changed active definition is replaced
 - unchanged active server is refreshed
 
-- [ ] **Step 4: Implement `refresh_server`, `restart_server`, and `reconcile`**
+- [x] **Step 4: Implement `refresh_server`, `restart_server`, and `reconcile`**
 
 Keep partial failures per-server. Response envelopes should include:
 
@@ -254,7 +254,7 @@ Keep partial failures per-server. Response envelopes should include:
 }
 ```
 
-- [ ] **Step 5: Run focused runtime tests**
+- [x] **Step 5: Run focused runtime tests**
 
 Run:
 

--- a/Docs/superpowers/plans/2026-05-31-mcp-unified-stage4n-external-lifecycle-runtime-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-05-31-mcp-unified-stage4n-external-lifecycle-runtime-implementation-plan.md
@@ -488,7 +488,7 @@ python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi
 
 Expected: runtime manager and FastAPI route tests pass.
 
-- [ ] **Step 6: Commit FastAPI routes**
+- [x] **Step 6: Commit FastAPI routes**
 
 ```bash
 git add mcp_unified/gateway/bootstrap.py mcp_unified/gateway/fastapi.py tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py
@@ -503,7 +503,7 @@ git commit -m "feat: expose external runtime gateway routes"
 - Modify: `backlog/tasks/task-581 - Implement-MCP-external-server-lifecycle-runtime-integration.md`
 - Modify: this plan file
 
-- [ ] **Step 1: Add boundary/export tests**
+- [x] **Step 1: Add boundary/export tests**
 
 Assert:
 
@@ -513,7 +513,7 @@ Assert:
   `ExternalServerInstaller` export if they are public
 - package import-boundary test still finds no `tldw_Server_API` imports
 
-- [ ] **Step 2: Run focused compatibility suite**
+- [x] **Step 2: Run focused compatibility suite**
 
 Run:
 
@@ -531,7 +531,7 @@ python -m pytest \
 
 Expected: all focused tests pass.
 
-- [ ] **Step 3: Run lint/security/whitespace checks**
+- [x] **Step 3: Run lint/security/whitespace checks**
 
 Run:
 
@@ -545,7 +545,7 @@ git diff --check
 Expected: Ruff passes, Bandit reports no new findings in touched package code,
 and diff check passes.
 
-- [ ] **Step 4: Update Backlog and plan status**
+- [x] **Step 4: Update Backlog and plan status**
 
 Record:
 
@@ -554,7 +554,7 @@ Record:
 - known skips, especially no durable CLI lifecycle commands by design
 - final summary
 
-- [ ] **Step 5: Commit final validation**
+- [x] **Step 5: Commit final validation**
 
 ```bash
 git add mcp_unified/gateway/__init__.py tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py Docs/superpowers/plans/2026-05-31-mcp-unified-stage4n-external-lifecycle-runtime-implementation-plan.md backlog/tasks/task-581\ -\ Implement-MCP-external-server-lifecycle-runtime-integration.md

--- a/Docs/superpowers/specs/2026-05-31-mcp-unified-stage4n-external-lifecycle-runtime-design.md
+++ b/Docs/superpowers/specs/2026-05-31-mcp-unified-stage4n-external-lifecycle-runtime-design.md
@@ -1,0 +1,446 @@
+# MCP Unified Stage 4N External Lifecycle Runtime Design
+
+Date: 2026-05-31
+Status: Approved for spec review
+Backlog: TASK-581
+
+## Summary
+
+Stage 4N adds the standalone gateway runtime layer for managed external MCP
+servers after Stage 4M made registry rows editable. The slice should give the
+package real lifecycle semantics for configured external servers: start, stop,
+restart, refresh discovery, reconcile against registry changes, and report
+health/state. It should also add the credential-secret and install/update
+contracts needed for safe operation without introducing a package-manager or
+marketplace implementation yet.
+
+The core design is a package-owned runtime manager that operates over
+`ExternalRegistryStore`, `AuditStore`, optional credential broker interfaces,
+and injected transport/installer adapters. The package remains free of
+`tldw_Server_API` imports. Host applications may inject real stdio/WebSocket
+transport adapters, while package tests use deterministic fake adapters.
+
+## Goals
+
+- Add a package-local external server runtime manager for start, stop, restart,
+  refresh, reconcile, list status, and virtual-tool execution.
+- Preserve the existing `mcp_unified` import boundary: no package code may
+  import `tldw_Server_API`.
+- Reuse `ExternalServerDefinition`, `ExternalRegistryStore`, `CredentialGrant`,
+  `AuditEvent`, and existing federation model contracts where possible.
+- Keep registry management and runtime lifecycle separate: registry CRUD remains
+  owned by `GatewayExternalRegistryManager`; lifecycle owns active transport
+  state.
+- Resolve credential material only at execution time through an explicit
+  broker interface and expose only safe key-name summaries in public metadata.
+- Add install/update flow contracts and gateway status responses that are safe
+  by default when no installer adapter is configured.
+- Keep real process/network side effects behind injected adapters with explicit
+  lifecycle methods and tests.
+
+## Non-Goals
+
+- No third-party MCP package-manager, marketplace, dependency resolver, or
+  automatic install/update execution in this slice.
+- No client-facing stdio MCP gateway entrypoint.
+- No secret values stored in `ExternalServerDefinition`, profile documents,
+  audit events, logs, or long-lived transport state.
+- No replacement for `tldw_server` MCP Hub external-server authority.
+- No WebUI changes.
+- No broad refactor of the existing host external federation manager beyond
+  optional compatibility adapters needed to preserve current behavior.
+
+## Current Foundation
+
+Stage 4M added gateway registry management over the package store:
+
+- `mcp_unified.gateway.external_registry.GatewayExternalRegistryManager`
+- `mcp_unified.interfaces.storage.ExternalRegistryStore`
+- `mcp_unified.storage.models.ExternalServerDefinition`
+- `mcp_unified.storage.sqlite.SQLiteMCPStore`
+
+The package also has a non-spawning federation shell:
+
+- `mcp_unified.federation.manager.ExternalFederationManager`
+- `mcp_unified.federation.transports.ExternalFederationTransport`
+- `mcp_unified.federation.transports.FakeExternalTransport`
+
+The real upstream transport implementation currently lives in the host tree:
+
+- `tldw_Server_API.app.core.MCP_unified.external_servers.manager.ExternalServerManager`
+- host stdio and WebSocket transport adapters
+- host credential broker and MCP Hub external registry services
+
+That code proves the needed behavior, but the stdio adapter depends on
+`tldw_Server_API.app.core.Agent_Client_Protocol.stdio_client`. Stage 4N should
+not move that dependency into `mcp_unified`. Instead, the package defines the
+neutral lifecycle contract and host adapters can bridge to it.
+
+## Approach Options
+
+### Option A: Move Host Real Adapters Into `mcp_unified`
+
+This would immediately expose the existing stdio/WebSocket implementations from
+the package.
+
+Tradeoff: it moves too much host coupling into the package because stdio still
+depends on `ACPStdioClient` under `tldw_Server_API`. It risks breaking the import
+boundary that earlier stages established.
+
+### Option B: Add Package Runtime Manager With Injected Adapters
+
+Create a package-owned lifecycle manager that uses injected transport and
+installer factories. The manager owns state transitions, locking, audit, health,
+reconcile, credential-broker calls, and virtual-tool execution. Real transports
+can be supplied by hosts or later package extras.
+
+Tradeoff: this creates a small abstraction layer before moving real adapters,
+but it keeps the package safe and testable.
+
+### Option C: Build Install/Update Flows First
+
+Add install/update commands and endpoints before lifecycle and credential
+contracts are complete.
+
+Tradeoff: this is the wrong dependency order. Install/update actions are
+side-effectful and need lifecycle, process policy, audit, and secret boundaries
+before they can be safe.
+
+## Recommended Approach
+
+Use Option B.
+
+Stage 4N should add lifecycle and credential contracts first, then expose
+install/update as disabled-by-default adapter hooks. This gives gateway users and
+future UI work a stable runtime status/control surface without pretending that
+arbitrary MCP server installation is safe.
+
+## Runtime Manager Contract
+
+Add a package-owned runtime manager, for example:
+
+```python
+class GatewayExternalRuntimeManager:
+    async def start_server(server_id: str) -> dict: ...
+    async def stop_server(server_id: str) -> dict: ...
+    async def restart_server(server_id: str) -> dict: ...
+    async def refresh_server(server_id: str | None = None) -> dict: ...
+    async def reconcile(server_id: str | None = None) -> dict: ...
+    async def list_runtime_servers() -> dict: ...
+    async def list_virtual_tools() -> list[VirtualExternalTool]: ...
+    async def execute_virtual_tool(...) -> FederatedToolResult: ...
+```
+
+The manager should own:
+
+- per-server runtime state
+- active transport instances
+- discovered virtual-tool cache
+- lifecycle locks
+- graceful stop behavior that continues across individual close failures
+- reconciliation against current enabled registry definitions
+- lifecycle/discovery/execution audit events
+- safe public status payloads
+- credential broker calls for execution
+
+The manager should not own:
+
+- registry CRUD
+- credential grant CRUD
+- profile CRUD
+- installer execution implementation
+- host-specific MCP Hub precedence rules
+
+## Transport Adapter Contract
+
+Use or extend the package transport protocol so every real or fake adapter can
+provide:
+
+```python
+server_id: str
+transport_name: str
+async connect() -> None
+async close() -> None
+async health_check() -> dict[str, bool]
+async list_tools() -> list[ExternalToolDefinition]
+async call_tool(tool_name, arguments, *, context=None, runtime_auth=None) -> ExternalToolCallResult
+```
+
+Actual stdio process spawning and WebSocket connections are allowed only through
+adapters supplied to the runtime manager. The default package factory should be
+safe: fake or unsupported until a caller opts into real transport extras or host
+adapters.
+
+## Lifecycle Semantics
+
+`start_server(server_id)`:
+
+- loads the current server definition from `ExternalRegistryStore`
+- rejects unknown, disabled, or invalid server definitions with reason codes
+- builds a transport through the injected factory
+- connects the transport
+- discovers tools
+- stores the transport and virtual tools only after successful connect and
+  discovery
+- closes partially connected transports on failure
+- emits lifecycle and discovery audit events
+
+`stop_server(server_id)`:
+
+- closes the active transport if present
+- clears virtual tools for that server
+- leaves the registry definition untouched
+- returns idempotent `already_stopped` for inactive known servers
+- captures close/audit failures in the response without leaking secrets
+
+`restart_server(server_id)`:
+
+- stops the active transport
+- reloads the registry definition
+- starts it again
+- returns combined stop/start status and reason codes
+
+`refresh_server(server_id | None)`:
+
+- re-runs `list_tools` for active transports only
+- clears tools for servers whose discovery fails
+- keeps other servers active
+- returns per-server error maps
+
+`reconcile(server_id | None)`:
+
+- reloads enabled registry definitions
+- starts newly enabled `auto_start` servers
+- stops disabled/deleted active servers
+- replaces active transports when material transport fields change
+- refreshes unchanged active servers
+- isolates partial failures to affected servers
+
+## State And Reason Codes
+
+Runtime status rows should include:
+
+```text
+id
+name
+transport
+configured
+active
+status: stopped | starting | healthy | degraded | unhealthy | stopping
+tool_count
+last_error
+checks
+lifecycle
+install
+update
+```
+
+Initial reason codes should include:
+
+- `external_server_started`
+- `external_server_stopped`
+- `external_server_already_stopped`
+- `external_server_restarted`
+- `external_server_refreshed`
+- `external_server_reconciled`
+- `external_server_not_found`
+- `external_server_disabled`
+- `external_server_start_failed`
+- `external_server_stop_failed`
+- `external_server_discovery_failed`
+- `external_server_transport_unavailable`
+- `external_server_install_not_configured`
+- `external_server_update_not_configured`
+- `external_server_install_unsupported`
+- `external_server_update_unsupported`
+- `required_credential_grant_missing`
+- `credential_broker_unavailable`
+
+Execution should fail closed when required policy, credential, or transport
+state is unavailable.
+
+## Credential-Secret Handling
+
+Add a package-local credential broker protocol for execution-time material:
+
+```python
+class ExternalCredentialBroker(Protocol):
+    async def resolve_external_credential(
+        self,
+        *,
+        server: ExternalServerDefinition,
+        tool_name: str,
+        arguments: dict[str, Any],
+        effective_policy: Any,
+        context: Any = None,
+    ) -> BrokeredExternalCredential | None: ...
+```
+
+Brokered credentials are ephemeral and may contain headers/env values for one
+transport call. Public metadata may include only:
+
+- credential mode/source strings
+- injected header names
+- injected environment variable names
+- grant ids or slot names only when they are not secret values
+
+The runtime manager must not:
+
+- persist credential values
+- include credential values in audit events
+- include credential values in log messages
+- mutate long-lived server definitions or active transport config with
+  credential values
+
+If a server requires credential slots and no broker/grant can satisfy them,
+execution must deny with `required_credential_grant_missing` or
+`credential_broker_unavailable`.
+
+## Install And Update Contracts
+
+Stage 4N should define safe install/update contracts without executing package
+manager commands by default.
+
+Recommended protocol:
+
+```python
+class ExternalServerInstaller(Protocol):
+    async def install_server(server: ExternalServerDefinition, *, context=None) -> dict: ...
+    async def update_server(server: ExternalServerDefinition, *, context=None) -> dict: ...
+    async def get_status(server: ExternalServerDefinition) -> dict: ...
+```
+
+When no installer is configured:
+
+- install requests return `external_server_install_not_configured`
+- update requests return `external_server_update_not_configured`
+- status reports `available: false`
+
+When an installer is configured but cannot support the server:
+
+- install returns `external_server_install_unsupported`
+- update returns `external_server_update_unsupported`
+
+The runtime manager may expose these as methods and FastAPI/CLI surfaces, but no
+default adapter may run shell commands, package managers, or network downloads.
+
+Future installer adapters must require explicit command allowlists, no shell,
+bounded cwd, audit, and operator-visible status before execution.
+
+## Gateway Surface
+
+Add lifecycle routes under the existing package gateway when an external runtime
+manager is configured:
+
+```text
+GET  /external-servers/runtime
+POST /external-servers/{server_id}/start
+POST /external-servers/{server_id}/stop
+POST /external-servers/{server_id}/restart
+POST /external-servers/refresh
+POST /external-servers/{server_id}/refresh
+POST /external-servers/reconcile
+POST /external-servers/{server_id}/reconcile
+POST /external-servers/{server_id}/install
+POST /external-servers/{server_id}/update
+```
+
+CLI support should not imply durable control over a separate running gateway
+process. A one-shot CLI process can safely expose registry-backed runtime
+inspection, install/update not-configured responses, and foreground smoke
+operations only when an injected runtime factory is explicitly available. Durable
+start/stop/restart of a running gateway belongs to the FastAPI/in-process manager
+surface until a future daemon-control client exists.
+
+If CLI commands are added in this slice, they must use the same config/bootstrap
+helper and make process-lifetime semantics explicit:
+
+```text
+external-server-runtime-list
+external-server-start
+external-server-stop
+external-server-restart
+external-server-refresh
+external-server-reconcile
+external-server-install
+external-server-update
+```
+
+Default CLI lifecycle commands should return deterministic
+`external_runtime_not_configured` or install/update not-configured results rather
+than pretending to control another process.
+
+If the runtime manager is not configured, route mounting should be opt-in and
+fail fast when explicitly enabled without dependencies.
+
+## Integration With Existing Host Runtime
+
+The existing `tldw_server` external manager should keep current behavior. Stage
+4N may add compatibility adapters that let host code supply its real transport
+factory to the package manager later, but it should not make MCP Hub lose
+authority over managed external servers.
+
+Host compatibility requirements:
+
+- `tldw_Server_API.app.core.MCP_unified.external_servers` imports keep working.
+- Existing host external federation tests continue passing.
+- MCP Hub external registry and credential broker services remain authoritative
+  in `tldw_server`.
+- Package code remains import-clean.
+
+## Testing Strategy
+
+Package-focused tests should cover:
+
+- start connects/discovers tools and records status
+- start failure closes partial transport and leaves no active tools
+- stop is idempotent and clears virtual tools
+- restart reloads changed registry data
+- refresh isolates discovery failure to one server
+- reconcile starts enabled auto-start servers and stops disabled/deleted active
+  servers
+- execution injects brokered credentials only for the call and redacts values
+  from metadata/audit
+- missing broker or grant denies required credential slots
+- install/update return deterministic not-configured results by default
+- configured installer unsupported results are surfaced without side effects
+- FastAPI and CLI route/command mappings
+- package import-boundary remains clean
+
+Host compatibility tests should cover:
+
+- existing host external manager behavior still passes
+- existing host credential broker runtime tests still pass
+- no new package import depends on `tldw_Server_API`
+
+Verification should include focused pytest, `git diff --check`, and Bandit on
+touched package Python files.
+
+## Risks And Mitigations
+
+- Hidden host imports in package lifecycle code: keep real transports injectable
+  and extend import-boundary tests.
+- Lifecycle manager becomes a second registry manager: keep CRUD out of the
+  runtime manager.
+- Secrets leak through status/audit/logging: centralize brokered credential
+  public-summary logic and test with sentinel secret values.
+- Install/update scope expands: only define adapter hooks and disabled default
+  responses in this slice.
+- Process-spawning safety gaps: no default package transport should spawn
+  unless a later adapter implements executable allowlists, cwd validation,
+  minimal env, resource limits, and audit.
+
+## Acceptance Criteria
+
+- A package-owned external runtime manager supports start, stop, restart,
+  refresh, reconcile, status, and virtual-tool execution over injected
+  transports.
+- The standalone gateway can expose lifecycle controls only when configured with
+  the runtime manager.
+- Credential values are never persisted or returned; execution uses brokered
+  ephemeral credentials when granted.
+- Install/update flows are represented with deterministic disabled/unsupported
+  outcomes and no default side effects.
+- Existing host behavior and package import-boundary tests remain compatible.
+- Focused tests, Bandit on touched Python package scope, and diff whitespace
+  checks pass before PR.

--- a/backlog/tasks/task-581 - Implement-MCP-external-server-lifecycle-runtime-integration.md
+++ b/backlog/tasks/task-581 - Implement-MCP-external-server-lifecycle-runtime-integration.md
@@ -9,6 +9,7 @@ labels:
 - security
 documentation:
 - Docs/superpowers/specs/2026-05-31-mcp-unified-stage4n-external-lifecycle-runtime-design.md
+- Docs/superpowers/plans/2026-05-31-mcp-unified-stage4n-external-lifecycle-runtime-implementation-plan.md
 ---
 
 ## Description
@@ -25,6 +26,12 @@ Implement the next MCP Unified slice after external registry management: real up
 - [ ] #4 Focused unit/integration tests cover lifecycle state transitions, credential redaction/resolution, install/update success and failure paths, and package boundary behavior.
 - [ ] #5 Bandit on touched Python source, focused pytest suite, and git diff --check pass before PR.
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Docs/superpowers/plans/2026-05-31-mcp-unified-stage4n-external-lifecycle-runtime-implementation-plan.md
+<!-- SECTION:PLAN:END -->
 
 ## Implementation Notes
 

--- a/backlog/tasks/task-581 - Implement-MCP-external-server-lifecycle-runtime-integration.md
+++ b/backlog/tasks/task-581 - Implement-MCP-external-server-lifecycle-runtime-integration.md
@@ -2,14 +2,20 @@
 id: TASK-581
 title: Implement MCP external server lifecycle runtime integration
 status: Done
+assignee: []
+created_date: ''
+updated_date: '2026-06-01 00:31'
 labels:
-- mcp-unified
-- external-servers
-- runtime
-- security
+  - mcp-unified
+  - external-servers
+  - runtime
+  - security
+dependencies: []
 documentation:
-- Docs/superpowers/specs/2026-05-31-mcp-unified-stage4n-external-lifecycle-runtime-design.md
-- Docs/superpowers/plans/2026-05-31-mcp-unified-stage4n-external-lifecycle-runtime-implementation-plan.md
+  - >-
+    Docs/superpowers/specs/2026-05-31-mcp-unified-stage4n-external-lifecycle-runtime-design.md
+  - >-
+    Docs/superpowers/plans/2026-05-31-mcp-unified-stage4n-external-lifecycle-runtime-implementation-plan.md
 ---
 
 ## Description
@@ -35,16 +41,17 @@ Docs/superpowers/plans/2026-05-31-mcp-unified-stage4n-external-lifecycle-runtime
 
 ## Implementation Notes
 
-<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
-- Added `GatewayExternalRuntimeManager` with injected transport, credential broker, and installer contracts.
+<!-- SECTION:NOTES:BEGIN -->
+- Added GatewayExternalRuntimeManager with injected transport, credential broker, and installer contracts.
 - Added FastAPI in-process lifecycle routes; durable CLI control remains deferred by design.
-- Verification recorded: expanded pytest suite passed (214 tests), Ruff passed, Bandit JSON has zero results/errors/skips at `/tmp/bandit_mcp_stage4n_external_runtime.json`, and `git diff --check` passed.
-<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+- Addressed PR review feedback after rebasing on origin/dev: runtime routes now use Pydantic response models; external execute enforces server/tool policy before transport calls; credential broker calls no longer deep-copy noncopyable policy/context objects; health-check failures produce unhealthy status rows instead of crashing; unknown virtual tools map to a 404-style reason; transport call failures are wrapped in structured runtime errors; lifecycle/install/broker/execute paths no longer hold the manager lock across external I/O; route-reserved external server ids are rejected.
+- Updated verification: focused pytest suite passed (144 tests), expanded MCP pytest suite passed (228 tests), Ruff passed, Bandit JSON has zero results at /tmp/bandit_mcp_stage4n_external_runtime.json, and git diff --check passed.
+<!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Implemented package-owned external runtime lifecycle integration for MCP Unified Stage 4N. Added start/stop/restart/refresh/reconcile manager behavior over injected transports; per-call credential broker resolution with public metadata redaction; disabled-by-default install/update contracts; FastAPI lifecycle/runtime routes; and package boundary/export coverage. Final verification: expanded pytest suite passed (214 tests); Ruff passed for touched package/test scope; Bandit passed for mcp_unified/gateway and mcp_unified/federation with zero results/errors/skips in /tmp/bandit_mcp_stage4n_external_runtime.json; git diff --check passed. Known deferrals by design: durable lifecycle CLI control, package-owned real stdio process spawning, and third-party install/update execution.
+Implemented package-owned external runtime lifecycle integration for MCP Unified Stage 4N and addressed all current PR review threads after rebasing on `origin/dev`. The follow-up fixes added validated FastAPI runtime response schemas, fail-closed policy enforcement for external execution, non-deepcopying broker context/policy handling, health-check fallback status rows, dedicated unknown-tool and call-failure reason codes, narrower lock scope around external I/O, and reserved-id validation for runtime management route names. Final verification: focused pytest suite passed (144 tests); expanded MCP pytest suite passed (228 tests); Ruff passed for touched package/test scope; Bandit passed for `mcp_unified/gateway` and `mcp_unified/federation` with zero results in `/tmp/bandit_mcp_stage4n_external_runtime.json`; `git diff --check` passed. Known deferrals by design remain durable lifecycle CLI control, package-owned real stdio process spawning, and third-party install/update execution.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-581 - Implement-MCP-external-server-lifecycle-runtime-integration.md
+++ b/backlog/tasks/task-581 - Implement-MCP-external-server-lifecycle-runtime-integration.md
@@ -1,0 +1,49 @@
+---
+id: TASK-581
+title: Implement MCP external server lifecycle runtime integration
+status: In Progress
+labels:
+- mcp-unified
+- external-servers
+- runtime
+- security
+documentation:
+- Docs/superpowers/specs/2026-05-31-mcp-unified-stage4n-external-lifecycle-runtime-design.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement the next MCP Unified slice after external registry management: real upstream external server start/stop/refresh behavior, credential-secret handling, and install/update flow foundations for the standalone gateway while keeping changes reviewable and tested.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 External server lifecycle operations expose deterministic start, stop, restart/refresh behavior through the package gateway/CLI or clearly scoped runtime layer.
+- [ ] #2 Credential-secret handling keeps secrets out of persisted catalog/plain responses/logs and resolves runtime environment values through explicit secret references or broker paths.
+- [ ] #3 Install/update flow support is defined and implemented to the agreed minimal slice with validation and safe failure modes.
+- [ ] #4 Focused unit/integration tests cover lifecycle state transitions, credential redaction/resolution, install/update success and failure paths, and package boundary behavior.
+- [ ] #5 Bandit on touched Python source, focused pytest suite, and git diff --check pass before PR.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-581 - Implement-MCP-external-server-lifecycle-runtime-integration.md
+++ b/backlog/tasks/task-581 - Implement-MCP-external-server-lifecycle-runtime-integration.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-581
 title: Implement MCP external server lifecycle runtime integration
-status: In Progress
+status: Done
 labels:
 - mcp-unified
 - external-servers
@@ -20,11 +20,11 @@ Implement the next MCP Unified slice after external registry management: real up
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 External server lifecycle operations expose deterministic start, stop, restart/refresh behavior through the package gateway/CLI or clearly scoped runtime layer.
-- [ ] #2 Credential-secret handling keeps secrets out of persisted catalog/plain responses/logs and resolves runtime environment values through explicit secret references or broker paths.
-- [ ] #3 Install/update flow support is defined and implemented to the agreed minimal slice with validation and safe failure modes.
-- [ ] #4 Focused unit/integration tests cover lifecycle state transitions, credential redaction/resolution, install/update success and failure paths, and package boundary behavior.
-- [ ] #5 Bandit on touched Python source, focused pytest suite, and git diff --check pass before PR.
+- [x] #1 External server lifecycle operations expose deterministic start, stop, restart/refresh behavior through the package gateway/CLI or clearly scoped runtime layer.
+- [x] #2 Credential-secret handling keeps secrets out of persisted catalog/plain responses/logs and resolves runtime environment values through explicit secret references or broker paths.
+- [x] #3 Install/update flow support is defined and implemented to the agreed minimal slice with validation and safe failure modes.
+- [x] #4 Focused unit/integration tests cover lifecycle state transitions, credential redaction/resolution, install/update success and failure paths, and package boundary behavior.
+- [x] #5 Bandit on touched Python source, focused pytest suite, and git diff --check pass before PR.
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -36,21 +36,23 @@ Docs/superpowers/plans/2026-05-31-mcp-unified-stage4n-external-lifecycle-runtime
 ## Implementation Notes
 
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
-
+- Added `GatewayExternalRuntimeManager` with injected transport, credential broker, and installer contracts.
+- Added FastAPI in-process lifecycle routes; durable CLI control remains deferred by design.
+- Verification recorded: expanded pytest suite passed (214 tests), Ruff passed, Bandit JSON has zero results/errors/skips at `/tmp/bandit_mcp_stage4n_external_runtime.json`, and `git diff --check` passed.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-
+Implemented package-owned external runtime lifecycle integration for MCP Unified Stage 4N. Added start/stop/restart/refresh/reconcile manager behavior over injected transports; per-call credential broker resolution with public metadata redaction; disabled-by-default install/update contracts; FastAPI lifecycle/runtime routes; and package boundary/export coverage. Final verification: expanded pytest suite passed (214 tests); Ruff passed for touched package/test scope; Bandit passed for mcp_unified/gateway and mcp_unified/federation with zero results/errors/skips in /tmp/bandit_mcp_stage4n_external_runtime.json; git diff --check passed. Known deferrals by design: durable lifecycle CLI control, package-owned real stdio process spawning, and third-party install/update execution.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->

--- a/mcp_unified/federation/__init__.py
+++ b/mcp_unified/federation/__init__.py
@@ -19,6 +19,7 @@ from .config_schema import (
     parse_external_server_registry,
 )
 from .manager import ExternalFederationManager
+from .installers import ExternalServerInstaller, NullExternalServerInstaller
 from .models import (
     BrokeredExternalCredential,
     ExternalToolCallResult,
@@ -40,6 +41,7 @@ __all__ = [
     "ExternalFederationTransport",
     "ExternalMCPServerConfig",
     "ExternalRetryConfig",
+    "ExternalServerInstaller",
     "ExternalServerRegistryConfig",
     "ExternalServerRegistryPartialLoadError",
     "ExternalStdioConfig",
@@ -54,6 +56,7 @@ __all__ = [
     "FederationPolicyDenied",
     "MCPAuthType",
     "MCPCatalogEntry",
+    "NullExternalServerInstaller",
     "VirtualExternalTool",
     "catalog_loader",
     "config_schema",

--- a/mcp_unified/federation/__init__.py
+++ b/mcp_unified/federation/__init__.py
@@ -18,8 +18,8 @@ from .config_schema import (
     load_external_server_registry,
     parse_external_server_registry,
 )
-from .manager import ExternalFederationManager
 from .installers import ExternalServerInstaller, NullExternalServerInstaller
+from .manager import ExternalFederationManager
 from .models import (
     BrokeredExternalCredential,
     ExternalToolCallResult,

--- a/mcp_unified/federation/installers.py
+++ b/mcp_unified/federation/installers.py
@@ -1,0 +1,80 @@
+"""External MCP server install/update contracts for standalone runtimes."""
+
+from __future__ import annotations
+
+from typing import Any, Protocol
+
+from mcp_unified.storage import ExternalServerDefinition
+
+
+class ExternalServerInstaller(Protocol):
+    """Adapter contract for optional external server install/update workflows."""
+
+    async def install_server(
+        self,
+        server: ExternalServerDefinition,
+        *,
+        context: Any = None,
+    ) -> dict[str, Any]:
+        """Install one configured external server, when supported."""
+        ...
+
+    async def update_server(
+        self,
+        server: ExternalServerDefinition,
+        *,
+        context: Any = None,
+    ) -> dict[str, Any]:
+        """Update one configured external server, when supported."""
+        ...
+
+    async def get_status(
+        self,
+        server: ExternalServerDefinition,
+    ) -> dict[str, Any]:
+        """Return installer availability/status for one server."""
+        ...
+
+
+class NullExternalServerInstaller:
+    """Disabled-by-default installer that performs no external side effects."""
+
+    async def install_server(
+        self,
+        server: ExternalServerDefinition,
+        *,
+        context: Any = None,
+    ) -> dict[str, Any]:
+        """Return a deterministic not-configured install response."""
+        del context
+        return {
+            "ok": False,
+            "available": False,
+            "reason_code": "external_server_install_not_configured",
+            "server_id": server.id,
+        }
+
+    async def update_server(
+        self,
+        server: ExternalServerDefinition,
+        *,
+        context: Any = None,
+    ) -> dict[str, Any]:
+        """Return a deterministic not-configured update response."""
+        del context
+        return {
+            "ok": False,
+            "available": False,
+            "reason_code": "external_server_update_not_configured",
+            "server_id": server.id,
+        }
+
+    async def get_status(
+        self,
+        server: ExternalServerDefinition,
+    ) -> dict[str, Any]:
+        """Return unavailable installer status for one server."""
+        return {
+            "available": False,
+            "server_id": server.id,
+        }

--- a/mcp_unified/federation/transports.py
+++ b/mcp_unified/federation/transports.py
@@ -5,7 +5,11 @@ from __future__ import annotations
 from copy import deepcopy
 from typing import Any, Protocol
 
-from .models import ExternalToolCallResult, ExternalToolDefinition
+from .models import (
+    BrokeredExternalCredential,
+    ExternalToolCallResult,
+    ExternalToolDefinition,
+)
 
 
 class ExternalFederationTransport(Protocol):
@@ -38,7 +42,9 @@ class ExternalFederationTransport(Protocol):
         self,
         tool_name: str,
         arguments: dict[str, Any],
+        *,
         context: Any = None,
+        runtime_auth: BrokeredExternalCredential | None = None,
     ) -> ExternalToolCallResult:
         """Execute a logical external tool call."""
         ...
@@ -63,6 +69,7 @@ class FakeExternalTransport:
         self.close_count = 0
         self.spawn_count = 0
         self.calls: list[tuple[str, dict[str, Any]]] = []
+        self.runtime_auth_seen: BrokeredExternalCredential | None = None
         self._tools = [tool.copy() for tool in tools or []]
         self._results = {
             name: result.copy()
@@ -97,12 +104,15 @@ class FakeExternalTransport:
         self,
         tool_name: str,
         arguments: dict[str, Any],
+        *,
         context: Any = None,
+        runtime_auth: BrokeredExternalCredential | None = None,
     ) -> ExternalToolCallResult:
         """Return a configured fake result for the requested tool."""
         del context
         call_args = deepcopy(arguments or {})
         self.calls.append((tool_name, call_args))
+        self.runtime_auth_seen = None if runtime_auth is None else runtime_auth.copy()
         result = self._results.get(tool_name)
         if result is None:
             return ExternalToolCallResult(

--- a/mcp_unified/gateway/__init__.py
+++ b/mcp_unified/gateway/__init__.py
@@ -25,11 +25,17 @@ from .runtime import GatewayPolicyDenied, GatewayRequestContext, GatewayRuntime
 from .stdio import GatewayStdioServer, handle_stdio_line
 
 if TYPE_CHECKING:
+    from .external_runtime import (
+        GatewayExternalRuntimeError,
+        GatewayExternalRuntimeManager,
+    )
     from .fastapi import create_gateway_app, create_gateway_router
 
 __all__ = [
     "GatewayPolicyDenied",
     "GatewayConfigFormat",
+    "GatewayExternalRuntimeError",
+    "GatewayExternalRuntimeManager",
     "GatewayProfileBootstrap",
     "GatewayProfileBootstrapConfig",
     "GatewayProfileManagementError",
@@ -60,5 +66,15 @@ def __getattr__(name: str) -> Any:
         return {
             "create_gateway_app": create_gateway_app,
             "create_gateway_router": create_gateway_router,
+        }[name]
+    if name in {"GatewayExternalRuntimeError", "GatewayExternalRuntimeManager"}:
+        from .external_runtime import (
+            GatewayExternalRuntimeError,
+            GatewayExternalRuntimeManager,
+        )
+
+        return {
+            "GatewayExternalRuntimeError": GatewayExternalRuntimeError,
+            "GatewayExternalRuntimeManager": GatewayExternalRuntimeManager,
         }[name]
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/mcp_unified/gateway/bootstrap.py
+++ b/mcp_unified/gateway/bootstrap.py
@@ -18,6 +18,7 @@ from .runtime import GatewayRuntime
 
 if TYPE_CHECKING:
     from mcp_unified.gateway.external_registry import GatewayExternalRegistryManager
+    from mcp_unified.gateway.external_runtime import GatewayExternalRuntimeManager
 
 
 @dataclass(frozen=True, slots=True)
@@ -33,6 +34,7 @@ class GatewayProfileBootstrap:
     default_profile_id: str | None
     seeded_profile_ids: tuple[str, ...]
     external_registry_manager: GatewayExternalRegistryManager | None = None
+    external_runtime_manager: GatewayExternalRuntimeManager | None = None
 
 
 async def bootstrap_profile_gateway(
@@ -46,6 +48,7 @@ async def bootstrap_profile_gateway(
     default_profile_id: str | None = None,
     default_preset_id: str | None = None,
     external_registry_manager: GatewayExternalRegistryManager | None = None,
+    external_runtime_manager: GatewayExternalRuntimeManager | None = None,
 ) -> GatewayProfileBootstrap:
     """Seed profile data and return a profile-aware gateway runtime."""
 
@@ -105,6 +108,7 @@ async def bootstrap_profile_gateway(
         default_profile_id=resolved_default_profile_id,
         seeded_profile_ids=seeded_profile_ids,
         external_registry_manager=external_registry_manager,
+        external_runtime_manager=external_runtime_manager,
     )
 
 

--- a/mcp_unified/gateway/external_runtime.py
+++ b/mcp_unified/gateway/external_runtime.py
@@ -70,57 +70,7 @@ class GatewayExternalRuntimeManager:
             self._require_enabled(server)
             if server.id in self._transports:
                 await self._stop_server_unlocked(server.id)
-
-            transport = self._transport_factory(server.model_copy(deep=True))
-            try:
-                await transport.connect()
-                tools = await transport.list_tools()
-            except Exception as exc:  # noqa: BLE001 - transport adapters define their own errors.
-                self._last_errors[server.id] = self._exception_summary(exc)
-                await self._close_best_effort(transport)
-                await self._audit_best_effort(
-                    "external_server.lifecycle",
-                    payload={
-                        "reason_code": "external_server_start_failed",
-                        "server_id": server.id,
-                        "error_type": type(exc).__name__,
-                        "error_message": str(exc),
-                    },
-                    target_type="external_server",
-                    target_id=server.id,
-                )
-                raise
-
-            self._servers[server.id] = server.model_copy(deep=True)
-            self._transports[server.id] = transport
-            self._last_errors[server.id] = None
-            self._replace_server_tools(server.id, tools)
-            await self._audit(
-                "external_server.lifecycle",
-                payload={
-                    "reason_code": "external_server_started",
-                    "server_id": server.id,
-                    "transport": server.transport,
-                },
-                target_type="external_server",
-                target_id=server.id,
-            )
-            await self._audit(
-                "external_server.discovery",
-                payload={
-                    "reason_code": "external_server_discovered",
-                    "server_id": server.id,
-                    "tool_count": len(tools),
-                },
-                target_type="external_server",
-                target_id=server.id,
-            )
-            return {
-                "ok": True,
-                "reason_code": "external_server_started",
-                "server_id": server.id,
-                "tool_count": len(tools),
-            }
+            return await self._start_server_unlocked(server)
 
     async def stop_server(self, server_id: str) -> dict[str, Any]:
         """Stop one external server and clear its discovered virtual tools."""
@@ -146,6 +96,137 @@ class GatewayExternalRuntimeManager:
                 "ok": True,
                 "reason_code": "external_server_stopped",
                 "server_id": server_id,
+            }
+
+    async def restart_server(self, server_id: str) -> dict[str, Any]:
+        """Reload one server definition and replace its active transport."""
+        async with self._lock:
+            stop_reason = "external_server_already_stopped"
+            if server_id in self._transports:
+                await self._stop_server_unlocked(server_id)
+                stop_reason = "external_server_stopped"
+            server = await self._load_server(server_id)
+            self._require_enabled(server)
+            started = await self._start_server_unlocked(server)
+            return {
+                "ok": True,
+                "reason_code": "external_server_restarted",
+                "server_id": server.id,
+                "stop_reason_code": stop_reason,
+                "start_reason_code": started["reason_code"],
+                "tool_count": started["tool_count"],
+            }
+
+    async def refresh_server(self, server_id: str | None = None) -> dict[str, Any]:
+        """Refresh discovered tools for one active server or every active server."""
+        async with self._lock:
+            if server_id is not None:
+                if server_id not in self._transports:
+                    await self._load_server(server_id)
+                    target_ids = [server_id]
+                else:
+                    target_ids = [server_id]
+            else:
+                target_ids = sorted(self._transports)
+
+            refreshed = 0
+            errors: dict[str, str] = {}
+            for target_id in target_ids:
+                if target_id not in self._transports:
+                    errors[target_id] = "external_server_not_running"
+                    continue
+                ok = await self._refresh_server_tools_unlocked(target_id)
+                if ok:
+                    refreshed += 1
+                else:
+                    errors[target_id] = "external_server_discovery_failed"
+
+            payload: dict[str, Any] = {
+                "ok": not errors,
+                "reason_code": "external_server_refreshed",
+                "refreshed_servers": refreshed,
+                "total_servers": len(target_ids),
+                "virtual_tools": len(self._virtual_tools),
+                "errors": errors,
+            }
+            if server_id is not None:
+                payload["server_id"] = server_id
+            return payload
+
+    async def reconcile(self, server_id: str | None = None) -> dict[str, Any]:
+        """Reconcile active transports against current registry definitions."""
+        async with self._lock:
+            definitions = {
+                server.id: server
+                for server in await self._list_server_definitions()
+            }
+            if server_id is not None:
+                if server_id not in definitions and server_id not in self._transports:
+                    raise GatewayExternalRuntimeError(
+                        f"External server '{server_id}' was not found",
+                        reason_code="external_server_not_found",
+                        server_id=server_id,
+                    )
+                target_ids = [server_id]
+            else:
+                target_ids = sorted(set(definitions) | set(self._transports))
+
+            started = 0
+            stopped = 0
+            restarted = 0
+            refreshed = 0
+            errors: dict[str, str] = {}
+
+            for target_id in target_ids:
+                server = definitions.get(target_id)
+                is_active = target_id in self._transports
+                if server is None:
+                    if is_active:
+                        await self._stop_server_unlocked(target_id)
+                        stopped += 1
+                    continue
+                if not server.enabled:
+                    if is_active:
+                        await self._stop_server_unlocked(target_id)
+                        stopped += 1
+                    continue
+                if not is_active:
+                    if server.auto_start:
+                        try:
+                            await self._start_server_unlocked(server)
+                        except GatewayExternalRuntimeError as exc:
+                            errors[target_id] = exc.reason_code
+                        else:
+                            started += 1
+                    continue
+
+                current = self._servers.get(target_id)
+                if current is None or self._definition_changed(current, server):
+                    await self._stop_server_unlocked(target_id)
+                    try:
+                        await self._start_server_unlocked(server)
+                    except GatewayExternalRuntimeError as exc:
+                        errors[target_id] = exc.reason_code
+                    else:
+                        restarted += 1
+                    continue
+
+                ok = await self._refresh_server_tools_unlocked(target_id)
+                if ok:
+                    refreshed += 1
+                else:
+                    errors[target_id] = "external_server_discovery_failed"
+
+            return {
+                "ok": not errors,
+                "reason_code": "external_server_reconciled",
+                "server_id": server_id,
+                "started_servers": started,
+                "stopped_servers": stopped,
+                "restarted_servers": restarted,
+                "refreshed_servers": refreshed,
+                "total_servers": len(target_ids),
+                "errors": errors,
             }
 
     async def list_runtime_servers(self) -> dict[str, Any]:
@@ -228,6 +309,99 @@ class GatewayExternalRuntimeManager:
             target_id=server_id,
         )
 
+    async def _start_server_unlocked(
+        self,
+        server: ExternalServerDefinition,
+    ) -> dict[str, Any]:
+        transport = self._transport_factory(server.model_copy(deep=True))
+        try:
+            await transport.connect()
+            tools = await transport.list_tools()
+        except Exception as exc:  # noqa: BLE001 - transport adapters define their own errors.
+            self._last_errors[server.id] = self._exception_summary(exc)
+            await self._close_best_effort(transport)
+            await self._audit_best_effort(
+                "external_server.lifecycle",
+                payload={
+                    "reason_code": "external_server_start_failed",
+                    "server_id": server.id,
+                    "error_type": type(exc).__name__,
+                    "error_message": str(exc),
+                },
+                target_type="external_server",
+                target_id=server.id,
+            )
+            raise GatewayExternalRuntimeError(
+                f"External server '{server.id}' failed to start",
+                reason_code="external_server_start_failed",
+                server_id=server.id,
+            ) from exc
+
+        self._servers[server.id] = server.model_copy(deep=True)
+        self._transports[server.id] = transport
+        self._last_errors[server.id] = None
+        self._replace_server_tools(server.id, tools)
+        await self._audit(
+            "external_server.lifecycle",
+            payload={
+                "reason_code": "external_server_started",
+                "server_id": server.id,
+                "transport": server.transport,
+            },
+            target_type="external_server",
+            target_id=server.id,
+        )
+        await self._audit(
+            "external_server.discovery",
+            payload={
+                "reason_code": "external_server_discovered",
+                "server_id": server.id,
+                "tool_count": len(tools),
+            },
+            target_type="external_server",
+            target_id=server.id,
+        )
+        return {
+            "ok": True,
+            "reason_code": "external_server_started",
+            "server_id": server.id,
+            "tool_count": len(tools),
+        }
+
+    async def _refresh_server_tools_unlocked(self, server_id: str) -> bool:
+        transport = self._transports[server_id]
+        try:
+            tools = await transport.list_tools()
+        except Exception as exc:  # noqa: BLE001 - discovery adapters define their own errors.
+            self._last_errors[server_id] = self._exception_summary(exc)
+            self._clear_server_tools(server_id)
+            await self._audit_best_effort(
+                "external_server.discovery",
+                payload={
+                    "reason_code": "external_server_discovery_failed",
+                    "server_id": server_id,
+                    "error_type": type(exc).__name__,
+                    "error_message": str(exc),
+                },
+                target_type="external_server",
+                target_id=server_id,
+            )
+            return False
+
+        self._last_errors[server_id] = None
+        self._replace_server_tools(server_id, tools)
+        await self._audit(
+            "external_server.discovery",
+            payload={
+                "reason_code": "external_server_discovered",
+                "server_id": server_id,
+                "tool_count": len(tools),
+            },
+            target_type="external_server",
+            target_id=server_id,
+        )
+        return True
+
     async def _load_server(self, server_id: str) -> ExternalServerDefinition:
         server = await self._find_server(server_id)
         if server is None:
@@ -302,6 +476,25 @@ class GatewayExternalRuntimeManager:
 
     def _count_tools_for_server(self, server_id: str) -> int:
         return sum(1 for tool in self._virtual_tools.values() if tool.server_id == server_id)
+
+    @classmethod
+    def _definition_changed(
+        cls,
+        current: ExternalServerDefinition,
+        latest: ExternalServerDefinition,
+    ) -> bool:
+        return cls._runtime_signature(current) != cls._runtime_signature(latest)
+
+    @staticmethod
+    def _runtime_signature(server: ExternalServerDefinition) -> tuple[Any, ...]:
+        return (
+            server.transport,
+            tuple(server.command),
+            server.url,
+            server.cwd,
+            tuple(server.env_allowlist),
+            tuple(server.credential_slots),
+        )
 
     async def _audit(
         self,

--- a/mcp_unified/gateway/external_runtime.py
+++ b/mcp_unified/gateway/external_runtime.py
@@ -3,14 +3,19 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Callable
+import inspect
+from collections.abc import Callable, Iterable
 from copy import deepcopy
 from datetime import datetime, timezone
-from typing import Any
+from typing import Any, Protocol
 from uuid import uuid4
 
 from mcp_unified.federation.models import (
+    BrokeredExternalCredential,
+    ExternalToolCallResult,
     ExternalToolDefinition,
+    FederatedToolResult,
+    FederationPolicyDenied,
     VirtualExternalTool,
 )
 from mcp_unified.federation.transports import ExternalFederationTransport
@@ -44,6 +49,23 @@ class GatewayExternalRuntimeError(RuntimeError):
         return payload
 
 
+class ExternalCredentialBroker(Protocol):
+    """Resolve ephemeral credential material for one external tool call."""
+
+    async def resolve_external_credential(
+        self,
+        *,
+        server: ExternalServerDefinition,
+        virtual_tool: VirtualExternalTool,
+        credential_slots: list[str],
+        effective_policy: Any = None,
+        actor_id: str | None = None,
+        context: Any = None,
+    ) -> BrokeredExternalCredential | dict[str, Any] | None:
+        """Return per-call credential material or None when no grant applies."""
+        ...
+
+
 class GatewayExternalRuntimeManager:
     """Manage active external server transports for one in-process gateway."""
 
@@ -53,10 +75,12 @@ class GatewayExternalRuntimeManager:
         external_registry_store: ExternalRegistryStore,
         transport_factory: Callable[[ExternalServerDefinition], ExternalFederationTransport],
         audit_store: AuditStore | None = None,
+        credential_broker: ExternalCredentialBroker | Callable[..., Any] | None = None,
     ) -> None:
         self._external_registry_store = external_registry_store
         self._transport_factory = transport_factory
         self._audit_store = audit_store
+        self._credential_broker = credential_broker
         self._servers: dict[str, ExternalServerDefinition] = {}
         self._transports: dict[str, ExternalFederationTransport] = {}
         self._virtual_tools: dict[str, VirtualExternalTool] = {}
@@ -285,6 +309,67 @@ class GatewayExternalRuntimeManager:
                 for name in sorted(self._virtual_tools)
             ]
 
+    async def execute_virtual_tool(
+        self,
+        virtual_tool_name: str,
+        arguments: dict[str, Any] | None,
+        *,
+        effective_policy: Any = None,
+        actor_id: str | None = None,
+        context: Any = None,
+    ) -> FederatedToolResult:
+        """Execute one virtual external tool with per-call credential brokering."""
+        async with self._lock:
+            virtual_tool = self._virtual_tools.get(virtual_tool_name)
+            if virtual_tool is None:
+                raise GatewayExternalRuntimeError(
+                    f"External virtual tool '{virtual_tool_name}' was not found",
+                    reason_code="external_server_transport_unavailable",
+                )
+            server = self._servers.get(virtual_tool.server_id)
+            transport = self._transports.get(virtual_tool.server_id)
+            if server is None or transport is None:
+                raise GatewayExternalRuntimeError(
+                    f"External server '{virtual_tool.server_id}' is not active",
+                    reason_code="external_server_transport_unavailable",
+                    server_id=virtual_tool.server_id,
+                )
+            runtime_auth = await self._resolve_runtime_auth(
+                server=server,
+                virtual_tool=virtual_tool,
+                effective_policy=effective_policy,
+                actor_id=actor_id,
+                context=context,
+            )
+            result = await transport.call_tool(
+                virtual_tool.upstream_tool_name,
+                deepcopy(arguments or {}),
+                context=context,
+                runtime_auth=runtime_auth,
+            )
+            if runtime_auth is not None:
+                metadata = deepcopy(result.metadata or {})
+                metadata.update(self._public_runtime_auth_metadata(runtime_auth))
+                metadata["credential_injection"] = self._summarize_runtime_auth(runtime_auth)
+                result = ExternalToolCallResult(
+                    content=deepcopy(result.content),
+                    is_error=result.is_error,
+                    metadata=metadata,
+                )
+            await self._audit_execution(
+                event_type="external_tool.allowed",
+                reason_code="allowed",
+                virtual_tool=virtual_tool,
+                actor_id=actor_id,
+                profile_id=self._policy_profile_id(effective_policy),
+                credential_injection=(
+                    self._summarize_runtime_auth(runtime_auth)
+                    if runtime_auth is not None
+                    else None
+                ),
+            )
+            return self._federated_result(virtual_tool, result)
+
     async def _stop_server_unlocked(self, server_id: str) -> None:
         transport = self._transports.pop(server_id, None)
         close_error: str | None = None
@@ -476,6 +561,244 @@ class GatewayExternalRuntimeManager:
 
     def _count_tools_for_server(self, server_id: str) -> int:
         return sum(1 for tool in self._virtual_tools.values() if tool.server_id == server_id)
+
+    async def _resolve_runtime_auth(
+        self,
+        *,
+        server: ExternalServerDefinition,
+        virtual_tool: VirtualExternalTool,
+        effective_policy: Any,
+        actor_id: str | None,
+        context: Any,
+    ) -> BrokeredExternalCredential | None:
+        required_slots = self._required_credential_slots(server)
+        if not required_slots:
+            return None
+        if self._credential_broker is None:
+            raise GatewayExternalRuntimeError(
+                f"Credential broker is unavailable for external server '{server.id}'",
+                reason_code="credential_broker_unavailable",
+                server_id=server.id,
+            )
+        missing_slots = self._missing_credential_slots(
+            server=server,
+            effective_policy=effective_policy,
+        )
+        if missing_slots:
+            raise FederationPolicyDenied(
+                "required_credential_grant_missing",
+                (
+                    f"External server '{server.id}' requires credential grants for "
+                    f"{', '.join(missing_slots)}"
+                ),
+                payload={
+                    "reason_code": "required_credential_grant_missing",
+                    "server_id": server.id,
+                    "credential_slots": list(missing_slots),
+                },
+            )
+        broker_result = await self._call_credential_broker(
+            server=server,
+            virtual_tool=virtual_tool,
+            credential_slots=required_slots,
+            effective_policy=effective_policy,
+            actor_id=actor_id,
+            context=context,
+        )
+        if broker_result is None:
+            raise FederationPolicyDenied(
+                "required_credential_grant_missing",
+                f"Credential broker returned no grant for external server '{server.id}'",
+                payload={
+                    "reason_code": "required_credential_grant_missing",
+                    "server_id": server.id,
+                    "credential_slots": list(required_slots),
+                },
+            )
+        return broker_result
+
+    async def _call_credential_broker(
+        self,
+        *,
+        server: ExternalServerDefinition,
+        virtual_tool: VirtualExternalTool,
+        credential_slots: list[str],
+        effective_policy: Any,
+        actor_id: str | None,
+        context: Any,
+    ) -> BrokeredExternalCredential | None:
+        broker = self._credential_broker
+        if broker is None:
+            return None
+        kwargs = {
+            "server": server.model_copy(deep=True),
+            "virtual_tool": virtual_tool.copy(),
+            "credential_slots": list(credential_slots),
+            "effective_policy": deepcopy(effective_policy),
+            "actor_id": actor_id,
+            "context": deepcopy(context),
+        }
+        if hasattr(broker, "resolve_external_credential"):
+            result = broker.resolve_external_credential(**kwargs)
+        else:
+            result = broker(**kwargs)
+        resolved = await result if inspect.isawaitable(result) else result
+        if resolved is None:
+            return None
+        if isinstance(resolved, BrokeredExternalCredential):
+            return resolved.copy()
+        if isinstance(resolved, dict):
+            return BrokeredExternalCredential(
+                headers=dict(resolved.get("headers") or {}),
+                env=dict(resolved.get("env") or {}),
+                metadata=deepcopy(resolved.get("metadata") or {}),
+            )
+        raise TypeError("credential broker must return BrokeredExternalCredential, dict, or None")
+
+    @staticmethod
+    def _required_credential_slots(server: ExternalServerDefinition) -> list[str]:
+        return sorted(
+            {
+                str(slot).strip()
+                for slot in server.credential_slots
+                if str(slot).strip()
+            }
+        )
+
+    def _missing_credential_slots(
+        self,
+        *,
+        server: ExternalServerDefinition,
+        effective_policy: Any,
+    ) -> list[str]:
+        required_slots = set(self._required_credential_slots(server))
+        if not required_slots:
+            return []
+        granted_slots: set[str] = set()
+        for grant in self._policy_dicts(effective_policy, "credential_grants"):
+            if not self._grant_matches_server(grant, server.id):
+                continue
+            granted_slots.update(self._credential_slots_for_grant(grant))
+        return sorted(required_slots - granted_slots)
+
+    @staticmethod
+    def _credential_slots_for_grant(grant: dict[str, Any]) -> set[str]:
+        slots: set[str] = set()
+        for key in ("credential_slot", "slot"):
+            value = str(grant.get(key) or "").strip()
+            if value:
+                slots.add(value)
+        for key in ("credential_slots", "slots"):
+            raw = grant.get(key)
+            if isinstance(raw, str):
+                values: Iterable[Any] = [raw]
+            elif isinstance(raw, Iterable) and not isinstance(raw, (bytes, dict)):
+                values = raw
+            else:
+                values = []
+            slots.update(str(value).strip() for value in values if str(value).strip())
+        return slots
+
+    @staticmethod
+    def _grant_matches_server(grant: dict[str, Any], server_id: str) -> bool:
+        if grant.get("enabled") is False:
+            return False
+        raw_server_id = (
+            grant.get("server_id")
+            or grant.get("external_server_id")
+            or grant.get("id")
+        )
+        return str(raw_server_id or "").strip() == server_id
+
+    @staticmethod
+    def _policy_dicts(effective_policy: Any, field_name: str) -> list[dict[str, Any]]:
+        values = GatewayExternalRuntimeManager._policy_value(effective_policy, field_name, [])
+        if isinstance(values, dict):
+            return [deepcopy(values)]
+        if not isinstance(values, Iterable) or isinstance(values, (str, bytes)):
+            return []
+        return [
+            deepcopy(value)
+            for value in values
+            if isinstance(value, dict)
+        ]
+
+    @staticmethod
+    def _policy_profile_id(effective_policy: Any) -> str | None:
+        value = GatewayExternalRuntimeManager._policy_value(
+            effective_policy,
+            "profile_id",
+            None,
+        )
+        return str(value) if value is not None else None
+
+    @staticmethod
+    def _policy_value(effective_policy: Any, field_name: str, default: Any) -> Any:
+        if isinstance(effective_policy, dict):
+            return effective_policy.get(field_name, default)
+        return getattr(effective_policy, field_name, default)
+
+    async def _audit_execution(
+        self,
+        *,
+        event_type: str,
+        reason_code: str,
+        virtual_tool: VirtualExternalTool,
+        actor_id: str | None,
+        profile_id: str | None,
+        credential_injection: dict[str, Any] | None = None,
+    ) -> None:
+        payload: dict[str, Any] = {
+            "reason_code": reason_code,
+            "server_id": virtual_tool.server_id,
+            "virtual_tool_name": virtual_tool.virtual_name,
+            "upstream_tool_name": virtual_tool.upstream_tool_name,
+        }
+        if credential_injection is not None:
+            payload["credential_injection"] = deepcopy(credential_injection)
+        await self._audit(
+            event_type,
+            actor_id=actor_id,
+            profile_id=profile_id,
+            target_type="external_tool",
+            target_id=virtual_tool.virtual_name,
+            payload=payload,
+        )
+
+    @staticmethod
+    def _public_runtime_auth_metadata(
+        runtime_auth: BrokeredExternalCredential,
+    ) -> dict[str, Any]:
+        metadata = runtime_auth.metadata or {}
+        if not isinstance(metadata, dict):
+            return {}
+        public: dict[str, Any] = {}
+        for key in ("credential_mode", "credential_source"):
+            value = metadata.get(key)
+            if isinstance(value, str) and value.strip():
+                public[key] = value
+        return public
+
+    @staticmethod
+    def _summarize_runtime_auth(runtime_auth: BrokeredExternalCredential) -> dict[str, Any]:
+        return {
+            "headers": sorted(str(name) for name in (runtime_auth.headers or {})),
+            "env": sorted(str(name) for name in (runtime_auth.env or {})),
+        }
+
+    @staticmethod
+    def _federated_result(
+        virtual_tool: VirtualExternalTool,
+        result: ExternalToolCallResult,
+    ) -> FederatedToolResult:
+        return FederatedToolResult(
+            content=deepcopy(result.content),
+            server_id=virtual_tool.server_id,
+            upstream_tool_name=virtual_tool.upstream_tool_name,
+            virtual_tool_name=virtual_tool.virtual_name,
+            is_error=result.is_error,
+            metadata=deepcopy(result.metadata),
+        )
 
     @classmethod
     def _definition_changed(

--- a/mcp_unified/gateway/external_runtime.py
+++ b/mcp_unified/gateway/external_runtime.py
@@ -95,177 +95,215 @@ class GatewayExternalRuntimeManager:
 
     async def start_server(self, server_id: str) -> dict[str, Any]:
         """Start one configured external server and discover its virtual tools."""
+        server = await self._load_server(server_id)
+        self._require_enabled(server)
+
         async with self._lock:
-            server = await self._load_server(server_id)
-            self._require_enabled(server)
-            if server.id in self._transports:
-                await self._stop_server_unlocked(server.id)
-            return await self._start_server_unlocked(server)
+            previous = self._pop_runtime_unlocked(server.id)
+        if previous is not None:
+            await self._close_stopped_transport(server.id, previous)
+
+        transport, tools = await self._connect_and_discover_server(server)
+        async with self._lock:
+            replaced = self._pop_runtime_unlocked(server.id)
+            self._commit_started_runtime_unlocked(server, transport, tools)
+        if replaced is not None:
+            await self._close_stopped_transport(server.id, replaced)
+
+        await self._audit(
+            "external_server.lifecycle",
+            payload={
+                "reason_code": "external_server_started",
+                "server_id": server.id,
+                "transport": server.transport,
+            },
+            target_type="external_server",
+            target_id=server.id,
+        )
+        await self._audit(
+            "external_server.discovery",
+            payload={
+                "reason_code": "external_server_discovered",
+                "server_id": server.id,
+                "tool_count": len(tools),
+            },
+            target_type="external_server",
+            target_id=server.id,
+        )
+        return {
+            "ok": True,
+            "reason_code": "external_server_started",
+            "server_id": server.id,
+            "tool_count": len(tools),
+        }
 
     async def stop_server(self, server_id: str) -> dict[str, Any]:
         """Stop one external server and clear its discovered virtual tools."""
+        server = await self._find_server(server_id)
         async with self._lock:
-            server = await self._find_server(server_id)
-            if server is None:
-                raise GatewayExternalRuntimeError(
-                    f"External server '{server_id}' was not found",
-                    reason_code="external_server_not_found",
-                    server_id=server_id,
-                )
-            if server_id not in self._transports:
-                self._clear_server_tools(server_id)
-                self._servers.pop(server_id, None)
-                self._last_errors.pop(server_id, None)
-                return {
-                    "ok": True,
-                    "reason_code": "external_server_already_stopped",
-                    "server_id": server_id,
-                }
-            await self._stop_server_unlocked(server_id)
+            known_active = server_id in self._transports or server_id in self._servers
+            transport = self._pop_runtime_unlocked(server_id)
+        if server is None and not known_active:
+            raise GatewayExternalRuntimeError(
+                f"External server '{server_id}' was not found",
+                reason_code="external_server_not_found",
+                server_id=server_id,
+            )
+        if transport is None:
             return {
                 "ok": True,
-                "reason_code": "external_server_stopped",
+                "reason_code": "external_server_already_stopped",
                 "server_id": server_id,
             }
+        await self._close_stopped_transport(server_id, transport)
+        return {
+            "ok": True,
+            "reason_code": "external_server_stopped",
+            "server_id": server_id,
+        }
 
     async def restart_server(self, server_id: str) -> dict[str, Any]:
         """Reload one server definition and replace its active transport."""
-        async with self._lock:
-            stop_reason = "external_server_already_stopped"
-            if server_id in self._transports:
-                await self._stop_server_unlocked(server_id)
-                stop_reason = "external_server_stopped"
-            server = await self._load_server(server_id)
-            self._require_enabled(server)
-            started = await self._start_server_unlocked(server)
-            return {
-                "ok": True,
-                "reason_code": "external_server_restarted",
-                "server_id": server.id,
-                "stop_reason_code": stop_reason,
-                "start_reason_code": started["reason_code"],
-                "tool_count": started["tool_count"],
-            }
+        stopped = await self.stop_server(server_id)
+        server = await self._load_server(server_id)
+        self._require_enabled(server)
+        started = await self.start_server(server.id)
+        return {
+            "ok": True,
+            "reason_code": "external_server_restarted",
+            "server_id": server.id,
+            "stop_reason_code": stopped["reason_code"],
+            "start_reason_code": started["reason_code"],
+            "tool_count": started["tool_count"],
+        }
 
     async def refresh_server(self, server_id: str | None = None) -> dict[str, Any]:
         """Refresh discovered tools for one active server or every active server."""
         async with self._lock:
             if server_id is not None:
-                if server_id not in self._transports:
-                    await self._load_server(server_id)
-                    target_ids = [server_id]
-                else:
-                    target_ids = [server_id]
+                running = server_id in self._transports
+                target_ids = [server_id]
             else:
                 target_ids = sorted(self._transports)
+                running = True
 
-            refreshed = 0
-            errors: dict[str, str] = {}
-            for target_id in target_ids:
-                if target_id not in self._transports:
-                    errors[target_id] = "external_server_not_running"
-                    continue
-                ok = await self._refresh_server_tools_unlocked(target_id)
-                if ok:
-                    refreshed += 1
-                else:
-                    errors[target_id] = "external_server_discovery_failed"
+        if server_id is not None and not running:
+            await self._load_server(server_id)
 
-            payload: dict[str, Any] = {
-                "ok": not errors,
-                "reason_code": "external_server_refreshed",
-                "refreshed_servers": refreshed,
-                "total_servers": len(target_ids),
-                "virtual_tools": len(self._virtual_tools),
-                "errors": errors,
-            }
-            if server_id is not None:
-                payload["server_id"] = server_id
-            return payload
+        refreshed = 0
+        errors: dict[str, str] = {}
+        for target_id in target_ids:
+            async with self._lock:
+                transport = self._transports.get(target_id)
+            if transport is None:
+                errors[target_id] = "external_server_not_running"
+                continue
+            ok = await self._refresh_server_tools(target_id, transport)
+            if ok:
+                refreshed += 1
+            else:
+                errors[target_id] = "external_server_discovery_failed"
+
+        async with self._lock:
+            virtual_tool_count = len(self._virtual_tools)
+        payload: dict[str, Any] = {
+            "ok": not errors,
+            "reason_code": "external_server_refreshed",
+            "refreshed_servers": refreshed,
+            "total_servers": len(target_ids),
+            "virtual_tools": virtual_tool_count,
+            "errors": errors,
+        }
+        if server_id is not None:
+            payload["server_id"] = server_id
+        return payload
 
     async def reconcile(self, server_id: str | None = None) -> dict[str, Any]:
         """Reconcile active transports against current registry definitions."""
+        definitions = {
+            server.id: server
+            for server in await self._list_server_definitions()
+        }
         async with self._lock:
-            definitions = {
-                server.id: server
-                for server in await self._list_server_definitions()
+            active_ids = set(self._transports)
+            current_definitions = {
+                target_id: server.model_copy(deep=True)
+                for target_id, server in self._servers.items()
             }
-            if server_id is not None:
-                if server_id not in definitions and server_id not in self._transports:
-                    raise GatewayExternalRuntimeError(
-                        f"External server '{server_id}' was not found",
-                        reason_code="external_server_not_found",
-                        server_id=server_id,
-                    )
-                target_ids = [server_id]
-            else:
-                target_ids = sorted(set(definitions) | set(self._transports))
+        if server_id is not None:
+            if server_id not in definitions and server_id not in active_ids:
+                raise GatewayExternalRuntimeError(
+                    f"External server '{server_id}' was not found",
+                    reason_code="external_server_not_found",
+                    server_id=server_id,
+                )
+            target_ids = [server_id]
+        else:
+            target_ids = sorted(set(definitions) | active_ids)
 
-            started = 0
-            stopped = 0
-            restarted = 0
-            refreshed = 0
-            errors: dict[str, str] = {}
+        started = 0
+        stopped = 0
+        restarted = 0
+        refreshed = 0
+        errors: dict[str, str] = {}
 
-            for target_id in target_ids:
-                server = definitions.get(target_id)
+        for target_id in target_ids:
+            server = definitions.get(target_id)
+            async with self._lock:
                 is_active = target_id in self._transports
-                if server is None:
-                    if is_active:
-                        await self._stop_server_unlocked(target_id)
-                        stopped += 1
-                    continue
-                if not server.enabled:
-                    if is_active:
-                        await self._stop_server_unlocked(target_id)
-                        stopped += 1
-                    continue
-                if not is_active:
-                    if server.auto_start:
-                        try:
-                            await self._start_server_unlocked(server)
-                        except GatewayExternalRuntimeError as exc:
-                            errors[target_id] = exc.reason_code
-                        else:
-                            started += 1
-                    continue
-
-                current = self._servers.get(target_id)
-                if current is None or self._definition_changed(current, server):
-                    await self._stop_server_unlocked(target_id)
+                current = current_definitions.get(target_id)
+            if server is None:
+                if is_active:
+                    await self.stop_server(target_id)
+                    stopped += 1
+                continue
+            if not server.enabled:
+                if is_active:
+                    await self.stop_server(target_id)
+                    stopped += 1
+                continue
+            if not is_active:
+                if server.auto_start:
                     try:
-                        await self._start_server_unlocked(server)
+                        await self.start_server(target_id)
                     except GatewayExternalRuntimeError as exc:
                         errors[target_id] = exc.reason_code
                     else:
-                        restarted += 1
-                    continue
+                        started += 1
+                continue
 
-                ok = await self._refresh_server_tools_unlocked(target_id)
-                if ok:
-                    refreshed += 1
+            if current is None or self._definition_changed(current, server):
+                try:
+                    await self.restart_server(target_id)
+                except GatewayExternalRuntimeError as exc:
+                    errors[target_id] = exc.reason_code
                 else:
-                    errors[target_id] = "external_server_discovery_failed"
+                    restarted += 1
+                continue
 
-            return {
-                "ok": not errors,
-                "reason_code": "external_server_reconciled",
-                "server_id": server_id,
-                "started_servers": started,
-                "stopped_servers": stopped,
-                "restarted_servers": restarted,
-                "refreshed_servers": refreshed,
-                "total_servers": len(target_ids),
-                "errors": errors,
-            }
+            payload = await self.refresh_server(target_id)
+            if payload["ok"]:
+                refreshed += 1
+            else:
+                errors[target_id] = "external_server_discovery_failed"
+
+        return {
+            "ok": not errors,
+            "reason_code": "external_server_reconciled",
+            "server_id": server_id,
+            "started_servers": started,
+            "stopped_servers": stopped,
+            "restarted_servers": restarted,
+            "refreshed_servers": refreshed,
+            "total_servers": len(target_ids),
+            "errors": errors,
+        }
 
     async def list_runtime_servers(self) -> dict[str, Any]:
         """Return runtime status rows for configured external servers."""
+        definitions = await self._list_server_definitions()
         async with self._lock:
-            configured = {
-                server.id: server
-                for server in await self._list_server_definitions()
-            }
+            configured = {server.id: server for server in definitions}
             for server_id, server in self._servers.items():
                 configured.setdefault(server_id, server.model_copy(deep=True))
             snapshots = [
@@ -287,7 +325,21 @@ class GatewayExternalRuntimeManager:
                 "initialized": False,
             }
             if transport is not None:
-                checks.update(await transport.health_check())
+                try:
+                    checks.update(await transport.health_check())
+                except Exception as exc:  # noqa: BLE001 - status must not break.
+                    last_error = self._exception_summary(exc)
+                    checks.update(
+                        {
+                            "connected": False,
+                            "initialized": False,
+                            "error": True,
+                            "error_type": type(exc).__name__,
+                        }
+                    )
+                    async with self._lock:
+                        if self._transports.get(server_id) is transport:
+                            self._last_errors[server_id] = last_error
             rows.append(
                 {
                     "id": server_id,
@@ -322,18 +374,17 @@ class GatewayExternalRuntimeManager:
         context: Any = None,
     ) -> dict[str, Any]:
         """Delegate optional install work to the configured installer adapter."""
-        async with self._lock:
-            server = await self._load_server(server_id)
-            self._require_enabled(server)
-            payload = await self._installer.install_server(
-                server.model_copy(deep=True),
-                context=context,
-            )
-            return self._installer_payload(
-                payload,
-                server=server,
-                fallback_reason_code="external_server_install_not_configured",
-            )
+        server = await self._load_server(server_id)
+        self._require_enabled(server)
+        payload = await self._installer.install_server(
+            server.model_copy(deep=True),
+            context=context,
+        )
+        return self._installer_payload(
+            payload,
+            server=server,
+            fallback_reason_code="external_server_install_not_configured",
+        )
 
     async def update_server(
         self,
@@ -342,18 +393,17 @@ class GatewayExternalRuntimeManager:
         context: Any = None,
     ) -> dict[str, Any]:
         """Delegate optional update work to the configured installer adapter."""
-        async with self._lock:
-            server = await self._load_server(server_id)
-            self._require_enabled(server)
-            payload = await self._installer.update_server(
-                server.model_copy(deep=True),
-                context=context,
-            )
-            return self._installer_payload(
-                payload,
-                server=server,
-                fallback_reason_code="external_server_update_not_configured",
-            )
+        server = await self._load_server(server_id)
+        self._require_enabled(server)
+        payload = await self._installer.update_server(
+            server.model_copy(deep=True),
+            context=context,
+        )
+        return self._installer_payload(
+            payload,
+            server=server,
+            fallback_reason_code="external_server_update_not_configured",
+        )
 
     async def execute_virtual_tool(
         self,
@@ -370,8 +420,9 @@ class GatewayExternalRuntimeManager:
             if virtual_tool is None:
                 raise GatewayExternalRuntimeError(
                     f"External virtual tool '{virtual_tool_name}' was not found",
-                    reason_code="external_server_transport_unavailable",
+                    reason_code="external_virtual_tool_not_found",
                 )
+            virtual_tool = virtual_tool.copy()
             server = self._servers.get(virtual_tool.server_id)
             transport = self._transports.get(virtual_tool.server_id)
             if server is None or transport is None:
@@ -380,53 +431,107 @@ class GatewayExternalRuntimeManager:
                     reason_code="external_server_transport_unavailable",
                     server_id=virtual_tool.server_id,
                 )
-            runtime_auth = await self._resolve_runtime_auth(
-                server=server,
+            server = server.model_copy(deep=True)
+
+        deny_reason = self._deny_reason(
+            server=server,
+            virtual_tool=virtual_tool,
+            effective_policy=effective_policy,
+        )
+        if deny_reason is not None:
+            profile_id = self._policy_profile_id(effective_policy)
+            await self._audit_execution(
+                event_type="external_tool.denied",
+                reason_code=deny_reason,
                 virtual_tool=virtual_tool,
-                effective_policy=effective_policy,
                 actor_id=actor_id,
-                context=context,
+                profile_id=profile_id,
             )
+            raise FederationPolicyDenied(
+                deny_reason,
+                f"External virtual tool '{virtual_tool.virtual_name}' is not allowed",
+                payload={
+                    "reason_code": deny_reason,
+                    "server_id": virtual_tool.server_id,
+                    "virtual_tool_name": virtual_tool.virtual_name,
+                },
+            )
+
+        runtime_auth = await self._resolve_runtime_auth(
+            server=server,
+            virtual_tool=virtual_tool,
+            effective_policy=effective_policy,
+            actor_id=actor_id,
+            context=context,
+        )
+        try:
             result = await transport.call_tool(
                 virtual_tool.upstream_tool_name,
                 deepcopy(arguments or {}),
                 context=context,
                 runtime_auth=runtime_auth,
             )
-            if runtime_auth is not None:
-                metadata = deepcopy(result.metadata or {})
-                metadata.update(self._public_runtime_auth_metadata(runtime_auth))
-                metadata["credential_injection"] = self._summarize_runtime_auth(runtime_auth)
-                result = ExternalToolCallResult(
-                    content=deepcopy(result.content),
-                    is_error=result.is_error,
-                    metadata=metadata,
-                )
+        except Exception as exc:  # noqa: BLE001 - transport adapters define call errors.
             await self._audit_execution(
-                event_type="external_tool.allowed",
-                reason_code="allowed",
+                event_type="external_tool.failed",
+                reason_code="external_tool_call_failed",
                 virtual_tool=virtual_tool,
                 actor_id=actor_id,
                 profile_id=self._policy_profile_id(effective_policy),
-                credential_injection=(
-                    self._summarize_runtime_auth(runtime_auth)
-                    if runtime_auth is not None
-                    else None
-                ),
+                extra_payload={
+                    "error_type": type(exc).__name__,
+                    "error_message": str(exc),
+                },
             )
-            return self._federated_result(virtual_tool, result)
+            raise GatewayExternalRuntimeError(
+                f"External tool '{virtual_tool.virtual_name}' failed during execution",
+                reason_code="external_tool_call_failed",
+                server_id=virtual_tool.server_id,
+            ) from exc
 
-    async def _stop_server_unlocked(self, server_id: str) -> None:
+        if runtime_auth is not None:
+            metadata = deepcopy(result.metadata or {})
+            metadata.update(self._public_runtime_auth_metadata(runtime_auth))
+            metadata["credential_injection"] = self._summarize_runtime_auth(runtime_auth)
+            result = ExternalToolCallResult(
+                content=deepcopy(result.content),
+                is_error=result.is_error,
+                metadata=metadata,
+            )
+        await self._audit_execution(
+            event_type="external_tool.allowed",
+            reason_code="allowed",
+            virtual_tool=virtual_tool,
+            actor_id=actor_id,
+            profile_id=self._policy_profile_id(effective_policy),
+            credential_injection=(
+                self._summarize_runtime_auth(runtime_auth)
+                if runtime_auth is not None
+                else None
+            ),
+        )
+        return self._federated_result(virtual_tool, result)
+
+    def _pop_runtime_unlocked(
+        self,
+        server_id: str,
+    ) -> ExternalFederationTransport | None:
         transport = self._transports.pop(server_id, None)
-        close_error: str | None = None
-        if transport is not None:
-            try:
-                await transport.close()
-            except Exception as exc:  # noqa: BLE001 - stop must still clear state.
-                close_error = self._exception_summary(exc)
         self._servers.pop(server_id, None)
         self._last_errors.pop(server_id, None)
         self._clear_server_tools(server_id)
+        return transport
+
+    async def _close_stopped_transport(
+        self,
+        server_id: str,
+        transport: ExternalFederationTransport,
+    ) -> None:
+        close_error: str | None = None
+        try:
+            await transport.close()
+        except Exception as exc:  # noqa: BLE001 - stop must still clear state.
+            close_error = self._exception_summary(exc)
         payload: dict[str, Any] = {
             "reason_code": "external_server_stopped",
             "server_id": server_id,
@@ -440,16 +545,17 @@ class GatewayExternalRuntimeManager:
             target_id=server_id,
         )
 
-    async def _start_server_unlocked(
+    async def _connect_and_discover_server(
         self,
         server: ExternalServerDefinition,
-    ) -> dict[str, Any]:
+    ) -> tuple[ExternalFederationTransport, list[ExternalToolDefinition]]:
         transport = self._transport_factory(server.model_copy(deep=True))
         try:
             await transport.connect()
             tools = await transport.list_tools()
         except Exception as exc:  # noqa: BLE001 - transport adapters define their own errors.
-            self._last_errors[server.id] = self._exception_summary(exc)
+            async with self._lock:
+                self._last_errors[server.id] = self._exception_summary(exc)
             await self._close_best_effort(transport)
             await self._audit_best_effort(
                 "external_server.lifecycle",
@@ -467,45 +573,31 @@ class GatewayExternalRuntimeManager:
                 reason_code="external_server_start_failed",
                 server_id=server.id,
             ) from exc
+        return transport, tools
 
+    def _commit_started_runtime_unlocked(
+        self,
+        server: ExternalServerDefinition,
+        transport: ExternalFederationTransport,
+        tools: list[ExternalToolDefinition],
+    ) -> None:
         self._servers[server.id] = server.model_copy(deep=True)
         self._transports[server.id] = transport
         self._last_errors[server.id] = None
         self._replace_server_tools(server.id, tools)
-        await self._audit(
-            "external_server.lifecycle",
-            payload={
-                "reason_code": "external_server_started",
-                "server_id": server.id,
-                "transport": server.transport,
-            },
-            target_type="external_server",
-            target_id=server.id,
-        )
-        await self._audit(
-            "external_server.discovery",
-            payload={
-                "reason_code": "external_server_discovered",
-                "server_id": server.id,
-                "tool_count": len(tools),
-            },
-            target_type="external_server",
-            target_id=server.id,
-        )
-        return {
-            "ok": True,
-            "reason_code": "external_server_started",
-            "server_id": server.id,
-            "tool_count": len(tools),
-        }
 
-    async def _refresh_server_tools_unlocked(self, server_id: str) -> bool:
-        transport = self._transports[server_id]
+    async def _refresh_server_tools(
+        self,
+        server_id: str,
+        transport: ExternalFederationTransport,
+    ) -> bool:
         try:
             tools = await transport.list_tools()
         except Exception as exc:  # noqa: BLE001 - discovery adapters define their own errors.
-            self._last_errors[server_id] = self._exception_summary(exc)
-            self._clear_server_tools(server_id)
+            async with self._lock:
+                if self._transports.get(server_id) is transport:
+                    self._last_errors[server_id] = self._exception_summary(exc)
+                    self._clear_server_tools(server_id)
             await self._audit_best_effort(
                 "external_server.discovery",
                 payload={
@@ -519,8 +611,11 @@ class GatewayExternalRuntimeManager:
             )
             return False
 
-        self._last_errors[server_id] = None
-        self._replace_server_tools(server_id, tools)
+        async with self._lock:
+            if self._transports.get(server_id) is not transport:
+                return True
+            self._last_errors[server_id] = None
+            self._replace_server_tools(server_id, tools)
         await self._audit(
             "external_server.discovery",
             payload={
@@ -622,6 +717,44 @@ class GatewayExternalRuntimeManager:
         result.setdefault("server_id", server.id)
         return result
 
+    def _deny_reason(
+        self,
+        *,
+        server: ExternalServerDefinition,
+        virtual_tool: VirtualExternalTool,
+        effective_policy: Any,
+    ) -> str | None:
+        if self._tool_matches_any(
+            virtual_tool,
+            self._policy_list(effective_policy, "denied_tools"),
+        ):
+            return "tool_denied"
+        if not self._has_server_grant(effective_policy, virtual_tool):
+            return "external_server_not_granted"
+        allowed_tools = self._policy_list(effective_policy, "allowed_tools")
+        if allowed_tools and not self._tool_matches_any(virtual_tool, allowed_tools):
+            return "tool_not_allowed"
+        if self._missing_credential_slots(
+            server=server,
+            effective_policy=effective_policy,
+        ):
+            return "required_credential_grant_missing"
+        return None
+
+    def _has_server_grant(
+        self,
+        effective_policy: Any,
+        virtual_tool: VirtualExternalTool,
+    ) -> bool:
+        for grant in self._policy_dicts(effective_policy, "external_server_grants"):
+            if not self._grant_matches_server(grant, virtual_tool.server_id):
+                continue
+            tool_patterns = self._grant_tool_patterns(grant)
+            if tool_patterns and not self._tool_matches_any(virtual_tool, tool_patterns):
+                continue
+            return True
+        return False
+
     async def _resolve_runtime_auth(
         self,
         *,
@@ -694,9 +827,9 @@ class GatewayExternalRuntimeManager:
             "server": server.model_copy(deep=True),
             "virtual_tool": virtual_tool.copy(),
             "credential_slots": list(credential_slots),
-            "effective_policy": deepcopy(effective_policy),
+            "effective_policy": effective_policy,
             "actor_id": actor_id,
-            "context": deepcopy(context),
+            "context": context,
         }
         if hasattr(broker, "resolve_external_credential"):
             result = broker.resolve_external_credential(**kwargs)
@@ -771,16 +904,67 @@ class GatewayExternalRuntimeManager:
         return str(raw_server_id or "").strip() == server_id
 
     @staticmethod
+    def _grant_tool_patterns(grant: dict[str, Any]) -> list[str]:
+        patterns: list[str] = []
+        for key in ("tools", "tool_names", "allowed_tools"):
+            raw = grant.get(key)
+            if isinstance(raw, str):
+                patterns.append(raw)
+            elif isinstance(raw, Iterable) and not isinstance(raw, (bytes, dict)):
+                patterns.extend(str(item) for item in raw)
+        return [pattern for pattern in patterns if pattern.strip()]
+
+    @classmethod
+    def _tool_matches_any(
+        cls,
+        virtual_tool: VirtualExternalTool,
+        patterns: list[str],
+    ) -> bool:
+        return any(cls._tool_matches_pattern(virtual_tool, pattern) for pattern in patterns)
+
+    @staticmethod
+    def _tool_matches_pattern(
+        virtual_tool: VirtualExternalTool,
+        pattern: str,
+    ) -> bool:
+        candidate = str(pattern or "").strip()
+        if candidate in {"*", "ext.*"}:
+            return True
+        if candidate.endswith("*"):
+            prefix = candidate[:-1]
+            return (
+                virtual_tool.virtual_name.startswith(prefix)
+                or virtual_tool.upstream_tool_name.startswith(prefix)
+            )
+        return candidate in {
+            virtual_tool.virtual_name,
+            virtual_tool.upstream_tool_name,
+        }
+
+    @staticmethod
     def _policy_dicts(effective_policy: Any, field_name: str) -> list[dict[str, Any]]:
         values = GatewayExternalRuntimeManager._policy_value(effective_policy, field_name, [])
         if isinstance(values, dict):
-            return [deepcopy(values)]
+            return [dict(values)]
         if not isinstance(values, Iterable) or isinstance(values, (str, bytes)):
             return []
         return [
-            deepcopy(value)
+            dict(value)
             for value in values
             if isinstance(value, dict)
+        ]
+
+    @staticmethod
+    def _policy_list(effective_policy: Any, field_name: str) -> list[str]:
+        values = GatewayExternalRuntimeManager._policy_value(effective_policy, field_name, [])
+        if isinstance(values, str):
+            return [values] if values.strip() else []
+        if not isinstance(values, Iterable) or isinstance(values, (bytes, dict)):
+            return []
+        return [
+            str(value)
+            for value in values
+            if str(value).strip()
         ]
 
     @staticmethod
@@ -807,6 +991,7 @@ class GatewayExternalRuntimeManager:
         actor_id: str | None,
         profile_id: str | None,
         credential_injection: dict[str, Any] | None = None,
+        extra_payload: dict[str, Any] | None = None,
     ) -> None:
         payload: dict[str, Any] = {
             "reason_code": reason_code,
@@ -816,6 +1001,8 @@ class GatewayExternalRuntimeManager:
         }
         if credential_injection is not None:
             payload["credential_injection"] = deepcopy(credential_injection)
+        if extra_payload is not None:
+            payload.update(deepcopy(extra_payload))
         await self._audit(
             event_type,
             actor_id=actor_id,

--- a/mcp_unified/gateway/external_runtime.py
+++ b/mcp_unified/gateway/external_runtime.py
@@ -1,0 +1,400 @@
+"""In-process external MCP server runtime management for the standalone gateway."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Callable
+from copy import deepcopy
+from datetime import datetime, timezone
+from typing import Any
+from uuid import uuid4
+
+from mcp_unified.federation.models import (
+    ExternalToolDefinition,
+    VirtualExternalTool,
+)
+from mcp_unified.federation.transports import ExternalFederationTransport
+from mcp_unified.interfaces.storage import AuditStore, ExternalRegistryStore
+from mcp_unified.storage import AuditEvent, ExternalServerDefinition
+
+
+class GatewayExternalRuntimeError(RuntimeError):
+    """Raised when an external runtime operation cannot be completed."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        reason_code: str,
+        server_id: str | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.reason_code = reason_code
+        self.server_id = server_id
+
+    def to_payload(self) -> dict[str, Any]:
+        """Return a JSON-serializable error payload for gateway callers."""
+        payload: dict[str, Any] = {
+            "ok": False,
+            "error": str(self),
+            "reason_code": self.reason_code,
+        }
+        if self.server_id is not None:
+            payload["server_id"] = self.server_id
+        return payload
+
+
+class GatewayExternalRuntimeManager:
+    """Manage active external server transports for one in-process gateway."""
+
+    def __init__(
+        self,
+        *,
+        external_registry_store: ExternalRegistryStore,
+        transport_factory: Callable[[ExternalServerDefinition], ExternalFederationTransport],
+        audit_store: AuditStore | None = None,
+    ) -> None:
+        self._external_registry_store = external_registry_store
+        self._transport_factory = transport_factory
+        self._audit_store = audit_store
+        self._servers: dict[str, ExternalServerDefinition] = {}
+        self._transports: dict[str, ExternalFederationTransport] = {}
+        self._virtual_tools: dict[str, VirtualExternalTool] = {}
+        self._last_errors: dict[str, str | None] = {}
+        self._lock = asyncio.Lock()
+
+    async def start_server(self, server_id: str) -> dict[str, Any]:
+        """Start one configured external server and discover its virtual tools."""
+        async with self._lock:
+            server = await self._load_server(server_id)
+            self._require_enabled(server)
+            if server.id in self._transports:
+                await self._stop_server_unlocked(server.id)
+
+            transport = self._transport_factory(server.model_copy(deep=True))
+            try:
+                await transport.connect()
+                tools = await transport.list_tools()
+            except Exception as exc:  # noqa: BLE001 - transport adapters define their own errors.
+                self._last_errors[server.id] = self._exception_summary(exc)
+                await self._close_best_effort(transport)
+                await self._audit_best_effort(
+                    "external_server.lifecycle",
+                    payload={
+                        "reason_code": "external_server_start_failed",
+                        "server_id": server.id,
+                        "error_type": type(exc).__name__,
+                        "error_message": str(exc),
+                    },
+                    target_type="external_server",
+                    target_id=server.id,
+                )
+                raise
+
+            self._servers[server.id] = server.model_copy(deep=True)
+            self._transports[server.id] = transport
+            self._last_errors[server.id] = None
+            self._replace_server_tools(server.id, tools)
+            await self._audit(
+                "external_server.lifecycle",
+                payload={
+                    "reason_code": "external_server_started",
+                    "server_id": server.id,
+                    "transport": server.transport,
+                },
+                target_type="external_server",
+                target_id=server.id,
+            )
+            await self._audit(
+                "external_server.discovery",
+                payload={
+                    "reason_code": "external_server_discovered",
+                    "server_id": server.id,
+                    "tool_count": len(tools),
+                },
+                target_type="external_server",
+                target_id=server.id,
+            )
+            return {
+                "ok": True,
+                "reason_code": "external_server_started",
+                "server_id": server.id,
+                "tool_count": len(tools),
+            }
+
+    async def stop_server(self, server_id: str) -> dict[str, Any]:
+        """Stop one external server and clear its discovered virtual tools."""
+        async with self._lock:
+            server = await self._find_server(server_id)
+            if server is None:
+                raise GatewayExternalRuntimeError(
+                    f"External server '{server_id}' was not found",
+                    reason_code="external_server_not_found",
+                    server_id=server_id,
+                )
+            if server_id not in self._transports:
+                self._clear_server_tools(server_id)
+                self._servers.pop(server_id, None)
+                self._last_errors.pop(server_id, None)
+                return {
+                    "ok": True,
+                    "reason_code": "external_server_already_stopped",
+                    "server_id": server_id,
+                }
+            await self._stop_server_unlocked(server_id)
+            return {
+                "ok": True,
+                "reason_code": "external_server_stopped",
+                "server_id": server_id,
+            }
+
+    async def list_runtime_servers(self) -> dict[str, Any]:
+        """Return runtime status rows for configured external servers."""
+        async with self._lock:
+            configured = {
+                server.id: server
+                for server in await self._list_server_definitions()
+            }
+            for server_id, server in self._servers.items():
+                configured.setdefault(server_id, server.model_copy(deep=True))
+            snapshots = [
+                (
+                    server_id,
+                    server.model_copy(deep=True),
+                    self._transports.get(server_id),
+                    self._last_errors.get(server_id),
+                    self._count_tools_for_server(server_id),
+                )
+                for server_id, server in sorted(configured.items())
+            ]
+
+        rows: list[dict[str, Any]] = []
+        for server_id, server, transport, last_error, tool_count in snapshots:
+            checks: dict[str, Any] = {
+                "configured": True,
+                "connected": False,
+                "initialized": False,
+            }
+            if transport is not None:
+                checks.update(await transport.health_check())
+            rows.append(
+                {
+                    "id": server_id,
+                    "name": server.name,
+                    "transport": server.transport,
+                    "enabled": server.enabled,
+                    "status": self._server_status(
+                        active=transport is not None,
+                        connected=bool(checks.get("connected")),
+                        enabled=server.enabled,
+                        last_error=last_error,
+                    ),
+                    "tool_count": tool_count,
+                    "checks": dict(checks),
+                    "last_error": last_error,
+                }
+            )
+        return {"servers": rows, "total_servers": len(rows)}
+
+    async def list_virtual_tools(self) -> list[VirtualExternalTool]:
+        """Return caller-owned discovered virtual tools sorted by name."""
+        async with self._lock:
+            return [
+                self._virtual_tools[name].copy()
+                for name in sorted(self._virtual_tools)
+            ]
+
+    async def _stop_server_unlocked(self, server_id: str) -> None:
+        transport = self._transports.pop(server_id, None)
+        close_error: str | None = None
+        if transport is not None:
+            try:
+                await transport.close()
+            except Exception as exc:  # noqa: BLE001 - stop must still clear state.
+                close_error = self._exception_summary(exc)
+        self._servers.pop(server_id, None)
+        self._last_errors.pop(server_id, None)
+        self._clear_server_tools(server_id)
+        payload: dict[str, Any] = {
+            "reason_code": "external_server_stopped",
+            "server_id": server_id,
+        }
+        if close_error is not None:
+            payload["close_error"] = close_error
+        await self._audit_best_effort(
+            "external_server.lifecycle",
+            payload=payload,
+            target_type="external_server",
+            target_id=server_id,
+        )
+
+    async def _load_server(self, server_id: str) -> ExternalServerDefinition:
+        server = await self._find_server(server_id)
+        if server is None:
+            raise GatewayExternalRuntimeError(
+                f"External server '{server_id}' was not found",
+                reason_code="external_server_not_found",
+                server_id=server_id,
+            )
+        return server
+
+    async def _find_server(self, server_id: str) -> ExternalServerDefinition | None:
+        row = await self._external_registry_store.get_server(server_id)
+        if row is None:
+            row = self._servers.get(server_id)
+        if row is None:
+            return None
+        return self._coerce_server_definition(row)
+
+    async def _list_server_definitions(self) -> list[ExternalServerDefinition]:
+        if hasattr(self._external_registry_store, "list_server_definitions"):
+            rows = await self._external_registry_store.list_server_definitions()
+        else:
+            rows = await self._external_registry_store.list_servers()
+        return [self._coerce_server_definition(row) for row in rows]
+
+    @staticmethod
+    def _coerce_server_definition(row: Any) -> ExternalServerDefinition:
+        if isinstance(row, ExternalServerDefinition):
+            return row.model_copy(deep=True)
+        if isinstance(row, dict):
+            return ExternalServerDefinition(**deepcopy(row))
+        raise TypeError("external registry rows must be ExternalServerDefinition or dict")
+
+    @staticmethod
+    def _require_enabled(server: ExternalServerDefinition) -> None:
+        if server.enabled:
+            return
+        raise GatewayExternalRuntimeError(
+            f"External server '{server.id}' is disabled",
+            reason_code="external_server_disabled",
+            server_id=server.id,
+        )
+
+    def _replace_server_tools(
+        self,
+        server_id: str,
+        tools: list[ExternalToolDefinition],
+    ) -> None:
+        self._clear_server_tools(server_id)
+        for tool in tools:
+            tool_copy = tool.copy()
+            metadata = deepcopy(tool_copy.metadata or {})
+            metadata.setdefault("external_server_id", server_id)
+            metadata.setdefault("upstream_tool_name", tool_copy.name)
+            virtual_name = self._virtual_tool_name(server_id, tool_copy.name)
+            self._virtual_tools[virtual_name] = VirtualExternalTool(
+                virtual_name=virtual_name,
+                server_id=server_id,
+                upstream_tool_name=tool_copy.name,
+                description=tool_copy.description,
+                input_schema=deepcopy(tool_copy.input_schema),
+                metadata=metadata,
+                is_write=self._is_write_tool(tool_copy.name, metadata),
+            )
+
+    def _clear_server_tools(self, server_id: str) -> None:
+        self._virtual_tools = {
+            name: tool
+            for name, tool in self._virtual_tools.items()
+            if tool.server_id != server_id
+        }
+
+    def _count_tools_for_server(self, server_id: str) -> int:
+        return sum(1 for tool in self._virtual_tools.values() if tool.server_id == server_id)
+
+    async def _audit(
+        self,
+        event_type: str,
+        *,
+        payload: dict[str, Any],
+        actor_id: str | None = None,
+        profile_id: str | None = None,
+        target_type: str | None = None,
+        target_id: str | None = None,
+    ) -> None:
+        if self._audit_store is None:
+            return
+        event = AuditEvent(
+            id=f"mcp-ext-runtime-{uuid4().hex}",
+            event_type=event_type,
+            actor_id=actor_id,
+            profile_id=profile_id,
+            target_type=target_type,
+            target_id=target_id,
+            payload=deepcopy(payload),
+            created_at=datetime.now(timezone.utc),
+        )
+        await self._audit_store.append_event(event)
+
+    async def _audit_best_effort(
+        self,
+        event_type: str,
+        *,
+        payload: dict[str, Any],
+        actor_id: str | None = None,
+        profile_id: str | None = None,
+        target_type: str | None = None,
+        target_id: str | None = None,
+    ) -> None:
+        try:
+            await self._audit(
+                event_type,
+                payload=payload,
+                actor_id=actor_id,
+                profile_id=profile_id,
+                target_type=target_type,
+                target_id=target_id,
+            )
+        except Exception:
+            return
+
+    @staticmethod
+    async def _close_best_effort(transport: ExternalFederationTransport) -> None:
+        try:
+            await transport.close()
+        except Exception:
+            return
+
+    @staticmethod
+    def _server_status(
+        *,
+        active: bool,
+        connected: bool,
+        enabled: bool,
+        last_error: str | None,
+    ) -> str:
+        if not enabled:
+            return "disabled"
+        if not active:
+            return "stopped" if last_error is None else "unhealthy"
+        if connected and last_error is None:
+            return "healthy"
+        if connected:
+            return "degraded"
+        return "unhealthy"
+
+    @staticmethod
+    def _exception_summary(exc: BaseException) -> str:
+        message = str(exc).strip()
+        error_type = type(exc).__name__
+        return f"{error_type}: {message}" if message else error_type
+
+    @staticmethod
+    def _virtual_tool_name(server_id: str, tool_name: str) -> str:
+        return f"ext.{server_id}.{tool_name}"
+
+    @staticmethod
+    def _is_write_tool(tool_name: str, metadata: dict[str, Any]) -> bool:
+        annotations = metadata.get("annotations")
+        if isinstance(annotations, dict) and isinstance(annotations.get("readOnlyHint"), bool):
+            return not annotations["readOnlyHint"]
+        for key in ("read_only", "readOnly", "is_read_only"):
+            value = metadata.get(key)
+            if isinstance(value, bool):
+                return not value
+        lowered = tool_name.lower()
+        return any(
+            token in lowered
+            for token in ("create", "update", "delete", "write", "patch", "import")
+        )

--- a/mcp_unified/gateway/external_runtime.py
+++ b/mcp_unified/gateway/external_runtime.py
@@ -10,6 +10,10 @@ from datetime import datetime, timezone
 from typing import Any, Protocol
 from uuid import uuid4
 
+from mcp_unified.federation.installers import (
+    ExternalServerInstaller,
+    NullExternalServerInstaller,
+)
 from mcp_unified.federation.models import (
     BrokeredExternalCredential,
     ExternalToolCallResult,
@@ -17,10 +21,6 @@ from mcp_unified.federation.models import (
     FederatedToolResult,
     FederationPolicyDenied,
     VirtualExternalTool,
-)
-from mcp_unified.federation.installers import (
-    ExternalServerInstaller,
-    NullExternalServerInstaller,
 )
 from mcp_unified.federation.transports import ExternalFederationTransport
 from mcp_unified.interfaces.storage import AuditStore, ExternalRegistryStore
@@ -922,14 +922,14 @@ class GatewayExternalRuntimeManager:
                 target_type=target_type,
                 target_id=target_id,
             )
-        except Exception:
+        except Exception:  # noqa: BLE001 - audit failures must not block cleanup.
             return
 
     @staticmethod
     async def _close_best_effort(transport: ExternalFederationTransport) -> None:
         try:
             await transport.close()
-        except Exception:
+        except Exception:  # noqa: BLE001 - adapter close failures are best-effort here.
             return
 
     @staticmethod

--- a/mcp_unified/gateway/external_runtime.py
+++ b/mcp_unified/gateway/external_runtime.py
@@ -18,6 +18,10 @@ from mcp_unified.federation.models import (
     FederationPolicyDenied,
     VirtualExternalTool,
 )
+from mcp_unified.federation.installers import (
+    ExternalServerInstaller,
+    NullExternalServerInstaller,
+)
 from mcp_unified.federation.transports import ExternalFederationTransport
 from mcp_unified.interfaces.storage import AuditStore, ExternalRegistryStore
 from mcp_unified.storage import AuditEvent, ExternalServerDefinition
@@ -76,11 +80,13 @@ class GatewayExternalRuntimeManager:
         transport_factory: Callable[[ExternalServerDefinition], ExternalFederationTransport],
         audit_store: AuditStore | None = None,
         credential_broker: ExternalCredentialBroker | Callable[..., Any] | None = None,
+        installer: ExternalServerInstaller | None = None,
     ) -> None:
         self._external_registry_store = external_registry_store
         self._transport_factory = transport_factory
         self._audit_store = audit_store
         self._credential_broker = credential_broker
+        self._installer = installer or NullExternalServerInstaller()
         self._servers: dict[str, ExternalServerDefinition] = {}
         self._transports: dict[str, ExternalFederationTransport] = {}
         self._virtual_tools: dict[str, VirtualExternalTool] = {}
@@ -308,6 +314,46 @@ class GatewayExternalRuntimeManager:
                 self._virtual_tools[name].copy()
                 for name in sorted(self._virtual_tools)
             ]
+
+    async def install_server(
+        self,
+        server_id: str,
+        *,
+        context: Any = None,
+    ) -> dict[str, Any]:
+        """Delegate optional install work to the configured installer adapter."""
+        async with self._lock:
+            server = await self._load_server(server_id)
+            self._require_enabled(server)
+            payload = await self._installer.install_server(
+                server.model_copy(deep=True),
+                context=context,
+            )
+            return self._installer_payload(
+                payload,
+                server=server,
+                fallback_reason_code="external_server_install_not_configured",
+            )
+
+    async def update_server(
+        self,
+        server_id: str,
+        *,
+        context: Any = None,
+    ) -> dict[str, Any]:
+        """Delegate optional update work to the configured installer adapter."""
+        async with self._lock:
+            server = await self._load_server(server_id)
+            self._require_enabled(server)
+            payload = await self._installer.update_server(
+                server.model_copy(deep=True),
+                context=context,
+            )
+            return self._installer_payload(
+                payload,
+                server=server,
+                fallback_reason_code="external_server_update_not_configured",
+            )
 
     async def execute_virtual_tool(
         self,
@@ -561,6 +607,20 @@ class GatewayExternalRuntimeManager:
 
     def _count_tools_for_server(self, server_id: str) -> int:
         return sum(1 for tool in self._virtual_tools.values() if tool.server_id == server_id)
+
+    @staticmethod
+    def _installer_payload(
+        payload: dict[str, Any],
+        *,
+        server: ExternalServerDefinition,
+        fallback_reason_code: str,
+    ) -> dict[str, Any]:
+        result = deepcopy(payload or {})
+        result.setdefault("ok", False)
+        result.setdefault("available", False)
+        result.setdefault("reason_code", fallback_reason_code)
+        result.setdefault("server_id", server.id)
+        return result
 
     async def _resolve_runtime_auth(
         self,

--- a/mcp_unified/gateway/fastapi.py
+++ b/mcp_unified/gateway/fastapi.py
@@ -16,6 +16,10 @@ from .external_registry import (
     GatewayExternalRegistryManagementError,
     GatewayExternalRegistryManager,
 )
+from .external_runtime import (
+    GatewayExternalRuntimeError,
+    GatewayExternalRuntimeManager,
+)
 from .jsonrpc import (
     GATEWAY_RESPONSE_TYPES as _GATEWAY_RESPONSE_TYPES,
 )
@@ -72,6 +76,16 @@ _EXTERNAL_REGISTRY_STATUS_CODES = {
     "invalid_external_server_request": 422,
     "invalid_external_server_patch": 422,
     "unexpected_external_server_delete_result": 500,
+}
+_EXTERNAL_RUNTIME_STATUS_CODES = {
+    "external_server_not_found": 404,
+    "external_server_disabled": 409,
+    "external_server_start_failed": 503,
+    "external_server_stop_failed": 503,
+    "external_server_discovery_failed": 503,
+    "external_server_transport_unavailable": 503,
+    "credential_broker_unavailable": 503,
+    "invalid_external_runtime_request": 422,
 }
 
 
@@ -303,6 +317,17 @@ def _external_registry_error_response(
     )
 
 
+def _external_runtime_error_response(
+    exc: GatewayExternalRuntimeError,
+) -> JSONResponse:
+    """Translate expected external-runtime errors into HTTP JSON responses."""
+
+    return JSONResponse(
+        status_code=_EXTERNAL_RUNTIME_STATUS_CODES.get(exc.reason_code, 500),
+        content=exc.to_payload(),
+    )
+
+
 def _external_registry_store_unavailable_response(
     *,
     server_id: str | None = None,
@@ -367,6 +392,24 @@ def _resolve_external_registry_manager(
     if enable_external_registry_management and resolved is None:
         raise ValueError(
             "external registry management requires external_registry_manager or profile_bootstrap"
+        )
+    return resolved
+
+
+def _resolve_external_runtime_manager(
+    *,
+    external_runtime_manager: GatewayExternalRuntimeManager | None,
+    profile_bootstrap: GatewayProfileBootstrap | None,
+    enable_external_runtime_management: bool,
+) -> GatewayExternalRuntimeManager | None:
+    """Return the configured external runtime manager or reject invalid gating."""
+
+    resolved = external_runtime_manager
+    if resolved is None and profile_bootstrap is not None:
+        resolved = getattr(profile_bootstrap, "external_runtime_manager", None)
+    if enable_external_runtime_management and resolved is None:
+        raise ValueError(
+            "external runtime management requires external_runtime_manager or profile_bootstrap"
         )
     return resolved
 
@@ -535,6 +578,107 @@ def _mount_external_registry_routes(
             return _external_registry_store_unavailable_response(server_id=server_id)
 
 
+def _mount_external_runtime_routes(
+    router: APIRouter,
+    manager: GatewayExternalRuntimeManager,
+) -> None:
+    """Mount external runtime lifecycle endpoints on the package gateway router."""
+
+    @router.get("/external-servers/runtime", response_model=None)
+    async def list_external_runtime_servers() -> dict[str, Any] | JSONResponse:
+        """Return external server runtime status rows."""
+        try:
+            return await manager.list_runtime_servers()
+        except GatewayExternalRuntimeError as exc:
+            return _external_runtime_error_response(exc)
+
+    @router.post("/external-servers/{server_id}/start", response_model=None)
+    async def start_external_runtime_server(
+        server_id: str,
+    ) -> dict[str, Any] | JSONResponse:
+        """Start one configured external MCP server runtime."""
+        try:
+            return await manager.start_server(server_id)
+        except GatewayExternalRuntimeError as exc:
+            return _external_runtime_error_response(exc)
+
+    @router.post("/external-servers/{server_id}/stop", response_model=None)
+    async def stop_external_runtime_server(
+        server_id: str,
+    ) -> dict[str, Any] | JSONResponse:
+        """Stop one configured external MCP server runtime."""
+        try:
+            return await manager.stop_server(server_id)
+        except GatewayExternalRuntimeError as exc:
+            return _external_runtime_error_response(exc)
+
+    @router.post("/external-servers/{server_id}/restart", response_model=None)
+    async def restart_external_runtime_server(
+        server_id: str,
+    ) -> dict[str, Any] | JSONResponse:
+        """Restart one configured external MCP server runtime."""
+        try:
+            return await manager.restart_server(server_id)
+        except GatewayExternalRuntimeError as exc:
+            return _external_runtime_error_response(exc)
+
+    @router.post("/external-servers/refresh", response_model=None)
+    async def refresh_external_runtime_servers() -> dict[str, Any] | JSONResponse:
+        """Refresh discovery for all active external MCP server runtimes."""
+        try:
+            return await manager.refresh_server(None)
+        except GatewayExternalRuntimeError as exc:
+            return _external_runtime_error_response(exc)
+
+    @router.post("/external-servers/{server_id}/refresh", response_model=None)
+    async def refresh_external_runtime_server(
+        server_id: str,
+    ) -> dict[str, Any] | JSONResponse:
+        """Refresh discovery for one active external MCP server runtime."""
+        try:
+            return await manager.refresh_server(server_id)
+        except GatewayExternalRuntimeError as exc:
+            return _external_runtime_error_response(exc)
+
+    @router.post("/external-servers/reconcile", response_model=None)
+    async def reconcile_external_runtime_servers() -> dict[str, Any] | JSONResponse:
+        """Reconcile all configured external MCP server runtimes."""
+        try:
+            return await manager.reconcile(None)
+        except GatewayExternalRuntimeError as exc:
+            return _external_runtime_error_response(exc)
+
+    @router.post("/external-servers/{server_id}/reconcile", response_model=None)
+    async def reconcile_external_runtime_server(
+        server_id: str,
+    ) -> dict[str, Any] | JSONResponse:
+        """Reconcile one configured external MCP server runtime."""
+        try:
+            return await manager.reconcile(server_id)
+        except GatewayExternalRuntimeError as exc:
+            return _external_runtime_error_response(exc)
+
+    @router.post("/external-servers/{server_id}/install", response_model=None)
+    async def install_external_runtime_server(
+        server_id: str,
+    ) -> dict[str, Any] | JSONResponse:
+        """Run the configured install contract for one external MCP server."""
+        try:
+            return await manager.install_server(server_id)
+        except GatewayExternalRuntimeError as exc:
+            return _external_runtime_error_response(exc)
+
+    @router.post("/external-servers/{server_id}/update", response_model=None)
+    async def update_external_runtime_server(
+        server_id: str,
+    ) -> dict[str, Any] | JSONResponse:
+        """Run the configured update contract for one external MCP server."""
+        try:
+            return await manager.update_server(server_id)
+        except GatewayExternalRuntimeError as exc:
+            return _external_runtime_error_response(exc)
+
+
 def create_gateway_router(
     runtime: GatewayRuntime,
     *,
@@ -543,6 +687,8 @@ def create_gateway_router(
     enable_profile_management: bool = False,
     external_registry_manager: GatewayExternalRegistryManager | None = None,
     enable_external_registry_management: bool = False,
+    external_runtime_manager: GatewayExternalRuntimeManager | None = None,
+    enable_external_runtime_management: bool = False,
 ) -> APIRouter:
     """Create a package-owned FastAPI router for a standalone MCP runtime."""
 
@@ -554,6 +700,13 @@ def create_gateway_router(
     )
     if resolved_profile_manager is not None:
         _mount_profile_management_routes(router, resolved_profile_manager)
+    resolved_external_runtime_manager = _resolve_external_runtime_manager(
+        external_runtime_manager=external_runtime_manager,
+        profile_bootstrap=profile_bootstrap,
+        enable_external_runtime_management=enable_external_runtime_management,
+    )
+    if resolved_external_runtime_manager is not None:
+        _mount_external_runtime_routes(router, resolved_external_runtime_manager)
     resolved_external_registry_manager = _resolve_external_registry_manager(
         external_registry_manager=external_registry_manager,
         profile_bootstrap=profile_bootstrap,
@@ -632,6 +785,8 @@ def create_gateway_app(
     enable_profile_management: bool = False,
     external_registry_manager: GatewayExternalRegistryManager | None = None,
     enable_external_registry_management: bool = False,
+    external_runtime_manager: GatewayExternalRuntimeManager | None = None,
+    enable_external_runtime_management: bool = False,
 ) -> FastAPI:
     """Create a minimal FastAPI app exposing the standalone MCP gateway router."""
 
@@ -644,6 +799,8 @@ def create_gateway_app(
             enable_profile_management=enable_profile_management,
             external_registry_manager=external_registry_manager,
             enable_external_registry_management=enable_external_registry_management,
+            external_runtime_manager=external_runtime_manager,
+            enable_external_runtime_management=enable_external_runtime_management,
         ),
         prefix=prefix,
     )

--- a/mcp_unified/gateway/fastapi.py
+++ b/mcp_unified/gateway/fastapi.py
@@ -79,14 +79,17 @@ _EXTERNAL_REGISTRY_STATUS_CODES = {
 }
 _EXTERNAL_RUNTIME_STATUS_CODES = {
     "external_server_not_found": 404,
+    "external_virtual_tool_not_found": 404,
     "external_server_disabled": 409,
     "external_server_start_failed": 503,
     "external_server_stop_failed": 503,
     "external_server_discovery_failed": 503,
     "external_server_transport_unavailable": 503,
+    "external_tool_call_failed": 503,
     "credential_broker_unavailable": 503,
     "invalid_external_runtime_request": 422,
 }
+_EXTERNAL_SERVER_RESERVED_IDS = frozenset({"runtime", "refresh", "reconcile"})
 
 
 class DuplicatePresetRequest(BaseModel):
@@ -215,6 +218,43 @@ class DeleteExternalServerResponse(BaseModel):
     store: StoreMetadataResponse
 
 
+class ExternalRuntimeServerStatusResponse(BaseModel):
+    """Response row for one external MCP server runtime."""
+
+    model_config = ConfigDict(extra="allow")
+
+    id: str
+    status: str
+    name: str | None = None
+    transport: str | None = None
+    enabled: bool | None = None
+    tool_count: int | None = None
+    checks: dict[str, Any] | None = None
+    last_error: str | None = None
+
+
+class ExternalRuntimeServerListResponse(BaseModel):
+    """Response body for listing external MCP server runtime status."""
+
+    model_config = ConfigDict(extra="allow")
+
+    servers: list[ExternalRuntimeServerStatusResponse]
+    ok: bool | None = None
+    total_servers: int | None = None
+
+
+class ExternalRuntimeOperationResponse(BaseModel):
+    """Response body for external MCP server lifecycle operations."""
+
+    model_config = ConfigDict(extra="allow")
+
+    ok: bool
+    reason_code: str
+    server_id: str | None = None
+    error: str | None = None
+    errors: dict[str, Any] | None = None
+
+
 async def _parse_json_body(request: Request) -> Any:
     """Parse raw JSON so malformed bodies return JSON-RPC parse errors."""
 
@@ -338,6 +378,24 @@ def _external_registry_store_unavailable_response(
         GatewayExternalRegistryManagementError(
             "External registry store unavailable",
             reason_code="external_registry_store_unavailable",
+            server_id=server_id,
+        )
+    )
+
+
+def _is_reserved_external_server_id(server_id: str) -> bool:
+    """Return true when a server id would collide with gateway routes."""
+
+    return server_id.strip().lower() in _EXTERNAL_SERVER_RESERVED_IDS
+
+
+def _reserved_external_server_id_response(server_id: str) -> JSONResponse:
+    """Return a registry error for route-reserved external server ids."""
+
+    return _external_registry_error_response(
+        GatewayExternalRegistryManagementError(
+            f"External server id '{server_id}' is reserved",
+            reason_code="invalid_external_server_request",
             server_id=server_id,
         )
     )
@@ -525,6 +583,8 @@ def _mount_external_registry_routes(
         server_id: str,
     ) -> ExternalServerResponse | JSONResponse:
         """Return a single stored external MCP server by id."""
+        if _is_reserved_external_server_id(server_id):
+            return _reserved_external_server_id_response(server_id)
         try:
             return await manager.show_server(server_id)
         except GatewayExternalRegistryManagementError as exc:
@@ -537,6 +597,8 @@ def _mount_external_registry_routes(
         request: CreateExternalServerRequest,
     ) -> ExternalServerResponse | JSONResponse:
         """Create a stored external MCP server definition."""
+        if _is_reserved_external_server_id(request.id):
+            return _reserved_external_server_id_response(request.id)
         try:
             return await manager.create_server(
                 request.model_dump(mode="json", exclude_unset=True)
@@ -552,6 +614,8 @@ def _mount_external_registry_routes(
         request: PatchExternalServerRequest,
     ) -> ExternalServerResponse | JSONResponse:
         """Apply an allowed patch to a stored external MCP server definition."""
+        if _is_reserved_external_server_id(server_id):
+            return _reserved_external_server_id_response(server_id)
         try:
             return await manager.patch_server(
                 server_id,
@@ -570,6 +634,8 @@ def _mount_external_registry_routes(
         server_id: str,
     ) -> DeleteExternalServerResponse | JSONResponse:
         """Delete a stored external MCP server definition."""
+        if _is_reserved_external_server_id(server_id):
+            return _reserved_external_server_id_response(server_id)
         try:
             return await manager.delete_server(server_id)
         except GatewayExternalRegistryManagementError as exc:
@@ -584,94 +650,125 @@ def _mount_external_runtime_routes(
 ) -> None:
     """Mount external runtime lifecycle endpoints on the package gateway router."""
 
-    @router.get("/external-servers/runtime", response_model=None)
-    async def list_external_runtime_servers() -> dict[str, Any] | JSONResponse:
+    @router.get(
+        "/external-servers/runtime",
+        response_model=ExternalRuntimeServerListResponse,
+        response_model_exclude_none=True,
+    )
+    async def list_external_runtime_servers() -> ExternalRuntimeServerListResponse | JSONResponse:
         """Return external server runtime status rows."""
         try:
             return await manager.list_runtime_servers()
         except GatewayExternalRuntimeError as exc:
             return _external_runtime_error_response(exc)
 
-    @router.post("/external-servers/{server_id}/start", response_model=None)
+    @router.post(
+        "/external-servers/{server_id}/start",
+        response_model=ExternalRuntimeOperationResponse,
+    )
     async def start_external_runtime_server(
         server_id: str,
-    ) -> dict[str, Any] | JSONResponse:
+    ) -> ExternalRuntimeOperationResponse | JSONResponse:
         """Start one configured external MCP server runtime."""
         try:
             return await manager.start_server(server_id)
         except GatewayExternalRuntimeError as exc:
             return _external_runtime_error_response(exc)
 
-    @router.post("/external-servers/{server_id}/stop", response_model=None)
+    @router.post(
+        "/external-servers/{server_id}/stop",
+        response_model=ExternalRuntimeOperationResponse,
+    )
     async def stop_external_runtime_server(
         server_id: str,
-    ) -> dict[str, Any] | JSONResponse:
+    ) -> ExternalRuntimeOperationResponse | JSONResponse:
         """Stop one configured external MCP server runtime."""
         try:
             return await manager.stop_server(server_id)
         except GatewayExternalRuntimeError as exc:
             return _external_runtime_error_response(exc)
 
-    @router.post("/external-servers/{server_id}/restart", response_model=None)
+    @router.post(
+        "/external-servers/{server_id}/restart",
+        response_model=ExternalRuntimeOperationResponse,
+    )
     async def restart_external_runtime_server(
         server_id: str,
-    ) -> dict[str, Any] | JSONResponse:
+    ) -> ExternalRuntimeOperationResponse | JSONResponse:
         """Restart one configured external MCP server runtime."""
         try:
             return await manager.restart_server(server_id)
         except GatewayExternalRuntimeError as exc:
             return _external_runtime_error_response(exc)
 
-    @router.post("/external-servers/refresh", response_model=None)
-    async def refresh_external_runtime_servers() -> dict[str, Any] | JSONResponse:
+    @router.post(
+        "/external-servers/refresh",
+        response_model=ExternalRuntimeOperationResponse,
+    )
+    async def refresh_external_runtime_servers() -> ExternalRuntimeOperationResponse | JSONResponse:
         """Refresh discovery for all active external MCP server runtimes."""
         try:
             return await manager.refresh_server(None)
         except GatewayExternalRuntimeError as exc:
             return _external_runtime_error_response(exc)
 
-    @router.post("/external-servers/{server_id}/refresh", response_model=None)
+    @router.post(
+        "/external-servers/{server_id}/refresh",
+        response_model=ExternalRuntimeOperationResponse,
+    )
     async def refresh_external_runtime_server(
         server_id: str,
-    ) -> dict[str, Any] | JSONResponse:
+    ) -> ExternalRuntimeOperationResponse | JSONResponse:
         """Refresh discovery for one active external MCP server runtime."""
         try:
             return await manager.refresh_server(server_id)
         except GatewayExternalRuntimeError as exc:
             return _external_runtime_error_response(exc)
 
-    @router.post("/external-servers/reconcile", response_model=None)
-    async def reconcile_external_runtime_servers() -> dict[str, Any] | JSONResponse:
+    @router.post(
+        "/external-servers/reconcile",
+        response_model=ExternalRuntimeOperationResponse,
+    )
+    async def reconcile_external_runtime_servers() -> ExternalRuntimeOperationResponse | JSONResponse:
         """Reconcile all configured external MCP server runtimes."""
         try:
             return await manager.reconcile(None)
         except GatewayExternalRuntimeError as exc:
             return _external_runtime_error_response(exc)
 
-    @router.post("/external-servers/{server_id}/reconcile", response_model=None)
+    @router.post(
+        "/external-servers/{server_id}/reconcile",
+        response_model=ExternalRuntimeOperationResponse,
+    )
     async def reconcile_external_runtime_server(
         server_id: str,
-    ) -> dict[str, Any] | JSONResponse:
+    ) -> ExternalRuntimeOperationResponse | JSONResponse:
         """Reconcile one configured external MCP server runtime."""
         try:
             return await manager.reconcile(server_id)
         except GatewayExternalRuntimeError as exc:
             return _external_runtime_error_response(exc)
 
-    @router.post("/external-servers/{server_id}/install", response_model=None)
+    @router.post(
+        "/external-servers/{server_id}/install",
+        response_model=ExternalRuntimeOperationResponse,
+    )
     async def install_external_runtime_server(
         server_id: str,
-    ) -> dict[str, Any] | JSONResponse:
+    ) -> ExternalRuntimeOperationResponse | JSONResponse:
         """Run the configured install contract for one external MCP server."""
         try:
             return await manager.install_server(server_id)
         except GatewayExternalRuntimeError as exc:
             return _external_runtime_error_response(exc)
 
-    @router.post("/external-servers/{server_id}/update", response_model=None)
+    @router.post(
+        "/external-servers/{server_id}/update",
+        response_model=ExternalRuntimeOperationResponse,
+    )
     async def update_external_runtime_server(
         server_id: str,
-    ) -> dict[str, Any] | JSONResponse:
+    ) -> ExternalRuntimeOperationResponse | JSONResponse:
         """Run the configured update contract for one external MCP server."""
         try:
             return await manager.update_server(server_id)

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_external_runtime.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_external_runtime.py
@@ -4,14 +4,13 @@ import json
 from typing import Any
 
 import pytest
-
+from mcp_unified.federation.installers import ExternalServerInstaller
 from mcp_unified.federation.models import (
     BrokeredExternalCredential,
     ExternalToolCallResult,
     ExternalToolDefinition,
     FederationPolicyDenied,
 )
-from mcp_unified.federation.installers import ExternalServerInstaller
 from mcp_unified.gateway.external_runtime import (
     GatewayExternalRuntimeError,
     GatewayExternalRuntimeManager,

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_external_runtime.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_external_runtime.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import json
 from typing import Any
 
@@ -117,6 +118,8 @@ class RecordingExternalTransport:
         self.calls: list[tuple[str, dict[str, Any]]] = []
         self.runtime_auth_seen: BrokeredExternalCredential | None = None
         self.fail_list = False
+        self.fail_health = False
+        self.fail_call = False
         self.tools = [tool.copy() for tool in tools or ()]
         self.result = result or ExternalToolCallResult(content={"ok": True})
 
@@ -132,6 +135,8 @@ class RecordingExternalTransport:
 
     async def health_check(self) -> dict[str, bool]:
         """Return deterministic fake health."""
+        if self.fail_health:
+            raise RuntimeError("health failed")
         return {
             "configured": True,
             "connected": self.connected,
@@ -155,9 +160,32 @@ class RecordingExternalTransport:
     ) -> ExternalToolCallResult:
         """Record and return the configured call result."""
         del context
+        if self.fail_call:
+            raise RuntimeError("call failed")
         self.calls.append((tool_name, dict(arguments or {})))
         self.runtime_auth_seen = None if runtime_auth is None else runtime_auth.copy()
         return self.result.copy()
+
+
+class BlockingConnectTransport(RecordingExternalTransport):
+    """Fake transport that pauses connection until the test releases it."""
+
+    def __init__(
+        self,
+        *,
+        server_id: str,
+        tools: list[ExternalToolDefinition] | None = None,
+    ) -> None:
+        super().__init__(server_id=server_id, tools=tools)
+        self.connect_started = asyncio.Event()
+        self.allow_connect = asyncio.Event()
+
+    async def connect(self) -> None:
+        """Wait for the test to allow connection completion."""
+        self.connect_count += 1
+        self.connect_started.set()
+        await self.allow_connect.wait()
+        self.connected = True
 
 
 class RecordingCredentialBroker:
@@ -262,6 +290,54 @@ async def test_external_runtime_start_discovers_tools_and_reports_healthy_status
         "external_server_started",
         "external_server_discovered",
     ]
+
+
+@pytest.mark.asyncio
+async def test_external_runtime_start_does_not_block_status_snapshot_during_connect() -> None:
+    store = InMemoryExternalRegistryStore([_server()])
+    transport = BlockingConnectTransport(
+        server_id="research",
+        tools=[ExternalToolDefinition(name="search")],
+    )
+    manager = GatewayExternalRuntimeManager(
+        external_registry_store=store,
+        transport_factory=lambda _server: transport,
+    )
+
+    start_task = asyncio.create_task(manager.start_server("research"))
+    try:
+        await asyncio.wait_for(transport.connect_started.wait(), timeout=1.0)
+        rows = await asyncio.wait_for(manager.list_runtime_servers(), timeout=0.2)
+    finally:
+        transport.allow_connect.set()
+        await start_task
+
+    assert rows["servers"][0]["id"] == "research"
+    assert rows["servers"][0]["status"] == "stopped"
+
+
+@pytest.mark.asyncio
+async def test_external_runtime_list_status_handles_health_check_failure() -> None:
+    store = InMemoryExternalRegistryStore([_server()])
+    transport = RecordingExternalTransport(
+        server_id="research",
+        tools=[ExternalToolDefinition(name="search")],
+    )
+    manager = GatewayExternalRuntimeManager(
+        external_registry_store=store,
+        transport_factory=lambda _server: transport,
+    )
+    await manager.start_server("research")
+
+    transport.fail_health = True
+    rows = await manager.list_runtime_servers()
+
+    row = rows["servers"][0]
+    assert row["id"] == "research"
+    assert row["status"] == "unhealthy"
+    assert row["checks"]["error"] is True
+    assert row["checks"]["error_type"] == "RuntimeError"
+    assert row["last_error"] == "RuntimeError: health failed"
 
 
 @pytest.mark.asyncio
@@ -526,6 +602,172 @@ async def test_external_runtime_execution_uses_brokered_credentials_without_leak
     assert secret_header not in serialized_public_data
     assert secret_env not in serialized_public_data
     assert (await store.get_server("research")).credential_slots == ["api_key"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("effective_policy", "reason_code"),
+    [
+        ({"profile_id": "project-researcher"}, "external_server_not_granted"),
+        (
+            {
+                "profile_id": "project-researcher",
+                "external_server_grants": [{"server_id": "research"}],
+                "denied_tools": ["ext.research.search"],
+            },
+            "tool_denied",
+        ),
+        (
+            {
+                "profile_id": "project-researcher",
+                "external_server_grants": [{"server_id": "research"}],
+                "allowed_tools": ["ext.research.lookup"],
+            },
+            "tool_not_allowed",
+        ),
+    ],
+)
+async def test_external_runtime_execution_enforces_policy_before_transport_call(
+    effective_policy: dict[str, Any],
+    reason_code: str,
+) -> None:
+    audit = RecordingAuditStore()
+    store = InMemoryExternalRegistryStore([_server()])
+    transport = RecordingExternalTransport(
+        server_id="research",
+        tools=[ExternalToolDefinition(name="search")],
+    )
+    manager = GatewayExternalRuntimeManager(
+        external_registry_store=store,
+        transport_factory=lambda _server: transport,
+        audit_store=audit,
+    )
+    await manager.start_server("research")
+
+    with pytest.raises(FederationPolicyDenied) as exc_info:
+        await manager.execute_virtual_tool(
+            "ext.research.search",
+            {"query": "MCP"},
+            effective_policy=effective_policy,
+            actor_id="user-1",
+        )
+
+    assert exc_info.value.reason_code == reason_code
+    assert transport.calls == []
+    denied = audit.events[-1]
+    assert denied.event_type == "external_tool.denied"
+    assert denied.actor_id == "user-1"
+    assert denied.profile_id == "project-researcher"
+    assert denied.payload["reason_code"] == reason_code
+    assert denied.payload["virtual_tool_name"] == "ext.research.search"
+
+
+@pytest.mark.asyncio
+async def test_external_runtime_unknown_virtual_tool_reports_not_found() -> None:
+    store = InMemoryExternalRegistryStore([_server()])
+    transport = RecordingExternalTransport(
+        server_id="research",
+        tools=[ExternalToolDefinition(name="search")],
+    )
+    manager = GatewayExternalRuntimeManager(
+        external_registry_store=store,
+        transport_factory=lambda _server: transport,
+    )
+    await manager.start_server("research")
+
+    with pytest.raises(GatewayExternalRuntimeError) as exc_info:
+        await manager.execute_virtual_tool(
+            "ext.research.missing",
+            {"query": "MCP"},
+            effective_policy={"external_server_grants": [{"server_id": "research"}]},
+        )
+
+    assert exc_info.value.reason_code == "external_virtual_tool_not_found"
+    assert transport.calls == []
+
+
+@pytest.mark.asyncio
+async def test_external_runtime_execution_wraps_transport_call_errors() -> None:
+    audit = RecordingAuditStore()
+    store = InMemoryExternalRegistryStore([_server()])
+    transport = RecordingExternalTransport(
+        server_id="research",
+        tools=[ExternalToolDefinition(name="search")],
+    )
+    manager = GatewayExternalRuntimeManager(
+        external_registry_store=store,
+        transport_factory=lambda _server: transport,
+        audit_store=audit,
+    )
+    await manager.start_server("research")
+
+    transport.fail_call = True
+    with pytest.raises(GatewayExternalRuntimeError) as exc_info:
+        await manager.execute_virtual_tool(
+            "ext.research.search",
+            {"query": "MCP"},
+            effective_policy={"external_server_grants": [{"server_id": "research"}]},
+            actor_id="user-1",
+        )
+
+    assert exc_info.value.reason_code == "external_tool_call_failed"
+    assert isinstance(exc_info.value.__cause__, RuntimeError)
+    failed = audit.events[-1]
+    assert failed.event_type == "external_tool.failed"
+    assert failed.actor_id == "user-1"
+    assert failed.payload["reason_code"] == "external_tool_call_failed"
+    assert failed.payload["error_type"] == "RuntimeError"
+
+
+@pytest.mark.asyncio
+async def test_external_runtime_credential_broker_accepts_noncopyable_policy_and_context() -> None:
+    class NonCopyablePolicy:
+        profile_id = "project-researcher"
+        external_server_grants = [{"server_id": "research"}]
+        credential_grants = [
+            {
+                "external_server_id": "research",
+                "credential_slot": "api_key",
+            }
+        ]
+        allowed_tools: list[str] = []
+        denied_tools: list[str] = []
+
+        def __deepcopy__(self, memo: dict[int, Any]) -> NonCopyablePolicy:
+            raise RuntimeError("policy cannot be copied")
+
+    class NonCopyableContext:
+        def __deepcopy__(self, memo: dict[int, Any]) -> NonCopyableContext:
+            raise RuntimeError("context cannot be copied")
+
+    policy = NonCopyablePolicy()
+    context = NonCopyableContext()
+    store = InMemoryExternalRegistryStore([_server(credential_slots=["api_key"])])
+    transport = RecordingExternalTransport(
+        server_id="research",
+        tools=[ExternalToolDefinition(name="search")],
+    )
+    broker = RecordingCredentialBroker(
+        BrokeredExternalCredential(headers={"Authorization": "Bearer test"})
+    )
+    manager = GatewayExternalRuntimeManager(
+        external_registry_store=store,
+        transport_factory=lambda _server: transport,
+        credential_broker=broker,
+    )
+    await manager.start_server("research")
+
+    result = await manager.execute_virtual_tool(
+        "ext.research.search",
+        {"query": "MCP"},
+        effective_policy=policy,
+        context=context,
+    )
+
+    assert result.content == {"ok": True}
+    assert broker.calls[0]["effective_policy"] is policy
+    assert broker.calls[0]["context"] is context
+    assert transport.runtime_auth_seen is not None
 
 
 @pytest.mark.asyncio

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_external_runtime.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_external_runtime.py
@@ -11,6 +11,7 @@ from mcp_unified.federation.models import (
     ExternalToolDefinition,
     FederationPolicyDenied,
 )
+from mcp_unified.federation.installers import ExternalServerInstaller
 from mcp_unified.gateway.external_runtime import (
     GatewayExternalRuntimeError,
     GatewayExternalRuntimeManager,
@@ -177,6 +178,49 @@ class RecordingCredentialBroker:
         """Record one broker request and return the configured result."""
         self.calls.append(dict(kwargs))
         return None if self.result is None else self.result.copy()
+
+
+class UnsupportedInstaller(ExternalServerInstaller):
+    """Installer fake that reports unsupported operations."""
+
+    def __init__(self) -> None:
+        self.install_calls: list[tuple[str, Any]] = []
+        self.update_calls: list[tuple[str, Any]] = []
+
+    async def install_server(
+        self,
+        server: ExternalServerDefinition,
+        *,
+        context: Any = None,
+    ) -> dict[str, Any]:
+        """Return an unsupported install response."""
+        self.install_calls.append((server.id, context))
+        return {
+            "ok": False,
+            "reason_code": "external_server_install_unsupported",
+            "server_id": server.id,
+        }
+
+    async def update_server(
+        self,
+        server: ExternalServerDefinition,
+        *,
+        context: Any = None,
+    ) -> dict[str, Any]:
+        """Return an unsupported update response."""
+        self.update_calls.append((server.id, context))
+        return {
+            "ok": False,
+            "reason_code": "external_server_update_unsupported",
+            "server_id": server.id,
+        }
+
+    async def get_status(
+        self,
+        server: ExternalServerDefinition,
+    ) -> dict[str, Any]:
+        """Return unavailable fake installer status."""
+        return {"available": False, "server_id": server.id}
 
 
 def _server(**overrides: Any) -> ExternalServerDefinition:
@@ -550,3 +594,52 @@ async def test_external_runtime_required_credentials_fail_closed_when_broker_ret
     assert exc_info.value.reason_code == "required_credential_grant_missing"
     assert broker.calls
     assert transport.calls == []
+
+
+@pytest.mark.asyncio
+async def test_external_runtime_default_install_update_are_not_configured() -> None:
+    store = InMemoryExternalRegistryStore([_server()])
+    manager = GatewayExternalRuntimeManager(
+        external_registry_store=store,
+        transport_factory=lambda server: RecordingExternalTransport(server_id=server.id),
+    )
+
+    install = await manager.install_server("research")
+    update = await manager.update_server("research")
+
+    assert install["reason_code"] == "external_server_install_not_configured"
+    assert update["reason_code"] == "external_server_update_not_configured"
+    assert install["available"] is False
+    assert update["available"] is False
+    assert store.mutations == 0
+
+
+@pytest.mark.asyncio
+async def test_external_runtime_installer_unsupported_does_not_mutate_runtime_state() -> None:
+    store = InMemoryExternalRegistryStore([_server()])
+    transport = RecordingExternalTransport(
+        server_id="research",
+        tools=[ExternalToolDefinition(name="search")],
+    )
+    installer = UnsupportedInstaller()
+    manager = GatewayExternalRuntimeManager(
+        external_registry_store=store,
+        transport_factory=lambda _server: transport,
+        installer=installer,
+    )
+    await manager.start_server("research")
+
+    install = await manager.install_server("research", context={"request_id": "install"})
+    update = await manager.update_server("research", context={"request_id": "update"})
+    rows = await manager.list_runtime_servers()
+    tools = await manager.list_virtual_tools()
+
+    assert install["reason_code"] == "external_server_install_unsupported"
+    assert update["reason_code"] == "external_server_update_unsupported"
+    assert installer.install_calls == [("research", {"request_id": "install"})]
+    assert installer.update_calls == [("research", {"request_id": "update"})]
+    assert store.mutations == 0
+    assert transport.connect_count == 1
+    assert transport.close_count == 0
+    assert rows["servers"][0]["status"] == "healthy"
+    assert [tool.virtual_name for tool in tools] == ["ext.research.search"]

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_external_runtime.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_external_runtime.py
@@ -21,6 +21,17 @@ class InMemoryExternalRegistryStore:
             server.id: server.model_copy(deep=True)
             for server in servers or ()
         }
+        self.mutations = 0
+
+    def set_server(self, server: ExternalServerDefinition) -> None:
+        """Store a caller-owned server definition."""
+        self.mutations += 1
+        self.servers[server.id] = server.model_copy(deep=True)
+
+    def delete_server(self, server_id: str) -> None:
+        """Delete a server definition from the fake registry."""
+        self.mutations += 1
+        self.servers.pop(server_id, None)
 
     async def get_server(self, server_id: str) -> ExternalServerDefinition | None:
         """Return one server definition by id."""
@@ -97,6 +108,7 @@ class RecordingExternalTransport:
         self.connected = False
         self.connect_count = 0
         self.close_count = 0
+        self.list_tools_count = 0
         self.calls: list[tuple[str, dict[str, Any]]] = []
         self.runtime_auth_seen: BrokeredExternalCredential | None = None
         self.fail_list = False
@@ -123,6 +135,7 @@ class RecordingExternalTransport:
 
     async def list_tools(self) -> list[ExternalToolDefinition]:
         """Return configured tools or raise a discovery failure."""
+        self.list_tools_count += 1
         if self.fail_list:
             raise RuntimeError("discovery failed")
         return [tool.copy() for tool in self.tools]
@@ -207,3 +220,169 @@ async def test_external_runtime_stop_is_idempotent_and_clears_tools() -> None:
     assert rows["servers"][0]["status"] == "stopped"
     assert rows["servers"][0]["tool_count"] == 0
     assert transport.close_count == 1
+
+
+@pytest.mark.asyncio
+async def test_external_runtime_refresh_failure_isolates_one_server() -> None:
+    research = RecordingExternalTransport(
+        server_id="research",
+        tools=[ExternalToolDefinition(name="search")],
+    )
+    docs = RecordingExternalTransport(
+        server_id="docs",
+        tools=[ExternalToolDefinition(name="lookup")],
+    )
+    store = InMemoryExternalRegistryStore(
+        [
+            _server(),
+            _server(id="docs", name="Docs", command=["fake-docs-mcp"]),
+        ]
+    )
+    manager = GatewayExternalRuntimeManager(
+        external_registry_store=store,
+        transport_factory=lambda server: {"research": research, "docs": docs}[server.id],
+    )
+    await manager.start_server("research")
+    await manager.start_server("docs")
+
+    research.fail_list = True
+    payload = await manager.refresh_server()
+    rows = await manager.list_runtime_servers()
+    tools = await manager.list_virtual_tools()
+
+    statuses = {row["id"]: row for row in rows["servers"]}
+    assert payload["reason_code"] == "external_server_refreshed"
+    assert payload["refreshed_servers"] == 1
+    assert payload["errors"] == {"research": "external_server_discovery_failed"}
+    assert statuses["research"]["status"] in {"degraded", "unhealthy"}
+    assert statuses["research"]["tool_count"] == 0
+    assert statuses["docs"]["status"] == "healthy"
+    assert [tool.virtual_name for tool in tools] == ["ext.docs.lookup"]
+
+
+@pytest.mark.asyncio
+async def test_external_runtime_restart_reloads_registry_definition() -> None:
+    first = RecordingExternalTransport(
+        server_id="research",
+        tools=[ExternalToolDefinition(name="search", description="Old search")],
+    )
+    second = RecordingExternalTransport(
+        server_id="research",
+        tools=[ExternalToolDefinition(name="lookup", description="New lookup")],
+    )
+    transports = [first, second]
+    store = InMemoryExternalRegistryStore([_server(name="Research v1")])
+    manager = GatewayExternalRuntimeManager(
+        external_registry_store=store,
+        transport_factory=lambda _server: transports.pop(0),
+    )
+    await manager.start_server("research")
+    store.set_server(_server(name="Research v2", command=["fake-research-mcp-v2"]))
+
+    payload = await manager.restart_server("research")
+    rows = await manager.list_runtime_servers()
+    tools = await manager.list_virtual_tools()
+
+    assert payload["reason_code"] == "external_server_restarted"
+    assert first.close_count == 1
+    assert second.connect_count == 1
+    assert rows["servers"][0]["name"] == "Research v2"
+    assert [tool.virtual_name for tool in tools] == ["ext.research.lookup"]
+
+
+@pytest.mark.asyncio
+async def test_external_runtime_reconcile_starts_stops_restarts_and_refreshes() -> None:
+    existing_servers = [
+        _server(id="unchanged", name="Unchanged", command=["fake-unchanged"]),
+        _server(id="changed", name="Changed", command=["fake-changed-v1"]),
+        _server(id="to_disable", name="To Disable", command=["fake-disable"]),
+        _server(id="to_delete", name="To Delete", command=["fake-delete"]),
+    ]
+    store = InMemoryExternalRegistryStore(existing_servers)
+    unchanged = RecordingExternalTransport(
+        server_id="unchanged",
+        tools=[ExternalToolDefinition(name="read")],
+    )
+    changed_old = RecordingExternalTransport(
+        server_id="changed",
+        tools=[ExternalToolDefinition(name="old")],
+    )
+    changed_new = RecordingExternalTransport(
+        server_id="changed",
+        tools=[ExternalToolDefinition(name="new")],
+    )
+    to_disable = RecordingExternalTransport(
+        server_id="to_disable",
+        tools=[ExternalToolDefinition(name="stop_me")],
+    )
+    to_delete = RecordingExternalTransport(
+        server_id="to_delete",
+        tools=[ExternalToolDefinition(name="remove_me")],
+    )
+    added = RecordingExternalTransport(
+        server_id="added",
+        tools=[ExternalToolDefinition(name="created")],
+    )
+    transport_queues: dict[str, list[RecordingExternalTransport]] = {
+        "unchanged": [unchanged],
+        "changed": [changed_old, changed_new],
+        "to_disable": [to_disable],
+        "to_delete": [to_delete],
+        "added": [added],
+    }
+
+    def factory(server: ExternalServerDefinition) -> RecordingExternalTransport:
+        return transport_queues[server.id].pop(0)
+
+    manager = GatewayExternalRuntimeManager(
+        external_registry_store=store,
+        transport_factory=factory,
+    )
+    for server in existing_servers:
+        await manager.start_server(server.id)
+
+    unchanged.tools = [ExternalToolDefinition(name="read_again")]
+    store.set_server(_server(id="changed", name="Changed", command=["fake-changed-v2"]))
+    store.set_server(
+        _server(
+            id="to_disable",
+            name="To Disable",
+            command=["fake-disable"],
+            enabled=False,
+        )
+    )
+    store.delete_server("to_delete")
+    store.set_server(
+        _server(
+            id="added",
+            name="Added",
+            command=["fake-added"],
+            auto_start=True,
+        )
+    )
+
+    payload = await manager.reconcile()
+    rows = await manager.list_runtime_servers()
+    tools = await manager.list_virtual_tools()
+
+    statuses = {row["id"]: row["status"] for row in rows["servers"]}
+    assert payload["reason_code"] == "external_server_reconciled"
+    assert payload["started_servers"] == 1
+    assert payload["stopped_servers"] == 2
+    assert payload["restarted_servers"] == 1
+    assert payload["refreshed_servers"] == 1
+    assert payload["errors"] == {}
+    assert unchanged.list_tools_count == 2
+    assert changed_old.close_count == 1
+    assert changed_new.connect_count == 1
+    assert to_disable.close_count == 1
+    assert to_delete.close_count == 1
+    assert added.connect_count == 1
+    assert statuses["added"] == "healthy"
+    assert statuses["changed"] == "healthy"
+    assert statuses["to_disable"] == "disabled"
+    assert [tool.virtual_name for tool in tools] == [
+        "ext.added.created",
+        "ext.changed.new",
+        "ext.unchanged.read_again",
+    ]

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_external_runtime.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_external_runtime.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from typing import Any
 
 import pytest
@@ -8,8 +9,12 @@ from mcp_unified.federation.models import (
     BrokeredExternalCredential,
     ExternalToolCallResult,
     ExternalToolDefinition,
+    FederationPolicyDenied,
 )
-from mcp_unified.gateway.external_runtime import GatewayExternalRuntimeManager
+from mcp_unified.gateway.external_runtime import (
+    GatewayExternalRuntimeError,
+    GatewayExternalRuntimeManager,
+)
 from mcp_unified.storage.models import AuditEvent, ExternalServerDefinition
 
 
@@ -153,6 +158,25 @@ class RecordingExternalTransport:
         self.calls.append((tool_name, dict(arguments or {})))
         self.runtime_auth_seen = None if runtime_auth is None else runtime_auth.copy()
         return self.result.copy()
+
+
+class RecordingCredentialBroker:
+    """Credential broker fake that records resolution requests."""
+
+    def __init__(
+        self,
+        result: BrokeredExternalCredential | None,
+    ) -> None:
+        self.result = result
+        self.calls: list[dict[str, Any]] = []
+
+    async def resolve_external_credential(
+        self,
+        **kwargs: Any,
+    ) -> BrokeredExternalCredential | None:
+        """Record one broker request and return the configured result."""
+        self.calls.append(dict(kwargs))
+        return None if self.result is None else self.result.copy()
 
 
 def _server(**overrides: Any) -> ExternalServerDefinition:
@@ -386,3 +410,143 @@ async def test_external_runtime_reconcile_starts_stops_restarts_and_refreshes() 
         "ext.changed.new",
         "ext.unchanged.read_again",
     ]
+
+
+@pytest.mark.asyncio
+async def test_external_runtime_execution_uses_brokered_credentials_without_leaking_secrets() -> None:
+    secret_header = "Bearer do-not-leak-header"
+    secret_env = "do-not-leak-env"
+    audit = RecordingAuditStore()
+    store = InMemoryExternalRegistryStore([_server(credential_slots=["api_key"])])
+    transport = RecordingExternalTransport(
+        server_id="research",
+        tools=[ExternalToolDefinition(name="search")],
+        result=ExternalToolCallResult(
+            content={"matches": ["paper-1"]},
+            metadata={"adapter": "fake"},
+        ),
+    )
+    broker = RecordingCredentialBroker(
+        BrokeredExternalCredential(
+            headers={"Authorization": secret_header},
+            env={"TOKEN": secret_env},
+            metadata={
+                "credential_mode": "brokered_ephemeral",
+                "credential_source": "test",
+                "unsafe_note": secret_env,
+            },
+        )
+    )
+    manager = GatewayExternalRuntimeManager(
+        external_registry_store=store,
+        transport_factory=lambda _server: transport,
+        audit_store=audit,
+        credential_broker=broker,
+    )
+    await manager.start_server("research")
+
+    result = await manager.execute_virtual_tool(
+        "ext.research.search",
+        {"query": "MCP"},
+        effective_policy={
+            "external_server_grants": [{"server_id": "research"}],
+            "credential_grants": [
+                {
+                    "external_server_id": "research",
+                    "credential_slot": "api_key",
+                }
+            ],
+        },
+        actor_id="user-1",
+        context={"request_id": "r1"},
+    )
+
+    assert transport.runtime_auth_seen is not None
+    assert transport.runtime_auth_seen.headers == {"Authorization": secret_header}
+    assert transport.runtime_auth_seen.env == {"TOKEN": secret_env}
+    assert result.content == {"matches": ["paper-1"]}
+    assert result.metadata["adapter"] == "fake"
+    assert result.metadata["credential_mode"] == "brokered_ephemeral"
+    assert result.metadata["credential_source"] == "test"
+    assert result.metadata["credential_injection"] == {
+        "headers": ["Authorization"],
+        "env": ["TOKEN"],
+    }
+    assert "unsafe_note" not in result.metadata
+    serialized_public_data = json.dumps(
+        {
+            "result_metadata": result.metadata,
+            "audit_payloads": [event.payload for event in audit.events],
+        },
+        sort_keys=True,
+    )
+    assert secret_header not in serialized_public_data
+    assert secret_env not in serialized_public_data
+    assert (await store.get_server("research")).credential_slots == ["api_key"]
+
+
+@pytest.mark.asyncio
+async def test_external_runtime_required_credentials_fail_closed_without_broker() -> None:
+    store = InMemoryExternalRegistryStore([_server(credential_slots=["api_key"])])
+    transport = RecordingExternalTransport(
+        server_id="research",
+        tools=[ExternalToolDefinition(name="search")],
+    )
+    manager = GatewayExternalRuntimeManager(
+        external_registry_store=store,
+        transport_factory=lambda _server: transport,
+    )
+    await manager.start_server("research")
+
+    with pytest.raises(GatewayExternalRuntimeError) as exc_info:
+        await manager.execute_virtual_tool(
+            "ext.research.search",
+            {"query": "MCP"},
+            effective_policy={
+                "external_server_grants": [{"server_id": "research"}],
+                "credential_grants": [
+                    {
+                        "external_server_id": "research",
+                        "credential_slot": "api_key",
+                    }
+                ],
+            },
+        )
+
+    assert exc_info.value.reason_code == "credential_broker_unavailable"
+    assert transport.calls == []
+
+
+@pytest.mark.asyncio
+async def test_external_runtime_required_credentials_fail_closed_when_broker_returns_none() -> None:
+    store = InMemoryExternalRegistryStore([_server(credential_slots=["api_key"])])
+    transport = RecordingExternalTransport(
+        server_id="research",
+        tools=[ExternalToolDefinition(name="search")],
+    )
+    broker = RecordingCredentialBroker(None)
+    manager = GatewayExternalRuntimeManager(
+        external_registry_store=store,
+        transport_factory=lambda _server: transport,
+        credential_broker=broker,
+    )
+    await manager.start_server("research")
+
+    with pytest.raises(FederationPolicyDenied) as exc_info:
+        await manager.execute_virtual_tool(
+            "ext.research.search",
+            {"query": "MCP"},
+            effective_policy={
+                "external_server_grants": [{"server_id": "research"}],
+                "credential_grants": [
+                    {
+                        "external_server_id": "research",
+                        "credential_slot": "api_key",
+                    }
+                ],
+            },
+        )
+
+    assert exc_info.value.reason_code == "required_credential_grant_missing"
+    assert broker.calls
+    assert transport.calls == []

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_external_runtime.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_external_runtime.py
@@ -1,0 +1,209 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from mcp_unified.federation.models import (
+    BrokeredExternalCredential,
+    ExternalToolCallResult,
+    ExternalToolDefinition,
+)
+from mcp_unified.gateway.external_runtime import GatewayExternalRuntimeManager
+from mcp_unified.storage.models import AuditEvent, ExternalServerDefinition
+
+
+class InMemoryExternalRegistryStore:
+    """Copy-isolated external registry store for runtime manager tests."""
+
+    def __init__(self, servers: list[ExternalServerDefinition] | None = None) -> None:
+        self.servers = {
+            server.id: server.model_copy(deep=True)
+            for server in servers or ()
+        }
+
+    async def get_server(self, server_id: str) -> ExternalServerDefinition | None:
+        """Return one server definition by id."""
+        server = self.servers.get(server_id)
+        return None if server is None else server.model_copy(deep=True)
+
+    async def list_servers(self) -> list[ExternalServerDefinition]:
+        """Return runtime-compatible server rows."""
+        return await self.list_server_definitions()
+
+    async def list_server_definitions(
+        self,
+        *,
+        enabled: bool | None = None,
+    ) -> list[ExternalServerDefinition]:
+        """Return typed server definitions matching the enabled filter."""
+        rows = [
+            server
+            for server in self.servers.values()
+            if enabled is None or server.enabled is enabled
+        ]
+        return [
+            server.model_copy(deep=True)
+            for server in sorted(rows, key=lambda item: item.id)
+        ]
+
+
+class RecordingAuditStore:
+    """Audit sink that preserves appended events for assertions."""
+
+    def __init__(self) -> None:
+        self.events: list[AuditEvent] = []
+
+    async def append_event(self, event: AuditEvent) -> AuditEvent:
+        """Record and return a copy of the event."""
+        stored = event.model_copy(deep=True)
+        self.events.append(stored)
+        return stored.model_copy(deep=True)
+
+    async def query_events(
+        self,
+        *,
+        actor_id: str | None = None,
+        profile_id: str | None = None,
+        event_type: str | None = None,
+        limit: int | None = None,
+    ) -> list[AuditEvent]:
+        """Return matching audit events."""
+        rows = [
+            event
+            for event in self.events
+            if (actor_id is None or event.actor_id == actor_id)
+            and (profile_id is None or event.profile_id == profile_id)
+            and (event_type is None or event.event_type == event_type)
+        ]
+        if limit is not None:
+            rows = rows[:limit]
+        return [event.model_copy(deep=True) for event in rows]
+
+
+class RecordingExternalTransport:
+    """Fake external transport that records lifecycle and call behavior."""
+
+    transport_name = "fake"
+
+    def __init__(
+        self,
+        *,
+        server_id: str,
+        tools: list[ExternalToolDefinition] | None = None,
+        result: ExternalToolCallResult | None = None,
+    ) -> None:
+        self.server_id = server_id
+        self.connected = False
+        self.connect_count = 0
+        self.close_count = 0
+        self.calls: list[tuple[str, dict[str, Any]]] = []
+        self.runtime_auth_seen: BrokeredExternalCredential | None = None
+        self.fail_list = False
+        self.tools = [tool.copy() for tool in tools or ()]
+        self.result = result or ExternalToolCallResult(content={"ok": True})
+
+    async def connect(self) -> None:
+        """Mark the fake transport connected."""
+        self.connect_count += 1
+        self.connected = True
+
+    async def close(self) -> None:
+        """Mark the fake transport closed."""
+        self.close_count += 1
+        self.connected = False
+
+    async def health_check(self) -> dict[str, bool]:
+        """Return deterministic fake health."""
+        return {
+            "configured": True,
+            "connected": self.connected,
+            "initialized": self.connected,
+        }
+
+    async def list_tools(self) -> list[ExternalToolDefinition]:
+        """Return configured tools or raise a discovery failure."""
+        if self.fail_list:
+            raise RuntimeError("discovery failed")
+        return [tool.copy() for tool in self.tools]
+
+    async def call_tool(
+        self,
+        tool_name: str,
+        arguments: dict[str, Any],
+        *,
+        context: Any = None,
+        runtime_auth: BrokeredExternalCredential | None = None,
+    ) -> ExternalToolCallResult:
+        """Record and return the configured call result."""
+        del context
+        self.calls.append((tool_name, dict(arguments or {})))
+        self.runtime_auth_seen = None if runtime_auth is None else runtime_auth.copy()
+        return self.result.copy()
+
+
+def _server(**overrides: Any) -> ExternalServerDefinition:
+    values: dict[str, Any] = {
+        "id": "research",
+        "name": "Research",
+        "transport": "stdio",
+        "command": ["fake-research-mcp"],
+    }
+    values.update(overrides)
+    return ExternalServerDefinition(**values)
+
+
+@pytest.mark.asyncio
+async def test_external_runtime_start_discovers_tools_and_reports_healthy_status() -> None:
+    audit = RecordingAuditStore()
+    store = InMemoryExternalRegistryStore([_server()])
+    transport = RecordingExternalTransport(
+        server_id="research",
+        tools=[ExternalToolDefinition(name="search", description="Search papers")],
+    )
+    manager = GatewayExternalRuntimeManager(
+        external_registry_store=store,
+        transport_factory=lambda _server: transport,
+        audit_store=audit,
+    )
+
+    payload = await manager.start_server("research")
+    rows = await manager.list_runtime_servers()
+    tools = await manager.list_virtual_tools()
+
+    assert payload["ok"] is True
+    assert payload["reason_code"] == "external_server_started"
+    assert rows["servers"][0]["id"] == "research"
+    assert rows["servers"][0]["status"] == "healthy"
+    assert rows["servers"][0]["tool_count"] == 1
+    assert [tool.virtual_name for tool in tools] == ["ext.research.search"]
+    assert transport.connect_count == 1
+    assert [event.payload["reason_code"] for event in audit.events] == [
+        "external_server_started",
+        "external_server_discovered",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_external_runtime_stop_is_idempotent_and_clears_tools() -> None:
+    store = InMemoryExternalRegistryStore([_server()])
+    transport = RecordingExternalTransport(
+        server_id="research",
+        tools=[ExternalToolDefinition(name="search")],
+    )
+    manager = GatewayExternalRuntimeManager(
+        external_registry_store=store,
+        transport_factory=lambda _server: transport,
+    )
+    await manager.start_server("research")
+
+    first = await manager.stop_server("research")
+    second = await manager.stop_server("research")
+    rows = await manager.list_runtime_servers()
+
+    assert first["reason_code"] == "external_server_stopped"
+    assert second["reason_code"] == "external_server_already_stopped"
+    assert await manager.list_virtual_tools() == []
+    assert rows["servers"][0]["status"] == "stopped"
+    assert rows["servers"][0]["tool_count"] == 0
+    assert transport.close_count == 1

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py
@@ -14,6 +14,7 @@ import mcp_unified.gateway.jsonrpc as gateway_jsonrpc
 import pytest
 from fastapi.testclient import TestClient
 from mcp_unified.gateway import create_gateway_app
+from mcp_unified.gateway.external_runtime import GatewayExternalRuntimeError
 from mcp_unified.storage.models import ExternalServerDefinition
 
 REPO_ROOT = Path(__file__).resolve().parents[5]
@@ -559,6 +560,114 @@ class _ExternalRegistryErrorManagerDouble(_ExternalRegistryManagerDouble):
     async def delete_server(self, server_id: str) -> dict[str, Any]:
         await self._raise_if_targeted("delete_server")
         return await super().delete_server(server_id)
+
+
+class _ExternalRuntimeManagerDouble:
+    """Small manager double for external runtime route tests."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, tuple[Any, ...], dict[str, Any]]] = []
+
+    async def list_runtime_servers(self) -> dict[str, Any]:
+        self.calls.append(("list_runtime_servers", (), {}))
+        return {
+            "ok": True,
+            "servers": [{"id": "research", "status": "healthy"}],
+        }
+
+    async def start_server(self, server_id: str) -> dict[str, Any]:
+        self.calls.append(("start_server", (server_id,), {}))
+        return {
+            "ok": True,
+            "reason_code": "external_server_started",
+            "server_id": server_id,
+        }
+
+    async def stop_server(self, server_id: str) -> dict[str, Any]:
+        self.calls.append(("stop_server", (server_id,), {}))
+        return {
+            "ok": True,
+            "reason_code": "external_server_stopped",
+            "server_id": server_id,
+        }
+
+    async def restart_server(self, server_id: str) -> dict[str, Any]:
+        self.calls.append(("restart_server", (server_id,), {}))
+        return {
+            "ok": True,
+            "reason_code": "external_server_restarted",
+            "server_id": server_id,
+        }
+
+    async def refresh_server(self, server_id: str | None = None) -> dict[str, Any]:
+        self.calls.append(("refresh_server", (server_id,), {}))
+        return {
+            "ok": True,
+            "reason_code": "external_server_refreshed",
+            "server_id": server_id,
+        }
+
+    async def reconcile(self, server_id: str | None = None) -> dict[str, Any]:
+        self.calls.append(("reconcile", (server_id,), {}))
+        return {
+            "ok": True,
+            "reason_code": "external_server_reconciled",
+            "server_id": server_id,
+        }
+
+    async def install_server(
+        self,
+        server_id: str,
+        *,
+        context: Any = None,
+    ) -> dict[str, Any]:
+        self.calls.append(("install_server", (server_id,), {"context": context}))
+        return {
+            "ok": False,
+            "reason_code": "external_server_install_not_configured",
+            "server_id": server_id,
+        }
+
+    async def update_server(
+        self,
+        server_id: str,
+        *,
+        context: Any = None,
+    ) -> dict[str, Any]:
+        self.calls.append(("update_server", (server_id,), {"context": context}))
+        return {
+            "ok": False,
+            "reason_code": "external_server_update_not_configured",
+            "server_id": server_id,
+        }
+
+
+class _ExternalRuntimeBootstrapDouble:
+    def __init__(self, manager: _ExternalRuntimeManagerDouble) -> None:
+        self.external_runtime_manager = manager
+
+
+class _ExternalRuntimeErrorManagerDouble(_ExternalRuntimeManagerDouble):
+    def __init__(self, method: str, reason_code: str) -> None:
+        super().__init__()
+        self.method = method
+        self.reason_code = reason_code
+
+    async def _raise_if_targeted(self, method: str) -> None:
+        if method == self.method:
+            raise GatewayExternalRuntimeError(
+                f"runtime failure: {self.reason_code}",
+                reason_code=self.reason_code,
+                server_id="research",
+            )
+
+    async def start_server(self, server_id: str) -> dict[str, Any]:
+        await self._raise_if_targeted("start_server")
+        return await super().start_server(server_id)
+
+    async def refresh_server(self, server_id: str | None = None) -> dict[str, Any]:
+        await self._raise_if_targeted("refresh_server")
+        return await super().refresh_server(server_id)
 
 
 def test_gateway_package_does_not_import_tldw_server_api() -> None:
@@ -1427,6 +1536,122 @@ def test_gateway_external_registry_management_malformed_or_missing_bodies_return
     assert malformed_patch.status_code == 422
     assert extra_create.status_code == 422
     assert extra_patch.status_code == 422
+
+
+def test_gateway_external_runtime_routes_are_not_mounted_by_default() -> None:
+    app = create_gateway_app(_FakeGatewayRuntime(), prefix="/mcp")
+
+    with TestClient(app) as client:
+        response = client.get("/mcp/external-servers/runtime")
+
+    assert response.status_code == 404
+
+
+def test_gateway_external_runtime_management_routes_mount_with_manager() -> None:
+    manager = _ExternalRuntimeManagerDouble()
+    app = create_gateway_app(
+        _FakeGatewayRuntime(),
+        prefix="/mcp",
+        external_runtime_manager=manager,
+    )
+
+    with TestClient(app) as client:
+        listed = client.get("/mcp/external-servers/runtime")
+        started = client.post("/mcp/external-servers/research/start")
+        stopped = client.post("/mcp/external-servers/research/stop")
+        refreshed_all = client.post("/mcp/external-servers/refresh")
+        refreshed_one = client.post("/mcp/external-servers/research/refresh")
+        reconciled_all = client.post("/mcp/external-servers/reconcile")
+        reconciled_one = client.post("/mcp/external-servers/research/reconcile")
+        installed = client.post("/mcp/external-servers/research/install")
+        updated = client.post("/mcp/external-servers/research/update")
+
+    assert listed.status_code == 200
+    assert listed.json()["servers"] == [{"id": "research", "status": "healthy"}]
+    assert started.json()["reason_code"] == "external_server_started"
+    assert stopped.json()["reason_code"] == "external_server_stopped"
+    assert refreshed_all.json()["server_id"] is None
+    assert refreshed_one.json()["server_id"] == "research"
+    assert reconciled_all.json()["server_id"] is None
+    assert reconciled_one.json()["server_id"] == "research"
+    assert installed.json()["reason_code"] == "external_server_install_not_configured"
+    assert updated.json()["reason_code"] == "external_server_update_not_configured"
+    assert manager.calls == [
+        ("list_runtime_servers", (), {}),
+        ("start_server", ("research",), {}),
+        ("stop_server", ("research",), {}),
+        ("refresh_server", (None,), {}),
+        ("refresh_server", ("research",), {}),
+        ("reconcile", (None,), {}),
+        ("reconcile", ("research",), {}),
+        ("install_server", ("research",), {"context": None}),
+        ("update_server", ("research",), {"context": None}),
+    ]
+
+
+def test_gateway_external_runtime_management_routes_mount_with_bootstrap() -> None:
+    manager = _ExternalRuntimeManagerDouble()
+    app = create_gateway_app(
+        _FakeGatewayRuntime(),
+        prefix="/mcp",
+        profile_bootstrap=_ExternalRuntimeBootstrapDouble(manager),
+    )
+
+    with TestClient(app) as client:
+        response = client.get("/mcp/external-servers/runtime")
+
+    assert response.status_code == 200
+    assert manager.calls == [("list_runtime_servers", (), {})]
+
+
+def test_gateway_external_runtime_management_enabled_without_manager_raises() -> None:
+    with pytest.raises(ValueError, match="external runtime management requires"):
+        gateway_fastapi.create_gateway_router(
+            _FakeGatewayRuntime(),
+            enable_external_runtime_management=True,
+        )
+
+    with pytest.raises(ValueError, match="external runtime management requires"):
+        create_gateway_app(
+            _FakeGatewayRuntime(),
+            prefix="/mcp",
+            enable_external_runtime_management=True,
+        )
+
+
+@pytest.mark.parametrize(
+    ("reason_code", "status_code"),
+    [
+        ("external_server_not_found", 404),
+        ("external_server_disabled", 409),
+        ("credential_broker_unavailable", 503),
+        ("external_server_transport_unavailable", 503),
+        ("invalid_external_runtime_request", 422),
+        ("unexpected_external_runtime_reason", 500),
+    ],
+)
+def test_gateway_external_runtime_management_error_status_mapping(
+    reason_code: str,
+    status_code: int,
+) -> None:
+    app = create_gateway_app(
+        _FakeGatewayRuntime(),
+        prefix="/mcp",
+        external_runtime_manager=_ExternalRuntimeErrorManagerDouble(
+            "start_server",
+            reason_code,
+        ),
+    )
+
+    with TestClient(app) as client:
+        response = client.post("/mcp/external-servers/research/start")
+
+    assert response.status_code == status_code
+    body = response.json()
+    assert body["ok"] is False
+    assert body["reason_code"] == reason_code
+    assert body["server_id"] == "research"
+    assert body["error"] == f"runtime failure: {reason_code}"
 
 
 def test_gateway_profile_runtime_requires_profile_for_tool_execution() -> None:

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py
@@ -1350,6 +1350,41 @@ def test_gateway_external_registry_management_routes_have_pydantic_response_mode
     }
 
 
+@pytest.mark.parametrize("server_id", ["runtime", "refresh", "reconcile"])
+def test_gateway_external_registry_management_rejects_reserved_server_ids(
+    server_id: str,
+) -> None:
+    manager = _ExternalRegistryManagerDouble()
+    app = create_gateway_app(
+        _FakeGatewayRuntime(),
+        prefix="/mcp",
+        external_registry_manager=manager,
+    )
+
+    with TestClient(app) as client:
+        created = client.post(
+            "/mcp/external-servers",
+            json={
+                "id": server_id,
+                "name": "Reserved",
+                "transport": "websocket",
+                "url": "wss://example.test/mcp",
+            },
+        )
+        shown = client.get(f"/mcp/external-servers/{server_id}")
+        patched = client.patch(
+            f"/mcp/external-servers/{server_id}",
+            json={"name": "Reserved v2"},
+        )
+        deleted = client.delete(f"/mcp/external-servers/{server_id}")
+
+    for response in (created, shown, patched, deleted):
+        assert response.status_code == 422
+        assert response.json()["reason_code"] == "invalid_external_server_request"
+        assert response.json()["server_id"] == server_id
+    assert manager.calls == []
+
+
 @pytest.mark.parametrize(
     ("method", "path", "json_body", "manager_method", "reason_code", "status_code"),
     [
@@ -1604,6 +1639,62 @@ def test_gateway_external_runtime_management_routes_mount_with_bootstrap() -> No
     assert manager.calls == [("list_runtime_servers", (), {})]
 
 
+def test_gateway_external_runtime_routes_have_pydantic_response_models() -> None:
+    app = create_gateway_app(
+        _FakeGatewayRuntime(),
+        prefix="/mcp",
+        external_runtime_manager=_ExternalRuntimeManagerDouble(),
+    )
+
+    paths = app.openapi()["paths"]
+    expected_refs = {
+        (
+            "/mcp/external-servers/runtime",
+            "get",
+        ): "#/components/schemas/ExternalRuntimeServerListResponse",
+        (
+            "/mcp/external-servers/{server_id}/start",
+            "post",
+        ): "#/components/schemas/ExternalRuntimeOperationResponse",
+        (
+            "/mcp/external-servers/{server_id}/stop",
+            "post",
+        ): "#/components/schemas/ExternalRuntimeOperationResponse",
+        (
+            "/mcp/external-servers/{server_id}/restart",
+            "post",
+        ): "#/components/schemas/ExternalRuntimeOperationResponse",
+        (
+            "/mcp/external-servers/refresh",
+            "post",
+        ): "#/components/schemas/ExternalRuntimeOperationResponse",
+        (
+            "/mcp/external-servers/{server_id}/refresh",
+            "post",
+        ): "#/components/schemas/ExternalRuntimeOperationResponse",
+        (
+            "/mcp/external-servers/reconcile",
+            "post",
+        ): "#/components/schemas/ExternalRuntimeOperationResponse",
+        (
+            "/mcp/external-servers/{server_id}/reconcile",
+            "post",
+        ): "#/components/schemas/ExternalRuntimeOperationResponse",
+        (
+            "/mcp/external-servers/{server_id}/install",
+            "post",
+        ): "#/components/schemas/ExternalRuntimeOperationResponse",
+        (
+            "/mcp/external-servers/{server_id}/update",
+            "post",
+        ): "#/components/schemas/ExternalRuntimeOperationResponse",
+    }
+
+    for (path, method), expected_ref in expected_refs.items():
+        schema = paths[path][method]["responses"]["200"]["content"]["application/json"]["schema"]
+        assert schema == {"$ref": expected_ref}
+
+
 def test_gateway_external_runtime_management_enabled_without_manager_raises() -> None:
     with pytest.raises(ValueError, match="external runtime management requires"):
         gateway_fastapi.create_gateway_router(
@@ -1626,6 +1717,8 @@ def test_gateway_external_runtime_management_enabled_without_manager_raises() ->
         ("external_server_disabled", 409),
         ("credential_broker_unavailable", 503),
         ("external_server_transport_unavailable", 503),
+        ("external_virtual_tool_not_found", 404),
+        ("external_tool_call_failed", 503),
         ("invalid_external_runtime_request", 422),
         ("unexpected_external_runtime_reason", 500),
     ],

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py
@@ -120,6 +120,24 @@ def test_host_external_manager_reexports_package_virtual_tool_contract() -> None
     assert package_federation.VirtualExternalTool is package_models.VirtualExternalTool
 
 
+def test_gateway_external_runtime_exports_are_package_owned() -> None:
+    """Gateway runtime exports must resolve without host package imports."""
+    package_gateway = importlib.import_module("mcp_unified.gateway")
+    package_runtime = importlib.import_module("mcp_unified.gateway.external_runtime")
+
+    assert package_gateway.GatewayExternalRuntimeManager is package_runtime.GatewayExternalRuntimeManager
+    assert package_gateway.GatewayExternalRuntimeError is package_runtime.GatewayExternalRuntimeError
+
+
+def test_federation_installer_contracts_are_public_exports() -> None:
+    """Installer contracts should be importable from the public federation package."""
+    package_federation = importlib.import_module("mcp_unified.federation")
+    package_installers = importlib.import_module("mcp_unified.federation.installers")
+
+    assert package_federation.ExternalServerInstaller is package_installers.ExternalServerInstaller
+    assert package_federation.NullExternalServerInstaller is package_installers.NullExternalServerInstaller
+
+
 def test_virtual_external_tool_copy_returns_caller_owned_data() -> None:
     """Virtual tool copies must not expose mutable source state."""
     package_models = importlib.import_module("mcp_unified.federation.models")


### PR DESCRIPTION
## Summary
- Adds a package-owned `GatewayExternalRuntimeManager` for external MCP lifecycle start, stop, restart, refresh, reconcile, status, and virtual tool execution over injected transports.
- Adds per-call credential broker handling with secret redaction in public result metadata and audit payloads.
- Adds disabled-by-default install/update contracts plus FastAPI lifecycle/runtime routes for in-process gateway management.

## Test Plan
- [x] `source ../../.venv/bin/activate && python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_gateway_external_runtime.py tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py tldw_Server_API/app/core/MCP_unified/tests/test_federation_shell_contracts.py tldw_Server_API/app/core/MCP_unified/tests/test_external_server_manager.py tldw_Server_API/app/core/MCP_unified/tests/test_external_credential_broker_runtime.py tldw_Server_API/app/core/MCP_unified/tests/test_gateway_external_registry_management.py tldw_Server_API/app/core/MCP_unified/tests/test_sqlite_storage_contracts.py -q`
- [x] `source ../../.venv/bin/activate && python -m ruff check mcp_unified/gateway mcp_unified/federation tldw_Server_API/app/core/MCP_unified/tests/test_gateway_external_runtime.py`
- [x] `source ../../.venv/bin/activate && python -m bandit -r mcp_unified/gateway mcp_unified/federation -f json -o /tmp/bandit_mcp_stage4n_external_runtime.json`
- [x] `git diff --check`

## Change Summary
Human-authored change summary required before merge per `Docs/superpowers/AI_GENERATED_PR_CHANGE_SUMMARY_POLICY_2026_04_17.md`.

## Deliberate Deferrals
- Durable lifecycle CLI control remains deferred until a daemon-control client exists.
- Package-owned real stdio process spawning remains deferred until process policy and validation are defined.
- Third-party install/update execution remains deferred; this PR only adds adapter contracts and safe default responses.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a package-owned external runtime to manage MCP servers end-to-end. It delivers deterministic lifecycle ops, per-call credential brokering, FastAPI runtime routes, and installer contracts to fulfill TASK-581 (install/update disabled by default).

- **New Features**
  - `GatewayExternalRuntimeManager`: start/stop/restart/refresh/reconcile/status and virtual tool calls over injected `ExternalFederationTransport`; emits `AuditStore` events.
  - Per-call credential brokering via `BrokeredExternalCredential`; secrets redacted in public metadata and audits.
  - Installer contracts: `ExternalServerInstaller` and `NullExternalServerInstaller`; install/update/status pathways available but off by default.
  - FastAPI runtime routes for lifecycle, discovery, reconcile, and tool execution with structured errors.
  - Transport API now accepts `runtime_auth` for tool calls.
  - Public exports via `mcp_unified.gateway` and `mcp_unified.federation`; `bootstrap_profile_gateway` accepts `external_runtime_manager`.
  - Added design and implementation docs plus expanded tests.

<sup>Written for commit f41293c4b4fc54e241ff8dea60492354ed86ec76. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2202?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

