### PR TITLE
Migrate ProviderKeysSettings alerts to design-system Alert

### DIFF
--- a/apps/packages/ui/scripts/design-system-product-state-baseline.json
+++ b/apps/packages/ui/scripts/design-system-product-state-baseline.json
@@ -418,28 +418,6 @@
     "migrationQueue": "shared-product-state"
   },
   {
-    "id": "antd-product-state-import:src/components/Option/Settings/ProviderKeysSettings.tsx:Alert#antd-alert-providerkeyssettings-type-error-line-196-tt66rs",
-    "path": "src/components/Option/Settings/ProviderKeysSettings.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/Option/Settings/ProviderKeysSettings.tsx before the stable duplicate-id guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
-    "id": "antd-product-state-import:src/components/Option/Settings/ProviderKeysSettings.tsx:Alert#antd-alert-providerkeyssettings-type-info-line-117-9uvxvl",
-    "path": "src/components/Option/Settings/ProviderKeysSettings.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/Option/Settings/ProviderKeysSettings.tsx before the stable duplicate-id guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
     "id": "antd-product-state-import:src/components/Option/Settings/splash.tsx:Alert",
     "path": "src/components/Option/Settings/splash.tsx",
     "rule": "antd-product-state-import",

--- a/apps/packages/ui/src/components/Option/Settings/ProviderKeysSettings.tsx
+++ b/apps/packages/ui/src/components/Option/Settings/ProviderKeysSettings.tsx
@@ -1,7 +1,8 @@
 import React, { useCallback, useEffect, useState } from "react"
 import { useTranslation } from "react-i18next"
-import { Alert, Button, Input, Modal, Select, Space, Table, Tag, Tooltip, message } from "antd"
+import { Button, Input, Modal, Select, Space, Table, Tag, Tooltip, message } from "antd"
 import { Key, Plus, RefreshCw, Trash2 } from "lucide-react"
+import { Alert } from "@/components/ui/primitives"
 import { tldwClient } from "@/services/tldw/TldwApiClient"
 
 type ProviderKey = {
@@ -115,11 +116,11 @@ export const ProviderKeysSettings = () => {
     return (
       <div className="mx-auto max-w-3xl px-4 py-6">
         <Alert
-          type="info"
-          showIcon
-          message={t("settings:providerKeys.unavailableTitle", "Provider key management is not available")}
-          description={t("settings:providerKeys.unavailableDesc", "Set BYOK_ENCRYPTION_KEY in your server's .env file to enable user-managed provider keys. Docker users: this is auto-generated on first run.")}
-        />
+          variant="info"
+          title={t("settings:providerKeys.unavailableTitle", "Provider key management is not available")}
+        >
+          {t("settings:providerKeys.unavailableDesc", "Set BYOK_ENCRYPTION_KEY in your server's .env file to enable user-managed provider keys. Docker users: this is auto-generated on first run.")}
+        </Alert>
       </div>
     )
   }
@@ -193,7 +194,13 @@ export const ProviderKeysSettings = () => {
       </div>
 
       {error && (
-        <Alert type="error" message={error} className="mb-4" closable onClose={() => setError(null)} />
+        <Alert
+          variant="error"
+          title={error}
+          className="mb-4"
+          dismissible
+          onDismiss={() => setError(null)}
+        />
       )}
 
       <div className="mb-4 flex items-center justify-between">

--- a/apps/packages/ui/src/components/Option/Settings/__tests__/ProviderKeysSettings.design-system-alert.test.tsx
+++ b/apps/packages/ui/src/components/Option/Settings/__tests__/ProviderKeysSettings.design-system-alert.test.tsx
@@ -1,0 +1,100 @@
+import { render, screen } from "@testing-library/react"
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest"
+
+import { expectInsideDesignSystemAlertAsync } from "@/test-utils/designSystemAlert"
+import { ProviderKeysSettings } from "../ProviderKeysSettings"
+
+const { listUserProviderKeysMock, translate } = vi.hoisted(() => ({
+  listUserProviderKeysMock: vi.fn(),
+  translate: (
+    key: string,
+    fallbackOrOptions?: string | { defaultValue?: string }
+  ) => {
+    if (typeof fallbackOrOptions === "string") return fallbackOrOptions
+    return fallbackOrOptions?.defaultValue ?? key
+  }
+}))
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: translate
+  })
+}))
+
+vi.mock("@/services/tldw/TldwApiClient", () => ({
+  tldwClient: {
+    listUserProviderKeys: listUserProviderKeysMock,
+    upsertUserProviderKey: vi.fn(),
+    deleteUserProviderKey: vi.fn()
+  }
+}))
+
+vi.mock("antd", async () => {
+  const actual = await vi.importActual<typeof import("antd")>("antd")
+  return {
+    ...actual,
+    Modal: {
+      ...actual.Modal,
+      confirm: vi.fn()
+    }
+  }
+})
+
+describe("ProviderKeysSettings design-system alerts", () => {
+  beforeAll(() => {
+    if (typeof window.matchMedia !== "function") {
+      Object.defineProperty(window, "matchMedia", {
+        writable: true,
+        value: vi.fn().mockImplementation((query: string) => ({
+          matches: false,
+          media: query,
+          onchange: null,
+          addListener: vi.fn(),
+          removeListener: vi.fn(),
+          addEventListener: vi.fn(),
+          removeEventListener: vi.fn(),
+          dispatchEvent: vi.fn()
+        }))
+      })
+    }
+
+    if (!(globalThis as any).ResizeObserver) {
+      ;(globalThis as any).ResizeObserver = class ResizeObserver {
+        observe() {}
+        unobserve() {}
+        disconnect() {}
+      }
+    }
+  })
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("renders BYOK unavailable guidance through the design-system Alert primitive", async () => {
+    listUserProviderKeysMock.mockRejectedValue({ status: 403 })
+
+    render(<ProviderKeysSettings />)
+
+    const alert = await expectInsideDesignSystemAlertAsync(
+      "Provider key management is not available"
+    )
+    expect(alert).toHaveAttribute("role", "status")
+    expect(
+      screen.getByText(
+        "Set BYOK_ENCRYPTION_KEY in your server's .env file to enable user-managed provider keys. Docker users: this is auto-generated on first run."
+      )
+    ).toBeInTheDocument()
+  })
+
+  it("renders provider-key load failures through the design-system Alert primitive", async () => {
+    listUserProviderKeysMock.mockRejectedValue(new Error("network unavailable"))
+
+    render(<ProviderKeysSettings />)
+
+    const alert = await expectInsideDesignSystemAlertAsync(
+      "Failed to load provider keys"
+    )
+    expect(alert).toHaveAttribute("role", "alert")
+  })
+})

