### PR TITLE
Add package upstream stdio transport

### DIFF
--- a/Docs/superpowers/plans/2026-06-01-mcp-upstream-stdio-transport-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-06-01-mcp-upstream-stdio-transport-implementation-plan.md
@@ -269,7 +269,7 @@ git diff --check
 
 Record files changed, verification commands, and final notes in TASK-582.
 
-- [ ] **Step 6: Commit**
+- [x] **Step 6: Commit**
 
 ```bash
 git add \

--- a/Docs/superpowers/plans/2026-06-01-mcp-upstream-stdio-transport-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-06-01-mcp-upstream-stdio-transport-implementation-plan.md
@@ -1,0 +1,283 @@
+# MCP Upstream Stdio Transport Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a package-owned upstream stdio subprocess transport for external MCP servers managed by the standalone gateway runtime.
+
+**Architecture:** Implement a focused `mcp_unified.federation.stdio_transport` module that launches one subprocess with shell-free argv execution, speaks newline-delimited JSON-RPC over stdio, normalizes MCP tool discovery/call responses, and satisfies the existing `ExternalFederationTransport` protocol. Tests drive behavior with temporary Python MCP stdio stub servers.
+
+**Tech Stack:** Python asyncio subprocesses, JSON-RPC 2.0 line framing, Pydantic storage models, pytest, Bandit.
+
+---
+
+## Scope And Constraints
+
+Spec: `Docs/superpowers/specs/2026-06-01-mcp-upstream-stdio-transport-design.md`
+
+Backlog: `TASK-582`
+
+Keep package code free of `tldw_Server_API` imports. Do not reuse the host
+`ACPStdioClient`; this transport must be package-owned.
+
+Do not add shell execution, install/update behavior, WebSocket upstream support,
+or default gateway bootstrap wiring in this slice.
+
+Use TDD: write failing tests first, verify red, then implement the minimal code.
+
+## File Structure
+
+- Create: `mcp_unified/federation/stdio_transport.py`
+  - process launch, JSON-RPC request/response handling, response normalization,
+    credential metadata injection, cleanup, and safe transport errors
+- Modify: `mcp_unified/federation/__init__.py`
+  - export `StdioExternalTransport`, `StdioExternalTransportError`, and
+    `create_external_transport`
+- Test: `tldw_Server_API/app/core/MCP_unified/tests/test_stdio_external_transport.py`
+  - subprocess-backed behavior tests and package-boundary checks
+- Modify: `backlog/tasks/task-582 - Implement-MCP-upstream-stdio-external-server-transport.md`
+  - progress notes and verification summary
+
+## Task 1: Validation And Package Boundary Red Tests
+
+**Files:**
+- Create: `tldw_Server_API/app/core/MCP_unified/tests/test_stdio_external_transport.py`
+
+- [x] **Step 1: Write failing tests**
+
+Tests:
+
+```python
+def test_stdio_transport_import_does_not_import_host_package():
+    code = (
+        "import sys; import mcp_unified.federation.stdio_transport; "
+        "print('tldw_Server_API' in sys.modules)"
+    )
+    result = subprocess.run([sys.executable, "-c", code], capture_output=True, text=True, check=True)
+    assert result.stdout.strip() == "False"
+```
+
+```python
+def test_stdio_transport_rejects_non_stdio_definition():
+    server = ExternalServerDefinition(
+        id="ws",
+        name="WebSocket",
+        transport="websocket",
+        url="ws://example.invalid",
+    )
+    with pytest.raises(StdioExternalTransportError, match="unsupported_transport"):
+        StdioExternalTransport(server)
+```
+
+```python
+def test_stdio_transport_rejects_missing_cwd(tmp_path):
+    server = _server(command=[sys.executable, "-c", "pass"], cwd=str(tmp_path / "missing"))
+    with pytest.raises(StdioExternalTransportError, match="invalid_cwd"):
+        StdioExternalTransport(server)
+```
+
+- [x] **Step 2: Verify red**
+
+Run:
+
+```bash
+source ../../.venv/bin/activate
+python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_stdio_external_transport.py -q
+```
+
+Expected: import failure for missing `mcp_unified.federation.stdio_transport`.
+
+## Task 2: Subprocess Round Trip
+
+**Files:**
+- Create: `mcp_unified/federation/stdio_transport.py`
+- Modify: `mcp_unified/federation/__init__.py`
+- Modify: `tldw_Server_API/app/core/MCP_unified/tests/test_stdio_external_transport.py`
+
+- [x] **Step 1: Add failing subprocess tests**
+
+Create a temporary Python script in the test that reads JSON lines from stdin
+and responds to `initialize`, `tools/list`, `tools/call`, and `ping`.
+
+Tests:
+
+```python
+async def test_stdio_transport_connect_list_call_and_close(tmp_path):
+    transport = StdioExternalTransport(_server(command=[sys.executable, "-u", script]))
+    await transport.connect()
+    assert (await transport.health_check())["initialized"] is True
+    tools = await transport.list_tools()
+    assert [tool.name for tool in tools] == ["docs.search", "docs.defaulted"]
+    result = await transport.call_tool("docs.search", {"q": "hello"})
+    assert result.content == [{"type": "text", "text": "search:hello"}]
+    await transport.close()
+    await transport.close()
+```
+
+```python
+async def test_stdio_transport_uses_only_allowlisted_environment(tmp_path, monkeypatch):
+    monkeypatch.setenv("MCP_ALLOWED", "yes")
+    monkeypatch.setenv("MCP_BLOCKED", "no")
+    result = await transport.call_tool("docs.env", {})
+    assert result.content == {"allowed": "yes", "blocked": None}
+```
+
+- [x] **Step 2: Implement minimal transport**
+
+Implement:
+
+- constructor validation
+- `connect()`
+- `_request()`
+- `list_tools()`
+- `call_tool()`
+- `health_check()`
+- `close()`
+- `create_external_transport()`
+
+Use `asyncio.create_subprocess_exec(*server.command, ...)` and a compact JSON
+line protocol. Serialize requests through an async lock.
+
+- [x] **Step 3: Verify green**
+
+Run:
+
+```bash
+source ../../.venv/bin/activate
+python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_stdio_external_transport.py -q
+```
+
+Expected: validation and round-trip tests pass.
+
+## Task 3: Failure, Timeout, Credential Redaction
+
+**Files:**
+- Modify: `mcp_unified/federation/stdio_transport.py`
+- Modify: `tldw_Server_API/app/core/MCP_unified/tests/test_stdio_external_transport.py`
+
+- [x] **Step 1: Add failing tests**
+
+Tests:
+
+```python
+async def test_stdio_transport_timeout_error_is_safe(tmp_path):
+    transport = StdioExternalTransport(_server(command=[sys.executable, "-u", script]), request_timeout_s=0.05)
+    with pytest.raises(StdioExternalTransportError) as exc_info:
+        await transport.call_tool("docs.slow", {})
+    assert exc_info.value.reason_code == "request_timeout"
+    assert "docs.slow" not in str(exc_info.value)
+```
+
+```python
+async def test_stdio_transport_sends_runtime_auth_in_meta_without_leaking_secret(tmp_path):
+    secret = "super-secret-token"
+    result = await transport.call_tool(
+        "docs.auth",
+        {},
+        runtime_auth=BrokeredExternalCredential(env={"DOCS_TOKEN": secret}),
+    )
+    assert result.content["has_secret"] is True
+    with pytest.raises(StdioExternalTransportError) as exc_info:
+        await transport.call_tool(
+            "docs.slow",
+            {},
+            runtime_auth=BrokeredExternalCredential(env={"DOCS_TOKEN": secret}),
+        )
+    assert secret not in str(exc_info.value)
+```
+
+```python
+async def test_stdio_transport_health_marks_exited_process_disconnected(tmp_path):
+    await transport.connect()
+    await transport.call_tool("docs.exit", {})
+    health = await transport.health_check()
+    assert health["connected"] is False
+```
+
+- [x] **Step 2: Harden implementation**
+
+Add safe structured error handling:
+
+- `StdioExternalTransportError(reason_code=...)`
+- request timeout wrapping
+- JSON-RPC error mapping
+- process exit detection
+- pending request cleanup
+- stderr drain without including stderr text in public errors
+- runtime-auth `_meta` injection with no logging
+
+- [x] **Step 3: Verify green**
+
+Run:
+
+```bash
+source ../../.venv/bin/activate
+python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_stdio_external_transport.py -q
+```
+
+Expected: all stdio transport tests pass.
+
+## Task 4: Integration Verification And Cleanup
+
+**Files:**
+- Modify: `backlog/tasks/task-582 - Implement-MCP-upstream-stdio-external-server-transport.md`
+
+- [x] **Step 1: Run focused existing package runtime tests**
+
+Run:
+
+```bash
+source ../../.venv/bin/activate
+python -m pytest \
+  tldw_Server_API/app/core/MCP_unified/tests/test_gateway_external_runtime.py \
+  tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py \
+  tldw_Server_API/app/core/MCP_unified/tests/test_stdio_external_transport.py \
+  -q
+```
+
+- [x] **Step 2: Run Ruff on touched package/tests**
+
+Run:
+
+```bash
+source ../../.venv/bin/activate
+python -m ruff check \
+  mcp_unified/federation/stdio_transport.py \
+  mcp_unified/federation/__init__.py \
+  tldw_Server_API/app/core/MCP_unified/tests/test_stdio_external_transport.py
+```
+
+- [x] **Step 3: Run Bandit on touched Python source**
+
+Run:
+
+```bash
+source ../../.venv/bin/activate
+python -m bandit -r \
+  mcp_unified/federation/stdio_transport.py \
+  -f json -o /tmp/bandit_mcp_stdio_transport.json
+```
+
+- [x] **Step 4: Run whitespace check**
+
+Run:
+
+```bash
+git diff --check
+```
+
+- [x] **Step 5: Update Backlog task**
+
+Record files changed, verification commands, and final notes in TASK-582.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add \
+  Docs/superpowers/specs/2026-06-01-mcp-upstream-stdio-transport-design.md \
+  Docs/superpowers/plans/2026-06-01-mcp-upstream-stdio-transport-implementation-plan.md \
+  mcp_unified/federation/stdio_transport.py \
+  mcp_unified/federation/__init__.py \
+  tldw_Server_API/app/core/MCP_unified/tests/test_stdio_external_transport.py \
+  "backlog/tasks/task-582 - Implement-MCP-upstream-stdio-external-server-transport.md"
+git commit -m "feat: add package upstream stdio transport"
+```

