### PR TITLE
feat(mcp): enforce stdio process policy

### DIFF
--- a/Docs/superpowers/plans/2026-06-01-mcp-stdio-process-policy-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-06-01-mcp-stdio-process-policy-implementation-plan.md
@@ -1,0 +1,425 @@
+# MCP Unified Stdio Process Policy Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add runtime-configurable process policy enforcement before package-owned upstream stdio MCP transports spawn external processes.
+
+**Architecture:** Create a focused `mcp_unified.federation.process_policy` module for policy coercion and validation, then keep `stdio_transport.py` responsible for subprocess JSON-RPC behavior while delegating executable/cwd/env decisions to the policy helper. Gateway bootstrap config will parse the policy and wrap the default stdio transport factory only when a config policy is supplied, preserving current default factory identity otherwise.
+
+**Tech Stack:** Python 3.10+, dataclasses, pathlib, asyncio subprocesses, Pydantic model inputs, pytest/pytest-asyncio, existing `mcp_unified` gateway/federation contracts.
+
+---
+
+## File Map
+
+- Create `mcp_unified/federation/process_policy.py`
+  - Own `StdioProcessPolicy`, `coerce_stdio_process_policy()`, and validation helpers for executable, cwd, env, PATH lookup, and shell wrapper denial.
+- Modify `mcp_unified/federation/stdio_transport.py`
+  - Accept optional `process_policy`, call policy validation during construction, use the effective cwd and env-name filtering returned by helpers, and pass policy through `create_external_transport()`.
+- Modify `mcp_unified/federation/__init__.py`
+  - Re-export `StdioProcessPolicy` and `coerce_stdio_process_policy`.
+- Modify `mcp_unified/federation/transports.py`
+  - Update stale docstrings that still claim the package contract is non-spawning.
+- Modify `mcp_unified/gateway/config.py`
+  - Add `process_policy` to `GatewayExternalRuntimeBootstrapConfig`, validate mappings, and wrap the default factory only when policy is configured.
+- Modify `mcp_unified/gateway/cli.py`
+  - Add compact policy summary to `validate-config`.
+- Modify `tldw_Server_API/app/core/MCP_unified/tests/test_stdio_external_transport.py`
+  - Add transport-level policy tests.
+- Modify `tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py`
+  - Add bootstrap and runtime-manager redaction/status tests.
+- Modify `tldw_Server_API/app/core/MCP_unified/tests/test_gateway_cli_package.py`
+  - Update validate-config expectations and add configured-policy summary coverage.
+- Modify `tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py`
+  - Add public export coverage for the new policy contract.
+- Update Backlog task `TASK-586` with touched files and verification results.
+
+## Stage 1: Policy Helper Module
+
+**Goal:** Add policy data model and pure validation helpers without touching subprocess launch behavior.
+
+**Success Criteria:** Helper tests fail before implementation, then pass with no subprocesses required.
+
+**Tests:** Focused unit tests in `test_stdio_external_transport.py` or a new nearby test section covering coercion, shell basename detection, PATH rules, cwd roots, env-name policy, and safe error details.
+
+**Status:** Not Started
+
+### Task 1: Write failing helper tests
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/MCP_unified/tests/test_stdio_external_transport.py`
+- Create later: `mcp_unified/federation/process_policy.py`
+
+- [ ] **Step 1: Add failing tests for policy coercion and denials**
+
+Add tests equivalent to:
+
+```python
+from mcp_unified.federation.process_policy import (
+    StdioProcessPolicy,
+    coerce_stdio_process_policy,
+)
+
+
+def test_stdio_process_policy_rejects_invalid_mapping_values() -> None:
+    with pytest.raises(ValueError, match="allowed_executables"):
+        coerce_stdio_process_policy({"allowed_executables": ["python", ""]})
+    with pytest.raises(ValueError, match="allow_path_lookup"):
+        coerce_stdio_process_policy({"allow_path_lookup": "false"})
+
+
+def test_stdio_process_policy_defaults_block_shell_wrappers() -> None:
+    server = _server(command=["/bin/bash", "-lc", "echo no"])
+    with pytest.raises(StdioExternalTransportError) as exc_info:
+        StdioExternalTransport(server)
+    assert exc_info.value.reason_code == "process_policy_shell_denied"
+    assert "echo no" not in str(exc_info.value)
+
+
+def test_stdio_process_policy_allows_explicit_shell_executable() -> None:
+    policy = StdioProcessPolicy(allowed_executables=("/bin/bash",))
+    transport = StdioExternalTransport(
+        _server(command=["/bin/bash", "--version"]),
+        process_policy=policy,
+    )
+    assert transport.server_id == "docs"
+```
+
+- [ ] **Step 2: Run helper tests and confirm they fail**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest \
+  tldw_Server_API/app/core/MCP_unified/tests/test_stdio_external_transport.py \
+  -k "process_policy" -q
+```
+
+Expected: FAIL because `mcp_unified.federation.process_policy` and `process_policy` constructor support do not exist.
+
+### Task 2: Implement policy model and pure helpers
+
+**Files:**
+- Create: `mcp_unified/federation/process_policy.py`
+
+- [ ] **Step 1: Add `StdioProcessPolicy` and coercion helper**
+
+Implement:
+
+```python
+@dataclass(frozen=True, slots=True)
+class StdioProcessPolicy:
+    allowed_executables: tuple[str, ...] = ()
+    allowed_cwd_roots: tuple[str | Path, ...] = ()
+    allowed_env_names: tuple[str, ...] | None = None
+    allow_path_lookup: bool = True
+    reject_shell_executables: bool = True
+    default_cwd: str | Path | None = None
+```
+
+Add `coerce_stdio_process_policy(value)` that:
+
+- returns default policy for `None`
+- returns the same immutable model for `StdioProcessPolicy`
+- accepts mappings from JSON/TOML config
+- rejects blank strings, non-string list entries, and non-bool booleans
+- preserves `allowed_env_names=None` distinct from `allowed_env_names=()`
+
+- [ ] **Step 2: Add validation helpers**
+
+Add helpers that can be called from `stdio_transport.py`:
+
+```python
+def validate_stdio_process_policy(
+    *,
+    server_id: str,
+    command: tuple[str, ...],
+    cwd: str | None,
+    env_allowlist: list[str],
+    policy: StdioProcessPolicy,
+    error_factory: Callable[..., Exception],
+) -> StdioProcessDecision:
+    ...
+```
+
+The returned decision should contain:
+
+- `command`
+- `cwd`
+- `allowed_env_names`
+
+Use safe reason codes from the spec.
+
+- [ ] **Step 3: Run helper tests**
+
+Run the same focused pytest command. Expected: failures should now be only in transport integration, if any.
+
+## Stage 2: Transport Enforcement
+
+**Goal:** Enforce process policy before spawning and keep stdio JSON-RPC behavior unchanged for allowed commands.
+
+**Success Criteria:** Existing stdio transport tests keep passing, new policy denial tests pass, and secret/command material is not leaked in error messages.
+
+**Tests:** `test_stdio_external_transport.py`.
+
+**Status:** Not Started
+
+### Task 3: Wire policy into `StdioExternalTransport`
+
+**Files:**
+- Modify: `mcp_unified/federation/stdio_transport.py`
+- Modify: `mcp_unified/federation/__init__.py`
+- Modify: `mcp_unified/federation/transports.py`
+
+- [ ] **Step 1: Update constructor and factory signatures**
+
+Add:
+
+```python
+process_policy: StdioProcessPolicy | Mapping[str, Any] | None = None
+```
+
+to `StdioExternalTransport.__init__()` and `create_external_transport()`.
+
+- [ ] **Step 2: Apply policy during construction**
+
+After `_validate_command()`, call `coerce_stdio_process_policy()` and the validation helper. Store:
+
+- `self._process_policy`
+- `self._cwd`
+- `self._allowed_env_names`
+
+Use `StdioExternalTransportError` with policy reason codes.
+
+- [ ] **Step 3: Apply env-name intersection in `_build_child_env()`**
+
+When `allowed_env_names` is not `None`, inherit only names present in both:
+
+- `server.env_allowlist`
+- `policy.allowed_env_names`
+- `os.environ`
+
+Do not include values in exceptions or logs.
+
+- [ ] **Step 4: Export the policy and fix stale docstrings**
+
+Update `mcp_unified/federation/__init__.py` public exports and revise `mcp_unified/federation/transports.py` docstrings from “non-spawning” to neutral language.
+
+- [ ] **Step 5: Run stdio transport tests**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest \
+  tldw_Server_API/app/core/MCP_unified/tests/test_stdio_external_transport.py -q
+```
+
+Expected: PASS.
+
+## Stage 3: Gateway Config And CLI Wiring
+
+**Goal:** Let gateway configs supply process policy while preserving existing default behavior and injected factory semantics.
+
+**Success Criteria:** Config validates policy mappings; default manager factory identity is unchanged when policy is omitted; configured policy wraps the default stdio factory; custom factories remain untouched.
+
+**Tests:** `test_gateway_fastapi_package.py`, `test_gateway_cli_package.py`, `test_runtime_package_boundary.py`.
+
+**Status:** Not Started
+
+### Task 4: Write failing gateway config and CLI tests
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py`
+- Modify: `tldw_Server_API/app/core/MCP_unified/tests/test_gateway_cli_package.py`
+- Modify: `tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py`
+
+- [ ] **Step 1: Add bootstrap tests**
+
+Add tests that assert:
+
+- `GatewayExternalRuntimeBootstrapConfig(process_policy={"allow_path_lookup": False})` is accepted
+- invalid process policy mapping raises `ValueError`
+- manager default factory identity remains `create_external_transport` when policy is omitted
+- manager default factory is wrapped when policy is configured
+- custom `external_transport_factory` is preserved even when config has policy
+
+- [ ] **Step 2: Add CLI summary test**
+
+Update existing validate-config success expectation to include:
+
+```json
+"process_policy": {
+  "configured": false,
+  "allowed_executables": 0,
+  "allowed_cwd_roots": 0,
+  "allowed_env_names": null,
+  "allow_path_lookup": true,
+  "reject_shell_executables": true,
+  "default_cwd": false
+}
+```
+
+Add a configured-policy test where counts are non-zero and paths are not echoed.
+
+- [ ] **Step 3: Add public export test**
+
+Assert `mcp_unified.federation.StdioProcessPolicy is mcp_unified.federation.process_policy.StdioProcessPolicy`.
+
+- [ ] **Step 4: Run focused tests and confirm failures**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest \
+  tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py \
+  tldw_Server_API/app/core/MCP_unified/tests/test_gateway_cli_package.py \
+  tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py \
+  -k "process_policy or validate_config_reports_success_json or builds_stdio_external_runtime_manager or external_runtime_uses_injected_transport_factory or public_exports" -q
+```
+
+Expected: FAIL until config, CLI, and exports are implemented.
+
+### Task 5: Implement gateway config and CLI support
+
+**Files:**
+- Modify: `mcp_unified/gateway/config.py`
+- Modify: `mcp_unified/gateway/cli.py`
+- Modify: `mcp_unified/federation/__init__.py`
+
+- [ ] **Step 1: Extend `GatewayExternalRuntimeBootstrapConfig`**
+
+Add `process_policy` field and normalize it in `__post_init__()`.
+
+Preserve whether the caller explicitly supplied policy, for example with an internal boolean or `None` field, so factory wrapping happens only when configured.
+
+- [ ] **Step 2: Thread policy through bootstrap**
+
+Add `process_policy` parameter to `external_runtime_manager_from_storage()`.
+
+When `transport_factory is None` and policy was configured, build a wrapper closure:
+
+```python
+def _policy_transport_factory(server: ExternalServerDefinition) -> ExternalFederationTransport:
+    return create_external_transport(server, process_policy=process_policy)
+```
+
+When no policy was configured, pass `create_external_transport` directly.
+
+- [ ] **Step 3: Add CLI summary**
+
+Update `_validated_config_payload()` with a compact `process_policy` summary. Do not expose raw paths or executable values.
+
+- [ ] **Step 4: Run gateway tests**
+
+Run the focused pytest command from Task 4. Expected: PASS.
+
+## Stage 4: Runtime Manager Redaction Coverage
+
+**Goal:** Verify process-policy denial through the runtime manager produces safe status and error metadata.
+
+**Success Criteria:** A policy-denied start fails with existing public reason code and status redaction does not include command args or env values.
+
+**Tests:** `test_gateway_fastapi_package.py` or `test_gateway_external_runtime.py`, whichever has the simplest existing fixtures.
+
+**Status:** Not Started
+
+### Task 6: Add and pass runtime-manager redaction test
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py`
+- Modify only if needed: `mcp_unified/gateway/external_runtime.py`
+
+- [ ] **Step 1: Write failing redaction test**
+
+Create a sqlite bootstrap with `external_runtime.enabled=True` and a restrictive process policy. Store an enabled stdio server with a denied command containing a unique argument marker and env allowlist containing a unique env name.
+
+Assert:
+
+- `manager.start_server("research")` raises `GatewayExternalRuntimeError` with reason `external_server_start_failed`
+- `manager.list_runtime_servers()` returns status containing a safe `last_error`
+- denied command argument marker is absent from the exception string and status JSON
+- env value marker is absent from the exception string and status JSON
+
+- [ ] **Step 2: Run test and confirm failure if runtime redaction needs adjustment**
+
+Run the focused gateway pytest command. Expected: FAIL only if current runtime stores too much exception text.
+
+- [ ] **Step 3: Adjust runtime error summarization only if needed**
+
+If the test fails due leakage, change only the start-failure path to store safe policy reason details instead of raw exception text. Keep existing payload shapes.
+
+- [ ] **Step 4: Run focused gateway tests**
+
+Expected: PASS.
+
+## Stage 5: Verification And Completion
+
+**Goal:** Validate touched behavior and update tracking records.
+
+**Success Criteria:** Targeted tests pass, Bandit runs on touched code, Backlog task records results, and commits are clean.
+
+**Tests:** Targeted pytest plus Bandit on touched code.
+
+**Status:** Not Started
+
+### Task 7: Run final verification
+
+**Files:**
+- No code changes expected unless verification exposes failures.
+
+- [ ] **Step 1: Run targeted pytest suite**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest \
+  tldw_Server_API/app/core/MCP_unified/tests/test_stdio_external_transport.py \
+  tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py \
+  tldw_Server_API/app/core/MCP_unified/tests/test_gateway_cli_package.py \
+  tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py \
+  -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run Bandit on touched package code**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit \
+  -r mcp_unified/federation mcp_unified/gateway \
+  -f json -o /tmp/bandit_mcp_stdio_process_policy.json
+```
+
+Expected: completes with no new findings in touched code. If Bandit is not installed, record that explicitly and run any available security checks for touched files.
+
+- [ ] **Step 3: Update Backlog task**
+
+Record:
+
+- touched files
+- test commands and results
+- Bandit result or skip reason
+- final summary
+
+- [ ] **Step 4: Commit implementation**
+
+Commit after tests pass:
+
+```bash
+git add mcp_unified/federation/process_policy.py \
+  mcp_unified/federation/stdio_transport.py \
+  mcp_unified/federation/__init__.py \
+  mcp_unified/federation/transports.py \
+  mcp_unified/gateway/config.py \
+  mcp_unified/gateway/cli.py \
+  tldw_Server_API/app/core/MCP_unified/tests/test_stdio_external_transport.py \
+  tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py \
+  tldw_Server_API/app/core/MCP_unified/tests/test_gateway_cli_package.py \
+  tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py \
+  "backlog/tasks/task-586 - Harden-MCP-external-stdio-process-policy.md"
+git commit -m "feat(mcp): enforce stdio process policy"
+```
+
+Expected: commit succeeds with a clean worktree afterward.

--- a/Docs/superpowers/plans/2026-06-01-mcp-stdio-process-policy-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-06-01-mcp-stdio-process-policy-implementation-plan.md
@@ -32,7 +32,7 @@
   - Update validate-config expectations and add configured-policy summary coverage.
 - Modify `tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py`
   - Add public export coverage for the new policy contract.
-- Update Backlog task `TASK-586` with touched files and verification results.
+- Update Backlog task `TASK-588` with touched files and verification results.
 
 ## Stage 1: Policy Helper Module
 
@@ -418,7 +418,7 @@ git add mcp_unified/federation/process_policy.py \
   tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py \
   tldw_Server_API/app/core/MCP_unified/tests/test_gateway_cli_package.py \
   tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py \
-  "backlog/tasks/task-586 - Harden-MCP-external-stdio-process-policy.md"
+  "backlog/tasks/task-588 - Harden-MCP-external-stdio-process-policy.md"
 git commit -m "feat(mcp): enforce stdio process policy"
 ```
 

