### PR TITLE
Fix chat rail collapse and sidepanel WebUI handoff

### DIFF
--- a/Docs/superpowers/plans/2026-05-31-chat-siderail-edge-expand-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-05-31-chat-siderail-edge-expand-implementation-plan.md
@@ -1,0 +1,635 @@
+# Chat Siderail Edge Expand Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix `/chat` desktop siderail collapse behavior so collapsed rails release layout width and remain recoverable through same-side edge-mounted expand buttons.
+
+**Architecture:** Keep existing stores as source of truth. At `lg` and wider `/chat` viewports, `OptionLayout` omits the full left `ChatSidebar` when collapsed and renders a left-edge expand button instead. `Playground` omits the right artifact flex child when closed, renders a right-edge expand button only when an active artifact exists, and preserves existing mobile/tablet artifact behavior.
+
+**Tech Stack:** React 18, Zustand stores, Tailwind utility classes, lucide-react icons, Vitest with Testing Library, Playwright.
+
+---
+
+## Source Spec
+
+- `Docs/superpowers/specs/2026-05-31-chat-siderail-collapse-design.md`
+- Backlog task: `TASK-485`
+
+## File Structure
+
+- Modify `apps/packages/ui/src/components/Layouts/Layout.tsx`
+  - Add `/chat` + desktop-only left-edge collapse behavior.
+  - Keep the existing narrow `ChatSidebar` collapsed rail for `md` widths and non-chat routes.
+  - Own focus transfer between the left edge button and the restored left rail.
+- Modify `apps/packages/ui/src/components/Option/Playground/Playground.tsx`
+  - Add desktop-only right-edge artifact expand behavior.
+  - Add a stable chat-shell test id for measurement-based browser checks.
+  - Route artifact focus events to the edge button when the panel was collapsed.
+- Modify `apps/packages/ui/src/components/Sidepanel/Chat/ArtifactsPanel.tsx`
+  - Add an accessible name and test id to the close button so restored focus can target a meaningful control.
+- Modify `apps/packages/ui/src/components/Layouts/__tests__/Layout.chat-sidebar-reset-signal.guard.test.ts`
+  - Extend the source guard to cover `/chat` desktop edge-collapse routing and preserve reset-key behavior.
+- Modify `apps/packages/ui/src/components/Option/Playground/__tests__/Playground.search.integration.test.tsx`
+  - Add right artifact edge-button behavior coverage using existing mocks.
+- Modify `apps/packages/ui/src/components/Option/Playground/__tests__/Playground.sticky-composer-layout.integration.test.tsx`
+  - Assert the chat shell measurement hook exists alongside the sticky composer contract.
+- Create `apps/tldw-frontend/e2e/workflows/chat-rails-collapse.spec.ts`
+  - Verify desktop width and vertical anchoring with browser measurements.
+  - Verify medium/tablet and mobile do not show desktop edge buttons.
+- Modify `backlog/tasks/task-485 - Fix-chat-rails-regression-coverage-and-sidepanel-handoff-target.md`
+  - Record implementation files, verification results, and known skips.
+
+## Task 1: Left Rail Desktop Edge Affordance
+
+**Files:**
+- Modify: `apps/packages/ui/src/components/Layouts/Layout.tsx`
+- Modify: `apps/packages/ui/src/components/Layouts/__tests__/Layout.chat-sidebar-reset-signal.guard.test.ts`
+
+- [ ] **Step 1: Add failing Layout source guard coverage**
+
+Update `Layout.chat-sidebar-reset-signal.guard.test.ts` with a new test that requires these contract markers:
+
+```ts
+it("scopes chat desktop collapsed sidebar to an edge expand affordance", () => {
+  const source = readFileSync(layoutSourcePath, "utf8")
+
+  expect(source).toContain("useDesktop")
+  expect(source).toContain("useChatEdgeCollapse")
+  expect(source).toContain('data-testid="chat-sidebar-edge-expand"')
+  expect(source).toContain("isChatScreen && isDesktop")
+  expect(source).toContain("!useChatEdgeCollapse || !chatSidebarCollapsed")
+})
+```
+
+This is a source guard because `OptionLayout` pulls in global shell, migration, query, sidebar, and header dependencies. The browser test in Task 3 provides behavior-level coverage.
+
+- [ ] **Step 2: Run the failing Layout guard**
+
+Run from `apps/packages/ui`:
+
+```bash
+bunx vitest run src/components/Layouts/__tests__/Layout.chat-sidebar-reset-signal.guard.test.ts
+```
+
+Expected: FAIL because `useDesktop`, `useChatEdgeCollapse`, and `chat-sidebar-edge-expand` do not exist yet.
+
+- [ ] **Step 3: Implement desktop-only left edge collapse routing**
+
+In `Layout.tsx`, import `useDesktop` and a compact lucide icon:
+
+```ts
+import { EraserIcon, PanelLeftOpen, XIcon } from "lucide-react"
+import { useDesktop, useMobile } from "@/hooks/useMediaQuery"
+```
+
+Add refs and route/breakpoint flags near the existing sidebar state:
+
+```ts
+const leftEdgeExpandRef = React.useRef<HTMLButtonElement>(null)
+const isDesktop = useDesktop()
+const useChatEdgeCollapse =
+  isChatScreen && isDesktop && showChatSidebar && !hideHeader && !hideSidebar
+const shouldRenderChatSidebar =
+  showChatSidebar &&
+  !hideHeader &&
+  !hideSidebar &&
+  !isMobile &&
+  (!useChatEdgeCollapse || !chatSidebarCollapsed)
+```
+
+Replace the current persistent sidebar condition with `shouldRenderChatSidebar`.
+
+In the `ChatSidebar` `onToggleCollapse` handler, preserve the existing reset signal and move focus to the left edge button after collapsing:
+
+```ts
+onToggleCollapse={() => {
+  if (chatSidebarCollapsed) signalChatSidebarOpen()
+  const collapsingFromDesktopChat =
+    useChatEdgeCollapse && !chatSidebarCollapsed
+  setChatSidebarCollapsed((prev) => !prev)
+  if (collapsingFromDesktopChat) {
+    window.requestAnimationFrame(() => {
+      leftEdgeExpandRef.current?.focus()
+    })
+  }
+}}
+```
+
+Render the edge button inside the same outer layout shell, before `<main>` or as the first child inside `<main>`:
+
+```tsx
+{useChatEdgeCollapse && chatSidebarCollapsed && (
+  <button
+    ref={leftEdgeExpandRef}
+    type="button"
+    data-testid="chat-sidebar-edge-expand"
+    aria-label={t("common:chatSidebar.expandRail", "Expand chat rail") as string}
+    title={t("common:chatSidebar.expandRail", "Expand chat rail") as string}
+    onClick={() => {
+      signalChatSidebarOpen()
+      setChatSidebarCollapsed(false)
+      window.requestAnimationFrame(() => {
+        document
+          .querySelector<HTMLButtonElement>('[data-testid="chat-sidebar-toggle"]')
+          ?.focus()
+      })
+    }}
+    className="absolute left-2 top-20 z-30 inline-flex h-9 w-9 items-center justify-center rounded-md border border-border bg-surface text-text-muted shadow-sm transition hover:bg-surface2 hover:text-text focus:outline-none focus-visible:ring-2 focus-visible:ring-focus focus-visible:ring-offset-2 focus-visible:ring-offset-bg"
+  >
+    <PanelLeftOpen className="h-4 w-4" aria-hidden="true" />
+  </button>
+)}
+```
+
+Keep `ChatSidebar`'s existing collapsed branch intact. It remains the `md` and non-chat-route behavior.
+
+- [ ] **Step 4: Run the Layout guard**
+
+Run from `apps/packages/ui`:
+
+```bash
+bunx vitest run src/components/Layouts/__tests__/Layout.chat-sidebar-reset-signal.guard.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit Task 1**
+
+Stage only the touched files:
+
+```bash
+git add apps/packages/ui/src/components/Layouts/Layout.tsx apps/packages/ui/src/components/Layouts/__tests__/Layout.chat-sidebar-reset-signal.guard.test.ts
+git commit -m "fix: add chat left rail edge expand affordance"
+```
+
+## Task 2: Right Artifact Rail Edge Affordance
+
+**Files:**
+- Modify: `apps/packages/ui/src/components/Option/Playground/Playground.tsx`
+- Modify: `apps/packages/ui/src/components/Sidepanel/Chat/ArtifactsPanel.tsx`
+- Modify: `apps/packages/ui/src/components/Option/Playground/__tests__/Playground.search.integration.test.tsx`
+- Modify: `apps/packages/ui/src/components/Option/Playground/__tests__/Playground.sticky-composer-layout.integration.test.tsx`
+
+- [ ] **Step 1: Add failing Playground tests for right-edge behavior**
+
+In `Playground.search.integration.test.tsx`, extend the `useMediaQuery` mock so tests can control both mobile and desktop:
+
+```ts
+const desktopViewportState = vi.hoisted(() => ({
+  value: true
+}))
+
+vi.mock("@/hooks/useMediaQuery", () => ({
+  useMobile: () => mobileViewportState.value,
+  useDesktop: () => desktopViewportState.value
+}))
+```
+
+Reset `desktopViewportState.value = true` in `beforeEach`.
+
+Add a helper artifact:
+
+```ts
+const artifactFixture = {
+  id: "artifact-1",
+  title: "Generated table",
+  content: "a,b\n1,2",
+  kind: "table" as const
+}
+```
+
+Also reset artifact state in `beforeEach` so tests do not leak active artifacts:
+
+```ts
+artifactsState.value.active = null
+artifactsState.value.history = []
+artifactsState.value.unreadCount = 0
+```
+
+Add tests:
+
+```ts
+it("shows a desktop right-edge artifacts expand button only when an artifact is active and the rail is closed", () => {
+  artifactsState.value.active = artifactFixture
+  artifactsState.value.isOpen = false
+
+  render(<Playground />)
+
+  expect(
+    screen.getByRole("button", { name: "Expand artifacts rail" })
+  ).toBeInTheDocument()
+  expect(screen.queryByTestId("artifacts-panel")).not.toBeInTheDocument()
+})
+
+it("does not show the right-edge artifacts expand button without an active artifact", () => {
+  artifactsState.value.active = null
+  artifactsState.value.isOpen = false
+
+  render(<Playground />)
+
+  expect(
+    screen.queryByRole("button", { name: "Expand artifacts rail" })
+  ).not.toBeInTheDocument()
+})
+
+it("opens artifacts from the right edge and marks them read", () => {
+  artifactsState.value.active = artifactFixture
+  artifactsState.value.isOpen = false
+
+  render(<Playground />)
+  fireEvent.click(screen.getByRole("button", { name: "Expand artifacts rail" }))
+
+  expect(artifactsState.value.setOpen).toHaveBeenCalledWith(true)
+  expect(artifactsState.value.markRead).toHaveBeenCalledTimes(1)
+})
+
+it("routes artifact focus events to the edge button when the rail is closed", async () => {
+  artifactsState.value.active = artifactFixture
+  artifactsState.value.isOpen = false
+
+  render(<Playground />)
+  const edgeButton = screen.getByRole("button", {
+    name: "Expand artifacts rail"
+  })
+
+  window.dispatchEvent(new CustomEvent("tldw:focus-artifacts-trigger"))
+
+  await waitFor(() => {
+    expect(document.activeElement).toBe(edgeButton)
+  })
+})
+```
+
+In `Playground.sticky-composer-layout.integration.test.tsx`, assert the measurable chat shell exists:
+
+```ts
+expect(screen.getByTestId("playground-chat-shell")).toBeInTheDocument()
+```
+
+- [ ] **Step 2: Run the failing Playground tests**
+
+Run from `apps/packages/ui`:
+
+```bash
+bunx vitest run src/components/Option/Playground/__tests__/Playground.search.integration.test.tsx src/components/Option/Playground/__tests__/Playground.sticky-composer-layout.integration.test.tsx
+```
+
+Expected: FAIL because the edge button, `useDesktop` mock path, and chat shell test id do not exist.
+
+- [ ] **Step 3: Implement right edge affordance and measurement hook**
+
+In `Playground.tsx`, import `PanelRightOpen` and `useDesktop`:
+
+```ts
+import { ChevronDown, Keyboard, PanelRightOpen, Search, X } from "lucide-react";
+import { useDesktop, useMobile } from "@/hooks/useMediaQuery";
+```
+
+Add refs and flags near the artifact store selectors:
+
+```ts
+const artifactsEdgeExpandRef = React.useRef<HTMLButtonElement>(null);
+const pendingArtifactsPanelFocusRef = React.useRef(false);
+const isDesktopViewport = useDesktop();
+const shouldShowArtifactsEdgeExpand =
+  isDesktopViewport && Boolean(activeArtifact) && !artifactsOpen;
+```
+
+Add an open helper:
+
+```ts
+const openArtifactsFromEdge = React.useCallback(() => {
+  if (!activeArtifact) return;
+  pendingArtifactsPanelFocusRef.current = true;
+  setArtifactsOpen(true);
+  markArtifactsRead();
+}, [activeArtifact, markArtifactsRead, setArtifactsOpen]);
+```
+
+Add a focus effect that runs after the panel opens. Because `ArtifactsPanel` is lazy-loaded, retry once on the next macrotask before falling back to the existing toolbar trigger:
+
+```ts
+React.useEffect(() => {
+  if (!artifactsOpen || !pendingArtifactsPanelFocusRef.current) return;
+  pendingArtifactsPanelFocusRef.current = false;
+  const focusPanelClose = () => {
+    const closeButton = document.querySelector<HTMLButtonElement>(
+      '[data-testid="artifacts-panel-close"]',
+    );
+    if (closeButton) {
+      closeButton.focus();
+      return true;
+    }
+    return false;
+  };
+  window.requestAnimationFrame(() => {
+    if (focusPanelClose()) return;
+    window.setTimeout(() => {
+      if (!focusPanelClose()) {
+        artifactsTriggerRef.current?.focus();
+      }
+    }, 0);
+  });
+}, [artifactsOpen]);
+```
+
+Update the existing `tldw:focus-artifacts-trigger` handler so collapsed desktop panels focus the edge button:
+
+```ts
+const handleFocusArtifactsTrigger = () => {
+  if (artifactsEdgeExpandRef.current) {
+    artifactsEdgeExpandRef.current.focus();
+    return;
+  }
+  artifactsTriggerRef.current?.focus();
+};
+```
+
+Add `data-testid="playground-chat-shell"` to the left flex child:
+
+```tsx
+<div
+  data-testid="playground-chat-shell"
+  className="flex h-full min-h-0 min-w-0 flex-1 flex-col"
+>
+```
+
+Render the edge expand button inside the `relative z-10 flex h-full min-h-0 w-full` shell after the chat shell and before the artifact panel:
+
+```tsx
+{shouldShowArtifactsEdgeExpand && (
+  <button
+    ref={artifactsEdgeExpandRef}
+    type="button"
+    data-testid="playground-artifacts-edge-expand"
+    aria-label={t("playground:regions.expandArtifactsRail", "Expand artifacts rail") as string}
+    title={t("playground:regions.expandArtifactsRail", "Expand artifacts rail") as string}
+    onClick={openArtifactsFromEdge}
+    className="absolute right-2 top-20 z-30 inline-flex h-9 w-9 items-center justify-center rounded-md border border-border bg-surface text-text-muted shadow-sm transition hover:bg-surface2 hover:text-text focus:outline-none focus-visible:ring-2 focus-visible:ring-focus focus-visible:ring-offset-2 focus-visible:ring-offset-bg"
+  >
+    <PanelRightOpen className="h-4 w-4" aria-hidden="true" />
+  </button>
+)}
+```
+
+Keep the existing top toolbar artifact chip. It remains a secondary control and state indicator.
+
+In `ArtifactsPanel.tsx`, make the close button explicitly targetable:
+
+```tsx
+<button
+  type="button"
+  data-testid="artifacts-panel-close"
+  aria-label={t("artifactsClose", "Close") as string}
+  ...
+>
+```
+
+- [ ] **Step 4: Run the focused Playground tests**
+
+Run from `apps/packages/ui`:
+
+```bash
+bunx vitest run src/components/Option/Playground/__tests__/Playground.search.integration.test.tsx src/components/Option/Playground/__tests__/Playground.sticky-composer-layout.integration.test.tsx
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Run the existing artifact panel guard**
+
+Run from `apps/packages/ui`:
+
+```bash
+bunx vitest run src/components/Sidepanel/Chat/__tests__/ArtifactsPanel.jump-source.guard.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit Task 2**
+
+Stage only the touched files:
+
+```bash
+git add apps/packages/ui/src/components/Option/Playground/Playground.tsx apps/packages/ui/src/components/Sidepanel/Chat/ArtifactsPanel.tsx apps/packages/ui/src/components/Option/Playground/__tests__/Playground.search.integration.test.tsx apps/packages/ui/src/components/Option/Playground/__tests__/Playground.sticky-composer-layout.integration.test.tsx
+git commit -m "fix: add chat artifact rail edge expand affordance"
+```
+
+## Task 3: Browser Measurement Regression
+
+**Files:**
+- Create: `apps/tldw-frontend/e2e/workflows/chat-rails-collapse.spec.ts`
+
+- [ ] **Step 1: Add failing Playwright coverage**
+
+Create `chat-rails-collapse.spec.ts` with desktop measurement and compact viewport checks. Reuse the local auth/setup pattern from `e2e/smoke/smoke.setup.ts` and stub provider metadata before navigation so the test reaches `/chat` reliably:
+
+```ts
+import { expect, test, type Page } from "@playwright/test"
+
+import { seedAuth } from "../smoke/smoke.setup"
+import { waitForAppShell } from "../utils/helpers"
+
+const artifactFixture = {
+  id: "artifact-rail-e2e",
+  title: "Rail artifact",
+  content: "value",
+  kind: "code",
+  language: "text"
+}
+
+const prepareChatRailPage = async (page: Page) => {
+  await seedAuth(page)
+  await page.route("**/api/v1/llm/models/metadata**", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ models: [] })
+    })
+  })
+  await page.route("**/api/v1/llm/providers**", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ providers: [] })
+    })
+  })
+  await page.addInitScript(() => {
+    window.localStorage.setItem("stickyChatInput", "true")
+    window.localStorage.setItem("playgroundComposerOptionsExpanded", "false")
+  })
+}
+
+const openArtifactPanel = async (page: Page) => {
+  await page.waitForFunction(() =>
+    Boolean((window as any).__tldw_useArtifactsStore),
+  )
+  await page.evaluate((artifact) => {
+    ;(window as any).__tldw_useArtifactsStore.getState().openArtifact(artifact)
+  }, artifactFixture)
+}
+
+test.describe("/chat siderail collapse", () => {
+  test("desktop collapsed rails expose same-side edge buttons and release width", async ({ page }) => {
+    await page.setViewportSize({ width: 1440, height: 960 })
+    await prepareChatRailPage(page)
+    await page.goto("/chat", { waitUntil: "domcontentloaded" })
+    await waitForAppShell(page)
+
+    const chatShell = page.getByTestId("playground-chat-shell")
+    const composer = page.getByTestId("playground-chat-composer-dock")
+    await expect(chatShell).toBeVisible()
+    await expect(composer).toBeVisible()
+
+    const leftEdge = page.getByTestId("chat-sidebar-edge-expand")
+    await expect(leftEdge).toBeVisible()
+    const leftCollapsedBox = await chatShell.boundingBox()
+    expect(leftCollapsedBox).not.toBeNull()
+
+    await leftEdge.click()
+    await expect(page.getByTestId("chat-sidebar")).toBeVisible()
+    const leftExpandedBox = await chatShell.boundingBox()
+    expect(leftExpandedBox).not.toBeNull()
+    expect(leftExpandedBox!.width).toBeLessThan(leftCollapsedBox!.width)
+
+    const expandedTop = leftExpandedBox!.y
+    await page.getByTestId("chat-sidebar-toggle").click()
+    await expect(leftEdge).toBeVisible()
+    const leftRecollapsedBox = await chatShell.boundingBox()
+    expect(leftRecollapsedBox).not.toBeNull()
+    expect(leftRecollapsedBox!.width).toBeGreaterThan(leftExpandedBox!.width)
+    expect(Math.abs(leftRecollapsedBox!.y - expandedTop)).toBeLessThanOrEqual(2)
+
+    await openArtifactPanel(page)
+    await expect(page.getByTestId("artifacts-panel")).toBeVisible()
+    const rightOpenBox = await chatShell.boundingBox()
+    expect(rightOpenBox).not.toBeNull()
+    await page.getByTestId("artifacts-panel-close").click()
+
+    const rightEdge = page.getByTestId("playground-artifacts-edge-expand")
+    await expect(rightEdge).toBeVisible()
+    const rightClosedBox = await chatShell.boundingBox()
+    expect(rightClosedBox).not.toBeNull()
+    expect(rightClosedBox!.width).toBeGreaterThan(rightOpenBox!.width)
+
+    const composerBox = await composer.boundingBox()
+    expect(composerBox).not.toBeNull()
+    expect(Math.abs(960 - (composerBox!.y + composerBox!.height))).toBeLessThanOrEqual(12)
+  })
+
+  test("medium and mobile viewports do not expose desktop edge buttons", async ({ page }) => {
+    await page.setViewportSize({ width: 900, height: 900 })
+    await prepareChatRailPage(page)
+    await page.goto("/chat", { waitUntil: "domcontentloaded" })
+    await waitForAppShell(page)
+    await expect(page.getByTestId("chat-sidebar-edge-expand")).toHaveCount(0)
+    await openArtifactPanel(page)
+    await page.getByTestId("artifacts-panel-close").click()
+    await expect(page.getByTestId("playground-artifacts-edge-expand")).toHaveCount(0)
+
+    await page.setViewportSize({ width: 390, height: 844 })
+    await page.goto("/chat", { waitUntil: "domcontentloaded" })
+    await waitForAppShell(page)
+    await expect(page.getByTestId("chat-sidebar-edge-expand")).toHaveCount(0)
+    await openArtifactPanel(page)
+    await page.getByTestId("artifacts-panel-close").click()
+    await expect(page.getByTestId("playground-artifacts-edge-expand")).toHaveCount(0)
+  })
+})
+```
+
+- [ ] **Step 2: Run the failing Playwright test before implementation if Task 1 and 2 are not done**
+
+If Task 1 and Task 2 were not implemented yet, run from `apps/tldw-frontend`:
+
+```bash
+TLDW_WEB_CMD='bun run dev -- -H 127.0.0.1 -p 18080' TLDW_WEB_URL=http://127.0.0.1:18080 bunx playwright test e2e/workflows/chat-rails-collapse.spec.ts --project=chromium --reporter=line
+```
+
+Expected before implementation: FAIL because selectors are missing.
+
+- [ ] **Step 3: Run the Playwright test after Task 1 and Task 2**
+
+Run from `apps/tldw-frontend`:
+
+```bash
+TLDW_WEB_CMD='bun run dev -- -H 127.0.0.1 -p 18080' TLDW_WEB_URL=http://127.0.0.1:18080 bunx playwright test e2e/workflows/chat-rails-collapse.spec.ts --project=chromium --reporter=line
+```
+
+Expected: PASS. If port `18080` is occupied, choose another high port and update both `TLDW_WEB_CMD` and `TLDW_WEB_URL`.
+
+- [ ] **Step 4: Commit Task 3**
+
+Stage only the new test:
+
+```bash
+git add apps/tldw-frontend/e2e/workflows/chat-rails-collapse.spec.ts
+git commit -m "test: cover chat rail collapse layout"
+```
+
+## Task 4: Focused Verification and Backlog Closeout
+
+**Files:**
+- Modify: `backlog/tasks/task-485 - Fix-chat-rails-regression-coverage-and-sidepanel-handoff-target.md`
+
+- [ ] **Step 1: Run the focused Vitest suite**
+
+Run from `apps/packages/ui`:
+
+```bash
+bunx vitest run src/components/Layouts/__tests__/Layout.chat-sidebar-reset-signal.guard.test.ts src/components/Option/Playground/__tests__/Playground.search.integration.test.tsx src/components/Option/Playground/__tests__/Playground.sticky-composer-layout.integration.test.tsx src/components/Sidepanel/Chat/__tests__/ArtifactsPanel.jump-source.guard.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run the focused Playwright suite**
+
+Run from `apps/tldw-frontend`:
+
+```bash
+TLDW_WEB_CMD='bun run dev -- -H 127.0.0.1 -p 18080' TLDW_WEB_URL=http://127.0.0.1:18080 bunx playwright test e2e/workflows/chat-rails-collapse.spec.ts --project=chromium --reporter=line
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Run diff hygiene**
+
+Run from repo root:
+
+```bash
+git diff --check
+```
+
+Expected: no output.
+
+- [ ] **Step 4: Document Bandit skip**
+
+No backend Python files are in scope. Record in `TASK-485` that Bandit was not run because the implementation touched frontend TypeScript/TSX, E2E tests, docs, and Backlog metadata only.
+
+- [ ] **Step 5: Update Backlog task**
+
+In `TASK-485`, update:
+
+- `modified_files` with every touched file.
+- Implementation Notes with test commands and results.
+- Final Summary with what changed and why.
+- Definition of Done checkboxes that are satisfied.
+
+- [ ] **Step 6: Commit closeout metadata**
+
+Stage only the task file:
+
+```bash
+git add 'backlog/tasks/task-485 - Fix-chat-rails-regression-coverage-and-sidepanel-handoff-target.md'
+git commit -m "docs: record chat rail collapse verification"
+```
+
+## Final Review Checklist
+
+- [ ] `/chat` at `>=1024px`: left collapsed rail does not reserve width and left-edge expand button is visible.
+- [ ] `/chat` at `>=1024px`: right closed artifact rail does not reserve width and right-edge expand button is visible only when `activeArtifact` exists.
+- [ ] `/chat` with both recoverable collapsed rails: chat shell uses the freed width, transcript top is stable, composer remains docked.
+- [ ] `/chat` at `768px-1023px`: no new desktop edge expand buttons appear.
+- [ ] `/chat` below `768px`: existing drawer/sheet behavior still works and no desktop edge buttons appear.
+- [ ] Header/sidebar toggles still work as secondary paths.
+- [ ] Focus moves to edge buttons after collapse and to meaningful restored controls after expand where practical.
+- [ ] Existing `ChatSidebar` collapsed narrow rail remains available for non-chat routes and medium widths.

--- a/Docs/superpowers/plans/2026-05-31-chat-siderail-edge-expand-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-05-31-chat-siderail-edge-expand-implementation-plan.md
@@ -175,6 +175,10 @@ git commit -m "fix: add chat left rail edge expand affordance"
 In `Playground.search.integration.test.tsx`, extend the `useMediaQuery` mock so tests can control both mobile and desktop:
 
 ```ts
