### PR TITLE
Add MCP external runtime lifecycle

### DIFF
--- a/Docs/superpowers/plans/2026-06-01-mcp-external-runtime-lifecycle-plan.md
+++ b/Docs/superpowers/plans/2026-06-01-mcp-external-runtime-lifecycle-plan.md
@@ -1,0 +1,64 @@
+# MCP External Runtime Lifecycle Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add safe-default startup and shutdown lifecycle handling for standalone gateway external runtimes.
+
+**Architecture:** Introduce a small lifecycle config shared by config bootstrap and FastAPI app creation. FastAPI lifespan delegates startup to `GatewayExternalRuntimeManager.reconcile()` and shutdown to a new `GatewayExternalRuntimeManager.stop_all()` helper only when explicitly enabled.
+
+**Tech Stack:** Python dataclasses, FastAPI lifespan, async gateway runtime manager, pytest.
+
+---
+
+### Task 1: Lifecycle Config And App Tests
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py`
+
+- [x] Add a failing test proving default app creation does not call external runtime lifecycle hooks.
+- [x] Add a failing test proving opt-in startup reconciliation calls `reconcile()` and records `app.state.external_runtime_startup`.
+- [x] Add a failing test proving startup reconcile failure payloads do not block `/status`.
+- [x] Add a failing test proving opt-in shutdown calls `stop_all()` and records `app.state.external_runtime_shutdown`.
+- [x] Add a failing test proving config bootstrap lifecycle settings flow into `create_gateway_app()`.
+- [x] Run the focused tests and confirm they fail for missing lifecycle wiring.
+
+### Task 2: Runtime Shutdown Helper
+
+**Files:**
+- Modify: `mcp_unified/gateway/external_runtime.py`
+- Modify: `tldw_Server_API/app/core/MCP_unified/tests/test_gateway_external_runtime.py`
+
+- [x] Add a failing runtime-manager test for `stop_all()` stopping active servers.
+- [x] Implement `GatewayExternalRuntimeManager.stop_all()` using an active-id snapshot under the runtime lock.
+- [x] Return a deterministic operation payload with `reason_code="external_runtime_stopped"`, counts, and per-server errors.
+- [x] Run the runtime-manager test and confirm it passes.
+
+### Task 3: Config And FastAPI Wiring
+
+**Files:**
+- Create: `mcp_unified/gateway/lifecycle.py`
+- Modify: `mcp_unified/gateway/bootstrap.py`
+- Modify: `mcp_unified/gateway/config.py`
+- Modify: `mcp_unified/gateway/fastapi.py`
+- Modify: `mcp_unified/gateway/__init__.py`
+- Modify: `mcp_unified/gateway/cli.py`
+
+- [x] Add `GatewayExternalRuntimeLifecycleConfig` with boolean validation.
+- [x] Carry lifecycle config through `GatewayProfileBootstrap`.
+- [x] Extend `GatewayExternalRuntimeBootstrapConfig` with `reconcile_on_startup` and `stop_on_shutdown`.
+- [x] Resolve explicit app lifecycle config before bootstrap-carried config.
+- [x] Add a FastAPI lifespan hook that performs opt-in startup reconcile and shutdown stop.
+- [x] Update CLI validated-config payloads for the new safe-default fields.
+- [x] Run the focused FastAPI/config tests and confirm they pass.
+
+### Task 4: Validation And PR
+
+**Files:**
+- Update: `backlog/tasks/task-584 - Wire-MCP-external-runtime-startup-and-shutdown-lifecycle.md`
+
+- [x] Run focused pytest for gateway FastAPI/config/runtime tests.
+- [x] Run Ruff on touched Python files.
+- [x] Run Bandit on touched Python source.
+- [x] Run `git diff --check`.
+- [x] Update Backlog task notes and verification.
+- [x] Commit, push, and open the PR.

--- a/Docs/superpowers/specs/2026-06-01-mcp-external-runtime-lifecycle-design.md
+++ b/Docs/superpowers/specs/2026-06-01-mcp-external-runtime-lifecycle-design.md
@@ -1,0 +1,50 @@
+# MCP External Runtime Lifecycle Design
+
+## Context
+
+The standalone gateway can now build a `GatewayExternalRuntimeManager` from config and can start, stop, refresh, reconcile, install, and update external server runtimes through explicit API calls. The remaining integration gap is app lifecycle behavior: configured `auto_start` servers are not reconciled when a gateway starts, and active transports are not stopped when the app shuts down.
+
+## Goals
+
+- Keep existing safe defaults: creating a gateway app must not start external servers unless lifecycle startup is explicitly enabled.
+- Add opt-in startup reconciliation that delegates to `GatewayExternalRuntimeManager.reconcile()`, preserving its existing `auto_start=True` semantics and per-server error isolation.
+- Add opt-in shutdown cleanup that stops active external transports cleanly.
+- Make config bootstrap able to carry lifecycle preferences through `GatewayProfileBootstrap` so config-driven standalone callers do not need ad hoc app wiring.
+- Keep errors observable without blocking app startup or shutdown for expected runtime failures.
+
+## Non-Goals
+
+- Adding background retry loops or periodic reconciliation.
+- Starting servers whose stored definitions have `auto_start=False`.
+- Adding websocket upstream transport support.
+- Changing external registry or runtime route contracts.
+
+## Design
+
+Add a small package-owned lifecycle config:
+
+- `GatewayExternalRuntimeLifecycleConfig(reconcile_on_startup=False, stop_on_shutdown=False)`
+
+Extend `GatewayExternalRuntimeBootstrapConfig` with the same two booleans. The config default remains fully inert. When config bootstrap returns a `GatewayProfileBootstrap`, it carries a `GatewayExternalRuntimeLifecycleConfig` alongside the optional runtime manager. `create_gateway_app()` can also accept an explicit lifecycle config, which takes precedence over the bootstrap-carried config.
+
+Startup behavior:
+
+- If no runtime manager is resolved, lifecycle flags are ignored unless explicitly enabled, in which case app creation raises a deterministic `ValueError`.
+- If `reconcile_on_startup=True`, the FastAPI lifespan calls `manager.reconcile()` on startup and stores the payload on `app.state.external_runtime_startup`.
+- `reconcile()` already starts only enabled servers with `auto_start=True` and records per-server failures in `errors`, so app startup should not fail for individual upstream process failures.
+- Unexpected lifecycle exceptions are caught and stored in a compact error payload without logging secrets.
+
+Shutdown behavior:
+
+- Add `GatewayExternalRuntimeManager.stop_all()` to snapshot active server ids, call `stop_server()` for each active server, and return a deterministic summary with `errors` by server id.
+- If `stop_on_shutdown=True`, the FastAPI lifespan calls `manager.stop_all()` and stores the payload on `app.state.external_runtime_shutdown`.
+- Transport close failures remain best-effort through the existing `stop_server()` cleanup path.
+
+## Testing
+
+- FastAPI app defaults do not call `reconcile()` or `stop_all()`.
+- Opt-in startup lifecycle calls `reconcile()` and records the startup payload.
+- Startup lifecycle with a failed reconcile payload still serves requests.
+- Opt-in shutdown lifecycle calls `stop_all()` and records the shutdown payload.
+- Config bootstrap carries lifecycle preferences from config to app creation.
+- Runtime manager `stop_all()` stops active transports and clears runtime state.

--- a/backlog/tasks/task-584 - Wire-MCP-external-runtime-startup-and-shutdown-lifecycle.md
+++ b/backlog/tasks/task-584 - Wire-MCP-external-runtime-startup-and-shutdown-lifecycle.md
@@ -1,0 +1,73 @@
+---
+id: TASK-584
+title: Wire MCP external runtime startup and shutdown lifecycle
+status: Done
+labels:
+- mcp-unified
+- gateway
+- external-servers
+- runtime
+- lifecycle
+documentation:
+- Docs/superpowers/specs/2026-06-01-mcp-external-runtime-lifecycle-design.md
+- Docs/superpowers/plans/2026-06-01-mcp-external-runtime-lifecycle-plan.md
+modified_files:
+- Docs/superpowers/specs/2026-06-01-mcp-external-runtime-lifecycle-design.md
+- Docs/superpowers/plans/2026-06-01-mcp-external-runtime-lifecycle-plan.md
+- mcp_unified/gateway/lifecycle.py
+- mcp_unified/gateway/bootstrap.py
+- mcp_unified/gateway/config.py
+- mcp_unified/gateway/fastapi.py
+- mcp_unified/gateway/external_runtime.py
+- mcp_unified/gateway/cli.py
+- mcp_unified/gateway/__init__.py
+- tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py
+- tldw_Server_API/app/core/MCP_unified/tests/test_gateway_external_runtime.py
+- tldw_Server_API/app/core/MCP_unified/tests/test_gateway_cli_package.py
+- tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py
+references:
+- https://github.com/rmusser01/tldw_server/pull/2206
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Add the next standalone gateway runtime integration slice: opt-in app lifecycle handling for configured external MCP servers so startup can reconcile auto_start-enabled servers and shutdown stops active external transports cleanly without changing safe defaults.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Gateway app/config exposes an explicit safe-default lifecycle option that does not start external servers unless enabled.
+- [x] #2 When lifecycle startup is enabled, configured enabled auto_start external servers are reconciled through GatewayExternalRuntimeManager without blocking app startup on individual server failures.
+- [x] #3 Gateway app shutdown stops active external transports cleanly and reports/records best-effort errors without leaving runtime state inconsistent.
+- [x] #4 Focused tests cover default no-autostart behavior, opt-in startup reconcile behavior, startup failure handling, shutdown stop behavior, and FastAPI lifespan integration.
+- [x] #5 Focused pytest, Ruff, Bandit on touched Python source, and git diff --check pass before PR.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Docs/superpowers/plans/2026-06-01-mcp-external-runtime-lifecycle-plan.md
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Implemented a safe-default external runtime lifecycle config and FastAPI lifespan integration. GatewayExternalRuntimeLifecycleConfig defaults to no startup or shutdown action. GatewayExternalRuntimeBootstrapConfig now carries reconcile_on_startup and stop_on_shutdown through GatewayProfileBootstrap so config-driven apps can opt in without ad hoc wiring. create_gateway_app resolves explicit lifecycle config before bootstrap-carried config, records startup/shutdown payloads on app.state, and avoids raw exception messages in lifecycle error payloads. GatewayExternalRuntimeManager.stop_all() snapshots active transports and stops them with deterministic counts/errors.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Added opt-in startup and shutdown lifecycle handling for standalone gateway external runtimes and addressed PR review findings. Startup reconciliation delegates to GatewayExternalRuntimeManager.reconcile(), shutdown cleanup delegates to stop_all(), and existing defaults remain inert unless lifecycle flags are set. Review fixes: stop_all no longer requires registry store lookups for already-active transports, unexpected stop failures are recorded per server without aborting cleanup of other transports, unexpected stop failures are logged with traceback diagnostics, lifecycle exception catches log contextual reason/error type, and config validation rejects lifecycle flags unless external_runtime.enabled is true. Verification: focused pytest passed (233 tests), Ruff passed on touched Python files, Bandit reported zero findings on touched gateway source, and git diff --check passed. No known blockers.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/mcp_unified/gateway/__init__.py
+++ b/mcp_unified/gateway/__init__.py
@@ -16,6 +16,7 @@ from .config import (
     bootstrap_profile_gateway_from_config,
     load_gateway_profile_bootstrap_config,
 )
+from .lifecycle import GatewayExternalRuntimeLifecycleConfig
 from .profile_runtime import ProfileAwareGatewayRuntime
 from .profiles import (
     GatewayProfileManagementError,
@@ -36,6 +37,7 @@ __all__ = [
     "GatewayPolicyDenied",
     "GatewayConfigFormat",
     "GatewayExternalRuntimeBootstrapConfig",
+    "GatewayExternalRuntimeLifecycleConfig",
     "GatewayExternalRuntimeError",
     "GatewayExternalRuntimeManager",
     "GatewayProfileBootstrap",

--- a/mcp_unified/gateway/bootstrap.py
+++ b/mcp_unified/gateway/bootstrap.py
@@ -6,6 +6,7 @@ from collections.abc import Iterable, Mapping
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
+from mcp_unified.gateway.lifecycle import GatewayExternalRuntimeLifecycleConfig
 from mcp_unified.gateway.profiles import GatewayProfileManager, GatewayProfileStoreMetadata
 from mcp_unified.interfaces.storage import AuditStore, ProfileAssignmentStore, ProfileStore
 from mcp_unified.profiles.models import MCPProfile
@@ -35,6 +36,7 @@ class GatewayProfileBootstrap:
     seeded_profile_ids: tuple[str, ...]
     external_registry_manager: GatewayExternalRegistryManager | None = None
     external_runtime_manager: GatewayExternalRuntimeManager | None = None
+    external_runtime_lifecycle: GatewayExternalRuntimeLifecycleConfig | None = None
 
 
 async def bootstrap_profile_gateway(
@@ -49,6 +51,7 @@ async def bootstrap_profile_gateway(
     default_preset_id: str | None = None,
     external_registry_manager: GatewayExternalRegistryManager | None = None,
     external_runtime_manager: GatewayExternalRuntimeManager | None = None,
+    external_runtime_lifecycle: GatewayExternalRuntimeLifecycleConfig | None = None,
 ) -> GatewayProfileBootstrap:
     """Seed profile data and return a profile-aware gateway runtime."""
 
@@ -109,6 +112,7 @@ async def bootstrap_profile_gateway(
         seeded_profile_ids=seeded_profile_ids,
         external_registry_manager=external_registry_manager,
         external_runtime_manager=external_runtime_manager,
+        external_runtime_lifecycle=external_runtime_lifecycle,
     )
 
 

--- a/mcp_unified/gateway/cli.py
+++ b/mcp_unified/gateway/cli.py
@@ -902,6 +902,8 @@ def _validated_config_payload(
         "default_profile_id": config.default_profile_id,
         "external_runtime": {
             "enabled": config.external_runtime.enabled,
+            "reconcile_on_startup": config.external_runtime.reconcile_on_startup,
+            "stop_on_shutdown": config.external_runtime.stop_on_shutdown,
             "transport_factory": config.external_runtime.transport_factory,
         },
         "ok": True,

--- a/mcp_unified/gateway/config.py
+++ b/mcp_unified/gateway/config.py
@@ -24,6 +24,7 @@ from mcp_unified.profiles.store import (
 
 from .bootstrap import GatewayProfileBootstrap, bootstrap_profile_gateway
 from .external_registry import GatewayExternalRegistryManager, GatewayStoreMetadata
+from .lifecycle import GatewayExternalRuntimeLifecycleConfig
 from .profiles import GatewayProfileStoreMetadata
 from .runtime import GatewayRuntime
 
@@ -75,12 +76,22 @@ class GatewayExternalRuntimeBootstrapConfig:
 
     enabled: bool = False
     transport_factory: GatewayExternalRuntimeFactoryKind = "stdio"
+    reconcile_on_startup: bool = False
+    stop_on_shutdown: bool = False
 
     def __post_init__(self) -> None:
         """Validate and normalize the configured runtime factory selector."""
 
         if not isinstance(self.enabled, bool):
             raise ValueError("external_runtime.enabled must be a boolean")
+        if not isinstance(self.reconcile_on_startup, bool):
+            raise ValueError("external_runtime.reconcile_on_startup must be a boolean")
+        if not isinstance(self.stop_on_shutdown, bool):
+            raise ValueError("external_runtime.stop_on_shutdown must be a boolean")
+        if not self.enabled and (self.reconcile_on_startup or self.stop_on_shutdown):
+            raise ValueError(
+                "external_runtime.enabled must be true when lifecycle hooks are enabled"
+            )
 
         normalized_factory = str(self.transport_factory).strip().lower()
         if normalized_factory != "stdio":
@@ -92,6 +103,14 @@ class GatewayExternalRuntimeBootstrapConfig:
             self,
             "transport_factory",
             cast(GatewayExternalRuntimeFactoryKind, normalized_factory),
+        )
+
+    def lifecycle_config(self) -> GatewayExternalRuntimeLifecycleConfig:
+        """Return lifecycle preferences as the shared app lifecycle config."""
+
+        return GatewayExternalRuntimeLifecycleConfig(
+            reconcile_on_startup=self.reconcile_on_startup,
+            stop_on_shutdown=self.stop_on_shutdown,
         )
 
 
@@ -233,6 +252,7 @@ async def bootstrap_profile_gateway_from_config(
         default_preset_id=resolved_config.default_preset_id,
         external_registry_manager=external_registry_manager,
         external_runtime_manager=resolved_external_runtime_manager,
+        external_runtime_lifecycle=resolved_config.external_runtime.lifecycle_config(),
     )
 
 

--- a/mcp_unified/gateway/external_runtime.py
+++ b/mcp_unified/gateway/external_runtime.py
@@ -10,6 +10,8 @@ from datetime import datetime, timezone
 from typing import Any, Protocol
 from uuid import uuid4
 
+from loguru import logger
+
 from mcp_unified.federation.installers import (
     ExternalServerInstaller,
     NullExternalServerInstaller,
@@ -139,11 +141,10 @@ class GatewayExternalRuntimeManager:
 
     async def stop_server(self, server_id: str) -> dict[str, Any]:
         """Stop one external server and clear its discovered virtual tools."""
-        server = await self._find_server(server_id)
         async with self._lock:
             known_active = server_id in self._transports or server_id in self._servers
             transport = self._pop_runtime_unlocked(server_id)
-        if server is None and not known_active:
+        if not known_active and await self._find_server(server_id) is None:
             raise GatewayExternalRuntimeError(
                 f"External server '{server_id}' was not found",
                 reason_code="external_server_not_found",
@@ -160,6 +161,41 @@ class GatewayExternalRuntimeManager:
             "ok": True,
             "reason_code": "external_server_stopped",
             "server_id": server_id,
+        }
+
+    async def stop_all(self) -> dict[str, Any]:
+        """Stop every active external server transport."""
+        async with self._lock:
+            target_ids = sorted(self._transports)
+
+        stopped = 0
+        errors: dict[str, Any] = {}
+        for target_id in target_ids:
+            try:
+                payload = await self.stop_server(target_id)
+            except GatewayExternalRuntimeError as exc:
+                errors[target_id] = exc.reason_code
+            except Exception as exc:  # noqa: BLE001 - shutdown must remain best-effort.
+                logger.opt(exception=True).error(
+                    "External runtime stop failed server_id={!r} error_type={!r}",
+                    target_id,
+                    type(exc).__name__,
+                )
+                errors[target_id] = {
+                    "reason_code": "external_server_stop_failed",
+                    "error_type": type(exc).__name__,
+                    "error_summary": self._exception_summary(exc),
+                }
+            else:
+                if payload["reason_code"] == "external_server_stopped":
+                    stopped += 1
+
+        return {
+            "ok": not errors,
+            "reason_code": "external_runtime_stopped",
+            "stopped_servers": stopped,
+            "total_servers": len(target_ids),
+            "errors": errors,
         }
 
     async def restart_server(self, server_id: str) -> dict[str, Any]:

--- a/mcp_unified/gateway/fastapi.py
+++ b/mcp_unified/gateway/fastapi.py
@@ -2,11 +2,13 @@
 
 from __future__ import annotations
 
-from collections.abc import Mapping
+from collections.abc import AsyncIterator, Mapping
+from contextlib import asynccontextmanager
 from typing import Any, Literal
 
 from fastapi import APIRouter, FastAPI, Request, Response, WebSocket, WebSocketDisconnect
 from fastapi.responses import JSONResponse
+from loguru import logger
 from pydantic import BaseModel, ConfigDict
 
 from mcp_unified.storage.models import ExternalServerDefinition
@@ -46,6 +48,10 @@ from .jsonrpc import (
 )
 from .jsonrpc import (
     runtime_version as _runtime_version,
+)
+from .lifecycle import (
+    GatewayExternalRuntimeLifecycleConfig,
+    normalize_external_runtime_lifecycle_config,
 )
 from .profiles import GatewayProfileManagementError, GatewayProfileManager
 from .runtime import GatewayRuntime
@@ -472,6 +478,114 @@ def _resolve_external_runtime_manager(
     return resolved
 
 
+def _resolve_external_runtime_lifecycle(
+    *,
+    external_runtime_lifecycle: (
+        GatewayExternalRuntimeLifecycleConfig | Mapping[str, Any] | None
+    ),
+    profile_bootstrap: GatewayProfileBootstrap | None,
+    external_runtime_manager: GatewayExternalRuntimeManager | None,
+) -> GatewayExternalRuntimeLifecycleConfig:
+    """Return resolved external runtime lifecycle behavior for one app."""
+
+    lifecycle = external_runtime_lifecycle
+    if lifecycle is None and profile_bootstrap is not None:
+        lifecycle = getattr(profile_bootstrap, "external_runtime_lifecycle", None)
+    resolved = normalize_external_runtime_lifecycle_config(lifecycle)
+    if resolved.enabled and external_runtime_manager is None:
+        raise ValueError(
+            "external runtime lifecycle requires external_runtime_manager or profile_bootstrap"
+        )
+    return resolved
+
+
+def _external_runtime_lifecycle_error_payload(
+    reason_code: str,
+    exc: BaseException,
+) -> dict[str, Any]:
+    """Return compact lifecycle failure metadata without traceback or secrets."""
+
+    return {
+        "ok": False,
+        "reason_code": reason_code,
+        "error_type": type(exc).__name__,
+        "error": "External runtime lifecycle operation failed",
+    }
+
+
+def _log_external_runtime_lifecycle_error(
+    reason_code: str,
+    exc: BaseException,
+) -> None:
+    """Log lifecycle failure context without exposing raw exception text."""
+
+    logger.opt(exception=True).error(
+        "External runtime lifecycle operation failed reason_code={!r} error_type={!r}",
+        reason_code,
+        type(exc).__name__,
+    )
+
+
+async def _run_external_runtime_startup(
+    manager: GatewayExternalRuntimeManager,
+) -> dict[str, Any]:
+    """Run best-effort external runtime startup reconciliation."""
+
+    try:
+        return await manager.reconcile()
+    except Exception as exc:  # noqa: BLE001 - app startup must report, not crash.
+        _log_external_runtime_lifecycle_error(
+            "external_runtime_startup_failed",
+            exc,
+        )
+        return _external_runtime_lifecycle_error_payload(
+            "external_runtime_startup_failed",
+            exc,
+        )
+
+
+async def _run_external_runtime_shutdown(
+    manager: GatewayExternalRuntimeManager,
+) -> dict[str, Any]:
+    """Run best-effort external runtime shutdown cleanup."""
+
+    try:
+        return await manager.stop_all()
+    except Exception as exc:  # noqa: BLE001 - shutdown cleanup is best-effort.
+        _log_external_runtime_lifecycle_error(
+            "external_runtime_shutdown_failed",
+            exc,
+        )
+        return _external_runtime_lifecycle_error_payload(
+            "external_runtime_shutdown_failed",
+            exc,
+        )
+
+
+def _create_external_runtime_lifespan(
+    *,
+    manager: GatewayExternalRuntimeManager,
+    lifecycle: GatewayExternalRuntimeLifecycleConfig,
+) -> Any:
+    """Create a FastAPI lifespan context for external runtime lifecycle work."""
+
+    @asynccontextmanager
+    async def lifespan(app: FastAPI) -> AsyncIterator[None]:
+        if lifecycle.reconcile_on_startup:
+            app.state.external_runtime_startup = await _run_external_runtime_startup(
+                manager,
+            )
+        try:
+            yield
+        finally:
+            if lifecycle.stop_on_shutdown:
+                app.state.external_runtime_shutdown = await _run_external_runtime_shutdown(
+                    manager,
+                )
+
+    return lifespan
+
+
 def _mount_profile_management_routes(
     router: APIRouter,
     manager: GatewayProfileManager,
@@ -884,10 +998,35 @@ def create_gateway_app(
     enable_external_registry_management: bool = False,
     external_runtime_manager: GatewayExternalRuntimeManager | None = None,
     enable_external_runtime_management: bool = False,
+    external_runtime_lifecycle: (
+        GatewayExternalRuntimeLifecycleConfig | Mapping[str, Any] | None
+    ) = None,
 ) -> FastAPI:
     """Create a minimal FastAPI app exposing the standalone MCP gateway router."""
 
-    app = FastAPI(title="MCP Unified Gateway", version=_runtime_version(runtime))
+    resolved_external_runtime_manager = _resolve_external_runtime_manager(
+        external_runtime_manager=external_runtime_manager,
+        profile_bootstrap=profile_bootstrap,
+        enable_external_runtime_management=enable_external_runtime_management,
+    )
+    resolved_lifecycle = _resolve_external_runtime_lifecycle(
+        external_runtime_lifecycle=external_runtime_lifecycle,
+        profile_bootstrap=profile_bootstrap,
+        external_runtime_manager=resolved_external_runtime_manager,
+    )
+    lifespan = (
+        _create_external_runtime_lifespan(
+            manager=resolved_external_runtime_manager,
+            lifecycle=resolved_lifecycle,
+        )
+        if resolved_external_runtime_manager is not None and resolved_lifecycle.enabled
+        else None
+    )
+    app = FastAPI(
+        title="MCP Unified Gateway",
+        version=_runtime_version(runtime),
+        lifespan=lifespan,
+    )
     app.include_router(
         create_gateway_router(
             runtime,
@@ -896,7 +1035,7 @@ def create_gateway_app(
             enable_profile_management=enable_profile_management,
             external_registry_manager=external_registry_manager,
             enable_external_registry_management=enable_external_registry_management,
-            external_runtime_manager=external_runtime_manager,
+            external_runtime_manager=resolved_external_runtime_manager,
             enable_external_runtime_management=enable_external_runtime_management,
         ),
         prefix=prefix,

--- a/mcp_unified/gateway/lifecycle.py
+++ b/mcp_unified/gateway/lifecycle.py
@@ -1,0 +1,52 @@
+"""Lifecycle configuration for standalone MCP gateway runtime integration."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True, slots=True)
+class GatewayExternalRuntimeLifecycleConfig:
+    """Opt-in startup and shutdown behavior for external runtime managers."""
+
+    reconcile_on_startup: bool = False
+    stop_on_shutdown: bool = False
+
+    def __post_init__(self) -> None:
+        """Validate lifecycle toggles as explicit booleans."""
+
+        if not isinstance(self.reconcile_on_startup, bool):
+            raise ValueError("external runtime reconcile_on_startup must be a boolean")
+        if not isinstance(self.stop_on_shutdown, bool):
+            raise ValueError("external runtime stop_on_shutdown must be a boolean")
+
+    @property
+    def enabled(self) -> bool:
+        """Return whether any lifecycle behavior is enabled."""
+
+        return self.reconcile_on_startup or self.stop_on_shutdown
+
+
+def normalize_external_runtime_lifecycle_config(
+    config: GatewayExternalRuntimeLifecycleConfig | Mapping[str, Any] | None,
+) -> GatewayExternalRuntimeLifecycleConfig:
+    """Return a validated external runtime lifecycle config."""
+
+    if config is None:
+        return GatewayExternalRuntimeLifecycleConfig()
+    if isinstance(config, GatewayExternalRuntimeLifecycleConfig):
+        return config
+    if isinstance(config, Mapping):
+        return GatewayExternalRuntimeLifecycleConfig(**config)
+    raise TypeError(
+        "external_runtime_lifecycle must be a "
+        "GatewayExternalRuntimeLifecycleConfig, mapping, or None"
+    )
+
+
+__all__ = [
+    "GatewayExternalRuntimeLifecycleConfig",
+    "normalize_external_runtime_lifecycle_config",
+]

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_cli_package.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_cli_package.py
@@ -58,6 +58,8 @@ def test_gateway_cli_validate_config_reports_success_json(
         "default_profile_id": None,
         "external_runtime": {
             "enabled": False,
+            "reconcile_on_startup": False,
+            "stop_on_shutdown": False,
             "transport_factory": "stdio",
         },
         "ok": True,

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_external_runtime.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_external_runtime.py
@@ -4,6 +4,7 @@ import asyncio
 import json
 from typing import Any
 
+import mcp_unified.gateway.external_runtime as gateway_external_runtime
 import pytest
 from mcp_unified.federation.installers import ExternalServerInstaller
 from mcp_unified.federation.models import (
@@ -16,6 +17,7 @@ from mcp_unified.gateway.external_runtime import (
     GatewayExternalRuntimeError,
     GatewayExternalRuntimeManager,
 )
+from mcp_unified.interfaces.storage import ExternalRegistryStoreUnavailableError
 from mcp_unified.storage.models import AuditEvent, ExternalServerDefinition
 
 
@@ -63,6 +65,20 @@ class InMemoryExternalRegistryStore:
             server.model_copy(deep=True)
             for server in sorted(rows, key=lambda item: item.id)
         ]
+
+
+class ToggleOutageExternalRegistryStore(InMemoryExternalRegistryStore):
+    """Registry store fake that can fail get_server calls after startup."""
+
+    def __init__(self, servers: list[ExternalServerDefinition] | None = None) -> None:
+        super().__init__(servers)
+        self.fail_get_server = False
+
+    async def get_server(self, server_id: str) -> ExternalServerDefinition | None:
+        """Return one server definition or simulate store unavailability."""
+        if self.fail_get_server:
+            raise ExternalRegistryStoreUnavailableError("registry unavailable")
+        return await super().get_server(server_id)
 
 
 class RecordingAuditStore:
@@ -165,6 +181,21 @@ class RecordingExternalTransport:
         self.calls.append((tool_name, dict(arguments or {})))
         self.runtime_auth_seen = None if runtime_auth is None else runtime_auth.copy()
         return self.result.copy()
+
+
+class FakeLogger:
+    """Logger fake that records structured exception log calls."""
+
+    def __init__(self) -> None:
+        self.opt_calls: list[dict[str, Any]] = []
+        self.error_calls: list[tuple[str, tuple[Any, ...]]] = []
+
+    def opt(self, **kwargs: Any) -> FakeLogger:
+        self.opt_calls.append(kwargs)
+        return self
+
+    def error(self, message: str, *args: Any) -> None:
+        self.error_calls.append((message, args))
 
 
 class BlockingConnectTransport(RecordingExternalTransport):
@@ -363,6 +394,145 @@ async def test_external_runtime_stop_is_idempotent_and_clears_tools() -> None:
     assert rows["servers"][0]["status"] == "stopped"
     assert rows["servers"][0]["tool_count"] == 0
     assert transport.close_count == 1
+
+
+@pytest.mark.asyncio
+async def test_external_runtime_stop_all_stops_active_transports_and_clears_tools() -> None:
+    store = InMemoryExternalRegistryStore(
+        [
+            _server(),
+            _server(id="docs", name="Docs", command=["fake-docs-mcp"]),
+        ]
+    )
+    transports = {
+        "research": RecordingExternalTransport(
+            server_id="research",
+            tools=[ExternalToolDefinition(name="search")],
+        ),
+        "docs": RecordingExternalTransport(
+            server_id="docs",
+            tools=[ExternalToolDefinition(name="lookup")],
+        ),
+    }
+    manager = GatewayExternalRuntimeManager(
+        external_registry_store=store,
+        transport_factory=lambda server: transports[server.id],
+    )
+    await manager.start_server("research")
+    await manager.start_server("docs")
+
+    payload = await manager.stop_all()
+    rows = await manager.list_runtime_servers()
+    tools = await manager.list_virtual_tools()
+
+    assert payload == {
+        "ok": True,
+        "reason_code": "external_runtime_stopped",
+        "stopped_servers": 2,
+        "total_servers": 2,
+        "errors": {},
+    }
+    assert {row["id"]: row["status"] for row in rows["servers"]} == {
+        "docs": "stopped",
+        "research": "stopped",
+    }
+    assert tools == []
+    assert transports["research"].close_count == 1
+    assert transports["docs"].close_count == 1
+
+
+@pytest.mark.asyncio
+async def test_external_runtime_stop_all_does_not_require_registry_store_for_active_transports() -> None:
+    store = ToggleOutageExternalRegistryStore(
+        [
+            _server(),
+            _server(id="docs", name="Docs", command=["fake-docs-mcp"]),
+        ]
+    )
+    transports = {
+        "research": RecordingExternalTransport(
+            server_id="research",
+            tools=[ExternalToolDefinition(name="search")],
+        ),
+        "docs": RecordingExternalTransport(
+            server_id="docs",
+            tools=[ExternalToolDefinition(name="lookup")],
+        ),
+    }
+    manager = GatewayExternalRuntimeManager(
+        external_registry_store=store,
+        transport_factory=lambda server: transports[server.id],
+    )
+    await manager.start_server("research")
+    await manager.start_server("docs")
+    store.fail_get_server = True
+
+    payload = await manager.stop_all()
+    tools = await manager.list_virtual_tools()
+
+    assert payload == {
+        "ok": True,
+        "reason_code": "external_runtime_stopped",
+        "stopped_servers": 2,
+        "total_servers": 2,
+        "errors": {},
+    }
+    assert tools == []
+    assert transports["research"].close_count == 1
+    assert transports["docs"].close_count == 1
+
+
+@pytest.mark.asyncio
+async def test_external_runtime_stop_all_continues_after_unexpected_stop_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class ExplodingStopRuntimeManager(GatewayExternalRuntimeManager):
+        async def stop_server(self, server_id: str) -> dict[str, Any]:
+            if server_id == "research":
+                raise RuntimeError("stop failed")
+            return await super().stop_server(server_id)
+
+    fake_logger = FakeLogger()
+    monkeypatch.setattr(gateway_external_runtime, "logger", fake_logger)
+    store = InMemoryExternalRegistryStore(
+        [
+            _server(),
+            _server(id="docs", name="Docs", command=["fake-docs-mcp"]),
+        ]
+    )
+    transports = {
+        "research": RecordingExternalTransport(
+            server_id="research",
+            tools=[ExternalToolDefinition(name="search")],
+        ),
+        "docs": RecordingExternalTransport(
+            server_id="docs",
+            tools=[ExternalToolDefinition(name="lookup")],
+        ),
+    }
+    manager = ExplodingStopRuntimeManager(
+        external_registry_store=store,
+        transport_factory=lambda server: transports[server.id],
+    )
+    await manager.start_server("research")
+    await manager.start_server("docs")
+
+    payload = await manager.stop_all()
+
+    assert payload["ok"] is False
+    assert payload["reason_code"] == "external_runtime_stopped"
+    assert payload["stopped_servers"] == 1
+    assert payload["total_servers"] == 2
+    assert payload["errors"]["research"]["reason_code"] == "external_server_stop_failed"
+    assert payload["errors"]["research"]["error_type"] == "RuntimeError"
+    assert fake_logger.opt_calls == [{"exception": True}]
+    assert fake_logger.error_calls == [
+        (
+            "External runtime stop failed server_id={!r} error_type={!r}",
+            ("research", "RuntimeError"),
+        )
+    ]
+    assert transports["docs"].close_count == 1
 
 
 @pytest.mark.asyncio

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py
@@ -615,6 +615,16 @@ class _ExternalRuntimeManagerDouble:
             "server_id": server_id,
         }
 
+    async def stop_all(self) -> dict[str, Any]:
+        self.calls.append(("stop_all", (), {}))
+        return {
+            "ok": True,
+            "reason_code": "external_runtime_stopped",
+            "stopped_servers": 1,
+            "total_servers": 1,
+            "errors": {},
+        }
+
     async def install_server(
         self,
         server_id: str,
@@ -643,8 +653,14 @@ class _ExternalRuntimeManagerDouble:
 
 
 class _ExternalRuntimeBootstrapDouble:
-    def __init__(self, manager: _ExternalRuntimeManagerDouble) -> None:
+    def __init__(
+        self,
+        manager: _ExternalRuntimeManagerDouble,
+        *,
+        lifecycle: Any = None,
+    ) -> None:
         self.external_runtime_manager = manager
+        self.external_runtime_lifecycle = lifecycle
 
 
 class _ExternalRuntimeErrorManagerDouble(_ExternalRuntimeManagerDouble):
@@ -668,6 +684,28 @@ class _ExternalRuntimeErrorManagerDouble(_ExternalRuntimeManagerDouble):
     async def refresh_server(self, server_id: str | None = None) -> dict[str, Any]:
         await self._raise_if_targeted("refresh_server")
         return await super().refresh_server(server_id)
+
+
+class _ExternalRuntimeReconcileFailureManagerDouble(_ExternalRuntimeManagerDouble):
+    async def reconcile(self, server_id: str | None = None) -> dict[str, Any]:
+        self.calls.append(("reconcile", (server_id,), {}))
+        return {
+            "ok": False,
+            "reason_code": "external_server_reconciled",
+            "server_id": server_id,
+            "started_servers": 0,
+            "stopped_servers": 0,
+            "restarted_servers": 0,
+            "refreshed_servers": 0,
+            "total_servers": 1,
+            "errors": {"research": "external_server_start_failed"},
+        }
+
+
+class _ExternalRuntimeLifecycleExceptionManagerDouble(_ExternalRuntimeManagerDouble):
+    async def reconcile(self, server_id: str | None = None) -> dict[str, Any]:
+        self.calls.append(("reconcile", (server_id,), {}))
+        raise RuntimeError("startup exploded")
 
 
 def test_gateway_package_does_not_import_tldw_server_api() -> None:
@@ -1710,6 +1748,158 @@ def test_gateway_external_runtime_management_enabled_without_manager_raises() ->
         )
 
 
+def test_gateway_external_runtime_lifecycle_is_disabled_by_default() -> None:
+    manager = _ExternalRuntimeManagerDouble()
+    app = create_gateway_app(
+        _FakeGatewayRuntime(),
+        prefix="/mcp",
+        external_runtime_manager=manager,
+    )
+
+    with TestClient(app) as client:
+        response = client.get("/mcp/status")
+
+    assert response.status_code == 200
+    assert manager.calls == []
+    assert not hasattr(app.state, "external_runtime_startup")
+    assert not hasattr(app.state, "external_runtime_shutdown")
+
+
+def test_gateway_external_runtime_lifecycle_reconciles_on_startup() -> None:
+    from mcp_unified.gateway.lifecycle import GatewayExternalRuntimeLifecycleConfig
+
+    manager = _ExternalRuntimeManagerDouble()
+    app = create_gateway_app(
+        _FakeGatewayRuntime(),
+        prefix="/mcp",
+        external_runtime_manager=manager,
+        external_runtime_lifecycle=GatewayExternalRuntimeLifecycleConfig(
+            reconcile_on_startup=True,
+        ),
+    )
+
+    with TestClient(app) as client:
+        response = client.get("/mcp/status")
+
+    assert response.status_code == 200
+    assert manager.calls == [("reconcile", (None,), {})]
+    assert app.state.external_runtime_startup == {
+        "ok": True,
+        "reason_code": "external_server_reconciled",
+        "server_id": None,
+    }
+    assert not hasattr(app.state, "external_runtime_shutdown")
+
+
+def test_gateway_external_runtime_lifecycle_uses_bootstrap_config_on_startup() -> None:
+    from mcp_unified.gateway.lifecycle import GatewayExternalRuntimeLifecycleConfig
+
+    manager = _ExternalRuntimeManagerDouble()
+    bootstrap = _ExternalRuntimeBootstrapDouble(
+        manager,
+        lifecycle=GatewayExternalRuntimeLifecycleConfig(reconcile_on_startup=True),
+    )
+    app = create_gateway_app(
+        _FakeGatewayRuntime(),
+        prefix="/mcp",
+        profile_bootstrap=bootstrap,
+    )
+
+    with TestClient(app) as client:
+        response = client.get("/mcp/status")
+
+    assert response.status_code == 200
+    assert manager.calls == [("reconcile", (None,), {})]
+    assert app.state.external_runtime_startup["reason_code"] == "external_server_reconciled"
+
+
+def test_gateway_external_runtime_lifecycle_startup_failure_payload_does_not_block_status() -> None:
+    from mcp_unified.gateway.lifecycle import GatewayExternalRuntimeLifecycleConfig
+
+    manager = _ExternalRuntimeReconcileFailureManagerDouble()
+    app = create_gateway_app(
+        _FakeGatewayRuntime(),
+        prefix="/mcp",
+        external_runtime_manager=manager,
+        external_runtime_lifecycle=GatewayExternalRuntimeLifecycleConfig(
+            reconcile_on_startup=True,
+        ),
+    )
+
+    with TestClient(app) as client:
+        response = client.get("/mcp/status")
+
+    assert response.status_code == 200
+    assert manager.calls == [("reconcile", (None,), {})]
+    assert app.state.external_runtime_startup["ok"] is False
+    assert app.state.external_runtime_startup["errors"] == {
+        "research": "external_server_start_failed",
+    }
+
+
+def test_gateway_external_runtime_lifecycle_logs_unexpected_startup_exception(
+    monkeypatch: Any,
+) -> None:
+    from mcp_unified.gateway.lifecycle import GatewayExternalRuntimeLifecycleConfig
+
+    manager = _ExternalRuntimeLifecycleExceptionManagerDouble()
+    app = create_gateway_app(
+        _FakeGatewayRuntime(),
+        prefix="/mcp",
+        external_runtime_manager=manager,
+        external_runtime_lifecycle=GatewayExternalRuntimeLifecycleConfig(
+            reconcile_on_startup=True,
+        ),
+    )
+    fake_logger = _FakeLogger()
+    monkeypatch.setattr(gateway_fastapi, "logger", fake_logger, raising=False)
+
+    with TestClient(app) as client:
+        response = client.get("/mcp/status")
+
+    assert response.status_code == 200
+    assert app.state.external_runtime_startup == {
+        "ok": False,
+        "reason_code": "external_runtime_startup_failed",
+        "error_type": "RuntimeError",
+        "error": "External runtime lifecycle operation failed",
+    }
+    assert fake_logger.opt_calls == [{"exception": True}]
+    assert fake_logger.error_calls == [
+        (
+            "External runtime lifecycle operation failed reason_code={!r} error_type={!r}",
+            ("external_runtime_startup_failed", "RuntimeError"),
+        )
+    ]
+
+
+def test_gateway_external_runtime_lifecycle_stops_on_shutdown() -> None:
+    from mcp_unified.gateway.lifecycle import GatewayExternalRuntimeLifecycleConfig
+
+    manager = _ExternalRuntimeManagerDouble()
+    app = create_gateway_app(
+        _FakeGatewayRuntime(),
+        prefix="/mcp",
+        external_runtime_manager=manager,
+        external_runtime_lifecycle=GatewayExternalRuntimeLifecycleConfig(
+            stop_on_shutdown=True,
+        ),
+    )
+
+    with TestClient(app) as client:
+        response = client.get("/mcp/status")
+
+    assert response.status_code == 200
+    assert manager.calls == [("stop_all", (), {})]
+    assert app.state.external_runtime_shutdown == {
+        "ok": True,
+        "reason_code": "external_runtime_stopped",
+        "stopped_servers": 1,
+        "total_servers": 1,
+        "errors": {},
+    }
+
+
 @pytest.mark.parametrize(
     ("reason_code", "status_code"),
     [
@@ -2445,6 +2635,18 @@ def test_gateway_config_bootstrap_rejects_unsupported_external_runtime_factory()
         )
 
 
+@pytest.mark.parametrize("lifecycle_flag", ["reconcile_on_startup", "stop_on_shutdown"])
+def test_gateway_config_bootstrap_rejects_lifecycle_flags_when_external_runtime_disabled(
+    lifecycle_flag: str,
+) -> None:
+    """Lifecycle hooks require the external runtime manager to be enabled."""
+
+    from mcp_unified.gateway.config import GatewayExternalRuntimeBootstrapConfig
+
+    with pytest.raises(ValueError, match="external_runtime.enabled"):
+        GatewayExternalRuntimeBootstrapConfig(**{lifecycle_flag: True})
+
+
 def test_gateway_config_bootstrap_rejects_external_runtime_without_registry_store() -> None:
     """Runtime management requires an external registry-capable store."""
 
@@ -2463,6 +2665,43 @@ def test_gateway_config_bootstrap_rejects_external_runtime_without_registry_stor
                 ),
             )
         )
+
+
+def test_gateway_config_bootstrap_carries_external_runtime_lifecycle(
+    tmp_path: Path,
+) -> None:
+    """Config bootstrap should carry lifecycle preferences into app creation."""
+
+    from mcp_unified.gateway.config import (
+        GatewayExternalRuntimeBootstrapConfig,
+        GatewayProfileBootstrapConfig,
+        GatewayProfileStoreConfig,
+        bootstrap_profile_gateway_from_config,
+    )
+    from mcp_unified.gateway.lifecycle import GatewayExternalRuntimeLifecycleConfig
+
+    sqlite_path = tmp_path / "gateway.db"
+    bootstrap = asyncio.run(
+        bootstrap_profile_gateway_from_config(
+            _MultiToolGatewayRuntime(),
+            GatewayProfileBootstrapConfig(
+                store=GatewayProfileStoreConfig(kind="sqlite", sqlite_path=sqlite_path),
+                external_runtime=GatewayExternalRuntimeBootstrapConfig(
+                    enabled=True,
+                    reconcile_on_startup=True,
+                    stop_on_shutdown=True,
+                ),
+            ),
+        )
+    )
+
+    try:
+        assert bootstrap.external_runtime_lifecycle == GatewayExternalRuntimeLifecycleConfig(
+            reconcile_on_startup=True,
+            stop_on_shutdown=True,
+        )
+    finally:
+        asyncio.run(bootstrap.profile_store.aclose())
 
 
 def test_gateway_config_bootstrap_preserves_injected_profile_store(tmp_path: Path) -> None:

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py
@@ -124,6 +124,7 @@ def test_gateway_external_runtime_exports_are_package_owned() -> None:
     """Gateway runtime exports must resolve without host package imports."""
     package_gateway = importlib.import_module("mcp_unified.gateway")
     package_config = importlib.import_module("mcp_unified.gateway.config")
+    package_lifecycle = importlib.import_module("mcp_unified.gateway.lifecycle")
     package_runtime = importlib.import_module("mcp_unified.gateway.external_runtime")
 
     assert package_gateway.GatewayExternalRuntimeManager is package_runtime.GatewayExternalRuntimeManager
@@ -131,6 +132,10 @@ def test_gateway_external_runtime_exports_are_package_owned() -> None:
     assert (
         package_gateway.GatewayExternalRuntimeBootstrapConfig
         is package_config.GatewayExternalRuntimeBootstrapConfig
+    )
+    assert (
+        package_gateway.GatewayExternalRuntimeLifecycleConfig
+        is package_lifecycle.GatewayExternalRuntimeLifecycleConfig
     )
 
 


### PR DESCRIPTION
## Summary

- Add safe-default external runtime lifecycle config for standalone MCP gateway apps.
- Thread lifecycle options through config/bootstrap/CLI validation output and FastAPI app creation.
- Add opt-in startup reconcile and shutdown stop handling, including best-effort state payloads.
- Add `GatewayExternalRuntimeManager.stop_all()` for deterministic shutdown cleanup.
- Cover default no-autostart, opt-in startup, bootstrap-carried startup config, startup failure handling, shutdown stop, and runtime stop-all behavior.

## Verification

- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py tldw_Server_API/app/core/MCP_unified/tests/test_gateway_cli_package.py tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py tldw_Server_API/app/core/MCP_unified/tests/test_gateway_external_runtime.py -q` -> 228 passed, 4 warnings
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m ruff check mcp_unified/gateway/lifecycle.py mcp_unified/gateway/bootstrap.py mcp_unified/gateway/config.py mcp_unified/gateway/fastapi.py mcp_unified/gateway/external_runtime.py mcp_unified/gateway/cli.py mcp_unified/gateway/__init__.py tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py tldw_Server_API/app/core/MCP_unified/tests/test_gateway_cli_package.py tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py tldw_Server_API/app/core/MCP_unified/tests/test_gateway_external_runtime.py` -> all checks passed
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r mcp_unified/gateway/lifecycle.py mcp_unified/gateway/bootstrap.py mcp_unified/gateway/config.py mcp_unified/gateway/fastapi.py mcp_unified/gateway/external_runtime.py mcp_unified/gateway/cli.py mcp_unified/gateway/__init__.py -f json -o /tmp/bandit_task584.json` -> zero findings
- `git diff --check` and `git diff --cached --check`

