### PR TITLE
docs: document personas and character cards

### DIFF
--- a/Docs/User_Guides/Server/Character_Cards_User_Guide.md
+++ b/Docs/User_Guides/Server/Character_Cards_User_Guide.md
@@ -67,7 +67,7 @@ POST   /api/v1/characters
 GET    /api/v1/characters
 GET    /api/v1/characters/query
 GET    /api/v1/characters/filter
-GET    /api/v1/characters/search/
+GET    /api/v1/characters/search
 GET    /api/v1/characters/{character_id}
 PUT    /api/v1/characters/{character_id}
 DELETE /api/v1/characters/{character_id}

--- a/Docs/User_Guides/Server/Character_Cards_User_Guide.md
+++ b/Docs/User_Guides/Server/Character_Cards_User_Guide.md
@@ -1,0 +1,345 @@
+# Character Cards and Character Chat User Guide
+
+Last updated: 2026-06-01
+
+This guide covers the server-side Character Cards and Character Chat workflows in `tldw_server`: creating and importing character cards, starting character-backed chats, using world books and chat dictionaries, and understanding safety, privacy, and common API errors.
+
+## What Character Cards Are
+
+Character Cards are stored assistant profiles. A card can hold identity, style, scenario, greeting text, example dialogue, tags, creator metadata, an avatar image, and optional extension metadata. Character-backed chats use the selected card to assemble prompt context before sending a request to the configured chat provider.
+
+Character Cards are separate from the Persona module. Character-backed chats are built around card fields and chat settings. Persona-backed chats may use some of the same chat-session infrastructure, but Persona Garden has its own profile/session model.
+
+## Storage And Ownership
+
+Character cards, conversations, messages, world books, dictionaries, prompt presets, settings, and related metadata are stored through the per-user `ChaChaNotes_DB` database layer. In multi-user mode, API access is scoped through the authenticated user. In single-user mode, the server still uses the same storage abstractions but authenticates with the configured single-user API key.
+
+Images and card text are local/self-hosted data unless you explicitly send chat completions to an external provider. If you use a commercial or hosted LLM provider, the assembled chat prompt may include character fields, selected greetings, author notes, world-book entries, memory blocks, message history, and any appended user message.
+
+## Character Card Fields
+
+The core fields are:
+
+- `name`: required for create/import.
+- `description`: identity and background.
+- `personality`: behavioral and voice guidance.
+- `scenario`: current situation or setting.
+- `system_prompt`: direct system-level instruction for the character.
+- `post_history_instructions`: extra instruction appended after history in supported presets.
+- `first_message`: default greeting/opening message.
+- `message_example`: example dialogue or cadence reference.
+- `alternate_greetings`: optional greeting variants.
+- `tags`: organization and filtering labels.
+- `creator`, `character_version`, `creator_notes`: attribution and maintenance metadata.
+- `extensions`: structured metadata used by presets or external card formats.
+- `image_base64`: optional avatar image data in API create/update payloads.
+
+Text fields have server-side length limits. List-like fields such as `tags` and `alternate_greetings` may be sent as JSON arrays or JSON strings depending on the client path; invalid JSON is rejected rather than silently ignored.
+
+## Importing Character Cards
+
+Use:
+
+```text
+POST /api/v1/characters/import
+```
+
+Upload a file as `character_file`. Supported extensions are `.png`, `.webp`, `.jpeg`, `.jpg`, `.json`, `.yaml`, `.yml`, `.txt`, and `.md`.
+
+The server validates both extension and content where possible. Image imports support embedded character metadata in PNG/WEBP-style card files; JPEG is accepted as an image type but normally does not carry the same embedded `chara` metadata. If no card metadata is found in an image, the endpoint returns a `422` response with `code=missing_character_data` and `can_import_image_only=true`. Retry with `allow_image_only=true` only when you intentionally want a card shell inferred from the image file name.
+
+Supported structured card parsing includes Character Card v1/v2/v3 plus common Tavern/SillyTavern, Pygmalion, Text Generation WebUI, and Alpaca-style shapes. Imports are sanitized for obvious script-like content and enforce image and metadata size limits.
+
+Common import responses:
+
+- `201`: card imported.
+- `200`: a name conflict was resolved by returning an existing matching card when the conflict can be mapped.
+- `400`: invalid extension, malformed data, unsupported content, or parse failure.
+- `413`: upload exceeds configured import size.
+- `422`: image-only import requires explicit confirmation.
+
+## Creating And Managing Cards
+
+Common endpoints:
+
+```text
+POST   /api/v1/characters
+GET    /api/v1/characters
+GET    /api/v1/characters/query
+GET    /api/v1/characters/filter
+GET    /api/v1/characters/search/
+GET    /api/v1/characters/{character_id}
+PUT    /api/v1/characters/{character_id}
+DELETE /api/v1/characters/{character_id}
+POST   /api/v1/characters/{character_id}/restore
+```
+
+Updates and deletes use the database version field for optimistic locking where the endpoint requires `expected_version`. On a version mismatch, refresh the character and retry with the current version. Deletes are soft deletes by default; restore is available while the configured retention window allows it.
+
+Bulk tag maintenance is available through:
+
+```text
+POST /api/v1/characters/tags/operations
+```
+
+Supported tag operations are `rename`, `merge`, and `delete`.
+
+## Exporting Cards
+
+Use:
+
+```text
+GET /api/v1/characters/{character_id}/export?format=v3
+```
+
+Supported export formats are:
+
+- `v3`: Character Card v3 JSON shape.
+- `v2`: Character Card v2 JSON shape.
+- `json`: raw stored character payload.
+- `png`: PNG character card with v2 JSON embedded in a `chara` metadata chunk.
+
+Add `include_world_books=true` to include associated world-book data where supported by the export path. PNG export returns `image/png`; the other formats return JSON.
+
+## Character Exemplars
+
+Character exemplars are example text snippets with source, label, safety, and rights metadata. They can be used for search and debug selection workflows around character voice and behavior.
+
+Common endpoints:
+
+```text
+POST   /api/v1/characters/{character_id}/exemplars
+GET    /api/v1/characters/{character_id}/exemplars/{exemplar_id}
+PUT    /api/v1/characters/{character_id}/exemplars/{exemplar_id}
+DELETE /api/v1/characters/{character_id}/exemplars/{exemplar_id}
+POST   /api/v1/characters/{character_id}/exemplars/search
+POST   /api/v1/characters/{character_id}/exemplars/select/debug
+```
+
+Exemplar embedding sync is best-effort. If semantic scoring is unavailable, lexical or stored-search behavior may still work depending on the configured database and embedding setup.
+
+## Starting A Character Chat
+
+Create a chat session with:
+
+```text
+POST /api/v1/chats
+```
+
+For a character-backed chat, provide either `character_id` or `assistant_kind="character"` with a numeric `assistant_id`. Optional creation fields include `title`, lifecycle metadata such as `state`, workspace scope fields, fork metadata, and source/external reference fields.
+
+Important creation query parameters:
+
+- `seed_first_message=true`: seed the chat with the card's first greeting when possible.
+- `greeting_strategy=default|alternate_random|alternate_index`: choose how seeded greeting text is selected.
+- `alternate_index`: zero-based greeting index when using `alternate_index`.
+
+The API also supports untracked/global chats and persona-backed chats through the same `/api/v1/chats` route family, but this guide focuses on character-backed chats.
+
+## Messages
+
+Common message endpoints:
+
+```text
+POST   /api/v1/chats/{chat_id}/messages
+GET    /api/v1/chats/{chat_id}/messages
+GET    /api/v1/messages/{message_id}
+PUT    /api/v1/messages/{message_id}
+DELETE /api/v1/messages/{message_id}
+GET    /api/v1/chats/{chat_id}/messages/search
+```
+
+Messages use roles `user`, `assistant`, or `system`. The server maps those roles to stored senders and applies placeholder replacement when returning character-aware context. A message can contain text, an image attachment, or both. Supported message image detection includes PNG, JPEG, GIF, WebP, BMP, and ICO; oversized or invalid base64 image data is rejected.
+
+For completion-ready history, call:
+
+```text
+GET /api/v1/chats/{chat_id}/messages?format_for_completions=true&include_character_context=true
+```
+
+Optional flags can include tool-call metadata, extra metadata, and message IDs in completion-formatted responses.
+
+## Character Chat Completions
+
+There are two main completion paths:
+
+```text
+POST /api/v1/chats/{chat_id}/completions
+POST /api/v1/chats/{chat_id}/complete-v2
+```
+
+`/completions` prepares messages for use with the main OpenAI-compatible chat endpoint and does not call an LLM. It is useful when a client wants to inspect or forward assembled messages itself.
+
+`/complete-v2` assembles context, resolves provider/model settings, enforces rate and message limits, calls the configured provider, and optionally persists messages. It accepts controls such as `append_user_message`, provider/model, `model="auto"` routing overrides, generation options, `tools`, `tool_choice`, prompt cache intents, message-steering flags, `prompt_preset`, and `stream`.
+
+Persistence rules:
+
+- Non-streaming completions persist the appended user message and assistant reply only when `save_to_db=true` or the server default save setting resolves true.
+- Streaming completions return Server-Sent Events and do not persist assistant content automatically, even when `save_to_db=true`.
+- After streaming, persist assistant text with:
+
+```text
+POST /api/v1/chats/{chat_id}/completions/persist
+```
+
+The persist endpoint can store speaker metadata, mood metadata, tool calls, usage, ranking, and chat rating.
+
+## Prompt Preview, Presets, Greetings, And Author Notes
+
+Prompt preview:
+
+```text
+POST /api/v1/chats/{chat_id}/prompt-preview
+```
+
+This returns supplemental prompt sections, token estimates, truncation flags, warnings, and lorebook diagnostics. It is the safest way to inspect what context will be injected before sending a real completion.
+
+Prompt presets:
+
+```text
+GET    /api/v1/chats/presets/tokens
+GET    /api/v1/chats/presets
+POST   /api/v1/chats/presets
+PUT    /api/v1/chats/presets/{preset_id}
+DELETE /api/v1/chats/presets/{preset_id}
+```
+
+Built-in presets include `default` and `st_default`; custom presets can define section order and templates. Built-ins cannot be modified or deleted.
+
+Greetings:
+
+```text
+GET /api/v1/chats/{chat_id}/greetings
+PUT /api/v1/chats/{chat_id}/greetings/select
+```
+
+The server returns all greetings from the card, tracks the selected index in chat settings, and reports staleness if the card greetings changed after the chat started.
+
+Author note:
+
+```text
+GET /api/v1/chats/{chat_id}/author-note/info
+```
+
+Author note info reports display text, prompt text, estimated token counts, budget, enabled/GM-only/excluded flags, scope, source, and warnings. Chat settings control the author note payload and injection behavior.
+
+## Chat Settings
+
+Use:
+
+```text
+GET /api/v1/chats/{chat_id}/settings
+PUT /api/v1/chats/{chat_id}/settings
+```
+
+Settings are stored as JSON and merged with timestamp-aware conflict behavior. Current settings used by the prompt assembly path include greeting scope, preset scope, memory scope, selected greeting, chat preset overrides, participant character IDs, turn-taking mode, author note controls, character memory notes, auto-summary options, and linked deep-research attachment metadata.
+
+Invalid settings are rejected or normalized. A settings row that only contains internal greeting checksum bootstrap metadata is not returned as user-visible settings.
+
+## Multi-Character Chats
+
+Character Chat can resolve additional participants from `participantCharacterIds` or `participant_character_ids` in chat settings. When multiple participants are configured, completion prep and `/complete-v2` can use `directed_character_id` to force the next response to a selected participant. If the ID is not part of the selected participant set, the server returns `400`.
+
+Without a directed participant, the server chooses an active character from turn context and recent assistant senders.
+
+## World Books
+
+World books, also called lorebooks in some chat UIs, inject relevant context when keywords or regex patterns match the conversation text.
+
+Common endpoints:
+
+```text
+GET    /api/v1/characters/world-books
+POST   /api/v1/characters/world-books
+GET    /api/v1/characters/world-books/{world_book_id}
+PUT    /api/v1/characters/world-books/{world_book_id}
+DELETE /api/v1/characters/world-books/{world_book_id}
+
+POST   /api/v1/characters/world-books/{world_book_id}/entries
+GET    /api/v1/characters/world-books/{world_book_id}/entries
+PUT    /api/v1/characters/world-books/entries/{entry_id}
+DELETE /api/v1/characters/world-books/entries/{entry_id}
+
+POST   /api/v1/characters/{character_id}/world-books
+GET    /api/v1/characters/{character_id}/world-books
+DELETE /api/v1/characters/{character_id}/world-books/{world_book_id}
+
+POST   /api/v1/characters/world-books/process
+POST   /api/v1/characters/world-books/import
+GET    /api/v1/characters/world-books/{world_book_id}/export
+GET    /api/v1/characters/world-books/{world_book_id}/statistics
+```
+
+World-book entries contain keywords, content, priority, enabled status, case sensitivity, regex/whole-word controls, optional grouping, appendable metadata, recursive-scanning metadata, and arbitrary metadata. The processing endpoint returns injected content, matched entry IDs, token usage, budget exhaustion flags, skipped-entry counts, and diagnostics.
+
+Attached world books are considered during character-chat prompt assembly. Diagnostics for world-book injection can be previewed with prompt preview and exported across turns with:
+
+```text
+GET /api/v1/chats/{chat_id}/diagnostics/lorebook
+```
+
+## Chat Dictionaries
+
+Chat dictionaries transform text with literal or regex replacement entries. They are mounted under the chat API:
+
+```text
+POST   /api/v1/chat/dictionaries
+GET    /api/v1/chat/dictionaries
+GET    /api/v1/chat/dictionaries/{dictionary_id}
+PUT    /api/v1/chat/dictionaries/{dictionary_id}
+DELETE /api/v1/chat/dictionaries/{dictionary_id}
+
+POST   /api/v1/chat/dictionaries/{dictionary_id}/entries
+GET    /api/v1/chat/dictionaries/{dictionary_id}/entries
+PUT    /api/v1/chat/dictionaries/entries/{entry_id}
+DELETE /api/v1/chat/dictionaries/entries/{entry_id}
+
+POST /api/v1/chat/dictionaries/process
+POST /api/v1/chat/dictionaries/import
+GET  /api/v1/chat/dictionaries/{dictionary_id}/export
+GET  /api/v1/chat/dictionaries/{dictionary_id}/export/json
+POST /api/v1/chat/dictionaries/import/json
+GET  /api/v1/chat/dictionaries/{dictionary_id}/statistics
+GET  /api/v1/chat/dictionaries/{dictionary_id}/activity
+GET  /api/v1/chat/dictionaries/{dictionary_id}/versions
+GET  /api/v1/chat/dictionaries/{dictionary_id}/versions/{revision}
+POST /api/v1/chat/dictionaries/{dictionary_id}/versions/{revision}/revert
+```
+
+Dictionary entries support literal or regex matching, probability, group, timed effects, max replacements, enabled status, case sensitivity, and ordering. Regex patterns are validated with server-side safety checks, including length limits and nested-quantifier heuristics.
+
+Use JSON import/export for full fidelity. Markdown import/export is useful for readable sharing but may not preserve every advanced field.
+
+## Safety, Privacy, And Provider Boundaries
+
+- Treat cards, world books, dictionaries, author notes, and memory notes as prompt material. They can be sent to the configured LLM provider during completion.
+- Do not put secrets, credentials, private keys, or access tokens in card fields or world-book entries.
+- Validate imported cards from untrusted sources before chatting with them. The server sanitizes obvious script-like content, but imported card instructions can still influence model behavior.
+- Regex dictionaries and regex world-book entries are bounded, but complex patterns can still be costly. Prefer literal entries unless regex is required.
+- Use prompt preview before sending sensitive or expensive completions.
+- External provider calls use configured server keys or BYOK resolution. If no credentials are available for a provider that requires them, `/complete-v2` returns `503` with `error_code=missing_provider_credentials`.
+
+## Common Errors And Fixes
+
+| Symptom | Likely Cause | Fix |
+| --- | --- | --- |
+| `400` invalid extension or content mismatch | File extension and magic bytes do not match, or data cannot be parsed | Export from the source tool again or upload JSON/YAML/text instead |
+| `413` file too large | Import or image attachment exceeds configured limit | Reduce image size or raise the relevant server limit |
+| `422` `missing_character_data` | Image has no embedded card metadata | Retry with `allow_image_only=true` only if you want an image-only card |
+| `404` character/chat/message not found | Wrong ID, deleted item, wrong user, or wrong workspace scope | Refresh list endpoints and include the correct scope fields |
+| `409` version mismatch | Optimistic-lock version is stale | Reload the object and retry with the current version |
+| `429` rate limit exceeded | Resource Governor or character-chat rate limit denied the request | Wait for the `Retry-After` window or adjust policy |
+| `503` missing provider credentials | Selected provider requires an API key | Configure server provider keys or BYOK credentials |
+| Streamed reply not in history | Streaming does not auto-persist assistant text | Call `/api/v1/chats/{chat_id}/completions/persist` after the stream finishes |
+
+## Related Source Files
+
+- Character routes: `tldw_Server_API/app/api/v1/endpoints/characters_endpoint.py`
+- Chat sessions and completions: `tldw_Server_API/app/api/v1/endpoints/character_chat_sessions.py`
+- Messages: `tldw_Server_API/app/api/v1/endpoints/character_messages.py`
+- Dictionaries: `tldw_Server_API/app/api/v1/endpoints/chat_dictionaries.py`
+- Character schemas: `tldw_Server_API/app/api/v1/schemas/character_schemas.py`
+- Chat session/message schemas: `tldw_Server_API/app/api/v1/schemas/chat_session_schemas.py`
+- World-book schemas: `tldw_Server_API/app/api/v1/schemas/world_book_schemas.py`
+- Dictionary schemas: `tldw_Server_API/app/api/v1/schemas/chat_dictionary_schemas.py`
+- Core module README: `tldw_Server_API/app/core/Character_Chat/README.md`