--- a/Docs/superpowers/specs/2026-06-01-mcp-upstream-stdio-transport-design.md
+++ b/Docs/superpowers/specs/2026-06-01-mcp-upstream-stdio-transport-design.md
@@ -1,0 +1,188 @@
+# MCP Unified Upstream Stdio Transport Design
+
+Date: 2026-06-01
+Status: Approved for implementation
+Backlog: TASK-582
+
+## Summary
+
+Add a package-owned upstream stdio transport for configured external MCP
+servers. This fills the gap left after Stage 4N: the standalone gateway runtime
+can already manage lifecycle state through injected `ExternalFederationTransport`
+instances, but `mcp_unified` still lacks a real transport that launches a stdio
+MCP server process without importing host `tldw_Server_API` code.
+
+The transport should live inside `mcp_unified.federation`, implement the existing
+`ExternalFederationTransport` protocol, use `asyncio.create_subprocess_exec`
+with newline-delimited JSON-RPC, and keep all secrets out of logs, persisted
+state, audit payloads, and exception messages.
+
+## Goals
+
+- Launch configured `transport="stdio"` external MCP server commands from the
+  standalone package.
+- Implement connect, discovery, tool calls, health checks, timeout handling,
+  and close cleanup through the existing transport protocol.
+- Keep subprocess execution shell-free and environment handling explicit.
+- Support brokered runtime credentials only through per-call JSON-RPC metadata;
+  do not mutate a long-lived process environment after start.
+- Preserve the package boundary: no imports from `tldw_Server_API`.
+- Add focused tests for validation, subprocess round trips, failures, cleanup,
+  timeout behavior, environment allowlisting, and credential redaction.
+
+## Non-Goals
+
+- No client-facing stdio gateway changes. `mcp_unified.gateway.stdio` already
+  handles stdin/stdout for front-end clients.
+- No WebSocket upstream transport in this slice.
+- No package-manager install/update implementation.
+- No shell command parsing or expansion.
+- No durable daemon/process supervisor. The transport owns one subprocess for
+  the in-process runtime manager.
+- No per-call process environment mutation. A subprocess environment is
+  process-scoped, so per-call env credentials would require a separate
+  short-lived adapter model and are intentionally deferred.
+
+## Existing Contracts
+
+The transport plugs into:
+
+- `mcp_unified.storage.models.ExternalServerDefinition`
+- `mcp_unified.federation.transports.ExternalFederationTransport`
+- `mcp_unified.federation.models.ExternalToolDefinition`
+- `mcp_unified.federation.models.ExternalToolCallResult`
+- `mcp_unified.federation.models.BrokeredExternalCredential`
+- `mcp_unified.gateway.external_runtime.GatewayExternalRuntimeManager`
+
+`ExternalServerDefinition.command` already stores an argv list. The first item
+is the executable and the remaining items are arguments. `cwd` is optional.
+`env_allowlist` stores names of current-process environment variables that may
+be inherited by the child process.
+
+## Transport Design
+
+Create `mcp_unified/federation/stdio_transport.py` with:
+
+- `StdioExternalTransport`
+- `StdioExternalTransportError`
+- `create_external_transport`
+
+`StdioExternalTransport(server, request_timeout_s=30.0, connect_timeout_s=30.0)`
+validates:
+
+- `server.transport == "stdio"`
+- `server.command` is non-empty
+- all command items are non-empty strings
+- `server.cwd`, when provided, resolves to an existing directory
+
+Process launch uses:
+
+```python
+asyncio.create_subprocess_exec(
+    *server.command,
+    stdin=asyncio.subprocess.PIPE,
+    stdout=asyncio.subprocess.PIPE,
+    stderr=asyncio.subprocess.PIPE,
+    cwd=resolved_cwd,
+    env=allowed_env,
+)
+```
+
+There is no shell. The child environment is built from only allowlisted names in
+`os.environ`. Static secret values are not read from `ExternalServerDefinition`.
+
+## JSON-RPC Behavior
+
+Requests and responses use JSON-RPC 2.0 with one compact JSON object per line.
+The transport sends:
+
+- `initialize` during `connect`
+- `tools/list` during discovery
+- `tools/call` for execution
+- `ping` for health when initialized and the process is still running
+
+Response normalization follows the host adapter behavior:
+
+- `tools/list` accepts `{"tools": [...]}` and filters invalid tool rows.
+- invalid or missing `inputSchema` falls back to `{"type": "object"}`.
+- invalid metadata falls back to `{}`.
+- `tools/call` maps MCP `content` and `isError` into `ExternalToolCallResult`.
+- JSON-RPC error responses become `ExternalToolCallResult(is_error=True)` for
+  tool calls and structured transport errors for lifecycle/discovery methods.
+
+The first implementation serializes requests with an async lock. That keeps the
+client small and deterministic while still fitting the runtime manager's awaited
+transport interface. Concurrent pipelining can be added later without changing
+the public protocol.
+
+## Runtime Credentials
+
+`BrokeredExternalCredential` can contain `headers`, `env`, and public metadata.
+For stdio, headers and env cannot be injected as HTTP headers or process env per
+call. The transport therefore supports request metadata only:
+
+```json
+{
+  "name": "tool",
+  "arguments": {},
+  "_meta": {
+    "mcp_unified_runtime_auth": {
+      "headers": {"Authorization": "..."},
+      "env": {"TOKEN": "..."},
+      "metadata": {"credential_source": "..."}
+    }
+  }
+}
+```
+
+This intentionally sends credentials only to the upstream server for the one
+tool call. The transport must not log, persist, include in health data, or echo
+secret values in exception messages. Runtime manager public summaries continue
+to expose only credential key names.
+
+## Error Handling And Cleanup
+
+`StdioExternalTransportError` includes a safe `reason_code`, `server_id`, and
+optional safe metadata. Error messages include method names and reason codes but
+not request bodies, environment values, stderr contents, or credential values.
+
+`close()` is idempotent:
+
+- close stdin when possible
+- terminate the process
+- wait up to a short shutdown timeout
+- kill on timeout
+- cancel reader/stderr tasks
+- resolve pending requests with safe transport errors
+
+`connect()` must close partial transports if initialize fails. `health_check()`
+must not throw for ordinary process exits; it returns configured/connected/
+initialized booleans and marks exited processes disconnected.
+
+## Tests
+
+Add `tldw_Server_API/app/core/MCP_unified/tests/test_stdio_external_transport.py`.
+The tests use small temporary Python stdio MCP server scripts so no network or
+third-party MCP server is required.
+
+Coverage:
+
+- validation rejects non-stdio definitions, empty commands, and bad cwd values
+- environment inheritance includes only allowlisted variables
+- connect initializes and reports healthy process state
+- list_tools normalizes tool definitions
+- call_tool round-trips arguments and maps success/error results
+- runtime_auth appears in the outbound JSON-RPC `_meta` for the call but secret
+  values do not appear in transport exceptions
+- request timeout raises a safe structured error
+- process exit updates health and pending calls fail safely
+- close is idempotent and cleans up the subprocess
+- package boundary tests confirm `mcp_unified.federation.stdio_transport` does
+  not import `tldw_Server_API`
+
+## Rollout
+
+This slice only adds the transport and a package factory helper. Gateway users
+can opt in by passing `create_external_transport` as the runtime manager's
+`transport_factory`. A later slice can wire this factory into CLI/config
+bootstrap defaults after policy and install/update UX are ready.

--- a/backlog/tasks/task-582 - Implement-MCP-upstream-stdio-external-server-transport.md
+++ b/backlog/tasks/task-582 - Implement-MCP-upstream-stdio-external-server-transport.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-582
 title: Implement MCP upstream stdio external server transport
