### PR TITLE
Wire MCP stdio runtime bootstrap

### DIFF
--- a/Docs/superpowers/plans/2026-06-01-mcp-stdio-bootstrap-factory-plan.md
+++ b/Docs/superpowers/plans/2026-06-01-mcp-stdio-bootstrap-factory-plan.md
@@ -1,0 +1,49 @@
+# MCP Stdio Bootstrap Factory Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Wire the package-owned stdio external transport factory into standalone gateway config bootstrap.
+
+**Architecture:** Add an explicit opt-in external runtime config nested under `GatewayProfileBootstrapConfig`. When enabled, `bootstrap_profile_gateway_from_config()` creates `GatewayExternalRuntimeManager` from the same external registry storage bundle already used for registry management, using `create_external_transport` unless the caller injects a factory or full runtime manager.
+
+**Tech Stack:** Python dataclasses, async gateway bootstrap helpers, package-owned MCP Unified runtime, pytest.
+
+---
+
+### Task 1: Bootstrap Config Tests
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py`
+
+- [x] Add tests proving external runtime is disabled by default for SQLite config.
+- [x] Add tests proving enabled SQLite config creates a runtime manager with the package stdio factory.
+- [x] Add tests proving injected transport factory overrides the package default.
+- [x] Add tests proving unsupported external runtime factory config is rejected.
+- [x] Add tests proving memory config cannot enable runtime management without external registry storage.
+- [x] Run the new tests and confirm they fail for missing config/runtime wiring.
+
+### Task 2: Config Runtime Wiring
+
+**Files:**
+- Modify: `mcp_unified/gateway/config.py`
+- Modify: `mcp_unified/gateway/__init__.py`
+
+- [x] Add `GatewayExternalRuntimeBootstrapConfig`.
+- [x] Normalize `external_runtime` in `GatewayProfileBootstrapConfig.__post_init__`.
+- [x] Add optional runtime dependency injection parameters to `bootstrap_profile_gateway_from_config()`.
+- [x] Build `GatewayExternalRuntimeManager` only when runtime config is enabled and no manager is injected.
+- [x] Use `mcp_unified.federation.create_external_transport` as the default factory.
+- [x] Export the new config type from package gateway modules.
+- [x] Run the focused tests and confirm they pass.
+
+### Task 3: Validation
+
+**Files:**
+- Update: `backlog/tasks/task-583 - Wire-MCP-stdio-transport-factory-into-gateway-bootstrap.md`
+
+- [x] Run focused pytest for gateway config/bootstrap tests.
+- [x] Run Ruff on touched Python files.
+- [x] Run Bandit on touched Python source.
+- [x] Run `git diff --check`.
+- [x] Update Backlog task notes and verification.
+- [x] Commit, push, and open the PR.

--- a/Docs/superpowers/specs/2026-06-01-mcp-stdio-bootstrap-factory-design.md
+++ b/Docs/superpowers/specs/2026-06-01-mcp-stdio-bootstrap-factory-design.md
@@ -1,0 +1,55 @@
+# MCP Stdio Bootstrap Factory Design
+
+## Context
+
+Stage 4N added package-owned external runtime management and Stage 4O added the stdio upstream transport factory. The remaining gap is bootstrap wiring: standalone gateway callers can persist external server definitions, but config bootstrap does not yet create a `GatewayExternalRuntimeManager` that uses the package `create_external_transport` factory.
+
+## Goals
+
+- Allow standalone gateway config bootstrap to opt into external runtime management.
+- Use the package-owned stdio transport factory by default when runtime management is enabled.
+- Preserve caller-injected runtime manager and transport factory overrides.
+- Keep safe defaults: profile config bootstrap must not start or expose external runtime management unless explicitly enabled or directly injected.
+- Keep package boundaries clean: `mcp_unified` must not import `tldw_Server_API`.
+
+## Non-Goals
+
+- Auto-starting external servers during bootstrap.
+- Adding websocket upstream runtime support.
+- Adding install/update adapters beyond the existing null installer default.
+- Changing FastAPI route semantics beyond consuming the bootstrap-created runtime manager that already exists on `GatewayProfileBootstrap`.
+
+## Design
+
+Add a nested `GatewayExternalRuntimeBootstrapConfig` with:
+
+- `enabled: bool = False`
+- `transport_factory: Literal["stdio"] = "stdio"`
+
+`GatewayProfileBootstrapConfig` owns this nested config as `external_runtime`. The default is disabled so existing memory and SQLite profile bootstrap behavior is unchanged.
+
+`bootstrap_profile_gateway_from_config()` will accept optional dependency overrides:
+
+- `external_runtime_manager`
+- `external_transport_factory`
+- `credential_broker`
+- `external_installer`
+
+Precedence:
+
+1. A directly supplied `external_runtime_manager` is passed through unchanged.
+2. If no manager is supplied and `external_runtime.enabled` is true, bootstrap builds `GatewayExternalRuntimeManager`.
+3. If runtime management is disabled, no runtime manager is built.
+
+When config builds the manager, it requires an external registry-capable store. SQLite profile storage satisfies this through `SQLiteMCPStore`; memory storage still requires an injected registry store and is rejected by the existing external registry storage configuration path. The transport factory is caller-provided when supplied, otherwise `mcp_unified.federation.create_external_transport`.
+
+Unsupported transport behavior stays in the factory/runtime path. Config only validates the factory selector value; a server definition with `transport="websocket"` can remain persisted, but starting it through the default package factory fails rather than pretending websocket support exists.
+
+## Risks And Mitigations
+
+- Risk: enabling runtime management accidentally starts processes.
+  Mitigation: bootstrap only constructs the manager; starts still require explicit runtime API calls or future reconcile/autostart behavior.
+- Risk: config accepts unsupported factory names silently.
+  Mitigation: `GatewayExternalRuntimeBootstrapConfig` validates selector values and rejects anything except `stdio`.
+- Risk: direct injection becomes less useful.
+  Mitigation: injected manager takes precedence; injected factory is used only when config builds the manager.

--- a/backlog/tasks/task-583 - Wire-MCP-stdio-transport-factory-into-gateway-bootstrap.md
+++ b/backlog/tasks/task-583 - Wire-MCP-stdio-transport-factory-into-gateway-bootstrap.md
@@ -1,0 +1,69 @@
+---
+id: TASK-583
+title: Wire MCP stdio transport factory into gateway bootstrap
+status: Done
+labels:
+- mcp-unified
+- gateway
+- external-servers
+- stdio
+- bootstrap
+documentation:
+- Docs/superpowers/specs/2026-06-01-mcp-stdio-bootstrap-factory-design.md
+- Docs/superpowers/plans/2026-06-01-mcp-stdio-bootstrap-factory-plan.md
+modified_files:
+- Docs/superpowers/specs/2026-06-01-mcp-stdio-bootstrap-factory-design.md
+- Docs/superpowers/plans/2026-06-01-mcp-stdio-bootstrap-factory-plan.md
+- mcp_unified/gateway/config.py
+- mcp_unified/gateway/__init__.py
+- mcp_unified/gateway/cli.py
+- mcp_unified/gateway/external_runtime.py
+- tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py
+- tldw_Server_API/app/core/MCP_unified/tests/test_gateway_cli_package.py
+- tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py
+references:
+- https://github.com/rmusser01/tldw_server/pull/2205
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Integrate the package-owned upstream stdio external transport factory into standalone gateway bootstrap/config so configured stdio external servers can be managed by GatewayExternalRuntimeManager without callers manually injecting a transport factory.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Standalone gateway bootstrap can create a GatewayExternalRuntimeManager using the package stdio transport factory when external runtime support is configured.
+- [x] #2 Configuration loading preserves safe defaults and does not enable unsupported transports silently.
+- [x] #3 Package boundary remains clean with no tldw_Server_API imports from mcp_unified integration paths.
+- [x] #4 Focused tests cover default bootstrap behavior, injected-factory override behavior, stdio factory wiring, and unsupported transport error behavior.
+- [x] #5 Focused pytest, Ruff, Bandit on touched Python source, and git diff --check pass before PR.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Docs/superpowers/plans/2026-06-01-mcp-stdio-bootstrap-factory-plan.md
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Implemented opt-in external runtime bootstrap wiring for standalone gateway config. Added GatewayExternalRuntimeBootstrapConfig with safe disabled default and stdio-only factory selector validation. bootstrap_profile_gateway_from_config now builds GatewayExternalRuntimeManager from resolved external registry storage only when external_runtime.enabled is true, using the package create_external_transport factory unless callers inject a factory or full runtime manager. Runtime start now wraps transport factory creation errors in the existing external_server_start_failed path so unsupported persisted transports fail at start time instead of escaping raw factory exceptions.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Wired standalone gateway config bootstrap to create a GatewayExternalRuntimeManager with the package stdio transport factory when explicitly enabled, while preserving disabled defaults and injection overrides. Added regression coverage for default-disabled behavior, stdio factory wiring, injected factory behavior, unsupported factory config rejection, unsupported server transport start failure, CLI safe-default reporting, and package-boundary exports. Verification: focused pytest passed (221 tests), Ruff passed on touched Python files, Bandit reported zero findings on touched gateway source, and git diff --check passed. PR: https://github.com/rmusser01/tldw_server/pull/2205. No known blockers.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/mcp_unified/gateway/__init__.py
+++ b/mcp_unified/gateway/__init__.py
@@ -9,6 +9,7 @@ from .bootstrap import (
 )
 from .config import (
     GatewayConfigFormat,
+    GatewayExternalRuntimeBootstrapConfig,
     GatewayProfileBootstrapConfig,
     GatewayProfileStoreConfig,
     GatewayProfileStoreKind,
@@ -34,6 +35,7 @@ if TYPE_CHECKING:
 __all__ = [
     "GatewayPolicyDenied",
     "GatewayConfigFormat",
+    "GatewayExternalRuntimeBootstrapConfig",
     "GatewayExternalRuntimeError",
     "GatewayExternalRuntimeManager",
     "GatewayProfileBootstrap",

--- a/mcp_unified/gateway/cli.py
+++ b/mcp_unified/gateway/cli.py
@@ -900,6 +900,10 @@ def _validated_config_payload(
     return {
         "default_preset_id": config.default_preset_id,
         "default_profile_id": config.default_profile_id,
+        "external_runtime": {
+            "enabled": config.external_runtime.enabled,
+            "transport_factory": config.external_runtime.transport_factory,
+        },
         "ok": True,
         "path": str(path),
         "profiles": len(config.profiles),

--- a/mcp_unified/gateway/config.py
+++ b/mcp_unified/gateway/config.py
@@ -3,11 +3,11 @@
 from __future__ import annotations
 
 import json
-from collections.abc import Iterable, Mapping
+from collections.abc import Callable, Iterable, Mapping
 from dataclasses import dataclass, field
 from json import JSONDecodeError
 from pathlib import Path
-from typing import Any, Literal, cast
+from typing import TYPE_CHECKING, Any, Literal, cast
 
 from mcp_unified.interfaces.storage import (
     AuditStore,
@@ -27,12 +27,22 @@ from .external_registry import GatewayExternalRegistryManager, GatewayStoreMetad
 from .profiles import GatewayProfileStoreMetadata
 from .runtime import GatewayRuntime
 
+if TYPE_CHECKING:
+    from mcp_unified.federation.installers import ExternalServerInstaller
+    from mcp_unified.federation.transports import ExternalFederationTransport
+    from mcp_unified.gateway.external_runtime import (
+        ExternalCredentialBroker,
+        GatewayExternalRuntimeManager,
+    )
+    from mcp_unified.storage.models import ExternalServerDefinition
+
 try:  # pragma: no cover - Python <3.11 fallback is exercised only on older runtimes.
     import tomllib as _tomllib
 except ModuleNotFoundError:  # pragma: no cover - defensive for unsupported runtimes.
     _tomllib = None
 
 GatewayConfigFormat = Literal["json", "toml"]
+GatewayExternalRuntimeFactoryKind = Literal["stdio"]
 GatewayProfileStoreKind = Literal["memory", "sqlite"]
 
 
@@ -60,6 +70,32 @@ class GatewayProfileStoreConfig:
 
 
 @dataclass(frozen=True, slots=True)
+class GatewayExternalRuntimeBootstrapConfig:
+    """External runtime manager bootstrap selection for standalone gateways."""
+
+    enabled: bool = False
+    transport_factory: GatewayExternalRuntimeFactoryKind = "stdio"
+
+    def __post_init__(self) -> None:
+        """Validate and normalize the configured runtime factory selector."""
+
+        if not isinstance(self.enabled, bool):
+            raise ValueError("external_runtime.enabled must be a boolean")
+
+        normalized_factory = str(self.transport_factory).strip().lower()
+        if normalized_factory != "stdio":
+            raise ValueError(
+                "Unsupported gateway external runtime factory: "
+                f"{self.transport_factory!r}"
+            )
+        object.__setattr__(
+            self,
+            "transport_factory",
+            cast(GatewayExternalRuntimeFactoryKind, normalized_factory),
+        )
+
+
+@dataclass(frozen=True, slots=True)
 class GatewayProfileBootstrapConfig:
     """Profile bootstrap configuration for a standalone gateway runtime."""
 
@@ -69,6 +105,9 @@ class GatewayProfileBootstrapConfig:
     profiles: Iterable[MCPProfile | Mapping[str, Any]] = field(default_factory=tuple)
     default_profile_id: str | None = None
     default_preset_id: str | None = None
+    external_runtime: GatewayExternalRuntimeBootstrapConfig | Mapping[str, Any] = field(
+        default_factory=GatewayExternalRuntimeBootstrapConfig
+    )
 
     def __post_init__(self) -> None:
         """Normalize nested config values into copy-isolated profile data."""
@@ -79,7 +118,17 @@ class GatewayProfileBootstrapConfig:
         elif not isinstance(store, GatewayProfileStoreConfig):
             raise TypeError("store must be a GatewayProfileStoreConfig or mapping")
 
+        external_runtime = self.external_runtime
+        if isinstance(external_runtime, Mapping):
+            external_runtime = GatewayExternalRuntimeBootstrapConfig(**external_runtime)
+        elif not isinstance(external_runtime, GatewayExternalRuntimeBootstrapConfig):
+            raise TypeError(
+                "external_runtime must be a "
+                "GatewayExternalRuntimeBootstrapConfig or mapping"
+            )
+
         object.__setattr__(self, "store", store)
+        object.__setattr__(self, "external_runtime", external_runtime)
         object.__setattr__(
             self,
             "profiles",
@@ -113,6 +162,12 @@ class ExternalRegistryStorageConfigurationError(ValueError):
     reason_code = "external_registry_store_unavailable"
 
 
+class ExternalRuntimeConfigurationError(ValueError):
+    """Raised when configured storage cannot support external runtime management."""
+
+    reason_code = "external_runtime_store_unavailable"
+
+
 async def bootstrap_profile_gateway_from_config(
     backend: GatewayRuntime,
     config: GatewayProfileBootstrapConfig | Mapping[str, Any] | None = None,
@@ -120,6 +175,14 @@ async def bootstrap_profile_gateway_from_config(
     profile_store: ProfileStore | None = None,
     assignment_store: ProfileAssignmentStore | None = None,
     audit_store: AuditStore | None = None,
+    external_runtime_manager: GatewayExternalRuntimeManager | None = None,
+    external_transport_factory: Callable[
+        [ExternalServerDefinition],
+        ExternalFederationTransport,
+    ]
+    | None = None,
+    credential_broker: ExternalCredentialBroker | Callable[..., Any] | None = None,
+    external_installer: ExternalServerInstaller | None = None,
 ) -> GatewayProfileBootstrap:
     """Build a profile-aware gateway runtime from explicit gateway config."""
 
@@ -131,6 +194,7 @@ async def bootstrap_profile_gateway_from_config(
         audit_store=audit_store,
     )
     external_registry_manager: GatewayExternalRegistryManager | None = None
+    external_storage: GatewayExternalRegistryStorageBundle | None = None
     if _supports_external_registry_store(storage.profile_store):
         external_storage = build_gateway_external_registry_storage(
             resolved_config.store,
@@ -139,6 +203,23 @@ async def bootstrap_profile_gateway_from_config(
         )
         external_registry_manager = external_registry_manager_from_storage(
             external_storage,
+        )
+
+    resolved_external_runtime_manager = external_runtime_manager
+    if (
+        resolved_external_runtime_manager is None
+        and resolved_config.external_runtime.enabled
+    ):
+        if external_storage is None:
+            raise ExternalRuntimeConfigurationError(
+                "external runtime management requires sqlite or an injected "
+                "external registry-capable profile store"
+            )
+        resolved_external_runtime_manager = external_runtime_manager_from_storage(
+            external_storage,
+            transport_factory=external_transport_factory,
+            credential_broker=credential_broker,
+            installer=external_installer,
         )
 
     return await bootstrap_profile_gateway(
@@ -151,6 +232,7 @@ async def bootstrap_profile_gateway_from_config(
         default_profile_id=resolved_config.default_profile_id,
         default_preset_id=resolved_config.default_preset_id,
         external_registry_manager=external_registry_manager,
+        external_runtime_manager=resolved_external_runtime_manager,
     )
 
 
@@ -275,6 +357,32 @@ def external_registry_manager_from_storage(
         credential_grant_store=bundle.credential_grant_store,
         audit_store=bundle.audit_store,
         store_metadata=bundle.metadata,
+    )
+
+
+def external_runtime_manager_from_storage(
+    bundle: GatewayExternalRegistryStorageBundle,
+    *,
+    transport_factory: Callable[
+        [ExternalServerDefinition],
+        ExternalFederationTransport,
+    ]
+    | None = None,
+    credential_broker: ExternalCredentialBroker | Callable[..., Any] | None = None,
+    installer: ExternalServerInstaller | None = None,
+) -> GatewayExternalRuntimeManager:
+    """Build an external runtime manager from resolved storage dependencies."""
+
+    from mcp_unified.federation import create_external_transport
+
+    from .external_runtime import GatewayExternalRuntimeManager
+
+    return GatewayExternalRuntimeManager(
+        external_registry_store=bundle.external_registry_store,
+        transport_factory=transport_factory or create_external_transport,
+        audit_store=bundle.audit_store,
+        credential_broker=credential_broker,
+        installer=installer,
     )
 
 
@@ -516,6 +624,8 @@ def _copy_profile(profile: MCPProfile | Mapping[str, Any]) -> MCPProfile:
 
 __all__ = [
     "GatewayConfigFormat",
+    "GatewayExternalRuntimeBootstrapConfig",
+    "GatewayExternalRuntimeFactoryKind",
     "GatewayExternalRegistryStorageBundle",
     "GatewayProfileBootstrapConfig",
     "GatewayProfileStoreConfig",
@@ -525,5 +635,6 @@ __all__ = [
     "build_gateway_external_registry_storage",
     "build_gateway_profile_storage",
     "external_registry_manager_from_storage",
+    "external_runtime_manager_from_storage",
     "load_gateway_profile_bootstrap_config",
 ]

--- a/mcp_unified/gateway/external_runtime.py
+++ b/mcp_unified/gateway/external_runtime.py
@@ -549,14 +549,16 @@ class GatewayExternalRuntimeManager:
         self,
         server: ExternalServerDefinition,
     ) -> tuple[ExternalFederationTransport, list[ExternalToolDefinition]]:
-        transport = self._transport_factory(server.model_copy(deep=True))
+        transport: ExternalFederationTransport | None = None
         try:
+            transport = self._transport_factory(server.model_copy(deep=True))
             await transport.connect()
             tools = await transport.list_tools()
         except Exception as exc:  # noqa: BLE001 - transport adapters define their own errors.
             async with self._lock:
                 self._last_errors[server.id] = self._exception_summary(exc)
-            await self._close_best_effort(transport)
+            if transport is not None:
+                await self._close_best_effort(transport)
             await self._audit_best_effort(
                 "external_server.lifecycle",
                 payload={

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_cli_package.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_cli_package.py
@@ -7,6 +7,7 @@ import io
 import json
 from datetime import datetime, timezone
 from pathlib import Path
+from typing import Any
 
 import pytest
 from mcp_unified.gateway import cli as gateway_cli
@@ -55,6 +56,10 @@ def test_gateway_cli_validate_config_reports_success_json(
     assert payload == {
         "default_preset_id": "project-researcher",
         "default_profile_id": None,
+        "external_runtime": {
+            "enabled": False,
+            "transport_factory": "stdio",
+        },
         "ok": True,
         "path": str(config_path),
         "profiles": 0,

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py
@@ -2244,6 +2244,7 @@ def test_gateway_config_sqlite_bootstrap_exposes_external_registry_manager(
         response = client.get("/mcp/external-servers")
 
     assert bootstrap.external_registry_manager is not None
+    assert bootstrap.external_runtime_manager is None
     assert bootstrap.external_registry_manager.external_registry_store is bootstrap.profile_store
     assert bootstrap.external_registry_manager.credential_grant_store is bootstrap.profile_store
     assert response.status_code == 200
@@ -2253,6 +2254,215 @@ def test_gateway_config_sqlite_bootstrap_exposes_external_registry_manager(
         "store": {"kind": "sqlite", "persistent": True},
     }
     asyncio.run(bootstrap.profile_store.aclose())
+
+
+def test_gateway_config_bootstrap_builds_stdio_external_runtime_manager(
+    tmp_path: Path,
+) -> None:
+    """Opt-in runtime config should wire the package stdio transport factory."""
+
+    from mcp_unified.federation import create_external_transport
+    from mcp_unified.gateway.config import (
+        GatewayExternalRuntimeBootstrapConfig,
+        GatewayProfileBootstrapConfig,
+        GatewayProfileStoreConfig,
+        bootstrap_profile_gateway_from_config,
+    )
+    from mcp_unified.gateway.external_runtime import GatewayExternalRuntimeManager
+
+    sqlite_path = tmp_path / "gateway.db"
+    bootstrap = asyncio.run(
+        bootstrap_profile_gateway_from_config(
+            _MultiToolGatewayRuntime(),
+            GatewayProfileBootstrapConfig(
+                store=GatewayProfileStoreConfig(kind="sqlite", sqlite_path=sqlite_path),
+                external_runtime=GatewayExternalRuntimeBootstrapConfig(enabled=True),
+            ),
+        )
+    )
+
+    try:
+        manager = bootstrap.external_runtime_manager
+
+        assert isinstance(manager, GatewayExternalRuntimeManager)
+        assert manager._transport_factory is create_external_transport
+        assert bootstrap.external_registry_manager is not None
+        assert bootstrap.external_registry_manager.external_registry_store is bootstrap.profile_store
+    finally:
+        asyncio.run(bootstrap.profile_store.aclose())
+
+
+def test_gateway_config_bootstrap_default_factory_rejects_unsupported_transport(
+    tmp_path: Path,
+) -> None:
+    """Unsupported server transports should fail at runtime start, not bootstrap."""
+
+    from mcp_unified.gateway.config import (
+        GatewayExternalRuntimeBootstrapConfig,
+        GatewayProfileBootstrapConfig,
+        GatewayProfileStoreConfig,
+        bootstrap_profile_gateway_from_config,
+    )
+    from mcp_unified.storage.models import ExternalServerDefinition
+
+    sqlite_path = tmp_path / "gateway.db"
+    bootstrap = asyncio.run(
+        bootstrap_profile_gateway_from_config(
+            _MultiToolGatewayRuntime(),
+            GatewayProfileBootstrapConfig(
+                store=GatewayProfileStoreConfig(kind="sqlite", sqlite_path=sqlite_path),
+                external_runtime=GatewayExternalRuntimeBootstrapConfig(enabled=True),
+            ),
+        )
+    )
+
+    try:
+        manager = bootstrap.external_runtime_manager
+        assert manager is not None
+        asyncio.run(
+            bootstrap.profile_store.create_server(
+                ExternalServerDefinition(
+                    id="remote-docs",
+                    name="Remote Docs",
+                    transport="websocket",
+                    url="wss://example.invalid/mcp",
+                )
+            )
+        )
+
+        with pytest.raises(GatewayExternalRuntimeError) as exc_info:
+            asyncio.run(manager.start_server("remote-docs"))
+
+        assert exc_info.value.reason_code == "external_server_start_failed"
+    finally:
+        asyncio.run(bootstrap.profile_store.aclose())
+
+
+def test_gateway_config_bootstrap_external_runtime_uses_injected_transport_factory(
+    tmp_path: Path,
+) -> None:
+    """Caller-injected transport factories should override the package default."""
+
+    from mcp_unified.federation.models import ExternalToolDefinition
+    from mcp_unified.gateway.config import (
+        GatewayExternalRuntimeBootstrapConfig,
+        GatewayProfileBootstrapConfig,
+        GatewayProfileStoreConfig,
+        bootstrap_profile_gateway_from_config,
+    )
+    from mcp_unified.storage.models import ExternalServerDefinition
+
+    class RecordingTransport:
+        transport_name = "recording"
+
+        def __init__(self, server_id: str) -> None:
+            self.server_id = server_id
+            self.connected = False
+            self.close_count = 0
+
+        async def connect(self) -> None:
+            self.connected = True
+
+        async def close(self) -> None:
+            self.close_count += 1
+            self.connected = False
+
+        async def health_check(self) -> dict[str, bool]:
+            return {
+                "configured": True,
+                "connected": self.connected,
+                "initialized": self.connected,
+            }
+
+        async def list_tools(self) -> list[ExternalToolDefinition]:
+            return [ExternalToolDefinition(name="search", description="Search")]
+
+        async def call_tool(
+            self,
+            tool_name: str,
+            arguments: dict[str, Any],
+            *,
+            context: Any = None,
+            runtime_auth: Any = None,
+        ) -> dict[str, Any]:
+            del tool_name, arguments, context, runtime_auth
+            return {"content": []}
+
+    transports: list[RecordingTransport] = []
+
+    def factory(server: ExternalServerDefinition) -> RecordingTransport:
+        transport = RecordingTransport(server.id)
+        transports.append(transport)
+        return transport
+
+    sqlite_path = tmp_path / "gateway.db"
+    bootstrap = asyncio.run(
+        bootstrap_profile_gateway_from_config(
+            _MultiToolGatewayRuntime(),
+            GatewayProfileBootstrapConfig(
+                store=GatewayProfileStoreConfig(kind="sqlite", sqlite_path=sqlite_path),
+                external_runtime=GatewayExternalRuntimeBootstrapConfig(enabled=True),
+            ),
+            external_transport_factory=factory,
+        )
+    )
+
+    try:
+        manager = bootstrap.external_runtime_manager
+        assert manager is not None
+        asyncio.run(
+            bootstrap.profile_store.create_server(
+                ExternalServerDefinition(
+                    id="research",
+                    name="Research",
+                    transport="stdio",
+                    command=["fake-mcp-server"],
+                )
+            )
+        )
+
+        payload = asyncio.run(manager.start_server("research"))
+        stop_payload = asyncio.run(manager.stop_server("research"))
+
+        assert payload["ok"] is True
+        assert payload["tool_count"] == 1
+        assert stop_payload["reason_code"] == "external_server_stopped"
+        assert [transport.server_id for transport in transports] == ["research"]
+        assert transports[0].close_count == 1
+    finally:
+        asyncio.run(bootstrap.profile_store.aclose())
+
+
+def test_gateway_config_bootstrap_rejects_unsupported_external_runtime_factory() -> None:
+    """Reject unsupported transport factory selectors instead of silently degrading."""
+
+    from mcp_unified.gateway.config import GatewayExternalRuntimeBootstrapConfig
+
+    with pytest.raises(ValueError, match="Unsupported gateway external runtime factory"):
+        GatewayExternalRuntimeBootstrapConfig(
+            enabled=True,
+            transport_factory="websocket",  # type: ignore[arg-type]
+        )
+
+
+def test_gateway_config_bootstrap_rejects_external_runtime_without_registry_store() -> None:
+    """Runtime management requires an external registry-capable store."""
+
+    from mcp_unified.gateway.config import (
+        GatewayExternalRuntimeBootstrapConfig,
+        GatewayProfileBootstrapConfig,
+        bootstrap_profile_gateway_from_config,
+    )
+
+    with pytest.raises(ValueError, match="external runtime management requires"):
+        asyncio.run(
+            bootstrap_profile_gateway_from_config(
+                _MultiToolGatewayRuntime(),
+                GatewayProfileBootstrapConfig(
+                    external_runtime=GatewayExternalRuntimeBootstrapConfig(enabled=True),
+                ),
+            )
+        )
 
 
 def test_gateway_config_bootstrap_preserves_injected_profile_store(tmp_path: Path) -> None:

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py
@@ -123,10 +123,15 @@ def test_host_external_manager_reexports_package_virtual_tool_contract() -> None
 def test_gateway_external_runtime_exports_are_package_owned() -> None:
     """Gateway runtime exports must resolve without host package imports."""
     package_gateway = importlib.import_module("mcp_unified.gateway")
+    package_config = importlib.import_module("mcp_unified.gateway.config")
     package_runtime = importlib.import_module("mcp_unified.gateway.external_runtime")
 
     assert package_gateway.GatewayExternalRuntimeManager is package_runtime.GatewayExternalRuntimeManager
     assert package_gateway.GatewayExternalRuntimeError is package_runtime.GatewayExternalRuntimeError
+    assert (
+        package_gateway.GatewayExternalRuntimeBootstrapConfig
+        is package_config.GatewayExternalRuntimeBootstrapConfig
+    )
 
 
 def test_federation_installer_contracts_are_public_exports() -> None:


### PR DESCRIPTION
## Summary

- Add an opt-in `GatewayExternalRuntimeBootstrapConfig` for standalone gateway profile bootstrap.
- Build `GatewayExternalRuntimeManager` from resolved external registry storage when `external_runtime.enabled` is true, using the package `create_external_transport` stdio factory by default.
- Preserve injection overrides for full runtime managers, transport factories, credential brokers, and installers.
- Wrap transport factory creation failures in the runtime manager's existing `external_server_start_failed` path so unsupported persisted transports fail through the runtime contract.
- Add design, implementation plan, Backlog tracking, and regression coverage for default-disabled behavior, stdio factory wiring, injected factory override, unsupported config, unsupported server transport, CLI safe-default reporting, and package-boundary exports.

## Verification

- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py tldw_Server_API/app/core/MCP_unified/tests/test_gateway_cli_package.py tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py tldw_Server_API/app/core/MCP_unified/tests/test_gateway_external_runtime.py -q` -> 221 passed, 4 warnings
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m ruff check mcp_unified/gateway/config.py mcp_unified/gateway/__init__.py mcp_unified/gateway/cli.py mcp_unified/gateway/external_runtime.py tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py tldw_Server_API/app/core/MCP_unified/tests/test_gateway_cli_package.py tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py` -> All checks passed
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r mcp_unified/gateway/config.py mcp_unified/gateway/__init__.py mcp_unified/gateway/cli.py mcp_unified/gateway/external_runtime.py -f json -o /tmp/bandit_task583.json` -> zero findings
- `git diff --cached --check` -> passed before commit

## Maintainer Change Summary

Required before merge per `Docs/superpowers/AI_GENERATED_PR_CHANGE_SUMMARY_POLICY_2026_04_17.md`: a human maintainer should replace this section with their own explanation of what changed and why these implementation choices were made.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds opt‑in external runtime bootstrap for standalone gateway profiles, wiring the package stdio transport (`mcp_unified.federation.create_external_transport`) so stored MCP servers can be managed without manual injection. Defaults stay off; configs without external registry support and unsupported transports return clear errors.

- **New Features**
  - Added `GatewayExternalRuntimeBootstrapConfig` under `GatewayProfileBootstrapConfig` (`enabled`, `transport_factory="stdio"` with validation).
  - Bootstrap builds `GatewayExternalRuntimeManager` via `external_runtime_manager_from_storage` only when enabled and storage supports external registry; injected manager/factory/credential broker/installer still override.
  - Exported new config in `mcp_unified.gateway`; CLI config validation now reports the `external_runtime` block.

- **Bug Fixes**
  - Hardened runtime start to handle transport factory failures safely, closing only when a transport was created and surfacing `external_server_start_failed`.

<sup>Written for commit 75842fca2eef9cb3091b3c9d1c81347285589953. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2205?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