--- a/Docs/superpowers/specs/2026-06-01-mcp-stdio-process-policy-design.md
+++ b/Docs/superpowers/specs/2026-06-01-mcp-stdio-process-policy-design.md
@@ -1,0 +1,278 @@
+# MCP Unified Stdio Process Policy Design
+
+Date: 2026-06-01
+Status: Approved for spec review
+Backlog: TASK-586
+
+## Summary
+
+Add an explicit process-execution policy layer for package-owned upstream stdio
+MCP transports. The package can now launch real external MCP server processes,
+so the next hardening step is to make executable, working-directory, PATH, and
+environment inheritance decisions deliberate and testable before adding real
+third-party install/update execution.
+
+The policy should live in `mcp_unified`, apply before any subprocess spawn, and
+return deterministic safe reason codes when a configured external server
+violates deployment policy. This slice should not add package-manager behavior,
+daemon control, or WebUI changes.
+
+## Goals
+
+- Enforce configurable executable allowlists before `asyncio.create_subprocess_exec`.
+- Support bounded canonical cwd validation for configured external stdio
+  servers.
+- Restrict inherited environment variable names through a runtime policy in
+  addition to each server's `env_allowlist`.
+- Make PATH lookup explicit and reject it when deployment policy disables it.
+- Reject shell wrapper executables by default unless a host deliberately allows
+  them.
+- Keep policy failures secret-safe in exceptions, logs, status payloads, and
+  audit events.
+- Preserve the `mcp_unified` package boundary with no imports from
+  `tldw_Server_API`.
+- Add focused regression tests for denied and allowed process-policy cases.
+
+## Non-Goals
+
+- No package-manager, marketplace, or automatic install/update execution.
+- No durable daemon or remote control client for already-running gateways.
+- No per-server persisted process-policy schema in
+  `ExternalServerDefinition`.
+- No shell parsing, command expansion, glob expansion, or variable expansion.
+- No WebSocket upstream transport policy in this slice.
+- No resource limits such as CPU, memory, or process groups. Those can be added
+  later as another policy dimension.
+
+## Current Foundation
+
+The current package code already provides:
+
+- `mcp_unified.federation.stdio_transport.StdioExternalTransport`
+- `mcp_unified.federation.stdio_transport.create_external_transport`
+- `mcp_unified.gateway.external_runtime.GatewayExternalRuntimeManager`
+- `mcp_unified.gateway.config.GatewayExternalRuntimeBootstrapConfig`
+- `mcp_unified.storage.models.ExternalServerDefinition`
+
+The stdio transport already uses `asyncio.create_subprocess_exec` without a
+shell, validates non-empty commands, validates configured cwd existence, and
+builds the child environment only from `ExternalServerDefinition.env_allowlist`.
+The remaining gap is that these checks are mostly syntactic. They do not let a
+deployment bound which executables, cwd roots, PATH lookup behavior, or env names
+are acceptable.
+
+## Approach Options
+
+### Option A: Runtime Process Policy Object
+
+Add a package-owned policy object, pass it into the stdio transport factory, and
+wire it through gateway bootstrap config. The registry continues storing only
+server definitions. Deployment owners configure process constraints once at
+runtime.
+
+Tradeoff: one more config surface, but it keeps mutable server records separate
+from host-level execution policy and avoids schema churn.
+
+### Option B: Persist Policy Per External Server
+
+Add policy fields directly to `ExternalServerDefinition`, store them in SQLite,
+and let each server carry its own execution constraints.
+
+Tradeoff: this gives granular control but lets editable registry records modify
+their own guardrails unless every mutation path learns new approval semantics.
+It also widens the storage schema for a policy that is better treated as a host
+deployment boundary.
+
+### Option C: Hardcode Safer Defaults Only
+
+Reject obvious shell wrappers and require absolute executable paths without
+adding a configurable policy model.
+
+Tradeoff: simple, but too rigid for real MCP deployments that commonly use
+package shims such as `node`, `python`, or `npx`. It also leaves no way for host
+applications to express their actual trust boundary.
+
+## Recommended Approach
+
+Use Option A.
+
+This makes the trust boundary explicit while keeping the work narrow. The
+runtime policy is injected into package factories and config bootstrap. Server
+definitions remain data records; policy remains a deployment control.
+
+## Policy Model
+
+Add a small model in `mcp_unified.federation.stdio_transport`, or a sibling
+module if the file becomes too crowded:
+
+```python
+@dataclass(frozen=True, slots=True)
+class StdioProcessPolicy:
+    allowed_executables: tuple[str, ...] = ()
+    allowed_cwd_roots: tuple[str | Path, ...] = ()
+    allowed_env_names: tuple[str, ...] | None = None
+    allow_path_lookup: bool = True
+    reject_shell_executables: bool = True
+    default_cwd: str | Path | None = None
+```
+
+Semantics:
+
+- `allowed_executables`: empty means no allowlist restriction. Entries may be
+  executable names such as `python` or canonical absolute paths such as
+  `/usr/bin/python3`. Entries with path separators are expanded and resolved
+  before comparison; bare-name entries match the normalized executable basename.
+- `allowed_cwd_roots`: empty means cwd only needs to exist. When non-empty, the
+  resolved cwd must be under one of the resolved roots.
+- `allowed_env_names`: `None` means the server's `env_allowlist` is the only env
+  name filter. A tuple means the server may only request names also present in
+  the policy list.
+- `allow_path_lookup`: when false, command executables without a path separator
+  are rejected. This is stricter than the current PATH allowlist requirement.
+- `reject_shell_executables`: when true, common shell wrappers such as `sh`,
+  `bash`, `zsh`, `fish`, `cmd`, `powershell`, and `pwsh` are rejected unless the
+  executable is explicitly listed in `allowed_executables`.
+- `default_cwd`: optional runtime cwd used when a server does not configure
+  `cwd`. It is resolved and checked against `allowed_cwd_roots`. If
+  `allowed_cwd_roots` is configured and neither the server nor policy provides a
+  cwd, transport construction should fail instead of silently inheriting the
+  process cwd.
+
+The default policy preserves most current behavior while blocking shell wrappers.
+Hosts that need stricter behavior can set `allow_path_lookup=false`,
+`allowed_executables`, and `allowed_cwd_roots`.
+
+## Transport Enforcement
+
+`StdioExternalTransport` should accept `process_policy: StdioProcessPolicy | Mapping[str, Any] | None`.
+During construction it should:
+
+- normalize and copy the policy
+- validate `server.transport == "stdio"`
+- validate and normalize `server.command`
+- apply executable policy before spawn
+- resolve the effective cwd using `server.cwd` or `policy.default_cwd`
+- ensure cwd exists and satisfies `allowed_cwd_roots` when configured
+- detect shell wrappers by basename so both `bash` and `/bin/bash` are covered
+- validate requested env names against `policy.allowed_env_names`
+- keep child env construction limited to the intersection of server allowlist,
+  policy allowlist when configured, and current `os.environ`
+
+Policy denials should raise `StdioExternalTransportError` with safe reason
+codes:
+
+- `process_policy_executable_denied`
+- `process_policy_shell_denied`
+- `process_policy_path_lookup_denied`
+- `process_policy_cwd_denied`
+- `process_policy_env_denied`
+
+Error `details` may include safe scalar data such as `server_id`, `field`,
+`executable_name`, or denied env names. It must not include full command arrays,
+environment values, credential values, request bodies, or stderr contents.
+
+## Gateway Config Wiring
+
+Extend `GatewayExternalRuntimeBootstrapConfig` with:
+
+```python
+process_policy: StdioProcessPolicy | Mapping[str, Any] | None = None
+```
+
+`external_runtime_manager_from_storage()` should accept the same policy and
+wrap the transport factory when using the package-owned stdio factory:
+
+```python
+def factory(server: ExternalServerDefinition) -> ExternalFederationTransport:
+    return create_external_transport(server, process_policy=policy)
+```
+
+If a caller supplies a custom `external_transport_factory`, the package should
+not force this stdio policy into it. Custom factories own their own enforcement
+boundary. The config validator should still parse and validate policy so bad
+gateway config fails early.
+
+The CLI `validate-config` output should include a compact `process_policy`
+summary with booleans/counts, not raw paths if that risks leaking deployment
+layout. A practical shape is:
+
+```json
+{
+  "external_runtime": {
+    "process_policy": {
+      "configured": true,
+      "allowed_executables": 2,
+      "allowed_cwd_roots": 1,
+      "allowed_env_names": 3,
+      "allow_path_lookup": false,
+      "reject_shell_executables": true,
+      "default_cwd": true
+    }
+  }
+}
+```
+
+## Data Flow
+
+1. A host loads gateway config from JSON or TOML.
+2. `GatewayExternalRuntimeBootstrapConfig` validates process-policy values.
+3. `bootstrap_profile_gateway_from_config()` builds the external runtime
+   manager with a stdio transport factory that closes over the policy.
+4. `GatewayExternalRuntimeManager.start_server()` loads an
+   `ExternalServerDefinition`.
+5. The factory creates `StdioExternalTransport(server, process_policy=policy)`.
+6. The transport applies process policy before any subprocess is spawned.
+7. Allowed transports continue to initialize, discover tools, and execute calls.
+8. Denied transports surface safe reason codes through existing lifecycle error
+   handling.
+
+## Error Handling
+
+Policy violations should fail before process creation. They should be treated
+like other transport start failures by the runtime manager:
+
+- `start_server()` returns or raises existing `external_server_start_failed`
+  envelopes at the gateway boundary.
+- `_last_errors` may include a safe exception summary with the policy reason
+  code.
+- Audit payloads should record the high-level failure reason only.
+- Logs should not include command arrays or env values.
+
+The transport may include the policy-specific reason code in the chained
+exception. The public gateway reason can remain the existing start-failed reason
+to preserve API compatibility.
+
+## Tests
+
+Add or extend focused tests under
+`tldw_Server_API/app/core/MCP_unified/tests/test_stdio_external_transport.py` and
+gateway config tests where appropriate.
+
+Coverage:
+
+- shell wrapper commands are rejected by default
+- shell wrapper commands can be allowed only by explicit executable allowlist
+- `allow_path_lookup=false` rejects bare executable names
+- executable allowlist accepts matching executable names
+- executable allowlist rejects non-matching executable names
+- cwd roots reject resolved cwd outside configured roots
+- cwd roots accept resolved cwd inside configured roots
+- `default_cwd` is used when server cwd is omitted
+- policy env allowlist rejects a server-requested env name outside the policy
+- allowed env values still inherit only from names present in `os.environ`
+- config loader validates process-policy mappings and rejects invalid types
+- bootstrap passes configured policy into the package stdio factory
+- denied policy errors do not include env values or full command arrays
+- `mcp_unified.federation.transports` documentation no longer describes the
+  package contract as non-spawning now that real stdio transport exists
+
+## Rollout
+
+This is a hardening slice. Existing direct API users can continue constructing
+`StdioExternalTransport(server)` without a custom policy, but default shell
+wrapper rejection is a deliberate behavior change. Gateway users can opt into
+stricter deployment policy through config before enabling real upstream stdio
+auto-start.
+
+Real install/update execution remains deferred until this process-policy layer
+is in place and reviewed.