-status: Done
+status: In Progress
 labels:
 - mcp-unified
 - external-servers
@@ -45,6 +45,7 @@ Docs/superpowers/plans/2026-06-01-mcp-upstream-stdio-transport-implementation-pl
 - Added `mcp_unified.federation.stdio_transport.StdioExternalTransport` with shell-free `asyncio.create_subprocess_exec` argv launch, cwd validation, environment allowlisting, JSON-RPC initialize/list/call/ping handling, deterministic timeouts, safe structured errors, and idempotent subprocess cleanup.
 - Added package factory/export helpers so gateway runtime callers can inject the package-owned stdio transport without host `tldw_Server_API` dependencies.
 - Added subprocess-backed tests for validation, package boundary import behavior, env allowlisting, discovery normalization, tool success/error calls, runtime auth `_meta` forwarding, timeout redaction, and exited-process health.
+- Reopened for PR review remediation and rebase onto latest `origin/dev`.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-582 - Implement-MCP-upstream-stdio-external-server-transport.md
+++ b/backlog/tasks/task-582 - Implement-MCP-upstream-stdio-external-server-transport.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-582
 title: Implement MCP upstream stdio external server transport
-status: In Progress
+status: Done
 labels:
 - mcp-unified
 - external-servers
@@ -46,20 +46,24 @@ Docs/superpowers/plans/2026-06-01-mcp-upstream-stdio-transport-implementation-pl
 - Added package factory/export helpers so gateway runtime callers can inject the package-owned stdio transport without host `tldw_Server_API` dependencies.
 - Added subprocess-backed tests for validation, package boundary import behavior, env allowlisting, discovery normalization, tool success/error calls, runtime auth `_meta` forwarding, timeout redaction, and exited-process health.
 - Reopened for PR review remediation and rebase onto latest `origin/dev`.
+- Rebased onto latest `origin/dev` (`f15f92809ae38420abd82ba77c4ea56b0718c112`) and addressed PR review feedback from Qodo, cubic, and CodeRabbit.
+- Fixed timeout cleanup so request timeouts raise immediately and schedule subprocess cleanup outside `_request_lock`.
+- Moved process capture/validation inside `_request_lock`, hardened process terminate/kill/wait races, added MCP initialize `capabilities`, sent `notifications/initialized`, rejected bare executable names without PATH allowlisting, and rejected non-numeric/non-finite timeout values.
+- Added module/helper/test docstrings and regression tests for initialize lifecycle, timeout cleanup bounds, PATH diagnostics, and timeout validation.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Implemented the package-owned upstream stdio transport in `mcp_unified.federation.stdio_transport`, exported the factory/helpers, and added subprocess-backed coverage for validation, package-boundary imports, environment allowlisting, discovery/calls, runtime-auth metadata, timeout redaction, and exited-process health.
+Implemented package upstream stdio transport and PR review remediation. The rebased branch now includes MCP-compliant initialize payloads plus `notifications/initialized`, non-blocking timeout cleanup, request-lock process capture, race-hardened close behavior, bare-command/PATH diagnostics, structured invalid-timeout handling, and docstrings for the new test module/functions.
 
-Verification recorded:
-- `../../.venv/bin/python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_gateway_external_runtime.py tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py tldw_Server_API/app/core/MCP_unified/tests/test_stdio_external_transport.py -q` -> 38 passed, 3 warnings
+Verification recorded after review remediation:
+- `../../.venv/bin/python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_gateway_external_runtime.py tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py tldw_Server_API/app/core/MCP_unified/tests/test_stdio_external_transport.py -q` -> 45 passed, 3 warnings
 - `../../.venv/bin/python -m ruff check mcp_unified/federation/stdio_transport.py mcp_unified/federation/__init__.py tldw_Server_API/app/core/MCP_unified/tests/test_stdio_external_transport.py` -> All checks passed
 - `../../.venv/bin/python -m bandit -r mcp_unified/federation/stdio_transport.py -f json -o /tmp/bandit_mcp_stdio_transport.json` -> exit 0
 - `git diff --check` -> exit 0
 
-Known skips/blockers: none.
+Known skips/blockers: GitHub checks were pending before the remediation push.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-582 - Implement-MCP-upstream-stdio-external-server-transport.md
+++ b/backlog/tasks/task-582 - Implement-MCP-upstream-stdio-external-server-transport.md
@@ -1,0 +1,72 @@
+---
+id: TASK-582
+title: Implement MCP upstream stdio external server transport
+status: Done
+labels:
+- mcp-unified
+- external-servers
+- runtime
+- stdio
+- security
+documentation:
+- Docs/superpowers/specs/2026-06-01-mcp-upstream-stdio-transport-design.md
+modified_files:
+- mcp_unified/federation/stdio_transport.py
+- mcp_unified/federation/__init__.py
+- tldw_Server_API/app/core/MCP_unified/tests/test_stdio_external_transport.py
+- Docs/superpowers/specs/2026-06-01-mcp-upstream-stdio-transport-design.md
+- Docs/superpowers/plans/2026-06-01-mcp-upstream-stdio-transport-implementation-plan.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Add the package-owned upstream stdio process transport for external MCP servers so the standalone gateway runtime manager can launch, discover, call, health-check, and stop configured stdio MCP server processes without depending on tldw_Server_API host code.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Package-owned stdio transport launches configured external MCP server commands with bounded cwd and explicit environment allowlist behavior.
+- [x] #2 Transport implements connect, list_tools, call_tool, health_check, and close against JSON-RPC over stdio with deterministic timeouts and structured failures.
+- [x] #3 Credential broker runtime_auth is injected only for per-call process environment/request metadata supported by the transport and never logged or persisted.
+- [x] #4 Focused tests cover launch validation, initialization/discovery, tool calls, health failures, process exit cleanup, timeout behavior, and secret redaction/no leakage.
+- [x] #5 Ruff, focused pytest, Bandit on touched Python source, and git diff --check pass before PR.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Docs/superpowers/plans/2026-06-01-mcp-upstream-stdio-transport-implementation-plan.md
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+- Added `mcp_unified.federation.stdio_transport.StdioExternalTransport` with shell-free `asyncio.create_subprocess_exec` argv launch, cwd validation, environment allowlisting, JSON-RPC initialize/list/call/ping handling, deterministic timeouts, safe structured errors, and idempotent subprocess cleanup.
+- Added package factory/export helpers so gateway runtime callers can inject the package-owned stdio transport without host `tldw_Server_API` dependencies.
+- Added subprocess-backed tests for validation, package boundary import behavior, env allowlisting, discovery normalization, tool success/error calls, runtime auth `_meta` forwarding, timeout redaction, and exited-process health.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Implemented the package-owned upstream stdio transport in `mcp_unified.federation.stdio_transport`, exported the factory/helpers, and added subprocess-backed coverage for validation, package-boundary imports, environment allowlisting, discovery/calls, runtime-auth metadata, timeout redaction, and exited-process health.
+
+Verification recorded:
+- `../../.venv/bin/python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_gateway_external_runtime.py tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py tldw_Server_API/app/core/MCP_unified/tests/test_stdio_external_transport.py -q` -> 38 passed, 3 warnings
+- `../../.venv/bin/python -m ruff check mcp_unified/federation/stdio_transport.py mcp_unified/federation/__init__.py tldw_Server_API/app/core/MCP_unified/tests/test_stdio_external_transport.py` -> All checks passed
+- `../../.venv/bin/python -m bandit -r mcp_unified/federation/stdio_transport.py -f json -o /tmp/bandit_mcp_stdio_transport.json` -> exit 0
+- `git diff --check` -> exit 0
+
+Known skips/blockers: none.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/mcp_unified/federation/__init__.py
+++ b/mcp_unified/federation/__init__.py
@@ -30,6 +30,11 @@ from .models import (
     MCPCatalogEntry,
     VirtualExternalTool,
 )