--- a/Docs/User_Guides/Server/Personas_User_Guide.md
+++ b/Docs/User_Guides/Server/Personas_User_Guide.md
@@ -1,0 +1,413 @@
+# Personas User Guide
+
+Last Updated: 2026-06-01
+
+## Overview
+
+Personas are persistent assistant profiles for tldw_server. A Persona can hold
+assistant instructions, durable state documents, scoped memories, style
+exemplars, tool policies, voice commands, live-session preferences, and visual
+Buddy packs. The same Persona can be used from ordinary chat, Persona Live, and
+other workflow surfaces that need a stable assistant identity.
+
+The Personas API is mounted under `/api/v1/persona`. It is user-scoped: profile
+records, sessions, memory entries, exemplars, connections, commands, and visual
+packs belong to the authenticated user.
+
+## Personas vs Characters
+
+Characters and Personas overlap conceptually, but they are not the same system.
+
+| Concept | Main Use | Storage/Behavior |
+| --- | --- | --- |
+| Character | Roleplay or character-card chat using imported card data, world books, and dictionaries. | Character cards and conversations live in the per-user `ChaChaNotes` database. |
+| Persona | Persistent assistant identity for chat, live sessions, scoped tools, state docs, exemplars, voice commands, and Buddy visuals. | Persona profiles and related records also live in the per-user `ChaChaNotes` database, but evolve independently after creation. |
+
+A Persona can reference a character card at creation time, but later Persona
+state, policies, exemplars, and visual packs are managed by the Persona feature.
+
+## Prerequisites
+
+1. Start the API server.
+2. Authenticate with either:
+   - `X-API-KEY` in single-user mode.
+   - `Authorization: Bearer <token>` in multi-user/JWT mode.
+3. Ensure Personas are enabled. In `Config_Files/config.txt`, `[persona] enabled = true`; the equivalent runtime setting is `PERSONA_ENABLED`.
+
+Examples below use an API key:
+
+```bash
+export BASE_URL="http://127.0.0.1:8000"
+export API_KEY="<your-api-key>"
+```
+
+## Quickstart
+
+### 1. List the active Persona catalog
+
+```bash
+curl -s "$BASE_URL/api/v1/persona/catalog" \
+  -H "X-API-KEY: $API_KEY" | jq
+```
+
+If the user has no active Personas yet, the server creates or returns the
+default Persona profile.
+
+### 2. Create a Persona profile
+
+```bash
+curl -s -X POST "$BASE_URL/api/v1/persona/profiles" \
+  -H "Content-Type: application/json" \
+  -H "X-API-KEY: $API_KEY" \
+  -d '{
+    "id": "research_helper",
+    "name": "Research Helper",
+    "mode": "session_scoped",
+    "system_prompt": "Help analyze sources carefully. Ask before using external tools.",
+    "is_active": true,
+    "use_persona_state_context_default": true
+  }' | jq
+```
+
+Save the returned `id` as `PERSONA_ID`.
+
+```bash
+export PERSONA_ID="research_helper"
+```
+
+### 3. Add durable state docs
+
+State docs are long-lived Markdown fields used to describe a Persona's durable
+self-model. They are separate from ordinary chat turns.
+
+```bash
+curl -s -X PUT "$BASE_URL/api/v1/persona/profiles/$PERSONA_ID/state" \
+  -H "Content-Type: application/json" \
+  -H "X-API-KEY: $API_KEY" \
+  -d '{
+    "identity_md": "You are a careful research assistant for technical reading.",
+    "soul_md": "Prefer source-grounded answers, explicit uncertainty, and concise next steps.",
+    "heartbeat_md": "Current focus: help the user inspect and summarize project documentation."
+  }' | jq
+```
+
+View state history:
+
+```bash
+curl -s "$BASE_URL/api/v1/persona/profiles/$PERSONA_ID/state/history" \
+  -H "X-API-KEY: $API_KEY" | jq
+```
+
+### 4. Add an exemplar
+
+Exemplars are compact examples of style, boundaries, scenario behavior, or tool
+behavior. They guide prompt assembly and runtime planning; they are not
+permissions.
+
+```bash
+curl -s -X POST "$BASE_URL/api/v1/persona/profiles/$PERSONA_ID/exemplars" \
+  -H "Content-Type: application/json" \
+  -H "X-API-KEY: $API_KEY" \
+  -d '{
+    "kind": "boundary",
+    "content": "If a request would use an external tool, briefly explain the action and wait for confirmation.",
+    "scenario_tags": ["tools", "safety"],
+    "priority": 10,
+    "enabled": true,
+    "source_type": "manual"
+  }' | jq
+```
+
+### 5. Start a Persona session
+
+```bash
+curl -s -X POST "$BASE_URL/api/v1/persona/session" \
+  -H "Content-Type: application/json" \
+  -H "X-API-KEY: $API_KEY" \
+  -d '{
+    "persona_id": "'"$PERSONA_ID"'",
+    "surface": "docs-example"
+  }' | jq
+```
+
+Save the returned `session_id`:
+
+```bash
+export SESSION_ID="<returned-session-id>"
+```
+
+### 6. List and inspect sessions
+
+```bash
+curl -s "$BASE_URL/api/v1/persona/sessions?persona_id=$PERSONA_ID" \
+  -H "X-API-KEY: $API_KEY" | jq
+```
+
+```bash
+curl -s "$BASE_URL/api/v1/persona/sessions/$SESSION_ID" \
+  -H "X-API-KEY: $API_KEY" | jq
+```
+
+## Core Concepts
+
+### Profiles
+
+A profile is the top-level Persona identity. Key fields include:
+
+- `id`: optional stable identifier supplied at creation, otherwise generated.
+- `name`: display name.
+- `mode`: `session_scoped` or `persistent_scoped`.
+- `system_prompt`: core assistant instructions.
+- `is_active`: controls catalog visibility.
+- `use_persona_state_context_default`: whether state docs are used by default.
+- `voice_defaults`: saved STT/TTS, wake phrase, and turn-detection defaults.
+- `setup`: setup wizard progress and status.
+
+List, create, update, soft-delete, and restore profiles with:
+
+- `GET /api/v1/persona/profiles`
+- `POST /api/v1/persona/profiles`
+- `GET /api/v1/persona/profiles/{persona_id}`
+- `PATCH /api/v1/persona/profiles/{persona_id}`
+- `DELETE /api/v1/persona/profiles/{persona_id}`
+- `POST /api/v1/persona/profiles/{persona_id}/restore`
+
+### Sessions
+
+A session binds a Persona to a runtime surface and stores a scope snapshot. The
+normal session endpoints are:
+
+- `POST /api/v1/persona/session`
+- `GET /api/v1/persona/sessions`
+- `GET /api/v1/persona/sessions/{session_id}`
+- `GET /api/v1/persona/sessions/{session_id}/export`
+
+Transcript export is RBAC-gated by `[persona.rbac] allow_export` or
+`PERSONA_RBAC_ALLOW_EXPORT`.
+
+### Live Sessions
+
+Persona Live adds focused runtime control around the same Persona identity:
+
+- `GET /api/v1/persona/live/sessions`
+- `POST /api/v1/persona/live/sessions`
+- `POST /api/v1/persona/live/sessions/{session_id}/focus`
+- `POST /api/v1/persona/live/sessions/{session_id}/stop`
+
+Live sessions are the intended path for WebSocket-backed interaction and Buddy
+state.
+
+## Live Sessions and WebSocket Stream
+
+The WebSocket endpoint is:
+
+```text
+WS /api/v1/persona/stream
+```
+
+The stream accepts JWT or API-key authentication. Query auth is supported for
+WebSocket clients that cannot set headers:
+
+```bash
+websocat "ws://127.0.0.1:8000/api/v1/persona/stream?api_key=$API_KEY"
+```
+
+Send a user turn:
+
+```json
+{
+  "type": "user_message",
+  "session_id": "<session-id>",
+  "text": "Summarize the active research context."
+}
+```
+
+Common client frame types include:
+
+- `user_message`: send a text turn.
+- `voice_config`: update voice runtime settings for a session.
+- `wake_activation` and `wake_deactivation`: manage manually armed wake phrase state.
+- `voice_commit`: commit a transcript as a Persona Live turn.
+- `audio_chunk`: send bounded audio chunks for live STT/TTS handling.
+- `confirm_plan`: approve selected tool-plan steps.
+- `retry_tool_call`: retry an approval-backed tool call.
+
+Common server events include:
+
+- `notice`: status, warning, error, and recovery messages.
+- `tool_plan`: proposed tool plan requiring client confirmation when needed.
+- `tool_call` and `tool_result`: tool execution lifecycle.
+- `assistant_delta`: assistant text output.
+- `tts_audio`: TTS chunk metadata followed by binary audio frames.
+
+The stream enforces feature flags, authentication, policy checks, tool
+confirmation, audio limits, and rate limits.
+
+## State, Memory, and Exemplars
+
+Personas use several context layers:
+
+- **Profile:** identity and default configuration.
+- **State docs:** durable Markdown fields: `soul_md`, `identity_md`, and `heartbeat_md`.
+- **Memory:** persisted Persona turn and tool outcome entries used by retrieval.
+- **Exemplars:** curated snippets that guide voice, boundaries, scenario style, or tool behavior.
+- **Scope snapshot:** rule-derived context captured when a session is materialized.
+
+Useful endpoints:
+
+- `GET /api/v1/persona/profiles/{persona_id}/state`
+- `PUT /api/v1/persona/profiles/{persona_id}/state`
+- `GET /api/v1/persona/profiles/{persona_id}/state/history`
+- `POST /api/v1/persona/profiles/{persona_id}/state/restore`
+- `POST /api/v1/persona/profiles/{persona_id}/state/archive`
+- `GET /api/v1/persona/profiles/{persona_id}/exemplars`
+- `POST /api/v1/persona/profiles/{persona_id}/exemplars`
+- `POST /api/v1/persona/profiles/{persona_id}/exemplars/import`
+
+Transcript import can create candidate exemplars from a bounded transcript:
+
+```bash
+curl -s -X POST "$BASE_URL/api/v1/persona/profiles/$PERSONA_ID/exemplars/import" \
+  -H "Content-Type: application/json" \
+  -H "X-API-KEY: $API_KEY" \
+  -d '{
+    "transcript": "User: Explain your safety policy. Assistant: I can help, but I need confirmation before tool actions.",
+    "source_ref": "manual-demo",
+    "max_candidates": 3
+  }' | jq
+```
+
+## Scope and Policy Rules
+
+Scope rules decide where a Persona applies. Supported rule types are:
+
+- `conversation_id`
+- `character_id`
+- `media_id`
+- `media_tag`
+- `note_id`
+
+Replace scope rules:
+
+```bash
+curl -s -X PUT "$BASE_URL/api/v1/persona/profiles/$PERSONA_ID/scope-rules" \
+  -H "Content-Type: application/json" \
+  -H "X-API-KEY: $API_KEY" \
+  -d '{
+    "rules": [
+      {"rule_type": "media_tag", "rule_value": "risk-review", "include": true}
+    ]
+  }' | jq
+```
+
+Policy rules gate capabilities. Supported rule kinds are:
+
+- `mcp_tool`
+- `skill`
+
+Replace policy rules:
+
+```bash
+curl -s -X PUT "$BASE_URL/api/v1/persona/profiles/$PERSONA_ID/policy-rules" \
+  -H "Content-Type: application/json" \
+  -H "X-API-KEY: $API_KEY" \
+  -d '{
+    "rules": [
+      {
+        "rule_kind": "mcp_tool",
+        "rule_name": "*",
+        "allowed": true,
+        "require_confirmation": true,
+        "max_calls_per_turn": 3
+      }
+    ]
+  }' | jq
+```
+
+Policy and scope rules do not grant authentication privileges by themselves.
+AuthNZ, MCP tool permissions, and Persona RBAC still apply.
+
+## Voice Commands and Connections
+
+Persona voice commands map heard phrases to actions. Commands can optionally
+reference Persona connections, which define a bounded external HTTP target and
+redacted secret/header configuration.
+
+Useful endpoints:
+
+- `GET /api/v1/persona/profiles/{persona_id}/voice-commands`
+- `POST /api/v1/persona/profiles/{persona_id}/voice-commands`
+- `PUT /api/v1/persona/profiles/{persona_id}/voice-commands/{command_id}`
+- `POST /api/v1/persona/profiles/{persona_id}/voice-commands/{command_id}/toggle`
+- `DELETE /api/v1/persona/profiles/{persona_id}/voice-commands/{command_id}`
+- `POST /api/v1/persona/profiles/{persona_id}/voice-commands/test`
+- `GET /api/v1/persona/profiles/{persona_id}/connections`
+- `POST /api/v1/persona/profiles/{persona_id}/connections`
+- `POST /api/v1/persona/profiles/{persona_id}/connections/{connection_id}/test`
+
+Use the dry-run endpoint before enabling a voice command in a live surface:
+
+```bash
+curl -s -X POST "$BASE_URL/api/v1/persona/profiles/$PERSONA_ID/voice-commands/test" \
+  -H "Content-Type: application/json" \
+  -H "X-API-KEY: $API_KEY" \
+  -d '{"heard_text": "summarize this source"}' | jq
+```
+
+## Visual Packs
+
+Persona Visual Packs are user-owned Buddy assets attached to Personas. The
+current activation path is manifest-backed `sprite_frames`; use the capabilities
+endpoint before assuming another renderer is active:
+
+```bash
+curl -s "$BASE_URL/api/v1/persona/visual-renderers" \
+  -H "X-API-KEY: $API_KEY" | jq
+```
+
+Common visual pack routes:
+
+- `GET /api/v1/persona/visual-starter-packs`
+- `POST /api/v1/persona/visual-starter-packs/{starter_pack_id}/copy`
+- `GET /api/v1/persona/profiles/{persona_id}/visual-packs`
+- `POST /api/v1/persona/profiles/{persona_id}/visual-packs`
+- `POST /api/v1/persona/profiles/{persona_id}/visual-packs/{pack_id}/assets`
+- `POST /api/v1/persona/profiles/{persona_id}/visual-packs/{pack_id}/activate`
+- `POST /api/v1/persona/profiles/{persona_id}/visual-packs/{pack_id}/export`
+- `POST /api/v1/persona/profiles/{persona_id}/visual-packs/import-previews`
+
+Generated or imported packs are not activated automatically. The user must
+explicitly activate a valid pack.
+
+## Privacy and Safety
+
+- Persona records are user-scoped.
+- Profile/session/state/exemplar data is stored in the authenticated user's
+  `ChaChaNotes` database.
+- Persona tool execution is gated by authentication, RBAC, policy rules, MCP
+  permissions, and confirmation flow.
+- State docs, memory, and exemplars should not be used to store secrets.
+- Connection responses redact secrets and expose only bounded metadata.
+- Visual assets are served through ownership-checked endpoints.
+- Dialogue-tree/runtime explorer features are defensive and feature-flagged.
+  They do not authorize actions and should not be treated as policy bypasses.
+- Wake phrase support is manually armed in the active live surface; pre-wake
+  audio is not sent to the server.
+
+## Common Errors
+
+| Status | Typical Cause | What To Check |
+| --- | --- | --- |
+| `401` | Missing or invalid API key/JWT. | Auth mode and headers/query credentials. |
+| `403` | RBAC denied an operation such as transcript export. | `[persona.rbac]` config and user permissions. |
+| `404` | Persona disabled or resource not found for this user. | `PERSONA_ENABLED`, profile id, session id, and ownership. |
+| `409` | Optimistic locking, import conflict, non-completed preview, or incompatible live-session state. | Version fields, import preview status, and requested target mode. |
+| `413` | State doc, upload, archive, or audio chunk is too large. | Configured size limits and request payload size. |
+| `422` | Request validation failed. | Field names, enum values, required fields, and max lengths. |
+
+## Related Docs
+
+- `tldw_Server_API/app/core/Persona/README.md` - developer guide for the core module.
+- `Docs/Code_Documentation/Persona_Visual_Packs.md` - Persona Visual Pack ownership, activation, import/export, and renderer notes.
+- `Docs/User_Guides/WebUI_Extension/Persona_Live_Wake_Phrases.md` - wake phrase behavior in the WebUI/extension surfaces.
+- `Docs/Operations/Persona_Memory_ChaCha_Cutover_Rollback_Runbook_2026_02_22.md` - memory cutover and rollback notes.