--- a/Docs/superpowers/specs/2026-06-01-mcp-stdio-process-policy-design.md
+++ b/Docs/superpowers/specs/2026-06-01-mcp-stdio-process-policy-design.md
@@ -2,7 +2,7 @@
 
 Date: 2026-06-01
 Status: Revised after design review
-Backlog: TASK-586
+Backlog: TASK-588
 
 ## Summary
 
@@ -133,7 +133,8 @@ Semantics:
 - `allowed_executables`: empty means no allowlist restriction. Entries may be
   executable names such as `python` or canonical absolute paths such as
   `/usr/bin/python3`. Entries with path separators are expanded and resolved
-  before comparison; bare-name entries match the normalized executable basename.
+  before comparison. Bare-name entries match only bare command names and never
+  authorize an absolute or relative command path with the same basename.
   Bare-name allowlists still trust the parent `PATH`, so strict deployments
   should use absolute executable paths and set `allow_path_lookup=false`.
 - `allowed_cwd_roots`: empty means cwd only needs to exist. When non-empty, the
@@ -213,7 +214,8 @@ process_policy: StdioProcessPolicy | Mapping[str, Any] | None = None
 
 `external_runtime_manager_from_storage()` should accept the same policy and
 wrap the transport factory only when a non-`None` config policy is supplied and
-the package-owned stdio factory is being used:
+the package-owned stdio factory is being used, including when a host explicitly
+passes `create_external_transport` instead of leaving the factory unset:
 
 ```python
 def factory(server: ExternalServerDefinition) -> ExternalFederationTransport:

--- a/Docs/superpowers/specs/2026-06-01-mcp-stdio-process-policy-design.md
+++ b/Docs/superpowers/specs/2026-06-01-mcp-stdio-process-policy-design.md
@@ -1,7 +1,7 @@
 # MCP Unified Stdio Process Policy Design
 
 Date: 2026-06-01
-Status: Approved for spec review
+Status: Revised after design review
 Backlog: TASK-586
 
 ## Summary
@@ -27,6 +27,8 @@ daemon control, or WebUI changes.
 - Make PATH lookup explicit and reject it when deployment policy disables it.
 - Reject shell wrapper executables by default unless a host deliberately allows
   them.
+- Treat Windows and POSIX executable path comparisons consistently enough that
+  shell detection and cwd-root checks do not depend on spelling differences.
 - Keep policy failures secret-safe in exceptions, logs, status payloads, and
   audit events.
 - Preserve the `mcp_unified` package boundary with no imports from
@@ -102,8 +104,11 @@ definitions remain data records; policy remains a deployment control.
 
 ## Policy Model
 
-Add a small model in `mcp_unified.federation.stdio_transport`, or a sibling
-module if the file becomes too crowded:
+Add the policy and coercion helpers in a sibling module,
+`mcp_unified.federation.process_policy`, instead of growing
+`stdio_transport.py` further. Re-export the public policy model from
+`mcp_unified.federation` for callers that already import federation utilities
+from the package root.
 
 ```python
 @dataclass(frozen=True, slots=True)
@@ -116,22 +121,35 @@ class StdioProcessPolicy:
     default_cwd: str | Path | None = None
 ```
 
+The module should provide a single normalization boundary, for example
+`coerce_stdio_process_policy(value)`, that accepts `None`,
+`StdioProcessPolicy`, or a mapping loaded from JSON/TOML. It should reject
+blank strings, non-string list entries, invalid booleans, and invalid path
+values with `ValueError` before runtime bootstrap succeeds. Normalization should
+copy caller data and store immutable tuples.
+
 Semantics:
 
 - `allowed_executables`: empty means no allowlist restriction. Entries may be
   executable names such as `python` or canonical absolute paths such as
   `/usr/bin/python3`. Entries with path separators are expanded and resolved
   before comparison; bare-name entries match the normalized executable basename.
+  Bare-name allowlists still trust the parent `PATH`, so strict deployments
+  should use absolute executable paths and set `allow_path_lookup=false`.
 - `allowed_cwd_roots`: empty means cwd only needs to exist. When non-empty, the
-  resolved cwd must be under one of the resolved roots.
+  resolved cwd must be under one of the resolved roots. Root and cwd comparison
+  should use resolved canonical paths, with platform-appropriate case
+  normalization where needed.
 - `allowed_env_names`: `None` means the server's `env_allowlist` is the only env
   name filter. A tuple means the server may only request names also present in
-  the policy list.
+  the policy list. An empty tuple means no inherited environment names are
+  allowed.
 - `allow_path_lookup`: when false, command executables without a path separator
   are rejected. This is stricter than the current PATH allowlist requirement.
 - `reject_shell_executables`: when true, common shell wrappers such as `sh`,
-  `bash`, `zsh`, `fish`, `cmd`, `powershell`, and `pwsh` are rejected unless the
-  executable is explicitly listed in `allowed_executables`.
+  `bash`, `zsh`, `fish`, `cmd`, `cmd.exe`, `powershell`, `powershell.exe`,
+  `pwsh`, and `pwsh.exe` are rejected unless the executable is explicitly listed
+  in `allowed_executables`.
 - `default_cwd`: optional runtime cwd used when a server does not configure
   `cwd`. It is resolved and checked against `allowed_cwd_roots`. If
   `allowed_cwd_roots` is configured and neither the server nor policy provides a
@@ -140,7 +158,7 @@ Semantics:
 
 The default policy preserves most current behavior while blocking shell wrappers.
 Hosts that need stricter behavior can set `allow_path_lookup=false`,
-`allowed_executables`, and `allowed_cwd_roots`.
+absolute-path `allowed_executables`, and `allowed_cwd_roots`.
 
 ## Transport Enforcement
 
@@ -153,10 +171,24 @@ During construction it should:
 - apply executable policy before spawn
 - resolve the effective cwd using `server.cwd` or `policy.default_cwd`
 - ensure cwd exists and satisfies `allowed_cwd_roots` when configured
-- detect shell wrappers by basename so both `bash` and `/bin/bash` are covered
+- detect shell wrappers by normalized basename so `bash`, `/bin/bash`, `cmd.exe`,
+  and `C:\Windows\System32\cmd.exe` are covered
 - validate requested env names against `policy.allowed_env_names`
 - keep child env construction limited to the intersection of server allowlist,
   policy allowlist when configured, and current `os.environ`
+
+PATH lookup rules should remain explicit:
+
+- if the command executable is a bare name and `allow_path_lookup=false`, reject
+  it before checking `PATH`
+- if the command executable is a bare name and `allow_path_lookup=true`,
+  `PATH` must be present in `server.env_allowlist`
+- if `policy.allowed_env_names` is configured, `PATH` must also be present in
+  that policy allowlist before a bare-name executable may be launched
+- if the command executable contains a path separator, compare it to executable
+  allowlist entries using a resolved path. Relative executable paths should be
+  resolved against the effective cwd when one exists, otherwise against the
+  current process cwd only for validation.
 
 Policy denials should raise `StdioExternalTransportError` with safe reason
 codes:
@@ -180,12 +212,19 @@ process_policy: StdioProcessPolicy | Mapping[str, Any] | None = None
 ```
 
 `external_runtime_manager_from_storage()` should accept the same policy and
-wrap the transport factory when using the package-owned stdio factory:
+wrap the transport factory only when a non-`None` config policy is supplied and
+the package-owned stdio factory is being used:
 
 ```python
 def factory(server: ExternalServerDefinition) -> ExternalFederationTransport:
     return create_external_transport(server, process_policy=policy)
 ```
+
+When no config policy is supplied, keep the existing factory identity
+(`manager._transport_factory is create_external_transport`) so current tests and
+callers that introspect the default factory remain compatible. The default
+`create_external_transport(server)` path should still apply the default
+`StdioProcessPolicy`, including shell-wrapper rejection.
 
 If a caller supplies a custom `external_transport_factory`, the package should
 not force this stdio policy into it. Custom factories own their own enforcement
@@ -215,9 +254,11 @@ layout. A practical shape is:
 ## Data Flow
 
 1. A host loads gateway config from JSON or TOML.
-2. `GatewayExternalRuntimeBootstrapConfig` validates process-policy values.
+2. `GatewayExternalRuntimeBootstrapConfig` coerces and validates process-policy
+   values with `coerce_stdio_process_policy()`.
 3. `bootstrap_profile_gateway_from_config()` builds the external runtime
-   manager with a stdio transport factory that closes over the policy.
+   manager. If config provided a policy, the default stdio transport factory
+   closes over that policy; otherwise the existing default factory is reused.
 4. `GatewayExternalRuntimeManager.start_server()` loads an
    `ExternalServerDefinition`.
 5. The factory creates `StdioExternalTransport(server, process_policy=policy)`.
@@ -261,8 +302,13 @@ Coverage:
 - policy env allowlist rejects a server-requested env name outside the policy
 - allowed env values still inherit only from names present in `os.environ`
 - config loader validates process-policy mappings and rejects invalid types
-- bootstrap passes configured policy into the package stdio factory
+- bootstrap passes configured policy into the package stdio factory while
+  preserving the default factory identity when policy is omitted
 - denied policy errors do not include env values or full command arrays
+- runtime-manager start failures caused by policy denial expose safe status and
+  `_last_errors` metadata without full command arrays or env values
+- Windows-style shell basenames and path normalization are covered at the helper
+  level where practical on the current platform
 - `mcp_unified.federation.transports` documentation no longer describes the
   package contract as non-spawning now that real stdio transport exists
 

--- a/backlog/tasks/task-586 - Harden-MCP-external-stdio-process-policy.md
+++ b/backlog/tasks/task-586 - Harden-MCP-external-stdio-process-policy.md
@@ -24,7 +24,7 @@ Add explicit process-execution policy for standalone MCP external stdio transpor
 ## Implementation Plan
 
 <!-- SECTION:PLAN:BEGIN -->
-Design phase: add runtime-configured StdioProcessPolicy for executable allowlists, cwd roots, PATH lookup controls, shell rejection, and env-name restrictions. Next step after spec review is an implementation plan and TDD pass in the isolated worktree.
+Design phase updated after review: the spec now requires a sibling process_policy module, explicit PATH trust semantics, JSON/TOML coercion validation, Windows/POSIX path normalization guidance, policy-aware env/PATH interaction, default factory identity preservation when no custom policy is configured, and runtime-manager redaction/status coverage for policy-denied starts.
 <!-- SECTION:PLAN:END -->
 
 ## Implementation Notes

--- a/backlog/tasks/task-586 - Harden-MCP-external-stdio-process-policy.md
+++ b/backlog/tasks/task-586 - Harden-MCP-external-stdio-process-policy.md
@@ -9,6 +9,7 @@ labels:
 priority: High
 documentation:
 - Docs/superpowers/specs/2026-06-01-mcp-stdio-process-policy-design.md