+const mobileViewportState = vi.hoisted(() => ({
+  value: false
+}))
+
 const desktopViewportState = vi.hoisted(() => ({
   value: true
 }))

--- a/Docs/superpowers/specs/2026-05-31-chat-siderail-collapse-design.md
+++ b/Docs/superpowers/specs/2026-05-31-chat-siderail-collapse-design.md
@@ -68,7 +68,7 @@ When the right artifact rail is expanded on desktop:
 
 When both rails are collapsed on desktop:
 
-- Both same-side edge expand buttons are visible.
+- The left-edge expand button is visible, and the right-edge expand button is visible when an active artifact exists.
 - The chat body occupies the combined available width.
 - The composer remains docked at the bottom and the transcript remains vertically anchored.
 - The page does not introduce a blank horizontal gutter where either rail used to be.
@@ -126,6 +126,7 @@ Implementation should include focused regression coverage plus browser verificat
   - Left collapsed, right open: left edge expand button visible; chat uses freed left width.
   - Right collapsed, left open or collapsed: right edge expand button visible; chat uses freed right width.
   - Both collapsed: both edge buttons visible; chat body/composer remain vertically anchored.
+  - Record layout measurements, not only screenshots: chat shell width increases after each rail collapse, chat shell top remains stable, and composer bottom remains docked.
 - Browser smoke at mobile viewport:
   - No desktop edge buttons appear unexpectedly.
   - Existing drawer/sheet controls still work.

--- a/Docs/superpowers/specs/2026-05-31-chat-siderail-collapse-design.md
+++ b/Docs/superpowers/specs/2026-05-31-chat-siderail-collapse-design.md
@@ -1,0 +1,138 @@
+# /chat Siderail Collapse Design
+
+## Task
+
+Backlog: `TASK-485`
+
+## Context
+
+The `/chat` route is rendered by `apps/tldw-frontend/pages/chat/index.tsx`, which loads the shared `Playground` route. The page sits inside `OptionLayout` from `apps/packages/ui/src/components/Layouts/Layout.tsx`.
+
+Desktop `/chat` currently has two side-adjacent surfaces:
+
+- Left chat navigation rail: `ChatSidebar` in `apps/packages/ui/src/components/Common/ChatSidebar.tsx`, controlled by `chatSidebarCollapsed` in `apps/packages/ui/src/store/layout-ui.ts`.
+- Right artifact rail: rendered from `Playground` when `useArtifactsStore().isOpen` is true.
+
+Live layout inspection showed the current collapsed states are not discoverable:
+
+- With the left rail collapsed and the right artifact rail open, there is no clear same-side affordance showing that the left rail can be expanded.
+- With both rails collapsed, there is no visible indication that either rail exists.
+- The chat body should gain horizontal space when a rail collapses; it should not move downward or lose its vertical anchoring.
+
+## Goal
+
+Make collapsed desktop `/chat` rails disappear from layout while leaving a same-side edge-mounted expand button. Expanding a rail should restore that rail on the side where the affordance appeared.
+
+For this task, desktop side-rail behavior means `lg` and wider viewports, matching the breakpoint where the artifact panel is currently eligible to render as a right-hand rail.
+
+## Non-Goals
+
+- Do not redesign the chat cockpit, composer, header, or empty state.
+- Do not change mobile drawer behavior except where shared code needs a guard to avoid desktop-only controls on mobile.
+- Do not change artifact creation, artifact content rendering, or chat history loading.
+- Do not add a new persisted settings model unless an existing store cannot express the required open/collapsed state.
+
+## UX Contract
+
+### Left Rail
+
+When the left chat rail is collapsed on desktop:
+
+- The left rail does not reserve its previous full width.
+- A compact expand button is mounted on the left content edge.
+- The expand button uses a clear accessible label, such as "Expand chat rail".
+- Activating the button restores the left chat rail on the left side.
+- The chat transcript and composer widen into the released horizontal space.
+
+When the left rail is expanded on desktop:
+
+- Existing `ChatSidebar` content and collapse behavior remain available.
+- The collapse control inside the rail collapses the rail back to the left-edge expand button state.
+
+### Right Rail
+
+When the right artifact rail is collapsed on desktop:
+
+- The artifact rail does not reserve its previous width.
+- A compact expand button is mounted on the right content edge when an artifact is available.
+- The expand button uses a clear accessible label, such as "Expand artifacts rail".
+- Activating the button restores the artifact rail on the right side.
+- The chat transcript and composer widen into the released horizontal space.
+
+When the right artifact rail is expanded on desktop:
+
+- The existing artifact panel content remains unchanged.
+- The close control collapses the artifact rail back to the right-edge expand button state when an artifact remains available.
+
+### Both Rails Collapsed
+
+When both rails are collapsed on desktop:
+
+- Both same-side edge expand buttons are visible.
+- The chat body occupies the combined available width.
+- The composer remains docked at the bottom and the transcript remains vertically anchored.
+- The page does not introduce a blank horizontal gutter where either rail used to be.
+
+## Layout Model
+
+Use the current desktop flex layout at `lg` and wider viewports, but make open rails conditional layout participants:
+
+- Left rail open: render `ChatSidebar` as a left flex child.
+- Left rail collapsed: omit the full-width `ChatSidebar` flex child and render a left-edge expand control over the chat shell.
+- Right rail open: render the artifact panel as the current right flex child.
+- Right rail collapsed: omit the artifact panel flex child and render a right-edge expand control over the chat shell when an active artifact exists.
+
+Edge controls should be positioned within the `/chat` page shell rather than in the document body. This keeps them scoped to the route, avoids covering global browser UI, and makes route teardown straightforward.
+
+## Component Boundaries
+
+Expected touch points for implementation planning:
+
+- `apps/packages/ui/src/components/Layouts/Layout.tsx`
+  - Decides whether the desktop left rail is rendered as a layout participant.
+  - Owns the left-edge expand control because the left rail belongs to the outer option layout.
+  - Any layout changes must be scoped to `/chat`/`Playground` so other option routes keep their current rail behavior.
+- `apps/packages/ui/src/components/Common/ChatSidebar.tsx`
+  - Keeps expanded rail content and the internal collapse button.
+  - Should not own the collapsed edge button if the collapsed rail is no longer mounted.
+- `apps/packages/ui/src/components/Option/Playground/Playground.tsx`
+  - Decides whether the right artifact rail is rendered as a layout participant.
+  - Owns the right-edge expand control because the artifact rail belongs to the chat playground shell.
+- `apps/packages/ui/src/store/layout-ui.ts` and `apps/packages/ui/src/store/artifacts.tsx`
+  - Existing state should remain the source of truth unless implementation planning finds a real gap.
+
+## Accessibility
+
+- Edge expand controls are real buttons.
+- Buttons have explicit `aria-label` text.
+- Buttons remain keyboard reachable in normal tab order.
+- When a rail is expanded from an edge button, focus should move to the restored rail's existing collapse button or first meaningful control.
+- When a rail is collapsed from inside the rail, focus should move to the corresponding edge expand button if possible.
+
+## Responsive Behavior
+
+- Desktop edge-button behavior applies at `lg` and wider viewports.
+- At `md`-only widths, 768px through 1023px, preserve the existing medium/tablet behavior. Do not introduce the new desktop edge expand buttons there in this task.
+- Mobile should continue to use existing drawer or sheet behavior.
+- Edge buttons should not appear below `lg` or when the corresponding rail is not a desktop layout participant.
+
+## Verification Plan
+
+Implementation should include focused regression coverage plus browser verification:
+
+- Unit or component coverage for `ChatSidebar`/layout state showing the collapsed left rail is not rendered as a full rail and that a left-edge expand button exists.
+- Unit or component coverage for `Playground` artifact rail state showing the collapsed right rail is not rendered as a full rail and that a right-edge expand button exists when an artifact is available.
+- Browser smoke at desktop viewport:
+  - Left collapsed, right open: left edge expand button visible; chat uses freed left width.
+  - Right collapsed, left open or collapsed: right edge expand button visible; chat uses freed right width.
+  - Both collapsed: both edge buttons visible; chat body/composer remain vertically anchored.
+- Browser smoke at mobile viewport:
+  - No desktop edge buttons appear unexpectedly.
+  - Existing drawer/sheet controls still work.
+- Browser smoke at medium/tablet viewport, 768px through 1023px:
+  - No new desktop edge buttons appear.
+  - Existing medium layout behavior is preserved.
+
+## Open Questions
+
+None. The requested collapsed state is an edge-mounted expand button, not a persistent narrow icon rail.

--- a/apps/extension/tests/e2e/sidepanel-chat-smoke.spec.ts
+++ b/apps/extension/tests/e2e/sidepanel-chat-smoke.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test, type BrowserContext, type Page } from "@playwright/test"
+import { expect, test, type Page } from "@playwright/test"
 import { launchWithExtensionOrSkip } from "./utils/real-server"
 import http from "node:http"
 import { AddressInfo } from "node:net"
@@ -179,36 +179,6 @@ const ensureChatInput = async (page: Page) => {
   return input
 }
 