--- a/Docs/User_Guides/index.md
+++ b/Docs/User_Guides/index.md
@@ -25,6 +25,11 @@ This section is organized by product surface so you can quickly find the right d
 - [Backups using Litestream](Server/Backups_Using_Litestream.md)
 - [CLI Reference](Server/CLI_Reference.md)
 
+### Chat and Characters
+
+- [Character Cards and Character Chat](Server/Character_Cards_User_Guide.md)
+- [Personas](Server/Personas_User_Guide.md)
+
 ### Ingestion, RAG, and Evaluations
 
 - [Media→Embeddings→RAG→Evals Workflow](Server/Media_to_RAG_Evals_Workflow.md)

--- a/Docs/superpowers/plans/2026-06-01-character-cards-documentation.md
+++ b/Docs/superpowers/plans/2026-06-01-character-cards-documentation.md
@@ -1,0 +1,41 @@
+# Character Cards Documentation Implementation Plan
+
+## Stage 1: Source Review
+
+**Goal**: Read the current Character Cards and Character Chat API/core files before writing docs.
+
+**Success Criteria**: Documentation statements are grounded in current route prefixes, schema fields, import/export behavior, prompt assembly, persistence, and limits.
+
+**Tests**: Local source inspection with `rg` and targeted file reads.
+
+**Status**: Complete
+
+## Stage 2: User Documentation
+
+**Goal**: Add a source user guide that explains practical Character Cards and Character Chat use.
+
+**Success Criteria**: Guide covers card fields, import/export, chat session flow, messages, completions, greetings, author notes, world books, dictionaries, safety/privacy boundaries, and common errors.
+
+**Tests**: Markdown/source-link checks and manual consistency review against endpoint/schema files.
+
+**Status**: Complete
+
+## Stage 3: Module README
+
+**Goal**: Replace stale `Character_Chat` module README content with a current developer map.
+
+**Success Criteria**: README describes module files, data flow, endpoint integration, limits, extension rules, and relevant test locations without stale line references.
+
+**Tests**: Verify referenced files/directories exist and run markdown whitespace checks.
+
+**Status**: Complete
+
+## Stage 4: Verification And Tracking
+
+**Goal**: Verify docs-only changes and close the Backlog task.
+
+**Success Criteria**: `git diff --check` passes, generated `Docs/Published` is untouched, docs avoid placeholder markers, Bandit skip is recorded as docs-only, and Backlog task is updated.
+
+**Tests**: `git diff --check`, generated-doc status check, path checks, and targeted text scans.
+
+**Status**: Complete