+- Docs/superpowers/plans/2026-06-01-mcp-stdio-process-policy-implementation-plan.md
 ---
 
 ## Description
@@ -24,7 +25,7 @@ Add explicit process-execution policy for standalone MCP external stdio transpor
 ## Implementation Plan
 
 <!-- SECTION:PLAN:BEGIN -->
-Design phase updated after review: the spec now requires a sibling process_policy module, explicit PATH trust semantics, JSON/TOML coercion validation, Windows/POSIX path normalization guidance, policy-aware env/PATH interaction, default factory identity preservation when no custom policy is configured, and runtime-manager redaction/status coverage for policy-denied starts.
+Implementation plan saved at Docs/superpowers/plans/2026-06-01-mcp-stdio-process-policy-implementation-plan.md. Stages: add process_policy helper tests/module, wire stdio transport enforcement, add gateway config/CLI wiring, add runtime-manager redaction coverage, then run targeted pytest and Bandit.
 <!-- SECTION:PLAN:END -->
 
 ## Implementation Notes

--- a/backlog/tasks/task-586 - Harden-MCP-external-stdio-process-policy.md
+++ b/backlog/tasks/task-586 - Harden-MCP-external-stdio-process-policy.md
@@ -10,6 +10,17 @@ priority: High
 documentation:
 - Docs/superpowers/specs/2026-06-01-mcp-stdio-process-policy-design.md
 - Docs/superpowers/plans/2026-06-01-mcp-stdio-process-policy-implementation-plan.md
+modified_files:
+- mcp_unified/federation/process_policy.py
+- mcp_unified/federation/stdio_transport.py
+- mcp_unified/federation/__init__.py
+- mcp_unified/federation/transports.py
+- mcp_unified/gateway/config.py
+- mcp_unified/gateway/cli.py
+- tldw_Server_API/app/core/MCP_unified/tests/test_stdio_external_transport.py
+- tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py
+- tldw_Server_API/app/core/MCP_unified/tests/test_gateway_cli_package.py
+- tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py
 ---
 
 ## Description
@@ -37,7 +48,7 @@ Implementation plan saved at Docs/superpowers/plans/2026-06-01-mcp-stdio-process
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-
+Added and verified MCP external stdio process-policy hardening. The package now has explicit, tested controls for command execution, cwd boundaries, PATH lookup, env inheritance, and safe error/status reporting before real upstream stdio processes are launched. Verification recorded: targeted pytest for stdio transport, gateway FastAPI package, gateway CLI package, and runtime package boundary passed (245 passed); Bandit on mcp_unified/federation and mcp_unified/gateway completed with no findings at /tmp/bandit_mcp_stdio_process_policy.json; git diff --check passed.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-586 - Harden-MCP-external-stdio-process-policy.md
+++ b/backlog/tasks/task-586 - Harden-MCP-external-stdio-process-policy.md
@@ -1,0 +1,50 @@
+---
+id: TASK-586
+title: Harden MCP external stdio process policy
+status: In Progress
+labels:
+- mcp
+- security
+- external-runtime
+priority: High
+documentation:
+- Docs/superpowers/specs/2026-06-01-mcp-stdio-process-policy-design.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Add explicit process-execution policy for standalone MCP external stdio transports: executable allowlisting, bounded cwd validation, environment allowlist checks, deterministic denial/status payloads, and focused tests before real installer execution work.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Design phase: add runtime-configured StdioProcessPolicy for executable allowlists, cwd roots, PATH lookup controls, shell rejection, and env-name restrictions. Next step after spec review is an implementation plan and TDD pass in the isolated worktree.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-588 - Harden-MCP-external-stdio-process-policy.md
+++ b/backlog/tasks/task-588 - Harden-MCP-external-stdio-process-policy.md
@@ -1,7 +1,7 @@
 ---
-id: TASK-586
+id: TASK-588
 title: Harden MCP external stdio process policy
-status: In Progress
+status: Done
 labels:
 - mcp
 - security
@@ -42,21 +42,26 @@ Implementation plan saved at Docs/superpowers/plans/2026-06-01-mcp-stdio-process
 ## Implementation Notes
 
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
-
+PR review pass after rebasing onto latest `origin/dev`: reproduced the active
+Gemini/Qodo findings with failing tests, then fixed the basename allowlist
+bypass, POSIX case-sensitive path comparisons, explicit package-factory
+process-policy wrapping, and private helper docstrings. The rebase introduced a
+Backlog ID collision with the `dev` branch's Personas documentation task, so
+this branch task moved from `TASK-586` to `TASK-588`.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Added and verified MCP external stdio process-policy hardening. The package now has explicit, tested controls for command execution, cwd boundaries, PATH lookup, env inheritance, and safe error/status reporting before real upstream stdio processes are launched. Verification recorded: targeted pytest for stdio transport, gateway FastAPI package, gateway CLI package, and runtime package boundary passed (245 passed); Bandit on mcp_unified/federation and mcp_unified/gateway completed with no findings at /tmp/bandit_mcp_stdio_process_policy.json; git diff --check passed.
+Added and verified MCP external stdio process-policy hardening. The package now has explicit, tested controls for command execution, cwd boundaries, PATH lookup, env inheritance, and safe error/status reporting before real upstream stdio processes are launched. PR review fixes also deny basename allowlist bypasses, preserve POSIX case-sensitive path semantics, and apply configured policy when the package stdio factory is explicitly injected. Verification recorded: targeted pytest for stdio transport, gateway FastAPI package, gateway CLI package, and runtime package boundary passed (249 passed); Bandit on mcp_unified/federation and mcp_unified/gateway completed with no findings at /tmp/bandit_mcp_stdio_process_policy.json; git diff --check passed.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->

--- a/backlog/tasks/task-588 - Harden-MCP-external-stdio-process-policy.md
+++ b/backlog/tasks/task-588 - Harden-MCP-external-stdio-process-policy.md
@@ -31,6 +31,12 @@ Add explicit process-execution policy for standalone MCP external stdio transpor
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
+- [x] #1 `StdioProcessPolicy` validates executable allowlists, cwd roots, PATH lookup, shell-wrapper rejection, and environment inheritance before stdio process spawn.
+- [x] #2 Bare executable allowlist entries authorize only bare commands, while relative or absolute command paths require explicit path allowlist entries.
+- [x] #3 POSIX path comparisons remain case-sensitive; Windows path comparisons continue to use platform path normalization.
+- [x] #4 Gateway config applies configured process policy when the package `create_external_transport` factory is used implicitly or injected explicitly, while custom factories remain caller-owned.
+- [x] #5 CLI `validate-config` reports a redacted process-policy summary with stable keys and no raw deployment paths.
+- [x] #6 Targeted MCP pytest coverage, Bandit on touched MCP code, and whitespace validation pass.
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -53,7 +59,7 @@ this branch task moved from `TASK-586` to `TASK-588`.
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Added and verified MCP external stdio process-policy hardening. The package now has explicit, tested controls for command execution, cwd boundaries, PATH lookup, env inheritance, and safe error/status reporting before real upstream stdio processes are launched. PR review fixes also deny basename allowlist bypasses, preserve POSIX case-sensitive path semantics, and apply configured policy when the package stdio factory is explicitly injected. Verification recorded: targeted pytest for stdio transport, gateway FastAPI package, gateway CLI package, and runtime package boundary passed (249 passed); Bandit on mcp_unified/federation and mcp_unified/gateway completed with no findings at /tmp/bandit_mcp_stdio_process_policy.json; git diff --check passed.
+Added and verified MCP external stdio process-policy hardening. The package now has explicit, tested controls for command execution, cwd boundaries, PATH lookup, env inheritance, and safe error/status reporting before real upstream stdio processes are launched. PR review fixes also deny basename allowlist bypasses, preserve POSIX case-sensitive path semantics, apply configured policy when the package stdio factory is explicitly injected, keep CLI process-policy summary keys stable, and avoid hardcoded shell paths in tests. Verification recorded: targeted pytest for stdio transport, gateway FastAPI package, gateway CLI package, and runtime package boundary passed (250 passed); Bandit on mcp_unified/federation and mcp_unified/gateway completed with no findings at /tmp/bandit_mcp_stdio_process_policy.json; git diff --check passed.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/mcp_unified/federation/__init__.py
+++ b/mcp_unified/federation/__init__.py
@@ -1,4 +1,4 @@
-"""Standalone non-spawning external federation shell."""
+"""Standalone external federation contracts and transports."""
 
 from . import catalog_loader, config_schema
 from .catalog_loader import get_catalog_entry, list_catalog_entries, load_mcp_catalog
@@ -30,6 +30,7 @@ from .models import (
     MCPCatalogEntry,
     VirtualExternalTool,
 )
