### PR TITLE
Harden MCP external runtime installer status contracts

### DIFF
--- a/Docs/superpowers/plans/2026-06-01-mcp-external-runtime-installer-status-plan.md
+++ b/Docs/superpowers/plans/2026-06-01-mcp-external-runtime-installer-status-plan.md
@@ -1,0 +1,109 @@
+# MCP External Runtime Installer Status Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add stable, sanitized installer status and install/update operation contracts for the standalone MCP gateway external runtime.
+
+**Architecture:** Keep `GatewayExternalRuntimeManager` as the public normalization boundary around pluggable `ExternalServerInstaller` adapters. Add best-effort installer status collection to runtime status rows and deterministic failure handling for install/update adapter exceptions. Do not implement real third-party package installation.
+
+**Tech Stack:** Python, async/await, FastAPI response models, pytest.
+
+---
+
+### Task 1: Runtime Manager Installer Status Contract
+
+**Files:**
+- Modify: `mcp_unified/gateway/external_runtime.py`
+- Test: `tldw_Server_API/app/core/MCP_unified/tests/test_gateway_external_runtime.py`
+
+- [ ] **Step 1: Write failing runtime-manager tests**
+
+Add tests that:
+- `list_runtime_servers()` includes default unavailable installer status.
+- A fake installer status payload is included after sanitization.
+- A failing `get_status()` logs diagnostics and returns deterministic unavailable status for that row.
+
+- [ ] **Step 2: Run tests to verify RED**
+
+Run: `source .venv/bin/activate && python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_gateway_external_runtime.py -k "installer_status" -q`
+
+Expected: FAIL because runtime rows do not include `installer` status yet.
+
+- [ ] **Step 3: Implement minimal status support**
+
+Add a private manager helper that calls `self._installer.get_status(server.model_copy(deep=True))`, sanitizes the payload, applies defaults, catches unexpected exceptions, logs them, and returns a stable unavailable status.
+
+- [ ] **Step 4: Run tests to verify GREEN**
+
+Run the same pytest command and confirm it passes.
+
+### Task 2: Install/Update Payload Normalization And Failure Handling
+
+**Files:**
+- Modify: `mcp_unified/gateway/external_runtime.py`
+- Test: `tldw_Server_API/app/core/MCP_unified/tests/test_gateway_external_runtime.py`
+
+- [ ] **Step 1: Write failing operation tests**
+
+Add tests that:
+- Successful fake install/update payloads preserve safe public metadata and apply default fields.
+- Nested secret-looking values are removed from operation payloads.
+- Adapter exceptions are logged and raised as `GatewayExternalRuntimeError` with install/update-specific reason codes.
+
+- [ ] **Step 2: Run tests to verify RED**
+
+Run: `source .venv/bin/activate && python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_gateway_external_runtime.py -k "installer" -q`
+
+Expected: FAIL because operation payload redaction and adapter exception wrapping are missing.
+
+- [ ] **Step 3: Implement minimal operation normalization**
+
+Centralize installer operation calls, reuse the sanitizer, keep default no-op behavior unchanged, and avoid raw exception text in public errors.
+
+- [ ] **Step 4: Run tests to verify GREEN**
+
+Run the same pytest command and confirm it passes.
+
+### Task 3: FastAPI Contract Coverage
+
+**Files:**
+- Modify: `mcp_unified/gateway/fastapi.py` if response models need explicit fields.
+- Test: `tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py`
+
+- [ ] **Step 1: Write or adjust failing HTTP tests**
+
+Verify runtime status JSON exposes the nested installer object and install/update failure responses use existing external runtime error translation.
+
+- [ ] **Step 2: Run tests to verify RED or baseline pass**
+
+Run: `source .venv/bin/activate && python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py -k "external_runtime" -q`
+
+Expected: FAIL only if FastAPI models block or omit the new response shape; otherwise document that no FastAPI code change is needed.
+
+- [ ] **Step 3: Implement minimal FastAPI model adjustments if needed**
+
+Keep route behavior unchanged and only widen response models where required.
+
+- [ ] **Step 4: Run tests to verify GREEN**
+
+Run the same pytest command and confirm it passes.
+
+### Task 4: Final Verification And Backlog Closeout
+
+**Files:**
+- Modify: `backlog/tasks/task-585 - Harden-MCP-external-runtime-installer-status-contracts.md`
+
+- [ ] **Step 1: Run focused tests**
+
+Run:
+- `source .venv/bin/activate && python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_gateway_external_runtime.py tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py -q`
+- `source .venv/bin/activate && python -m bandit -r mcp_unified/gateway/external_runtime.py mcp_unified/gateway/fastapi.py -f json -o /tmp/bandit_mcp_external_runtime_installer_status.json`
+- `git diff --check`
+
+- [ ] **Step 2: Update Backlog task**
+
+Record touched files, verification results, skipped scope, and final summary in `TASK-585`.
+
+- [ ] **Step 3: Commit**
+
+Commit the implementation, tests, docs, and Backlog task together with a message referencing `TASK-585`.

--- a/Docs/superpowers/plans/2026-06-01-mcp-external-runtime-installer-status-plan.md
+++ b/Docs/superpowers/plans/2026-06-01-mcp-external-runtime-installer-status-plan.md
@@ -31,7 +31,7 @@ Expected: FAIL because runtime rows do not include `installer` status yet.
 
 - [ ] **Step 3: Implement minimal status support**
 
-Add a private manager helper that calls `self._installer.get_status(server.model_copy(deep=True))`, sanitizes the payload, applies defaults, catches unexpected exceptions, logs them, and returns a stable unavailable status.
+Add a private manager helper that calls `self._installer.get_status(server.model_copy(deep=True))` with a bounded timeout, sanitizes the payload, applies defaults, catches unexpected exceptions, logs only sanitized diagnostic fields, and returns a stable unavailable status.
 
 - [ ] **Step 4: Run tests to verify GREEN**
 
@@ -48,7 +48,7 @@ Run the same pytest command and confirm it passes.
 Add tests that:
 - Successful fake install/update payloads preserve safe public metadata and apply default fields.
 - Nested secret-looking values are removed from operation payloads.
-- Adapter exceptions are logged and raised as `GatewayExternalRuntimeError` with install/update-specific reason codes.
+- Adapter exceptions are logged without traceback/raw exception text and raised as `GatewayExternalRuntimeError` with install/update-specific reason codes.
 
 - [ ] **Step 2: Run tests to verify RED**
 