--- a/Docs/superpowers/plans/2026-06-01-personas-documentation.md
+++ b/Docs/superpowers/plans/2026-06-01-personas-documentation.md
@@ -1,0 +1,140 @@
+# Personas Documentation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Create source documentation for the Personas feature and refresh the Persona core module README.
+
+**Architecture:** Keep user-facing workflow documentation in `Docs/User_Guides/Server/` and developer/module documentation beside the code in `tldw_Server_API/app/core/Persona/README.md`. Do not edit `Docs/Published/` because the published tree is generated.
+
+**Tech Stack:** Markdown documentation, FastAPI route references, Persona core Python module map, Backlog.md CLI tracking.
+
+---
+
+## File Structure
+
+- Create: `Docs/User_Guides/Server/Personas_User_Guide.md`
+  - Source user guide for Personas workflows, concepts, API examples, privacy, safety, and troubleshooting.
+- Modify: `tldw_Server_API/app/core/Persona/README.md`
+  - Developer/module guide for core Persona responsibilities, module map, lifecycle, persistence, extension points, and tests.
+- Update: `backlog/tasks/task-586 - Document-Personas-feature-and-core-module.md`
+  - Task notes, verification results, touched files, and final summary through the Backlog CLI.
+
+## Task 1: Write Personas User Guide
+
+**Files:**
+- Create: `Docs/User_Guides/Server/Personas_User_Guide.md`
+
+- [x] **Step 1: Create the source user guide**
+
+Add a Markdown guide with these sections:
+
+```markdown
+# Personas User Guide
+
+Last Updated: 2026-06-01
+
+## Overview
+## Personas vs Characters
+## Prerequisites
+## Quickstart
+## Core Concepts
+## Live Sessions and WebSocket Stream
+## State, Memory, and Exemplars
+## Scope and Policy Rules
+## Voice Commands and Connections
+## Visual Packs
+## Privacy and Safety
+## Common Errors
+## Related Docs
+```
+
+- [x] **Step 2: Check route names against current code**
+
+Run:
+
+```bash
+rg -n '@router\.(get|post|put|patch|delete|websocket)' tldw_Server_API/app/api/v1/endpoints/persona.py
+```
+
+Expected: output includes `/profiles`, `/catalog`, `/session`, `/sessions`, `/live/sessions`, and `/stream`.
+
+## Task 2: Refresh Core Persona README
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/Persona/README.md`
+
+- [x] **Step 1: Replace the compact status note with a developer module guide**
+
+Use these sections:
+
+```markdown
+# Persona Module
+
+## Purpose
+## Responsibilities
+## Module Map
+## Runtime Lifecycle
+## Persistence Model
+## API Touch Points
+## Runtime Concepts
+## Visual Packs and Buddy Runtime
+## Security and Privacy Boundaries
+## Configuration
+## Testing
+## Extension Guidance
+## Common Pitfalls
+```
+
+- [x] **Step 2: Keep links source-oriented**
+
+Reference `Docs/User_Guides/Server/Personas_User_Guide.md` and `Docs/Code_Documentation/Persona_Visual_Packs.md`. Do not reference `Docs/Published/` as an editable source.
+
+## Task 3: Verify Documentation Scope
+
+**Files:**
+- Inspect: `Docs/User_Guides/Server/Personas_User_Guide.md`
+- Inspect: `tldw_Server_API/app/core/Persona/README.md`
+- Inspect: `git diff --name-only`
+
+- [x] **Step 1: Confirm no generated published files were edited**
+
+Run:
+
+```bash
+git diff --name-only | rg '^Docs/Published/' || true
+```
+
+Expected: no output.
+
+- [x] **Step 2: Run whitespace check**
+
+Run:
+
+```bash
+git diff --check -- Docs/User_Guides/Server/Personas_User_Guide.md tldw_Server_API/app/core/Persona/README.md
+```
+
+Expected: no output and exit code 0.
+
+- [x] **Step 3: Record Bandit skip**
+
+Because this plan touches Markdown only, record in Backlog that Bandit was skipped as non-code.
+
+## Task 4: Backlog Closeout
+
+**Files:**
+- Update: `backlog/tasks/task-586 - Document-Personas-feature-and-core-module.md`
+
+- [x] **Step 1: Add final notes**
+
+Record touched files, verification commands, and the Bandit non-code skip.
+
+- [x] **Step 2: Mark task done**
+
+Run:
+
+```bash
+backlog task edit 586 --status Done --plain
+```
+
+Expected: task status is Done.

--- a/Docs/superpowers/specs/2026-06-01-character-cards-documentation-design.md
+++ b/Docs/superpowers/specs/2026-06-01-character-cards-documentation-design.md
@@ -1,0 +1,53 @@
+# Character Cards Documentation Design
+
+## Purpose
+
+Create source documentation for the Character Cards and Character Chat surfaces without editing generated `Docs/Published` output.
+
+## Audience
+
+- Server users and API clients who need a practical guide for character cards, character-backed chats, world books, dictionaries, and common error handling.
+- Contributors who need to understand the `tldw_Server_API/app/core/Character_Chat/` module boundary and its FastAPI touch points before changing code.
+
+## Source Of Truth
+
+- `tldw_Server_API/app/api/v1/endpoints/characters_endpoint.py`
+- `tldw_Server_API/app/api/v1/endpoints/character_chat_sessions.py`
+- `tldw_Server_API/app/api/v1/endpoints/character_messages.py`
+- `tldw_Server_API/app/api/v1/endpoints/chat_dictionaries.py`
+- `tldw_Server_API/app/api/v1/schemas/character_schemas.py`
+- `tldw_Server_API/app/api/v1/schemas/chat_session_schemas.py`
+- `tldw_Server_API/app/api/v1/schemas/world_book_schemas.py`
+- `tldw_Server_API/app/api/v1/schemas/chat_dictionary_schemas.py`
+- `tldw_Server_API/app/core/Character_Chat/`
+- `tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py`
+
+## Scope
+
+In scope:
+
+- Add a server user guide for Character Cards and Character Chat workflows.
+- Refresh the `Character_Chat` module README for current responsibilities, data flow, extension guidance, endpoints, and tests.
+- Link the new user guide from the source user-guide index.
+- Record verification and leave `Docs/Published` untouched.
+
+Out of scope:
+
+- API or database behavior changes.
+- Generated published-doc updates.
+- Frontend UX changes.
+
+## Accuracy Constraints
+
+- Do not claim automatic editing of `Docs/Published`; it is generated separately.
+- Do not promise UI controls that are not guaranteed by the backend.
+- Use route families and source file names rather than fragile line-number references.
+- Call out streaming persistence behavior accurately: `stream=true` returns SSE and does not persist assistant content automatically; clients persist streamed content with `POST /api/v1/chats/{chat_id}/completions/persist`.
+- Distinguish character cards from Personas. Character-card chats can coexist with persona-backed chats, but Character Cards are not the Persona Garden runtime.
+
+## Deliverables
+
+- `Docs/User_Guides/Server/Character_Cards_User_Guide.md`
+- `tldw_Server_API/app/core/Character_Chat/README.md`
+- `Docs/User_Guides/index.md`
+- Backlog task notes with verification and known skips.

--- a/Docs/superpowers/specs/2026-06-01-personas-documentation-design.md
+++ b/Docs/superpowers/specs/2026-06-01-personas-documentation-design.md
@@ -1,0 +1,35 @@
+# Personas Documentation Design
+
+## Goal
+
+Create source documentation for the Personas feature and refresh the Persona core module README so users and contributors can understand the current implementation without relying on generated published docs or older design notes.
+
+## Scope
+
+This work updates source documentation only:
+
+- `Docs/User_Guides/Server/Personas_User_Guide.md`
+- `tldw_Server_API/app/core/Persona/README.md`
+
+`Docs/Published/` is intentionally out of scope because it is generated.
+
+## User Guide Design
+
+The user guide explains Personas as persistent assistant identities that can carry instructions, state docs, exemplars, scope rules, policy rules, live sessions, voice commands, and visual packs across user-owned workflows. It distinguishes Personas from Character Chat: characters are roleplay/chat cards, while Personas are broader assistant profiles for chat, live sessions, tools, and workflow context.
+
+The guide includes prerequisites, authentication notes, a curl quickstart, WebSocket usage notes, common concepts, privacy and safety boundaries, and troubleshooting. Examples use `/api/v1/persona` routes and avoid claiming generated docs output.
+
+## Module README Design
+
+The core README becomes a developer-oriented module guide. It maps responsibilities, file layout, request/session lifecycle, persistence in `ChaChaNotes_DB`, runtime concepts, visual-pack boundaries, security constraints, extension points, and targeted tests.
+
+The README keeps operational guidance concise and code-facing. It points to the user guide for workflow examples and to existing visual-pack docs for the deeper visual asset contract.
+
+## Verification
+
+Verification is documentation-oriented:
+
+- Confirm the two intended source docs exist.
+- Confirm no `Docs/Published/` files were modified.
+- Run markdown/link sanity checks available without network.
+- Run Bandit only if Python code changes occur; otherwise record the non-code skip in `TASK-586`.

--- a/backlog/tasks/task-586 - Document-Personas-feature-and-core-module.md
+++ b/backlog/tasks/task-586 - Document-Personas-feature-and-core-module.md
@@ -4,7 +4,7 @@ title: Document Personas feature and core module
 status: Done
 assignee: []
 created_date: '2026-06-01 05:44'
-updated_date: '2026-06-01 06:24'
+updated_date: '2026-06-01 07:20'
 labels: []
 dependencies: []
 documentation:
@@ -51,6 +51,8 @@ Final verification: git diff --check passed for the new/modified Markdown files;
 PR integration: combined with TASK-587 in branch codex/personas-character-cards-documentation, based on origin/dev. Added Docs/User_Guides/index.md source link for the Personas guide.
 
 Combined branch verification before PR: git diff --check passed; git status --short Docs/Published produced no output; trailing-whitespace scan returned no matches; stale placeholder scan returned no matches; source route scans confirmed documented Persona mount and key endpoint paths. Pytest and Bandit were not run because this PR changes Markdown documentation only.
+
+PR: https://github.com/rmusser01/tldw_server/pull/2212
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-586 - Document-Personas-feature-and-core-module.md
+++ b/backlog/tasks/task-586 - Document-Personas-feature-and-core-module.md
@@ -1,0 +1,71 @@
+---
+id: TASK-586
+title: Document Personas feature and core module
+status: Done
+assignee: []
+created_date: '2026-06-01 05:44'
+updated_date: '2026-06-01 06:24'
+labels: []
+dependencies: []
+documentation:
+  - Docs/User_Guides/Server/Personas_User_Guide.md
+  - tldw_Server_API/app/core/Persona/README.md
+  - Docs/User_Guides/index.md
+  - Docs/superpowers/plans/2026-06-01-personas-documentation.md
+  - Docs/superpowers/specs/2026-06-01-personas-documentation-design.md
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Create source documentation for the Personas feature and refresh the Persona core module README. Do not edit Docs/Published because it is generated.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Source user guide explains Personas concepts, quickstart, safety/privacy boundaries, and common errors.
+- [x] #2 Core Persona README maps module responsibilities, data flow, API touch points, extension guidance, and targeted tests.
+- [x] #3 Generated Docs/Published output is not edited manually.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Spec: Docs/superpowers/specs/2026-06-01-personas-documentation-design.md
+Plan: Docs/superpowers/plans/2026-06-01-personas-documentation.md
+Scope: create source Personas user guide and refresh core Persona README; do not edit Docs/Published.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implementation in clean worktree: /Users/appledev/Documents/GitHub/tldw_server/.worktrees/personas-documentation on branch codex/personas-documentation.
+Touched source docs: Docs/User_Guides/Server/Personas_User_Guide.md; tldw_Server_API/app/core/Persona/README.md.
+Tracking artifacts: Docs/superpowers/specs/2026-06-01-personas-documentation-design.md; Docs/superpowers/plans/2026-06-01-personas-documentation.md.
+Verification so far: route reference check with rg passed; git status shows no Docs/Published changes; git diff --check passed for tracked README changes; trailing-whitespace scan passed for tracked and untracked docs; referenced source docs/files exist.
+Bandit: skipped because this task changes Markdown documentation only and no Python code.
+
+Final verification: git diff --check passed for the new/modified Markdown files; git status --short Docs/Published produced no output; TODO/TBD/FIXME scan found no matches in the Personas guide or Persona README. Markdown lint/link checker binaries were not installed, so verification used git/rg checks.
+
+PR integration: combined with TASK-587 in branch codex/personas-character-cards-documentation, based on origin/dev. Added Docs/User_Guides/index.md source link for the Personas guide.
+
+Combined branch verification before PR: git diff --check passed; git status --short Docs/Published produced no output; trailing-whitespace scan returned no matches; stale placeholder scan returned no matches; source route scans confirmed documented Persona mount and key endpoint paths. Pytest and Bandit were not run because this PR changes Markdown documentation only.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Created a source Personas user guide covering concepts, quickstart API usage, live sessions, memory/state/exemplars, policy/scope rules, voice integrations, visual packs, privacy/safety, troubleshooting, and related source docs. Refreshed the Persona core module README with module responsibilities, runtime lifecycle, persistence, API touch points, security boundaries, testing guidance, extension guidance, and common pitfalls. Left Docs/Published untouched because published docs are generated.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+- [x] #7 Backlog task records plan, touched files, verification, and final summary.
+<!-- DOD:END -->

--- a/backlog/tasks/task-587 - Document-Character-Cards-and-Character-Chat-core-module.md
+++ b/backlog/tasks/task-587 - Document-Character-Cards-and-Character-Chat-core-module.md
@@ -4,7 +4,7 @@ title: Document Character Cards and Character Chat core module
 status: Done
 assignee: []
 created_date: '2026-06-01 06:23'
-updated_date: '2026-06-01 06:25'
+updated_date: '2026-06-01 07:20'
 labels: []
 dependencies: []
 documentation:
@@ -45,6 +45,8 @@ Implementation was prepared in the clean worktree /Users/appledev/Documents/GitH
 Verification: git diff --check passed for tracked modified docs; trailing-whitespace scan over all touched docs returned no matches; stale endpoint/path scan returned no matches; route-source scan confirmed /tags/operations, /world-books/process, /complete-v2, /completions/persist, and dictionary entry paths; git status for Docs/Published returned no changes. Bandit skipped because touched files are Markdown/docs only. Pytest not run because no runtime code changed.
 
 Combined branch verification before PR: git diff --check passed; git status --short Docs/Published produced no output; trailing-whitespace scan returned no matches; stale placeholder scan returned no matches; route-source scans confirmed documented Character Cards, Character Chat, world book, completion persistence, and chat dictionary paths. Pytest and Bandit were not run because this PR changes Markdown documentation only.
+
+PR: https://github.com/rmusser01/tldw_server/pull/2212
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-587 - Document-Character-Cards-and-Character-Chat-core-module.md
+++ b/backlog/tasks/task-587 - Document-Character-Cards-and-Character-Chat-core-module.md
@@ -1,0 +1,64 @@
+---
+id: TASK-587
+title: Document Character Cards and Character Chat core module
+status: Done
+assignee: []
+created_date: '2026-06-01 06:23'
+updated_date: '2026-06-01 06:25'
+labels: []
+dependencies: []
+documentation:
+  - Docs/User_Guides/Server/Character_Cards_User_Guide.md
+  - tldw_Server_API/app/core/Character_Chat/README.md
+  - Docs/User_Guides/index.md
+  - Docs/superpowers/plans/2026-06-01-character-cards-documentation.md
+  - Docs/superpowers/specs/2026-06-01-character-cards-documentation-design.md
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Create source documentation for Character Cards workflows and refresh the Character_Chat core module README. Do not edit Docs/Published because it is generated.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Source user guide explains character cards, import/export, chat sessions, world books, dictionaries, safety/privacy boundaries, and common errors.
+- [x] #2 Core Character_Chat README maps module responsibilities, data flow, API touch points, extension guidance, and targeted tests.
+- [x] #3 Generated Docs/Published output is not edited manually.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Spec: Docs/superpowers/specs/2026-06-01-character-cards-documentation-design.md
+Plan: Docs/superpowers/plans/2026-06-01-character-cards-documentation.md
+Scope: create source Character Cards user guide and refresh core Character_Chat README; do not edit Docs/Published.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implementation was prepared in the clean worktree /Users/appledev/Documents/GitHub/tldw_server/.worktrees/character-cards-documentation, then combined into PR branch codex/personas-character-cards-documentation.
+
+Verification: git diff --check passed for tracked modified docs; trailing-whitespace scan over all touched docs returned no matches; stale endpoint/path scan returned no matches; route-source scan confirmed /tags/operations, /world-books/process, /complete-v2, /completions/persist, and dictionary entry paths; git status for Docs/Published returned no changes. Bandit skipped because touched files are Markdown/docs only. Pytest not run because no runtime code changed.
+
+Combined branch verification before PR: git diff --check passed; git status --short Docs/Published produced no output; trailing-whitespace scan returned no matches; stale placeholder scan returned no matches; route-source scans confirmed documented Character Cards, Character Chat, world book, completion persistence, and chat dictionary paths. Pytest and Bandit were not run because this PR changes Markdown documentation only.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Added source user documentation for Character Cards and Character Chat, refreshed the Character_Chat core module README against current endpoints/core files, linked the guide from the source user-guide index, and left generated Docs/Published untouched.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/tldw_Server_API/app/core/Character_Chat/README.md
+++ b/tldw_Server_API/app/core/Character_Chat/README.md
@@ -1,221 +1,214 @@
-# Character Chat Module (Developer Guide)
+# Character_Chat Core Module
 
-## 1. Current Feature Set
+Last updated: 2026-06-01
 
-The Character Chat subsystem powers persona-driven conversations in tldw_server. It provides:
-- Character cards lifecycle: import/export across common formats (PNG/WEBP with embedded JSON, JSON/Markdown, Card v1/v2/v3)
-- Conversations and messages: session creation, message history, edits, search, ranking, and exports
-- Lorebooks (world books): per-user knowledge injected via keyword rules; bulk entry ops; context processing
-- Chat dictionaries: pattern-based replacements with token budgets, import/export (Markdown/JSON), statistics
-- Rate limiting and quotas: per-user guardrails for imports, creation, messages; Redis-backed with in-memory fallback
-- Per-user storage: all state in `ChaChaNotes.db` (SQLite by default, Postgres supported)
+`tldw_Server_API/app/core/Character_Chat/` contains the core helpers used by Character Cards, character-backed chat sessions, world books, chat dictionaries, prompt assembly, and character-chat rate/size guardrails.
 
-## 2. Technical Details of Features
+The module is backend/runtime code. User-facing API behavior is exposed through the FastAPI routers under `tldw_Server_API/app/api/v1/endpoints/`.
 
-### High-Level Responsibilities
-| Concern | Implementation |
-| --- | --- |
-| Character card lifecycle | `modules/character_io.py`, `modules/character_db.py`, `ccv3_parser.py` |
-| Conversation management | `modules/character_chat.py` |
-| Text transformation | `chat_dictionary.py` (pattern-based replacements, token budgets) |
-| Lore/world context | `world_book_manager.py` (keyword matching, recursive scanning) |
-| Throughput guardrails | `character_rate_limiter.py` (Redis + in-memory fallbacks) |
-| Compatibility facade | `Character_Chat_Lib_facade.py`, `modules/__init__.py` (re-exported symbols for older call sites) |
+## Current Responsibilities
 
-All persistence flows through `ChaChaNotes_DB` (per-user SQLite/Postgres wrapper) from `tldw_Server_API.app.core.DB_Management`.
+- Import, validate, normalize, store, load, and export Character Cards.
+- Manage character-backed conversations and messages through `CharactersRAGDB`.
+- Build character-aware prompt context from card fields, chat history, greetings, author notes, memory, presets, and world books.
+- Process world-book/lorebook keyword and regex matches with priority, token budget, diagnostics, and optional recursive scanning.
+- Process chat dictionaries with literal/regex replacements, grouping, probability, timed effects, ordering, token budgets, activity records, and version history.
+- Enforce character/chat guardrails through `character_limits.py` and `character_rate_limiter.py`.
+- Preserve compatibility for older call sites through `Character_Chat_Lib_facade.py`.
 
----
+This module does not own provider integrations, AuthNZ, BYOK, OpenAI-compatible chat schemas, or generated documentation.
 
-### Module Layout & Entry Points
-```
+## Module Layout
+
+```text
 Character_Chat/
-├── Character_Chat_Lib_facade.py    # Facade exposing modular helpers under a single import path
-├── modules/                        # Split modules with focused concerns
-│   ├── character_utils.py          # Placeholder replacement, UI helpers
-│   ├── character_io.py             # Card import/export (PNG/WEBP/JSON/MD) + validation
-│   ├── character_validation.py     # V1/V2/Pygmalion/TextGen/Alpaca format parsers
-│   ├── character_db.py             # CRUD around `ChaChaNotes_DB` tables
-│   ├── character_chat.py           # Conversations, messages, metadata
-│   └── character_templates.py      # Built-in template helpers (seed characters, clones)
-├── chat_dictionary.py              # Pattern-based runtime text replacement engine
-├── world_book_manager.py           # Lorebook manager with keyword scanning
-├── character_rate_limiter.py       # Import/update/message budget guardrails
-├── ccv3_parser.py                  # Character Card v3 validation + mapping
-└── chat_dictionary.py / world_book_manager.py ...  # see sections below
+├── Character_Chat_Lib_facade.py
+├── __init__.py
+├── ccv3_parser.py
+├── character_limits.py
+├── character_rate_limiter.py
+├── chat_dictionary.py
+├── chat_grammar.py
+├── constants.py
+├── regex_safety.py
+├── world_book_manager.py
+├── world_book_prompt_context.py
+└── modules/
+    ├── __init__.py
+    ├── character_chat.py
+    ├── character_db.py
+    ├── character_generation_presets.py
+    ├── character_io.py
+    ├── character_memory_extraction.py
+    ├── character_prompt_presets.py
+    ├── character_templates.py
+    ├── character_utils.py
+    ├── character_validation.py
+    ├── persona_exemplar_embeddings.py
+    ├── persona_exemplar_selector.py
+    └── persona_exemplar_telemetry.py
 ```
 