+from .process_policy import StdioProcessPolicy, coerce_stdio_process_policy
 from .stdio_transport import (
     StdioExternalTransport,
     StdioExternalTransportError,
@@ -64,9 +65,11 @@ __all__ = [
     "NullExternalServerInstaller",
     "StdioExternalTransport",
     "StdioExternalTransportError",
+    "StdioProcessPolicy",
     "VirtualExternalTool",
     "catalog_loader",
     "config_schema",
+    "coerce_stdio_process_policy",
     "create_external_transport",
     "get_catalog_entry",
     "list_catalog_entries",

--- a/mcp_unified/federation/process_policy.py
+++ b/mcp_unified/federation/process_policy.py
@@ -160,7 +160,7 @@ def validate_stdio_process_policy(
     )
     if (
         policy.reject_shell_executables
-        and _normcase(executable_name) in _SHELL_EXECUTABLES
+        and executable_name.lower() in _SHELL_EXECUTABLES
         and not allowed_executable
     ):
         raise StdioProcessPolicyViolation(
@@ -244,6 +244,8 @@ def _require_allowed_env_name(
     normalized_env: tuple[str, ...],
     allowed_env_names: tuple[str, ...] | None,
 ) -> None:
+    """Require an inherited env name in both server and policy allowlists."""
+
     if env_name not in normalized_env:
         raise StdioProcessPolicyViolation(
             "External stdio command requires PATH inheritance",
@@ -264,6 +266,13 @@ def _executable_allowed(
     policy: StdioProcessPolicy,
     cwd: str | None,
 ) -> bool:
+    """Return whether the executable satisfies the configured allowlist.
+
+    Bare allowlist entries only match bare command names. A command that names a
+    relative or absolute path must match a path allowlist entry after resolution,
+    which prevents basename-only entries from authorizing arbitrary binaries.
+    """
+
     if not policy.allowed_executables:
         return False
 
@@ -276,15 +285,23 @@ def _executable_allowed(
     )
     for allowed in policy.allowed_executables:
         if _has_path_separator(allowed) or Path(allowed).is_absolute():
-            if executable_path is not None and executable_path == _resolve_path_key(allowed):
+            if (
+                executable_path is not None
+                and executable_path == _resolve_path_key(allowed)
+            ):
                 return True
             continue
-        if executable_name == _normcase(_executable_basename(allowed)):
+        if (
+            not executable_has_path
+            and executable_name == _normcase(_executable_basename(allowed))
+        ):
             return True
     return False
 
 
 def _resolve_executable_path(executable: str, *, cwd: str | None) -> str:
+    """Resolve an executable path relative to cwd or the current process cwd."""
+
     path = Path(executable).expanduser()
     if not path.is_absolute():
         base = Path(cwd).expanduser() if cwd is not None else Path.cwd()
@@ -293,10 +310,14 @@ def _resolve_executable_path(executable: str, *, cwd: str | None) -> str:
 
 
 def _resolve_path_key(path: str | Path) -> str:
+    """Return the normalized comparison key for a process filesystem path."""
+
     return _normcase(str(Path(path).expanduser().resolve(strict=False)))
 
 
 def _path_is_relative_to(child: Path, root: str | Path) -> bool:
+    """Return whether child resolves inside root using platform path semantics."""
+
     child_key = _resolve_path_key(child)
     root_key = _resolve_path_key(root)
     try:
@@ -306,26 +327,38 @@ def _path_is_relative_to(child: Path, root: str | Path) -> bool:
 
 
 def _normalize_env_names(values: Sequence[str]) -> tuple[str, ...]:
+    """Normalize env allowlist names while dropping blank values."""
+
     return tuple(str(value).strip() for value in values if str(value).strip())
 
 
 def _is_bare_executable(executable: str) -> bool:
+    """Return true when an executable command relies on PATH lookup."""
+
     return not _has_path_separator(executable)
 
 
 def _has_path_separator(value: str) -> bool:
+    """Return true when value contains POSIX or Windows path separators."""
+
     return "/" in value or "\\" in value
 
 
 def _executable_basename(executable: str) -> str:
+    """Return the final path component for POSIX or Windows-style commands."""
+
     return executable.replace("\\", "/").rsplit("/", maxsplit=1)[-1].strip()
 
 
 def _normcase(value: str) -> str:
-    return os.path.normcase(value).lower()
+    """Normalize path case only on platforms where paths are case-insensitive."""
+
+    return os.path.normcase(value)
 
 
 def _coerce_text_tuple(value: Any, *, field_name: str) -> tuple[str, ...]:
+    """Coerce a config sequence into a tuple of non-empty text values."""
+
     if isinstance(value, str) or not isinstance(value, Sequence):
         raise ValueError(f"{field_name} must be a list of non-empty strings")
     items: list[str] = []
@@ -340,6 +373,8 @@ def _coerce_text_tuple(value: Any, *, field_name: str) -> tuple[str, ...]:
 
 
 def _coerce_path_tuple(value: Any, *, field_name: str) -> tuple[str | Path, ...]:
+    """Coerce a config sequence into a tuple of non-empty path values."""
+
     if isinstance(value, (str, Path)) or not isinstance(value, Sequence):
         raise ValueError(f"{field_name} must be a list of non-empty paths")
     items: list[str | Path] = []
@@ -353,6 +388,8 @@ def _coerce_path_tuple(value: Any, *, field_name: str) -> tuple[str | Path, ...]
 
 
 def _coerce_optional_path(value: Any, *, field_name: str) -> str | Path | None:
+    """Coerce an optional config value into a non-empty path or None."""
+
     if value is None:
         return None
     if not isinstance(value, (str, Path)):
@@ -363,6 +400,8 @@ def _coerce_optional_path(value: Any, *, field_name: str) -> str | Path | None:
 
 
 def _coerce_bool(value: Any, *, field_name: str) -> bool:
+    """Coerce a config value that must already be a boolean."""
+
     if not isinstance(value, bool):
         raise ValueError(f"{field_name} must be a boolean")
     return value

--- a/mcp_unified/federation/process_policy.py
+++ b/mcp_unified/federation/process_policy.py
@@ -1,0 +1,377 @@
+"""Process execution policy helpers for upstream stdio MCP transports."""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+_SHELL_EXECUTABLES = frozenset(
+    {
+        "sh",
+        "bash",
+        "zsh",
+        "fish",
+        "cmd",
+        "cmd.exe",
+        "powershell",
+        "powershell.exe",
+        "pwsh",
+        "pwsh.exe",
+    }
+)
+
+
+@dataclass(frozen=True, slots=True)
+class StdioProcessPolicy:
+    """Deployment-level process policy for upstream stdio MCP servers."""
+
+    allowed_executables: tuple[str, ...] = ()
+    allowed_cwd_roots: tuple[str | Path, ...] = ()
+    allowed_env_names: tuple[str, ...] | None = None
+    allow_path_lookup: bool = True
+    reject_shell_executables: bool = True
+    default_cwd: str | Path | None = None
+
+    def __post_init__(self) -> None:
+        """Normalize direct constructor inputs into immutable safe values."""
+
+        object.__setattr__(
+            self,
+            "allowed_executables",
+            _coerce_text_tuple(
+                self.allowed_executables,
+                field_name="allowed_executables",
+            ),
+        )
+        object.__setattr__(
+            self,
+            "allowed_cwd_roots",
+            _coerce_path_tuple(
+                self.allowed_cwd_roots,
+                field_name="allowed_cwd_roots",
+            ),
+        )
+        object.__setattr__(
+            self,
+            "allowed_env_names",
+            (
+                None
+                if self.allowed_env_names is None
+                else _coerce_text_tuple(
+                    self.allowed_env_names,
+                    field_name="allowed_env_names",
+                )
+            ),
+        )
+        object.__setattr__(
+            self,
+            "allow_path_lookup",
+            _coerce_bool(self.allow_path_lookup, field_name="allow_path_lookup"),
+        )
+        object.__setattr__(
+            self,
+            "reject_shell_executables",
+            _coerce_bool(
+                self.reject_shell_executables,
+                field_name="reject_shell_executables",
+            ),
+        )
+        object.__setattr__(
+            self,
+            "default_cwd",
+            _coerce_optional_path(self.default_cwd, field_name="default_cwd"),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class StdioProcessDecision:
+    """Normalized process-policy decision consumed by the stdio transport."""
+
+    cwd: str | None
+    allowed_env_names: tuple[str, ...] | None
+
+
+class StdioProcessPolicyViolation(ValueError):
+    """Raised when process policy denies a stdio server before spawn."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        reason_code: str,
+        details: dict[str, Any] | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.reason_code = reason_code
+        self.details = dict(details or {})
+
+
+def coerce_stdio_process_policy(
+    value: StdioProcessPolicy | Mapping[str, Any] | None,
+) -> StdioProcessPolicy:
+    """Return a normalized stdio process policy from config or caller input."""
+
+    if value is None:
+        return StdioProcessPolicy()
+    if isinstance(value, StdioProcessPolicy):
+        return value
+    if not isinstance(value, Mapping):
+        raise ValueError("process_policy must be a mapping, StdioProcessPolicy, or None")
+    supported = {
+        "allowed_executables",
+        "allowed_cwd_roots",
+        "allowed_env_names",
+        "allow_path_lookup",
+        "reject_shell_executables",
+        "default_cwd",
+    }
+    unknown = sorted(str(key) for key in set(value) - supported)
+    if unknown:
+        raise ValueError(f"process_policy has unsupported fields: {', '.join(unknown)}")
+    return StdioProcessPolicy(**dict(value))
+
+
+def validate_stdio_process_policy(
+    *,
+    server_id: str,
+    command: tuple[str, ...],
+    cwd: str | None,
+    env_allowlist: Sequence[str],
+    policy: StdioProcessPolicy,
+) -> StdioProcessDecision:
+    """Validate one stdio launch request against deployment process policy."""
+
+    if not command:
+        raise StdioProcessPolicyViolation(
+            "External stdio process policy requires a command",
+            reason_code="missing_command",
+            details={"server_id": server_id, "field": "command"},
+        )
+
+    executable = command[0]
+    executable_name = _executable_basename(executable)
+    allowed_executable = _executable_allowed(
+        executable,
+        policy=policy,
+        cwd=cwd,
+    )
+    if (
+        policy.reject_shell_executables
+        and _normcase(executable_name) in _SHELL_EXECUTABLES
+        and not allowed_executable
+    ):
+        raise StdioProcessPolicyViolation(
+            "External stdio process policy denied shell executable",
+            reason_code="process_policy_shell_denied",
+            details={
+                "server_id": server_id,
+                "field": "command",
+                "executable_name": executable_name,
+            },
+        )
+
+    if policy.allowed_executables and not allowed_executable:
+        raise StdioProcessPolicyViolation(
+            "External stdio process policy denied executable",
+            reason_code="process_policy_executable_denied",
+            details={
+                "server_id": server_id,
+                "field": "command",
+                "executable_name": executable_name,
+            },
+        )
+
+    bare_executable = _is_bare_executable(executable)
+    normalized_env = _normalize_env_names(env_allowlist)
+    allowed_env_names = policy.allowed_env_names
+    if bare_executable and not policy.allow_path_lookup:
+        raise StdioProcessPolicyViolation(
+            "External stdio process policy denied PATH lookup",
+            reason_code="process_policy_path_lookup_denied",
+            details={
+                "server_id": server_id,
+                "field": "command",
+                "executable_name": executable_name,
+            },
+        )
+    if bare_executable:
+        _require_allowed_env_name(
+            "PATH",
+            server_id=server_id,
+            normalized_env=normalized_env,
+            allowed_env_names=allowed_env_names,
+        )
+
+    if allowed_env_names is not None:
+        allowed_set = set(allowed_env_names)
+        for env_name in normalized_env:
+            if env_name not in allowed_set:
+                raise StdioProcessPolicyViolation(
+                    "External stdio process policy denied environment inheritance",
+                    reason_code="process_policy_env_denied",
+                    details={
+                        "server_id": server_id,
+                        "field": "env_allowlist",
+                        "env_name": env_name,
+                    },
+                )
+
+    if policy.allowed_cwd_roots:
+        if cwd is None:
+            raise StdioProcessPolicyViolation(
+                "External stdio process policy requires a bounded cwd",
+                reason_code="process_policy_cwd_denied",
+                details={"server_id": server_id, "field": "cwd"},
+            )
+        cwd_path = Path(cwd).resolve(strict=False)
+        if not any(_path_is_relative_to(cwd_path, root) for root in policy.allowed_cwd_roots):
+            raise StdioProcessPolicyViolation(
+                "External stdio process policy denied cwd",
+                reason_code="process_policy_cwd_denied",
+                details={"server_id": server_id, "field": "cwd"},
+            )
+
+    return StdioProcessDecision(cwd=cwd, allowed_env_names=allowed_env_names)
+
+
+def _require_allowed_env_name(
+    env_name: str,
+    *,
+    server_id: str,
+    normalized_env: tuple[str, ...],
+    allowed_env_names: tuple[str, ...] | None,
+) -> None:
+    if env_name not in normalized_env:
+        raise StdioProcessPolicyViolation(
+            "External stdio command requires PATH inheritance",
+            reason_code="invalid_command",
+            details={"server_id": server_id, "field": "env_allowlist", "env_name": env_name},
+        )
+    if allowed_env_names is not None and env_name not in allowed_env_names:
+        raise StdioProcessPolicyViolation(
+            "External stdio process policy denied PATH inheritance",
+            reason_code="process_policy_env_denied",
+            details={"server_id": server_id, "field": "env_allowlist", "env_name": env_name},
+        )
+
+
+def _executable_allowed(
+    executable: str,
+    *,
+    policy: StdioProcessPolicy,
+    cwd: str | None,
+) -> bool:
+    if not policy.allowed_executables:
+        return False
+
+    executable_has_path = _has_path_separator(executable)
+    executable_name = _normcase(_executable_basename(executable))
+    executable_path = (
+        _resolve_executable_path(executable, cwd=cwd)
+        if executable_has_path
+        else None
+    )
+    for allowed in policy.allowed_executables:
+        if _has_path_separator(allowed) or Path(allowed).is_absolute():
+            if executable_path is not None and executable_path == _resolve_path_key(allowed):
+                return True
+            continue
+        if executable_name == _normcase(_executable_basename(allowed)):
+            return True
+    return False
+
+
+def _resolve_executable_path(executable: str, *, cwd: str | None) -> str:
+    path = Path(executable).expanduser()
+    if not path.is_absolute():
+        base = Path(cwd).expanduser() if cwd is not None else Path.cwd()
+        path = base / path
+    return _resolve_path_key(path)
+
+
+def _resolve_path_key(path: str | Path) -> str:
+    return _normcase(str(Path(path).expanduser().resolve(strict=False)))
+
+
+def _path_is_relative_to(child: Path, root: str | Path) -> bool:
+    child_key = _resolve_path_key(child)
+    root_key = _resolve_path_key(root)
+    try:
+        return os.path.commonpath([child_key, root_key]) == root_key
+    except ValueError:
+        return False
+
+
+def _normalize_env_names(values: Sequence[str]) -> tuple[str, ...]:
+    return tuple(str(value).strip() for value in values if str(value).strip())
+
+
+def _is_bare_executable(executable: str) -> bool:
+    return not _has_path_separator(executable)
+
+
+def _has_path_separator(value: str) -> bool:
+    return "/" in value or "\\" in value
+
+
+def _executable_basename(executable: str) -> str:
+    return executable.replace("\\", "/").rsplit("/", maxsplit=1)[-1].strip()
+
+
+def _normcase(value: str) -> str:
+    return os.path.normcase(value).lower()
+
+
+def _coerce_text_tuple(value: Any, *, field_name: str) -> tuple[str, ...]:
+    if isinstance(value, str) or not isinstance(value, Sequence):
+        raise ValueError(f"{field_name} must be a list of non-empty strings")
+    items: list[str] = []
+    for item in value:
+        if not isinstance(item, str):
+            raise ValueError(f"{field_name} entries must be strings")
+        text = item.strip()
+        if not text:
+            raise ValueError(f"{field_name} entries cannot be empty")
+        items.append(text)
+    return tuple(items)
+
+
+def _coerce_path_tuple(value: Any, *, field_name: str) -> tuple[str | Path, ...]:
+    if isinstance(value, (str, Path)) or not isinstance(value, Sequence):
+        raise ValueError(f"{field_name} must be a list of non-empty paths")
+    items: list[str | Path] = []
+    for item in value:
+        if not isinstance(item, (str, Path)):
+            raise ValueError(f"{field_name} entries must be paths")
+        if not str(item).strip():
+            raise ValueError(f"{field_name} entries cannot be empty")
+        items.append(item)
+    return tuple(items)
+
+
+def _coerce_optional_path(value: Any, *, field_name: str) -> str | Path | None:
+    if value is None:
+        return None
+    if not isinstance(value, (str, Path)):
+        raise ValueError(f"{field_name} must be a path or None")
+    if not str(value).strip():
+        raise ValueError(f"{field_name} cannot be empty")
+    return value
+
+
+def _coerce_bool(value: Any, *, field_name: str) -> bool:
+    if not isinstance(value, bool):
+        raise ValueError(f"{field_name} must be a boolean")
+    return value
+
+
+__all__ = [
+    "StdioProcessDecision",
+    "StdioProcessPolicy",
+    "StdioProcessPolicyViolation",
+    "coerce_stdio_process_policy",
+    "validate_stdio_process_policy",
+]

--- a/mcp_unified/federation/stdio_transport.py
+++ b/mcp_unified/federation/stdio_transport.py
@@ -7,6 +7,7 @@ import contextlib
 import json
 import math
 import os
+from collections.abc import Mapping
 from copy import deepcopy
 from pathlib import Path
 from typing import Any
@@ -15,6 +16,12 @@ from mcp_unified.federation.models import (
     BrokeredExternalCredential,
     ExternalToolCallResult,
     ExternalToolDefinition,
+)
+from mcp_unified.federation.process_policy import (
+    StdioProcessPolicy,
+    StdioProcessPolicyViolation,
+    coerce_stdio_process_policy,
+    validate_stdio_process_policy,
 )
 from mcp_unified.storage.models import ExternalServerDefinition
 
@@ -58,11 +65,36 @@ class StdioExternalTransport:
         request_timeout_s: float = _DEFAULT_REQUEST_TIMEOUT_S,
         close_timeout_s: float = _DEFAULT_CLOSE_TIMEOUT_S,
         health_timeout_s: float = _DEFAULT_HEALTH_TIMEOUT_S,
+        process_policy: StdioProcessPolicy | Mapping[str, Any] | None = None,
     ) -> None:
         self._server = server.model_copy(deep=True)
         self.server_id = self._server.id
         self._command = self._validate_command(self._server)
-        self._cwd = self._resolve_cwd(self._server.cwd)
+        self._process_policy = coerce_stdio_process_policy(process_policy)
+        self._cwd = self._resolve_cwd(
+            self._server.cwd
+            if self._server.cwd is not None
+            else (
+                str(self._process_policy.default_cwd)
+                if self._process_policy.default_cwd is not None
+                else None
+            )
+        )
+        try:
+            process_decision = validate_stdio_process_policy(
+                server_id=self.server_id,
+                command=self._command,
+                cwd=self._cwd,
+                env_allowlist=self._server.env_allowlist,
+                policy=self._process_policy,
+            )
+        except StdioProcessPolicyViolation as exc:
+            raise self._error(
+                "External stdio process policy denied launch",
+                reason_code=exc.reason_code,
+                details=exc.details,
+            ) from exc
+        self._allowed_env_names = process_decision.allowed_env_names
         self._connect_timeout_s = self._positive_timeout(connect_timeout_s, "connect_timeout_s")
         self._request_timeout_s = self._positive_timeout(request_timeout_s, "request_timeout_s")
         self._close_timeout_s = self._positive_timeout(close_timeout_s, "close_timeout_s")
@@ -472,9 +504,18 @@ class StdioExternalTransport:
 
     def _build_child_env(self) -> dict[str, str]:
         child_env: dict[str, str] = {}
+        allowed_env_names = (
+            None
+            if self._allowed_env_names is None
+            else set(self._allowed_env_names)
+        )
         for name in self._server.env_allowlist:
             env_name = str(name).strip()
-            if env_name and env_name in os.environ:
+            if (
+                env_name
+                and env_name in os.environ
+                and (allowed_env_names is None or env_name in allowed_env_names)
+            ):
                 child_env[env_name] = os.environ[env_name]
         return child_env
 
@@ -571,10 +612,14 @@ class StdioExternalTransport:
         return payload
 
 
-def create_external_transport(server: ExternalServerDefinition) -> StdioExternalTransport:
+def create_external_transport(
+    server: ExternalServerDefinition,
+    *,
+    process_policy: StdioProcessPolicy | Mapping[str, Any] | None = None,
+) -> StdioExternalTransport:
     """Create a package-owned external transport for a supported server definition."""
     if server.transport == "stdio":
-        return StdioExternalTransport(server)
+        return StdioExternalTransport(server, process_policy=process_policy)
     raise StdioExternalTransportError(
         "External server transport is not supported by the package factory",
         reason_code="unsupported_transport",

--- a/mcp_unified/federation/transports.py
+++ b/mcp_unified/federation/transports.py
@@ -1,4 +1,4 @@
-"""Non-spawning transport contracts for standalone external federation."""
+"""Transport contracts for standalone external federation."""
 
 from __future__ import annotations
 
@@ -13,7 +13,7 @@ from .models import (
 
 
 class ExternalFederationTransport(Protocol):
-    """Minimal external transport lifecycle used by the standalone shell."""
+    """Minimal external transport lifecycle used by the standalone gateway."""
 
     server_id: str
 
@@ -23,7 +23,7 @@ class ExternalFederationTransport(Protocol):
         ...
 
     async def connect(self) -> None:
-        """Start the logical transport lifecycle without launching processes."""
+        """Start the transport lifecycle."""
         ...
 
     async def close(self) -> None:

--- a/mcp_unified/gateway/cli.py
+++ b/mcp_unified/gateway/cli.py
@@ -902,6 +902,7 @@ def _validated_config_payload(
         "default_profile_id": config.default_profile_id,
         "external_runtime": {
             "enabled": config.external_runtime.enabled,
+            "process_policy": _process_policy_summary(config.external_runtime),
             "reconcile_on_startup": config.external_runtime.reconcile_on_startup,
             "stop_on_shutdown": config.external_runtime.stop_on_shutdown,
             "transport_factory": config.external_runtime.transport_factory,
@@ -913,6 +914,26 @@ def _validated_config_payload(
             "kind": config.store.kind,
             "sqlite_path": str(sqlite_path) if sqlite_path is not None else None,
         },
+    }
+
+
+def _process_policy_summary(
+    external_runtime: Any,
+) -> dict[str, Any]:
+    """Return a compact process-policy summary without path or command values."""
+
+    policy = external_runtime.process_policy
+    allowed_env_names = policy.allowed_env_names
+    return {
+        "allow_path_lookup": policy.allow_path_lookup,
+        "allowed_cwd_roots": len(policy.allowed_cwd_roots),
+        "allowed_env_names": (
+            None if allowed_env_names is None else len(allowed_env_names)
+        ),
+        "allowed_executables": len(policy.allowed_executables),
+        "configured": external_runtime.process_policy_configured,
+        "default_cwd": policy.default_cwd is not None,
+        "reject_shell_executables": policy.reject_shell_executables,
     }
 
 

--- a/mcp_unified/gateway/cli.py
+++ b/mcp_unified/gateway/cli.py
@@ -922,18 +922,37 @@ def _process_policy_summary(
 ) -> dict[str, Any]:
     """Return a compact process-policy summary without path or command values."""
 
-    policy = external_runtime.process_policy
-    allowed_env_names = policy.allowed_env_names
+    policy = getattr(external_runtime, "process_policy", None)
+    if policy is None:
+        return {
+            "allow_path_lookup": False,
+            "allowed_cwd_roots": 0,
+            "allowed_env_names": None,
+            "allowed_executables": 0,
+            "configured": getattr(
+                external_runtime,
+                "process_policy_configured",
+                False,
+            ),
+            "default_cwd": False,
+            "reject_shell_executables": False,
+        }
+
+    allowed_env_names = getattr(policy, "allowed_env_names", None)
     return {
-        "allow_path_lookup": policy.allow_path_lookup,
-        "allowed_cwd_roots": len(policy.allowed_cwd_roots),
+        "allow_path_lookup": getattr(policy, "allow_path_lookup", False),
+        "allowed_cwd_roots": len(getattr(policy, "allowed_cwd_roots", ())),
         "allowed_env_names": (
             None if allowed_env_names is None else len(allowed_env_names)
         ),
-        "allowed_executables": len(policy.allowed_executables),
-        "configured": external_runtime.process_policy_configured,
-        "default_cwd": policy.default_cwd is not None,
-        "reject_shell_executables": policy.reject_shell_executables,
+        "allowed_executables": len(getattr(policy, "allowed_executables", ())),
+        "configured": getattr(external_runtime, "process_policy_configured", False),
+        "default_cwd": getattr(policy, "default_cwd", None) is not None,
+        "reject_shell_executables": getattr(
+            policy,
+            "reject_shell_executables",
+            False,
+        ),
     }
 
 

--- a/mcp_unified/gateway/config.py
+++ b/mcp_unified/gateway/config.py
@@ -9,6 +9,10 @@ from json import JSONDecodeError
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal, cast
 
+from mcp_unified.federation.process_policy import (
+    StdioProcessPolicy,
+    coerce_stdio_process_policy,
+)
 from mcp_unified.interfaces.storage import (
     AuditStore,
     CredentialGrantStore,
@@ -78,6 +82,8 @@ class GatewayExternalRuntimeBootstrapConfig:
     transport_factory: GatewayExternalRuntimeFactoryKind = "stdio"
     reconcile_on_startup: bool = False
     stop_on_shutdown: bool = False
+    process_policy: StdioProcessPolicy | Mapping[str, Any] | None = None
+    process_policy_configured: bool = field(default=False, init=False)
 
     def __post_init__(self) -> None:
         """Validate and normalize the configured runtime factory selector."""
@@ -103,6 +109,17 @@ class GatewayExternalRuntimeBootstrapConfig:
             self,
             "transport_factory",
             cast(GatewayExternalRuntimeFactoryKind, normalized_factory),
+        )
+        process_policy_configured = self.process_policy is not None
+        object.__setattr__(
+            self,
+            "process_policy",
+            coerce_stdio_process_policy(self.process_policy),
+        )
+        object.__setattr__(
+            self,
+            "process_policy_configured",
+            process_policy_configured,
         )
 
     def lifecycle_config(self) -> GatewayExternalRuntimeLifecycleConfig:
@@ -237,6 +254,8 @@ async def bootstrap_profile_gateway_from_config(
         resolved_external_runtime_manager = external_runtime_manager_from_storage(
             external_storage,
             transport_factory=external_transport_factory,
+            process_policy=resolved_config.external_runtime.process_policy,
+            process_policy_configured=resolved_config.external_runtime.process_policy_configured,
             credential_broker=credential_broker,
             installer=external_installer,
         )
@@ -388,6 +407,8 @@ def external_runtime_manager_from_storage(
         ExternalFederationTransport,
     ]
     | None = None,
+    process_policy: StdioProcessPolicy | None = None,
+    process_policy_configured: bool = False,
     credential_broker: ExternalCredentialBroker | Callable[..., Any] | None = None,
     installer: ExternalServerInstaller | None = None,
 ) -> GatewayExternalRuntimeManager:
@@ -397,9 +418,25 @@ def external_runtime_manager_from_storage(
 
     from .external_runtime import GatewayExternalRuntimeManager
 
+    resolved_transport_factory = transport_factory
+    if resolved_transport_factory is None:
+        if process_policy_configured:
+
+            def _policy_transport_factory(
+                server: ExternalServerDefinition,
+            ) -> ExternalFederationTransport:
+                return create_external_transport(
+                    server,
+                    process_policy=process_policy,
+                )
+
+            resolved_transport_factory = _policy_transport_factory
+        else:
+            resolved_transport_factory = create_external_transport
+
     return GatewayExternalRuntimeManager(
         external_registry_store=bundle.external_registry_store,
-        transport_factory=transport_factory or create_external_transport,
+        transport_factory=resolved_transport_factory,
         audit_store=bundle.audit_store,
         credential_broker=credential_broker,
         installer=installer,

--- a/mcp_unified/gateway/config.py
+++ b/mcp_unified/gateway/config.py
@@ -418,21 +418,22 @@ def external_runtime_manager_from_storage(
 
     from .external_runtime import GatewayExternalRuntimeManager
 
-    resolved_transport_factory = transport_factory
-    if resolved_transport_factory is None:
-        if process_policy_configured:
+    resolved_transport_factory = (
+        create_external_transport if transport_factory is None else transport_factory
+    )
+    if (
+        process_policy_configured
+        and resolved_transport_factory is create_external_transport
+    ):
+        def _policy_transport_factory(
+            server: ExternalServerDefinition,
+        ) -> ExternalFederationTransport:
+            return create_external_transport(
+                server,
+                process_policy=process_policy,
+            )
 
-            def _policy_transport_factory(
-                server: ExternalServerDefinition,
-            ) -> ExternalFederationTransport:
-                return create_external_transport(
-                    server,
-                    process_policy=process_policy,
-                )
-
-            resolved_transport_factory = _policy_transport_factory
-        else:
-            resolved_transport_factory = create_external_transport
+        resolved_transport_factory = _policy_transport_factory
 
     return GatewayExternalRuntimeManager(
         external_registry_store=bundle.external_registry_store,

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_cli_package.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_cli_package.py
@@ -58,6 +58,15 @@ def test_gateway_cli_validate_config_reports_success_json(
         "default_profile_id": None,
         "external_runtime": {
             "enabled": False,
+            "process_policy": {
+                "allow_path_lookup": True,
+                "allowed_cwd_roots": 0,
+                "allowed_env_names": None,
+                "allowed_executables": 0,
+                "configured": False,
+                "default_cwd": False,
+                "reject_shell_executables": True,
+            },
             "reconcile_on_startup": False,
             "stop_on_shutdown": False,
             "transport_factory": "stdio",
@@ -67,6 +76,51 @@ def test_gateway_cli_validate_config_reports_success_json(
         "profiles": 0,
         "store": {"kind": "memory", "sqlite_path": None},
     }
+
+
+def test_gateway_cli_validate_config_reports_process_policy_summary(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Validate-config reports policy counts without echoing path details."""
+
+    secret_path = tmp_path / "workspace"
+    config_path = tmp_path / "gateway.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "store": {"kind": "memory"},
+                "external_runtime": {
+                    "enabled": True,
+                    "process_policy": {
+                        "allowed_executables": ["/usr/bin/python3", "node"],
+                        "allowed_cwd_roots": [str(secret_path)],
+                        "allowed_env_names": ["PATH", "TOKEN"],
+                        "allow_path_lookup": False,
+                        "default_cwd": str(secret_path),
+                    },
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    exit_code = gateway_cli.main(["validate-config", str(config_path)])
+
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+    assert exit_code == 0
+    assert captured.err == ""
+    assert payload["external_runtime"]["process_policy"] == {
+        "allow_path_lookup": False,
+        "allowed_cwd_roots": 1,
+        "allowed_env_names": 2,
+        "allowed_executables": 2,
+        "configured": True,
+        "default_cwd": True,
+        "reject_shell_executables": True,
+    }
+    assert str(secret_path) not in captured.out
 
 
 def test_gateway_cli_validate_config_reports_error_json(

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_cli_package.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_cli_package.py
@@ -123,6 +123,22 @@ def test_gateway_cli_validate_config_reports_process_policy_summary(
     assert str(secret_path) not in captured.out
 
 
+def test_gateway_cli_process_policy_summary_handles_missing_policy() -> None:
+    """Process-policy summaries keep stable keys for older runtime config shapes."""
+
+    runtime = type("LegacyRuntimeConfig", (), {})()
+
+    assert gateway_cli._process_policy_summary(runtime) == {
+        "allow_path_lookup": False,
+        "allowed_cwd_roots": 0,
+        "allowed_env_names": None,
+        "allowed_executables": 0,
+        "configured": False,
+        "default_cwd": False,
+        "reject_shell_executables": False,
+    }
+
+
 def test_gateway_cli_validate_config_reports_error_json(
     tmp_path: Path,
     capsys: pytest.CaptureFixture[str],

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py
@@ -2721,6 +2721,56 @@ def test_gateway_config_bootstrap_wraps_default_factory_when_policy_configured(
         asyncio.run(bootstrap.profile_store.aclose())
 
 
+def test_gateway_config_bootstrap_wraps_explicit_package_factory_when_policy_configured(
+    tmp_path: Path,
+) -> None:
+    """Explicit package stdio factories receive configured process policy too."""
+
+    from mcp_unified.federation import create_external_transport
+    from mcp_unified.federation.stdio_transport import StdioExternalTransportError
+    from mcp_unified.gateway.config import (
+        GatewayExternalRuntimeBootstrapConfig,
+        GatewayProfileBootstrapConfig,
+        GatewayProfileStoreConfig,
+        bootstrap_profile_gateway_from_config,
+    )
+    from mcp_unified.storage.models import ExternalServerDefinition
+
+    sqlite_path = tmp_path / "gateway.db"
+    bootstrap = asyncio.run(
+        bootstrap_profile_gateway_from_config(
+            _MultiToolGatewayRuntime(),
+            GatewayProfileBootstrapConfig(
+                store=GatewayProfileStoreConfig(kind="sqlite", sqlite_path=sqlite_path),
+                external_runtime=GatewayExternalRuntimeBootstrapConfig(
+                    enabled=True,
+                    process_policy={"allow_path_lookup": False},
+                ),
+            ),
+            external_transport_factory=create_external_transport,
+        )
+    )
+
+    try:
+        manager = bootstrap.external_runtime_manager
+        assert manager is not None
+        assert manager._transport_factory is not create_external_transport
+        with pytest.raises(StdioExternalTransportError) as exc_info:
+            manager._transport_factory(
+                ExternalServerDefinition(
+                    id="research",
+                    name="Research",
+                    transport="stdio",
+                    command=["python"],
+                    env_allowlist=["PATH"],
+                )
+            )
+
+        assert exc_info.value.reason_code == "process_policy_path_lookup_denied"
+    finally:
+        asyncio.run(bootstrap.profile_store.aclose())
+
+
 def test_gateway_config_bootstrap_custom_factory_ignores_config_process_policy(
     tmp_path: Path,
 ) -> None:

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py
@@ -2658,6 +2658,170 @@ def test_gateway_config_bootstrap_external_runtime_uses_injected_transport_facto
         asyncio.run(bootstrap.profile_store.aclose())
 
 
+def test_gateway_config_bootstrap_accepts_process_policy_mapping() -> None:
+    """External runtime config validates and stores stdio process policy mappings."""
+
+    from mcp_unified.gateway.config import GatewayExternalRuntimeBootstrapConfig
+
+    config = GatewayExternalRuntimeBootstrapConfig(
+        enabled=True,
+        process_policy={"allow_path_lookup": False, "allowed_env_names": ["PATH"]},
+    )
+
+    assert config.process_policy is not None
+    assert config.process_policy.allow_path_lookup is False
+    assert config.process_policy.allowed_env_names == ("PATH",)
+    assert config.process_policy_configured is True
+
+
+def test_gateway_config_bootstrap_rejects_invalid_process_policy_mapping() -> None:
+    """External runtime config rejects invalid process-policy mappings early."""
+
+    from mcp_unified.gateway.config import GatewayExternalRuntimeBootstrapConfig
+
+    with pytest.raises(ValueError, match="allowed_executables"):
+        GatewayExternalRuntimeBootstrapConfig(
+            enabled=True,
+            process_policy={"allowed_executables": ["python", ""]},
+        )
+
+
+def test_gateway_config_bootstrap_wraps_default_factory_when_policy_configured(
+    tmp_path: Path,
+) -> None:
+    """Configured process policy should wrap only the package stdio factory."""
+
+    from mcp_unified.federation import create_external_transport
+    from mcp_unified.gateway.config import (
+        GatewayExternalRuntimeBootstrapConfig,
+        GatewayProfileBootstrapConfig,
+        GatewayProfileStoreConfig,
+        bootstrap_profile_gateway_from_config,
+    )
+
+    sqlite_path = tmp_path / "gateway.db"
+    bootstrap = asyncio.run(
+        bootstrap_profile_gateway_from_config(
+            _MultiToolGatewayRuntime(),
+            GatewayProfileBootstrapConfig(
+                store=GatewayProfileStoreConfig(kind="sqlite", sqlite_path=sqlite_path),
+                external_runtime=GatewayExternalRuntimeBootstrapConfig(
+                    enabled=True,
+                    process_policy={"allow_path_lookup": False},
+                ),
+            ),
+        )
+    )
+
+    try:
+        manager = bootstrap.external_runtime_manager
+        assert manager is not None
+        assert manager._transport_factory is not create_external_transport
+    finally:
+        asyncio.run(bootstrap.profile_store.aclose())
+
+
+def test_gateway_config_bootstrap_custom_factory_ignores_config_process_policy(
+    tmp_path: Path,
+) -> None:
+    """Caller-injected factories own their own process-policy boundary."""
+
+    from mcp_unified.gateway.config import (
+        GatewayExternalRuntimeBootstrapConfig,
+        GatewayProfileBootstrapConfig,
+        GatewayProfileStoreConfig,
+        bootstrap_profile_gateway_from_config,
+    )
+    from mcp_unified.storage.models import ExternalServerDefinition
+
+    def factory(server: ExternalServerDefinition) -> Any:
+        return server.id
+
+    sqlite_path = tmp_path / "gateway.db"
+    bootstrap = asyncio.run(
+        bootstrap_profile_gateway_from_config(
+            _MultiToolGatewayRuntime(),
+            GatewayProfileBootstrapConfig(
+                store=GatewayProfileStoreConfig(kind="sqlite", sqlite_path=sqlite_path),
+                external_runtime=GatewayExternalRuntimeBootstrapConfig(
+                    enabled=True,
+                    process_policy={"allow_path_lookup": False},
+                ),
+            ),
+            external_transport_factory=factory,
+        )
+    )
+
+    try:
+        manager = bootstrap.external_runtime_manager
+        assert manager is not None
+        assert manager._transport_factory is factory
+    finally:
+        asyncio.run(bootstrap.profile_store.aclose())
+
+
+def test_gateway_external_runtime_process_policy_start_failure_is_redacted(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Runtime status should expose policy-denied starts without command/env secrets."""
+
+    from mcp_unified.gateway.config import (
+        GatewayExternalRuntimeBootstrapConfig,
+        GatewayProfileBootstrapConfig,
+        GatewayProfileStoreConfig,
+        bootstrap_profile_gateway_from_config,
+    )
+    from mcp_unified.gateway.external_runtime import GatewayExternalRuntimeError
+    from mcp_unified.storage.models import ExternalServerDefinition
+
+    secret_arg = "do-not-leak-command-argument"
+    secret_env_value = "do-not-leak-env-value"
+    monkeypatch.setenv("MCP_POLICY_SECRET", secret_env_value)
+    sqlite_path = tmp_path / "gateway.db"
+    bootstrap = asyncio.run(
+        bootstrap_profile_gateway_from_config(
+            _MultiToolGatewayRuntime(),
+            GatewayProfileBootstrapConfig(
+                store=GatewayProfileStoreConfig(kind="sqlite", sqlite_path=sqlite_path),
+                external_runtime=GatewayExternalRuntimeBootstrapConfig(
+                    enabled=True,
+                    process_policy={"allow_path_lookup": False},
+                ),
+            ),
+        )
+    )
+
+    try:
+        manager = bootstrap.external_runtime_manager
+        assert manager is not None
+        asyncio.run(
+            bootstrap.profile_store.create_server(
+                ExternalServerDefinition(
+                    id="research",
+                    name="Research",
+                    transport="stdio",
+                    command=["python", secret_arg],
+                    env_allowlist=["PATH", "MCP_POLICY_SECRET"],
+                )
+            )
+        )
+
+        with pytest.raises(GatewayExternalRuntimeError) as exc_info:
+            asyncio.run(manager.start_server("research"))
+
+        status = asyncio.run(manager.list_runtime_servers())
+        status_json = json.dumps(status, sort_keys=True)
+        assert exc_info.value.reason_code == "external_server_start_failed"
+        assert "process_policy_path_lookup_denied" in status_json
+        assert secret_arg not in str(exc_info.value)
+        assert secret_arg not in status_json
+        assert secret_env_value not in str(exc_info.value)
+        assert secret_env_value not in status_json
+    finally:
+        asyncio.run(bootstrap.profile_store.aclose())
+
+
 def test_gateway_config_bootstrap_rejects_unsupported_external_runtime_factory() -> None:
     """Reject unsupported transport factory selectors instead of silently degrading."""
 

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py
@@ -148,6 +148,18 @@ def test_federation_installer_contracts_are_public_exports() -> None:
     assert package_federation.NullExternalServerInstaller is package_installers.NullExternalServerInstaller
 
 
+def test_federation_process_policy_contracts_are_public_exports() -> None:
+    """Stdio process-policy contracts should be public federation exports."""
+    package_federation = importlib.import_module("mcp_unified.federation")
+    package_policy = importlib.import_module("mcp_unified.federation.process_policy")
+
+    assert package_federation.StdioProcessPolicy is package_policy.StdioProcessPolicy
+    assert (
+        package_federation.coerce_stdio_process_policy
+        is package_policy.coerce_stdio_process_policy
+    )
+
+
 def test_virtual_external_tool_copy_returns_caller_owned_data() -> None:
     """Virtual tool copies must not expose mutable source state."""
     package_models = importlib.import_module("mcp_unified.federation.models")

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_stdio_external_transport.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_stdio_external_transport.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import os
+import shutil
 import subprocess
 import sys
 from pathlib import Path
@@ -307,8 +308,11 @@ def test_stdio_process_policy_rejects_invalid_mapping_values() -> None:
 
 def test_stdio_process_policy_defaults_block_shell_wrappers() -> None:
     """Default process policy blocks direct shell-wrapper launches."""
+    shell = shutil.which("bash") or shutil.which("sh")
+    if shell is None:
+        pytest.skip("No POSIX shell wrapper available on this host")
     secret_arg = "do-not-leak-shell-argument"
-    server = _server(command=["/bin/bash", "-lc", secret_arg])
+    server = _server(command=[shell, "-lc", secret_arg])
 
     with pytest.raises(StdioExternalTransportError) as exc_info:
         StdioExternalTransport(server)
@@ -320,9 +324,12 @@ def test_stdio_process_policy_defaults_block_shell_wrappers() -> None:
 
 def test_stdio_process_policy_allows_explicit_shell_executable() -> None:
     """Hosts can deliberately allow a shell executable through allowlisting."""
-    policy = StdioProcessPolicy(allowed_executables=("/bin/bash",))
+    shell = shutil.which("bash") or shutil.which("sh")
+    if shell is None:
+        pytest.skip("No POSIX shell wrapper available on this host")
+    policy = StdioProcessPolicy(allowed_executables=(shell,))
     transport = StdioExternalTransport(
-        _server(command=["/bin/bash", "--version"]),
+        _server(command=[shell, "--version"]),
         process_policy=policy,
     )
 

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_stdio_external_transport.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_stdio_external_transport.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import os
 import subprocess
 import sys
 from pathlib import Path
@@ -13,7 +14,9 @@ import pytest
 from mcp_unified.federation.models import BrokeredExternalCredential
 from mcp_unified.federation.process_policy import (
     StdioProcessPolicy,
+    StdioProcessPolicyViolation,
     coerce_stdio_process_policy,
+    validate_stdio_process_policy,
 )
 from mcp_unified.federation.stdio_transport import (
     StdioExternalTransport,
@@ -324,6 +327,65 @@ def test_stdio_process_policy_allows_explicit_shell_executable() -> None:
     )
 
     assert transport.server_id == "docs"
+
+
+def test_stdio_process_policy_bare_allowlist_denies_path_with_same_basename(
+    tmp_path: Path,
+) -> None:
+    """Bare executable allowlist entries do not authorize arbitrary matching paths."""
+    suspicious_python = tmp_path / "untrusted" / "python"
+
+    with pytest.raises(StdioExternalTransportError) as exc_info:
+        StdioExternalTransport(
+            _server(command=[str(suspicious_python), "--version"]),
+            process_policy=StdioProcessPolicy(allowed_executables=("python",)),
+        )
+
+    assert exc_info.value.reason_code == "process_policy_executable_denied"
+
+
+@pytest.mark.skipif(
+    os.name == "nt",
+    reason="Windows process paths are intentionally compared case-insensitively.",
+)
+def test_stdio_process_policy_posix_executable_paths_are_case_sensitive(
+    tmp_path: Path,
+) -> None:
+    """POSIX executable path allowlists keep distinct path casing separate."""
+    allowed_python = tmp_path / "Allowed" / "python"
+    denied_python = tmp_path / "allowed" / "python"
+
+    with pytest.raises(StdioExternalTransportError) as exc_info:
+        StdioExternalTransport(
+            _server(command=[str(denied_python), "--version"]),
+            process_policy=StdioProcessPolicy(
+                allowed_executables=(str(allowed_python),),
+            ),
+        )
+
+    assert exc_info.value.reason_code == "process_policy_executable_denied"
+
+
+@pytest.mark.skipif(
+    os.name == "nt",
+    reason="Windows process paths are intentionally compared case-insensitively.",
+)
+def test_stdio_process_policy_posix_cwd_roots_are_case_sensitive(
+    tmp_path: Path,
+) -> None:
+    """POSIX cwd-root checks keep distinct path casing separate."""
+    with pytest.raises(StdioProcessPolicyViolation) as exc_info:
+        validate_stdio_process_policy(
+            server_id="docs",
+            command=(sys.executable, "-c", "pass"),
+            cwd=str(tmp_path / "Allowed" / "workspace"),
+            env_allowlist=(),
+            policy=StdioProcessPolicy(
+                allowed_cwd_roots=(tmp_path / "allowed",),
+            ),
+        )
+
+    assert getattr(exc_info.value, "reason_code", None) == "process_policy_cwd_denied"
 
 
 def test_stdio_process_policy_path_lookup_can_be_disabled() -> None:

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_stdio_external_transport.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_stdio_external_transport.py
@@ -11,6 +11,10 @@ from time import monotonic
 
 import pytest
 from mcp_unified.federation.models import BrokeredExternalCredential
+from mcp_unified.federation.process_policy import (
+    StdioProcessPolicy,
+    coerce_stdio_process_policy,
+)
 from mcp_unified.federation.stdio_transport import (
     StdioExternalTransport,
     StdioExternalTransportError,
@@ -284,6 +288,141 @@ def test_stdio_transport_rejects_bare_command_without_path_allowlist() -> None:
 
     assert exc_info.value.reason_code == "invalid_command"
     assert "PATH" in str(exc_info.value)
+
+
+def test_stdio_process_policy_rejects_invalid_mapping_values() -> None:
+    """Policy config rejects ambiguous values before runtime bootstrap."""
+    with pytest.raises(ValueError, match="allowed_executables"):
+        coerce_stdio_process_policy({"allowed_executables": ["python", ""]})
+
+    with pytest.raises(ValueError, match="allow_path_lookup"):
+        coerce_stdio_process_policy({"allow_path_lookup": "false"})
+
+    with pytest.raises(ValueError, match="allowed_env_names"):
+        coerce_stdio_process_policy({"allowed_env_names": ["TOKEN", 7]})
+
+
+def test_stdio_process_policy_defaults_block_shell_wrappers() -> None:
+    """Default process policy blocks direct shell-wrapper launches."""
+    secret_arg = "do-not-leak-shell-argument"
+    server = _server(command=["/bin/bash", "-lc", secret_arg])
+
+    with pytest.raises(StdioExternalTransportError) as exc_info:
+        StdioExternalTransport(server)
+
+    assert exc_info.value.reason_code == "process_policy_shell_denied"
+    assert secret_arg not in str(exc_info.value)
+    assert secret_arg not in repr(exc_info.value.details)
+
+
+def test_stdio_process_policy_allows_explicit_shell_executable() -> None:
+    """Hosts can deliberately allow a shell executable through allowlisting."""
+    policy = StdioProcessPolicy(allowed_executables=("/bin/bash",))
+    transport = StdioExternalTransport(
+        _server(command=["/bin/bash", "--version"]),
+        process_policy=policy,
+    )
+
+    assert transport.server_id == "docs"
+
+
+def test_stdio_process_policy_path_lookup_can_be_disabled() -> None:
+    """Strict deployments can reject bare executables even when PATH is allowlisted."""
+    server = _server(command=["python"], env_allowlist=["PATH"])
+
+    with pytest.raises(StdioExternalTransportError) as exc_info:
+        StdioExternalTransport(
+            server,
+            process_policy=StdioProcessPolicy(allow_path_lookup=False),
+        )
+
+    assert exc_info.value.reason_code == "process_policy_path_lookup_denied"
+
+
+def test_stdio_process_policy_env_allowlist_must_allow_path_for_bare_command() -> None:
+    """Policy env allowlists also gate PATH inheritance for bare executable lookup."""
+    server = _server(command=["python"], env_allowlist=["PATH"])
+
+    with pytest.raises(StdioExternalTransportError) as exc_info:
+        StdioExternalTransport(
+            server,
+            process_policy=StdioProcessPolicy(allowed_env_names=("OTHER",)),
+        )
+
+    assert exc_info.value.reason_code == "process_policy_env_denied"
+    assert exc_info.value.details["env_name"] == "PATH"
+
+
+def test_stdio_process_policy_rejects_cwd_outside_allowed_roots(tmp_path: Path) -> None:
+    """Configured cwd values must stay inside deployment-approved roots."""
+    allowed_root = tmp_path / "allowed"
+    denied_root = tmp_path / "denied"
+    allowed_root.mkdir()
+    denied_root.mkdir()
+    server = _server(command=[sys.executable, "-c", "pass"], cwd=str(denied_root))
+
+    with pytest.raises(StdioExternalTransportError) as exc_info:
+        StdioExternalTransport(
+            server,
+            process_policy=StdioProcessPolicy(allowed_cwd_roots=(allowed_root,)),
+        )
+
+    assert exc_info.value.reason_code == "process_policy_cwd_denied"
+
+
+def test_stdio_process_policy_uses_default_cwd_inside_allowed_root(tmp_path: Path) -> None:
+    """Policy default cwd is used when a server does not configure one."""
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    transport = StdioExternalTransport(
+        _server(command=[sys.executable, "-c", "pass"]),
+        process_policy=StdioProcessPolicy(
+            allowed_cwd_roots=(workspace,),
+            default_cwd=workspace,
+        ),
+    )
+
+    assert transport._cwd == str(workspace.resolve())
+
+
+def test_stdio_process_policy_rejects_disallowed_environment_names() -> None:
+    """Policy env allowlists reject server-requested environment names outside policy."""
+    with pytest.raises(StdioExternalTransportError) as exc_info:
+        StdioExternalTransport(
+            _server(
+                command=[sys.executable, "-c", "pass"],
+                env_allowlist=["MCP_ALLOWED", "MCP_BLOCKED"],
+            ),
+            process_policy=StdioProcessPolicy(allowed_env_names=("MCP_ALLOWED",)),
+        )
+
+    assert exc_info.value.reason_code == "process_policy_env_denied"
+    assert exc_info.value.details["env_name"] == "MCP_BLOCKED"
+
+
+@pytest.mark.asyncio
+async def test_stdio_process_policy_allows_policy_approved_environment_names(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Approved policy env names still inherit only values present in os.environ."""
+    script_path = _write_stub_server(tmp_path)
+    monkeypatch.setenv("MCP_ALLOWED", "yes")
+    transport = StdioExternalTransport(
+        _server(
+            command=[sys.executable, "-u", script_path],
+            env_allowlist=["MCP_ALLOWED"],
+        ),
+        process_policy=StdioProcessPolicy(allowed_env_names=("MCP_ALLOWED",)),
+    )
+
+    try:
+        result = await transport.call_tool("docs.env", {})
+
+        assert result.is_error is False
+        assert result.content == {"allowed": "yes", "blocked": None}
+    finally:
+        await transport.close()
 
 
 @pytest.mark.parametrize("timeout", [0, -1, "bad", float("nan"), float("inf")])


### PR DESCRIPTION
## Summary
- Add package-owned stdio process-policy helpers for executable allowlists, shell denial, PATH lookup policy, cwd roots/default cwd, and env inheritance checks.
- Wire policy through stdio transport and gateway config while preserving default factory identity and custom factory behavior.
- Add redacted CLI config summaries and regression coverage for policy denials/status redaction.

## Test Plan
- [x] /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_stdio_external_transport.py tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py tldw_Server_API/app/core/MCP_unified/tests/test_gateway_cli_package.py tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py -q
- [x] /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r mcp_unified/federation mcp_unified/gateway -f json -o /tmp/bandit_mcp_stdio_process_policy.json
- [x] git diff --check

## Change summary
Human-authored summary required before merge: this PR hardens package-owned external stdio MCP process launches by separating deployment process policy from editable server registry rows. The implementation keeps policy in runtime config, validates it before spawning, and preserves existing default factory/custom factory behavior so hosts can opt into stricter controls without widening storage schema or changing installer scope.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a runtime-enforced stdio process policy to `mcp_unified` for external MCP servers, covering executable allowlists, cwd roots, PATH lookup, and env inheritance. Defaults block shells; gateway config can set a `process_policy`, factory wrapping happens only when configured (including explicit default factory), the CLI shows a redacted, stable-key summary, and runtime status surfaces safe denial reasons. Addresses TASK-588.

- New Features
  - Introduced `mcp_unified.federation.process_policy` with `StdioProcessPolicy`, `coerce_stdio_process_policy`, validation helpers, tightened shell detection and basename allowlist rules, and safe reason codes with POSIX/Windows path normalization.
  - `StdioExternalTransport`/`create_external_transport` accept `process_policy`, enforce it before spawn, and inherit env via the server/policy intersection.
  - Gateway config adds `process_policy` with a `process_policy_configured` flag; wraps the package stdio factory only when configured (including when `create_external_transport` is injected), custom factories remain unchanged. CLI `validate-config` prints a compact summary (stable keys with counts/booleans, no paths). Public exports added; transport docs updated.

- Migration
  - Shell wrappers (e.g., `bash`, `sh`, `cmd.exe`, `powershell`) are blocked by default. Allow explicitly in `allowed_executables` or call target binaries directly.
  - Bare executables require `PATH` in the server `env_allowlist`; if `allow_path_lookup=false`, use absolute paths.
  - If you set `allowed_env_names`, include `PATH` for bare commands and any required vars; others are denied.
  - If you set `allowed_cwd_roots`, ensure servers use a cwd within a root or provide `default_cwd` via policy.

<sup>Written for commit dbc11171d6fdd615e8fbdfcece99d24bf467a01a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2213?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