@@ -58,7 +58,7 @@ Expected: FAIL because operation payload redaction and adapter exception wrappin
 
 - [ ] **Step 3: Implement minimal operation normalization**
 
-Centralize installer operation calls, reuse the sanitizer, keep default no-op behavior unchanged, and avoid raw exception text in public errors.
+Centralize installer operation calls, reuse the sanitizer, keep default no-op behavior unchanged, and avoid raw exception text in public errors or logs.
 
 - [ ] **Step 4: Run tests to verify GREEN**
 

--- a/Docs/superpowers/specs/2026-06-01-mcp-external-runtime-installer-status-design.md
+++ b/Docs/superpowers/specs/2026-06-01-mcp-external-runtime-installer-status-design.md
@@ -12,7 +12,7 @@ This slice keeps the existing `ExternalServerInstaller` adapter seam and the def
 
 `GatewayExternalRuntimeManager` remains the orchestration boundary. It loads the external server definition, enforces enabled/not-found checks, delegates optional work to the configured installer, and converts installer adapter output into a stable public payload. The installer adapter may return richer metadata, but the runtime manager owns public response normalization and redaction.
 
-Runtime status rows gain an `installer` object from `ExternalServerInstaller.get_status(server)`. The manager sanitizes that object before returning it. If the installer status call fails, the manager logs diagnostics with traceback and returns a deterministic unavailable installer status for that server instead of breaking the whole status list.
+Runtime status rows gain an `installer` object from `ExternalServerInstaller.get_status(server)`. The manager bounds that call with a short timeout, sanitizes the returned object before returning it, and never logs raw adapter exception messages or tracebacks because those can contain secret material. If the installer status call fails or times out, the manager logs sanitized diagnostics and returns a deterministic unavailable installer status for that server instead of breaking the whole status list.
 
 Install/update operations use the same sanitization rules. Expected unavailable or unsupported results pass through with normalized defaults. Unexpected adapter exceptions are logged and surfaced as `GatewayExternalRuntimeError` with `external_server_install_failed` or `external_server_update_failed`, without raw exception text in HTTP responses.
 