-`Character_Chat_Lib_facade.py` re-exports the functions from `modules` (and provides small wrappers such as placeholder substitution for `retrieve_message_details`) so downstream code can rely on a single import path. `modules/__init__.py` collects the public surface area; new helpers should be added there for discoverability.
+Key files:
 
----
+- `Character_Chat_Lib_facade.py`: stable import surface that re-exports modular helpers for legacy callers.
+- `modules/character_io.py`: card import from image/text/JSON/YAML, metadata extraction, sanitization, image validation, and chat-history import helpers.
+- `modules/character_validation.py`: Character Card v1/v2 and common external card-shape parsers.
+- `ccv3_parser.py`: minimal Character Card v3 validation and mapping.
+- `modules/character_db.py`: character CRUD helpers around `CharactersRAGDB`.
+- `modules/character_chat.py`: conversation/message helper functions and placeholder-aware history formatting.
+- `modules/character_prompt_presets.py`: default and custom character prompt section assembly.
+- `modules/character_generation_presets.py`: generation-setting extraction from card extension metadata.
+- `world_book_manager.py`: world-book CRUD, entries, import/export, statistics, matching, and context processing.
+- `world_book_prompt_context.py`: adapter that builds and injects world-book context into prompt messages.
+- `chat_dictionary.py`: chat dictionary CRUD, entry processing, import/export, activity, stats, and version history.
+- `character_limits.py`: non-rate character/chat limits from settings or environment.
+- `character_rate_limiter.py`: Resource Governor-backed enforcement wrapper for character operations and chat flows.
+- `constants.py`: shared bounds for regex, streaming, tool-call metadata, imports, and message content.
 
-### Data & Persistence Model
-- Storage is handled by `CharactersRAGDB` (`ChaChaNotes_DB`), which produces per-user SQLite (default) or Postgres databases located under `<USER_DB_BASE_DIR>/<user_id>/ChaChaNotes.db` (defaults to `Databases/user_databases` under repo root). `USER_DB_BASE_DIR` is defined in `tldw_Server_API.app.core.config` and can be overridden via environment variable or `Config_Files/config.txt`.
-- Tables include `character_cards`, `conversations`, `messages`, `world_books`, `world_book_entries`, `chat_dictionary_groups`, and `chat_dictionary_entries`.
-- All functions accept an explicit `CharactersRAGDB` instance (dependency-injected in FastAPI endpoints). There is no global state or implicit connections.
-- JSON-like fields (alternate greetings, tags, extensions, metadata) are stored as JSON text in the DB and materialized as Python objects inside the library helpers.
+## Data Flow
 
-For schema details inspect `tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py`.
+1. API dependencies resolve the authenticated user and per-user `CharactersRAGDB` with `get_chacha_db_for_user`.
+2. Character/card endpoints call import, validation, DB, exemplar, world-book, or export helpers.
+3. Chat-session endpoints load conversation state, card data, chat settings, messages, and optional participant cards.
+4. Prompt assembly applies card context, summaries, greetings, author notes, character memory, message steering, world-book context, and provider/model options.
+5. Provider dispatch happens outside this module through shared chat provider helpers.
+6. Non-streaming completion responses may persist user and assistant turns through the character chat helpers. Streaming responses are returned as SSE and require a follow-up persist call if the assistant text should be saved.
 
----
+Persistence flows through `tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py`, primarily via `CharactersRAGDB`. Important data families include `character_cards`, `character_exemplars`, `conversations`, `messages`, message metadata, conversation settings, world books, world-book entries, character/world-book attachments, chat dictionaries, dictionary entries, dictionary activity, and dictionary revisions.
 
-### Character Card Import & Export
-The import pipeline (in `modules/character_io.py`) supports:
-- Embedded metadata inside PNG/WEBP (`extract_json_from_image_file`).
-- JSON/Markdown cards from TavernAI, SillyTavern, Pygmalion, Text Generation WebUI, Alpaca, and Character Card spec v1/v2/v3.
-- Automatic image optimization (conversion to WEBP, resize) during `_prepare_character_data_for_db_storage`.
-- Conflict detection: `create_new_character_from_data` raises `ConflictError` when names collide, allowing endpoints to return helpful responses.
+## Character Card Import And Export
 
-The `ccv3_parser.py` module brings minimal support for the emerging Character Card v3 spec (`validate_v3_card`, `parse_v3_card`). V3 parsing is attempted before falling back to v2/v1 heuristics.
+The import path accepts file content from `POST /api/v1/characters/import` after endpoint-level type and size validation. Supported upload extensions are `.png`, `.webp`, `.jpeg`, `.jpg`, `.json`, `.yaml`, `.yml`, `.txt`, and `.md`.
 
-Common helpers:
-- `import_and_save_character_from_file(...)` - orchestrates file type detection, parsing, validation, DB insert/update.
-- `load_character_and_image(...)` - loads a single card with placeholder substitution and decoded `PIL.Image`.
-- `get_character_list_for_ui(...)`, `extract_character_id_from_ui_choice(...)` - UI helper utilities.
+Important behavior:
 
-### API Usage
-`app/api/v1/endpoints/characters_endpoint.py` delegates to these helpers for the `/characters` REST API. Rate limits are enforced before imports or bulk operations (see below).
+- Image imports detect PNG, WebP, and JPEG magic bytes. Metadata extraction is most useful for PNG/WEBP card files that carry `chara` metadata.
+- Image-only import is explicit. If no card metadata is detected, the endpoint returns `missing_character_data` unless `allow_image_only=true` is provided.
+- Text imports support JSON/YAML and text/Markdown containing card JSON.
+- Parsed card text is sanitized for null bytes and obvious script-like patterns before persistence.
+- Card formats include Character Card v1/v2/v3 and common Tavern/SillyTavern, Pygmalion, Text Generation WebUI, and Alpaca-style shapes.
+- Export supports `v3`, `v2`, `json`, and `png`. PNG export embeds v2 card JSON into a PNG `chara` metadata chunk.
 
----
+## Prompt Assembly
 
-## Conversation & Message Management
-Key functions live in `modules/character_chat.py`:
-- `start_new_chat_session(...)`, `list_character_conversations(...)`, `delete_conversation_by_id(...)` - conversation CRUD.
-- `post_message_to_conversation(...)`, `edit_message_content(...)`, `set_message_ranking(...)`, `find_messages_in_conversation(...)` - message lifecycle helpers.
-- `process_db_messages_to_ui_history(...)` - convert raw message rows into `(user, bot)` tuples for UI consumption, handling placeholder replacements and consecutive message merges.
-- `load_chat_and_character(...)` - fetches character metadata, conversation payload, and message list in a single call.
+Character prompt assembly is spread across the API endpoint and focused helpers because it combines request flags, chat settings, current DB state, and provider options.
 
-Placeholder replacement is centralized via `modules/character_utils.replace_placeholders`, ensuring tokens like `{{char}}` or `<USER>` resolve consistently.
+Primary components:
 
-Endpoints `character_chat_sessions.py` and `character_messages.py` rely heavily on these functions, so maintain backwards compatibility when refactoring signatures.
+- System prompt and card sections from `modules/character_prompt_presets.py`.
+- Character generation defaults from `modules/character_generation_presets.py`.
+- Greeting selection and staleness checks in `character_chat_sessions.py`.
+- Author note resolution from chat settings and card extension fields.
+- Character memory injection through the character-memory endpoint/database path.
+- Auto-summary settings stored in conversation settings.
+- World-book context from `world_book_prompt_context.py`.
+- Message steering flags for continue-as-user, impersonate-user, and forced narration.
+- Multi-character participant resolution from `participantCharacterIds` or `participant_character_ids` settings.
 