--- a/backlog/tasks/task-45.44.6.10 - Migrate-ProviderKeysSettings-alerts-to-design-system-Alert.md
+++ b/backlog/tasks/task-45.44.6.10 - Migrate-ProviderKeysSettings-alerts-to-design-system-Alert.md
@@ -1,0 +1,67 @@
+---
+id: TASK-45.44.6.10
+title: Migrate ProviderKeysSettings alerts to design-system Alert
+status: Done
+assignee: []
+created_date: ''
+updated_date: '2026-06-01 06:26'
+labels:
+  - design-system
+  - webui
+  - extension
+  - product-state
+dependencies: []
+references:
+  - apps/packages/ui/src/components/Option/Settings/ProviderKeysSettings.tsx
+  - >-
+    apps/packages/ui/src/components/Option/Settings/__tests__/ProviderKeysSettings.design-system-alert.test.tsx
+  - apps/packages/ui/scripts/design-system-product-state-baseline.json
+  - 'https://github.com/rmusser01/tldw_server/issues/1659'
+parent_task_id: TASK-45.44.6
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Continue the Settings/account-security product-state migration by replacing ProviderKeysSettings AntD Alert product-state callouts with the shared design-system Alert primitive, then remove the matching baseline exceptions.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 ProviderKeysSettings product-state callouts render through the shared design-system Alert primitive while preserving user-facing copy and severity.
+- [x] #2 The ProviderKeysSettings AntD Alert product-state baseline entries are removed without introducing new unbaselined findings for that path.
+- [x] #3 Focused regression coverage verifies the design-system Alert marker for the migrated branches.
+- [x] #4 Focused tests, scoped product-state guard verification, TypeScript/touched-scope check, diff whitespace check, and Bandit skip rationale are recorded.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+- Added focused ProviderKeysSettings design-system Alert regression tests for BYOK-unavailable guidance and provider-key load failures. The RED Vitest run failed 2/2 because the current AntD Alert markup did not expose data-ds-component="Alert".
+- Replaced the two ProviderKeysSettings AntD Alert callouts with the shared design-system Alert primitive while preserving info/error severity, title/body copy, and dismiss behavior for the error state.
+- Removed the two matching ProviderKeysSettings baseline exceptions; baseline count moved from 79 to 77 and the touched path now has zero baseline entries.
+- Verification: focused ProviderKeysSettings Vitest passed 2/2; product-state guard unit passed 54/54; bun run verify:design-system-state exited 0 with 77 baseline exceptions; baseline parse reported ProviderKeysSettings count 0; git diff --check exited 0.
+- TypeScript caveat: node --max-old-space-size=8192 ./node_modules/typescript/bin/tsc --noEmit --pretty false exits 2 on unrelated existing frontend baseline diagnostics in QuickIngest, Layout shell overrides, setup onboarding, and quick-ingest-open; the output included no ProviderKeysSettings, ProviderKeysSettings.design-system-alert, baseline, or TASK-45.44.6.10 diagnostics.
+- Bandit skipped because this slice touched frontend TSX/test/JSON/Backlog markdown only, with no Python code.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Migrated ProviderKeysSettings BYOK-unavailable and load-error product-state alerts from direct AntD Alert usage to the shared design-system Alert primitive, added focused DOM coverage for both branches, and removed the two matching ProviderKeysSettings product-state baseline exceptions. Baseline count moved from 79 to 77 total exceptions.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+<!-- SECTION:NOTES:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## Summary