@@ -24,8 +24,8 @@ Operation responses always include `ok`, `available`, `reason_code`, and `server
 
 ## Error Handling
 
-Disabled and not-found servers continue to use the existing `GatewayExternalRuntimeError` paths. Installer adapter failures are treated as runtime operation failures, logged with traceback for diagnostics, and exposed with stable reason codes. Status collection is best-effort per server so one failing installer status check does not prevent reporting other runtime rows.
+Disabled and not-found servers continue to use the existing `GatewayExternalRuntimeError` paths. Installer adapter failures are treated as runtime operation failures, logged with sanitized diagnostic fields, and exposed with stable reason codes. Status collection is best-effort per server so one failing or hanging installer status check does not prevent reporting other runtime rows.
 
 ## Tests
 
-Focused pytest coverage will verify default unsupported status, successful fake installer status and install/update responses, disabled/not-found operation behavior, adapter exception handling, and redaction of nested secret-looking fields from status and operation responses.
+Focused pytest coverage will verify default unsupported status, successful fake installer status and install/update responses, disabled/not-found operation behavior, adapter exception handling, status timeout handling, docstring-backed helper intent, and redaction of nested secret-looking fields from status and operation responses/log assertions.

--- a/Docs/superpowers/specs/2026-06-01-mcp-external-runtime-installer-status-design.md
+++ b/Docs/superpowers/specs/2026-06-01-mcp-external-runtime-installer-status-design.md
@@ -1,0 +1,31 @@
+# MCP External Runtime Installer Status Design
+
+## Goal
+
+Harden the standalone MCP gateway's external server install/update surface so frontends and operators can distinguish unsupported, unavailable, failed, disabled, and successful installer states without exposing secrets or adding real package-manager execution in this slice.
+
+## Scope
+
+This slice keeps the existing `ExternalServerInstaller` adapter seam and the default `NullExternalServerInstaller`. It adds a public, sanitized installer status contract to runtime status rows and normalizes install/update operation payloads. Real npm, pip, uvx, or other third-party installation execution remains out of scope.
+
+## Architecture
+
+`GatewayExternalRuntimeManager` remains the orchestration boundary. It loads the external server definition, enforces enabled/not-found checks, delegates optional work to the configured installer, and converts installer adapter output into a stable public payload. The installer adapter may return richer metadata, but the runtime manager owns public response normalization and redaction.
+
+Runtime status rows gain an `installer` object from `ExternalServerInstaller.get_status(server)`. The manager sanitizes that object before returning it. If the installer status call fails, the manager logs diagnostics with traceback and returns a deterministic unavailable installer status for that server instead of breaking the whole status list.
+
+Install/update operations use the same sanitization rules. Expected unavailable or unsupported results pass through with normalized defaults. Unexpected adapter exceptions are logged and surfaced as `GatewayExternalRuntimeError` with `external_server_install_failed` or `external_server_update_failed`, without raw exception text in HTTP responses.
+
+## Public Payload Rules
+
+Allowed public fields are lightweight scalars and scalar lists/maps such as `ok`, `available`, `reason_code`, `server_id`, `installer`, `version`, `installed_version`, `latest_version`, `message`, `details`, `required_fields`, and `warnings`. Sensitive values are removed recursively from public payloads when keys indicate secrets, tokens, passwords, credentials, headers, env, authorization, or command arguments.
+
+Operation responses always include `ok`, `available`, `reason_code`, and `server_id`. Status responses always include `available`, `reason_code`, and `server_id`.
+
+## Error Handling
+
+Disabled and not-found servers continue to use the existing `GatewayExternalRuntimeError` paths. Installer adapter failures are treated as runtime operation failures, logged with traceback for diagnostics, and exposed with stable reason codes. Status collection is best-effort per server so one failing installer status check does not prevent reporting other runtime rows.
+
+## Tests
+
+Focused pytest coverage will verify default unsupported status, successful fake installer status and install/update responses, disabled/not-found operation behavior, adapter exception handling, and redaction of nested secret-looking fields from status and operation responses.

--- a/backlog/tasks/task-585 - Harden-MCP-external-runtime-installer-status-contracts.md
+++ b/backlog/tasks/task-585 - Harden-MCP-external-runtime-installer-status-contracts.md
@@ -1,0 +1,60 @@
+---
+id: TASK-585
+title: Harden MCP external runtime installer status contracts
+status: Done
+assignee: []
+created_date: ''
+updated_date: '2026-06-01 03:58'
+labels:
+  - mcp-unified
+  - external-runtime
+dependencies: []
+documentation:
+  - >-
+    Docs/superpowers/specs/2026-06-01-mcp-external-runtime-installer-status-design.md
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Add stable, sanitized installer availability/status and install/update operation contracts for the standalone MCP gateway external runtime. Keep default installer side-effect-free and defer real package-manager execution.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Runtime status rows expose sanitized installer capability/status metadata per configured external server.
+- [x] #2 Install/update operation responses are normalized, deterministic, and do not leak credential, env, header, or command secret values.
+- [x] #3 Unexpected installer adapter failures are logged for diagnostics and surfaced through stable external runtime reason codes.
+- [x] #4 Focused tests cover default unsupported behavior, fake installer status/operation success, adapter failure handling, disabled/not-found paths, and secret redaction.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Docs/superpowers/plans/2026-06-01-mcp-external-runtime-installer-status-plan.md
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+['Design approved by user on 2026-06-01.', 'Real third-party install/update execution, durable lifecycle CLI controls, frontend changes, and WebSocket upstream transport are out of scope for this slice.']
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Implemented stable, sanitized installer status and install/update operation contracts for the standalone MCP gateway external runtime. Runtime status rows now include best-effort installer capability metadata, install/update adapter payloads are normalized and redacted, adapter failures are logged internally and surfaced through deterministic reason codes, and FastAPI response models document the new fields. Verification: focused gateway pytest suite passed (168 tests), Ruff passed on touched Python files, Bandit passed on touched gateway source with JSON output at /tmp/bandit_mcp_external_runtime_installer_status.json, and git diff --check passed. Out of scope remains real third-party package-manager execution, durable CLI lifecycle controls, frontend changes, and WebSocket upstream transport.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-585 - Harden-MCP-external-runtime-installer-status-contracts.md
+++ b/backlog/tasks/task-585 - Harden-MCP-external-runtime-installer-status-contracts.md
@@ -4,7 +4,7 @@ title: Harden MCP external runtime installer status contracts
 status: Done
 assignee: []
 created_date: ''
-updated_date: '2026-06-01 03:58'
+updated_date: '2026-06-01 04:14'
 labels:
   - mcp-unified
   - external-runtime
@@ -38,15 +38,13 @@ Docs/superpowers/plans/2026-06-01-mcp-external-runtime-installer-status-plan.md
 ## Implementation Notes
 
 <!-- SECTION:NOTES:BEGIN -->
-<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
-['Design approved by user on 2026-06-01.', 'Real third-party install/update execution, durable lifecycle CLI controls, frontend changes, and WebSocket upstream transport are out of scope for this slice.']
-<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+Design approved by user on 2026-06-01. Real third-party install/update execution, durable lifecycle CLI controls, frontend changes, and WebSocket upstream transport are out of scope. PR #2209 review follow-up addressed Qodo/cubic secret-logging feedback, Qodo helper-docstring feedback, and Qodo installer-status timeout feedback after rebasing on latest dev.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Implemented stable, sanitized installer status and install/update operation contracts for the standalone MCP gateway external runtime. Runtime status rows now include best-effort installer capability metadata, install/update adapter payloads are normalized and redacted, adapter failures are logged internally and surfaced through deterministic reason codes, and FastAPI response models document the new fields. Verification: focused gateway pytest suite passed (168 tests), Ruff passed on touched Python files, Bandit passed on touched gateway source with JSON output at /tmp/bandit_mcp_external_runtime_installer_status.json, and git diff --check passed. Out of scope remains real third-party package-manager execution, durable CLI lifecycle controls, frontend changes, and WebSocket upstream transport.
+Implemented stable, sanitized installer status and install/update operation contracts for the standalone MCP gateway external runtime. PR review follow-up removed raw traceback logging for installer adapter failures, suppressed raw adapter exception context from wrapped operation errors, added a bounded installer status timeout with a timeout-specific reason code, and documented the installer helper intent. Verification: focused gateway pytest suite passed (169 tests), Ruff passed on touched Python files, Bandit passed on touched gateway source with JSON output at /tmp/bandit_mcp_external_runtime_installer_status.json, and git diff --check passed. Out of scope remains real third-party package-manager execution, durable CLI lifecycle controls, frontend changes, and WebSocket upstream transport.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/mcp_unified/gateway/external_runtime.py
+++ b/mcp_unified/gateway/external_runtime.py
@@ -846,7 +846,7 @@ class GatewayExternalRuntimeManager:
                 f"External server {operation} failed",
                 reason_code=failure_reason_code,
                 server_id=server.id,
-            ) from None
+            ) from exc
         return self._installer_payload(
             payload,
             server=server,

--- a/mcp_unified/gateway/external_runtime.py
+++ b/mcp_unified/gateway/external_runtime.py
@@ -61,6 +61,7 @@ _INSTALLER_SENSITIVE_KEY_TOKENS = (
     "argv",
 )
 _UNSAFE_INSTALLER_VALUE = object()
+_DEFAULT_INSTALLER_STATUS_TIMEOUT_SECONDS = 2.0
 
 
 class GatewayExternalRuntimeError(RuntimeError):
@@ -117,12 +118,14 @@ class GatewayExternalRuntimeManager:
         audit_store: AuditStore | None = None,
         credential_broker: ExternalCredentialBroker | Callable[..., Any] | None = None,
         installer: ExternalServerInstaller | None = None,
+        installer_status_timeout_seconds: float = _DEFAULT_INSTALLER_STATUS_TIMEOUT_SECONDS,
     ) -> None:
         self._external_registry_store = external_registry_store
         self._transport_factory = transport_factory
         self._audit_store = audit_store
         self._credential_broker = credential_broker
         self._installer = installer or NullExternalServerInstaller()
+        self._installer_status_timeout_seconds = installer_status_timeout_seconds
         self._servers: dict[str, ExternalServerDefinition] = {}
         self._transports: dict[str, ExternalFederationTransport] = {}
         self._virtual_tools: dict[str, VirtualExternalTool] = {}
@@ -782,10 +785,26 @@ class GatewayExternalRuntimeManager:
         self,
         server: ExternalServerDefinition,
     ) -> dict[str, Any]:
+        """Return sanitized best-effort installer status for one server row."""
+
         try:
-            payload = await self._installer.get_status(server.model_copy(deep=True))
+            payload = await asyncio.wait_for(
+                self._installer.get_status(server.model_copy(deep=True)),
+                timeout=self._installer_status_timeout_seconds,
+            )
+        except asyncio.TimeoutError:
+            logger.error(
+                "External installer status timed out server_id={!r}",
+                server.id,
+            )
+            return {
+                "available": False,
+                "reason_code": "external_server_installer_status_timeout",
+                "server_id": server.id,
+                "error_type": "TimeoutError",
+            }
         except Exception as exc:  # noqa: BLE001 - installer adapters are optional.
-            logger.opt(exception=True).error(
+            logger.error(
                 "External installer status failed server_id={!r} error_type={!r}",
                 server.id,
                 type(exc).__name__,
@@ -812,10 +831,12 @@ class GatewayExternalRuntimeManager:
         fallback_reason_code: str,
         failure_reason_code: str,
     ) -> dict[str, Any]:
+        """Run one installer operation and expose only sanitized public metadata."""
+
         try:
             payload = await callback()
         except Exception as exc:  # noqa: BLE001 - installer adapters define failures.
-            logger.opt(exception=True).error(
+            logger.error(
                 "External installer operation failed operation={!r} server_id={!r} error_type={!r}",
                 operation,
                 server.id,
@@ -825,7 +846,7 @@ class GatewayExternalRuntimeManager:
                 f"External server {operation} failed",
                 reason_code=failure_reason_code,
                 server_id=server.id,
-            ) from exc
+            ) from None
         return self._installer_payload(
             payload,
             server=server,
@@ -841,6 +862,8 @@ class GatewayExternalRuntimeManager:
         fallback_reason_code: str,
         include_ok: bool = True,
     ) -> dict[str, Any]:
+        """Normalize an installer adapter payload into the public gateway shape."""
+
         result = cls._sanitize_installer_payload(payload or {})
         if include_ok:
             result.setdefault("ok", False)
@@ -853,6 +876,8 @@ class GatewayExternalRuntimeManager:
 
     @classmethod
     def _sanitize_installer_payload(cls, payload: dict[str, Any]) -> dict[str, Any]:
+        """Return only allowlisted installer fields with nested sensitive keys removed."""
+
         sanitized: dict[str, Any] = {}
         for key, value in payload.items():
             normalized_key = str(key)
@@ -867,6 +892,8 @@ class GatewayExternalRuntimeManager:
 
     @classmethod
     def _sanitize_installer_value(cls, value: Any) -> Any:
+        """Recursively sanitize installer payload values into JSON-safe public data."""
+
         if isinstance(value, dict):
             sanitized: dict[str, Any] = {}
             for key, child in value.items():
@@ -893,6 +920,8 @@ class GatewayExternalRuntimeManager:
 
     @staticmethod
     def _is_sensitive_installer_key(key: str) -> bool:
+        """Return true when a key name suggests credentials or command material."""
+
         lowered = key.strip().lower()
         return any(token in lowered for token in _INSTALLER_SENSITIVE_KEY_TOKENS)
 

--- a/mcp_unified/gateway/external_runtime.py
+++ b/mcp_unified/gateway/external_runtime.py
@@ -793,7 +793,7 @@ class GatewayExternalRuntimeManager:
                 timeout=self._installer_status_timeout_seconds,
             )
         except asyncio.TimeoutError:
-            logger.error(
+            logger.opt(exception=True).error(
                 "External installer status timed out server_id={!r}",
                 server.id,
             )

--- a/mcp_unified/gateway/external_runtime.py
+++ b/mcp_unified/gateway/external_runtime.py
@@ -28,6 +28,40 @@ from mcp_unified.federation.transports import ExternalFederationTransport
 from mcp_unified.interfaces.storage import AuditStore, ExternalRegistryStore
 from mcp_unified.storage import AuditEvent, ExternalServerDefinition
 
+_INSTALLER_PUBLIC_KEYS = frozenset(
+    {
+        "ok",
+        "available",
+        "reason_code",
+        "server_id",
+        "installer",
+        "version",
+        "installed_version",
+        "latest_version",
+        "message",
+        "details",
+        "required_fields",
+        "warnings",
+        "error_type",
+    }
+)
+_INSTALLER_SENSITIVE_KEY_TOKENS = (
+    "secret",
+    "token",
+    "password",
+    "credential",
+    "authorization",
+    "api_key",
+    "apikey",
+    "headers",
+    "header",
+    "env",
+    "command",
+    "args",
+    "argv",
+)
+_UNSAFE_INSTALLER_VALUE = object()
+
 
 class GatewayExternalRuntimeError(RuntimeError):
     """Raised when an external runtime operation cannot be completed."""
@@ -391,6 +425,7 @@ class GatewayExternalRuntimeManager:
                     "tool_count": tool_count,
                     "checks": dict(checks),
                     "last_error": last_error,
+                    "installer": await self._installer_status(server),
                 }
             )
         return {"servers": rows, "total_servers": len(rows)}
@@ -412,14 +447,15 @@ class GatewayExternalRuntimeManager:
         """Delegate optional install work to the configured installer adapter."""
         server = await self._load_server(server_id)
         self._require_enabled(server)
-        payload = await self._installer.install_server(
-            server.model_copy(deep=True),
-            context=context,
-        )
-        return self._installer_payload(
-            payload,
+        return await self._installer_operation_payload(
+            "install",
             server=server,
+            callback=lambda: self._installer.install_server(
+                server.model_copy(deep=True),
+                context=context,
+            ),
             fallback_reason_code="external_server_install_not_configured",
+            failure_reason_code="external_server_install_failed",
         )
 
     async def update_server(
@@ -431,14 +467,15 @@ class GatewayExternalRuntimeManager:
         """Delegate optional update work to the configured installer adapter."""
         server = await self._load_server(server_id)
         self._require_enabled(server)
-        payload = await self._installer.update_server(
-            server.model_copy(deep=True),
-            context=context,
-        )
-        return self._installer_payload(
-            payload,
+        return await self._installer_operation_payload(
+            "update",
             server=server,
+            callback=lambda: self._installer.update_server(
+                server.model_copy(deep=True),
+                context=context,
+            ),
             fallback_reason_code="external_server_update_not_configured",
+            failure_reason_code="external_server_update_failed",
         )
 
     async def execute_virtual_tool(
@@ -741,19 +778,123 @@ class GatewayExternalRuntimeManager:
     def _count_tools_for_server(self, server_id: str) -> int:
         return sum(1 for tool in self._virtual_tools.values() if tool.server_id == server_id)
 
-    @staticmethod
+    async def _installer_status(
+        self,
+        server: ExternalServerDefinition,
+    ) -> dict[str, Any]:
+        try:
+            payload = await self._installer.get_status(server.model_copy(deep=True))
+        except Exception as exc:  # noqa: BLE001 - installer adapters are optional.
+            logger.opt(exception=True).error(
+                "External installer status failed server_id={!r} error_type={!r}",
+                server.id,
+                type(exc).__name__,
+            )
+            return {
+                "available": False,
+                "reason_code": "external_server_installer_status_unavailable",
+                "server_id": server.id,
+                "error_type": type(exc).__name__,
+            }
+        return self._installer_payload(
+            payload,
+            server=server,
+            fallback_reason_code="external_server_installer_not_configured",
+            include_ok=False,
+        )
+
+    async def _installer_operation_payload(
+        self,
+        operation: str,
+        *,
+        server: ExternalServerDefinition,
+        callback: Callable[[], Any],
+        fallback_reason_code: str,
+        failure_reason_code: str,
+    ) -> dict[str, Any]:
+        try:
+            payload = await callback()
+        except Exception as exc:  # noqa: BLE001 - installer adapters define failures.
+            logger.opt(exception=True).error(
+                "External installer operation failed operation={!r} server_id={!r} error_type={!r}",
+                operation,
+                server.id,
+                type(exc).__name__,
+            )
+            raise GatewayExternalRuntimeError(
+                f"External server {operation} failed",
+                reason_code=failure_reason_code,
+                server_id=server.id,
+            ) from exc
+        return self._installer_payload(
+            payload,
+            server=server,
+            fallback_reason_code=fallback_reason_code,
+        )
+
+    @classmethod
     def _installer_payload(
+        cls,
         payload: dict[str, Any],
         *,
         server: ExternalServerDefinition,
         fallback_reason_code: str,
+        include_ok: bool = True,
     ) -> dict[str, Any]:
-        result = deepcopy(payload or {})
-        result.setdefault("ok", False)
+        result = cls._sanitize_installer_payload(payload or {})
+        if include_ok:
+            result.setdefault("ok", False)
+        else:
+            result.pop("ok", None)
         result.setdefault("available", False)
         result.setdefault("reason_code", fallback_reason_code)
-        result.setdefault("server_id", server.id)
+        result["server_id"] = server.id
         return result
+
+    @classmethod
+    def _sanitize_installer_payload(cls, payload: dict[str, Any]) -> dict[str, Any]:
+        sanitized: dict[str, Any] = {}
+        for key, value in payload.items():
+            normalized_key = str(key)
+            if normalized_key not in _INSTALLER_PUBLIC_KEYS:
+                continue
+            if cls._is_sensitive_installer_key(normalized_key):
+                continue
+            sanitized_value = cls._sanitize_installer_value(value)
+            if sanitized_value is not _UNSAFE_INSTALLER_VALUE:
+                sanitized[normalized_key] = sanitized_value
+        return sanitized
+
+    @classmethod
+    def _sanitize_installer_value(cls, value: Any) -> Any:
+        if isinstance(value, dict):
+            sanitized: dict[str, Any] = {}
+            for key, child in value.items():
+                normalized_key = str(key)
+                if cls._is_sensitive_installer_key(normalized_key):
+                    continue
+                sanitized_child = cls._sanitize_installer_value(child)
+                if sanitized_child is not _UNSAFE_INSTALLER_VALUE:
+                    sanitized[normalized_key] = sanitized_child
+            return sanitized
+        if isinstance(value, list):
+            sanitized_items = [
+                cls._sanitize_installer_value(item)
+                for item in value
+            ]
+            return [
+                item
+                for item in sanitized_items
+                if item is not _UNSAFE_INSTALLER_VALUE
+            ]
+        if value is None or isinstance(value, (str, int, float, bool)):
+            return value
+        return _UNSAFE_INSTALLER_VALUE
+
+    @staticmethod
+    def _is_sensitive_installer_key(key: str) -> bool:
+        lowered = key.strip().lower()
+        return any(token in lowered for token in _INSTALLER_SENSITIVE_KEY_TOKENS)
 
     def _deny_reason(
         self,

--- a/mcp_unified/gateway/fastapi.py
+++ b/mcp_unified/gateway/fastapi.py
@@ -237,6 +237,7 @@ class ExternalRuntimeServerStatusResponse(BaseModel):
     tool_count: int | None = None
     checks: dict[str, Any] | None = None
     last_error: str | None = None
+    installer: dict[str, Any] | None = None
 
 
 class ExternalRuntimeServerListResponse(BaseModel):
@@ -257,6 +258,15 @@ class ExternalRuntimeOperationResponse(BaseModel):
     ok: bool
     reason_code: str
     server_id: str | None = None
+    available: bool | None = None
+    installer: str | None = None
+    version: str | None = None
+    installed_version: str | None = None
+    latest_version: str | None = None
+    message: str | None = None
+    details: dict[str, Any] | None = None
+    required_fields: list[str] | None = None
+    warnings: list[Any] | None = None
     error: str | None = None
     errors: dict[str, Any] | None = None
 

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_external_runtime.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_external_runtime.py
@@ -281,6 +281,126 @@ class UnsupportedInstaller(ExternalServerInstaller):
         return {"available": False, "server_id": server.id}
 
 
+class SuccessfulInstaller(ExternalServerInstaller):
+    """Installer fake that returns rich public and secret-looking metadata."""
+
+    def __init__(self) -> None:
+        self.install_calls: list[tuple[str, Any]] = []
+        self.update_calls: list[tuple[str, Any]] = []
+
+    async def install_server(
+        self,
+        server: ExternalServerDefinition,
+        *,
+        context: Any = None,
+    ) -> dict[str, Any]:
+        """Return a successful install payload with nested sensitive fields."""
+        self.install_calls.append((server.id, context))
+        return self._payload(
+            server.id,
+            reason_code="external_server_installed",
+            version="1.2.3",
+        )
+
+    async def update_server(
+        self,
+        server: ExternalServerDefinition,
+        *,
+        context: Any = None,
+    ) -> dict[str, Any]:
+        """Return a successful update payload with nested sensitive fields."""
+        self.update_calls.append((server.id, context))
+        return self._payload(
+            server.id,
+            reason_code="external_server_updated",
+            installed_version="1.2.4",
+        )
+
+    async def get_status(
+        self,
+        server: ExternalServerDefinition,
+    ) -> dict[str, Any]:
+        """Return available fake installer status with nested sensitive fields."""
+        return self._payload(
+            server.id,
+            ok=True,
+            reason_code="external_server_installer_available",
+            latest_version="1.2.4",
+        )
+
+    @staticmethod
+    def _payload(
+        server_id: str,
+        *,
+        reason_code: str,
+        ok: bool = True,
+        version: str | None = None,
+        installed_version: str | None = None,
+        latest_version: str | None = None,
+    ) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            "ok": ok,
+            "available": True,
+            "reason_code": reason_code,
+            "server_id": server_id,
+            "installer": "fake",
+            "message": "ready",
+            "details": {
+                "channel": "stable",
+                "authorization": "Bearer do-not-leak",
+                "headers": {"Authorization": "Bearer do-not-leak"},
+                "env": {"TOKEN": "do-not-leak-env"},
+                "nested": [
+                    {
+                        "safe": "kept",
+                        "password": "do-not-leak-password",
+                    }
+                ],
+            },
+            "command": ["do-not-leak-command"],
+            "credential_slots": ["api_key"],
+        }
+        if version is not None:
+            payload["version"] = version
+        if installed_version is not None:
+            payload["installed_version"] = installed_version
+        if latest_version is not None:
+            payload["latest_version"] = latest_version
+        return payload
+
+
+class ExplodingInstaller(ExternalServerInstaller):
+    """Installer fake that raises from all adapter methods."""
+
+    async def install_server(
+        self,
+        server: ExternalServerDefinition,
+        *,
+        context: Any = None,
+    ) -> dict[str, Any]:
+        """Raise a failure containing text that must not become public."""
+        del server, context
+        raise RuntimeError("install failed with do-not-leak-token")
+
+    async def update_server(
+        self,
+        server: ExternalServerDefinition,
+        *,
+        context: Any = None,
+    ) -> dict[str, Any]:
+        """Raise a failure containing text that must not become public."""
+        del server, context
+        raise RuntimeError("update failed with do-not-leak-token")
+
+    async def get_status(
+        self,
+        server: ExternalServerDefinition,
+    ) -> dict[str, Any]:
+        """Raise a failure containing text that must not become public."""
+        del server
+        raise RuntimeError("status failed with do-not-leak-token")
+
+
 def _server(**overrides: Any) -> ExternalServerDefinition:
     values: dict[str, Any] = {
         "id": "research",
@@ -1026,6 +1146,81 @@ async def test_external_runtime_default_install_update_are_not_configured() -> N
 
 
 @pytest.mark.asyncio
+async def test_external_runtime_default_installer_status_is_not_configured() -> None:
+    store = InMemoryExternalRegistryStore([_server()])
+    manager = GatewayExternalRuntimeManager(
+        external_registry_store=store,
+        transport_factory=lambda server: RecordingExternalTransport(server_id=server.id),
+    )
+
+    rows = await manager.list_runtime_servers()
+
+    assert rows["servers"][0]["installer"] == {
+        "available": False,
+        "reason_code": "external_server_installer_not_configured",
+        "server_id": "research",
+    }
+
+
+@pytest.mark.asyncio
+async def test_external_runtime_installer_status_is_sanitized() -> None:
+    store = InMemoryExternalRegistryStore([_server()])
+    manager = GatewayExternalRuntimeManager(
+        external_registry_store=store,
+        transport_factory=lambda server: RecordingExternalTransport(server_id=server.id),
+        installer=SuccessfulInstaller(),
+    )
+
+    rows = await manager.list_runtime_servers()
+
+    installer = rows["servers"][0]["installer"]
+    assert installer == {
+        "available": True,
+        "reason_code": "external_server_installer_available",
+        "server_id": "research",
+        "installer": "fake",
+        "latest_version": "1.2.4",
+        "message": "ready",
+        "details": {
+            "channel": "stable",
+            "nested": [{"safe": "kept"}],
+        },
+    }
+    assert "do-not-leak" not in json.dumps(installer, sort_keys=True)
+
+
+@pytest.mark.asyncio
+async def test_external_runtime_installer_status_failure_is_row_scoped(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_logger = FakeLogger()
+    monkeypatch.setattr(gateway_external_runtime, "logger", fake_logger)
+    store = InMemoryExternalRegistryStore([_server()])
+    manager = GatewayExternalRuntimeManager(
+        external_registry_store=store,
+        transport_factory=lambda server: RecordingExternalTransport(server_id=server.id),
+        installer=ExplodingInstaller(),
+    )
+
+    rows = await manager.list_runtime_servers()
+
+    assert rows["servers"][0]["installer"] == {
+        "available": False,
+        "reason_code": "external_server_installer_status_unavailable",
+        "server_id": "research",
+        "error_type": "RuntimeError",
+    }
+    assert "do-not-leak" not in json.dumps(rows, sort_keys=True)
+    assert fake_logger.opt_calls == [{"exception": True}]
+    assert fake_logger.error_calls == [
+        (
+            "External installer status failed server_id={!r} error_type={!r}",
+            ("research", "RuntimeError"),
+        )
+    ]
+
+
+@pytest.mark.asyncio
 async def test_external_runtime_installer_unsupported_does_not_mutate_runtime_state() -> None:
     store = InMemoryExternalRegistryStore([_server()])
     transport = RecordingExternalTransport(
@@ -1054,3 +1249,113 @@ async def test_external_runtime_installer_unsupported_does_not_mutate_runtime_st
     assert transport.close_count == 0
     assert rows["servers"][0]["status"] == "healthy"
     assert [tool.virtual_name for tool in tools] == ["ext.research.search"]
+
+
+@pytest.mark.asyncio
+async def test_external_runtime_installer_operations_reject_disabled_and_missing_servers() -> None:
+    store = InMemoryExternalRegistryStore([_server(enabled=False)])
+    installer = SuccessfulInstaller()
+    manager = GatewayExternalRuntimeManager(
+        external_registry_store=store,
+        transport_factory=lambda server: RecordingExternalTransport(server_id=server.id),
+        installer=installer,
+    )
+
+    with pytest.raises(GatewayExternalRuntimeError) as disabled_exc:
+        await manager.install_server("research")
+    with pytest.raises(GatewayExternalRuntimeError) as missing_exc:
+        await manager.update_server("missing")
+
+    assert disabled_exc.value.reason_code == "external_server_disabled"
+    assert missing_exc.value.reason_code == "external_server_not_found"
+    assert installer.install_calls == []
+    assert installer.update_calls == []
+
+
+@pytest.mark.asyncio
+async def test_external_runtime_installer_operations_are_sanitized() -> None:
+    store = InMemoryExternalRegistryStore([_server()])
+    installer = SuccessfulInstaller()
+    manager = GatewayExternalRuntimeManager(
+        external_registry_store=store,
+        transport_factory=lambda server: RecordingExternalTransport(server_id=server.id),
+        installer=installer,
+    )
+
+    install = await manager.install_server("research", context={"request_id": "install"})
+    update = await manager.update_server("research", context={"request_id": "update"})
+
+    assert install == {
+        "ok": True,
+        "available": True,
+        "reason_code": "external_server_installed",
+        "server_id": "research",
+        "installer": "fake",
+        "version": "1.2.3",
+        "message": "ready",
+        "details": {
+            "channel": "stable",
+            "nested": [{"safe": "kept"}],
+        },
+    }
+    assert update == {
+        "ok": True,
+        "available": True,
+        "reason_code": "external_server_updated",
+        "server_id": "research",
+        "installer": "fake",
+        "installed_version": "1.2.4",
+        "message": "ready",
+        "details": {
+            "channel": "stable",
+            "nested": [{"safe": "kept"}],
+        },
+    }
+    assert installer.install_calls == [("research", {"request_id": "install"})]
+    assert installer.update_calls == [("research", {"request_id": "update"})]
+    assert "do-not-leak" not in json.dumps(
+        {"install": install, "update": update},
+        sort_keys=True,
+    )
+
+
+@pytest.mark.asyncio
+async def test_external_runtime_installer_operation_failures_are_wrapped(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_logger = FakeLogger()
+    monkeypatch.setattr(gateway_external_runtime, "logger", fake_logger)
+    store = InMemoryExternalRegistryStore([_server()])
+    manager = GatewayExternalRuntimeManager(
+        external_registry_store=store,
+        transport_factory=lambda server: RecordingExternalTransport(server_id=server.id),
+        installer=ExplodingInstaller(),
+    )
+
+    with pytest.raises(GatewayExternalRuntimeError) as install_exc:
+        await manager.install_server("research")
+    with pytest.raises(GatewayExternalRuntimeError) as update_exc:
+        await manager.update_server("research")
+
+    assert install_exc.value.reason_code == "external_server_install_failed"
+    assert install_exc.value.server_id == "research"
+    assert str(install_exc.value) == "External server install failed"
+    assert update_exc.value.reason_code == "external_server_update_failed"
+    assert update_exc.value.server_id == "research"
+    assert str(update_exc.value) == "External server update failed"
+    public_payloads = {
+        "install": install_exc.value.to_payload(),
+        "update": update_exc.value.to_payload(),
+    }
+    assert "do-not-leak" not in json.dumps(public_payloads, sort_keys=True)
+    assert fake_logger.opt_calls == [{"exception": True}, {"exception": True}]
+    assert fake_logger.error_calls == [
+        (
+            "External installer operation failed operation={!r} server_id={!r} error_type={!r}",
+            ("install", "research", "RuntimeError"),
+        ),
+        (
+            "External installer operation failed operation={!r} server_id={!r} error_type={!r}",
+            ("update", "research", "RuntimeError"),
+        ),
+    ]

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_external_runtime.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_external_runtime.py
@@ -401,6 +401,39 @@ class ExplodingInstaller(ExternalServerInstaller):
         raise RuntimeError("status failed with do-not-leak-token")
 
 
+class HangingInstaller(ExternalServerInstaller):
+    """Installer fake that never returns status for timeout coverage."""
+
+    async def install_server(
+        self,
+        server: ExternalServerDefinition,
+        *,
+        context: Any = None,
+    ) -> dict[str, Any]:
+        """Return an unused install payload."""
+        del context
+        return {"ok": True, "available": True, "server_id": server.id}
+
+    async def update_server(
+        self,
+        server: ExternalServerDefinition,
+        *,
+        context: Any = None,
+    ) -> dict[str, Any]:
+        """Return an unused update payload."""
+        del context
+        return {"ok": True, "available": True, "server_id": server.id}
+
+    async def get_status(
+        self,
+        server: ExternalServerDefinition,
+    ) -> dict[str, Any]:
+        """Block until cancelled by the runtime status timeout."""
+        del server
+        await asyncio.Event().wait()
+        return {"available": True}
+
+
 def _server(**overrides: Any) -> ExternalServerDefinition:
     values: dict[str, Any] = {
         "id": "research",
@@ -1211,11 +1244,43 @@ async def test_external_runtime_installer_status_failure_is_row_scoped(
         "error_type": "RuntimeError",
     }
     assert "do-not-leak" not in json.dumps(rows, sort_keys=True)
-    assert fake_logger.opt_calls == [{"exception": True}]
+    assert fake_logger.opt_calls == []
     assert fake_logger.error_calls == [
         (
             "External installer status failed server_id={!r} error_type={!r}",
             ("research", "RuntimeError"),
+        )
+    ]
+    assert "do-not-leak" not in json.dumps(fake_logger.error_calls, sort_keys=True)
+
+
+@pytest.mark.asyncio
+async def test_external_runtime_installer_status_timeout_is_row_scoped(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_logger = FakeLogger()
+    monkeypatch.setattr(gateway_external_runtime, "logger", fake_logger)
+    store = InMemoryExternalRegistryStore([_server()])
+    manager = GatewayExternalRuntimeManager(
+        external_registry_store=store,
+        transport_factory=lambda server: RecordingExternalTransport(server_id=server.id),
+        installer=HangingInstaller(),
+        installer_status_timeout_seconds=0.01,
+    )
+
+    rows = await asyncio.wait_for(manager.list_runtime_servers(), timeout=0.2)
+
+    assert rows["servers"][0]["installer"] == {
+        "available": False,
+        "reason_code": "external_server_installer_status_timeout",
+        "server_id": "research",
+        "error_type": "TimeoutError",
+    }
+    assert fake_logger.opt_calls == []
+    assert fake_logger.error_calls == [
+        (
+            "External installer status timed out server_id={!r}",
+            ("research",),
         )
     ]
 
@@ -1340,15 +1405,19 @@ async def test_external_runtime_installer_operation_failures_are_wrapped(
     assert install_exc.value.reason_code == "external_server_install_failed"
     assert install_exc.value.server_id == "research"
     assert str(install_exc.value) == "External server install failed"
+    assert install_exc.value.__cause__ is None
+    assert install_exc.value.__suppress_context__ is True
     assert update_exc.value.reason_code == "external_server_update_failed"
     assert update_exc.value.server_id == "research"
     assert str(update_exc.value) == "External server update failed"
+    assert update_exc.value.__cause__ is None
+    assert update_exc.value.__suppress_context__ is True
     public_payloads = {
         "install": install_exc.value.to_payload(),
         "update": update_exc.value.to_payload(),
     }
     assert "do-not-leak" not in json.dumps(public_payloads, sort_keys=True)
-    assert fake_logger.opt_calls == [{"exception": True}, {"exception": True}]
+    assert fake_logger.opt_calls == []
     assert fake_logger.error_calls == [
         (
             "External installer operation failed operation={!r} server_id={!r} error_type={!r}",
@@ -1359,3 +1428,4 @@ async def test_external_runtime_installer_operation_failures_are_wrapped(
             ("update", "research", "RuntimeError"),
         ),
     ]
+    assert "do-not-leak" not in json.dumps(fake_logger.error_calls, sort_keys=True)

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py
@@ -572,7 +572,17 @@ class _ExternalRuntimeManagerDouble:
         self.calls.append(("list_runtime_servers", (), {}))
         return {
             "ok": True,
-            "servers": [{"id": "research", "status": "healthy"}],
+            "servers": [
+                {
+                    "id": "research",
+                    "status": "healthy",
+                    "installer": {
+                        "available": False,
+                        "reason_code": "external_server_installer_not_configured",
+                        "server_id": "research",
+                    },
+                }
+            ],
         }
 
     async def start_server(self, server_id: str) -> dict[str, Any]:
@@ -1640,7 +1650,17 @@ def test_gateway_external_runtime_management_routes_mount_with_manager() -> None
         updated = client.post("/mcp/external-servers/research/update")
 
     assert listed.status_code == 200
-    assert listed.json()["servers"] == [{"id": "research", "status": "healthy"}]
+    assert listed.json()["servers"] == [
+        {
+            "id": "research",
+            "status": "healthy",
+            "installer": {
+                "available": False,
+                "reason_code": "external_server_installer_not_configured",
+                "server_id": "research",
+            },
+        }
+    ]
     assert started.json()["reason_code"] == "external_server_started"
     assert stopped.json()["reason_code"] == "external_server_stopped"
     assert refreshed_all.json()["server_id"] is None
@@ -1731,6 +1751,21 @@ def test_gateway_external_runtime_routes_have_pydantic_response_models() -> None
     for (path, method), expected_ref in expected_refs.items():
         schema = paths[path][method]["responses"]["200"]["content"]["application/json"]["schema"]
         assert schema == {"$ref": expected_ref}
+
+
+def test_gateway_external_runtime_response_models_document_installer_fields() -> None:
+    app = create_gateway_app(
+        _FakeGatewayRuntime(),
+        prefix="/mcp",
+        external_runtime_manager=_ExternalRuntimeManagerDouble(),
+    )
+
+    schemas = app.openapi()["components"]["schemas"]
+
+    status_props = schemas["ExternalRuntimeServerStatusResponse"]["properties"]
+    operation_props = schemas["ExternalRuntimeOperationResponse"]["properties"]
+    assert "installer" in status_props
+    assert "available" in operation_props
 
 
 def test_gateway_external_runtime_management_enabled_without_manager_raises() -> None:


### PR DESCRIPTION
## Summary
- Adds sanitized installer capability/status metadata to external runtime status rows.
- Normalizes install/update adapter payloads and redacts secret-looking fields before returning them publicly.
- Wraps installer adapter failures with stable runtime reason codes and documents the new FastAPI response fields.

## Test Plan
- source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_gateway_external_runtime.py tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py -q
- source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m ruff check mcp_unified/gateway/external_runtime.py mcp_unified/gateway/fastapi.py tldw_Server_API/app/core/MCP_unified/tests/test_gateway_external_runtime.py tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py
- source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m bandit -r mcp_unified/gateway/external_runtime.py mcp_unified/gateway/fastapi.py -f json -o /tmp/bandit_mcp_external_runtime_installer_status.json
- git diff --check

## Change summary
Human requester must fill in this section before merge per the AI-generated PR change-summary policy.

Refs TASK-585

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds sanitized installer status and operation responses to the MCP external runtime with stable reason codes, per-row status timeouts, and diagnostics that avoid leaking secrets. Extends `FastAPI` response models to expose installer metadata on status and install/update endpoints. Addresses TASK-585.

- **Bug Fixes**
  - Added a bounded installer status timeout via `installer_status_timeout_seconds`; failures/timeouts return row-scoped, sanitized payloads with `error_type` and reason codes (`external_server_installer_status_unavailable`, `external_server_installer_status_timeout`).
  - Normalized and sanitized installer status/install/update payloads: allowlisted public fields and recursively stripped secret-like data (secrets/tokens/passwords/headers/env/command args). Wrapped adapter exceptions as `GatewayExternalRuntimeError` with stable reason codes; logs now include only operation, `server_id`, and `error_type`.
  - Updated `FastAPI` models: status rows include an `installer` object; operation responses include optional installer/version fields (`available`, `installer`, `version`, `installed_version`, `latest_version`, `message`, `details`, `required_fields`, `warnings`).

<sup>Written for commit 0c8357211c05412732a8af830f1db0a91a2ace00. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2209?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