----
+Prompt preview is exposed by `POST /api/v1/chats/{chat_id}/prompt-preview` and should remain aligned with `/complete-v2` whenever prompt assembly changes.
 
-## World Books (Lorebooks)
-Implemented in `world_book_manager.py`:
-- `WorldBookService` keeps CRUD isolated per user database.
-- `WorldBookEntry` pre-compiles regex/literal patterns for fast matching. Supports case sensitivity, whole-word matching, and explicit regex.
-- `process_context(...)` assembles lore snippets from applicable world books, respecting token budgets (`_count_tokens`), priorities, optional recursive scanning, and scan depth.
-- Attachments: characters can link to multiple world books (`attach_world_books_to_character`, etc.).
-- Bulk operations (import/export, statistics) power the `/world-books/*` endpoints.
+## FastAPI Touch Points
 
-Token counting uses the shared tokenizer from `tldw_Server_API.app.core.Utils.tokenizer`.
+Route mounting:
 
----
+- `characters_endpoint.py` is mounted under `/api/v1/characters`.
+- `character_chat_sessions.py` is mounted under `/api/v1/chats`.
+- `character_messages.py` is mounted under `/api/v1`.
+- `chat_dictionaries.py` is included by the main chat router, mounted under `/api/v1/chat`.
+- `character_memory.py` is mounted under `/api/v1/characters` and is used by character memory injection paths.
 
-## Chat Dictionary
-`chat_dictionary.py` provides a pattern-based replacement engine applied to outbound/inbound chat text:
-- `ChatDictionaryService` caches active dictionaries per request, sorts entries by priority, and enforces probability-based application, timed effects (sticky, cooldown, delay), max replacements, and token budgets.
-- Patterns support literal matches or `/regex/flags` notation (with `i`, `m`, `s`, `x`).
-- Each entry tracks runtime state (`last_triggered`, `trigger_count`) to enforce timed behaviour.
-- Warnings are emitted via `TokenBudgetExceededWarning` when transformations exceed configured budgets.
+Major route families:
 
-The chat API (`app/api/v1/endpoints/chat.py`, section around dictionary endpoints) exposes CRUD and testing endpoints for end users.
+- Character cards: `/api/v1/characters`, `/api/v1/characters/import`, `/api/v1/characters/{character_id}`, `/api/v1/characters/{character_id}/export`.
+- Character versions and restore: `/api/v1/characters/{character_id}/versions`, `/api/v1/characters/{character_id}/versions/diff`, `/api/v1/characters/{character_id}/revert`, `/api/v1/characters/{character_id}/restore`.
+- Exemplars: `/api/v1/characters/{character_id}/exemplars...`.
+- World books: `/api/v1/characters/world-books...` and `/api/v1/characters/{character_id}/world-books...`.
+- Chat sessions and completions: `/api/v1/chats`, `/api/v1/chats/{chat_id}`, `/api/v1/chats/{chat_id}/completions`, `/api/v1/chats/{chat_id}/complete-v2`, `/api/v1/chats/{chat_id}/completions/persist`.
+- Prompt helpers: `/api/v1/chats/{chat_id}/prompt-preview`, `/api/v1/chats/{chat_id}/greetings`, `/api/v1/chats/{chat_id}/author-note/info`, `/api/v1/chats/{chat_id}/diagnostics/lorebook`.
+- Messages: `/api/v1/chats/{chat_id}/messages`, `/api/v1/messages/{message_id}`.
+- Chat dictionaries: `/api/v1/chat/dictionaries...`.
 
----
+## Settings And Environment
 
-## Rate Limiting & Quotas
-`character_rate_limiter.py` ensures character operations and chat completions cannot overwhelm the system:
-- Redis-backed ZSET implementation when a Redis client is supplied; falls back to per-process memory otherwise.
-- Limits:
-  - `max_operations/window_seconds` - generic operations (create/update/import).
-  - `max_characters`, `max_chats_per_user`, `max_messages_per_chat`.
-  - `max_chat_completions_per_minute`, `max_message_sends_per_minute`.
-  - `max_import_size_mb` guard for oversized uploads.
-- Helper methods (e.g., `check_rate_limit`, `check_character_limit`, `check_import_size`) raise `HTTPException` (429/403/413) when exceeded.
-- `get_character_rate_limiter()` (defined in API deps) instantiates a singleton rate limiter per process.
+Character/chat limits are read from settings with environment overrides:
 
-Unit tests validating this behaviour live in `tldw_Server_API/tests/unit/test_character_rate_limiter.py` and `tests/Character_Chat/test_rate_limits_specific.py`.
+- `MAX_CHARACTERS_PER_USER`
+- `MAX_CHARACTER_IMPORT_SIZE_MB`
+- `MAX_CHATS_PER_USER`
+- `MAX_MESSAGES_PER_CHAT`
+- `MAX_MESSAGES_PER_CHAT_SOFT`
+- `MAX_CHARACTER_IMPORT_AVATAR_SIZE_BYTES`
+- `MAX_CHARACTER_IMPORT_AVATAR_SIZE_MB`
+- `MAX_MESSAGE_IMAGE_BYTES`
 
----
+Provider/model defaults for character completions can come from chat settings, configured provider defaults, and character-chat environment overrides such as `CHAR_CHAT_PROVIDER` and `CHAR_CHAT_MODEL`. Strict model selection is controlled outside this module in the chat/provider routing path.
 
-### API Integration Touch Points
-The Character Chat module is consumed across several FastAPI routers:
-- `characters_endpoint.py` - card CRUD, import/export, world book management.
-- `character_chat_sessions.py` - conversation creation & metadata updates.
-- `character_messages.py` - message history, edits, ranking, search.
-- `chat_dictionaries.py` - dictionary CRUD and validation used during completions.
+Rate limiting goes through `CharacterRateLimiter`. Current enforcement is Resource Governor-backed when character RG enforcement is enabled; otherwise the legacy shim logs deprecation and allows the request.
 
-Each endpoint resolves the per-user `CharactersRAGDB` via `get_chacha_db_for_user` and ensures the correct AuthNZ dependencies (`get_request_user`) before calling into this module.
+## Safety And Boundaries
 
----
+- Do not bypass `CharactersRAGDB`; this module should use database abstractions rather than ad hoc SQL.
+- Keep import sanitization and size checks in place for untrusted cards and images.
+- Keep regex length and safety checks aligned between world books, dictionaries, and `regex_safety.py`.
+- Treat card fields, world books, dictionaries, author notes, memory, and message history as prompt material that may leave the host when an external provider is used.
+- Preserve streaming persistence semantics: streaming responses do not automatically save assistant content.
+- Avoid adding global mutable runtime state. Per-request state should flow through dependencies, DB rows, settings payloads, or bounded helpers.
 
-### Testing Strategy
-Relevant suites:
-- `tldw_Server_API/tests/Characters/test_character_chat_lib.py` - large unit suite covering helper behaviour.
-- `tldw_Server_API/tests/Characters/test_ccv3_parser.py` - verifies v3 parsing.
-- `tldw_Server_API/tests/Character_Chat_NEW/*` - property tests and newer unit coverage for dictionary + world book interactions.
-- `tldw_Server_API/tests/integration/test_chatbook_integration.py` - exercises cross-module interactions (Chatbooks + Character Chat).
-- `tldw_Server_API/tests/Chat/unit/test_chat_dictionary_endpoints.py` - API layer coverage for dictionary endpoints.
+## Extension Guidance
 
-Run targeted tests after touching core logic:
+When adding a card field:
+
+1. Update `character_schemas.py`.
+2. Update parser/export mappings in `character_validation.py`, `ccv3_parser.py`, and `characters_endpoint.py` as needed.
+3. Update DB storage through `ChaChaNotes_DB` migrations/abstractions.
+4. Update prompt preset assembly only if the field should affect model context.
+5. Add focused tests for parsing, API create/update, export, and prompt assembly where relevant.
+
+When changing prompt assembly:
+
+1. Keep `/completions`, `/complete-v2`, and `/prompt-preview` behavior aligned.
+2. Include token/budget diagnostics where context can grow.
+3. Verify streaming and non-streaming persistence paths separately.
+4. Add regression tests for participant routing if multi-character behavior changes.
+
+When changing dictionaries or world books:
+
+1. Keep regex safety and token budgets intact.
+2. Preserve import/export fidelity for JSON paths.
+3. Update statistics, versioning, and activity behavior when entry lifecycle changes.
+4. Add tests for literal, regex, ordering, budget, and disabled-entry behavior.
+
+## Relevant Schemas
+
+- `tldw_Server_API/app/api/v1/schemas/character_schemas.py`
+- `tldw_Server_API/app/api/v1/schemas/chat_session_schemas.py`
+- `tldw_Server_API/app/api/v1/schemas/world_book_schemas.py`
+- `tldw_Server_API/app/api/v1/schemas/chat_dictionary_schemas.py`
+- `tldw_Server_API/app/api/v1/schemas/character_memory_schemas.py`
+
+## Relevant Tests
+
+Current targeted suites include:
+
+- `tldw_Server_API/tests/Character_Chat/`
+- `tldw_Server_API/tests/Character_Chat_NEW/`
+- `tldw_Server_API/tests/ChaChaNotesDB/test_chacha_character_store.py`
+- `tldw_Server_API/tests/ChaChaNotesDB/test_character_card_tag_search.py`
+- `tldw_Server_API/tests/ChaChaNotesDB/test_character_exemplars_db.py`
+- `tldw_Server_API/tests/Character_Chat/unit/test_chat_session_character_scope_api.py`
+- `tldw_Server_API/tests/Chat/unit/test_chat_dictionary_endpoints.py`
+- `tldw_Server_API/tests/Streaming/test_character_chat_sse_unified_flag.py`
+- `tldw_Server_API/tests/RAG/test_dual_backend_characters_retriever.py`
+
+Useful targeted commands:
+
 ```bash
-python -m pytest tldw_Server_API/tests/Characters -v
-python -m pytest tldw_Server_API/tests/Character_Chat_NEW -v
-python -m pytest tldw_Server_API/tests/unit/test_character_rate_limiter.py -q
+source .venv/bin/activate
+python -m pytest tldw_Server_API/tests/Character_Chat -q
+python -m pytest tldw_Server_API/tests/Character_Chat_NEW -q
+python -m pytest tldw_Server_API/tests/Chat/unit/test_chat_dictionary_endpoints.py -q
+python -m pytest tldw_Server_API/tests/ChaChaNotesDB/test_character_exemplars_db.py -q
 ```
 