- Migrates ProviderKeysSettings BYOK-unavailable and load-error product-state alerts from direct AntD `Alert` usage to the shared design-system `Alert` primitive.
- Adds focused regression coverage for both migrated branches using the shared design-system Alert test helper.
- Removes the two matching ProviderKeysSettings product-state baseline exceptions, reducing the baseline from 79 to 77 entries.
- Closes out `TASK-45.44.6.10`.

## Verification

- RED: `bunx vitest run src/components/Option/Settings/__tests__/ProviderKeysSettings.design-system-alert.test.tsx --maxWorkers=1 --no-file-parallelism` failed 2/2 before implementation because the existing AntD Alert markup did not expose `data-ds-component="Alert"`.
- GREEN: `bunx vitest run src/components/Option/Settings/__tests__/ProviderKeysSettings.design-system-alert.test.tsx --maxWorkers=1 --no-file-parallelism` passed 2/2 after implementation and again after rebase.
- `bunx vitest run src/design-system/__tests__/product-state-guard.test.ts --maxWorkers=1 --no-file-parallelism` passed 54/54 after rebase.
- `bun run verify:design-system-state` exited 0 after rebase with 77 allowed baseline exceptions.
- Baseline sanity check reported ProviderKeysSettings count 0 and total 77.
- `git diff --check origin/dev...HEAD` exited 0.
- TypeScript caveat: `node --max-old-space-size=8192 ./node_modules/typescript/bin/tsc --noEmit --pretty false` exits 2 on unrelated existing frontend baseline diagnostics in QuickIngest, Layout shell overrides, setup onboarding, and quick-ingest-open. The output includes no ProviderKeysSettings, ProviderKeysSettings design-system test, baseline, or task diagnostics.
- Bandit skipped: frontend TSX/test/JSON/Backlog markdown only, no Python touched.

## UX Audit Checklist

- N/A. This is a primitive migration preserving existing ProviderKeysSettings copy and visibility behavior.

## Watchlists Accessibility Checklist

- N/A. No Watchlists files touched.

## Watchlists Scale Checklist

- N/A. No Watchlists data-path changes.

## Docstring Coverage

- N/A. Frontend-only TypeScript/JSON/Backlog slice.

## Risk / Rollback

- Low risk: isolated to two ProviderKeysSettings alert branches and focused regression coverage.
- Rollback: revert this commit to restore previous AntD Alert usage and baseline entries.

## Change Summary

Maintainer-written summary required before merge: explain what changed and why the design-system Alert primitive is the right migration target for these ProviderKeysSettings product-state callouts.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrated ProviderKeysSettings BYOK-unavailable and load-error alerts from `antd` Alert to the shared design-system Alert to unify UI and behavior. Added focused tests and removed two baseline exceptions (79 → 77), completing TASK-45.44.6.10.

- **Refactors**
  - Replaced `antd` `Alert` with design-system `Alert` for BYOK-unavailable and load-error states, preserving severity, copy, and dismiss behavior.
  - Added targeted tests using the design-system Alert helper to cover both branches.
  - Removed two ProviderKeysSettings legacy product-state baseline entries (79 → 77).

<sup>Written for commit ad2865db5ec54085017267ca73abba3867793625. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2210?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