-const waitForOpenedExtensionRoute = async (
-  context: BrowserContext,
-  expectedUrl: string,
-  trigger: () => Promise<void>
-) => {
-  const popupPromise = context
-    .waitForEvent("page", { timeout: 10000 })
-    .catch(() => null)
-
-  await trigger()
-
-  const popup = await popupPromise
-  if (popup) {
-    await popup.waitForLoadState("domcontentloaded").catch(() => {})
-  }
-
-  await expect
-    .poll(
-      () => context.pages().some((page) => page.url() === expectedUrl),
-      { timeout: 10000 }
-    )
-    .toBe(true)
-
-  const openedPage = context
-    .pages()
-    .find((page) => page.url() === expectedUrl)
-  expect(openedPage, `Expected ${expectedUrl} to open`).toBeTruthy()
-  return openedPage as Page
-}
-
 test.describe("Sidepanel chat smoke", () => {
   test("keeps the 390px sidepanel chat layout inside the viewport", async () => {
     test.setTimeout(90000)
@@ -341,15 +311,18 @@ test.describe("Sidepanel chat smoke", () => {
         fullPage: true
       })
 
-      const expectedFullChatUrl = `chrome-extension://${extensionId}/options.html#/chat`
-      const openedFullChatPage = await waitForOpenedExtensionRoute(
-        context,
-        expectedFullChatUrl,
-        () => headerFullScreen.click()
-      )
-      await expect(openedFullChatPage.locator("body")).not.toContainText(
-        "CharacterControlRail"
-      )
+      const [openedFullChatPage] = await Promise.all([
+        context.waitForEvent("page"),
+        headerFullScreen.click()
+      ])
+      await expect
+        .poll(() => openedFullChatPage.url(), { timeout: 10_000 })
+        .toContain(`${new URL(baseUrl).origin}/chat`)
+
+      const openedUrl = new URL(openedFullChatPage.url())
+      expect(openedUrl.href).not.toContain("/options.html")
+      expect(openedUrl.searchParams.has("handoff")).toBe(false)
+      expect(new URLSearchParams(openedUrl.hash.slice(1)).get("handoff")).toBeTruthy()
     } finally {
       await context.close()
       await stopChatMockServer(server)

--- a/apps/extension/tests/e2e/sidepanel-options-handoff.spec.ts
+++ b/apps/extension/tests/e2e/sidepanel-options-handoff.spec.ts
@@ -49,8 +49,11 @@ test.describe("Sidepanel / Options page handoff", () => {
       const openedUrl = new URL(newPage.url())
       expect(openedUrl.pathname).toBe("/chat")
       expect(openedUrl.href).not.toContain("/options.html")
+      expect(openedUrl.searchParams.has("handoff")).toBe(false)
 
-      const encodedHandoff = openedUrl.searchParams.get("handoff")
+      const encodedHandoff = new URLSearchParams(
+        openedUrl.hash.slice(1)
+      ).get("handoff")
       expect(encodedHandoff).toBeTruthy()
       const decodedHandoff = JSON.parse(
         Buffer.from(

--- a/apps/extension/tests/e2e/sidepanel-options-handoff.spec.ts
+++ b/apps/extension/tests/e2e/sidepanel-options-handoff.spec.ts
@@ -9,16 +9,17 @@ import path from "path"
 const EXT_PATH = path.resolve("build/chrome-mv3")
 
 test.describe("Sidepanel / Options page handoff", () => {
-  test("Open full view from sidepanel navigates to options page", async () => {
+  test("Open full view from sidepanel opens WebUI chat with handoff context", async () => {
     test.setTimeout(90_000)
 
-    const { context, page, openSidepanel, extensionId } =
+    const { context, openSidepanel } =
       await launchWithExtensionOrSkip(test, EXT_PATH, {
         seedConfig: {
           __tldw_first_run_complete: true,
           __tldw_allow_offline: true,
           tldwConfig: {
             serverUrl: "http://127.0.0.1:8000",
+            webUiUrl: "http://127.0.0.1:8080",
             authMode: "single-user",
             apiKey: "test-key"
           }
@@ -34,53 +35,36 @@ test.describe("Sidepanel / Options page handoff", () => {
         "handoff:sp-connected"
       )
 
-      // Look for a button/link that opens the full options page from sidepanel.
-      // Common patterns: "Open full view", "Full page", settings icon, expand icon
-      const fullViewButton = sidepanel.getByRole("button", {
-        name: /Open full view|Full page|Expand|Open in tab/i
-      })
-      const settingsLink = sidepanel.getByRole("link", {
-        name: /Settings|Options|Full view/i
-      })
-      const settingsButton = sidepanel.getByRole("button", {
-        name: /Settings|Open settings/i
-      })
+      const draft = `handoff draft ${Date.now()}`
+      await sidepanel.getByTestId("chat-input").fill(draft)
 
-      let targetButton = null
-      for (const candidate of [fullViewButton, settingsLink, settingsButton]) {
-        if ((await candidate.count()) > 0) {
-          targetButton = candidate.first()
-          break
-        }
-      }
-
-      if (!targetButton) {
-        // If no explicit full-view button exists, verify the sidepanel at
-        // least renders its primary UI and the options page is accessible
-        // separately.
-        const optionsUrl = `chrome-extension://${extensionId}/options.html`
-        const optionsPage = await context.newPage()
-        await optionsPage.goto(optionsUrl, { waitUntil: "domcontentloaded" })
-        await expect(optionsPage.locator("#root")).toBeAttached({
-          timeout: 10_000
-        })
-
-        // Sidepanel should have rendered its root
-        await expect(sidepanel.locator("#root")).toBeAttached({
-          timeout: 10_000
-        })
-
-        await context.close()
-        return
-      }
-
-      // Click the full-view button and verify a new tab opens with options URL
       const [newPage] = await Promise.all([
         context.waitForEvent("page"),
-        targetButton.click()
+        sidepanel.getByTestId("chat-open-full-screen").click()
       ])
-      await newPage.waitForLoadState("domcontentloaded")
-      await expect(newPage).toHaveURL(/options\.html/i)
+      await expect
+        .poll(() => newPage.url(), { timeout: 10_000 })
+        .toContain("http://127.0.0.1:8080/chat")
+
+      const openedUrl = new URL(newPage.url())
+      expect(openedUrl.pathname).toBe("/chat")
+      expect(openedUrl.href).not.toContain("/options.html")
+
+      const encodedHandoff = openedUrl.searchParams.get("handoff")
+      expect(encodedHandoff).toBeTruthy()
+      const decodedHandoff = JSON.parse(
+        Buffer.from(
+          encodedHandoff!.replace(/-/g, "+").replace(/_/g, "/"),
+          "base64"
+        ).toString("utf8")
+      )
+      expect(decodedHandoff).toMatchObject({
+        source: "sidepanel-chat",
+        draft,
+        chatMode: "normal",
+        webSearch: false,
+        toolChoice: "none"
+      })
 
       await context.close()
     } catch (error) {

--- a/apps/packages/ui/src/components/Layouts/Layout.tsx
+++ b/apps/packages/ui/src/components/Layouts/Layout.tsx
@@ -1,7 +1,7 @@
 import React, { lazy, Suspense, useContext, useState } from "react"
 
 import { Drawer, Tooltip } from "antd"
-import { EraserIcon, XIcon } from "lucide-react"
+import { EraserIcon, PanelLeftOpen, XIcon } from "lucide-react"
 import { IconButton } from "../Common/IconButton"
 import { useLocation, useNavigate } from "react-router-dom"
 import { useTranslation } from "react-i18next"
@@ -32,7 +32,7 @@ import { useServerOnline } from "@/hooks/useServerOnline"
 import { ChatSidebar } from "@/components/Common/ChatSidebar"
 import { EventOnlyHosts } from "@/components/Common/EventHosts"
 import { PageAssistLoader } from "@/components/Common/PageAssistLoader"
-import { useMobile } from "@/hooks/useMediaQuery"
+import { useDesktop, useMobile } from "@/hooks/useMediaQuery"
 import { setSettingsReturnTo } from "@/utils/settings-return"
 import { requestQuickIngestOpen } from "@/utils/quick-ingest-open"
 import { VIEWPORT_CONSTRAINED_PATHS } from "@/routes/route-paths"
@@ -131,6 +131,7 @@ const OptionLayoutInner: React.FC<OptionLayoutProps> = ({
   const setChatSidebarCollapsed = useLayoutUiStore(
     (state) => state.setChatSidebarCollapsed
   )
+  const leftEdgeExpandRef = React.useRef<HTMLButtonElement>(null)
   const { t } = useTranslation(["option", "common", "settings"])
   const navigate = useNavigate()
   const [openModelSettings, setOpenModelSettings] = useState(false)
@@ -138,11 +139,20 @@ const OptionLayoutInner: React.FC<OptionLayoutProps> = ({
   const { demoEnabled } = useDemoMode()
   const [showChatSidebar] = useChatSidebar()
   const isMobile = useMobile()
+  const isDesktop = useDesktop()
   useServerOnline()
   const location = useLocation()
   const mobileSidebarPathRef = React.useRef(location.pathname)
   const [chatBackgroundImage] = useSetting(CHAT_BACKGROUND_IMAGE_SETTING)
   const isChatScreen = location.pathname === "/chat"
+  const useChatEdgeCollapse =
+    isChatScreen && isDesktop && showChatSidebar && !hideHeader && !hideSidebar
+  const shouldRenderChatSidebar =
+    showChatSidebar &&
+    !hideHeader &&
+    !hideSidebar &&
+    !isMobile &&
+    (!useChatEdgeCollapse || !chatSidebarCollapsed)
   const isViewportConstrainedRoute = (
     VIEWPORT_CONSTRAINED_PATHS as readonly string[]
   ).includes(location.pathname)
@@ -373,16 +383,50 @@ const OptionLayoutInner: React.FC<OptionLayoutProps> = ({
         style={chatScreenBackgroundStyle}
       >
         {/* Persistent ChatSidebar when feature flag enabled */}
-        {showChatSidebar && !hideHeader && !hideSidebar && !isMobile && (
+        {shouldRenderChatSidebar && (
           <ChatSidebar
             collapsed={chatSidebarCollapsed}
             openResetKey={chatSidebarOpenResetKey}
             onToggleCollapse={() => {
               if (chatSidebarCollapsed) signalChatSidebarOpen()
+              const collapsingFromDesktopChat =
+                useChatEdgeCollapse && !chatSidebarCollapsed
               setChatSidebarCollapsed((prev) => !prev)
+              if (collapsingFromDesktopChat) {
+                window.requestAnimationFrame(() => {
+                  leftEdgeExpandRef.current?.focus()
+                })
+              }
             }}
             className="sticky top-0 shrink-0 border-r border-border"
           />
+        )}
+        {useChatEdgeCollapse && chatSidebarCollapsed && (
+          <button
+            ref={leftEdgeExpandRef}
+            type="button"
+            data-testid="chat-sidebar-edge-expand"
+            aria-label={
+              t("common:chatSidebar.expandRail", "Expand chat rail") as string
+            }
+            title={
+              t("common:chatSidebar.expandRail", "Expand chat rail") as string
+            }
+            onClick={() => {
+              signalChatSidebarOpen()
+              setChatSidebarCollapsed(false)
+              window.requestAnimationFrame(() => {
+                document
+                  .querySelector<HTMLButtonElement>(
+                    '[data-testid="chat-sidebar-toggle"]'
+                  )
+                  ?.focus()
+              })
+            }}
+            className="absolute left-2 top-20 z-30 inline-flex h-9 w-9 items-center justify-center rounded-md border border-border bg-surface text-text-muted shadow-sm transition hover:bg-surface2 hover:text-text focus:outline-none focus-visible:ring-2 focus-visible:ring-focus focus-visible:ring-offset-2 focus-visible:ring-offset-bg"
+          >
+            <PanelLeftOpen className="h-4 w-4" aria-hidden="true" />
+          </button>
         )}
         <main
           className={classNames(

--- a/apps/packages/ui/src/components/Layouts/Layout.tsx
+++ b/apps/packages/ui/src/components/Layouts/Layout.tsx
@@ -423,9 +423,15 @@ const OptionLayoutInner: React.FC<OptionLayoutProps> = ({
                   ?.focus()
               })
             }}
-            className="absolute left-2 top-20 z-30 inline-flex h-9 w-9 items-center justify-center rounded-md border border-border bg-surface text-text-muted shadow-sm transition hover:bg-surface2 hover:text-text focus:outline-none focus-visible:ring-2 focus-visible:ring-focus focus-visible:ring-offset-2 focus-visible:ring-offset-bg"
+            className="absolute left-0 top-1/2 z-40 inline-flex h-28 w-10 -translate-y-1/2 flex-col items-center justify-center gap-2 rounded-r-lg border border-l-0 border-border bg-surface/95 text-text-muted shadow-lg backdrop-blur transition hover:bg-surface2 hover:text-text focus:outline-none focus-visible:ring-2 focus-visible:ring-focus focus-visible:ring-offset-2 focus-visible:ring-offset-bg"
           >
             <PanelLeftOpen className="h-4 w-4" aria-hidden="true" />
+            <span
+              aria-hidden="true"
+              className="rotate-180 text-[10px] font-semibold uppercase tracking-[0.16em] [writing-mode:vertical-rl]"
+            >
+              Chats
+            </span>
           </button>
         )}
         <main

--- a/apps/packages/ui/src/components/Layouts/Layout.tsx
+++ b/apps/packages/ui/src/components/Layouts/Layout.tsx
@@ -430,7 +430,7 @@ const OptionLayoutInner: React.FC<OptionLayoutProps> = ({
               aria-hidden="true"
               className="rotate-180 text-[10px] font-semibold uppercase tracking-[0.16em] [writing-mode:vertical-rl]"
             >
-              Chats
+              {t("common:chatSidebar.title", "Chats") as string}
             </span>
           </button>
         )}

--- a/apps/packages/ui/src/components/Layouts/__tests__/Layout.chat-sidebar-reset-signal.guard.test.ts
+++ b/apps/packages/ui/src/components/Layouts/__tests__/Layout.chat-sidebar-reset-signal.guard.test.ts
@@ -25,4 +25,14 @@ describe("Layout chat sidebar reset signal", () => {
     expect(source).toContain("if (chatSidebarCollapsed) signalChatSidebarOpen()")
     expect(source).toContain('window.addEventListener("tldw:open-chat-sidebar", handler)')
   })
+
+  it("scopes chat desktop collapsed sidebar to an edge expand affordance", () => {
+    const source = readFileSync(layoutSourcePath, "utf8")
+
+    expect(source).toContain("useDesktop")
+    expect(source).toContain("useChatEdgeCollapse")
+    expect(source).toContain('data-testid="chat-sidebar-edge-expand"')
+    expect(source).toContain("isChatScreen && isDesktop")
+    expect(source).toContain("!useChatEdgeCollapse || !chatSidebarCollapsed")
+  })
 })

--- a/apps/packages/ui/src/components/Option/Playground/Playground.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/Playground.tsx
@@ -111,6 +111,10 @@ import {
   SETTINGS_HISTORY_ID_PARAM,
   SETTINGS_SERVER_CHAT_ID_PARAM,
 } from "@/utils/settings-return";
+import {
+  decodeSidepanelChatWebUiHandoff,
+  SIDEPANEL_CHAT_WEBUI_HANDOFF_PARAM,
+} from "@/services/tldw/sidepanel-chat-webui-handoff";
 import { useChatSurfaceCoordinatorStore } from "@/store/chat-surface-coordinator";
 import { useLocation, useNavigate } from "react-router-dom";
 import {
@@ -350,6 +354,12 @@ export const Playground = () => {
     setServerChatId,
     contextFiles,
     setContextFiles,
+    chatMode,
+    setChatMode,
+    setWebSearch,
+    setTemporaryChat,
+    useOCR,
+    setUseOCR,
     createChatBranch,
     streaming,
     isProcessing,
@@ -494,6 +504,7 @@ export const Playground = () => {
     typeof setTimeout
   > | null>(null);
   const initializePlaygroundRef = React.useRef(false);
+  const sidepanelHandoffAppliedRef = React.useRef(false);
   const routeCharacterIntentAppliedRef = React.useRef<string | null>(null);
   const routeCharacterIntentInFlightRef = React.useRef<string | null>(null);
   const routeCharacterIntentRequestRef = React.useRef(0);
@@ -1385,6 +1396,7 @@ export const Playground = () => {
         historyId: null as string | null,
         serverChatId: null as string | null,
         researchReturnRunId: null as string | null,
+        sidepanelHandoff: null,
       };
     }
     const params = new URLSearchParams(window.location.search);
@@ -1393,13 +1405,17 @@ export const Playground = () => {
       params.get(SETTINGS_SERVER_CHAT_ID_PARAM)?.trim() || null;
     const researchReturnRunId =
       params.get(RESEARCH_RETURN_RUN_ID_PARAM)?.trim() || null;
-    return { historyId, serverChatId, researchReturnRunId };
+    const sidepanelHandoff = decodeSidepanelChatWebUiHandoff(
+      params.get(SIDEPANEL_CHAT_WEBUI_HANDOFF_PARAM),
+    );
+    return { historyId, serverChatId, researchReturnRunId, sidepanelHandoff };
   }, []);
 
   const returnHistoryIdFromSettings = settingsReturnContext.historyId;
   const returnServerChatIdFromSettings = settingsReturnContext.serverChatId;
   const returnResearchRunIdFromSettings =
     settingsReturnContext.researchReturnRunId;
+  const sidepanelChatHandoff = settingsReturnContext.sidepanelHandoff;
 
   React.useEffect(() => {
     if (!playgroundReady) return;
@@ -1478,6 +1494,114 @@ export const Playground = () => {
     serverChatId,
     setServerChatId,
     dismissedReturnedResearchRunId,
+  ]);
+
+  React.useEffect(() => {
+    if (
+      !playgroundReady ||
+      !sidepanelChatHandoff ||
+      sidepanelHandoffAppliedRef.current
+    ) {
+      return;
+    }
+    sidepanelHandoffAppliedRef.current = true;
+
+    if (
+      sidepanelChatHandoff.serverChatId &&
+      sidepanelChatHandoff.serverChatId !== serverChatId
+    ) {
+      setServerChatId(sidepanelChatHandoff.serverChatId);
+    }
+    if (
+      sidepanelChatHandoff.selectedModel &&
+      sidepanelChatHandoff.selectedModel !== selectedModel
+    ) {
+      setSelectedModel(sidepanelChatHandoff.selectedModel);
+    }
+    if (
+      sidepanelChatHandoff.selectedSystemPrompt &&
+      sidepanelChatHandoff.selectedSystemPrompt !== selectedSystemPrompt
+    ) {
+      setSelectedSystemPrompt(sidepanelChatHandoff.selectedSystemPrompt);
+    }
+    if (
+      sidepanelChatHandoff.selectedQuickPrompt &&
+      sidepanelChatHandoff.selectedQuickPrompt !== selectedQuickPrompt
+    ) {
+      setSelectedQuickPrompt(sidepanelChatHandoff.selectedQuickPrompt);
+    }
+    if (
+      sidepanelChatHandoff.chatMode &&
+      sidepanelChatHandoff.chatMode !== chatMode
+    ) {
+      setChatMode(sidepanelChatHandoff.chatMode);
+    }
+    if (
+      typeof sidepanelChatHandoff.webSearch === "boolean" &&
+      sidepanelChatHandoff.webSearch !== webSearch
+    ) {
+      setWebSearch(sidepanelChatHandoff.webSearch);
+    }
+    if (
+      sidepanelChatHandoff.toolChoice &&
+      sidepanelChatHandoff.toolChoice !== toolChoice
+    ) {
+      setToolChoice(sidepanelChatHandoff.toolChoice);
+    }
+    if (
+      typeof sidepanelChatHandoff.temporaryChat === "boolean" &&
+      sidepanelChatHandoff.temporaryChat !== temporaryChat
+    ) {
+      setTemporaryChat(sidepanelChatHandoff.temporaryChat);
+    }
+    if (
+      typeof sidepanelChatHandoff.useOCR === "boolean" &&
+      sidepanelChatHandoff.useOCR !== useOCR
+    ) {
+      setUseOCR(sidepanelChatHandoff.useOCR);
+    }
+
+    if (sidepanelChatHandoff.draft?.trim()) {
+      requestAnimationFrame(() => {
+        window.dispatchEvent(
+          new CustomEvent("tldw:set-composer-message", {
+            detail: {
+              message: sidepanelChatHandoff.draft,
+              ifEmptyOnly: true,
+            },
+          }),
+        );
+      });
+    }
+
+    if (typeof window !== "undefined") {
+      const url = new URL(window.location.href);
+      url.searchParams.delete(SIDEPANEL_CHAT_WEBUI_HANDOFF_PARAM);
+      const nextQuery = url.searchParams.toString();
+      const nextPath = `${url.pathname}${nextQuery ? `?${nextQuery}` : ""}${url.hash}`;
+      window.history.replaceState(window.history.state, "", nextPath);
+    }
+  }, [
+    chatMode,
+    playgroundReady,
+    selectedModel,
+    selectedQuickPrompt,
+    selectedSystemPrompt,
+    serverChatId,
+    setChatMode,
+    setSelectedModel,
+    setSelectedQuickPrompt,
+    setSelectedSystemPrompt,
+    setServerChatId,
+    setTemporaryChat,
+    setToolChoice,
+    setUseOCR,
+    setWebSearch,
+    sidepanelChatHandoff,
+    temporaryChat,
+    toolChoice,
+    useOCR,
+    webSearch,
   ]);
 
   const pendingTimelineActionRef = React.useRef<TimelineActionDetail | null>(
@@ -3489,7 +3613,9 @@ export const Playground = () => {
             <div
               ref={composerDockRef}
               data-testid={
-                stickyChatInput ? "playground-chat-composer-dock" : undefined
+                stickyChatInput
+                  ? "playground-chat-composer-dock"
+                  : "playground-chat-composer-region"
               }
               className={`relative w-full ${
                 mobileCockpitComposerConstrained
@@ -3599,9 +3725,15 @@ export const Playground = () => {
               ) as string
             }
             onClick={openArtifactsFromEdge}
-            className="absolute right-2 top-20 z-30 inline-flex h-9 w-9 items-center justify-center rounded-md border border-border bg-surface text-text-muted shadow-sm transition hover:bg-surface2 hover:text-text focus:outline-none focus-visible:ring-2 focus-visible:ring-focus focus-visible:ring-offset-2 focus-visible:ring-offset-bg"
+            className="absolute right-0 top-1/2 z-40 inline-flex h-32 w-10 -translate-y-1/2 flex-col items-center justify-center gap-2 rounded-l-lg border border-r-0 border-border bg-surface/95 text-text-muted shadow-lg backdrop-blur transition hover:bg-surface2 hover:text-text focus:outline-none focus-visible:ring-2 focus-visible:ring-focus focus-visible:ring-offset-2 focus-visible:ring-offset-bg"
           >
             <PanelRightOpen className="h-4 w-4" aria-hidden="true" />
+            <span
+              aria-hidden="true"
+              className="text-[10px] font-semibold uppercase tracking-[0.16em] [writing-mode:vertical-rl]"
+            >
+              Artifacts
+            </span>
           </button>
         )}
         {artifactsOpen && (

--- a/apps/packages/ui/src/components/Option/Playground/Playground.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/Playground.tsx
@@ -60,7 +60,7 @@ import {
 } from "@/store/model";
 import { getDesignSystemState } from "@/design-system";
 import { useSmartScroll } from "@/hooks/useSmartScroll";
-import { ChevronDown, Keyboard, Search, X } from "lucide-react";
+import { ChevronDown, Keyboard, PanelRightOpen, Search, X } from "lucide-react";
 import { CHAT_BACKGROUND_IMAGE_SETTING } from "@/services/settings/ui-settings";
 import { otherUnsupportedTypes } from "../Knowledge/utils/unsupported-types";
 import { useTranslation } from "react-i18next";
@@ -71,7 +71,7 @@ import { useSetting } from "@/hooks/useSetting";
 import { useStorage } from "@plasmohq/storage/hook";
 import { DEFAULT_CHAT_SETTINGS } from "@/types/chat-settings";
 import { useMcpToolsStore } from "@/store/mcp-tools";
-import { useMobile } from "@/hooks/useMediaQuery";
+import { useDesktop, useMobile } from "@/hooks/useMediaQuery";
 import { useLoadLocalConversation } from "@/hooks/useLoadLocalConversation";
 import { tldwClient } from "@/services/tldw/TldwApiClient";
 import { resolvePlaygroundShortcutAction } from "./playground-shortcuts";
@@ -221,6 +221,8 @@ const normalizeChatWorkflowMode = (
 export const Playground = () => {
   const drop = React.useRef<HTMLDivElement>(null);
   const artifactsTriggerRef = React.useRef<HTMLButtonElement>(null);
+  const artifactsEdgeExpandRef = React.useRef<HTMLButtonElement>(null);
+  const pendingArtifactsPanelFocusRef = React.useRef(false);
   const threadSearchInputRef = React.useRef<HTMLInputElement>(null);
   const shortcutsTriggerRef = React.useRef<HTMLButtonElement>(null);
   const shortcutsCloseRef = React.useRef<HTMLButtonElement>(null);
@@ -262,6 +264,7 @@ export const Playground = () => {
     DEFAULT_CHAT_SETTINGS.stickyChatInput,
   );
   const isMobileViewport = useMobile();
+  const isDesktopViewport = useDesktop();
   const location = useLocation();
   const defaultChatLayoutMode: PlaygroundCockpitMode = isMobileViewport
     ? "focus"
@@ -1665,6 +1668,8 @@ export const Playground = () => {
   const setArtifactsOpen = useArtifactsStore((state) => state.setOpen);
   const closeArtifacts = useArtifactsStore((state) => state.closeArtifact);
   const markArtifactsRead = useArtifactsStore((state) => state.markRead);
+  const shouldShowArtifactsEdgeExpand =
+    isDesktopViewport && Boolean(activeArtifact) && !artifactsOpen;
 
   const parentMeta =
     historyId && compareParentByHistory
@@ -1725,6 +1730,35 @@ export const Playground = () => {
       artifactsTriggerRef.current?.focus();
     });
   }, [closeArtifacts]);
+  const openArtifactsFromEdge = React.useCallback(() => {
+    if (!activeArtifact) return;
+    pendingArtifactsPanelFocusRef.current = true;
+    setArtifactsOpen(true);
+    markArtifactsRead();
+  }, [activeArtifact, markArtifactsRead, setArtifactsOpen]);
+
+  React.useEffect(() => {
+    if (!artifactsOpen || !pendingArtifactsPanelFocusRef.current) return;
+    pendingArtifactsPanelFocusRef.current = false;
+    const focusPanelClose = () => {
+      const closeButton = document.querySelector<HTMLButtonElement>(
+        '[data-testid="artifacts-panel-close"]',
+      );
+      if (closeButton) {
+        closeButton.focus();
+        return true;
+      }
+      return false;
+    };
+    window.requestAnimationFrame(() => {
+      if (focusPanelClose()) return;
+      window.setTimeout(() => {
+        if (!focusPanelClose()) {
+          artifactsTriggerRef.current?.focus();
+        }
+      }, 0);
+    });
+  }, [artifactsOpen]);
 
   React.useEffect(() => {
     if (typeof window === "undefined") return;
@@ -1819,6 +1853,10 @@ export const Playground = () => {
   React.useEffect(() => {
     if (typeof window === "undefined") return;
     const handleFocusArtifactsTrigger = () => {
+      if (artifactsEdgeExpandRef.current) {
+        artifactsEdgeExpandRef.current.focus();
+        return;
+      }
       artifactsTriggerRef.current?.focus();
     };
     window.addEventListener(
@@ -3543,6 +3581,29 @@ export const Playground = () => {
             </div>
           </div>
         </PlaygroundCockpitShell>
+        {shouldShowArtifactsEdgeExpand && (
+          <button
+            ref={artifactsEdgeExpandRef}
+            type="button"
+            data-testid="playground-artifacts-edge-expand"
+            aria-label={
+              t(
+                "playground:regions.expandArtifactsRail",
+                "Expand artifacts rail",
+              ) as string
+            }
+            title={
+              t(
+                "playground:regions.expandArtifactsRail",
+                "Expand artifacts rail",
+              ) as string
+            }
+            onClick={openArtifactsFromEdge}
+            className="absolute right-2 top-20 z-30 inline-flex h-9 w-9 items-center justify-center rounded-md border border-border bg-surface text-text-muted shadow-sm transition hover:bg-surface2 hover:text-text focus:outline-none focus-visible:ring-2 focus-visible:ring-focus focus-visible:ring-offset-2 focus-visible:ring-offset-bg"
+          >
+            <PanelRightOpen className="h-4 w-4" aria-hidden="true" />
+          </button>
+        )}
         {artifactsOpen && (
           <>
             <div className="hidden h-full w-[36%] min-w-[280px] max-w-[520px] shrink-0 lg:flex">

--- a/apps/packages/ui/src/components/Option/Playground/Playground.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/Playground.tsx
@@ -3206,7 +3206,10 @@ export const Playground = () => {
           rightRail={cockpitRightRail}
           statusStrip={cockpitStatusStrip}
         >
-          <div className="flex h-full min-h-0 min-w-0 flex-1 flex-col">
+          <div
+            data-testid="playground-chat-shell"
+            className="flex h-full min-h-0 min-w-0 flex-1 flex-col"
+          >
             {parentMeta?.parentHistoryId && (
               <div className="flex w-full justify-center px-5 pt-2">
                 <div className="inline-flex flex-wrap items-center justify-center gap-2">

--- a/apps/packages/ui/src/components/Option/Playground/Playground.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/Playground.tsx
@@ -139,6 +139,20 @@ import {
 import type { Character } from "@/types/character";
 import { getAssistantSelectionMode } from "@/types/assistant-selection";
 
+const readSidepanelChatWebUiHandoffFromLocation = () => {
+  if (typeof window === "undefined") return null;
+  const params = new URLSearchParams(window.location.search);
+  const hashParams = new URLSearchParams(
+    window.location.hash.startsWith("#")
+      ? window.location.hash.slice(1)
+      : window.location.hash,
+  );
+  return decodeSidepanelChatWebUiHandoff(
+    hashParams.get(SIDEPANEL_CHAT_WEBUI_HANDOFF_PARAM) ??
+      params.get(SIDEPANEL_CHAT_WEBUI_HANDOFF_PARAM),
+  );
+};
+
 type ChatModelCatalog = Awaited<ReturnType<typeof fetchChatModels>>;
 
 const getAssistantMessageRouteLabel = (
@@ -1284,6 +1298,9 @@ export const Playground = () => {
     if (routeCharacterIntentId) {
       return;
     }
+    if (readSidepanelChatWebUiHandoffFromLocation()) {
+      return;
+    }
 
     // 2. Fall back to existing webUIResumeLastChat behavior
     const isEnabled = await webUIResumeLastChat();
@@ -1405,9 +1422,7 @@ export const Playground = () => {
       params.get(SETTINGS_SERVER_CHAT_ID_PARAM)?.trim() || null;
     const researchReturnRunId =
       params.get(RESEARCH_RETURN_RUN_ID_PARAM)?.trim() || null;
-    const sidepanelHandoff = decodeSidepanelChatWebUiHandoff(
-      params.get(SIDEPANEL_CHAT_WEBUI_HANDOFF_PARAM),
-    );
+    const sidepanelHandoff = readSidepanelChatWebUiHandoffFromLocation();
     return { historyId, serverChatId, researchReturnRunId, sidepanelHandoff };
   }, []);
 
@@ -1498,7 +1513,6 @@ export const Playground = () => {
 
   React.useEffect(() => {
     if (
-      !playgroundReady ||
       !sidepanelChatHandoff ||
       sidepanelHandoffAppliedRef.current
     ) {
@@ -1506,84 +1520,118 @@ export const Playground = () => {
     }
     sidepanelHandoffAppliedRef.current = true;
 
-    if (
-      sidepanelChatHandoff.serverChatId &&
-      sidepanelChatHandoff.serverChatId !== serverChatId
-    ) {
-      setServerChatId(sidepanelChatHandoff.serverChatId);
-    }
-    if (
-      sidepanelChatHandoff.selectedModel &&
-      sidepanelChatHandoff.selectedModel !== selectedModel
-    ) {
-      setSelectedModel(sidepanelChatHandoff.selectedModel);
-    }
-    if (
-      sidepanelChatHandoff.selectedSystemPrompt &&
-      sidepanelChatHandoff.selectedSystemPrompt !== selectedSystemPrompt
-    ) {
-      setSelectedSystemPrompt(sidepanelChatHandoff.selectedSystemPrompt);
-    }
-    if (
-      sidepanelChatHandoff.selectedQuickPrompt &&
-      sidepanelChatHandoff.selectedQuickPrompt !== selectedQuickPrompt
-    ) {
-      setSelectedQuickPrompt(sidepanelChatHandoff.selectedQuickPrompt);
-    }
-    if (
-      sidepanelChatHandoff.chatMode &&
-      sidepanelChatHandoff.chatMode !== chatMode
-    ) {
-      setChatMode(sidepanelChatHandoff.chatMode);
-    }
-    if (
-      typeof sidepanelChatHandoff.webSearch === "boolean" &&
-      sidepanelChatHandoff.webSearch !== webSearch
-    ) {
-      setWebSearch(sidepanelChatHandoff.webSearch);
-    }
-    if (
-      sidepanelChatHandoff.toolChoice &&
-      sidepanelChatHandoff.toolChoice !== toolChoice
-    ) {
-      setToolChoice(sidepanelChatHandoff.toolChoice);
-    }
-    if (
-      typeof sidepanelChatHandoff.temporaryChat === "boolean" &&
-      sidepanelChatHandoff.temporaryChat !== temporaryChat
-    ) {
-      setTemporaryChat(sidepanelChatHandoff.temporaryChat);
-    }
-    if (
-      typeof sidepanelChatHandoff.useOCR === "boolean" &&
-      sidepanelChatHandoff.useOCR !== useOCR
-    ) {
-      setUseOCR(sidepanelChatHandoff.useOCR);
-    }
+    let cancelled = false;
+    const applySidepanelHandoff = async () => {
+      if (
+        sidepanelChatHandoff.historyId &&
+        sidepanelChatHandoff.historyId !== historyId
+      ) {
+        await loadLocalConversation(sidepanelChatHandoff.historyId);
+      }
+      if (cancelled) return;
 
-    if (sidepanelChatHandoff.draft?.trim()) {
-      requestAnimationFrame(() => {
-        window.dispatchEvent(
-          new CustomEvent("tldw:set-composer-message", {
-            detail: {
-              message: sidepanelChatHandoff.draft,
-              ifEmptyOnly: true,
-            },
-          }),
+      if (
+        sidepanelChatHandoff.serverChatId &&
+        sidepanelChatHandoff.serverChatId !== serverChatId
+      ) {
+        setServerChatId(sidepanelChatHandoff.serverChatId);
+      }
+      if (
+        sidepanelChatHandoff.selectedModel &&
+        sidepanelChatHandoff.selectedModel !== selectedModel
+      ) {
+        setSelectedModel(sidepanelChatHandoff.selectedModel);
+      }
+      if (
+        Object.prototype.hasOwnProperty.call(
+          sidepanelChatHandoff,
+          "selectedSystemPrompt",
+        )
+      ) {
+        const nextSystemPrompt =
+          sidepanelChatHandoff.selectedSystemPrompt ?? null;
+        if (nextSystemPrompt !== selectedSystemPrompt) {
+          setSelectedSystemPrompt(nextSystemPrompt);
+        }
+      }
+      if (
+        Object.prototype.hasOwnProperty.call(
+          sidepanelChatHandoff,
+          "selectedQuickPrompt",
+        )
+      ) {
+        const nextQuickPrompt = sidepanelChatHandoff.selectedQuickPrompt ?? null;
+        if (nextQuickPrompt !== selectedQuickPrompt) {
+          setSelectedQuickPrompt(nextQuickPrompt);
+        }
+      }
+      if (
+        sidepanelChatHandoff.chatMode &&
+        sidepanelChatHandoff.chatMode !== chatMode
+      ) {
+        setChatMode(sidepanelChatHandoff.chatMode);
+      }
+      if (
+        typeof sidepanelChatHandoff.webSearch === "boolean" &&
+        sidepanelChatHandoff.webSearch !== webSearch
+      ) {
+        setWebSearch(sidepanelChatHandoff.webSearch);
+      }
+      if (
+        sidepanelChatHandoff.toolChoice &&
+        sidepanelChatHandoff.toolChoice !== toolChoice
+      ) {
+        setToolChoice(sidepanelChatHandoff.toolChoice);
+      }
+      if (
+        typeof sidepanelChatHandoff.temporaryChat === "boolean" &&
+        sidepanelChatHandoff.temporaryChat !== temporaryChat
+      ) {
+        setTemporaryChat(sidepanelChatHandoff.temporaryChat);
+      }
+      if (
+        typeof sidepanelChatHandoff.useOCR === "boolean" &&
+        sidepanelChatHandoff.useOCR !== useOCR
+      ) {
+        setUseOCR(sidepanelChatHandoff.useOCR);
+      }
+
+      if (sidepanelChatHandoff.draft?.trim()) {
+        requestAnimationFrame(() => {
+          window.dispatchEvent(
+            new CustomEvent("tldw:set-composer-message", {
+              detail: {
+                message: sidepanelChatHandoff.draft,
+                ifEmptyOnly: true,
+              },
+            }),
+          );
+        });
+      }
+
+      if (typeof window !== "undefined") {
+        const url = new URL(window.location.href);
+        url.searchParams.delete(SIDEPANEL_CHAT_WEBUI_HANDOFF_PARAM);
+        const hashParams = new URLSearchParams(
+          url.hash.startsWith("#") ? url.hash.slice(1) : url.hash,
         );
-      });
-    }
+        hashParams.delete(SIDEPANEL_CHAT_WEBUI_HANDOFF_PARAM);
+        const nextQuery = url.searchParams.toString();
+        const nextHash = hashParams.toString();
+        const nextPath = `${url.pathname}${nextQuery ? `?${nextQuery}` : ""}${nextHash ? `#${nextHash}` : ""}`;
+        window.history.replaceState(window.history.state, "", nextPath);
+      }
+    };
 
-    if (typeof window !== "undefined") {
-      const url = new URL(window.location.href);
-      url.searchParams.delete(SIDEPANEL_CHAT_WEBUI_HANDOFF_PARAM);
-      const nextQuery = url.searchParams.toString();
-      const nextPath = `${url.pathname}${nextQuery ? `?${nextQuery}` : ""}${url.hash}`;
-      window.history.replaceState(window.history.state, "", nextPath);
-    }
+    void applySidepanelHandoff();
+
+    return () => {
+      cancelled = true;
+    };
   }, [
     chatMode,
-    playgroundReady,
+    historyId,
+    loadLocalConversation,
     selectedModel,
     selectedQuickPrompt,
     selectedSystemPrompt,

--- a/apps/packages/ui/src/components/Option/Playground/__tests__/Playground.search.integration.test.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/__tests__/Playground.search.integration.test.tsx
@@ -56,6 +56,17 @@ const mobileViewportState = vi.hoisted(() => ({
   value: false
 }))
 
+const desktopViewportState = vi.hoisted(() => ({
+  value: true
+}))
+
+const artifactFixture = vi.hoisted(() => ({
+  id: "artifact-1",
+  title: "Generated table",
+  content: "a,b\n1,2",
+  kind: "table" as const
+}))
+
 const storeOptionState = vi.hoisted(() => ({
   value: {
     compareParentByHistory: {} as Record<
@@ -67,6 +78,11 @@ const storeOptionState = vi.hoisted(() => ({
 
 const routerState = vi.hoisted(() => ({
   navigate: vi.fn()
+}))
+
+const chatSettingsState = vi.hoisted(() => ({
+  syncChatSettingsForServerChat: vi.fn(async () => null),
+  applyChatSettingsPatch: vi.fn(async () => null)
 }))
 
 vi.mock("react-i18next", () => ({
@@ -177,7 +193,15 @@ vi.mock("@plasmohq/storage/hook", () => ({
 }))
 
 vi.mock("@/hooks/useMediaQuery", () => ({
-  useMobile: () => mobileViewportState.value
+  useMobile: () => mobileViewportState.value,
+  useDesktop: () => desktopViewportState.value
+}))
+
+vi.mock("@/services/chat-settings", () => ({
+  syncChatSettingsForServerChat: (...args: unknown[]) =>
+    chatSettingsState.syncChatSettingsForServerChat(...args),
+  applyChatSettingsPatch: (...args: unknown[]) =>
+    chatSettingsState.applyChatSettingsPatch(...args)
 }))
 
 vi.mock("@/hooks/useLoadLocalConversation", () => ({
@@ -213,7 +237,11 @@ describe("Playground thread search integration", () => {
   beforeEach(() => {
     vi.clearAllMocks()
     mobileViewportState.value = false
+    desktopViewportState.value = true
     artifactsState.value.isOpen = false
+    artifactsState.value.active = null
+    artifactsState.value.history = []
+    artifactsState.value.unreadCount = 0
     storeOptionState.value.compareParentByHistory = {}
   })
 
@@ -273,6 +301,56 @@ describe("Playground thread search integration", () => {
       screen.queryByTestId("playground-chat-workflows-trigger")
     ).not.toBeInTheDocument()
     expect(routerState.navigate).not.toHaveBeenCalled()
+  })
+
+  it("shows a desktop right-edge artifacts expand button only when an artifact is active and the rail is closed", () => {
+    artifactsState.value.active = artifactFixture
+    artifactsState.value.isOpen = false
+
+    render(<Playground />)
+
+    expect(
+      screen.getByRole("button", { name: "Expand artifacts rail" })
+    ).toBeInTheDocument()
+    expect(screen.queryByTestId("artifacts-panel")).not.toBeInTheDocument()
+  })
+
+  it("does not show the right-edge artifacts expand button without an active artifact", () => {
+    artifactsState.value.active = null
+    artifactsState.value.isOpen = false
+
+    render(<Playground />)
+
+    expect(
+      screen.queryByRole("button", { name: "Expand artifacts rail" })
+    ).not.toBeInTheDocument()
+  })
+
+  it("opens artifacts from the right edge and marks them read", () => {
+    artifactsState.value.active = artifactFixture
+    artifactsState.value.isOpen = false
+
+    render(<Playground />)
+    fireEvent.click(screen.getByRole("button", { name: "Expand artifacts rail" }))
+
+    expect(artifactsState.value.setOpen).toHaveBeenCalledWith(true)
+    expect(artifactsState.value.markRead).toHaveBeenCalledTimes(1)
+  })
+
+  it("routes artifact focus events to the edge button when the rail is closed", async () => {
+    artifactsState.value.active = artifactFixture
+    artifactsState.value.isOpen = false
+
+    render(<Playground />)
+    const edgeButton = screen.getByRole("button", {
+      name: "Expand artifacts rail"
+    })
+
+    window.dispatchEvent(new CustomEvent("tldw:focus-artifacts-trigger"))
+
+    await waitFor(() => {
+      expect(document.activeElement).toBe(edgeButton)
+    })
   })
 
   it("shows mobile artifacts sheet context and returns focus to trigger when closing", async () => {

--- a/apps/packages/ui/src/components/Option/Playground/__tests__/Playground.search.integration.test.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/__tests__/Playground.search.integration.test.tsx
@@ -4,6 +4,12 @@ import { fireEvent, render, screen, waitFor } from "@testing-library/react"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
 import { Playground } from "../Playground"
+import {
+  decodeSidepanelChatWebUiHandoff,
+  encodeSidepanelChatWebUiHandoff,
+  SIDEPANEL_CHAT_WEBUI_HANDOFF_PARAM,
+  SIDEPANEL_CHAT_WEBUI_HANDOFF_SOURCE
+} from "@/services/tldw/sidepanel-chat-webui-handoff"
 
 const messageOptionState = vi.hoisted(() => ({
   value: {
@@ -15,12 +21,26 @@ const messageOptionState = vi.hoisted(() => ({
     historyId: "history-1",
     serverChatId: "chat-1",
     isLoading: false,
+    selectedModel: "model-1",
+    selectedSystemPrompt: "prompt-1",
+    selectedQuickPrompt: "quick-1",
+    chatMode: "normal",
+    webSearch: false,
+    toolChoice: "none",
+    temporaryChat: false,
+    useOCR: false,
     setHistoryId: vi.fn(),
     setHistory: vi.fn(),
     setMessages: vi.fn(),
     setSelectedSystemPrompt: vi.fn(),
+    setSelectedQuickPrompt: vi.fn(),
     setSelectedModel: vi.fn(),
     setServerChatId: vi.fn(),
+    setChatMode: vi.fn(),
+    setWebSearch: vi.fn(),
+    setToolChoice: vi.fn(),
+    setTemporaryChat: vi.fn(),
+    setUseOCR: vi.fn(),
     setContextFiles: vi.fn(),
     createChatBranch: vi.fn(),
     streaming: false,
@@ -84,6 +104,8 @@ const chatSettingsState = vi.hoisted(() => ({
   syncChatSettingsForServerChat: vi.fn(async () => null),
   applyChatSettingsPatch: vi.fn(async () => null)
 }))
+
+const loadLocalConversationMock = vi.hoisted(() => vi.fn(async () => {}))
 
 vi.mock("react-i18next", () => ({
   useTranslation: () => ({
@@ -205,7 +227,7 @@ vi.mock("@/services/chat-settings", () => ({
 }))
 
 vi.mock("@/hooks/useLoadLocalConversation", () => ({
-  useLoadLocalConversation: () => vi.fn(async () => {})
+  useLoadLocalConversation: () => loadLocalConversationMock
 }))
 
 vi.mock("../playground-shortcuts", () => ({
@@ -238,11 +260,23 @@ describe("Playground thread search integration", () => {
     vi.clearAllMocks()
     mobileViewportState.value = false
     desktopViewportState.value = true
+    loadLocalConversationMock.mockClear()
+    messageOptionState.value.historyId = "history-1"
+    messageOptionState.value.serverChatId = "chat-1"
+    messageOptionState.value.selectedModel = "model-1"
+    messageOptionState.value.selectedSystemPrompt = "prompt-1"
+    messageOptionState.value.selectedQuickPrompt = "quick-1"
+    messageOptionState.value.chatMode = "normal"
+    messageOptionState.value.webSearch = false
+    messageOptionState.value.toolChoice = "none"
+    messageOptionState.value.temporaryChat = false
+    messageOptionState.value.useOCR = false
     artifactsState.value.isOpen = false
     artifactsState.value.active = null
     artifactsState.value.history = []
     artifactsState.value.unreadCount = 0
     storeOptionState.value.compareParentByHistory = {}
+    window.history.replaceState(null, "", "/chat")
   })
 
   it("opens in-thread search on Cmd/Ctrl+F and forwards query to PlaygroundChat", async () => {
@@ -411,5 +445,61 @@ describe("Playground thread search integration", () => {
     })
 
     window.removeEventListener("tldw:open-history", onOpenHistory)
+  })
+
+  it("restores sidepanel WebUI handoff state from the URL fragment and clears the fragment", async () => {
+    messageOptionState.value.historyId = "history-1"
+    messageOptionState.value.serverChatId = null
+    messageOptionState.value.selectedSystemPrompt = "stale-system"
+    messageOptionState.value.selectedQuickPrompt = "stale-quick"
+
+    const encodedHandoff = encodeSidepanelChatWebUiHandoff({
+      source: SIDEPANEL_CHAT_WEBUI_HANDOFF_SOURCE,
+      createdAt: Date.now(),
+      draft: "continue from the sidepanel",
+      historyId: "history-handoff",
+      serverChatId: "server-handoff",
+      selectedSystemPrompt: null,
+      selectedQuickPrompt: "",
+      chatMode: "rag",
+      webSearch: true,
+      toolChoice: "auto",
+      temporaryChat: true,
+      useOCR: true
+    })
+    const hashParams = new URLSearchParams()
+    hashParams.set(SIDEPANEL_CHAT_WEBUI_HANDOFF_PARAM, encodedHandoff)
+    window.history.replaceState(null, "", `/chat#${hashParams.toString()}`)
+    expect(decodeSidepanelChatWebUiHandoff(encodedHandoff)).toMatchObject({
+      historyId: "history-handoff"
+    })
+
+    render(<Playground />)
+
+    await waitFor(
+      () => {
+        expect(loadLocalConversationMock).toHaveBeenCalledWith(
+          "history-handoff"
+        )
+      },
+      { timeout: 5_000 }
+    )
+    await waitFor(() => {
+      expect(messageOptionState.value.setServerChatId).toHaveBeenCalledWith(
+        "server-handoff"
+      )
+    })
+    expect(
+      messageOptionState.value.setSelectedSystemPrompt
+    ).toHaveBeenCalledWith(null)
+    expect(messageOptionState.value.setSelectedQuickPrompt).toHaveBeenCalledWith(
+      null
+    )
+    expect(messageOptionState.value.setChatMode).toHaveBeenCalledWith("rag")
+    expect(messageOptionState.value.setWebSearch).toHaveBeenCalledWith(true)
+    expect(messageOptionState.value.setToolChoice).toHaveBeenCalledWith("auto")
+    expect(messageOptionState.value.setTemporaryChat).toHaveBeenCalledWith(true)
+    expect(messageOptionState.value.setUseOCR).toHaveBeenCalledWith(true)
+    expect(window.location.hash).toBe("")
   })
 })

--- a/apps/packages/ui/src/components/Option/Playground/__tests__/Playground.sticky-composer-layout.integration.test.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/__tests__/Playground.sticky-composer-layout.integration.test.tsx
@@ -193,6 +193,7 @@ vi.mock("@plasmohq/storage/hook", () => ({
 
 vi.mock("@/hooks/useMediaQuery", () => ({
   useMobile: () => false,
+  useDesktop: () => true,
 }));
 
 vi.mock("@/services/chat-settings", () => ({
@@ -261,6 +262,7 @@ describe("Playground sticky composer layout integration", () => {
     const transcript = screen.getByTestId("playground-chat-transcript");
     const dock = screen.getByTestId("playground-chat-composer-dock");
 
+    expect(screen.getByTestId("playground-chat-shell")).toBeInTheDocument();
     expect(transcript).toBeInTheDocument();
     expect(dock).toBeInTheDocument();
     expect(dock.className).toContain("sticky");

--- a/apps/packages/ui/src/components/Sidepanel/Chat/ArtifactsPanel.tsx
+++ b/apps/packages/ui/src/components/Sidepanel/Chat/ArtifactsPanel.tsx
@@ -281,6 +281,8 @@ export const ArtifactsPanel = () => {
           <Tooltip title={t("artifactsClose", "Close")}>
             <button
               type="button"
+              data-testid="artifacts-panel-close"
+              aria-label={t("artifactsClose", "Close") as string}
               onClick={() => {
                 closeArtifact()
                 window.setTimeout(() => {

--- a/apps/packages/ui/src/components/Sidepanel/Chat/ControlRow.tsx
+++ b/apps/packages/ui/src/components/Sidepanel/Chat/ControlRow.tsx
@@ -83,6 +83,7 @@ interface ControlRowProps {
   onToggleRag: () => void
   // Connection state
   isConnected: boolean
+  onOpenChatInWebUi?: () => Promise<void> | void
 }
 
 const ControlRowBase: React.FC<ControlRowProps> = ({
@@ -109,7 +110,8 @@ const ControlRowBase: React.FC<ControlRowProps> = ({
   getVisiblePageContextForHandoff,
   onImageUpload,
   onToggleRag,
-  isConnected
+  isConnected,
+  onOpenChatInWebUi
 }) => {
   const { t } = useTranslation(["sidepanel", "playground", "common"])
   const [selectedAssistant, setSelectedAssistant] = useSelectedAssistant(null)
@@ -469,6 +471,17 @@ const ControlRowBase: React.FC<ControlRowProps> = ({
   }, [])
 
   const openFullApp = () => {
+    if (onOpenChatInWebUi) {
+      Promise.resolve(onOpenChatInWebUi())
+        .catch((error) => {
+          console.error("Failed to open WebUI chat handoff:", error)
+        })
+        .finally(() => {
+          setMoreOpen(false)
+          requestAnimationFrame(() => moreBtnRef.current?.focus())
+        })
+      return
+    }
     void openFullAppPath(fullAppChatPath)
   }
 

--- a/apps/packages/ui/src/components/Sidepanel/Chat/SidepanelHeaderSimple.tsx
+++ b/apps/packages/ui/src/components/Sidepanel/Chat/SidepanelHeaderSimple.tsx
@@ -17,6 +17,7 @@ type SidepanelHeaderSimpleProps = {
   setSidebarOpen?: (open: boolean) => void
   activeTitle?: string
   onRenameTitle?: (nextTitle: string) => void
+  onOpenChatInWebUi?: () => Promise<void> | void
 }
 
 /**
@@ -32,7 +33,8 @@ export const SidepanelHeaderSimple = ({
   sidebarOpen: propSidebarOpen,
   setSidebarOpen: propSetSidebarOpen,
   activeTitle,
-  onRenameTitle
+  onRenameTitle,
+  onOpenChatInWebUi
 }: SidepanelHeaderSimpleProps = {}) => {
   const { temporaryChat } = useMessage()
   const { t } = useTranslation(["sidepanel", "common", "option"])
@@ -104,7 +106,6 @@ export const SidepanelHeaderSimple = ({
   }, [activeTitle, draftTitle, onRenameTitle])
 
   const openFullScreen = React.useCallback(() => {
-    const url = browser.runtime.getURL(`/options.html#${CHAT_PATH}`)
     const showFailure = () => {
       notification.error({
         message: t(
@@ -113,6 +114,14 @@ export const SidepanelHeaderSimple = ({
         )
       })
     }
+    if (onOpenChatInWebUi) {
+      Promise.resolve(onOpenChatInWebUi()).catch((error) => {
+        console.error("Failed to open WebUI chat handoff:", error)
+        showFailure()
+      })
+      return
+    }
+    const url = browser.runtime.getURL(`/options.html#${CHAT_PATH}`)
     const openFallback = () => {
       const opened = window.open(url, "_blank")
       if (!opened) {
@@ -127,7 +136,7 @@ export const SidepanelHeaderSimple = ({
       return
     }
     openFallback()
-  }, [notification, t])
+  }, [notification, onOpenChatInWebUi, t])
 
   const openDashboard = React.useCallback(() => {
     const url = browser.runtime.getURL("/options.html#/flashcards")

--- a/apps/packages/ui/src/components/Sidepanel/Chat/__tests__/SidepanelHeaderSimple.webui-handoff.test.tsx
+++ b/apps/packages/ui/src/components/Sidepanel/Chat/__tests__/SidepanelHeaderSimple.webui-handoff.test.tsx
@@ -1,0 +1,101 @@
+import React from "react"
+import { fireEvent, render, screen, waitFor } from "@testing-library/react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { SidepanelHeaderSimple } from "../SidepanelHeaderSimple"
+
+const { runtimeGetURLMock, tabsCreateMock } = vi.hoisted(() => ({
+  runtimeGetURLMock: vi.fn((path: string) => `chrome-extension://test${path}`),
+  tabsCreateMock: vi.fn().mockResolvedValue(undefined)
+}))
+
+vi.mock("@/assets/icon.png", () => ({
+  default: "chrome-extension://test/icon.png"
+}))
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (_key: string, fallback?: string) => fallback ?? _key
+  })
+}))
+
+vi.mock("react-router-dom", () => ({
+  Link: ({
+    children,
+    to,
+    ...props
+  }: {
+    children?: React.ReactNode
+    to: string
+  }) => (
+    <a href={to} {...props}>
+      {children}
+    </a>
+  )
+}))
+
+vi.mock("antd", () => ({
+  Tooltip: ({ children }: { children?: React.ReactNode }) => <>{children}</>
+}))
+
+vi.mock("wxt/browser", () => ({
+  browser: {
+    runtime: {
+      getURL: runtimeGetURLMock
+    },
+    tabs: {
+      create: tabsCreateMock
+    }
+  }
+}))
+
+vi.mock("@/hooks/useMessage", () => ({
+  useMessage: () => ({
+    temporaryChat: false
+  })
+}))
+
+vi.mock("@/hooks/useAntdNotification", () => ({
+  useAntdNotification: () => ({
+    error: vi.fn()
+  })
+}))
+
+vi.mock("@/hooks/useServerCapabilities", () => ({
+  useServerCapabilities: () => ({
+    capabilities: { hasPersona: false }
+  })
+}))
+
+vi.mock("../StatusDot", () => ({
+  StatusDot: () => <span data-testid="status-dot" />
+}))
+
+vi.mock("../TtsClipsDrawer", () => ({
+  TtsClipsDrawer: () => <div data-testid="tts-clips-drawer" />
+}))
+
+describe("SidepanelHeaderSimple WebUI chat handoff", () => {
+  beforeEach(() => {
+    runtimeGetURLMock.mockClear()
+    tabsCreateMock.mockClear()
+  })
+
+  it("delegates the visible full-screen chat action to the WebUI chat handoff", async () => {
+    const onOpenChatInWebUi = vi.fn().mockResolvedValue(undefined)
+
+    render(
+      React.createElement(SidepanelHeaderSimple as React.ComponentType, {
+        onOpenChatInWebUi
+      })
+    )
+
+    fireEvent.click(screen.getByTestId("chat-open-full-screen"))
+
+    await waitFor(() =>
+      expect(onOpenChatInWebUi).toHaveBeenCalledTimes(1)
+    )
+    expect(runtimeGetURLMock).not.toHaveBeenCalledWith("/options.html#/")
+    expect(tabsCreateMock).not.toHaveBeenCalled()
+  })
+})

--- a/apps/packages/ui/src/components/Sidepanel/Chat/form.tsx
+++ b/apps/packages/ui/src/components/Sidepanel/Chat/form.tsx
@@ -156,6 +156,7 @@ type Props = {
   inputRef?: React.RefObject<HTMLTextAreaElement>
   onHeightChange?: (height: number) => void
   draftKey?: string
+  onOpenChatInWebUi?: () => Promise<void> | void
 }
 
 type DefaultCharacterPreferenceQueryResult = {
@@ -172,7 +173,8 @@ export const SidepanelForm = ({
   dropedFile,
   inputRef,
   onHeightChange,
-  draftKey
+  draftKey,
+  onOpenChatInWebUi
 }: Props) => {
   const formContainerRef = React.useRef<HTMLDivElement>(null)
   const localTextareaRef = React.useRef<HTMLTextAreaElement>(null)
@@ -3074,6 +3076,7 @@ export const SidepanelForm = ({
                               getVisiblePageContextForHandoff={
                                 getVisiblePageContextForHandoff
                               }
+                              onOpenChatInWebUi={onOpenChatInWebUi}
                             />
                           )}
                           <div className="flex min-w-0 flex-wrap items-center justify-end gap-2">

--- a/apps/packages/ui/src/services/__tests__/sidepanel-chat-webui-handoff.test.ts
+++ b/apps/packages/ui/src/services/__tests__/sidepanel-chat-webui-handoff.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  buildSidepanelChatWebUiHandoffUrl,
+  decodeSidepanelChatWebUiHandoff,
+  resolveSidepanelChatWebUiBaseUrl,
+  SIDEPANEL_CHAT_WEBUI_HANDOFF_PARAM,
+  SIDEPANEL_CHAT_WEBUI_HANDOFF_SOURCE
+} from "@/services/tldw/sidepanel-chat-webui-handoff"
+import { SETTINGS_SERVER_CHAT_ID_PARAM } from "@/utils/settings-return"
+
+describe("sidepanel chat WebUI handoff", () => {
+  it("builds a real WebUI /chat URL and preserves draft/context in the handoff", () => {
+    const url = new URL(
+      buildSidepanelChatWebUiHandoffUrl({
+        config: {
+          serverUrl: "http://127.0.0.1:8000",
+          webUiUrl: "http://127.0.0.1:8080/"
+        },
+        payload: {
+          source: SIDEPANEL_CHAT_WEBUI_HANDOFF_SOURCE,
+          createdAt: 1_762_000_000_000,
+          draft: "Summarize the active page",
+          serverChatId: "server-chat-123",
+          historyId: "local-history-456",
+          chatMode: "rag",
+          webSearch: true,
+          toolChoice: "auto",
+          selectedModel: "openai/gpt-4o-mini",
+          selectedSystemPrompt: "prompt-1",
+          selectedQuickPrompt: "quick-1",
+          temporaryChat: false,
+          useOCR: true,
+          title: "Research tab"
+        }
+      })
+    )
+
+    expect(url.origin).toBe("http://127.0.0.1:8080")
+    expect(url.pathname).toBe("/chat")
+    expect(url.href).not.toContain("/options.html")
+    expect(url.searchParams.get(SETTINGS_SERVER_CHAT_ID_PARAM)).toBe(
+      "server-chat-123"
+    )
+
+    const decoded = decodeSidepanelChatWebUiHandoff(
+      url.searchParams.get(SIDEPANEL_CHAT_WEBUI_HANDOFF_PARAM)
+    )
+    expect(decoded).toMatchObject({
+      source: SIDEPANEL_CHAT_WEBUI_HANDOFF_SOURCE,
+      draft: "Summarize the active page",
+      serverChatId: "server-chat-123",
+      historyId: "local-history-456",
+      chatMode: "rag",
+      webSearch: true,
+      toolChoice: "auto",
+      selectedModel: "openai/gpt-4o-mini",
+      selectedSystemPrompt: "prompt-1",
+      selectedQuickPrompt: "quick-1",
+      temporaryChat: false,
+      useOCR: true,
+      title: "Research tab"
+    })
+  })
+
+  it("infers the documented local WebUI port from the local API URL", () => {
+    expect(
+      resolveSidepanelChatWebUiBaseUrl({
+        serverUrl: "http://127.0.0.1:8000"
+      })
+    ).toBe("http://127.0.0.1:8080")
+  })
+})

--- a/apps/packages/ui/src/services/__tests__/sidepanel-chat-webui-handoff.test.ts
+++ b/apps/packages/ui/src/services/__tests__/sidepanel-chat-webui-handoff.test.ts
@@ -1,16 +1,31 @@
-import { describe, expect, it } from "vitest"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
 import {
   buildSidepanelChatWebUiHandoffUrl,
   decodeSidepanelChatWebUiHandoff,
+  encodeSidepanelChatWebUiHandoff,
   resolveSidepanelChatWebUiBaseUrl,
+  SIDEPANEL_CHAT_WEBUI_HANDOFF_MAX_AGE_MS,
   SIDEPANEL_CHAT_WEBUI_HANDOFF_PARAM,
   SIDEPANEL_CHAT_WEBUI_HANDOFF_SOURCE
 } from "@/services/tldw/sidepanel-chat-webui-handoff"
-import { SETTINGS_SERVER_CHAT_ID_PARAM } from "@/utils/settings-return"
 
 describe("sidepanel chat WebUI handoff", () => {
-  it("builds a real WebUI /chat URL and preserves draft/context in the handoff", () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date("2026-06-01T12:00:00.000Z"))
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  const getFragmentHandoff = (url: URL) =>
+    new URLSearchParams(url.hash.slice(1)).get(
+      SIDEPANEL_CHAT_WEBUI_HANDOFF_PARAM
+    )
+
+  it("builds a real WebUI /chat URL and preserves draft/context in a fragment handoff", () => {
     const url = new URL(
       buildSidepanelChatWebUiHandoffUrl({
         config: {
@@ -19,7 +34,7 @@ describe("sidepanel chat WebUI handoff", () => {
         },
         payload: {
           source: SIDEPANEL_CHAT_WEBUI_HANDOFF_SOURCE,
-          createdAt: 1_762_000_000_000,
+          createdAt: Date.now(),
           draft: "Summarize the active page",
           serverChatId: "server-chat-123",
           historyId: "local-history-456",
@@ -39,13 +54,10 @@ describe("sidepanel chat WebUI handoff", () => {
     expect(url.origin).toBe("http://127.0.0.1:8080")
     expect(url.pathname).toBe("/chat")
     expect(url.href).not.toContain("/options.html")
-    expect(url.searchParams.get(SETTINGS_SERVER_CHAT_ID_PARAM)).toBe(
-      "server-chat-123"
-    )
+    expect(url.searchParams.has(SIDEPANEL_CHAT_WEBUI_HANDOFF_PARAM)).toBe(false)
+    expect(url.search).toBe("")
 
-    const decoded = decodeSidepanelChatWebUiHandoff(
-      url.searchParams.get(SIDEPANEL_CHAT_WEBUI_HANDOFF_PARAM)
-    )
+    const decoded = decodeSidepanelChatWebUiHandoff(getFragmentHandoff(url))
     expect(decoded).toMatchObject({
       source: SIDEPANEL_CHAT_WEBUI_HANDOFF_SOURCE,
       draft: "Summarize the active page",
@@ -63,11 +75,73 @@ describe("sidepanel chat WebUI handoff", () => {
     })
   })
 
+  it("preserves explicit WebUI subpaths when building the /chat route", () => {
+    const url = new URL(
+      buildSidepanelChatWebUiHandoffUrl({
+        config: {
+          webUiUrl: "https://example.test/tldw/"
+        },
+        payload: {
+          source: SIDEPANEL_CHAT_WEBUI_HANDOFF_SOURCE,
+          createdAt: Date.now()
+        }
+      })
+    )
+
+    expect(url.origin).toBe("https://example.test")
+    expect(url.pathname).toBe("/tldw/chat")
+  })
+
+  it.each([
+    "file:///tmp/app.html",
+    "chrome-extension://extension-id/options.html",
+    "about:blank",
+    "data:text/plain,hello"
+  ])("ignores non-http WebUI config values and still returns a safe URL: %s", (webUiUrl) => {
+    const url = new URL(
+      buildSidepanelChatWebUiHandoffUrl({
+        config: { webUiUrl },
+        payload: {
+          source: SIDEPANEL_CHAT_WEBUI_HANDOFF_SOURCE,
+          createdAt: Date.now()
+        }
+      })
+    )
+
+    expect(["http:", "https:"]).toContain(url.protocol)
+    expect(url.pathname).toBe("/chat")
+    expect(getFragmentHandoff(url)).toBeTruthy()
+  })
+
   it("infers the documented local WebUI port from the local API URL", () => {
     expect(
       resolveSidepanelChatWebUiBaseUrl({
         serverUrl: "http://127.0.0.1:8000"
       })
     ).toBe("http://127.0.0.1:8080")
+  })
+
+  it("expires stale handoff payloads", () => {
+    const encoded = encodeSidepanelChatWebUiHandoff({
+      source: SIDEPANEL_CHAT_WEBUI_HANDOFF_SOURCE,
+      createdAt: Date.now() - SIDEPANEL_CHAT_WEBUI_HANDOFF_MAX_AGE_MS - 1,
+      draft: "old draft"
+    })
+
+    expect(decodeSidepanelChatWebUiHandoff(encoded)).toBeNull()
+  })
+
+  it("preserves explicit null prompt clears when decoding", () => {
+    const encoded = encodeSidepanelChatWebUiHandoff({
+      source: SIDEPANEL_CHAT_WEBUI_HANDOFF_SOURCE,
+      createdAt: Date.now(),
+      selectedSystemPrompt: null,
+      selectedQuickPrompt: ""
+    })
+
+    expect(decodeSidepanelChatWebUiHandoff(encoded)).toMatchObject({
+      selectedSystemPrompt: null,
+      selectedQuickPrompt: null
+    })
   })
 })

--- a/apps/packages/ui/src/services/tldw/sidepanel-chat-webui-handoff.ts
+++ b/apps/packages/ui/src/services/tldw/sidepanel-chat-webui-handoff.ts
@@ -1,0 +1,180 @@
+import { SETTINGS_SERVER_CHAT_ID_PARAM } from "@/utils/settings-return"
+import type { ToolChoice } from "@/store/option"
+
+export const SIDEPANEL_CHAT_WEBUI_HANDOFF_PARAM = "handoff"
+export const SIDEPANEL_CHAT_WEBUI_HANDOFF_SOURCE = "sidepanel-chat"
+const DEFAULT_WEBUI_URL = "http://127.0.0.1:8080"
+
+export type SidepanelChatWebUiConfig = {
+  serverUrl?: string | null
+  webUiUrl?: string | null
+  webuiUrl?: string | null
+}
+
+export type SidepanelChatWebUiHandoffPayload = {
+  source: typeof SIDEPANEL_CHAT_WEBUI_HANDOFF_SOURCE
+  createdAt: number
+  draft?: string
+  historyId?: string | null
+  serverChatId?: string | null
+  chatMode?: "normal" | "rag" | "vision"
+  webSearch?: boolean
+  toolChoice?: ToolChoice
+  selectedModel?: string | null
+  selectedSystemPrompt?: string | null
+  selectedQuickPrompt?: string | null
+  temporaryChat?: boolean
+  useOCR?: boolean
+  title?: string | null
+}
+
+const normalizeOptionalString = (value: unknown): string | null => {
+  if (typeof value !== "string") return null
+  const trimmed = value.trim()
+  return trimmed.length > 0 ? trimmed : null
+}
+
+const isChatMode = (
+  value: unknown
+): value is SidepanelChatWebUiHandoffPayload["chatMode"] =>
+  value === "normal" || value === "rag" || value === "vision"
+
+const isToolChoice = (
+  value: unknown
+): value is SidepanelChatWebUiHandoffPayload["toolChoice"] =>
+  value === "auto" || value === "none" || value === "required"
+
+const trimTrailingSlash = (value: string) => value.replace(/\/+$/, "")
+
+const normalizeBaseUrl = (value: string | null | undefined): string | null => {
+  const trimmed = normalizeOptionalString(value)
+  if (!trimmed) return null
+  try {
+    const url = new URL(trimmed)
+    return trimTrailingSlash(url.origin)
+  } catch {
+    return null
+  }
+}
+
+export const resolveSidepanelChatWebUiBaseUrl = (
+  config: SidepanelChatWebUiConfig = {}
+) => {
+  const explicitWebUiUrl =
+    normalizeBaseUrl(config.webUiUrl) ?? normalizeBaseUrl(config.webuiUrl)
+  if (explicitWebUiUrl) return explicitWebUiUrl
+
+  const serverUrl = normalizeOptionalString(config.serverUrl)
+  if (serverUrl) {
+    try {
+      const url = new URL(serverUrl)
+      if (url.port === "8000") {
+        url.port = "8080"
+      }
+      return trimTrailingSlash(url.origin)
+    } catch {
+      // Fall through to the browser origin/default below.
+    }
+  }
+
+  if (typeof window !== "undefined" && window.location?.origin) {
+    const origin = window.location.origin
+    if (origin.startsWith("http://") || origin.startsWith("https://")) {
+      return trimTrailingSlash(origin)
+    }
+  }
+
+  return DEFAULT_WEBUI_URL
+}
+
+const encodeBase64Url = (value: string) => {
+  const bytes = new TextEncoder().encode(value)
+  let binary = ""
+  bytes.forEach((byte) => {
+    binary += String.fromCharCode(byte)
+  })
+  return btoa(binary)
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/g, "")
+}
+
+const decodeBase64Url = (value: string) => {
+  const normalized = value.replace(/-/g, "+").replace(/_/g, "/")
+  const padded =
+    normalized.length % 4 === 0
+      ? normalized
+      : `${normalized}${"=".repeat(4 - (normalized.length % 4))}`
+  const binary = atob(padded)
+  const bytes = Uint8Array.from(binary, (char) => char.charCodeAt(0))
+  return new TextDecoder().decode(bytes)
+}
+
+export const encodeSidepanelChatWebUiHandoff = (
+  payload: SidepanelChatWebUiHandoffPayload
+) => encodeBase64Url(JSON.stringify(payload))
+
+export const decodeSidepanelChatWebUiHandoff = (
+  value: string | null | undefined
+): SidepanelChatWebUiHandoffPayload | null => {
+  const encoded = normalizeOptionalString(value)
+  if (!encoded) return null
+
+  try {
+    const parsed = JSON.parse(decodeBase64Url(encoded)) as Record<string, unknown>
+    if (
+      !parsed ||
+      parsed.source !== SIDEPANEL_CHAT_WEBUI_HANDOFF_SOURCE ||
+      typeof parsed.createdAt !== "number"
+    ) {
+      return null
+    }
+
+    return {
+      source: SIDEPANEL_CHAT_WEBUI_HANDOFF_SOURCE,
+      createdAt: parsed.createdAt,
+      draft: normalizeOptionalString(parsed.draft) ?? undefined,
+      historyId: normalizeOptionalString(parsed.historyId),
+      serverChatId: normalizeOptionalString(parsed.serverChatId),
+      chatMode: isChatMode(parsed.chatMode) ? parsed.chatMode : undefined,
+      webSearch:
+        typeof parsed.webSearch === "boolean" ? parsed.webSearch : undefined,
+      toolChoice: isToolChoice(parsed.toolChoice)
+        ? parsed.toolChoice
+        : undefined,
+      selectedModel: normalizeOptionalString(parsed.selectedModel),
+      selectedSystemPrompt: normalizeOptionalString(parsed.selectedSystemPrompt),
+      selectedQuickPrompt: normalizeOptionalString(parsed.selectedQuickPrompt),
+      temporaryChat:
+        typeof parsed.temporaryChat === "boolean"
+          ? parsed.temporaryChat
+          : undefined,
+      useOCR: typeof parsed.useOCR === "boolean" ? parsed.useOCR : undefined,
+      title: normalizeOptionalString(parsed.title)
+    }
+  } catch {
+    return null
+  }
+}
+
+export const buildSidepanelChatWebUiHandoffUrl = ({
+  config,
+  payload
+}: {
+  config?: SidepanelChatWebUiConfig
+  payload: SidepanelChatWebUiHandoffPayload
+}) => {
+  const webUiBaseUrl = resolveSidepanelChatWebUiBaseUrl(config)
+  const url = new URL("/chat", `${webUiBaseUrl}/`)
+  url.searchParams.set(
+    SIDEPANEL_CHAT_WEBUI_HANDOFF_PARAM,
+    encodeSidepanelChatWebUiHandoff(payload)
+  )
+
+  const serverChatId = normalizeOptionalString(payload.serverChatId)
+  if (serverChatId) {
+    url.searchParams.set(SETTINGS_SERVER_CHAT_ID_PARAM, serverChatId)
+  }
+
+  return url.toString()
+}

--- a/apps/packages/ui/src/services/tldw/sidepanel-chat-webui-handoff.ts
+++ b/apps/packages/ui/src/services/tldw/sidepanel-chat-webui-handoff.ts
@@ -1,8 +1,9 @@
-import { SETTINGS_SERVER_CHAT_ID_PARAM } from "@/utils/settings-return"
 import type { ToolChoice } from "@/store/option"
 
 export const SIDEPANEL_CHAT_WEBUI_HANDOFF_PARAM = "handoff"
 export const SIDEPANEL_CHAT_WEBUI_HANDOFF_SOURCE = "sidepanel-chat"
+export const SIDEPANEL_CHAT_WEBUI_HANDOFF_MAX_AGE_MS = 10 * 60 * 1000
+const SIDEPANEL_CHAT_WEBUI_HANDOFF_MAX_CLOCK_SKEW_MS = 60 * 1000
 const DEFAULT_WEBUI_URL = "http://127.0.0.1:8080"
 
 export type SidepanelChatWebUiConfig = {
@@ -46,12 +47,45 @@ const isToolChoice = (
 
 const trimTrailingSlash = (value: string) => value.replace(/\/+$/, "")
 
-const normalizeBaseUrl = (value: string | null | undefined): string | null => {
+const hasOwn = (record: Record<string, unknown>, key: string) =>
+  Object.prototype.hasOwnProperty.call(record, key)
+
+const isHttpUrl = (url: URL) =>
+  url.protocol === "http:" || url.protocol === "https:"
+
+const normalizeNullableStringField = (
+  record: Record<string, unknown>,
+  key: string
+): string | null | undefined => {
+  if (!hasOwn(record, key)) return undefined
+  const raw = record[key]
+  if (raw == null) return null
+  if (typeof raw !== "string") return undefined
+  const trimmed = raw.trim()
+  return trimmed.length > 0 ? trimmed : null
+}
+
+const normalizeWebUiBaseUrl = (
+  value: string | null | undefined
+): string | null => {
   const trimmed = normalizeOptionalString(value)
   if (!trimmed) return null
   try {
     const url = new URL(trimmed)
-    return trimTrailingSlash(url.origin)
+    if (!isHttpUrl(url)) return null
+    const pathname = trimTrailingSlash(url.pathname)
+    return trimTrailingSlash(`${url.origin}${pathname === "/" ? "" : pathname}`)
+  } catch {
+    return null
+  }
+}
+
+const normalizeOriginBaseUrl = (value: string | null | undefined): URL | null => {
+  const trimmed = normalizeOptionalString(value)
+  if (!trimmed) return null
+  try {
+    const url = new URL(trimmed)
+    return isHttpUrl(url) ? url : null
   } catch {
     return null
   }
@@ -61,20 +95,16 @@ export const resolveSidepanelChatWebUiBaseUrl = (
   config: SidepanelChatWebUiConfig = {}
 ) => {
   const explicitWebUiUrl =
-    normalizeBaseUrl(config.webUiUrl) ?? normalizeBaseUrl(config.webuiUrl)
+    normalizeWebUiBaseUrl(config.webUiUrl) ??
+    normalizeWebUiBaseUrl(config.webuiUrl)
   if (explicitWebUiUrl) return explicitWebUiUrl
 
-  const serverUrl = normalizeOptionalString(config.serverUrl)
+  const serverUrl = normalizeOriginBaseUrl(config.serverUrl)
   if (serverUrl) {
-    try {
-      const url = new URL(serverUrl)
-      if (url.port === "8000") {
-        url.port = "8080"
-      }
-      return trimTrailingSlash(url.origin)
-    } catch {
-      // Fall through to the browser origin/default below.
+    if (serverUrl.port === "8000") {
+      serverUrl.port = "8080"
     }
+    return trimTrailingSlash(serverUrl.origin)
   }
 
   if (typeof window !== "undefined" && window.location?.origin) {
@@ -110,6 +140,15 @@ const decodeBase64Url = (value: string) => {
   return new TextDecoder().decode(bytes)
 }
 
+const isFreshHandoffCreatedAt = (createdAt: number) => {
+  if (!Number.isFinite(createdAt)) return false
+  const ageMs = Date.now() - createdAt
+  return (
+    ageMs <= SIDEPANEL_CHAT_WEBUI_HANDOFF_MAX_AGE_MS &&
+    ageMs >= -SIDEPANEL_CHAT_WEBUI_HANDOFF_MAX_CLOCK_SKEW_MS
+  )
+}
+
 export const encodeSidepanelChatWebUiHandoff = (
   payload: SidepanelChatWebUiHandoffPayload
 ) => encodeBase64Url(JSON.stringify(payload))
@@ -125,7 +164,8 @@ export const decodeSidepanelChatWebUiHandoff = (
     if (
       !parsed ||
       parsed.source !== SIDEPANEL_CHAT_WEBUI_HANDOFF_SOURCE ||
-      typeof parsed.createdAt !== "number"
+      typeof parsed.createdAt !== "number" ||
+      !isFreshHandoffCreatedAt(parsed.createdAt)
     ) {
       return null
     }
@@ -134,24 +174,40 @@ export const decodeSidepanelChatWebUiHandoff = (
       source: SIDEPANEL_CHAT_WEBUI_HANDOFF_SOURCE,
       createdAt: parsed.createdAt,
       draft: normalizeOptionalString(parsed.draft) ?? undefined,
-      historyId: normalizeOptionalString(parsed.historyId),
-      serverChatId: normalizeOptionalString(parsed.serverChatId),
+      historyId: normalizeNullableStringField(parsed, "historyId"),
+      serverChatId: normalizeNullableStringField(parsed, "serverChatId"),
       chatMode: isChatMode(parsed.chatMode) ? parsed.chatMode : undefined,
       webSearch:
         typeof parsed.webSearch === "boolean" ? parsed.webSearch : undefined,
       toolChoice: isToolChoice(parsed.toolChoice)
         ? parsed.toolChoice
         : undefined,
-      selectedModel: normalizeOptionalString(parsed.selectedModel),
-      selectedSystemPrompt: normalizeOptionalString(parsed.selectedSystemPrompt),
-      selectedQuickPrompt: normalizeOptionalString(parsed.selectedQuickPrompt),
+      selectedModel: normalizeNullableStringField(parsed, "selectedModel"),
+      selectedSystemPrompt: normalizeNullableStringField(
+        parsed,
+        "selectedSystemPrompt"
+      ),
+      selectedQuickPrompt: normalizeNullableStringField(
+        parsed,
+        "selectedQuickPrompt"
+      ),
       temporaryChat:
         typeof parsed.temporaryChat === "boolean"
           ? parsed.temporaryChat
           : undefined,
       useOCR: typeof parsed.useOCR === "boolean" ? parsed.useOCR : undefined,
-      title: normalizeOptionalString(parsed.title)
+      title: normalizeNullableStringField(parsed, "title")
     }
+  } catch {
+    return null
+  }
+}
+
+const buildWebUiChatUrl = (baseUrl: string): URL | null => {
+  try {
+    const base = new URL(`${baseUrl}/`)
+    if (!isHttpUrl(base)) return null
+    return new URL("chat", base)
   } catch {
     return null
   }
@@ -165,16 +221,16 @@ export const buildSidepanelChatWebUiHandoffUrl = ({
   payload: SidepanelChatWebUiHandoffPayload
 }) => {
   const webUiBaseUrl = resolveSidepanelChatWebUiBaseUrl(config)
-  const url = new URL("/chat", `${webUiBaseUrl}/`)
-  url.searchParams.set(
+  const url =
+    buildWebUiChatUrl(webUiBaseUrl) ??
+    buildWebUiChatUrl(DEFAULT_WEBUI_URL) ??
+    new URL("/chat", DEFAULT_WEBUI_URL)
+  const fragmentParams = new URLSearchParams()
+  fragmentParams.set(
     SIDEPANEL_CHAT_WEBUI_HANDOFF_PARAM,
     encodeSidepanelChatWebUiHandoff(payload)
   )
-
-  const serverChatId = normalizeOptionalString(payload.serverChatId)
-  if (serverChatId) {
-    url.searchParams.set(SETTINGS_SERVER_CHAT_ID_PARAM, serverChatId)
-  }
+  url.hash = fragmentParams.toString()
 
   return url.toString()
 }

--- a/apps/tldw-frontend/components/layout/WebLayout.tsx
+++ b/apps/tldw-frontend/components/layout/WebLayout.tsx
@@ -439,7 +439,7 @@ const OptionLayoutInner: React.FC<OptionLayoutProps> = ({
               aria-hidden="true"
               className="rotate-180 text-[10px] font-semibold uppercase tracking-[0.16em] [writing-mode:vertical-rl]"
             >
-              Chats
+              {t('common:chatSidebar.title', 'Chats') as string}
             </span>
           </button>
         )}

--- a/apps/tldw-frontend/components/layout/WebLayout.tsx
+++ b/apps/tldw-frontend/components/layout/WebLayout.tsx
@@ -1,7 +1,7 @@
 import React, { lazy, Suspense, useState, useContext, useEffect, useCallback } from 'react';
 
 import { Drawer, Tooltip } from 'antd';
-import { EraserIcon, XIcon } from 'lucide-react';
+import { EraserIcon, PanelLeftOpen, XIcon } from 'lucide-react';
 import { IconButton } from '@/components/Common/IconButton';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
@@ -33,7 +33,7 @@ import { useMigration } from '@/hooks/useMigration';
 import { useStorageMigrations } from '@/hooks/useStorageMigrations';
 import { useLayoutEffectsOwner } from '@/hooks/useLayoutEffectsOwner';
 import { useChatSidebar } from '@/hooks/useFeatureFlags';
-import { useMobile } from '@/hooks/useMediaQuery';
+import { useDesktop, useMobile } from '@/hooks/useMediaQuery';
 import { useSetting } from '@/hooks/useSetting';
 import { useServerOnline } from '@/hooks/useServerOnline';
 import { ChatSidebar } from '@/components/Common/ChatSidebar';
@@ -107,6 +107,7 @@ const OptionLayoutInner: React.FC<OptionLayoutProps> = ({
   }, []);
   const chatSidebarCollapsed = useLayoutUiStore((state) => state.chatSidebarCollapsed);
   const setChatSidebarCollapsed = useLayoutUiStore((state) => state.setChatSidebarCollapsed);
+  const leftEdgeExpandRef = React.useRef<HTMLButtonElement>(null);
   const { t } = useTranslation(['option', 'common', 'settings']);
   const navigate = useNavigate();
   const [openModelSettings, setOpenModelSettings] = useState(false);
@@ -114,6 +115,7 @@ const OptionLayoutInner: React.FC<OptionLayoutProps> = ({
   const { demoEnabled } = useDemoMode();
   const [showChatSidebar] = useChatSidebar();
   const isMobileViewport = useMobile();
+  const isDesktopViewport = useDesktop();
   useServerOnline();
 
   // Notification unread count for header bell
@@ -157,6 +159,14 @@ const OptionLayoutInner: React.FC<OptionLayoutProps> = ({
   const [chatBackgroundImage] = useSetting(CHAT_BACKGROUND_IMAGE_SETTING);
   const [stickyChatInput] = useStorage('stickyChatInput', false);
   const isChatScreen = location.pathname === '/chat';
+  const useChatEdgeCollapse =
+    isChatScreen && isDesktopViewport && showChatSidebar && !hideHeader && !hideSidebar;
+  const shouldRenderChatSidebar =
+    showChatSidebar &&
+    !hideHeader &&
+    !hideSidebar &&
+    !isMobileViewport &&
+    (!useChatEdgeCollapse || !chatSidebarCollapsed);
   const stickyChatLayoutActive = isChatScreen && stickyChatInput;
   const isViewportConstrainedRoute =
     stickyChatLayoutActive ||
@@ -389,16 +399,43 @@ const OptionLayoutInner: React.FC<OptionLayoutProps> = ({
         style={chatScreenBackgroundStyle}
       >
         {/* Persistent ChatSidebar when feature flag enabled */}
-        {showChatSidebar && !hideHeader && !hideSidebar && !isMobileViewport && (
+        {shouldRenderChatSidebar && (
           <ChatSidebar
             collapsed={chatSidebarCollapsed}
             openResetKey={chatSidebarOpenResetKey}
             onToggleCollapse={() => {
               if (chatSidebarCollapsed) signalChatSidebarOpen();
+              const collapsingFromDesktopChat = useChatEdgeCollapse && !chatSidebarCollapsed;
               setChatSidebarCollapsed((prev) => !prev);
+              if (collapsingFromDesktopChat) {
+                window.requestAnimationFrame(() => {
+                  leftEdgeExpandRef.current?.focus();
+                });
+              }
             }}
             className="sticky top-0 shrink-0 border-r border-border"
           />
+        )}
+        {useChatEdgeCollapse && chatSidebarCollapsed && (
+          <button
+            ref={leftEdgeExpandRef}
+            type="button"
+            data-testid="chat-sidebar-edge-expand"
+            aria-label={t('common:chatSidebar.expandRail', 'Expand chat rail') as string}
+            title={t('common:chatSidebar.expandRail', 'Expand chat rail') as string}
+            onClick={() => {
+              signalChatSidebarOpen();
+              setChatSidebarCollapsed(false);
+              window.requestAnimationFrame(() => {
+                document
+                  .querySelector<HTMLButtonElement>('[data-testid="chat-sidebar-toggle"]')
+                  ?.focus();
+              });
+            }}
+            className="absolute left-2 top-20 z-30 inline-flex h-9 w-9 items-center justify-center rounded-md border border-border bg-surface text-text-muted shadow-sm transition hover:bg-surface2 hover:text-text focus:outline-none focus-visible:ring-2 focus-visible:ring-focus focus-visible:ring-offset-2 focus-visible:ring-offset-bg"
+          >
+            <PanelLeftOpen className="h-4 w-4" aria-hidden="true" />
+          </button>
         )}
         <main
           className={classNames('relative flex-1 min-w-0 flex flex-col', hideHeader ? 'bg-bg ' : '')}

--- a/apps/tldw-frontend/components/layout/WebLayout.tsx
+++ b/apps/tldw-frontend/components/layout/WebLayout.tsx
@@ -432,9 +432,15 @@ const OptionLayoutInner: React.FC<OptionLayoutProps> = ({
                   ?.focus();
               });
             }}
-            className="absolute left-2 top-20 z-30 inline-flex h-9 w-9 items-center justify-center rounded-md border border-border bg-surface text-text-muted shadow-sm transition hover:bg-surface2 hover:text-text focus:outline-none focus-visible:ring-2 focus-visible:ring-focus focus-visible:ring-offset-2 focus-visible:ring-offset-bg"
+            className="absolute left-0 top-1/2 z-40 inline-flex h-28 w-10 -translate-y-1/2 flex-col items-center justify-center gap-2 rounded-r-lg border border-l-0 border-border bg-surface/95 text-text-muted shadow-lg backdrop-blur transition hover:bg-surface2 hover:text-text focus:outline-none focus-visible:ring-2 focus-visible:ring-focus focus-visible:ring-offset-2 focus-visible:ring-offset-bg"
           >
             <PanelLeftOpen className="h-4 w-4" aria-hidden="true" />
+            <span
+              aria-hidden="true"
+              className="rotate-180 text-[10px] font-semibold uppercase tracking-[0.16em] [writing-mode:vertical-rl]"
+            >
+              Chats
+            </span>
           </button>
         )}
         <main

--- a/apps/tldw-frontend/e2e/workflows/chat-rails-collapse.spec.ts
+++ b/apps/tldw-frontend/e2e/workflows/chat-rails-collapse.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test, type Page } from "@playwright/test"
+import { expect, test, type Locator, type Page } from "@playwright/test"
 
 import { seedAuth } from "../smoke/smoke.setup"
 import { waitForAppShell } from "../utils/helpers"
@@ -17,20 +17,45 @@ const prepareChatRailPage = async (page: Page) => {
     await route.fulfill({
       status: 200,
       contentType: "application/json",
-      body: JSON.stringify({ models: [] })
+      body: JSON.stringify({
+        models: [
+          {
+            id: "openai/gpt-4o",
+            name: "gpt-4o",
+            provider: "openai",
+            type: "chat",
+            is_configured: true,
+            provider_enabled: true,
+            availability: "available"
+          }
+        ]
+      })
     })
   })
   await page.route("**/api/v1/llm/providers**", async (route) => {
     await route.fulfill({
       status: 200,
       contentType: "application/json",
-      body: JSON.stringify({ providers: [] })
+      body: JSON.stringify({
+        providers: [
+          {
+            name: "openai",
+            display_name: "OpenAI",
+            is_configured: true,
+            enabled: true,
+            models: ["gpt-4o"]
+          }
+        ]
+      })
     })
   })
   await page.addInitScript(() => {
     window.localStorage.setItem("ff_chatSidebar", "true")
-    window.localStorage.setItem("stickyChatInput", "true")
-    window.localStorage.setItem("playgroundComposerOptionsExpanded", "false")
+    window.localStorage.setItem("selectedModel", JSON.stringify("openai/gpt-4o"))
+    window.localStorage.removeItem("stickyChatInput")
+    window.localStorage.removeItem("tldw:nextgenComposerEnabled")
+    window.localStorage.removeItem("tldw:composerVariant")
+    window.localStorage.removeItem("playgroundComposerOptionsExpanded")
   })
 }
 
@@ -52,56 +77,106 @@ const closeVisibleArtifactPanel = async (page: Page) => {
 const visibleArtifactPanel = (page: Page) =>
   page.locator('[data-testid="artifacts-panel"]:visible')
 
+const expectStableVerticalPosition = (
+  actual: { y: number } | null,
+  expected: { y: number },
+) => {
+  expect(actual).not.toBeNull()
+  expect(Math.abs(actual!.y - expected.y)).toBeLessThanOrEqual(2)
+}
+
+const expectStableBottomPosition = (
+  actual: { y: number; height: number } | null,
+  expected: { y: number; height: number },
+) => {
+  expect(actual).not.toBeNull()
+  const actualBottom = actual!.y + actual!.height
+  const expectedBottom = expected.y + expected.height
+  expect(Math.abs(actualBottom - expectedBottom)).toBeLessThanOrEqual(2)
+}
+
+const expectLeftEdgeHandle = async (button: Locator) => {
+  const box = await button.boundingBox()
+  expect(box).not.toBeNull()
+  expect(box!.x).toBeLessThanOrEqual(1)
+  expect(box!.height).toBeGreaterThan(box!.width * 2)
+}
+
+const expectRightEdgeHandle = async (page: Page, button: Locator) => {
+  const box = await button.boundingBox()
+  const viewport = page.viewportSize()
+  expect(box).not.toBeNull()
+  expect(viewport).not.toBeNull()
+  expect(box!.x + box!.width).toBeGreaterThanOrEqual(viewport!.width - 1)
+  expect(box!.height).toBeGreaterThan(box!.width * 2)
+}
+
 test.describe("/chat siderail collapse", () => {
-  test("desktop collapsed rails expose same-side edge buttons and release width", async ({ page }) => {
+  test("desktop default composer keeps collapsed rails recoverable from the same edge", async ({ page }) => {
     await page.setViewportSize({ width: 1440, height: 960 })
     await prepareChatRailPage(page)
     await page.goto("/chat", { waitUntil: "domcontentloaded" })
     await waitForAppShell(page)
 
     const chatShell = page.getByTestId("playground-chat-shell")
-    const composer = page.getByTestId("playground-chat-composer-dock")
+    const composerRegion = page.getByTestId("playground-chat-composer-region")
+    const composerInput = page.getByTestId("chat-input")
     await expect(chatShell).toBeVisible()
-    await expect(composer).toBeVisible()
+    await expect(composerRegion).toBeVisible()
+    await expect(composerInput).toBeVisible()
+    await expect(page.getByTestId("playground-chat-composer-dock")).toHaveCount(0)
 
     const leftEdge = page.getByTestId("chat-sidebar-edge-expand")
     await expect(leftEdge).toBeVisible()
-    const leftCollapsedBox = await chatShell.boundingBox()
-    expect(leftCollapsedBox).not.toBeNull()
+    await expectLeftEdgeHandle(leftEdge)
 
     await leftEdge.click()
     await expect(page.getByTestId("chat-sidebar")).toBeVisible()
-    const leftExpandedBox = await chatShell.boundingBox()
-    expect(leftExpandedBox).not.toBeNull()
-    expect(leftExpandedBox!.width).toBeLessThan(leftCollapsedBox!.width)
-
-    const expandedTop = leftExpandedBox!.y
-    await page.getByTestId("chat-sidebar-toggle").click()
-    await expect(leftEdge).toBeVisible()
-    const leftRecollapsedBox = await chatShell.boundingBox()
-    expect(leftRecollapsedBox).not.toBeNull()
-    expect(leftRecollapsedBox!.width).toBeGreaterThan(leftExpandedBox!.width)
-    expect(Math.abs(leftRecollapsedBox!.y - expandedTop)).toBeLessThanOrEqual(2)
-
     await openArtifactPanel(page)
     const artifactPanel = visibleArtifactPanel(page)
     await expect(artifactPanel).toHaveCount(1)
     await expect(artifactPanel).toBeVisible()
+    await expect(leftEdge).toHaveCount(0)
+    await expect(page.getByTestId("playground-artifacts-edge-expand")).toHaveCount(0)
+
+    const bothOpenBox = await chatShell.boundingBox()
+    const bothOpenComposerBox = await composerRegion.boundingBox()
+    expect(bothOpenBox).not.toBeNull()
+    expect(bothOpenComposerBox).not.toBeNull()
+
+    await page.getByTestId("chat-sidebar-toggle").click()
+    await expect(leftEdge).toBeVisible()
+    await expectLeftEdgeHandle(leftEdge)
+    await expect(page.getByTestId("playground-artifacts-edge-expand")).toHaveCount(0)
+    await expect(artifactPanel).toHaveCount(1)
+    await expect(artifactPanel).toBeVisible()
+    const leftCollapsedBox = await chatShell.boundingBox()
+    const leftCollapsedComposerBox = await composerRegion.boundingBox()
+    expect(leftCollapsedBox).not.toBeNull()
+    expect(leftCollapsedBox!.width).toBeGreaterThan(bothOpenBox!.width)
+    expectStableVerticalPosition(leftCollapsedBox, bothOpenBox!)
+    expectStableBottomPosition(leftCollapsedComposerBox, bothOpenComposerBox!)
+
+    await leftEdge.click()
+    await expect(page.getByTestId("chat-sidebar")).toBeVisible()
     const rightOpenBox = await chatShell.boundingBox()
+    const rightOpenComposerBox = await composerRegion.boundingBox()
     expect(rightOpenBox).not.toBeNull()
+    expect(rightOpenComposerBox).not.toBeNull()
     await closeVisibleArtifactPanel(page)
 
     const rightEdge = page.getByTestId("playground-artifacts-edge-expand")
     await expect(rightEdge).toBeVisible()
+    await expectRightEdgeHandle(page, rightEdge)
+    await expect(page.getByTestId("chat-sidebar")).toBeVisible()
+    await expect(leftEdge).toHaveCount(0)
+    await expect(artifactPanel).toHaveCount(0)
     const rightClosedBox = await chatShell.boundingBox()
+    const rightClosedComposerBox = await composerRegion.boundingBox()
     expect(rightClosedBox).not.toBeNull()
     expect(rightClosedBox!.width).toBeGreaterThan(rightOpenBox!.width)
-
-    const composerBox = await composer.boundingBox()
-    expect(composerBox).not.toBeNull()
-    expect(
-      Math.abs(960 - (composerBox!.y + composerBox!.height))
-    ).toBeLessThanOrEqual(12)
+    expectStableVerticalPosition(rightClosedBox, rightOpenBox!)
+    expectStableBottomPosition(rightClosedComposerBox, rightOpenComposerBox!)
   })
 
   test("medium and mobile viewports do not expose desktop edge buttons", async ({ page }) => {

--- a/apps/tldw-frontend/e2e/workflows/chat-rails-collapse.spec.ts
+++ b/apps/tldw-frontend/e2e/workflows/chat-rails-collapse.spec.ts
@@ -1,0 +1,125 @@
+import { expect, test, type Page } from "@playwright/test"
+
+import { seedAuth } from "../smoke/smoke.setup"
+import { waitForAppShell } from "../utils/helpers"
+
+const artifactFixture = {
+  id: "artifact-rail-e2e",
+  title: "Rail artifact",
+  content: "value",
+  kind: "code",
+  language: "text"
+}
+
+const prepareChatRailPage = async (page: Page) => {
+  await seedAuth(page)
+  await page.route("**/api/v1/llm/models/metadata**", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ models: [] })
+    })
+  })
+  await page.route("**/api/v1/llm/providers**", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ providers: [] })
+    })
+  })
+  await page.addInitScript(() => {
+    window.localStorage.setItem("ff_chatSidebar", "true")
+    window.localStorage.setItem("stickyChatInput", "true")
+    window.localStorage.setItem("playgroundComposerOptionsExpanded", "false")
+  })
+}
+
+const openArtifactPanel = async (page: Page) => {
+  await page.waitForFunction(() =>
+    Boolean((window as any).__tldw_useArtifactsStore),
+  )
+  await page.evaluate((artifact) => {
+    ;(window as any).__tldw_useArtifactsStore.getState().openArtifact(artifact)
+  }, artifactFixture)
+}
+
+const closeVisibleArtifactPanel = async (page: Page) => {
+  const closeButton = page.locator('[data-testid="artifacts-panel-close"]:visible')
+  await expect(closeButton).toHaveCount(1)
+  await closeButton.click()
+}
+
+const visibleArtifactPanel = (page: Page) =>
+  page.locator('[data-testid="artifacts-panel"]:visible')
+
+test.describe("/chat siderail collapse", () => {
+  test("desktop collapsed rails expose same-side edge buttons and release width", async ({ page }) => {
+    await page.setViewportSize({ width: 1440, height: 960 })
+    await prepareChatRailPage(page)
+    await page.goto("/chat", { waitUntil: "domcontentloaded" })
+    await waitForAppShell(page)
+
+    const chatShell = page.getByTestId("playground-chat-shell")
+    const composer = page.getByTestId("playground-chat-composer-dock")
+    await expect(chatShell).toBeVisible()
+    await expect(composer).toBeVisible()
+
+    const leftEdge = page.getByTestId("chat-sidebar-edge-expand")
+    await expect(leftEdge).toBeVisible()
+    const leftCollapsedBox = await chatShell.boundingBox()
+    expect(leftCollapsedBox).not.toBeNull()
+
+    await leftEdge.click()
+    await expect(page.getByTestId("chat-sidebar")).toBeVisible()
+    const leftExpandedBox = await chatShell.boundingBox()
+    expect(leftExpandedBox).not.toBeNull()
+    expect(leftExpandedBox!.width).toBeLessThan(leftCollapsedBox!.width)
+
+    const expandedTop = leftExpandedBox!.y
+    await page.getByTestId("chat-sidebar-toggle").click()
+    await expect(leftEdge).toBeVisible()
+    const leftRecollapsedBox = await chatShell.boundingBox()
+    expect(leftRecollapsedBox).not.toBeNull()
+    expect(leftRecollapsedBox!.width).toBeGreaterThan(leftExpandedBox!.width)
+    expect(Math.abs(leftRecollapsedBox!.y - expandedTop)).toBeLessThanOrEqual(2)
+
+    await openArtifactPanel(page)
+    const artifactPanel = visibleArtifactPanel(page)
+    await expect(artifactPanel).toHaveCount(1)
+    await expect(artifactPanel).toBeVisible()
+    const rightOpenBox = await chatShell.boundingBox()
+    expect(rightOpenBox).not.toBeNull()
+    await closeVisibleArtifactPanel(page)
+
+    const rightEdge = page.getByTestId("playground-artifacts-edge-expand")
+    await expect(rightEdge).toBeVisible()
+    const rightClosedBox = await chatShell.boundingBox()
+    expect(rightClosedBox).not.toBeNull()
+    expect(rightClosedBox!.width).toBeGreaterThan(rightOpenBox!.width)
+
+    const composerBox = await composer.boundingBox()
+    expect(composerBox).not.toBeNull()
+    expect(
+      Math.abs(960 - (composerBox!.y + composerBox!.height))
+    ).toBeLessThanOrEqual(12)
+  })
+
+  test("medium and mobile viewports do not expose desktop edge buttons", async ({ page }) => {
+    await page.setViewportSize({ width: 900, height: 900 })
+    await prepareChatRailPage(page)
+    await page.goto("/chat", { waitUntil: "domcontentloaded" })
+    await waitForAppShell(page)
+    await expect(page.getByTestId("chat-sidebar-edge-expand")).toHaveCount(0)
+    await openArtifactPanel(page)
+    await closeVisibleArtifactPanel(page)
+    await expect(page.getByTestId("playground-artifacts-edge-expand")).toHaveCount(0)
+
+    await page.setViewportSize({ width: 390, height: 844 })
+    await page.goto("/chat", { waitUntil: "domcontentloaded" })
+    await waitForAppShell(page)
+    await expect(page.getByTestId("chat-sidebar-edge-expand")).toHaveCount(0)
+    await openArtifactPanel(page)
+    await closeVisibleArtifactPanel(page)
+    await expect(page.getByTestId("playground-artifacts-edge-expand")).toHaveCount(0)
+  })
+})

--- a/apps/tldw-frontend/extension/routes/sidepanel-chat.tsx
+++ b/apps/tldw-frontend/extension/routes/sidepanel-chat.tsx
@@ -29,6 +29,7 @@ import type { ServerChatMessage as ApiServerChatMessage } from "@/services/tldw/
 import { createSafeStorage } from "@/utils/safe-storage"
 import { CHAT_BACKGROUND_IMAGE_SETTING } from "@/services/settings/ui-settings"
 import { useStorage } from "@plasmohq/storage/hook"
+import { browser } from "wxt/browser"
 import { ChevronDown } from "lucide-react"
 import React, { lazy, Suspense } from "react"
 import { useTranslation } from "react-i18next"
@@ -62,6 +63,11 @@ import {
   type OpenHistoryDetail,
   type TimelineActionDetail
 } from "@/utils/timeline-actions"
+import {
+  buildSidepanelChatWebUiHandoffUrl,
+  SIDEPANEL_CHAT_WEBUI_HANDOFF_SOURCE,
+  type SidepanelChatWebUiConfig
+} from "@/services/tldw/sidepanel-chat-webui-handoff"
 
 // Lazy-load Timeline to reduce initial bundle size (~1.2MB cytoscape)
 const TimelineModal = lazy(() =>
@@ -1710,6 +1716,82 @@ const SidepanelChat = () => {
     return t("sidepanel:tabs.newChat", "New chat")
   }, [activeTabId, tabs, t])
 
+  const readWebUiHandoffConfig = React.useCallback(async () => {
+    const storage = storageRef.current
+    const readStorageValue = async <T,>(key: string): Promise<T | null> => {
+      try {
+        const value = await storage.get<T>(key)
+        return value ?? null
+      } catch {
+        return null
+      }
+    }
+    const storedConfig = await readStorageValue<Record<string, unknown>>(
+      "tldwConfig"
+    )
+    const legacyWebUiUrl =
+      (await readStorageValue<string>("webUiUrl")) ??
+      (await readStorageValue<string>("webuiUrl"))
+
+    const config: SidepanelChatWebUiConfig = {
+      serverUrl:
+        typeof storedConfig?.serverUrl === "string"
+          ? storedConfig.serverUrl
+          : null,
+      webUiUrl:
+        typeof storedConfig?.webUiUrl === "string"
+          ? storedConfig.webUiUrl
+          : typeof storedConfig?.webuiUrl === "string"
+            ? storedConfig.webuiUrl
+            : legacyWebUiUrl
+    }
+
+    return config
+  }, [])
+
+  const openChatInWebUi = React.useCallback(async () => {
+    const snapshot = buildSnapshot()
+    const draft = textareaRef.current?.value ?? ""
+    const config = await readWebUiHandoffConfig()
+    const url = buildSidepanelChatWebUiHandoffUrl({
+      config,
+      payload: {
+        source: SIDEPANEL_CHAT_WEBUI_HANDOFF_SOURCE,
+        createdAt: Date.now(),
+        draft,
+        historyId: snapshot.historyId ?? null,
+        serverChatId: snapshot.serverChatId ?? null,
+        chatMode: snapshot.chatMode ?? "normal",
+        webSearch: snapshot.webSearch ?? false,
+        toolChoice: snapshot.toolChoice ?? "none",
+        selectedModel: snapshot.selectedModel ?? null,
+        selectedSystemPrompt: snapshot.selectedSystemPrompt ?? null,
+        selectedQuickPrompt: snapshot.selectedQuickPrompt ?? null,
+        temporaryChat: snapshot.temporaryChat ?? false,
+        useOCR: snapshot.useOCR ?? false,
+        title: activeTabLabel
+      }
+    })
+
+    const openFallback = () => {
+      const opened = window.open(url, "_blank")
+      if (!opened) {
+        throw new Error("Window popup was blocked")
+      }
+    }
+
+    try {
+      if (browser.tabs?.create) {
+        await browser.tabs.create({ url })
+        return
+      }
+    } catch (error) {
+      console.error("Failed to open WebUI chat tab:", error)
+    }
+
+    openFallback()
+  }, [activeTabLabel, buildSnapshot, readWebUiHandoffConfig])
+
   const commandPaletteChats = React.useMemo(
     () =>
       [...tabs]
@@ -1761,6 +1843,7 @@ const SidepanelChat = () => {
             setSidebarOpen={setSidebarOpen}
             activeTitle={activeTabLabel}
             onRenameTitle={handleRenameActiveTab}
+            onOpenChatInWebUi={openChatInWebUi}
           />
           <ConnectionBanner className="pt-12" />
         </div>
@@ -1867,6 +1950,7 @@ const SidepanelChat = () => {
                   inputRef={textareaRef}
                   onHeightChange={setComposerHeight}
                   draftKey={draftKey}
+                  onOpenChatInWebUi={openChatInWebUi}
                 />
               </div>
             )}
@@ -1898,6 +1982,7 @@ const SidepanelChat = () => {
                 inputRef={textareaRef}
                 onHeightChange={setComposerHeight}
                 draftKey={draftKey}
+                onOpenChatInWebUi={openChatInWebUi}
               />
             </div>
           )}

--- a/backlog/tasks/task-485 - Fix-chat-rails-regression-coverage-and-sidepanel-handoff-target.md
+++ b/backlog/tasks/task-485 - Fix-chat-rails-regression-coverage-and-sidepanel-handoff-target.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-485
 title: Fix /chat rails regression coverage and sidepanel handoff target
-status: In Progress
+status: Done
 labels:
 - webui
 - chat
@@ -14,6 +14,14 @@ documentation:
 modified_files:
 - Docs/superpowers/specs/2026-05-31-chat-siderail-collapse-design.md
 - Docs/superpowers/plans/2026-05-31-chat-siderail-edge-expand-implementation-plan.md
+- apps/packages/ui/src/components/Layouts/Layout.tsx
+- apps/packages/ui/src/components/Layouts/__tests__/Layout.chat-sidebar-reset-signal.guard.test.ts
+- apps/packages/ui/src/components/Option/Playground/Playground.tsx
+- apps/packages/ui/src/components/Option/Playground/__tests__/Playground.search.integration.test.tsx
+- apps/packages/ui/src/components/Option/Playground/__tests__/Playground.sticky-composer-layout.integration.test.tsx
+- apps/packages/ui/src/components/Sidepanel/Chat/ArtifactsPanel.tsx
+- apps/tldw-frontend/components/layout/WebLayout.tsx
+- apps/tldw-frontend/e2e/workflows/chat-rails-collapse.spec.ts
 ---
 
 ## Description
@@ -44,20 +52,25 @@ Follow-up spec review clarified two planning details before implementation: the 
 Implementation plan drafted at Docs/superpowers/plans/2026-05-31-chat-siderail-edge-expand-implementation-plan.md before runtime code changes.
 
 Plan review loop completed. Initial review required the Playwright plan to reuse auth/setup seeding and provider endpoint stubs, plus verify right-edge absence below lg with an active artifact. Plan was updated and re-review status was Approved.
+Implementation completed in commits cb2a400815, d6608e4b7e, and 89f7c6b72c. The shared options/extension shell and the Next WebUI shell now remove the desktop chat rail from layout when collapsed and expose the left-edge expand button. The artifact rail exposes a right-edge expand button only when an active artifact exists and the panel is collapsed. The new Playwright workflow covers desktop width release/top stability/composer docking plus medium and mobile absence of desktop edge controls.
+
+Verification recorded: `bunx vitest run src/components/Layouts/__tests__/Layout.chat-sidebar-reset-signal.guard.test.ts src/components/Option/Playground/__tests__/Playground.search.integration.test.tsx src/components/Option/Playground/__tests__/Playground.sticky-composer-layout.integration.test.tsx src/components/Sidepanel/Chat/__tests__/ArtifactsPanel.jump-source.guard.test.ts` passed 4 files / 16 tests. `TLDW_WEB_CMD='bun run dev -- -H 127.0.0.1 -p 18081' TLDW_WEB_URL=http://127.0.0.1:18081 bunx playwright test e2e/workflows/chat-rails-collapse.spec.ts --project=chromium --reporter=line` passed 2 tests. Scoped whitespace checks for the touched WebLayout and E2E files passed. Full `git diff --check` is blocked by unrelated pre-existing trailing whitespace in `Docs/Design/Agents.md:155`. Bandit skipped because this slice touched frontend TypeScript/TSX and Playwright coverage only, with no Python runtime or tests changed.
+
+Screenshot evidence captured after the fix: `/private/tmp/tldw-chat-left-rail-collapsed.png` and `/private/tmp/tldw-chat-right-rail-collapsed.png`. The stubbed provider state intentionally shows the existing no-provider warning while exercising layout behavior.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-
+Implemented same-side desktop edge expand affordances for collapsed /chat rails across the shared layout, artifact panel, and Next WebUI shell. Added focused Playwright coverage for left and right rail collapse/expand behavior, chat width release, vertical stability, composer docking, and no desktop edge buttons below the lg breakpoint.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->

--- a/backlog/tasks/task-485 - Fix-chat-rails-regression-coverage-and-sidepanel-handoff-target.md
+++ b/backlog/tasks/task-485 - Fix-chat-rails-regression-coverage-and-sidepanel-handoff-target.md
@@ -10,8 +10,10 @@ labels:
 priority: High
 documentation:
 - Docs/superpowers/specs/2026-05-31-chat-siderail-collapse-design.md
+- Docs/superpowers/plans/2026-05-31-chat-siderail-edge-expand-implementation-plan.md
 modified_files:
 - Docs/superpowers/specs/2026-05-31-chat-siderail-collapse-design.md
+- Docs/superpowers/plans/2026-05-31-chat-siderail-edge-expand-implementation-plan.md
 ---
 
 ## Description
@@ -38,6 +40,10 @@ Design addendum 2026-05-31: collapsed /chat siderails must disappear from layout
 Design spec committed and reviewed through the brainstorming spec-review loop. Initial review flagged ambiguous 768-1023px behavior and shared OptionLayout scope. Spec was updated to scope edge-mounted expand buttons to lg-and-wider /chat side-rail behavior, preserve md/tablet behavior, and require /chat/Playground-scoped layout changes. Re-review status: Approved.
 
 Follow-up spec review clarified two planning details before implementation: the right-edge expand button is only visible when an active artifact exists, and browser verification must include layout measurements for chat width, chat-shell top stability, and composer bottom docking.
+
+Implementation plan drafted at Docs/superpowers/plans/2026-05-31-chat-siderail-edge-expand-implementation-plan.md before runtime code changes.
+
+Plan review loop completed. Initial review required the Playwright plan to reuse auth/setup seeding and provider endpoint stubs, plus verify right-edge absence below lg with an active artifact. Plan was updated and re-review status was Approved.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-485 - Fix-chat-rails-regression-coverage-and-sidepanel-handoff-target.md
+++ b/backlog/tasks/task-485 - Fix-chat-rails-regression-coverage-and-sidepanel-handoff-target.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-485
 title: Fix /chat rails regression coverage and sidepanel handoff target
-status: In Progress
+status: Done
 labels:
 - webui
 - chat
@@ -72,7 +72,10 @@ User rejected the closeout screenshots and validation because they did not show 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
+PR: https://github.com/rmusser01/tldw_server/pull/2208
+
 Implemented same-side desktop edge expand affordances for collapsed /chat rails across the shared layout, artifact panel, and Next WebUI shell. Added focused Playwright coverage for left and right rail collapse/expand behavior, chat width release, vertical stability, composer docking, and no desktop edge buttons below the lg breakpoint.
+
 2026-06-01 sidepanel handoff slice: visible sidepanel chat actions now open real WebUI `/chat` with encoded handoff draft/context and WebUI `/chat` restores that handoff. Focused unit coverage and rail-collapse Playwright verification pass; extension handoff e2e is updated but remains blocked by the existing WXT production build hang before test execution.
 <!-- SECTION:FINAL_SUMMARY:END -->
 

--- a/backlog/tasks/task-485 - Fix-chat-rails-regression-coverage-and-sidepanel-handoff-target.md
+++ b/backlog/tasks/task-485 - Fix-chat-rails-regression-coverage-and-sidepanel-handoff-target.md
@@ -36,6 +36,8 @@ Design addendum 2026-05-31: collapsed /chat siderails must disappear from layout
 
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
 Design spec committed and reviewed through the brainstorming spec-review loop. Initial review flagged ambiguous 768-1023px behavior and shared OptionLayout scope. Spec was updated to scope edge-mounted expand buttons to lg-and-wider /chat side-rail behavior, preserve md/tablet behavior, and require /chat/Playground-scoped layout changes. Re-review status: Approved.
+
+Follow-up spec review clarified two planning details before implementation: the right-edge expand button is only visible when an active artifact exists, and browser verification must include layout measurements for chat width, chat-shell top stability, and composer bottom docking.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-485 - Fix-chat-rails-regression-coverage-and-sidepanel-handoff-target.md
+++ b/backlog/tasks/task-485 - Fix-chat-rails-regression-coverage-and-sidepanel-handoff-target.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-485
 title: Fix /chat rails regression coverage and sidepanel handoff target
-status: Done
+status: In Progress
 labels:
 - webui
 - chat
@@ -14,14 +14,22 @@ documentation:
 modified_files:
 - Docs/superpowers/specs/2026-05-31-chat-siderail-collapse-design.md
 - Docs/superpowers/plans/2026-05-31-chat-siderail-edge-expand-implementation-plan.md
+- apps/extension/tests/e2e/sidepanel-options-handoff.spec.ts
 - apps/packages/ui/src/components/Layouts/Layout.tsx
 - apps/packages/ui/src/components/Layouts/__tests__/Layout.chat-sidebar-reset-signal.guard.test.ts
 - apps/packages/ui/src/components/Option/Playground/Playground.tsx
 - apps/packages/ui/src/components/Option/Playground/__tests__/Playground.search.integration.test.tsx
 - apps/packages/ui/src/components/Option/Playground/__tests__/Playground.sticky-composer-layout.integration.test.tsx
 - apps/packages/ui/src/components/Sidepanel/Chat/ArtifactsPanel.tsx
+- apps/packages/ui/src/components/Sidepanel/Chat/ControlRow.tsx
+- apps/packages/ui/src/components/Sidepanel/Chat/SidepanelHeaderSimple.tsx
+- apps/packages/ui/src/components/Sidepanel/Chat/__tests__/SidepanelHeaderSimple.webui-handoff.test.tsx
+- apps/packages/ui/src/components/Sidepanel/Chat/form.tsx
+- apps/packages/ui/src/services/__tests__/sidepanel-chat-webui-handoff.test.ts
+- apps/packages/ui/src/services/tldw/sidepanel-chat-webui-handoff.ts
 - apps/tldw-frontend/components/layout/WebLayout.tsx
 - apps/tldw-frontend/e2e/workflows/chat-rails-collapse.spec.ts
+- apps/tldw-frontend/extension/routes/sidepanel-chat.tsx
 ---
 
 ## Description
@@ -57,12 +65,15 @@ Implementation completed in commits cb2a400815, d6608e4b7e, and 89f7c6b72c. The 
 Verification recorded: `bunx vitest run src/components/Layouts/__tests__/Layout.chat-sidebar-reset-signal.guard.test.ts src/components/Option/Playground/__tests__/Playground.search.integration.test.tsx src/components/Option/Playground/__tests__/Playground.sticky-composer-layout.integration.test.tsx src/components/Sidepanel/Chat/__tests__/ArtifactsPanel.jump-source.guard.test.ts` passed 4 files / 16 tests. `TLDW_WEB_CMD='bun run dev -- -H 127.0.0.1 -p 18081' TLDW_WEB_URL=http://127.0.0.1:18081 bunx playwright test e2e/workflows/chat-rails-collapse.spec.ts --project=chromium --reporter=line` passed 2 tests. Scoped whitespace checks for the touched WebLayout and E2E files passed. Full `git diff --check` is blocked by unrelated pre-existing trailing whitespace in `Docs/Design/Agents.md:155`. Bandit skipped because this slice touched frontend TypeScript/TSX and Playwright coverage only, with no Python runtime or tests changed.
 
 Screenshot evidence captured after the fix: `/private/tmp/tldw-chat-left-rail-collapsed.png` and `/private/tmp/tldw-chat-right-rail-collapsed.png`. The stubbed provider state intentionally shows the existing no-provider warning while exercising layout behavior.
+User rejected the closeout screenshots and validation because they did not show the required visual states: both rails expanded as a baseline, one rail expanded while the opposite same-side expand affordance is visible, and the composer did not match the current /chat surface. Reopened for live-state reproduction and correction.
+2026-06-01 slice: implemented sidepanel chat WebUI handoff helper and wired the visible sidepanel full-screen/header action plus composer overflow Open full app action through `/chat?handoff=...` instead of the extension options hash. The payload preserves draft text, server chat id via existing `settingsServerChatId`, and chat context controls such as model, prompts, chat mode, web search, tool choice, temporary chat, OCR, and title. WebUI `/chat` now decodes the handoff, applies supported context state, seeds the composer with `tldw:set-composer-message` using `ifEmptyOnly`, and cleans the `handoff` query param. Updated extension e2e coverage to assert the sidepanel opens `http://127.0.0.1:8080/chat` with decoded draft/context rather than `options.html`. Verification: focused Vitest set passed 6 files / 19 tests; extension `bun run compile` passed; rail-collapse Playwright e2e passed 2 tests after elevated local-server permission; scoped `git diff --check` passed. Extension handoff Playwright e2e was not completed because its global setup repeatedly entered the existing WXT production build hang and had to be terminated; no test assertion ran. Bandit skipped because this slice touched frontend TS/TSX and Playwright only, no Python runtime files.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
 Implemented same-side desktop edge expand affordances for collapsed /chat rails across the shared layout, artifact panel, and Next WebUI shell. Added focused Playwright coverage for left and right rail collapse/expand behavior, chat width release, vertical stability, composer docking, and no desktop edge buttons below the lg breakpoint.
+2026-06-01 sidepanel handoff slice: visible sidepanel chat actions now open real WebUI `/chat` with encoded handoff draft/context and WebUI `/chat` restores that handoff. Focused unit coverage and rail-collapse Playwright verification pass; extension handoff e2e is updated but remains blocked by the existing WXT production build hang before test execution.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-485 - Fix-chat-rails-regression-coverage-and-sidepanel-handoff-target.md
+++ b/backlog/tasks/task-485 - Fix-chat-rails-regression-coverage-and-sidepanel-handoff-target.md
@@ -1,0 +1,55 @@
+---
+id: TASK-485
+title: Fix /chat rails regression coverage and sidepanel handoff target
+status: In Progress
+labels:
+- webui
+- chat
+- sidepanel
+- ux
+priority: High
+documentation:
+- Docs/superpowers/specs/2026-05-31-chat-siderail-collapse-design.md
+modified_files:
+- Docs/superpowers/specs/2026-05-31-chat-siderail-collapse-design.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+PR 1 from the fresh /chat UX re-evaluation: preserve restored /chat cockpit rails and fix the directly connected sidepanel chat handoff so visible sidepanel actions target WebUI /chat with draft/context handoff instead of /options.html#/chat.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Stage 0/1: add failing regression coverage for /chat desktop rails and sidepanel handoff route; trace existing model selector/handoff controls; implement the minimal route/visible-action changes so sidepanel Continue in WebUI opens /chat?handoff=<id>; verify with focused tests and browser smoke.
+
+Design addendum 2026-05-31: collapsed /chat siderails must disappear from layout and leave same-side edge-mounted expand buttons. Left chat rail collapse releases left width and shows a left-edge expand button. Right artifact rail collapse releases right width and shows a right-edge expand button when an artifact is available. Both collapsed states must keep chat/composer vertically anchored and visibly recoverable from both edges.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Design spec committed and reviewed through the brainstorming spec-review loop. Initial review flagged ambiguous 768-1023px behavior and shared OptionLayout scope. Spec was updated to scope edge-mounted expand buttons to lg-and-wider /chat side-rail behavior, preserve md/tablet behavior, and require /chat/Playground-scoped layout changes. Re-review status: Approved.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-585 - Address-PR-2208-sidepanel-handoff-review-comments.md
+++ b/backlog/tasks/task-585 - Address-PR-2208-sidepanel-handoff-review-comments.md
@@ -1,0 +1,50 @@
+---
+id: TASK-585
+title: Address PR 2208 sidepanel handoff review comments
+status: Done
+references:
+- TASK-485
+- https://github.com/rmusser01/tldw_server/pull/2208
+modified_files:
+- apps/packages/ui/src/services/tldw/sidepanel-chat-webui-handoff.ts
+- apps/packages/ui/src/services/__tests__/sidepanel-chat-webui-handoff.test.ts
+- apps/packages/ui/src/components/Option/Playground/Playground.tsx
+- apps/packages/ui/src/components/Option/Playground/__tests__/Playground.search.integration.test.tsx
+- apps/packages/ui/src/components/Layouts/Layout.tsx
+- apps/tldw-frontend/components/layout/WebLayout.tsx
+- apps/extension/tests/e2e/sidepanel-options-handoff.spec.ts
+- apps/extension/tests/e2e/sidepanel-chat-smoke.spec.ts
+- Docs/superpowers/plans/2026-05-31-chat-siderail-edge-expand-implementation-plan.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Resolve the actionable PR #2208 review feedback on the sidepanel WebUI chat handoff and chat rail collapse slice, including URL safety, fragment transport, handoff expiry, prompt/history restoration, localized rail labels, focused tests, and verification.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Resolved PR #2208 review clusters: validated explicit WebUI URLs as http(s), preserved explicit WebUI subpaths, moved encoded sidepanel WebUI payloads from query string to URL fragment, enforced a 10 minute max handoff age, preserved explicit prompt clear values, restored local history IDs via loadLocalConversation, localized the desktop chat edge label from the existing chat sidebar title key, and fixed the plan mock snippet noted by cubic. Verification: focused Vitest suite passed with 6 files / 28 tests; `bun run compile` passed in apps/extension; `bun run build:chrome` completed successfully with existing Rollup/chunk warnings; `git diff --check origin/dev...HEAD` passed. Focused Playwright sidepanel handoff e2e was attempted with `.output/chrome-mv3` and `TLDW_E2E_EXTENSION_HEADLESS=1`, but both tests were skipped by the harness because Chromium extension launch aborts in this environment (`launchPersistentContext` closed/SIGABRT, kill EPERM). Bandit not run because this slice only touches TypeScript/TSX/docs/backlog files, not Python.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## Summary

- Route visible extension sidepanel chat actions to the real WebUI `/chat` route instead of `options.html#/chat`.
- Preserve sidepanel draft and chat context during handoff, including server chat id, history id, mode, search/tools settings, selected model, prompt selections, temporary chat, OCR state, and title.
- Keep the current chat rail collapse fixes in this branch and extend focused coverage around WebUI handoff and rail edge collapse.

## Change summary

This slice keeps the handoff payload encoded in a short-lived `/chat?handoff=...` URL so the sidepanel can open the WebUI without depending on extension-only hash routing. The WebUI decodes that payload on load, applies the matching chat state, restores the composer draft only when the composer is still empty, and then removes the handoff parameter from the URL. Existing sidepanel actions now use a route-provided opener so the same helper can be unit-tested and reused by both the header action and the composer overflow action.

The rail collapse fixes remain in this branch because TASK-485 is closing the regression slice together with the handoff correction. The e2e coverage now checks the desktop left/right rail collapse and restore paths.

## Verification

- `bunx vitest run src/components/Sidepanel/Chat/__tests__/SidepanelHeaderSimple.webui-handoff.test.tsx` failed first as the expected red test before implementation.
- `bunx vitest run src/components/Sidepanel/Chat/__tests__/SidepanelHeaderSimple.webui-handoff.test.tsx src/services/__tests__/sidepanel-chat-webui-handoff.test.ts src/components/Layouts/__tests__/Layout.chat-sidebar-reset-signal.guard.test.ts src/components/Option/Playground/__tests__/Playground.search.integration.test.tsx src/components/Option/Playground/__tests__/Playground.sticky-composer-layout.integration.test.tsx src/components/Sidepanel/Chat/__tests__/ArtifactsPanel.jump-source.guard.test.ts`
- `bun run compile`
- `TLDW_WEB_CMD='bun run dev -- -H 127.0.0.1 -p 18081' TLDW_WEB_URL=http://127.0.0.1:18081 bunx playwright test e2e/workflows/chat-rails-collapse.spec.ts --project=chromium --reporter=line`
- `git diff --check`
- `git diff --cached --check`

## Known Remaining Work

- Extension route e2e handoff coverage was updated but could not complete locally because the Playwright global setup starts a WXT production extension build that repeatedly hung before any test assertion ran. This appears to match existing TASK-306 (`Fix extension WXT build pre-render hang blocking E2E route verification`).
- Bandit was skipped for this slice because the touched implementation and tests are frontend TypeScript/TSX, Playwright, and Backlog markdown only.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the sidepanel → WebUI chat handoff by opening the real `/chat` with restored state, and repairs desktop rail collapse with same-side edge expand buttons that free layout width and keep focus. Addresses TASK-485 and TASK-585 with focused unit and e2e coverage.

- **Bug Fixes**
  - Route sidepanel actions to WebUI `/chat` using a short-lived `#handoff=...` fragment (10‑min TTL with skew); decode on load, apply state, then remove it.
  - Preserve chat context during handoff: server/history IDs, mode, web search/tool choice, selected model, system/quick prompts, temporary chat, OCR, title; only restore draft if the composer is empty.
  - Add `@/services/tldw/sidepanel-chat-webui-handoff` to resolve the WebUI base from `webUiUrl` (fallback `http://127.0.0.1:8080`), build/encode/decode the payload; used by the header full-screen and composer overflow actions; unit tests included.
  - Desktop `/chat` rails: collapsing removes layout width and shows edge expand buttons at desktop breakpoints (left rail; right rail only when an active artifact exists); focus transfers on collapse/expand; implemented in both `Layout` and `WebLayout`.
  - Tests: unit tests for handoff encode/decode, integration tests for playground chat shell and layout, Playwright e2e for rail edge collapse, and updated extension e2e to assert the WebUI `/chat` fragment handoff.

<sup>Written for commit 02c29a126ac273e9889775ccd6bfcf7ecea4f67f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2208?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