-Most tests rely on fixtures that stub `CharactersRAGDB` and set `TEST_MODE=1` to disable background tasks.
-
----
-
-## 3. Developer Guide for Contributors
-
-### Related Endpoints
-- Characters (mounted under `/api/v1/characters`):
-  - Import character: tldw_Server_API/app/api/v1/endpoints/characters_endpoint.py:72
-  - List characters: tldw_Server_API/app/api/v1/endpoints/characters_endpoint.py:188
-  - Create character: tldw_Server_API/app/api/v1/endpoints/characters_endpoint.py:217
-  - Filter by tags: tldw_Server_API/app/api/v1/endpoints/characters_endpoint.py:236
-  - Search characters: tldw_Server_API/app/api/v1/endpoints/characters_endpoint.py:519
-  - Update character: tldw_Server_API/app/api/v1/endpoints/characters_endpoint.py:396
-  - Delete character: tldw_Server_API/app/api/v1/endpoints/characters_endpoint.py:452
-  - World books (create/list/update/delete/process/import/export/stats): see router block starting at tldw_Server_API/app/api/v1/endpoints/characters_endpoint.py:541 and below
-- Chat Sessions (mounted under `/api/v1/chats`):
-  - Create session: tldw_Server_API/app/api/v1/endpoints/character_chat_sessions.py:150
-  - Get session: tldw_Server_API/app/api/v1/endpoints/character_chat_sessions.py:285
-  - Get context: tldw_Server_API/app/api/v1/endpoints/character_chat_sessions.py:341
-  - Prepare completion: tldw_Server_API/app/api/v1/endpoints/character_chat_sessions.py:432
-  - List sessions: tldw_Server_API/app/api/v1/endpoints/character_chat_sessions.py:865
-  - Update session: tldw_Server_API/app/api/v1/endpoints/character_chat_sessions.py:937
-  - Delete session: tldw_Server_API/app/api/v1/endpoints/character_chat_sessions.py:1018
-  - Export session: tldw_Server_API/app/api/v1/endpoints/character_chat_sessions.py:1112
-- Messages (mounted under `/api/v1`):
-  - Send message: tldw_Server_API/app/api/v1/endpoints/character_messages.py:141
-  - Get messages: tldw_Server_API/app/api/v1/endpoints/character_messages.py:287
-  - Get message: tldw_Server_API/app/api/v1/endpoints/character_messages.py:539
-  - Update message: tldw_Server_API/app/api/v1/endpoints/character_messages.py:586
-  - Delete message: tldw_Server_API/app/api/v1/endpoints/character_messages.py:669
-  - Search messages: tldw_Server_API/app/api/v1/endpoints/character_messages.py:735
-- Chat Dictionaries (mounted under `/api/v1/chat`):
-  - Create/list/export/import/statistics endpoints: tldw_Server_API/app/api/v1/endpoints/chat_dictionaries.py
-
-Note: Line numbers reflect the current repository state and may change after refactors.
-
-### Related Schemas
-- Characters: tldw_Server_API/app/api/v1/schemas/character_schemas.py:1
-- World books: tldw_Server_API/app/api/v1/schemas/world_book_schemas.py:1
-- Chat dictionaries: tldw_Server_API/app/api/v1/schemas/chat_dictionary_schemas.py:1
-
-### Related Tests (selection)
-- Core helpers: tldw_Server_API/tests/Characters/test_character_chat_lib.py:1
-- Character Card v3 parsing: tldw_Server_API/tests/Characters/test_ccv3_parser.py:1
-- Newer property/unit tests: tldw_Server_API/tests/Character_Chat_NEW/
-- Chat dictionary API: tldw_Server_API/tests/Chat/unit/test_chat_dictionary_endpoints.py:1
-- Rate limiter: tldw_Server_API/tests/unit/test_character_rate_limiter.py:1
-1. **Prefer the modular files** (`modules/*.py`). Keep the facade updated if you rename or move functions that legacy imports still reference.
-2. **Schema changes** must be mirrored in `ChaChaNotes_DB` migrations; avoid ad-hoc SQL in this module.
-3. **Preserve placeholder semantics**. Any new message or text field should run through `replace_placeholders` where end users expect templated values.
-4. **Respect budgets & limits**. When introducing new operations (e.g., bulk imports), enforce rate limits and token budgets similar to existing ones.
-5. **Document supported formats** in this README if import/export changes.
-6. **Add tests** in the matching suite (`tests/Characters`, `tests/Character_Chat_NEW`) to capture new behaviour and regressions.
-
----
-
-### Quick Reference
-- **Import character**: `import_and_save_character_from_file(db, file_content=..., file_type=...)`
-- **Create conversation**: `start_new_chat_session(db, character_id, title)`
-- **Run dictionary transform**: `ChatDictionaryService(db).process_text(text, token_budget=2048)`
-- **Process lore**: `WorldBookService(db).process_context(input_text, world_book_ids=[...])`
-- **Enforce limits**: `rate_limiter.check_rate_limit(user_id, "character_import")`
-
-With this overview, contributors can navigate the Character Chat subsystem confidently and extend it without breaking legacy flows. Keep this document in sync when making significant changes to module surfaces or behaviour.
+For docs-only changes to this README, targeted source checks and `git diff --check` are usually sufficient. Run the tests above when behavior or schemas change.

--- a/tldw_Server_API/app/core/Persona/README.md
+++ b/tldw_Server_API/app/core/Persona/README.md
@@ -1,102 +1,288 @@
-# Persona
+# Persona Module
 
-## 1. Current Feature Set
+The Persona module implements persistent assistant profiles, live Persona
+sessions, state docs, exemplar retrieval, scoped tool policy, voice command
+support, and Persona Buddy visual-pack services.
 
-- Purpose: Persona Garden provides persisted persona profiles, live persona sessions, scoped tool usage, persona state docs, persona exemplars, and websocket-based interaction for persona-driven workflows.
-- Capabilities:
-  - Persona profile catalog backed by ChaChaNotes persistence
-  - Persona session create/resume/list/detail flows
-  - Persona state docs (`soul`, `identity`, `heartbeat`) with history/restore
-  - Persona scope and policy rule management
-  - Persona exemplar bank with CRUD, transcript import, review flow, and adaptive retrieval
-  - Live websocket session flow with tool-plan proposal, policy enforcement, personalization memory/state-doc usage, and shared persona exemplar guidance
-  - Ordinary persona-backed chat and live Persona Garden both consume the shared exemplar retrieval/prompt-assembly layer
-  - Defensive dialogue-tree robustness checks for persona and character targets
-- Inputs/Outputs:
-  - Input: persona profile/session HTTP requests, websocket JSON frames, transcript import payloads, persona configuration writes
-  - Output: persisted persona metadata, session history, live stream events (`notice`, `tool_plan`, `tool_call`, `tool_result`, `assistant_delta`), exemplar retrieval influence in prompt/planning inputs
-- Related Endpoints:
-  - `tldw_Server_API/app/api/v1/endpoints/persona.py`
-  - `tldw_Server_API/app/api/v1/endpoints/chat.py`
-- Related Schemas:
-  - `tldw_Server_API/app/api/v1/schemas/persona.py`
+For user-facing workflows and curl examples, see
+`Docs/User_Guides/Server/Personas_User_Guide.md`. For the visual asset contract,
+see `Docs/Code_Documentation/Persona_Visual_Packs.md`.
 
-## 2. Technical Details
+## Purpose
 
-- Architecture & Data Flow:
-  - Persona profiles, sessions, state docs, scope rules, policy rules, and exemplars persist in `ChaChaNotes_DB`.
-  - Persona websocket sessions use the process-local `SessionManager` for live turn snapshots while also persisting turn history through `memory_integration.persist_persona_turn(...)`.
-  - Persona exemplar retrieval is deterministic today: turn classification -> exemplar selection -> shared prompt assembly.
-  - Dialogue-tree evaluation is a defensive adaptation only. It explores candidate persona behavior for robustness, policy, and privacy failures; it is not a roleplay feature and must not expand persona authority.
-  - Offline dialogue-tree runs use the shared Evaluations recipe and Jobs execution path. Do not add a persona-specific eval queue or run-history store.
-  - The runtime persona explorer wraps websocket plan proposal only when `PERSONA_RUNTIME_EXPLORER_ENABLED=true`; it is off by default.
-  - Runtime explorer prompt inputs are filtered through the dialogue-tree context redaction boundary before generator calls. They contain bounded user text, sanitized plan shape, IDs, and counts rather than raw memory rows, raw tool output, or secrets.
-  - Runtime hard blockers are deterministic policy/safety pruners. LLM judges are offline-only by default, can rank or warn, and cannot authorize actions.
-  - Runtime-selected plans still pass the existing persona policy evaluator and confirmation flow before emission/execution.
-  - Character Chat support is offline robustness coverage only; there is no `/complete-v2` runtime response explorer in this design.
-  - Ordinary persona-backed chat and live Persona Garden both reuse the same shared exemplar prompt assembly helpers.
-  - Policy/scope enforcement remains authoritative over tools and capabilities; exemplars shape in-character guidance only.
-- Key Modules:
-  - `Persona/session_manager.py`
-  - `Persona/memory_integration.py`
-  - `Persona/exemplar_retrieval.py`
-  - `Persona/exemplar_prompt_assembly.py`
-  - `Persona/exemplar_turn_classifier.py`
-  - `Persona/exemplar_ingestion.py`
-- Dependencies:
-  - Internal: MCP Unified server, AuthNZ, ChaChaNotes DB, personalization memory integration, streaming infrastructure
-- Data Models & DB:
-  - Persona profiles, sessions, policy rules, scope rules, and exemplars are persisted
-  - Persona live sessions keep an in-process runtime snapshot for low-latency websocket interaction
-- Configuration:
-  - `PERSONA_ENABLED`
-  - `persona` and `persona.rbac` config sections
-  - memory/state-doc limits and websocket runtime knobs from config
-- Concurrency & Performance:
-  - Websocket runtime offloads blocking persistence work with `asyncio.to_thread(...)`
-  - exemplar lookup and persona persistence are structured to avoid blocking the live event loop
-- Error Handling:
-  - graceful websocket notices/close behavior on auth or policy failures
-  - explicit HTTP exceptions for persona CRUD/configuration routes
-- Security:
-  - websocket auth supports JWT and API key flows
-  - scope and policy rules gate tool execution
-  - rate limits apply on persona exemplar CRUD/import endpoints
-  - dialogue-tree traces and reports are redacted; red-team fixtures must never write into persona memory, exemplars, state docs, or chat history
+Personas give tldw_server a first-class assistant identity that can persist
+across sessions and surfaces. A Persona is broader than a character card: it can
+carry durable state, scoped memories, tool policies, exemplar guidance, voice
+commands, live-session preferences, and an optional Buddy visual pack.
 
-## 3. Developer Notes
+The core module keeps business rules and reusable runtime helpers out of the
+FastAPI router where possible. The router remains the API integration layer; the
+module files here define the behavior that chat, Persona Live, visual packs, and
+offline evaluation paths share.
 