+from .stdio_transport import (
+    StdioExternalTransport,
+    StdioExternalTransportError,
+    create_external_transport,
+)
 from .transports import ExternalFederationTransport, FakeExternalTransport
 
 __all__ = [
@@ -57,9 +62,12 @@ __all__ = [
     "MCPAuthType",
     "MCPCatalogEntry",
     "NullExternalServerInstaller",
+    "StdioExternalTransport",
+    "StdioExternalTransportError",
     "VirtualExternalTool",
     "catalog_loader",
     "config_schema",
+    "create_external_transport",
     "get_catalog_entry",
     "list_catalog_entries",
     "load_external_server_registry",

--- a/mcp_unified/federation/stdio_transport.py
+++ b/mcp_unified/federation/stdio_transport.py
@@ -1,0 +1,480 @@
+"""Upstream stdio transport for standalone external MCP servers."""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+import os
+from copy import deepcopy
+from pathlib import Path
+from typing import Any
+
+from mcp_unified.federation.models import (
+    BrokeredExternalCredential,
+    ExternalToolCallResult,
+    ExternalToolDefinition,
+)
+from mcp_unified.storage.models import ExternalServerDefinition
+
+_MCP_PROTOCOL_VERSION = "2024-11-05"
+_CLIENT_INFO = {"name": "mcp_unified_external_federation", "version": "0.1.0"}
+_DEFAULT_CONNECT_TIMEOUT_S = 30.0
+_DEFAULT_REQUEST_TIMEOUT_S = 30.0
+_DEFAULT_CLOSE_TIMEOUT_S = 5.0
+_DEFAULT_HEALTH_TIMEOUT_S = 1.0
+
+
+class StdioExternalTransportError(RuntimeError):
+    """Raised when a stdio transport operation fails without exposing secrets."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        reason_code: str,
+        server_id: str | None = None,
+        method: str | None = None,
+        details: dict[str, Any] | None = None,
+    ) -> None:
+        super().__init__(f"{message} (reason_code={reason_code})")
+        self.reason_code = reason_code
+        self.server_id = server_id
+        self.method = method
+        self.details = deepcopy(details or {})
+
+
+class StdioExternalTransport:
+    """JSON-RPC over stdio transport for one configured upstream MCP server."""
+
+    transport_name = "stdio"
+
+    def __init__(
+        self,
+        server: ExternalServerDefinition,
+        *,
+        connect_timeout_s: float = _DEFAULT_CONNECT_TIMEOUT_S,
+        request_timeout_s: float = _DEFAULT_REQUEST_TIMEOUT_S,
+        close_timeout_s: float = _DEFAULT_CLOSE_TIMEOUT_S,
+        health_timeout_s: float = _DEFAULT_HEALTH_TIMEOUT_S,
+    ) -> None:
+        self._server = server.model_copy(deep=True)
+        self.server_id = self._server.id
+        self._command = self._validate_command(self._server)
+        self._cwd = self._resolve_cwd(self._server.cwd)
+        self._connect_timeout_s = self._positive_timeout(connect_timeout_s, "connect_timeout_s")
+        self._request_timeout_s = self._positive_timeout(request_timeout_s, "request_timeout_s")
+        self._close_timeout_s = self._positive_timeout(close_timeout_s, "close_timeout_s")
+        self._health_timeout_s = self._positive_timeout(health_timeout_s, "health_timeout_s")
+        self._request_lock = asyncio.Lock()
+        self._connect_lock = asyncio.Lock()
+        self._proc: asyncio.subprocess.Process | None = None
+        self._stderr_task: asyncio.Task[None] | None = None
+        self._stderr_bytes = 0
+        self._next_request_id = 1
+        self._initialized = False
+
+    async def connect(self) -> None:
+        """Launch the stdio process and initialize the MCP session."""
+        if self._initialized and self._is_running():
+            return
+
+        async with self._connect_lock:
+            if self._initialized and self._is_running():
+                return
+            if self._proc is not None:
+                await self._close_process_unlocked()
+
+            try:
+                self._proc = await asyncio.wait_for(
+                    asyncio.create_subprocess_exec(
+                        *self._command,
+                        stdin=asyncio.subprocess.PIPE,
+                        stdout=asyncio.subprocess.PIPE,
+                        stderr=asyncio.subprocess.PIPE,
+                        cwd=self._cwd,
+                        env=self._build_child_env(),
+                    ),
+                    timeout=self._connect_timeout_s,
+                )
+            except StdioExternalTransportError:
+                raise
+            except asyncio.TimeoutError as exc:
+                raise self._error(
+                    "External stdio process launch timed out",
+                    reason_code="connect_timeout",
+                ) from exc
+            except Exception as exc:  # noqa: BLE001 - subprocess launch errors vary by platform.
+                raise self._error(
+                    "External stdio process launch failed",
+                    reason_code="process_launch_failed",
+                    details={"error_type": type(exc).__name__},
+                ) from exc
+
+            self._stderr_task = asyncio.create_task(self._drain_stderr())
+            try:
+                await self._request(
+                    "initialize",
+                    {
+                        "protocolVersion": _MCP_PROTOCOL_VERSION,
+                        "clientInfo": _CLIENT_INFO,
+                    },
+                    timeout_s=self._connect_timeout_s,
+                )
+            except Exception:
+                await self._close_process_unlocked()
+                raise
+            self._initialized = True
+
+    async def close(self) -> None:
+        """Terminate the subprocess and release stdio resources."""
+        async with self._connect_lock:
+            await self._close_process_unlocked()
+
+    async def health_check(self) -> dict[str, bool]:
+        """Return quick process and initialization health indicators."""
+        checks = {
+            "configured": True,
+            "connected": self._is_running(),
+            "initialized": self._initialized and self._is_running(),
+            "spawns_process": True,
+        }
+        if not checks["connected"]:
+            self._initialized = False
+            checks["initialized"] = False
+            return checks
+        if not self._initialized:
+            return checks
+
+        try:
+            await self._request("ping", {}, timeout_s=self._health_timeout_s)
+        except StdioExternalTransportError:
+            checks["connected"] = self._is_running()
+            checks["initialized"] = False
+            self._initialized = False
+        return checks
+
+    async def list_tools(self) -> list[ExternalToolDefinition]:
+        """Discover and normalize upstream MCP tool definitions."""
+        await self._ensure_connected()
+        response = await self._request("tools/list", {})
+        result = response.get("result") or {}
+        if isinstance(result, dict):
+            raw_tools = result.get("tools") or []
+        elif isinstance(result, list):
+            raw_tools = result
+        else:
+            raw_tools = []
+
+        tools: list[ExternalToolDefinition] = []
+        for item in raw_tools:
+            if not isinstance(item, dict):
+                continue
+            name = item.get("name")
+            if not isinstance(name, str) or not name.strip():
+                continue
+            description = item.get("description")
+            if not isinstance(description, str):
+                description = ""
+            input_schema = item.get("inputSchema")
+            if not isinstance(input_schema, dict):
+                input_schema = {"type": "object"}
+            metadata = item.get("metadata")
+            if not isinstance(metadata, dict):
+                metadata = {}
+            tools.append(
+                ExternalToolDefinition(
+                    name=name,
+                    description=description,
+                    input_schema=deepcopy(input_schema),
+                    metadata=deepcopy(metadata),
+                )
+            )
+        return tools
+
+    async def call_tool(
+        self,
+        tool_name: str,
+        arguments: dict[str, Any],
+        *,
+        context: Any = None,
+        runtime_auth: BrokeredExternalCredential | None = None,
+    ) -> ExternalToolCallResult:
+        """Execute one upstream MCP tool call."""
+        del context
+        await self._ensure_connected()
+        params: dict[str, Any] = {
+            "name": tool_name,
+            "arguments": deepcopy(arguments or {}),
+        }
+        runtime_auth_meta = self._runtime_auth_meta(runtime_auth)
+        if runtime_auth_meta:
+            params["_meta"] = {"mcp_unified_runtime_auth": runtime_auth_meta}
+
+        response = await self._request("tools/call", params, raise_on_error=False)
+        error = response.get("error")
+        if isinstance(error, dict):
+            message = error.get("message")
+            if not isinstance(message, str) or not message:
+                message = "External MCP tool call failed"
+            return ExternalToolCallResult(
+                content=[{"type": "text", "text": message}],
+                is_error=True,
+                metadata={
+                    "server_id": self.server_id,
+                    "tool_name": tool_name,
+                    "reason_code": "upstream_error",
+                },
+            )
+
+        result = response.get("result")
+        if isinstance(result, dict):
+            content = result.get("content") if "content" in result else result
+            is_error = bool(result.get("isError"))
+        else:
+            content = result
+            is_error = False
+        return ExternalToolCallResult(
+            content=deepcopy(content),
+            is_error=is_error,
+            metadata={"server_id": self.server_id, "tool_name": tool_name},
+        )
+
+    async def _ensure_connected(self) -> None:
+        if not self._initialized or not self._is_running():
+            await self.connect()
+
+    async def _request(
+        self,
+        method: str,
+        params: dict[str, Any],
+        *,
+        timeout_s: float | None = None,
+        raise_on_error: bool = True,
+    ) -> dict[str, Any]:
+        proc = self._proc
+        if proc is None or proc.stdin is None or proc.stdout is None:
+            raise self._error(
+                "External stdio process is not connected",
+                reason_code="not_connected",
+                method=method,
+            )
+
+        request_id = self._next_request_id
+        self._next_request_id += 1
+        payload = {
+            "jsonrpc": "2.0",
+            "id": request_id,
+            "method": method,
+            "params": deepcopy(params or {}),
+        }
+
+        async with self._request_lock:
+            try:
+                encoded = json.dumps(payload, separators=(",", ":"))
+            except (TypeError, ValueError) as exc:
+                raise self._error(
+                    "External stdio request is not JSON serializable",
+                    reason_code="invalid_request",
+                    method=method,
+                ) from exc
+            if "\n" in encoded:
+                raise self._error(
+                    "External stdio request contains an invalid newline",
+                    reason_code="invalid_request",
+                    method=method,
+                )
+
+            try:
+                proc.stdin.write((encoded + "\n").encode("utf-8"))
+                await proc.stdin.drain()
+                response = await asyncio.wait_for(
+                    self._read_response(request_id),
+                    timeout=timeout_s or self._request_timeout_s,
+                )
+            except asyncio.TimeoutError as exc:
+                await self._close_process_unlocked()
+                raise self._error(
+                    f"External stdio request timed out for method '{method}'",
+                    reason_code="request_timeout",
+                    method=method,
+                ) from exc
+            except (BrokenPipeError, ConnectionError) as exc:
+                self._initialized = False
+                raise self._error(
+                    "External stdio process connection closed",
+                    reason_code="connection_closed",
+                    method=method,
+                ) from exc
+
+        if response.get("error") and raise_on_error:
+            raise self._error(
+                f"External stdio request failed for method '{method}'",
+                reason_code="upstream_error",
+                method=method,
+            )
+        return response
+
+    async def _read_response(self, request_id: int) -> dict[str, Any]:
+        proc = self._proc
+        if proc is None or proc.stdout is None:
+            raise self._error(
+                "External stdio process stdout is not available",
+                reason_code="not_connected",
+            )
+
+        while True:
+            line = await proc.stdout.readline()
+            if not line:
+                self._initialized = False
+                raise self._error(
+                    "External stdio process connection closed",
+                    reason_code="connection_closed",
+                )
+            try:
+                payload = json.loads(line.decode("utf-8"))
+            except (UnicodeDecodeError, json.JSONDecodeError):
+                continue
+            if not isinstance(payload, dict):
+                continue
+            if payload.get("id") != request_id:
+                continue
+            return payload
+
+    async def _close_process_unlocked(self) -> None:
+        proc = self._proc
+        self._proc = None
+        self._initialized = False
+
+        stderr_task = self._stderr_task
+        self._stderr_task = None
+        if stderr_task is not None:
+            stderr_task.cancel()
+
+        if proc is not None:
+            stdin = proc.stdin
+            if stdin is not None:
+                with contextlib.suppress(Exception):
+                    stdin.close()
+            if proc.returncode is None:
+                proc.terminate()
+                try:
+                    await asyncio.wait_for(proc.wait(), timeout=self._close_timeout_s)
+                except asyncio.TimeoutError:
+                    proc.kill()
+                    await proc.wait()
+                except ProcessLookupError:
+                    pass
+
+        if stderr_task is not None:
+            with contextlib.suppress(asyncio.CancelledError):
+                await stderr_task
+
+    async def _drain_stderr(self) -> None:
+        proc = self._proc
+        if proc is None or proc.stderr is None:
+            return
+        while True:
+            line = await proc.stderr.readline()
+            if not line:
+                return
+            self._stderr_bytes += len(line)
+
+    def _build_child_env(self) -> dict[str, str]:
+        child_env: dict[str, str] = {}
+        for name in self._server.env_allowlist:
+            env_name = str(name).strip()
+            if env_name and env_name in os.environ:
+                child_env[env_name] = os.environ[env_name]
+        return child_env
+
+    def _is_running(self) -> bool:
+        return self._proc is not None and self._proc.returncode is None
+
+    def _error(
+        self,
+        message: str,
+        *,
+        reason_code: str,
+        method: str | None = None,
+        details: dict[str, Any] | None = None,
+    ) -> StdioExternalTransportError:
+        return StdioExternalTransportError(
+            message,
+            reason_code=reason_code,
+            server_id=self.server_id,
+            method=method,
+            details=details,
+        )
+
+    @classmethod
+    def _validate_command(cls, server: ExternalServerDefinition) -> tuple[str, ...]:
+        if server.transport != "stdio":
+            raise StdioExternalTransportError(
+                "External stdio transport received an unsupported server transport",
+                reason_code="unsupported_transport",
+                server_id=server.id,
+            )
+        command = tuple(str(part).strip() for part in server.command if str(part).strip())
+        if not command:
+            raise StdioExternalTransportError(
+                "External stdio transport requires a non-empty command",
+                reason_code="missing_command",
+                server_id=server.id,
+            )
+        return command
+
+    @classmethod
+    def _resolve_cwd(cls, cwd: str | None) -> str | None:
+        if cwd is None:
+            return None
+        path = Path(cwd).expanduser()
+        if not path.exists() or not path.is_dir():
+            raise StdioExternalTransportError(
+                "External stdio transport cwd is not an existing directory",
+                reason_code="invalid_cwd",
+            )
+        return str(path)
+
+    @classmethod
+    def _positive_timeout(cls, value: float, field_name: str) -> float:
+        timeout = float(value)
+        if timeout <= 0:
+            raise StdioExternalTransportError(
+                f"External stdio transport {field_name} must be positive",
+                reason_code="invalid_timeout",
+            )
+        return timeout
+
+    @staticmethod
+    def _runtime_auth_meta(
+        runtime_auth: BrokeredExternalCredential | None,
+    ) -> dict[str, Any]:
+        if runtime_auth is None:
+            return {}
+        payload: dict[str, Any] = {}
+        if runtime_auth.headers:
+            payload["headers"] = dict(runtime_auth.headers)
+        if runtime_auth.env:
+            payload["env"] = dict(runtime_auth.env)
+        if runtime_auth.metadata:
+            payload["metadata"] = deepcopy(runtime_auth.metadata)
+        return payload
+
+
+def create_external_transport(server: ExternalServerDefinition) -> StdioExternalTransport:
+    """Create a package-owned external transport for a supported server definition."""
+    if server.transport == "stdio":
+        return StdioExternalTransport(server)
+    raise StdioExternalTransportError(
+        "External server transport is not supported by the package factory",
+        reason_code="unsupported_transport",
+        server_id=server.id,
+    )
+
+
+__all__ = [
+    "StdioExternalTransport",
+    "StdioExternalTransportError",
+    "create_external_transport",
+]

--- a/mcp_unified/federation/stdio_transport.py
+++ b/mcp_unified/federation/stdio_transport.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import json
+import math
 import os
 from copy import deepcopy
 from pathlib import Path
@@ -117,10 +118,12 @@ class StdioExternalTransport:
                     "initialize",
                     {
                         "protocolVersion": _MCP_PROTOCOL_VERSION,
+                        "capabilities": {},
                         "clientInfo": _CLIENT_INFO,
                     },
                     timeout_s=self._connect_timeout_s,
                 )
+                await self._notify("notifications/initialized", {})
             except Exception:
                 await self._close_process_unlocked()
                 raise
@@ -252,24 +255,23 @@ class StdioExternalTransport:
         timeout_s: float | None = None,
         raise_on_error: bool = True,
     ) -> dict[str, Any]:
-        proc = self._proc
-        if proc is None or proc.stdin is None or proc.stdout is None:
-            raise self._error(
-                "External stdio process is not connected",
-                reason_code="not_connected",
-                method=method,
-            )
-
-        request_id = self._next_request_id
-        self._next_request_id += 1
-        payload = {
-            "jsonrpc": "2.0",
-            "id": request_id,
-            "method": method,
-            "params": deepcopy(params or {}),
-        }
-
         async with self._request_lock:
+            proc = self._proc
+            if proc is None or proc.stdin is None or proc.stdout is None:
+                raise self._error(
+                    "External stdio process is not connected",
+                    reason_code="not_connected",
+                    method=method,
+                )
+
+            request_id = self._next_request_id
+            self._next_request_id += 1
+            payload = {
+                "jsonrpc": "2.0",
+                "id": request_id,
+                "method": method,
+                "params": deepcopy(params or {}),
+            }
             try:
                 encoded = json.dumps(payload, separators=(",", ":"))
             except (TypeError, ValueError) as exc:
@@ -289,18 +291,18 @@ class StdioExternalTransport:
                 proc.stdin.write((encoded + "\n").encode("utf-8"))
                 await proc.stdin.drain()
                 response = await asyncio.wait_for(
-                    self._read_response(request_id),
+                    self._read_response(proc, request_id),
                     timeout=timeout_s or self._request_timeout_s,
                 )
             except asyncio.TimeoutError as exc:
-                await self._close_process_unlocked()
+                self._schedule_process_cleanup(proc)
                 raise self._error(
                     f"External stdio request timed out for method '{method}'",
                     reason_code="request_timeout",
                     method=method,
                 ) from exc
             except (BrokenPipeError, ConnectionError) as exc:
-                self._initialized = False
+                self._schedule_process_cleanup(proc)
                 raise self._error(
                     "External stdio process connection closed",
                     reason_code="connection_closed",
@@ -315,9 +317,61 @@ class StdioExternalTransport:
             )
         return response
 
-    async def _read_response(self, request_id: int) -> dict[str, Any]:
-        proc = self._proc
-        if proc is None or proc.stdout is None:
+    async def _notify(self, method: str, params: dict[str, Any]) -> None:
+        async with self._request_lock:
+            proc = self._proc
+            if proc is None or proc.stdin is None:
+                raise self._error(
+                    "External stdio process is not connected",
+                    reason_code="not_connected",
+                    method=method,
+                )
+            payload = {
+                "jsonrpc": "2.0",
+                "method": method,
+                "params": deepcopy(params or {}),
+            }
+            try:
+                encoded = json.dumps(payload, separators=(",", ":"))
+            except (TypeError, ValueError) as exc:
+                raise self._error(
+                    "External stdio notification is not JSON serializable",
+                    reason_code="invalid_request",
+                    method=method,
+                ) from exc
+            if "\n" in encoded:
+                raise self._error(
+                    "External stdio notification contains an invalid newline",
+                    reason_code="invalid_request",
+                    method=method,
+                )
+            try:
+                proc.stdin.write((encoded + "\n").encode("utf-8"))
+                await asyncio.wait_for(
+                    proc.stdin.drain(),
+                    timeout=self._request_timeout_s,
+                )
+            except asyncio.TimeoutError as exc:
+                self._schedule_process_cleanup(proc)
+                raise self._error(
+                    f"External stdio notification timed out for method '{method}'",
+                    reason_code="request_timeout",
+                    method=method,
+                ) from exc
+            except (BrokenPipeError, ConnectionError) as exc:
+                self._schedule_process_cleanup(proc)
+                raise self._error(
+                    "External stdio process connection closed",
+                    reason_code="connection_closed",
+                    method=method,
+                ) from exc
+
+    async def _read_response(
+        self,
+        proc: asyncio.subprocess.Process,
+        request_id: int,
+    ) -> dict[str, Any]:
+        if proc.stdout is None:
             raise self._error(
                 "External stdio process stdout is not available",
                 reason_code="not_connected",
@@ -326,7 +380,8 @@ class StdioExternalTransport:
         while True:
             line = await proc.stdout.readline()
             if not line:
-                self._initialized = False
+                if self._proc is proc:
+                    self._initialized = False
                 raise self._error(
                     "External stdio process connection closed",
                     reason_code="connection_closed",
@@ -348,6 +403,22 @@ class StdioExternalTransport:
 
         stderr_task = self._stderr_task
         self._stderr_task = None
+        await self._terminate_process(proc, stderr_task)
+
+    def _schedule_process_cleanup(self, proc: asyncio.subprocess.Process) -> None:
+        stderr_task = self._stderr_task if self._proc is proc else None
+        if self._proc is proc:
+            self._proc = None
+            self._stderr_task = None
+        self._initialized = False
+        task = asyncio.create_task(self._terminate_process(proc, stderr_task))
+        task.add_done_callback(self._discard_cleanup_result)
+
+    async def _terminate_process(
+        self,
+        proc: asyncio.subprocess.Process | None,
+        stderr_task: asyncio.Task[None] | None,
+    ) -> None:
         if stderr_task is not None:
             stderr_task.cancel()
 
@@ -357,18 +428,37 @@ class StdioExternalTransport:
                 with contextlib.suppress(Exception):
                     stdin.close()
             if proc.returncode is None:
-                proc.terminate()
                 try:
-                    await asyncio.wait_for(proc.wait(), timeout=self._close_timeout_s)
+                    if proc.returncode is None:
+                        proc.terminate()
+                except ProcessLookupError:
+                    pass
+                try:
+                    if proc.returncode is None:
+                        await asyncio.wait_for(proc.wait(), timeout=self._close_timeout_s)
                 except asyncio.TimeoutError:
-                    proc.kill()
-                    await proc.wait()
+                    try:
+                        if proc.returncode is None:
+                            proc.kill()
+                    except ProcessLookupError:
+                        pass
+                    with contextlib.suppress(ProcessLookupError):
+                        await proc.wait()
                 except ProcessLookupError:
                     pass
 
         if stderr_task is not None:
             with contextlib.suppress(asyncio.CancelledError):
                 await stderr_task
+
+    @staticmethod
+    def _discard_cleanup_result(task: asyncio.Task[None]) -> None:
+        try:
+            task.result()
+        except asyncio.CancelledError:
+            return
+        except Exception:  # noqa: BLE001 - background cleanup must not leak task warnings.
+            return
 
     async def _drain_stderr(self) -> None:
         proc = self._proc
@@ -422,6 +512,13 @@ class StdioExternalTransport:
                 reason_code="missing_command",
                 server_id=server.id,
             )
+        env_names = {str(name).strip() for name in server.env_allowlist}
+        if cls._requires_path_lookup(command[0]) and "PATH" not in env_names:
+            raise StdioExternalTransportError(
+                "Command requires PATH; allowlist PATH or use an absolute executable path",
+                reason_code="invalid_command",
+                server_id=server.id,
+            )
         return command
 
     @classmethod
@@ -438,13 +535,25 @@ class StdioExternalTransport:
 
     @classmethod
     def _positive_timeout(cls, value: float, field_name: str) -> float:
-        timeout = float(value)
-        if timeout <= 0:
+        try:
+            timeout = float(value)
+        except (TypeError, ValueError) as exc:
             raise StdioExternalTransportError(
-                f"External stdio transport {field_name} must be positive",
+                f"External stdio transport {field_name} must be a finite positive number",
+                reason_code="invalid_timeout",
+            ) from exc
+        if timeout <= 0 or not math.isfinite(timeout):
+            raise StdioExternalTransportError(
+                f"External stdio transport {field_name} must be a finite positive number",
                 reason_code="invalid_timeout",
             )
         return timeout
+
+    @staticmethod
+    def _requires_path_lookup(executable: str) -> bool:
+        if Path(executable).is_absolute():
+            return False
+        return not any(separator and separator in executable for separator in (os.sep, os.altsep))
 
     @staticmethod
     def _runtime_auth_meta(

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_stdio_external_transport.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_stdio_external_transport.py
@@ -1,9 +1,13 @@
+"""Subprocess-backed tests for the package upstream stdio MCP transport."""
+
 from __future__ import annotations
 
+import asyncio
 import subprocess
 import sys
 from pathlib import Path
 from textwrap import dedent
+from time import monotonic
 
 import pytest
 from mcp_unified.federation.models import BrokeredExternalCredential
@@ -17,8 +21,16 @@ from mcp_unified.storage import ExternalServerDefinition
 _STUB_SERVER_SCRIPT = r"""
 import json
 import os
+import signal
 import sys
 import time
+
+
+IGNORE_SIGTERM = False
+initialized_notification = False
+
+if IGNORE_SIGTERM:
+    signal.signal(signal.SIGTERM, signal.SIG_IGN)
 
 
 def send(payload):
@@ -36,6 +48,13 @@ for raw in sys.stdin:
     params = message.get("params") or {}
 
     if method == "initialize":
+        if not isinstance(params.get("capabilities"), dict):
+            send({
+                "jsonrpc": "2.0",
+                "id": request_id,
+                "error": {"code": -32602, "message": "missing capabilities"},
+            })
+            continue
         send({
             "jsonrpc": "2.0",
             "id": request_id,
@@ -43,6 +62,18 @@ for raw in sys.stdin:
                 "protocolVersion": "2024-11-05",
                 "serverInfo": {"name": "stub-stdio"},
             },
+        })
+        continue
+
+    if method == "notifications/initialized":
+        initialized_notification = True
+        continue
+
+    if not initialized_notification:
+        send({
+            "jsonrpc": "2.0",
+            "id": request_id,
+            "error": {"code": -32002, "message": "session not initialized"},
         })
         continue
 
@@ -157,9 +188,13 @@ for raw in sys.stdin:
 """
 
 
-def _write_stub_server(tmp_path: Path) -> str:
+def _write_stub_server(tmp_path: Path, *, ignore_sigterm: bool = False) -> str:
+    """Write a temporary MCP-like stdio server for transport tests."""
     script_path = tmp_path / "stub_stdio_mcp_server.py"
-    script_path.write_text(dedent(_STUB_SERVER_SCRIPT), encoding="utf-8")
+    script = dedent(_STUB_SERVER_SCRIPT)
+    if ignore_sigterm:
+        script = script.replace("IGNORE_SIGTERM = False", "IGNORE_SIGTERM = True")
+    script_path.write_text(script, encoding="utf-8")
     return str(script_path)
 
 
@@ -169,6 +204,7 @@ def _server(
     cwd: str | None = None,
     env_allowlist: list[str] | None = None,
 ) -> ExternalServerDefinition:
+    """Build a stdio external server definition for tests."""
     return ExternalServerDefinition(
         id="docs",
         name="Docs",
@@ -180,6 +216,7 @@ def _server(
 
 
 def test_stdio_transport_import_does_not_import_host_package() -> None:
+    """Importing the package stdio transport must not import host code."""
     code = (
         "import sys; import mcp_unified.federation.stdio_transport; "
         "print('tldw_Server_API' in sys.modules)"
@@ -195,6 +232,7 @@ def test_stdio_transport_import_does_not_import_host_package() -> None:
 
 
 def test_stdio_transport_rejects_non_stdio_definition() -> None:
+    """The stdio transport rejects non-stdio server definitions."""
     server = ExternalServerDefinition(
         id="ws",
         name="WebSocket",
@@ -209,6 +247,7 @@ def test_stdio_transport_rejects_non_stdio_definition() -> None:
 
 
 def test_stdio_transport_rejects_empty_command_even_when_definition_disabled() -> None:
+    """The transport validates its own command contract for disabled rows too."""
     server = ExternalServerDefinition(
         id="disabled",
         name="Disabled",
@@ -224,6 +263,7 @@ def test_stdio_transport_rejects_empty_command_even_when_definition_disabled() -
 
 
 def test_stdio_transport_rejects_missing_cwd(tmp_path: Path) -> None:
+    """Configured cwd paths must resolve to existing directories."""
     server = _server(
         command=[sys.executable, "-c", "pass"],
         cwd=str(tmp_path / "missing"),
@@ -235,7 +275,31 @@ def test_stdio_transport_rejects_missing_cwd(tmp_path: Path) -> None:
     assert exc_info.value.reason_code == "invalid_cwd"
 
 
+def test_stdio_transport_rejects_bare_command_without_path_allowlist() -> None:
+    """Bare executable names require PATH allowlisting for predictable launch."""
+    server = _server(command=["python"])
+
+    with pytest.raises(StdioExternalTransportError) as exc_info:
+        StdioExternalTransport(server)
+
+    assert exc_info.value.reason_code == "invalid_command"
+    assert "PATH" in str(exc_info.value)
+
+
+@pytest.mark.parametrize("timeout", [0, -1, "bad", float("nan"), float("inf")])
+def test_stdio_transport_rejects_invalid_request_timeouts(timeout: object) -> None:
+    """Timeout configuration errors are reported as structured transport errors."""
+    with pytest.raises(StdioExternalTransportError) as exc_info:
+        StdioExternalTransport(
+            _server(command=[sys.executable, "-c", "pass"]),
+            request_timeout_s=timeout,  # type: ignore[arg-type]
+        )
+
+    assert exc_info.value.reason_code == "invalid_timeout"
+
+
 def test_create_external_transport_factory_returns_stdio_transport() -> None:
+    """The package factory returns the stdio transport for stdio definitions."""
     transport = create_external_transport(_server(command=[sys.executable, "-c", "pass"]))
 
     assert isinstance(transport, StdioExternalTransport)
@@ -243,6 +307,7 @@ def test_create_external_transport_factory_returns_stdio_transport() -> None:
 
 @pytest.mark.asyncio
 async def test_stdio_transport_connect_list_call_and_close(tmp_path: Path) -> None:
+    """The transport initializes, sends initialized notification, lists, calls, and closes."""
     script_path = _write_stub_server(tmp_path)
     transport = StdioExternalTransport(
         _server(command=[sys.executable, "-u", script_path]),
@@ -284,6 +349,7 @@ async def test_stdio_transport_uses_only_allowlisted_environment(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    """Child process environments include only explicitly allowlisted variables."""
     script_path = _write_stub_server(tmp_path)
     monkeypatch.setenv("MCP_ALLOWED", "yes")
     monkeypatch.setenv("MCP_BLOCKED", "no")
@@ -307,6 +373,7 @@ async def test_stdio_transport_uses_only_allowlisted_environment(
 async def test_stdio_transport_sends_runtime_auth_in_meta_without_leaking_secret(
     tmp_path: Path,
 ) -> None:
+    """Runtime credentials are passed through call metadata without leaking in errors."""
     script_path = _write_stub_server(tmp_path)
     secret = "super-secret-token"
     transport = StdioExternalTransport(
@@ -347,7 +414,32 @@ async def test_stdio_transport_sends_runtime_auth_in_meta_without_leaking_secret
 
 
 @pytest.mark.asyncio
+async def test_stdio_transport_timeout_does_not_wait_for_shutdown_timeout(tmp_path: Path) -> None:
+    """Request timeout returns before asynchronous process cleanup finishes."""
+    script_path = _write_stub_server(tmp_path, ignore_sigterm=True)
+    transport = StdioExternalTransport(
+        _server(command=[sys.executable, "-u", script_path]),
+        request_timeout_s=0.05,
+        close_timeout_s=0.4,
+    )
+
+    try:
+        await transport.connect()
+        started_at = monotonic()
+        with pytest.raises(StdioExternalTransportError) as exc_info:
+            await transport.call_tool("docs.slow", {})
+        elapsed = monotonic() - started_at
+
+        assert exc_info.value.reason_code == "request_timeout"
+        assert elapsed < 0.25
+        await asyncio.sleep(0.5)
+    finally:
+        await transport.close()
+
+
+@pytest.mark.asyncio
 async def test_stdio_transport_health_marks_exited_process_disconnected(tmp_path: Path) -> None:
+    """Health checks mark a process that exited after a call as disconnected."""
     script_path = _write_stub_server(tmp_path)
     transport = StdioExternalTransport(_server(command=[sys.executable, "-u", script_path]))
 

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_stdio_external_transport.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_stdio_external_transport.py
@@ -1,0 +1,363 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+from textwrap import dedent
+
+import pytest
+from mcp_unified.federation.models import BrokeredExternalCredential
+from mcp_unified.federation.stdio_transport import (
+    StdioExternalTransport,
+    StdioExternalTransportError,
+    create_external_transport,
+)
+from mcp_unified.storage import ExternalServerDefinition
+
+_STUB_SERVER_SCRIPT = r"""
+import json
+import os
+import sys
+import time
+
+
+def send(payload):
+    sys.stdout.write(json.dumps(payload, separators=(",", ":")) + "\n")
+    sys.stdout.flush()
+
+
+for raw in sys.stdin:
+    line = raw.strip()
+    if not line:
+        continue
+    message = json.loads(line)
+    request_id = message.get("id")
+    method = message.get("method")
+    params = message.get("params") or {}
+
+    if method == "initialize":
+        send({
+            "jsonrpc": "2.0",
+            "id": request_id,
+            "result": {
+                "protocolVersion": "2024-11-05",
+                "serverInfo": {"name": "stub-stdio"},
+            },
+        })
+        continue
+
+    if method == "ping":
+        send({"jsonrpc": "2.0", "id": request_id, "result": {"pong": True}})
+        continue
+
+    if method == "tools/list":
+        send({
+            "jsonrpc": "2.0",
+            "id": request_id,
+            "result": {
+                "tools": [
+                    {
+                        "name": "docs.search",
+                        "description": "Search docs",
+                        "inputSchema": {
+                            "type": "object",
+                            "properties": {"q": {"type": "string"}},
+                        },
+                        "metadata": {"category": "read"},
+                    },
+                    {"name": "docs.defaulted", "description": 7, "inputSchema": "bad", "metadata": []},
+                    {"name": 42, "description": "invalid"},
+                ]
+            },
+        })
+        continue
+
+    if method == "tools/call":
+        tool_name = str(params.get("name") or "")
+        arguments = params.get("arguments") or {}
+        runtime_auth = (params.get("_meta") or {}).get("mcp_unified_runtime_auth") or {}
+
+        if tool_name == "docs.search":
+            send({
+                "jsonrpc": "2.0",
+                "id": request_id,
+                "result": {
+                    "content": [{"type": "text", "text": f"search:{arguments.get('q')}"}],
+                    "isError": False,
+                },
+            })
+            continue
+
+        if tool_name == "docs.env":
+            send({
+                "jsonrpc": "2.0",
+                "id": request_id,
+                "result": {
+                    "content": {
+                        "allowed": os.environ.get("MCP_ALLOWED"),
+                        "blocked": os.environ.get("MCP_BLOCKED"),
+                    },
+                    "isError": False,
+                },
+            })
+            continue
+
+        if tool_name == "docs.auth":
+            send({
+                "jsonrpc": "2.0",
+                "id": request_id,
+                "result": {
+                    "content": {
+                        "has_secret": runtime_auth.get("env", {}).get("DOCS_TOKEN") == arguments.get("expected"),
+                        "header_keys": sorted(runtime_auth.get("headers", {})),
+                        "metadata": runtime_auth.get("metadata", {}),
+                    },
+                    "isError": False,
+                },
+            })
+            continue
+
+        if tool_name == "docs.fail":
+            send({
+                "jsonrpc": "2.0",
+                "id": request_id,
+                "error": {"code": -32042, "message": "upstream failed"},
+            })
+            continue
+
+        if tool_name == "docs.slow":
+            time.sleep(0.3)
+            send({
+                "jsonrpc": "2.0",
+                "id": request_id,
+                "result": {"content": [{"type": "text", "text": "slow"}], "isError": False},
+            })
+            continue
+
+        if tool_name == "docs.exit":
+            send({
+                "jsonrpc": "2.0",
+                "id": request_id,
+                "result": {"content": {"exiting": True}, "isError": False},
+            })
+            sys.exit(0)
+
+        send({
+            "jsonrpc": "2.0",
+            "id": request_id,
+            "error": {"code": -32601, "message": f"unknown tool: {tool_name}"},
+        })
+        continue
+
+    send({
+        "jsonrpc": "2.0",
+        "id": request_id,
+        "error": {"code": -32601, "message": f"unknown method: {method}"},
+    })
+"""
+
+
+def _write_stub_server(tmp_path: Path) -> str:
+    script_path = tmp_path / "stub_stdio_mcp_server.py"
+    script_path.write_text(dedent(_STUB_SERVER_SCRIPT), encoding="utf-8")
+    return str(script_path)
+
+
+def _server(
+    *,
+    command: list[str],
+    cwd: str | None = None,
+    env_allowlist: list[str] | None = None,
+) -> ExternalServerDefinition:
+    return ExternalServerDefinition(
+        id="docs",
+        name="Docs",
+        transport="stdio",
+        command=command,
+        cwd=cwd,
+        env_allowlist=env_allowlist or [],
+    )
+
+
+def test_stdio_transport_import_does_not_import_host_package() -> None:
+    code = (
+        "import sys; import mcp_unified.federation.stdio_transport; "
+        "print('tldw_Server_API' in sys.modules)"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+    assert result.stdout.strip() == "False"
+
+
+def test_stdio_transport_rejects_non_stdio_definition() -> None:
+    server = ExternalServerDefinition(
+        id="ws",
+        name="WebSocket",
+        transport="websocket",
+        url="ws://example.invalid",
+    )
+
+    with pytest.raises(StdioExternalTransportError) as exc_info:
+        StdioExternalTransport(server)
+
+    assert exc_info.value.reason_code == "unsupported_transport"
+
+
+def test_stdio_transport_rejects_empty_command_even_when_definition_disabled() -> None:
+    server = ExternalServerDefinition(
+        id="disabled",
+        name="Disabled",
+        transport="stdio",
+        command=[],
+        enabled=False,
+    )
+
+    with pytest.raises(StdioExternalTransportError) as exc_info:
+        StdioExternalTransport(server)
+
+    assert exc_info.value.reason_code == "missing_command"
+
+
+def test_stdio_transport_rejects_missing_cwd(tmp_path: Path) -> None:
+    server = _server(
+        command=[sys.executable, "-c", "pass"],
+        cwd=str(tmp_path / "missing"),
+    )
+
+    with pytest.raises(StdioExternalTransportError) as exc_info:
+        StdioExternalTransport(server)
+
+    assert exc_info.value.reason_code == "invalid_cwd"
+
+
+def test_create_external_transport_factory_returns_stdio_transport() -> None:
+    transport = create_external_transport(_server(command=[sys.executable, "-c", "pass"]))
+
+    assert isinstance(transport, StdioExternalTransport)
+
+
+@pytest.mark.asyncio
+async def test_stdio_transport_connect_list_call_and_close(tmp_path: Path) -> None:
+    script_path = _write_stub_server(tmp_path)
+    transport = StdioExternalTransport(
+        _server(command=[sys.executable, "-u", script_path]),
+        request_timeout_s=0.2,
+    )
+
+    try:
+        await transport.connect()
+
+        health = await transport.health_check()
+        assert health["configured"] is True
+        assert health["connected"] is True
+        assert health["initialized"] is True
+
+        tools = await transport.list_tools()
+        assert [tool.name for tool in tools] == ["docs.search", "docs.defaulted"]
+        assert tools[0].description == "Search docs"
+        assert tools[0].input_schema["type"] == "object"
+        assert tools[0].metadata == {"category": "read"}
+        assert tools[1].description == ""
+        assert tools[1].input_schema == {"type": "object"}
+        assert tools[1].metadata == {}
+
+        ok = await transport.call_tool("docs.search", {"q": "hello"})
+        assert ok.is_error is False
+        assert ok.content == [{"type": "text", "text": "search:hello"}]
+
+        err = await transport.call_tool("docs.fail", {})
+        assert err.is_error is True
+        assert err.content == [{"type": "text", "text": "upstream failed"}]
+        assert err.metadata["reason_code"] == "upstream_error"
+    finally:
+        await transport.close()
+        await transport.close()
+
+
+@pytest.mark.asyncio
+async def test_stdio_transport_uses_only_allowlisted_environment(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    script_path = _write_stub_server(tmp_path)
+    monkeypatch.setenv("MCP_ALLOWED", "yes")
+    monkeypatch.setenv("MCP_BLOCKED", "no")
+    transport = StdioExternalTransport(
+        _server(
+            command=[sys.executable, "-u", script_path],
+            env_allowlist=["MCP_ALLOWED"],
+        )
+    )
+
+    try:
+        result = await transport.call_tool("docs.env", {})
+
+        assert result.is_error is False
+        assert result.content == {"allowed": "yes", "blocked": None}
+    finally:
+        await transport.close()
+
+
+@pytest.mark.asyncio
+async def test_stdio_transport_sends_runtime_auth_in_meta_without_leaking_secret(
+    tmp_path: Path,
+) -> None:
+    script_path = _write_stub_server(tmp_path)
+    secret = "super-secret-token"
+    transport = StdioExternalTransport(
+        _server(command=[sys.executable, "-u", script_path]),
+        request_timeout_s=0.05,
+    )
+
+    try:
+        result = await transport.call_tool(
+            "docs.auth",
+            {"expected": secret},
+            runtime_auth=BrokeredExternalCredential(
+                headers={"Authorization": "Bearer header-secret"},
+                env={"DOCS_TOKEN": secret},
+                metadata={"credential_source": "pytest"},
+            ),
+        )
+
+        assert result.is_error is False
+        assert result.content == {
+            "has_secret": True,
+            "header_keys": ["Authorization"],
+            "metadata": {"credential_source": "pytest"},
+        }
+
+        with pytest.raises(StdioExternalTransportError) as exc_info:
+            await transport.call_tool(
+                "docs.slow",
+                {},
+                runtime_auth=BrokeredExternalCredential(env={"DOCS_TOKEN": secret}),
+            )
+
+        assert exc_info.value.reason_code == "request_timeout"
+        assert secret not in str(exc_info.value)
+        assert "header-secret" not in str(exc_info.value)
+    finally:
+        await transport.close()
+
+
+@pytest.mark.asyncio
+async def test_stdio_transport_health_marks_exited_process_disconnected(tmp_path: Path) -> None:
+    script_path = _write_stub_server(tmp_path)
+    transport = StdioExternalTransport(_server(command=[sys.executable, "-u", script_path]))
+
+    try:
+        await transport.connect()
+        result = await transport.call_tool("docs.exit", {})
+        assert result.content == {"exiting": True}
+
+        health = await transport.health_check()
+        assert health["connected"] is False
+        assert health["initialized"] is False
+    finally:
+        await transport.close()


### PR DESCRIPTION
## Summary

- Add `mcp_unified.federation.stdio_transport.StdioExternalTransport`, a package-owned upstream MCP stdio subprocess transport with shell-free argv launch, cwd validation, explicit environment allowlisting, JSON-RPC initialize/list/call/ping handling, timeouts, safe errors, and idempotent cleanup.
- Export the stdio transport and `create_external_transport` factory for gateway runtime injection without importing host `tldw_Server_API` code.
- Add spec, implementation plan, Backlog TASK-582, and subprocess-backed tests for validation, discovery/calls, env allowlisting, runtime-auth `_meta`, timeout redaction, and exited-process health.

## Verification

- `../../.venv/bin/python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_gateway_external_runtime.py tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py tldw_Server_API/app/core/MCP_unified/tests/test_stdio_external_transport.py -q` -> 38 passed, 3 warnings
- `../../.venv/bin/python -m ruff check mcp_unified/federation/stdio_transport.py mcp_unified/federation/__init__.py tldw_Server_API/app/core/MCP_unified/tests/test_stdio_external_transport.py` -> All checks passed
- `../../.venv/bin/python -m bandit -r mcp_unified/federation/stdio_transport.py -f json -o /tmp/bandit_mcp_stdio_transport.json` -> exit 0
- `git diff --check` -> exit 0

## Change summary

Human-authored change summary required before merge per `Docs/superpowers/AI_GENERATED_PR_CHANGE_SUMMARY_POLICY_2026_04_17.md`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a package-owned stdio transport for external MCP servers so the gateway can launch and talk to subprocess servers without `tldw_Server_API` dependencies. Now includes MCP-compliant initialize plus `notifications/initialized`, stricter command/cwd/timeout validation, and race-safe non-blocking cleanup; meets TASK-582.

- **New Features**
  - `mcp_unified.federation.stdio_transport.StdioExternalTransport`: shell-free argv launch, cwd check, explicit `env_allowlist`, newline-delimited JSON-RPC (initialize/tools.list/tools.call/ping), serialized requests, and safe stderr drain.
  - Hardened lifecycle: initialize sends `capabilities` and `notifications/initialized`; deterministic, validated timeouts; non-blocking timeout cleanup with race-safe terminate/kill; health marks exited processes disconnected.
  - Command safety: reject bare executables unless `PATH` is allowlisted or an absolute path is used.
  - Exposes `StdioExternalTransport`, `StdioExternalTransportError`, and `create_external_transport`; tests cover discovery/calls, runtime-auth `_meta`, timeout redaction, and PATH/timeout validation.

- **Migration**
  - Pass `create_external_transport` as the runtime manager `transport_factory`.
  - Configure servers with `transport="stdio"`, argv `command`, optional existing `cwd`, and `env_allowlist` (include `PATH` if using a bare executable).
  - Use per-call credentials in `_meta` via `BrokeredExternalCredential`; no shell execution; custom timeouts must be finite positive numbers.

<sup>Written for commit 138bab6ca32befe21efd469249c1b72ced66e59d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2204?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