## Change summary

Maintainer to complete before merge per `Docs/superpowers/AI_GENERATED_PR_CHANGE_SUMMARY_POLICY_2026_04_17.md`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds opt-in external runtime lifecycle for the standalone MCP gateway. Startup can reconcile auto_start servers; shutdown cleanly stops active transports, with safe defaults that do nothing.

- **New Features**
  - `GatewayExternalRuntimeLifecycleConfig` with `reconcile_on_startup` and `stop_on_shutdown`; resolved from `create_gateway_app(..., external_runtime_lifecycle=...)` or via `GatewayProfileBootstrap` (explicit takes precedence). Mapping input is supported via `normalize_external_runtime_lifecycle_config`; exported in `mcp_unified.gateway`.
  - FastAPI lifespan runs `reconcile()` on startup and `stop_all()` on shutdown; results saved to `app.state.external_runtime_startup` and `app.state.external_runtime_shutdown`.
  - `GatewayExternalRuntimeManager.stop_all()` returns a deterministic summary (`ok`, counts, per-server errors), continues on failures, and does not require the registry for already-active transports.
  - Config and validation updates: `GatewayExternalRuntimeBootstrapConfig` includes lifecycle flags; CLI validated output shows them; validation rejects lifecycle flags unless `external_runtime.enabled` is true; app raises if lifecycle is enabled without a runtime manager.
  - Lifecycle errors are logged with reason codes and captured as compact payloads; they never block app startup or shutdown.

- **Migration**
  - No changes by default. To enable:
    - Pass `external_runtime_lifecycle=GatewayExternalRuntimeLifecycleConfig(...)` to `create_gateway_app()`, or set `reconcile_on_startup`/`stop_on_shutdown` in `GatewayExternalRuntimeBootstrapConfig` (requires `external_runtime.enabled=True`).
    - Provide an external runtime manager via `create_gateway_app(..., external_runtime_manager=...)` or through profile bootstrap when lifecycle is enabled.

<sup>Written for commit 7bbabb7108da6ad65d87c00f19e6f4005549cef6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2206?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