-- Folder Structure:
-  - Runtime/core logic in `tldw_Server_API/app/core/Persona/`
-  - HTTP and websocket entrypoints in `tldw_Server_API/app/api/v1/endpoints/persona.py`
-- Extension Points:
-  - websocket-specific exemplar debug events are not yet exposed to clients
-  - richer live assistant generation beyond plan/tool scaffolding can build on the shared exemplar/state/memory seam
-  - future retrieval improvements can evolve classifier/ranking behavior without changing storage shape
-  - runtime dialogue-tree generators must declare their input contract and consume only the filtered context bundle
-- Coding Patterns:
-  - keep persona layers distinct:
-    - profile = top-level identity/config
-    - state docs = durable self-model
-    - memory = retrieved experience
-    - policy/scope = permissions
-    - exemplars = retrieved voice/boundary/style guidance
-  - prefer shared helpers over runtime-specific duplication
-- Tests:
-  - websocket behavior: `tldw_Server_API/tests/Persona/test_persona_ws.py`
-  - session routes: `tldw_Server_API/tests/Persona/test_persona_sessions.py`
-  - exemplar retrieval/ingestion/eval: `tldw_Server_API/tests/Persona/`
-  - dialogue-tree robustness/runtime: `tldw_Server_API/tests/Persona/test_dialogue_tree*.py`, `test_persona_dialogue_tree_robustness_eval.py`, `test_runtime_explorer.py`, `test_persona_ws_dialogue_tree_runtime.py`
-  - character offline robustness: `tldw_Server_API/tests/Character_Chat/test_persona_dialogue_tree_character_eval.py`
-  - prompt assembly and persona-backed chat: `tldw_Server_API/tests/Chat/`
-- Local Dev Tips:
-  - connect to `/api/v1/persona/stream` with a websocket client and send `{ "type": "user_message", "text": "<query>" }`
-  - inspect persisted persona sessions via `/api/v1/persona/sessions`
-  - when the optional runtime explorer is enabled, fallback, circuit-open, and safe-denial paths emit a `notice` event with `RUNTIME_EXPLORER_*` reason codes and bounded `runtime_explorer` diagnostics; disabled mode emits no runtime-explorer notice
-- Pitfalls & Gotchas:
-  - personas are created from characters conceptually, but evolve independently after creation
-  - do not store exemplar text snapshots in turn metadata when compact IDs/reasons are sufficient
-  - keep websocket protocol changes separate from runtime retrieval/persistence changes unless explicitly scoped together
-  - keep runtime explorer changes behind feature flags and preserve disabled-mode websocket behavior
-- Current Limitation:
-  - live websocket turns now use shared exemplar retrieval and persist compact selection metadata, but websocket-specific exemplar debug events are still not exposed to clients
+## Responsibilities
+
+- Materialize Persona sessions with a profile, policy rules, scope snapshot, and
+  runtime preferences.
+- Keep live session snapshots in process while persisting durable session data
+  through `ChaChaNotes_DB`.
+- Persist and retrieve Persona memory/state rows.
+- Classify turns, select exemplars, and assemble bounded prompt sections.
+- Evaluate Persona tool policy before tool execution.
+- Validate and serve Persona Visual Pack manifests and user-owned assets.
+- Queue visual generation, import-preview, import-commit, and export jobs.
+- Maintain defensive dialogue-tree and runtime-explorer helpers behind feature
+  flags.
+- Provide redaction and trace-safety boundaries for runtime diagnostics.
+
+## Module Map
+
+| File or Folder | Responsibility |
+| --- | --- |
+| `session_materialization.py` | Creates or resumes persisted Persona sessions, ensures default profiles, builds scope snapshots, and normalizes session preferences. |
+| `session_manager.py` | Process-local live session snapshots, turns, pending plans, and runtime preferences. |
+| `live_control.py` | Focus/stop/list helpers for Persona Live control sessions and active Buddy target state. |
+| `memory_integration.py` | Persona memory retrieval, turn persistence, tool outcome persistence, and legacy/ChaCha read-write mode handling. |
+| `policy_evaluator.py` | Normalizes and evaluates Persona policy rules for MCP tool and skill actions. |
+| `exemplar_turn_classifier.py` | Classifies latest turns into style, boundary, scenario, and tool-behavior retrieval needs. |
+| `exemplar_retrieval.py` | Deterministically selects exemplar rows from enabled candidates. |
+| `exemplar_prompt_assembly.py` | Formats selected exemplars into bounded prompt sections. |
+| `exemplar_runtime.py` | Async runtime bridge used by chat and live Persona flows. |
+| `exemplar_ingestion.py` | Converts transcript text into candidate exemplar rows and appends review notes. |
+| `exemplar_eval_harness.py` | Offline fixture/evaluation helpers for exemplar behavior. |
+| `connections.py` | Validates Persona external connection targets, templates headers/payloads, resolves secrets, and redacts headers. |
+| `buddy.py` | Derives and resolves stable Persona Buddy identity summaries from profile data. |
+| `visuals.py` | Validates manifest shape, animation frames, state catalog, fallbacks, and authored triggers. |
+| `visual_service.py` | Creates, duplicates, activates, deactivates, and reviews visual packs, assets, and generated candidates. |
+| `visual_library_service.py` | Saves and reuses user-owned visual packs through a personal library. |
+| `visual_starter_catalog.py` and `visual_starter_fixtures.py` | Bundled starter pack catalog and fixture assets. |
+| `visual_renderer_capabilities.py` | Renderer capability registry surfaced by `/persona/visual-renderers`. |
+| `visual_jobs.py` and `visual_jobs_worker.py` | Jobs integration for candidate generation, pack export, import preview, and import commit. |
+| `visual_portability/` | Archive validation, import preview, import commit, export, Codex Pet adapter, provider envelope normalization, and fingerprinting. |
+| `dialogue_tree*.py` | Defensive tree exploration, context redaction, pruning, scoring, and trace serialization. |
+| `runtime_explorer.py` | Optional runtime plan exploration layer, disabled by default. |
+| `robustness_eval.py` | Offline robustness evaluation helpers. |
+| `archetype_loader.py` | Loads bundled Persona archetype templates from configuration. |
+
+## Runtime Lifecycle
+
+1. A user creates or lists profiles through `/api/v1/persona/profiles` or the
+   active catalog through `/api/v1/persona/catalog`.
+2. The session API calls `materialize_persona_session(...)` to select a profile,
+   build a scope snapshot, merge preferences, and create or resume a persisted
+   session row.
+3. Persona Live creates or focuses a live control session and mirrors current
+   state into the process-local `SessionManager`.
+4. WebSocket turns enter through `/api/v1/persona/stream`.
+5. Runtime code loads the persisted session context, state docs, memory,
+   exemplars, and policy rules.
+6. Tool plans are proposed, evaluated, and emitted for confirmation when needed.
+7. Confirmed steps are rechecked against policy and RBAC before execution.
+8. Turns, tool outcomes, summaries, and compact metadata are persisted back to
+   Persona memory/session storage.
+
+The live `SessionManager` is a latency optimization, not the authority for
+durable state. Persisted session rows and memory entries remain the recovery
+source for API reads.
+
+## Persistence Model
+
+Persona persistence is handled by `CharactersRAGDB` in
+`tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py`.
+
+Per-user records include:
+
+- Persona profiles.
+- Persona sessions and session preferences.
+- Scope rules and policy rules.
+- Persona memory entries, including state docs and connection records.
+- Persona exemplars.
+- Persona setup and voice analytics.
+- Persona visual packs, assets, candidates, library rows, and portability job
+  metadata.
+
+Do not add raw SQL in the Persona module for new persistence behavior. Add or
+reuse `ChaChaNotes_DB` methods so API routes, core helpers, tests, and future
+Postgres paths stay aligned.
+
+## API Touch Points
+
+Primary router:
+
+- `tldw_Server_API/app/api/v1/endpoints/persona.py`
+
+Schemas:
+
+- `tldw_Server_API/app/api/v1/schemas/persona.py`
+- `tldw_Server_API/app/api/v1/schemas/voice_assistant_schemas.py`
+
+Important route groups:
+
+- Profiles and catalog: `/profiles`, `/profiles/{persona_id}`, `/catalog`
+- Sessions: `/session`, `/sessions`, `/sessions/{session_id}`
+- Live control: `/live/sessions`, `/live/sessions/{session_id}/focus`,
+  `/live/sessions/{session_id}/stop`
+- WebSocket stream: `/stream`
+- State docs: `/profiles/{persona_id}/state`
+- Exemplars: `/profiles/{persona_id}/exemplars`
+- Scope and policy: `/profiles/{persona_id}/scope-rules`,
+  `/profiles/{persona_id}/policy-rules`
+- Voice commands and connections: `/profiles/{persona_id}/voice-commands`,
+  `/profiles/{persona_id}/connections`
+- Visual packs and library: `/visual-renderers`, `/visual-starter-packs`,
+  `/visual-library`, `/profiles/{persona_id}/visual-packs`
+
+Router registration:
+
+- `tldw_Server_API/app/api/v1/router_groups/minimal.py`
+- `tldw_Server_API/app/api/v1/router_groups/content.py`
+
+## Runtime Concepts
+
+- **Profile:** top-level identity, mode, system prompt, active flag, state-doc
+  default, voice defaults, and setup status.
+- **State docs:** durable Markdown state fields: `soul_md`, `identity_md`, and
+  `heartbeat_md`.
+- **Memory:** retrieved Persona experience and persisted turn/tool outcomes.
+- **Exemplars:** selected examples that shape style, boundaries, scenario
+  behavior, or tool behavior.
+- **Scope rules:** include/exclude rules for conversations, characters, media,
+  media tags, and notes.
+- **Policy rules:** allow/deny/confirmation rules for MCP tools and skills.
+- **Session preferences:** persisted and process-local runtime knobs, including
+  voice runtime configuration and session policy overrides.
+- **Buddy summary:** derived stable visual/behavior summary projected from the
+  profile for UI rendering.
+
+Keep these layers distinct. In particular, exemplars guide output style and
+boundaries; they do not grant tool authority. Policy and RBAC remain the
+authority for capability use.
+
+## Visual Packs and Buddy Runtime
+
+Persona Visual Packs are attached to Personas and remain user-owned. The
+supported activation path is manifest-backed `sprite_frames`; clients should
+read `list_persona_visual_renderer_capabilities()` or
+`GET /api/v1/persona/visual-renderers` before assuming a renderer is usable.
+
+Important invariants:
+
+- Generated candidates are review artifacts until accepted.
+- Imported packs are previewed and committed through Jobs-backed portability
+  flows.
+- Draft, review, and archived packs do not affect the live Buddy until explicit
+  activation.
+- Activation validates the manifest before marking a pack active.
+- Asset content is served only after user, persona, pack, and asset ownership
+  checks.
+- Provider envelopes and generation provenance are bounded and redaction-safe.
+
+See `Docs/Code_Documentation/Persona_Visual_Packs.md` for the full visual-pack
+contract and Codex Pet import notes.
+
+## Security and Privacy Boundaries
+
+- All HTTP routes require `get_request_user`; the WebSocket stream authenticates
+  before accepting active behavior.
+- API-key and JWT auth are both supported for the WebSocket stream.
+- Persona records are scoped by authenticated user id.
+- Scope and policy rules are evaluated before tool execution.
+- Transcript export is gated by Persona RBAC settings. Delete-capable runtime
+  scopes are exposed only when Persona RBAC allows them, then rechecked in the
+  policy flow before tool execution.
+- Runtime explorer inputs pass through redaction and truncation boundaries.
+- Dialogue-tree traces and reports must not contain raw secrets, raw memory
+  rows, raw tool output, local paths, or provider secrets.
+- Connection secrets are stored as redacted memory content and responses expose
+  only bounded metadata.
+- Red-team and offline robustness fixtures must not write into Persona memory,
+  exemplars, state docs, or chat history.
+
+## Configuration
+
+Main config lives under `[persona]` and `[persona.rbac]` in
+`tldw_Server_API/Config_Files/config.txt`. Environment variables with uppercase
+names override the matching settings where supported.
+
+Key settings:
+
+- `PERSONA_ENABLED` / `[persona] enabled`
+- `PERSONA_DEFAULT_PERSONA` / `[persona] default_persona`
+- `PERSONA_VOICE` / `[persona] voice`
+- `PERSONA_STT` / `[persona] stt`
+- `PERSONA_MAX_TOOL_STEPS` / `[persona] max_tool_steps`
+- `PERSONA_MEMORY_READ_MODE` / `[persona] persona_memory_read_mode`
+- `PERSONA_MEMORY_WRITE_MODE` / `[persona] persona_memory_write_mode`
+- `PERSONA_DIALOGUE_TREE_EVAL_ENABLED`
+- `PERSONA_RUNTIME_EXPLORER_ENABLED`
+- `PERSONA_RUNTIME_EXPLORER_MAX_DEPTH`
+- `PERSONA_RUNTIME_EXPLORER_MAX_BRANCHING`
+- `PERSONA_RUNTIME_EXPLORER_MAX_PROVIDER_CALLS`
+- `PERSONA_RUNTIME_EXPLORER_TIMEOUT_MS`
+- `PERSONA_RUNTIME_EXPLORER_MAX_TOKENS`
+- `PERSONA_RUNTIME_EXPLORER_LLM_JUDGES_ENABLED`
+- `PERSONA_DIALOGUE_TREE_TRACE_RETENTION_DAYS`
+- `PERSONA_RBAC_ALLOW_EXPORT` / `[persona.rbac] allow_export`
+- `PERSONA_RBAC_ALLOW_DELETE` / `[persona.rbac] allow_delete`
+
+Runtime explorer and LLM judges are off by default. LLM judges are offline or
+warning/ranking helpers and must not authorize runtime actions.
+
+## Testing
+
+Use the project virtual environment before running Python tests:
+
+```bash
+source .venv/bin/activate
+```
+
+Recommended targeted suites:
+
+```bash
+python -m pytest tldw_Server_API/tests/Persona/test_persona_sessions.py -q
+python -m pytest tldw_Server_API/tests/Persona/test_persona_ws.py -q
+python -m pytest tldw_Server_API/tests/Persona/test_persona_memory_integration.py -q
+python -m pytest tldw_Server_API/tests/Persona/test_persona_policy_evaluator.py -q
+python -m pytest tldw_Server_API/tests/Persona/test_persona_profiles_api.py -q
+python -m pytest tldw_Server_API/tests/Persona/test_persona_visual*.py -q
+python -m pytest tldw_Server_API/tests/Persona/test_dialogue_tree*.py -q
+python -m pytest tldw_Server_API/tests/Chat -k persona -q
+python -m pytest tldw_Server_API/tests/Character_Chat/test_persona_dialogue_tree_character_eval.py -q
+```
+
+Pick the smallest relevant subset for narrow changes. Broaden to the WebSocket,
+visual, Chat, or Character Chat suites when changing shared runtime behavior.
+
+## Extension Guidance
+
+- Keep FastAPI route handlers thin. Put reusable logic in this module or in
+  `DB_Management` when persistence is involved.
+- Add DB behavior through `ChaChaNotes_DB` methods instead of ad hoc SQL.
+- Preserve user isolation on every read and write.
+- Treat Persona session preferences as persisted state with process-local cache
+  projection, not as cache-only state.
+- Keep visual renderer support behind the capability registry.
+- Keep runtime explorer behavior feature-flagged and preserve disabled-mode
+  WebSocket behavior.
+- Store compact IDs, reasons, and metadata rather than raw exemplar text or raw
+  tool output when tracing runtime decisions.
+- If a new feature needs user-facing status, consider Jobs for queue visibility;
+  use Scheduler only for internal orchestration where dependency handling is the
+  central concern.
+- Update this README and `Docs/User_Guides/Server/Personas_User_Guide.md` when
+  public behavior or extension points change.
+
+## Common Pitfalls
+
+- Confusing Personas with Character Chat cards. Personas can seed from
+  characters, but they evolve independently.
+- Letting exemplars act like permissions. They are prompt guidance only.
+- Treating the process-local `SessionManager` as durable storage.
+- Returning raw secrets, raw tool payloads, raw memory rows, or local paths in
+  traces, diagnostics, or API responses.
+- Activating generated or imported visual assets without an explicit user
+  activation step.
+- Adding WebSocket message types without preserving existing `notice`,
+  `tool_plan`, `tool_call`, `tool_result`, and `assistant_delta` behavior.
+- Enabling runtime explorer features without bounded context, deterministic
+  hard blockers, and policy re-evaluation before execution.


### PR DESCRIPTION
## Summary
- Add source user guides for Personas and Character Cards/Character Chat.
- Refresh the Persona and Character_Chat core module READMEs against current APIs and module boundaries.
- Link both guides from the source user-guide index and record TASK-586/TASK-587 tracking.

## Verification
- git diff --check
- git status --short Docs/Published (no output)
- rg trailing-whitespace scan over touched docs/tasks (no matches)
- rg stale placeholder scan for TODO/TBD/FIXME and stale Character Chat paths (no matches)
- rg route-source scans for documented Persona and Character Cards paths

## Not Run
- pytest: docs-only Markdown changes
- Bandit: docs-only Markdown changes

## Merge Note
This PR was materially authored by AI. Per repo policy, a human-written Change summary is required before merge.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
New user guides for Personas and Character Cards/Character Chat, plus refreshed core module READMEs. Adds index links, supporting plans/specs, and backlog task updates (with PR link) to clarify current APIs and module boundaries, including follow-up edits to the Character Cards guide.

- **Documentation**
  - Added `Docs/User_Guides/Server/Personas_User_Guide.md` and `Docs/User_Guides/Server/Character_Cards_User_Guide.md`.
  - Updated `tldw_Server_API/app/core/Persona/README.md` and `tldw_Server_API/app/core/Character_Chat/README.md` to reflect current behavior.
  - Linked both guides from `Docs/User_Guides/index.md`.
  - Added supporting plans/specs under `Docs/superpowers/`.
  - Updated `TASK-586` and `TASK-587` to tie docs to tracked work and recorded the PR link for traceability.

<sup>Written for commit 48e1d529936538d74eff906c19e9aaf7c44dda4d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2212?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

