### PR TITLE
Improve first-run onboarding confidence flow

### DIFF
--- a/Docs/superpowers/plans/2026-06-01-onboarding-confidence-flow-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-06-01-onboarding-confidence-flow-implementation-plan.md
@@ -1,0 +1,847 @@
+# Onboarding Confidence Flow Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make first-time solo onboarding reliable enough for a new user to configure a provider, validate it, complete a real first chat, and immediately add one useful source.
+
+**Architecture:** Build on the merged unified onboarding flow and the existing setup/readiness APIs. Backend remains authoritative for first-run state, provider persistence, readiness, first-chat verification, skip, and completion; frontend state remains limited to unsaved form values, transient validation cache, readiness disclosure state, recovery UI state, and dismissed tips.
+
+**Tech Stack:** FastAPI, Pydantic, pytest, Next.js, React, TypeScript, Vitest, Playwright, Backlog.md.
+
+---
+
+## Source Documents
+
+- Spec: `Docs/superpowers/specs/2026-06-01-onboarding-confidence-flow-design.md`
+- Backlog: `TASK-583`
+- Existing backend provider validation: `tldw_Server_API/app/core/Setup/provider_validation.py`
+- Existing backend schemas: `tldw_Server_API/app/api/v1/schemas/setup_schemas.py`
+- Existing frontend onboarding client: `apps/packages/ui/src/services/tldw/domains/setup-onboarding.ts`
+- Existing frontend readiness client: `apps/packages/ui/src/services/tldw/setup-readiness.ts`
+- Existing post-onboarding readiness hook: `apps/packages/ui/src/hooks/usePostOnboardingMediaReadiness.ts`
+- Existing first-source quick ingest opener: `apps/packages/ui/src/utils/quick-ingest-open.ts`
+
+## File Map
+
+Backend provider validation:
+
+- Modify `tldw_Server_API/app/api/v1/schemas/setup_schemas.py`
+  - Add optional non-secret validation metadata to `SetupProviderValidationResponse`: `validation_level` and `can_gate_first_chat`.
+- Modify `tldw_Server_API/app/core/Setup/provider_validation.py`
+  - Populate the new response fields for hosted accepted checks, local OpenAI-compatible checks, native Kobold checks, and failures.
+- Modify `tldw_Server_API/tests/Setup/test_setup_provider_validation.py`
+  - Lock accepted hosted validation, ready local validation, failed validation, discovered models, and secret-safety semantics.
+
+Frontend provider validation:
+
+- Modify `apps/packages/ui/src/types/setup-onboarding.ts`
+  - Mirror the additive validation response fields.
+- Modify `apps/packages/ui/src/components/Option/Onboarding/steps/ProviderSetupStep.tsx`
+  - Add manual `Validate` actions, validation cache, model discovery display, invalidation on edit, and the default-provider gate.
+- Modify `apps/packages/ui/src/components/Option/Onboarding/UnifiedSetupWizard.tsx`
+  - Pass `validateProvider` to `ProviderSetupStep` and refresh setup readiness after provider validation/save.
+- Modify `apps/packages/ui/src/components/Option/Onboarding/__tests__/ProviderSetupStep.test.tsx`
+  - Cover default-provider validation gate, non-default unverified save, edit invalidation, accepted vs ready copy, and model discovery fallback.
+- Modify `apps/packages/ui/src/components/Option/Onboarding/__tests__/UnifiedSetupWizard.test.tsx`
+  - Cover validation plumbing and wizard advance only after provider save plus validation.
+
+Readiness panel:
+
+- Create `apps/packages/ui/src/hooks/useSetupReadinessSummary.ts`
+  - Thin first-run wrapper around `getSetupReadinessStatus({ mode: "first-run" })`.
+- Create `apps/packages/ui/src/components/Option/Onboarding/SetupReadinessPanel.tsx`
+  - Compact lane summary for Chat, Embeddings/RAG, and Speech using existing readiness response shapes.
+- Create `apps/packages/ui/src/components/Option/Onboarding/__tests__/SetupReadinessPanel.test.tsx`
+  - Cover lane statuses, blockers, warnings, overlays, retry, and collapsed details.
+- Modify `apps/packages/ui/src/components/Option/Onboarding/UnifiedSetupWizard.tsx`
+  - Render the panel in the focused shell and refresh it after setup-changing actions.
+- Modify `apps/packages/ui/src/hooks/__tests__/useSetupReadinessSummary.test.tsx`
+  - Cover successful status load and request failure.
+
+First-chat recovery:
+
+- Modify `apps/packages/ui/src/components/Option/Onboarding/steps/FirstChatStep.tsx`
+  - Add inline recovery actions: retry, edit provider, switch provider, skip setup, and check endpoint.
+- Modify `apps/packages/ui/src/components/Option/Onboarding/UnifiedSetupWizard.tsx`
+  - Wire recovery callbacks to provider setup, skip, and local endpoint/provider validation paths.
+- Modify `apps/packages/ui/src/components/Option/Onboarding/__tests__/FirstChatStep.test.tsx`
+  - Cover categorized failure copy and all recovery buttons.
+- Modify `apps/packages/ui/src/components/Option/Onboarding/__tests__/UnifiedSetupWizard.test.tsx`
+  - Cover first-chat recovery navigation and skip propagation.
+
+First-source milestone:
+
+- Modify `apps/packages/ui/src/components/Option/Onboarding/FirstSourceMilestonePrompt.tsx`
+  - Upgrade from a single CTA to a three-choice picker: Web URL, File upload, Paste text.
+- Modify `apps/packages/ui/src/utils/quick-ingest-open.ts`
+  - Add typed first-source kind metadata while preserving the existing first-source session seed behavior.
+- Modify `apps/packages/ui/src/routes/option-index.tsx`
+  - Pass the selected source kind to quick ingest, watch quick ingest run summary, and only offer grounded chat after an ingest success has a queryable media id or backend media readiness is confirmed.
+- Modify `apps/packages/ui/src/components/Option/Onboarding/__tests__/FirstSourceMilestonePrompt.test.tsx`
+  - Cover default Web URL choice, file/paste choices, progress/error/success states, dismiss, retry, and ask-about-source visibility.
+- Modify `apps/packages/ui/src/routes/__tests__/option-index.unified-setup.test.tsx`
+  - Cover selected source kind propagation and readiness-gated grounded chat CTA.
+- Modify `apps/tldw-frontend/e2e/workflows/unified-first-run-onboarding.spec.ts`
+  - Extend the mocked unified first-run journey to validate provider before continue, show readiness, recover from one first-chat failure, and open first-source ingest after completion.
+
+## Commit Plan
+
+Ship one PR with four staged commits:
+
+1. `feat: validate onboarding providers before first chat`
+2. `feat: show setup readiness in onboarding wizard`
+3. `fix: add first-chat onboarding recovery actions`
+4. `feat: guide first source after onboarding`
+
+Backlog task updates, plan status updates, and verification notes should be committed with the related staged commit unless the user asks for different staging.
+
+## Review Adjustments Before Execution
+
+This plan deliberately avoids two implementation traps found during local review:
+
+- Provider validation should use a validate-first happy path. The gate is "validated and saved"; saving may clear the raw API key from the UI, so validation must survive that safe key clearing when a masked saved key is present.
+- First-source "Ask a question about this source" must not overclaim grounded readiness. If implementation cannot find an existing backend source/queryable readiness signal, keep the ask action hidden and show a safe source/view action instead of presenting grounded chat as ready.
+
+---
+
+## Task 1: Provider Validation Gate
+
+**Goal:** The default first-chat provider cannot continue until the user manually validates it and saves it. Non-default providers can still be saved unverified.
+
+**Files:**
+
+- Modify `tldw_Server_API/app/api/v1/schemas/setup_schemas.py`
+- Modify `tldw_Server_API/app/core/Setup/provider_validation.py`
+- Modify `tldw_Server_API/tests/Setup/test_setup_provider_validation.py`
+- Modify `apps/packages/ui/src/types/setup-onboarding.ts`
+- Modify `apps/packages/ui/src/components/Option/Onboarding/steps/ProviderSetupStep.tsx`
+- Modify `apps/packages/ui/src/components/Option/Onboarding/UnifiedSetupWizard.tsx`
+- Modify `apps/packages/ui/src/components/Option/Onboarding/__tests__/ProviderSetupStep.test.tsx`
+- Modify `apps/packages/ui/src/components/Option/Onboarding/__tests__/UnifiedSetupWizard.test.tsx`
+- Update `backlog/tasks/task-583 - Design-onboarding-confidence-flow-follow-up.md`
+
+### Backend Contract
+
+Add fields:
+
+```python
+class SetupProviderValidationResponse(BaseModel):
+    """Provider validation result safe to return to unauthenticated setup clients."""
+
+    provider_key: str
+    status: str
+    failure_category: str | None = None
+    message: str | None = None
+    models: list[str] = Field(default_factory=list)
+    validation_level: str | None = None
+    can_gate_first_chat: bool = False
+```
+
+Response semantics:
+
+- `ready`, `validation_level="live_non_generative"`, `can_gate_first_chat=True`: local OpenAI-compatible `/models` validation succeeded.
+- `ready`, `validation_level="live_endpoint_shape"`, `can_gate_first_chat=True`: existing native Kobold endpoint shape check succeeded. Do not expand this into new generative checks.
+- `accepted`, `validation_level="local_syntax"`, `can_gate_first_chat=True`: hosted key passed local syntax/presence checks, but first chat remains the live verification.
+- `failed`, `can_gate_first_chat=False`: auth, required field, endpoint, model, API shape, or unknown validation failure.
+
+### Frontend Contract
+
+Add fields:
+
+```ts
+export type SetupProviderValidationResponse = {
+  provider_key: string
+  status: string
+  failure_category?: string | null
+  message?: string | null
+  models: string[]
+  validation_level?: string | null
+  can_gate_first_chat?: boolean
+}
+```
+
+Add local validation helpers near `ProviderSetupStep`:
+
+```ts
+type ProviderValidationViewState = {
+  fingerprint: string
+  response: SetupProviderValidationResponse
+}
+
+const validationCanGate = (
+  response: SetupProviderValidationResponse | null | undefined
+) =>
+  Boolean(
+    response?.can_gate_first_chat ??
+      (response?.status === "ready" || response?.status === "accepted")
+  )
+```
+
+Provider fingerprint must never include raw secrets:
+
+```ts
+const providerValidationFingerprint = (
+  provider: SetupProviderCatalogEntry,
+  values: ProviderFormValues,
+  saved: SetupProviderSaveResponse | undefined,
+  model: string
+) =>
+  [
+    provider.provider_key,
+    provider.provider_type === "local_endpoint"
+      ? values.baseUrl.trim() || provider.default_base_url || ""
+      : "",
+    model.trim(),
+    values.apiKey.trim() || saved?.masked_api_key ? "secret-present" : "no-secret"
+  ].join("|")
+```
+
+When a user edits `apiKey`, `baseUrl`, or `model`, clear that provider's validation result immediately. Do not clear validation when the component clears the raw API key after a successful save and a masked key is present.
+
+### Steps
+
+- [ ] **Step 1: Add backend failing tests for response metadata**
+
+Add assertions to `test_hosted_provider_validation_accepts_plausible_openai_key_without_echo`, `test_openai_models_shape_maps_to_ready`, and one failed-validation test:
+
+```python
+assert response.validation_level == "local_syntax"
+assert response.can_gate_first_chat is True
+```
+
+For ready local OpenAI-compatible validation:
+
+```python
+assert response.validation_level == "live_non_generative"
+assert response.can_gate_first_chat is True
+```
+
+For failed validation:
+
+```python
+assert response.can_gate_first_chat is False
+```
+
+- [ ] **Step 2: Run backend RED**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Setup/test_setup_provider_validation.py -q
+```
+
+Expected: FAIL because `validation_level` and `can_gate_first_chat` do not exist yet.
+
+- [ ] **Step 3: Implement backend metadata**
+
+Update `SetupProviderValidationResponse` and populate fields in `provider_validation.py`. Prefer tiny response helpers:
+
+```python
+def _ready_response(
+    provider_key: str,
+    *,
+    validation_level: str,
+    models: list[str] | None = None,
+) -> SetupProviderValidationResponse:
+    return SetupProviderValidationResponse(
+        provider_key=provider_key,
+        status=VALIDATION_STATUS_READY,
+        models=models or [],
+        validation_level=validation_level,
+        can_gate_first_chat=True,
+    )
+```
+
+Use the same pattern for accepted and failed responses.
+
+- [ ] **Step 4: Run backend GREEN**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Setup/test_setup_provider_validation.py -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Add frontend failing tests for provider validation**
+
+In `ProviderSetupStep.test.tsx`, add tests that assert:
+
+- Continue is disabled until the default provider is both validated and saved.
+- The happy path validates first, saves second, and the validation result remains valid after the saved provider clears the raw API key while retaining a masked key.
+- `accepted` validation enables continue but shows copy like "First chat verifies this provider."
+- Failed validation keeps continue disabled and shows a categorized message.
+- Non-default selected provider can be saved without validation.
+- Discovered models are visible while manual model entry remains available.
+- Editing the default model invalidates the validation result.
+
+Representative test shape:
+
+```tsx
+const validateProvider = vi.fn().mockResolvedValue({
+  provider_key: "openai",
+  status: "accepted",
+  validation_level: "local_syntax",
+  can_gate_first_chat: true,
+  models: []
+})
+
+render(
+  <ProviderSetupStep
+    providers={[openAiProvider]}
+    onSaveProvider={saveProvider}
+    onValidateProvider={validateProvider}
+    onContinue={onContinue}
+  />
+)
+```
+
+- [ ] **Step 6: Run frontend RED**
+
+Run:
+
+```bash
+bunx vitest run apps/packages/ui/src/components/Option/Onboarding/__tests__/ProviderSetupStep.test.tsx apps/packages/ui/src/components/Option/Onboarding/__tests__/UnifiedSetupWizard.test.tsx
+```
+
+Expected: FAIL because the component has no validation prop or validation UI.
+
+- [ ] **Step 7: Implement ProviderSetupStep validation UI**
+
+Add prop:
+
+```ts
+onValidateProvider: (
+  payload: SetupProviderSaveRequest
+) => Promise<SetupProviderValidationResponse>
+```
+
+Add per-provider `Validate` button, visible states, model discovery, and `canContinue`:
+
+```ts
+const defaultValidation =
+  validationByProvider[defaultProvider]?.fingerprint === currentFingerprint
+    ? validationByProvider[defaultProvider]?.response
+    : null
+
+const canContinue = Boolean(
+  defaultProvider &&
+    selectedDefaultModel &&
+    savedProviders[defaultProvider] &&
+    validationCanGate(defaultValidation)
+)
+```
+
+Validation request uses the same sanitized save payload shape as persistence. Validation failures must never render raw keys or raw endpoint exception text.
+
+- [ ] **Step 8: Wire validation through UnifiedSetupWizard**
+
+Destructure `validateProvider` from `useSetupOnboarding()`.
+
+Pass to `ProviderSetupStep`:
+
+```tsx
+onValidateProvider={async (payload) => {
+  const response = await validateProvider(payload)
+  await refreshReadiness?.()
+  return response
+}}
+```
+
+If the readiness hook is added in Task 2, use a temporary no-op here and replace it in Task 2.
+
+- [ ] **Step 9: Run frontend GREEN**
+
+Run:
+
+```bash
+bunx vitest run apps/packages/ui/src/components/Option/Onboarding/__tests__/ProviderSetupStep.test.tsx apps/packages/ui/src/components/Option/Onboarding/__tests__/UnifiedSetupWizard.test.tsx
+```
+
+Expected: PASS.
+
+- [ ] **Step 10: Commit Task 1**
+
+Run:
+
+```bash
+git add tldw_Server_API/app/api/v1/schemas/setup_schemas.py tldw_Server_API/app/core/Setup/provider_validation.py tldw_Server_API/tests/Setup/test_setup_provider_validation.py apps/packages/ui/src/types/setup-onboarding.ts apps/packages/ui/src/components/Option/Onboarding/steps/ProviderSetupStep.tsx apps/packages/ui/src/components/Option/Onboarding/UnifiedSetupWizard.tsx apps/packages/ui/src/components/Option/Onboarding/__tests__/ProviderSetupStep.test.tsx apps/packages/ui/src/components/Option/Onboarding/__tests__/UnifiedSetupWizard.test.tsx "backlog/tasks/task-583 - Design-onboarding-confidence-flow-follow-up.md"
+git diff --cached --check
+git commit -m "feat: validate onboarding providers before first chat"
+```
+
+---
+
+## Task 2: Setup Readiness Panel
+
+**Goal:** Show a compact, always-visible readiness summary in the focused wizard shell without making optional readiness lanes mandatory.
+
+**Files:**
+
+- Create `apps/packages/ui/src/hooks/useSetupReadinessSummary.ts`
+- Create `apps/packages/ui/src/hooks/__tests__/useSetupReadinessSummary.test.tsx`
+- Create `apps/packages/ui/src/components/Option/Onboarding/SetupReadinessPanel.tsx`
+- Create `apps/packages/ui/src/components/Option/Onboarding/__tests__/SetupReadinessPanel.test.tsx`
+- Modify `apps/packages/ui/src/components/Option/Onboarding/UnifiedSetupWizard.tsx`
+- Update `backlog/tasks/task-583 - Design-onboarding-confidence-flow-follow-up.md`
+
+### Component Contract
+
+`SetupReadinessPanel` should accept already-loaded backend data and no-op gracefully when readiness is unavailable:
+
+```ts
+type SetupReadinessPanelProps = {
+  status: SetupReadinessStatusResponse | null
+  loading?: boolean
+  error?: string | null
+  onRetry?: () => void
+}
+```
+
+Status labels:
+
+- Chat lane: blocking when backend says `failed` or `blocked`; ready when `ready` or `ready_with_warnings`.
+- Embeddings/RAG lane: optional if not configured, skipped, or blocked by packages/downloads unless user opted in.
+- Speech lane: optional if not configured, skipped, or blocked by packages/downloads unless user opted in.
+
+Use backend overlays directly. Expected overlay labels:
+
+- `restart_required`
+- `admin_required`
+- `remote_setup_blocked`
+- `downloads_disabled`
+- `package_installs_disabled`
+- `network_unavailable`
+
+### Steps
+
+- [ ] **Step 1: Write hook tests**
+
+In `useSetupReadinessSummary.test.tsx`, mock `getSetupReadinessStatus` and assert:
+
+- Hook loads status on mount.
+- Hook exposes `refresh`.
+- Hook exposes sanitized error state on failure.
+
+- [ ] **Step 2: Write panel tests**
+
+In `SetupReadinessPanel.test.tsx`, render sample lanes:
+
+```ts
+const status = {
+  active_overlays: ["downloads_disabled"],
+  lanes: [
+    { lane_id: "chat", label: "Chat", status: "ready" },
+    {
+      lane_id: "embeddings_rag",
+      label: "Embeddings/RAG",
+      status: "ready_with_warnings",
+      warnings: ["Embedding provider not configured."]
+    },
+    {
+      lane_id: "speech",
+      label: "Speech",
+      status: "blocked",
+      blockers: ["Audio downloads disabled."]
+    }
+  ]
+}
+```
+
+Assert lane labels, warning/blocker disclosure, optional lane language, and retry button.
+
+- [ ] **Step 3: Run RED**
+
+Run:
+
+```bash
+bunx vitest run apps/packages/ui/src/hooks/__tests__/useSetupReadinessSummary.test.tsx apps/packages/ui/src/components/Option/Onboarding/__tests__/SetupReadinessPanel.test.tsx
+```
+
+Expected: FAIL because the hook and panel do not exist.
+
+- [ ] **Step 4: Implement useSetupReadinessSummary**
+
+Use the existing client only:
+
+```ts
+import { getSetupReadinessStatus } from "@/services/tldw/setup-readiness"
+```
+
+Do not duplicate readiness types.
+
+- [ ] **Step 5: Implement SetupReadinessPanel**
+
+Use compact layout, expandable lane details, and stable button dimensions. Keep it outside the main step card so it reads as shell state, not another wizard step.
+
+- [ ] **Step 6: Wire the panel into UnifiedSetupWizard**
+
+Render below the shell header and above the active step. Refresh after provider save, provider validation, ingest defaults save, audio defaults save, optional advanced save, first-chat success, setup completion, and skip failure retry.
+
+- [ ] **Step 7: Run GREEN**
+
+Run:
+
+```bash
+bunx vitest run apps/packages/ui/src/hooks/__tests__/useSetupReadinessSummary.test.tsx apps/packages/ui/src/components/Option/Onboarding/__tests__/SetupReadinessPanel.test.tsx apps/packages/ui/src/components/Option/Onboarding/__tests__/UnifiedSetupWizard.test.tsx
+```
+
+Expected: PASS.
+
+- [ ] **Step 8: Commit Task 2**
+
+Run:
+
+```bash
+git add apps/packages/ui/src/hooks/useSetupReadinessSummary.ts apps/packages/ui/src/hooks/__tests__/useSetupReadinessSummary.test.tsx apps/packages/ui/src/components/Option/Onboarding/SetupReadinessPanel.tsx apps/packages/ui/src/components/Option/Onboarding/__tests__/SetupReadinessPanel.test.tsx apps/packages/ui/src/components/Option/Onboarding/UnifiedSetupWizard.tsx "backlog/tasks/task-583 - Design-onboarding-confidence-flow-follow-up.md"
+git diff --cached --check
+git commit -m "feat: show setup readiness in onboarding wizard"
+```
+
+---
+
+## Task 3: First-Chat Recovery Actions
+
+**Goal:** A failed first-chat attempt stays visible inline and gives the user explicit recovery buttons instead of a generic failure state.
+
+**Files:**
+
+- Modify `apps/packages/ui/src/components/Option/Onboarding/steps/FirstChatStep.tsx`
+- Modify `apps/packages/ui/src/components/Option/Onboarding/UnifiedSetupWizard.tsx`
+- Modify `apps/packages/ui/src/components/Option/Onboarding/__tests__/FirstChatStep.test.tsx`
+- Modify `apps/packages/ui/src/components/Option/Onboarding/__tests__/UnifiedSetupWizard.test.tsx`
+- Update `backlog/tasks/task-583 - Design-onboarding-confidence-flow-follow-up.md`
+
+### Recovery Mapping
+
+Normalize backend categories before display:
+
+```ts
+type FirstChatRecoveryCategory =
+  | "auth_failed"
+  | "quota_or_rate_limit"
+  | "endpoint_unreachable"
+  | "unsupported_api_shape"
+  | "model_unavailable"
+  | "config_write_failed"
+  | "provider_unvalidated"
+  | "unknown"
+```
+
+Map aliases:
+
+- `auth`, `authentication_failed`, `provider_api_key_invalid` -> `auth_failed`
+- `rate_limit`, `quota`, `quota_exceeded` -> `quota_or_rate_limit`
+- `local_provider_unreachable`, `endpoint_unreachable` -> `endpoint_unreachable`
+- `unsupported_api_shape` -> `unsupported_api_shape`
+- `model_not_found`, `model_unavailable` -> `model_unavailable`
+- `provider_unvalidated` -> `provider_unvalidated`
+- otherwise `unknown`
+
+### Steps
+
+- [ ] **Step 1: Write FirstChatStep recovery tests**
+
+Add tests for:
+
+- Failed auth response shows credential copy and buttons: Retry, Edit provider, Switch provider, Skip setup.
+- Endpoint failure shows Check endpoint.
+- Retry calls `verifyFirstChat` again and keeps the failed attempt visible until a new result exists.
+- Completion failure after successful chat still uses the separate completion error copy.
+
+- [ ] **Step 2: Run RED**
+
+Run:
+
+```bash
+bunx vitest run apps/packages/ui/src/components/Option/Onboarding/__tests__/FirstChatStep.test.tsx
+```
+
+Expected: FAIL because recovery buttons and category mapping do not exist.
+
+- [ ] **Step 3: Implement FirstChatStep recovery props**
+
+Add props:
+
+```ts
+onEditProvider: () => void
+onSwitchProvider: () => void
+onSkip: () => void
+onCheckEndpoint?: () => void
+```
+
+Keep `onBack` as a plain back action if existing tests or users rely on it, but route visible recovery buttons through the explicit callbacks.
+
+- [ ] **Step 4: Implement categorized recovery UI**
+
+Use stable, accessible buttons. Do not auto-navigate. Render endpoint-specific guidance only for endpoint/API-shape failures.
+
+- [ ] **Step 5: Wire callbacks in UnifiedSetupWizard**
+
+- `Edit provider`: set step to `provider_setup`.
+- `Switch provider`: set step to `provider_setup`.
+- `Check endpoint`: set step to `provider_setup`; keep any current provider selection.
+- `Skip setup`: call existing `handleSkip`.
+
+- [ ] **Step 6: Run GREEN**
+
+Run:
+
+```bash
+bunx vitest run apps/packages/ui/src/components/Option/Onboarding/__tests__/FirstChatStep.test.tsx apps/packages/ui/src/components/Option/Onboarding/__tests__/UnifiedSetupWizard.test.tsx
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit Task 3**
+
+Run:
+
+```bash
+git add apps/packages/ui/src/components/Option/Onboarding/steps/FirstChatStep.tsx apps/packages/ui/src/components/Option/Onboarding/UnifiedSetupWizard.tsx apps/packages/ui/src/components/Option/Onboarding/__tests__/FirstChatStep.test.tsx apps/packages/ui/src/components/Option/Onboarding/__tests__/UnifiedSetupWizard.test.tsx "backlog/tasks/task-583 - Design-onboarding-confidence-flow-follow-up.md"
+git diff --cached --check
+git commit -m "fix: add first-chat onboarding recovery actions"
+```
+
+---
+
+## Task 4: First-Source Guided Milestone
+
+**Goal:** After first chat completes, immediately offer one guided first-source flow with Web URL selected by default, while only offering grounded chat after ingest readiness is verified.
+
+**Files:**
+
+- Modify `apps/packages/ui/src/components/Option/Onboarding/FirstSourceMilestonePrompt.tsx`
+- Modify `apps/packages/ui/src/components/Option/Onboarding/__tests__/FirstSourceMilestonePrompt.test.tsx`
+- Modify `apps/packages/ui/src/utils/quick-ingest-open.ts`
+- Modify `apps/packages/ui/src/routes/option-index.tsx`
+- Modify `apps/packages/ui/src/routes/__tests__/option-index.unified-setup.test.tsx`
+- Modify `apps/tldw-frontend/e2e/workflows/unified-first-run-onboarding.spec.ts`
+- Update `backlog/tasks/task-583 - Design-onboarding-confidence-flow-follow-up.md`
+
+### Prompt Contract
+
+Add source kind:
+
+```ts
+export type FirstSourceKind = "web_url" | "file_upload" | "paste_text"
+```
+
+Prompt props:
+
+```ts
+type FirstSourceMilestonePromptProps = {
+  readinessStatus: "idle" | "processing" | "ready" | "error"
+  lastSourceLabel?: string | null
+  errorMessage?: string | null
+  onAddSource: (kind: FirstSourceKind) => void
+  onAskAboutSource?: () => void
+  onRetry?: () => void
+  onDismiss: () => void
+}
+```
+
+Default selected kind is `web_url`.
+
+### Quick Ingest Contract
+
+Extend first-source quick ingest detail without breaking existing seed behavior:
+
+```ts
+type FirstSourceQuickIngestKind = "web_url" | "file_upload" | "paste_text"
+```
+
+Add optional metadata to the existing `source: "first_source_milestone"` detail:
+
+```ts
+firstSourceKind?: FirstSourceQuickIngestKind
+```
+
+The current `createQuickIngestSessionSeedFromOpenDetail` should still return a first-source seed when `source === "first_source_milestone"` or `firstSource === true`.
+
+### Readiness Gate
+
+Use existing quick ingest and media readiness state:
+
+- Show picker before ingest starts.
+- Show processing copy while the quick ingest session is running.
+- Show retry/edit actions on quick ingest failure.
+- Show `Ask a question about this source` only when:
+  - `useQuickIngestStore().lastRunSummary.status === "success"`, and
+  - `lastRunSummary.firstMediaId` is present, and
+  - media readiness is `ready`.
+- Dispatch `tldw:discuss-media` with `{ mediaId, title, mode: "rag_media" }` for the ask-about-source action.
+
+If the backend cannot confirm media readiness, keep the user on a safe "view or add another source" action and do not offer grounded chat.
+
+### Steps
+
+- [ ] **Step 1: Write prompt tests**
+
+Cover:
+
+- Web URL is selected by default.
+- File upload and Paste text can be selected.
+- `onAddSource("web_url")`, `onAddSource("file_upload")`, and `onAddSource("paste_text")` fire correctly.
+- Processing state hides the picker and shows progress copy.
+- Error state shows retry.
+- Ready state shows Ask about this source only when provided.
+
+- [ ] **Step 2: Write route tests**
+
+In `option-index.unified-setup.test.tsx`, cover:
+
+- First-source detail includes `firstSourceKind: "web_url"` by default.
+- Selecting file/paste changes the quick ingest detail.
+- Ask-about-source is not shown before media readiness.
+- Ask-about-source dispatches `tldw:discuss-media` after quick ingest success and readiness.
+
+- [ ] **Step 3: Run RED**
+
+Run:
+
+```bash
+bunx vitest run apps/packages/ui/src/components/Option/Onboarding/__tests__/FirstSourceMilestonePrompt.test.tsx apps/packages/ui/src/routes/__tests__/option-index.unified-setup.test.tsx
+```
+
+Expected: FAIL because the picker and readiness-gated ask action do not exist.
+
+- [ ] **Step 4: Implement FirstSourceMilestonePrompt picker**
+
+Use radio or segmented buttons with stable dimensions. Keep buttons concise:
+
+- Web URL
+- File
+- Paste
+
+Use `FilePlus2`, `Link`, and `ClipboardPaste` lucide icons where available.
+
+- [ ] **Step 5: Extend quick-ingest detail typing**
+
+Update `QuickIngestOpenDetail` to include `firstSourceKind`. Keep all existing branches compatible.
+
+- [ ] **Step 6: Wire OptionIndex**
+
+Use:
+
+```ts
+requestQuickIngestOpen(
+  {
+    source: "first_source_milestone",
+    preferredPreset: "quick",
+    firstSource: true,
+    firstSourceKind: selectedKind
+  },
+  { focusTrigger: true }
+)
+```
+
+Subscribe to `useQuickIngestStore` for `lastRunSummary`; derive prompt readiness state from `lastRunSummary` and `usePostOnboardingMediaReadiness`.
+
+- [ ] **Step 7: Run frontend GREEN**
+
+Run:
+
+```bash
+bunx vitest run apps/packages/ui/src/components/Option/Onboarding/__tests__/FirstSourceMilestonePrompt.test.tsx apps/packages/ui/src/routes/__tests__/option-index.unified-setup.test.tsx apps/packages/ui/src/hooks/__tests__/usePostOnboardingMediaReadiness.test.tsx
+```
+
+Expected: PASS.
+
+- [ ] **Step 8: Update E2E mock and test**
+
+In `unified-first-run-onboarding.spec.ts`, add route handling for provider validation:
+
+```ts
+if (path === '/api/v1/setup/first-run/providers/validate' && method === 'POST') {
+  const body = requestJson(route);
+  await json(route, {
+    provider_key: body.provider_key,
+    status: 'accepted',
+    validation_level: 'local_syntax',
+    can_gate_first_chat: true,
+    models: []
+  });
+  return;
+}
+```
+
+Extend the happy path to click `Validate` before save/continue and assert the first-source picker opens quick ingest with `firstSourceKind: "web_url"`.
+
+- [ ] **Step 9: Run E2E focused test**
+
+Run with working directory `apps/tldw-frontend`:
+
+```bash
+bun run e2e:pw e2e/workflows/unified-first-run-onboarding.spec.ts --project=chromium --reporter=line
+```
+
+Expected: PASS.
+
+- [ ] **Step 10: Commit Task 4**
+
+Run:
+
+```bash
+git add apps/packages/ui/src/components/Option/Onboarding/FirstSourceMilestonePrompt.tsx apps/packages/ui/src/components/Option/Onboarding/__tests__/FirstSourceMilestonePrompt.test.tsx apps/packages/ui/src/utils/quick-ingest-open.ts apps/packages/ui/src/routes/option-index.tsx apps/packages/ui/src/routes/__tests__/option-index.unified-setup.test.tsx apps/tldw-frontend/e2e/workflows/unified-first-run-onboarding.spec.ts "backlog/tasks/task-583 - Design-onboarding-confidence-flow-follow-up.md"
+git diff --cached --check
+git commit -m "feat: guide first source after onboarding"
+```
+
+---
+
+## Final Verification
+
+Run these from the repo root unless noted.
+
+Backend:
+
+```bash
+source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Setup/test_setup_provider_validation.py tldw_Server_API/tests/Setup/test_setup_first_chat_completion.py -q
+```
+
+Frontend unit/integration:
+
+```bash
+bunx vitest run apps/packages/ui/src/components/Option/Onboarding/__tests__/ProviderSetupStep.test.tsx apps/packages/ui/src/components/Option/Onboarding/__tests__/UnifiedSetupWizard.test.tsx apps/packages/ui/src/components/Option/Onboarding/__tests__/FirstChatStep.test.tsx apps/packages/ui/src/components/Option/Onboarding/__tests__/FirstSourceMilestonePrompt.test.tsx apps/packages/ui/src/components/Option/Onboarding/__tests__/SetupReadinessPanel.test.tsx apps/packages/ui/src/hooks/__tests__/useSetupReadinessSummary.test.tsx apps/packages/ui/src/hooks/__tests__/usePostOnboardingMediaReadiness.test.tsx apps/packages/ui/src/routes/__tests__/option-index.unified-setup.test.tsx
+```
+
+Frontend E2E:
+
+```bash
+bun run e2e:pw e2e/workflows/unified-first-run-onboarding.spec.ts --project=chromium --reporter=line
+```
+
+Bandit for touched backend setup scope:
+
+```bash
+source .venv/bin/activate && python -m bandit -r tldw_Server_API/app/api/v1/schemas/setup_schemas.py tldw_Server_API/app/core/Setup/provider_validation.py -f json -o /tmp/bandit_onboarding_confidence_flow.json
+```
+
+Diff checks:
+
+```bash
+git diff --check
+git status --short --branch
+```
+
+Manual UAT after implementation:
+
+1. Start a clean server/database install in a temporary copy or test worktree.
+2. Use the existing project `.env` OpenAI key.
+3. Select OpenAI as default, validate it, save providers, and continue.
+4. Set TTS to `pocket-tts`.
+5. Set STT to `onnx-parakeet`.
+6. Complete privacy/security, ingest defaults, audio defaults, optional advanced, and first chat.
+7. Confirm first chat only completes after a real successful response.
+8. Confirm the first-source picker appears, defaults to Web URL, opens quick ingest, and only offers grounded chat after ingest readiness is confirmed.
+9. Repeat a failure path: invalid provider key, unreachable local endpoint, and first-chat failure. Confirm inline recovery buttons work.
+
+## Cleanup Requirements
+
+- Keep `.worktrees/unified-solo-onboarding` untouched unless the user explicitly asks to inspect it as a reference.
+- Do not rebase or cherry-pick broad stale worktree changes.
+- Remove any temporary screenshots, Playwright artifacts, mock server logs, or generated UAT files before final staging unless they are intentionally part of test output.
+- Update `TASK-583` notes after each staged commit with tests run and known skips.
+- If a test cannot run because of missing local dependencies, record the exact command, error, and reason in the Backlog task and final response.

--- a/Docs/superpowers/specs/2026-06-01-onboarding-confidence-flow-design.md
+++ b/Docs/superpowers/specs/2026-06-01-onboarding-confidence-flow-design.md
@@ -1,0 +1,267 @@
+# Onboarding Confidence Flow Design
+
+Date: 2026-06-01
+Status: Ready for user review
+Backlog: TASK-583
+
+## Summary
+
+Extend the unified first-time solo onboarding flow with a focused confidence pass before and after the first-chat completion gate. The PR should ship as one coherent change with four staged commits:
+
+1. Manual provider validation.
+2. Compact setup readiness panel.
+3. Inline first-chat recovery.
+4. Guided first-source milestone.
+
+The goal is to make the first successful chat more reliable, make setup posture visible without adding another blocking step, and carry the user from "chat works" to "I added a source and got value."
+
+This work must start from current `origin/dev`. The old `.worktrees/unified-solo-onboarding` branch is only a reference artifact; it must not be rebased or replayed wholesale because it predates newer setup readiness modules now present on `dev`.
+
+## Source Of Truth
+
+Current `dev` already contains the unified onboarding baseline and the setup readiness architecture. The next PR should preserve these contracts:
+
+- Backend first-run state remains authoritative for setup progress, skip, first-chat success, and completion.
+- Existing setup readiness modules remain authoritative for readiness lanes, statuses, overlays, previews, provisioning, and persisted readiness snapshots.
+- WebUI local state remains temporary: unsaved form values, expanded rows, transient validation responses, and dismissed UI.
+- `/setup` remains the backend/operator recovery surface and should share the same APIs and vocabulary as the WebUI.
+- Completion still requires a real successful first-chat response unless the user explicitly skips setup.
+
+## Goals
+
+- Prevent avoidable first-chat failures by validating the default provider before continuing.
+- Keep validation manual-first so the user controls hosted API calls and local endpoint checks.
+- Surface setup readiness in the wizard shell without creating another mandatory step.
+- Turn first-chat failures into clear recovery actions instead of generic error text.
+- Convert the post-completion "add your first source" prompt into a guided first-value milestone.
+- Preserve the existing first-run setup state and readiness APIs rather than adding a parallel onboarding state system.
+
+## Non-Goals
+
+- Do not manage or install Ollama, llama.cpp, or other local runtimes.
+- Do not require validation for every non-default provider configured during setup.
+- Do not make RAG, embeddings, speech, or storage path readiness mandatory for first-chat completion.
+- Do not replace backend `/setup`.
+- Do not redesign the entire app shell or settings area.
+- Do not rebase or resurrect broad unrelated changes from the stale onboarding worktree.
+
+## Stage 1: Provider Validation
+
+Provider validation is manual-first. The user enters provider settings, clicks `Validate`, reviews the result, then saves and continues.
+
+Rules:
+
+- The selected default provider for first chat must have a non-failed manual validation attempt before `Continue` is enabled.
+- Default-provider validation can satisfy the gate in two ways:
+  - `ready`: live non-generative validation, local endpoint reachability, or model discovery/check succeeded.
+  - `accepted`: the provider has no safe live preflight in this setup path, or the current backend only supports syntax/presence checks. The UI must label this plainly as "format accepted; first chat verifies the provider."
+- `failed`, `blocked`, or missing validation results cannot satisfy the default-provider gate.
+- Non-default selected providers can be saved as `unverified`.
+- Validation should not run automatically on every keystroke, blur, or debounce.
+- Hosted providers use non-generative validation when available: model list, auth check, or provider-specific metadata endpoint.
+- Hosted providers without safe preflight can be saved as `unverified` when non-default. If selected as the default, the backend must return an explicit `accepted` validation result rather than letting the frontend infer success.
+- Local and OpenAI-compatible providers should attempt reachability and model discovery when supported.
+- Local providers keep manual model entry fallback when model discovery fails or is unsupported.
+- Validation must mask secrets in requests, responses, state, logs, and test fixtures.
+
+UI behavior:
+
+- Each selected provider shows a `Validate` action and a validation state.
+- Possible visible states: `Not validated`, `Checking`, `Ready`, `Saved unverified`, `Auth failed`, `Endpoint unreachable`, `Model unavailable`, `Unsupported API shape`, `Rate limited`, `Provider validation unavailable`.
+- The default-provider radio/selection remains explicit.
+- If a validated provider is edited after validation, its validation state is invalidated until revalidated.
+- Model discovery should populate a model picker when available, while keeping a manual model input available.
+
+Backend/API behavior:
+
+- Reuse the existing provider catalog and provider save contracts where practical.
+- Add or extend setup provider validation so responses include provider key, status, validation level, failure category, safe message, discovered models if available, and whether the result can satisfy the default-provider gate.
+- Keep validation result vocabulary explicit. `ready` means the backend checked the live provider or endpoint without generating tokens. `accepted` means the backend performed only local syntax/presence checks or the provider lacks safe preflight. `failed` means the provider cannot continue as the first-chat default until fixed or changed.
+- Do not persist raw provider secrets in first-run state. Persist only masked or derived status where needed.
+- Save operations should stay about persistence. Prefer separate validation metadata, or frontend validation cache tied to a non-secret fingerprint, over widening the existing save status enum unless backend persistence truly needs it.
+
+## Stage 2: Setup Readiness Panel
+
+The readiness panel is a compact always-visible summary inside the focused setup shell. It is not a separate wizard step and does not replace first-chat completion.
+
+Panel behavior:
+
+- Show lane summaries for Chat, Embeddings/RAG, and Speech.
+- Use backend readiness statuses and overlays only.
+- Surface blockers and warnings in expandable lane details.
+- Show restart, admin-required, remote-setup-blocked, downloads-disabled, package-installs-disabled, and network-unavailable overlays when returned by the backend.
+- Provide next actions without forcing the user out of the wizard.
+- Keep optional lanes visibly deferrable.
+
+Placement:
+
+- On desktop, the summary can live in the setup shell header/sidebar area.
+- On mobile, the summary should collapse into a compact disclosure above the active step.
+- It should not expose normal global app navigation before onboarding completion.
+
+Readiness semantics:
+
+- Chat readiness should reflect the selected provider/default model and validation outcome where available.
+- Embeddings/RAG readiness can remain warning/skipped/deferred unless the user explicitly configures it.
+- Speech readiness can reflect audio/STT/TTS defaults and setup readiness recommendations but must remain optional.
+- Readiness panel status must never mark setup complete; only first-chat completion can do that.
+
+## Stage 3: First-Chat Recovery
+
+When first chat fails, the failed attempt stays visible inline on the first-chat step. The UI should explain the failure category and offer explicit recovery actions.
+
+Recovery actions:
+
+- `Retry`
+- `Edit provider`
+- `Switch provider`
+- `Skip setup`
+- `Check endpoint` for local/OpenAI-compatible endpoints
+
+Failure categories should map to practical copy and actions:
+
+- `auth_failed`: update credentials or switch provider.
+- `quota_or_rate_limit`: retry later or switch provider.
+- `endpoint_unreachable`: check endpoint URL, process, port, firewall, or local service.
+- `unsupported_api_shape`: verify OpenAI-compatible path and provider type.
+- `model_unavailable`: pick a discovered model or enter a different model.
+- `config_write_failed`: retry save or open operator setup recovery.
+- `provider_unvalidated`: return to provider validation.
+- `unknown`: retry, edit provider, or view operator diagnostics.
+
+The first-chat response text remains visible on success. If setup completion fails after chat succeeds, show that as a separate completion-state problem rather than implying the model response failed.
+
+## Stage 4: First-Source Milestone
+
+After first chat succeeds and setup is completed, the next guided milestone is adding a first source. V1 should upgrade the current prompt into a small guided picker.
+
+Source options:
+
+- `Web URL` as the default focused option.
+- `File upload`.
+- `Paste text`.
+
+Flow:
+
+1. Show the source picker immediately after onboarding completion.
+2. Let the user add exactly one first source through the selected path.
+3. Show ingest progress and readiness in plain language.
+4. Offer `Ask a question about this source` only after the source is queryable or the backend marks it ready for grounded chat.
+5. If ingest fails, keep the chosen source visible and show retry/edit actions.
+6. If ingest succeeds but the source is still processing, show processing/readiness status and a safe next action such as viewing the source.
+7. Let the user dismiss the milestone; dismissal is frontend-local unless the backend already has a suitable milestone state.
+
+This milestone is post-onboarding. It must not block setup completion and must not require RAG/storage tuning during first-run setup.
+
+## Data And State
+
+Backend-authoritative:
+
+- First-run setup status and current step.
+- Completed/acknowledged setup steps.
+- Skip state and skip reason.
+- First-chat verification and completion state.
+- Provider config writes and masked provider status.
+- Setup readiness status, lanes, overlays, preview, and provisioning state.
+
+Frontend-local:
+
+- Current unsaved provider form values.
+- Expanded readiness lanes.
+- Temporary validation response cache for currently edited fields.
+- First-source milestone dismissal.
+- Unsaved first-source picker state.
+
+State invalidation:
+
+- Editing a validated provider field invalidates that provider's validation result.
+- Validation results should be keyed by a non-secret provider fingerprint: provider key, base URL, model, and whether a secret was present. Never include the raw secret in the fingerprint.
+- Changing the default provider/model requires validation for the new default.
+- A failed first-chat attempt should not erase prior provider validation, but it can annotate the provider with the observed failure category.
+- Readiness panel data should refresh after provider validation, provider save, audio defaults save, optional advanced save, first-chat success, and setup completion.
+
+## API Shape
+
+Prefer narrow additions to existing setup API domains:
+
+- Provider catalog: no new catalog source.
+- Provider validation: extend the existing validation endpoint/client if available.
+- Provider save: add explicit verified/unverified response semantics if needed.
+- Readiness status/profiles: consume existing readiness endpoints from the wizard. Do not create a second readiness client or duplicate readiness types.
+- First-chat verification: preserve the existing completion gate and enrich failure categories if needed.
+- First-source milestone: reuse existing quick-ingest/media APIs and post-onboarding media readiness helpers rather than adding a new ingestion backend.
+
+Any new response fields should be additive, optional where possible, and covered by tests on both backend and client types.
+
+## Error Handling
+
+User-facing errors should be categorized and actionable. Raw exception text, stack traces, filesystem paths, request headers, and secrets should not appear in primary UI.
+
+Provider validation and first-chat errors should use the same category vocabulary where practical. Operator-only diagnostics can expose deeper details behind guarded setup or admin surfaces.
+
+## Testing Strategy
+
+Backend tests:
+
+- Default provider validation passes for safe mocked hosted validation.
+- Hosted provider without safe preflight returns an explicit `accepted` validation result that can gate only when the UI labels first-chat verification honestly.
+- Local endpoint model discovery success returns model choices.
+- Local endpoint discovery failure still allows manual model fallback.
+- Validation failures return safe categories and do not leak secrets.
+- Validation fingerprints invalidate when provider key, base URL, model, or secret presence changes without storing raw secrets.
+- Readiness endpoints remain compatible with the existing lane and overlay contracts.
+- First-chat completion still rejects completion without a successful chat.
+
+Frontend unit tests:
+
+- Default provider `Continue` is disabled until validation passes.
+- Non-default providers can be saved as unverified.
+- Editing provider fields invalidates validation.
+- Discovered models populate the picker and manual entry remains available.
+- Readiness panel renders lane statuses, blockers, warnings, overlays, and collapsed mobile state.
+- First-chat failure renders inline recovery actions without auto-navigation.
+- First-source picker defaults to Web URL and supports file/paste choices.
+
+E2E tests:
+
+- Happy path: configure provider, validate, first chat succeeds, setup completes, first-source milestone appears.
+- Hosted auth failure: validation blocks default provider continuation and shows credential recovery.
+- Hosted provider with syntax-only validation shows `accepted`, allows first-chat verification, and does not claim live readiness.
+- Local endpoint failure: validation shows endpoint recovery and model fallback.
+- First-chat failure after validated provider: inline recovery allows editing provider and retry.
+- Post-onboarding first source: URL ingest succeeds, waits for queryable readiness, then offers a grounded-question follow-up.
+
+## PR And Commit Plan
+
+One PR, four staged commits:
+
+1. `feat: validate onboarding providers before first chat`
+2. `feat: show setup readiness in onboarding wizard`
+3. `fix: add first-chat onboarding recovery actions`
+4. `feat: guide first source after onboarding`
+
+Each commit should keep tests close to the changed contract. If a stage reveals stale old-worktree code that conflicts with current `dev`, prefer reimplementing against current contracts over cherry-picking.
+
+## Risks
+
+- Provider validation can accidentally become generative or quota-consuming.
+  - Mitigation: manual-first, non-generative validation by default, and explicit unverified status for providers without safe preflight.
+- Readiness panel can add cognitive load.
+  - Mitigation: compact summary by default, details behind disclosure, optional lanes marked deferrable.
+- First-source milestone can grow into a second onboarding wizard.
+  - Mitigation: one-source V1, three input types, and one next action after ingest.
+- Old worktree rebase can delete newer readiness architecture.
+  - Mitigation: start fresh from `origin/dev`; old branch is reference only.
+
+## Acceptance Criteria
+
+- Manual provider validation is required for the default first-chat provider.
+- Non-default providers can be saved as unverified.
+- Local providers discover models when supported and keep manual fallback.
+- Hosted validation avoids token-generating calls where possible.
+- Syntax-only hosted validation is labeled as `accepted`, not live-ready.
+- Setup readiness is visible in the wizard shell using backend lanes and overlays.
+- First-chat failures stay inline and expose explicit recovery actions.
+- Post-completion first-source milestone supports Web URL, file upload, and pasted text, and waits for queryable source readiness before offering a grounded question.
+- The implementation does not remove or replace current `dev` setup readiness modules.
+- Tests cover backend validation categories, WebUI gating, readiness rendering, first-chat recovery, and first-source milestone behavior.

--- a/apps/packages/ui/src/components/Common/QuickIngest/AddContentStep.tsx
+++ b/apps/packages/ui/src/components/Common/QuickIngest/AddContentStep.tsx
@@ -248,9 +248,15 @@ export const AddContentStep: React.FC<AddContentStepProps> = ({
     setConferenceBatchMetadata,
     goNext,
   } = useIngestWizard()
-  const { queueItems, conferenceBatchMetadata, playlistPreflightSeed } = state
+  const {
+    queueItems,
+    conferenceBatchMetadata,
+    playlistPreflightSeed,
+    firstSourceAddMode,
+  } = state
 
   const [urlInput, setUrlInput] = useState("")
+  const [pastedTextInput, setPastedTextInput] = useState("")
   const [playlistPreflightUrl, setPlaylistPreflightUrl] = useState("")
   const [playlistPreflight, setPlaylistPreflight] = useState<PlaylistPreflightResult | null>(null)
   const [duplicatePolicy, setDuplicatePolicy] = useState<ConferenceDuplicatePolicy>("skip")
@@ -258,6 +264,8 @@ export const AddContentStep: React.FC<AddContentStepProps> = ({
   const [playlistPreflightError, setPlaylistPreflightError] = useState<string | null>(null)
   const { capabilities } = useServerCapabilities()
   const seededPlaylistUrlRef = React.useRef<string | null>(null)
+  const shouldShowPastedTextInput = firstSourceAddMode === "paste_text"
+  const shouldFocusUrlInput = firstSourceAddMode === "web_url"
 
   const qi = useCallback(
     (key: string, defaultValue: string, options?: Record<string, unknown>) =>
@@ -322,6 +330,27 @@ export const AddContentStep: React.FC<AddContentStepProps> = ({
     setDuplicatePolicy("skip")
     setPlaylistPreflightError(null)
   }, [urlInput, queueItems, setQueueItems])
+
+  const handleAddPastedText = useCallback(() => {
+    const text = pastedTextInput.trim()
+    if (!text) return
+
+    const file = new File([text], "pasted-text.txt", { type: "text/plain" })
+    const detectedType = detectTypeFromFile(file)
+    const item: WizardQueueItem = {
+      id: crypto.randomUUID(),
+      fileName: file.name,
+      file,
+      detectedType,
+      icon: ICON_NAME_MAP[detectedType],
+      fileSize: file.size,
+      mimeType: file.type || undefined,
+      validation: { valid: true },
+    }
+    item.validation = validateQueueItem(item, queueItems)
+    setQueueItems([...queueItems, item])
+    setPastedTextInput("")
+  }, [pastedTextInput, queueItems, setQueueItems])
 
   const playlistCandidateUrls = useMemo(
     () =>
@@ -554,6 +583,7 @@ export const AddContentStep: React.FC<AddContentStepProps> = ({
         <FileDropZone
           onFilesAdded={handleFilesAdded}
           isOnlineForIngest={isOnlineForIngest}
+          autoFocus={firstSourceAddMode === "file_upload"}
         />
         <Typography.Text className="text-[11px] text-text-subtle">
           {qi(
@@ -568,6 +598,38 @@ export const AddContentStep: React.FC<AddContentStepProps> = ({
             "Add URLs or files. Stored items appear in Media; analyzed and chunked items become searchable in Knowledge."
           )}
         </Typography.Text>
+
+        {shouldShowPastedTextInput && (
+          <div>
+            <Typography.Text className="text-xs text-text-muted">
+              {qi("pasteTextTitle", "Paste text:")}
+            </Typography.Text>
+            <div className="mt-1 flex gap-2">
+              <Input.TextArea
+                value={pastedTextInput}
+                onChange={(e) => setPastedTextInput(e.target.value)}
+                placeholder={qi(
+                  "pasteTextPlaceholder",
+                  "Paste article text, notes, or a short document..."
+                )}
+                autoSize={{ minRows: 3, maxRows: 6 }}
+                autoFocus
+                aria-label={qi("pasteTextInputAria", "Pasted text input")}
+                className="flex-1"
+              />
+              <Button
+                type="primary"
+                onClick={handleAddPastedText}
+                disabled={!pastedTextInput.trim()}
+                aria-label={qi("addPastedTextAria", "Add pasted text to queue")}
+                className="self-end"
+              >
+                <Plus className="mr-1 h-4 w-4" />
+                {qi("addPastedText", "Add text")}
+              </Button>
+            </div>
+          </div>
+        )}
 
         {hasLargeFiles && (
           <DesignSystemAlert
@@ -597,6 +659,7 @@ export const AddContentStep: React.FC<AddContentStepProps> = ({
                 "https://example.com/article\nhttps://youtube.com/watch?v=..."
               )}
               autoSize={{ minRows: 2, maxRows: 4 }}
+              autoFocus={shouldFocusUrlInput}
               aria-label={qi("urlsInputAria", "URL input area")}
               className="flex-1"
             />

--- a/apps/packages/ui/src/components/Common/QuickIngest/AddContentStep.tsx
+++ b/apps/packages/ui/src/components/Common/QuickIngest/AddContentStep.tsx
@@ -332,10 +332,11 @@ export const AddContentStep: React.FC<AddContentStepProps> = ({
   }, [urlInput, queueItems, setQueueItems])
 
   const handleAddPastedText = useCallback(() => {
-    const text = pastedTextInput.trim()
-    if (!text) return
+    if (!pastedTextInput.trim()) return
 
-    const file = new File([text], "pasted-text.txt", { type: "text/plain" })
+    const file = new File([pastedTextInput], "pasted-text.txt", {
+      type: "text/plain"
+    })
     const detectedType = detectTypeFromFile(file)
     const item: WizardQueueItem = {
       id: crypto.randomUUID(),

--- a/apps/packages/ui/src/components/Common/QuickIngest/IngestWizardContext.tsx
+++ b/apps/packages/ui/src/components/Common/QuickIngest/IngestWizardContext.tsx
@@ -22,7 +22,10 @@ import {
   mergePresetConfig,
   configMatchesPreset,
 } from "./presets"
-import type { QuickIngestOpenDetail } from "@/utils/quick-ingest-open"
+import type {
+  FirstSourceQuickIngestKind,
+  QuickIngestOpenDetail,
+} from "@/utils/quick-ingest-open"
 
 // ---------------------------------------------------------------------------
 // State shape
@@ -38,6 +41,7 @@ export type IngestWizardState = {
   presetConfig: PresetConfig
   customOptions: Partial<PresetConfig>
   playlistPreflightSeed: QuickIngestOpenDetail | null
+  firstSourceAddMode: FirstSourceQuickIngestKind | null
   conferenceBatchMetadata: ConferenceBatchMetadata | null
   processingState: WizardProcessingState
   results: WizardResultItem[]
@@ -166,6 +170,7 @@ const createInitialState = (): IngestWizardState => ({
   presetConfig: DEFAULT_PRESETS[DEFAULT_PRESET],
   customOptions: {},
   playlistPreflightSeed: null,
+  firstSourceAddMode: null,
   conferenceBatchMetadata: null,
   processingState: { ...INITIAL_PROCESSING_STATE },
   results: [],
@@ -188,6 +193,7 @@ const createInitialStateFromSeed = (
     customOptions: seed.customOptions ?? base.customOptions,
     playlistPreflightSeed:
       seed.playlistPreflightSeed ?? base.playlistPreflightSeed,
+    firstSourceAddMode: seed.firstSourceAddMode ?? base.firstSourceAddMode,
     conferenceBatchMetadata:
       seed.conferenceBatchMetadata ?? base.conferenceBatchMetadata,
     processingState: seed.processingState

--- a/apps/packages/ui/src/components/Common/QuickIngest/QueueTab/FileDropZone.tsx
+++ b/apps/packages/ui/src/components/Common/QuickIngest/QueueTab/FileDropZone.tsx
@@ -17,6 +17,8 @@ interface FileDropZoneProps {
   running?: boolean
   /** Whether server is online for ingest */
   isOnlineForIngest?: boolean
+  /** Focus the drop zone when it is first shown. */
+  autoFocus?: boolean
   /** Additional CSS classes */
   className?: string
 }
@@ -34,17 +36,24 @@ export const FileDropZone: React.FC<FileDropZoneProps> = ({
   onFilesRejected,
   running = false,
   isOnlineForIngest = true,
+  autoFocus = false,
   className
 }) => {
   const { t } = useTranslation(["option"])
   const [isDragging, setIsDragging] = React.useState(false)
   const [isDragReject, setIsDragReject] = React.useState(false)
   const [dragFileCount, setDragFileCount] = React.useState(0)
+  const dropZoneRef = React.useRef<HTMLDivElement>(null)
   const inputRef = React.useRef<HTMLInputElement>(null)
   // Drag counter prevents flickering when dragging over nested elements
   const dragCounterRef = React.useRef(0)
 
   const disabled = running || !isOnlineForIngest
+
+  React.useEffect(() => {
+    if (!autoFocus || disabled) return
+    dropZoneRef.current?.focus()
+  }, [autoFocus, disabled])
 
   const qi = useCallback(
     (key: string, defaultValue: string, options?: Record<string, unknown>) =>
@@ -268,6 +277,7 @@ export const FileDropZone: React.FC<FileDropZoneProps> = ({
 
   return (
     <div
+      ref={dropZoneRef}
       onDragEnter={handleDragEnter}
       onDragOver={handleDragOver}
       onDragLeave={handleDragLeave}

--- a/apps/packages/ui/src/components/Common/QuickIngest/QueueTab/FileDropZone.tsx
+++ b/apps/packages/ui/src/components/Common/QuickIngest/QueueTab/FileDropZone.tsx
@@ -47,12 +47,18 @@ export const FileDropZone: React.FC<FileDropZoneProps> = ({
   const inputRef = React.useRef<HTMLInputElement>(null)
   // Drag counter prevents flickering when dragging over nested elements
   const dragCounterRef = React.useRef(0)
+  const hasAutoFocusedRef = React.useRef(false)
 
   const disabled = running || !isOnlineForIngest
 
   React.useEffect(() => {
-    if (!autoFocus || disabled) return
+    if (!autoFocus) {
+      hasAutoFocusedRef.current = false
+      return
+    }
+    if (disabled || hasAutoFocusedRef.current) return
     dropZoneRef.current?.focus()
+    hasAutoFocusedRef.current = true
   }, [autoFocus, disabled])
 
   const qi = useCallback(

--- a/apps/packages/ui/src/components/Common/QuickIngest/__tests__/FileDropZone.acceptance.test.tsx
+++ b/apps/packages/ui/src/components/Common/QuickIngest/__tests__/FileDropZone.acceptance.test.tsx
@@ -25,6 +25,48 @@ vi.mock("react-i18next", () => ({
 import { FileDropZone } from "../QueueTab/FileDropZone"
 
 describe("FileDropZone acceptance", () => {
+  it("only autofocuses once when disabled state clears", () => {
+    const focusSpy = vi
+      .spyOn(HTMLElement.prototype, "focus")
+      .mockImplementation(() => undefined)
+    const { rerender } = render(
+      <FileDropZone
+        autoFocus
+        disabled
+        onFilesAdded={vi.fn()}
+        onFilesRejected={vi.fn()}
+      />
+    )
+
+    rerender(
+      <FileDropZone
+        autoFocus
+        disabled={false}
+        onFilesAdded={vi.fn()}
+        onFilesRejected={vi.fn()}
+      />
+    )
+    rerender(
+      <FileDropZone
+        autoFocus
+        disabled
+        onFilesAdded={vi.fn()}
+        onFilesRejected={vi.fn()}
+      />
+    )
+    rerender(
+      <FileDropZone
+        autoFocus
+        disabled={false}
+        onFilesAdded={vi.fn()}
+        onFilesRejected={vi.fn()}
+      />
+    )
+
+    expect(focusSpy).toHaveBeenCalledTimes(1)
+    focusSpy.mockRestore()
+  })
+
   it("accepts mkv uploads even when the browser does not provide a MIME type", async () => {
     const user = userEvent.setup()
     const onFilesAdded = vi.fn()

--- a/apps/packages/ui/src/components/Common/QuickIngest/__tests__/QuickIngestWizardModal.integration.test.tsx
+++ b/apps/packages/ui/src/components/Common/QuickIngest/__tests__/QuickIngestWizardModal.integration.test.tsx
@@ -634,12 +634,16 @@ describe("QuickIngestWizardModal — full wizard flow integration", () => {
     const pastedTextInput = await screen.findByRole("textbox", {
       name: /pasted text input/i
     })
-    await user.type(pastedTextInput, "These are first-source notes.")
+    const pastedText = "  These are first-source notes.\nKeep spacing.  "
+    await user.type(pastedTextInput, pastedText)
     await user.click(
       screen.getByRole("button", { name: /add pasted text to queue/i })
     )
 
     expect(await screen.findByText("pasted-text.txt")).toBeInTheDocument()
+    await expect(ctxRef?.state.queueItems[0]?.file?.text()).resolves.toBe(
+      pastedText
+    )
     expect(pastedTextInput).toHaveValue("")
   })
 

--- a/apps/packages/ui/src/components/Common/QuickIngest/__tests__/QuickIngestWizardModal.integration.test.tsx
+++ b/apps/packages/ui/src/components/Common/QuickIngest/__tests__/QuickIngestWizardModal.integration.test.tsx
@@ -285,44 +285,56 @@ vi.mock("@/components/Common/QuickIngest/useIngestSSE", () => ({
 vi.mock(
   "@/components/Common/QuickIngest/QueueTab/FileDropZone",
   () => ({
-    FileDropZone: ({ onFilesAdded }: any) => (
-      <div data-testid="file-drop-zone">
-        FileDropZone
-        <button
-          type="button"
-          onClick={() =>
-            onFilesAdded?.([
-              {
-                name: "large-audio.mp3",
-                size: 45 * 1024 * 1024,
-                type: "audio/mpeg",
-              },
-            ])
-          }
-        >
-          Add large audio file
-        </button>
-      </div>
-    ),
-    default: ({ onFilesAdded }: any) => (
-      <div data-testid="file-drop-zone">
-        FileDropZone
-        <button
-          type="button"
-          onClick={() =>
-            onFilesAdded?.([
-              {
-                name: "large-audio.mp3",
-                size: 45 * 1024 * 1024,
-                type: "audio/mpeg",
-              },
-            ])
-          }
-        >
-          Add large audio file
-        </button>
-      </div>
-    ),
+    FileDropZone: ({ onFilesAdded, autoFocus }: any) => {
+      const ref = React.useRef<HTMLDivElement>(null)
+      React.useEffect(() => {
+        if (autoFocus) ref.current?.focus()
+      }, [autoFocus])
+      return (
+        <div data-testid="file-drop-zone" ref={ref} tabIndex={0}>
+          FileDropZone
+          <button
+            type="button"
+            onClick={() =>
+              onFilesAdded?.([
+                {
+                  name: "large-audio.mp3",
+                  size: 45 * 1024 * 1024,
+                  type: "audio/mpeg",
+                },
+              ])
+            }
+          >
+            Add large audio file
+          </button>
+        </div>
+      )
+    },
+    default: ({ onFilesAdded, autoFocus }: any) => {
+      const ref = React.useRef<HTMLDivElement>(null)
+      React.useEffect(() => {
+        if (autoFocus) ref.current?.focus()
+      }, [autoFocus])
+      return (
+        <div data-testid="file-drop-zone" ref={ref} tabIndex={0}>
+          FileDropZone
+          <button
+            type="button"
+            onClick={() =>
+              onFilesAdded?.([
+                {
+                  name: "large-audio.mp3",
+                  size: 45 * 1024 * 1024,
+                  type: "audio/mpeg",
+                },
+              ])
+            }
+          >
+            Add large audio file
+          </button>
+        </div>
+      )
+    },
   })
 )
 
@@ -580,6 +592,55 @@ describe("QuickIngestWizardModal — full wizard flow integration", () => {
     expect(screen.getByText(/Add URLs or files/i)).toBeInTheDocument()
     expect(screen.getByText(/Media/i)).toBeInTheDocument()
     expect(screen.getByText(/Knowledge/i)).toBeInTheDocument()
+  })
+
+  it("Step 1 — focuses file upload when first-source file choice opens quick ingest", async () => {
+    render(
+      <WizardTestHarness
+        onClose={onClose}
+        initialState={{ firstSourceAddMode: "file_upload" }}
+      />
+    )
+
+    await waitFor(() => {
+      expect(screen.getByTestId("file-drop-zone")).toHaveFocus()
+    })
+  })
+
+  it("Step 1 — focuses pasted text input when first-source paste choice opens quick ingest", async () => {
+    render(
+      <WizardTestHarness
+        onClose={onClose}
+        initialState={{ firstSourceAddMode: "paste_text" }}
+      />
+    )
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("textbox", { name: /pasted text input/i })
+      ).toHaveFocus()
+    })
+  })
+
+  it("Step 1 — queues pasted first-source text as a text file", async () => {
+    const user = userEvent.setup()
+    render(
+      <WizardTestHarness
+        onClose={onClose}
+        initialState={{ firstSourceAddMode: "paste_text" }}
+      />
+    )
+
+    const pastedTextInput = await screen.findByRole("textbox", {
+      name: /pasted text input/i
+    })
+    await user.type(pastedTextInput, "These are first-source notes.")
+    await user.click(
+      screen.getByRole("button", { name: /add pasted text to queue/i })
+    )
+
+    expect(await screen.findByText("pasted-text.txt")).toBeInTheDocument()
+    expect(pastedTextInput).toHaveValue("")
   })
 
   it("Step 1 — renders at step 1 and allows adding a URL", async () => {

--- a/apps/packages/ui/src/components/Common/QuickIngest/__tests__/QuickIngestWizardModal.session.test.tsx
+++ b/apps/packages/ui/src/components/Common/QuickIngest/__tests__/QuickIngestWizardModal.session.test.tsx
@@ -278,7 +278,7 @@ vi.mock("@/components/Common/QuickIngest/WizardResultsStep", async () => {
     }: {
       onOpenCollection?: (collectionId: string) => void
     }) => {
-      const { state } = actual.useIngestWizard()
+      const { state, reset } = actual.useIngestWizard()
       return (
         <div data-testid="wizard-results">
           {state.processingState.status}:{state.results.length}
@@ -295,6 +295,9 @@ vi.mock("@/components/Common/QuickIngest/WizardResultsStep", async () => {
               Open collection
             </button>
           ) : null}
+          <button type="button" onClick={reset}>
+            Start over
+          </button>
         </div>
       )
     },
@@ -435,6 +438,25 @@ describe("QuickIngestWizardModal session runtime", () => {
     expect(useQuickIngestSessionStore.getState().session?.openDetail).toEqual(
       firstSourceDetail
     )
+  })
+
+  it("syncs cleared first-source add mode from wizard reset", async () => {
+    const user = userEvent.setup()
+    useQuickIngestSessionStore.getState().createDraftSession({
+      firstSourceAddMode: "paste_text",
+    })
+
+    render(<QuickIngestWizardModal open onClose={vi.fn()} />)
+
+    await user.click(screen.getByRole("button", { name: "Queue And Process" }))
+    await screen.findByTestId("wizard-results")
+    await user.click(screen.getByRole("button", { name: "Start over" }))
+
+    await waitFor(() => {
+      expect(
+        useQuickIngestSessionStore.getState().session?.firstSourceAddMode,
+      ).toBeNull()
+    })
   })
 
   it("submits conference batch metadata and item overrides through the session payload", async () => {

--- a/apps/packages/ui/src/components/Common/QuickIngest/__tests__/QuickIngestWizardModal.session.test.tsx
+++ b/apps/packages/ui/src/components/Common/QuickIngest/__tests__/QuickIngestWizardModal.session.test.tsx
@@ -396,6 +396,47 @@ describe("QuickIngestWizardModal session runtime", () => {
     })
   })
 
+  it("preserves first-source open detail while syncing wizard state", async () => {
+    const user = userEvent.setup()
+    const firstSourceDetail = {
+      source: "first_source_milestone" as const,
+      preferredPreset: "quick" as const,
+      firstSource: true,
+      firstSourceKind: "file_upload" as const,
+    }
+    useQuickIngestSessionStore.getState().createDraftSession({
+      openDetail: firstSourceDetail,
+    })
+    mocks.startQuickIngestSession.mockResolvedValue({
+      ok: true,
+      sessionId: "qi-direct-first-source",
+    })
+    mocks.submitQuickIngestBatch.mockResolvedValue({
+      ok: true,
+      results: [
+        {
+          id: "queued-url-1",
+          status: "ok",
+          url: "https://example.com/article",
+          type: "html",
+          mediaId: "42",
+          title: "Example article",
+        },
+      ],
+    })
+
+    render(<QuickIngestWizardModal open onClose={vi.fn()} />)
+
+    await user.click(screen.getByRole("button", { name: "Queue And Process" }))
+
+    await waitFor(() => {
+      expect(screen.getByTestId("wizard-results")).toHaveTextContent("complete:1")
+    })
+    expect(useQuickIngestSessionStore.getState().session?.openDetail).toEqual(
+      firstSourceDetail
+    )
+  })
+
   it("submits conference batch metadata and item overrides through the session payload", async () => {
     const user = userEvent.setup()
     useQuickIngestSessionStore.getState().createDraftSession()

--- a/apps/packages/ui/src/components/Common/QuickIngestWizardModal.tsx
+++ b/apps/packages/ui/src/components/Common/QuickIngestWizardModal.tsx
@@ -574,12 +574,26 @@ const buildInitialWizardState = (
   playlistPreflightSeed: isQuickIngestPlaylistPreflightDetail(session.openDetail)
     ? session.openDetail
     : null,
+  firstSourceAddMode: session.firstSourceAddMode ?? null,
   processingState: session.processingState,
   results: session.results,
   conferenceBatchMetadata: session.conferenceBatchMetadata ?? null,
   isMinimized:
     session.visibility === "hidden" && session.lifecycle === "processing",
 })
+
+const buildOpenDetailPatch = (
+  state: IngestWizardState,
+  session: QuickIngestSessionRecord
+): QuickIngestSessionRecord["openDetail"] => {
+  if (state.playlistPreflightSeed) {
+    return state.playlistPreflightSeed
+  }
+  if (isQuickIngestPlaylistPreflightDetail(session.openDetail)) {
+    return null
+  }
+  return session.openDetail ?? null
+}
 
 const buildSessionPatchFromWizardState = (
   state: IngestWizardState,
@@ -597,7 +611,8 @@ const buildSessionPatchFromWizardState = (
     conferenceBatchMetadata: state.conferenceBatchMetadata,
     processingState: state.processingState,
     results: state.results,
-    openDetail: state.playlistPreflightSeed,
+    openDetail: buildOpenDetailPatch(state, session),
+    firstSourceAddMode: session.firstSourceAddMode ?? null,
     badge: {
       queueCount:
         lifecycle === "draft"

--- a/apps/packages/ui/src/components/Common/QuickIngestWizardModal.tsx
+++ b/apps/packages/ui/src/components/Common/QuickIngestWizardModal.tsx
@@ -612,7 +612,7 @@ const buildSessionPatchFromWizardState = (
     processingState: state.processingState,
     results: state.results,
     openDetail: buildOpenDetailPatch(state, session),
-    firstSourceAddMode: session.firstSourceAddMode ?? null,
+    firstSourceAddMode: state.firstSourceAddMode ?? null,
     badge: {
       queueCount:
         lifecycle === "draft"

--- a/apps/packages/ui/src/components/Option/Onboarding/FirstSourceMilestonePrompt.tsx
+++ b/apps/packages/ui/src/components/Option/Onboarding/FirstSourceMilestonePrompt.tsx
@@ -1,15 +1,43 @@
 import React from "react"
-import { FilePlus2, X } from "lucide-react"
+import { ClipboardPaste, FilePlus2, Link, Loader2, Upload, X } from "lucide-react"
+
+export type FirstSourceKind = "web_url" | "file_upload" | "paste_text"
 
 type FirstSourceMilestonePromptProps = {
-  onAddSource: () => void
+  readinessStatus: "idle" | "processing" | "ready" | "error"
+  lastSourceLabel?: string | null
+  errorMessage?: string | null
+  onAddSource: (kind: FirstSourceKind) => void
+  onAskAboutSource?: () => void
+  onRetry?: () => void
   onDismiss: () => void
 }
 
+const SOURCE_KIND_OPTIONS: Array<{
+  kind: FirstSourceKind
+  label: string
+  Icon: typeof Link
+}> = [
+  { kind: "web_url", label: "Web URL", Icon: Link },
+  { kind: "file_upload", label: "File", Icon: Upload },
+  { kind: "paste_text", label: "Paste", Icon: ClipboardPaste },
+]
+
 export function FirstSourceMilestonePrompt({
+  readinessStatus,
+  lastSourceLabel,
+  errorMessage,
   onAddSource,
+  onAskAboutSource,
+  onRetry,
   onDismiss
 }: FirstSourceMilestonePromptProps) {
+  const [selectedKind, setSelectedKind] =
+    React.useState<FirstSourceKind>("web_url")
+  const isProcessing = readinessStatus === "processing"
+  const isError = readinessStatus === "error"
+  const isReady = readinessStatus === "ready"
+
   return (
     <section
       aria-labelledby="first-source-milestone-title"
@@ -18,9 +46,13 @@ export function FirstSourceMilestonePrompt({
       <div className="flex flex-wrap items-start justify-between gap-3">
         <div className="flex min-w-0 items-start gap-3">
           <span className="inline-flex size-10 shrink-0 items-center justify-center rounded-md bg-surface2 text-primary">
-            <FilePlus2 className="size-5" aria-hidden="true" />
+            {isProcessing ? (
+              <Loader2 className="size-5 animate-spin" aria-hidden="true" />
+            ) : (
+              <FilePlus2 className="size-5" aria-hidden="true" />
+            )}
           </span>
-          <div>
+          <div className="min-w-0">
             <h2
               id="first-source-milestone-title"
               className="text-base font-semibold text-text"
@@ -28,19 +60,54 @@ export function FirstSourceMilestonePrompt({
               Add your first source
             </h2>
             <p className="mt-1 max-w-2xl text-sm text-text-muted">
-              First chat is working. Add a source next so chat can use your own
-              material.
+              {isProcessing
+                ? "Processing your source. Chat about it will unlock when it is ready."
+                : isReady
+                  ? "Your first source is ready for grounded chat."
+                  : isError
+                    ? "Source ingest did not finish. Retry or add a different source."
+                    : "First chat is working. Add a source next so chat can use your own material."}
             </p>
+            {lastSourceLabel ? (
+              <p className="mt-2 max-w-2xl truncate text-sm font-medium text-text">
+                {lastSourceLabel}
+              </p>
+            ) : null}
+            {errorMessage ? (
+              <p className="mt-2 max-w-2xl text-sm text-danger">
+                {errorMessage}
+              </p>
+            ) : null}
           </div>
         </div>
-        <div className="flex shrink-0 gap-2">
-          <button
-            type="button"
-            onClick={onAddSource}
-            className="rounded-md bg-primary px-3 py-2 text-sm font-semibold text-primary-foreground"
-          >
-            Add source
-          </button>
+        <div className="flex shrink-0 flex-wrap justify-end gap-2">
+          {isReady && onAskAboutSource ? (
+            <button
+              type="button"
+              onClick={onAskAboutSource}
+              className="rounded-md bg-primary px-3 py-2 text-sm font-semibold text-primary-foreground"
+            >
+              Ask a question about this source
+            </button>
+          ) : null}
+          {isError && onRetry ? (
+            <button
+              type="button"
+              onClick={onRetry}
+              className="rounded-md bg-primary px-3 py-2 text-sm font-semibold text-primary-foreground"
+            >
+              Retry
+            </button>
+          ) : null}
+          {!isProcessing && !isReady && !isError ? (
+            <button
+              type="button"
+              onClick={() => onAddSource(selectedKind)}
+              className="rounded-md bg-primary px-3 py-2 text-sm font-semibold text-primary-foreground"
+            >
+              Add source
+            </button>
+          ) : null}
           <button
             type="button"
             aria-label="Dismiss"
@@ -51,6 +118,34 @@ export function FirstSourceMilestonePrompt({
           </button>
         </div>
       </div>
+      {!isProcessing && !isReady && !isError ? (
+        <div className="mt-4 grid gap-2 sm:grid-cols-3">
+          {SOURCE_KIND_OPTIONS.map(({ kind, label, Icon }) => {
+            const selected = selectedKind === kind
+            return (
+              <label
+                key={kind}
+                className={`flex min-h-12 cursor-pointer items-center gap-2 rounded-md border px-3 py-2 text-sm font-medium ${
+                  selected
+                    ? "border-primary bg-primary/10 text-text"
+                    : "border-border bg-bg text-text-muted hover:bg-surface2"
+                }`}
+              >
+                <input
+                  type="radio"
+                  name="first-source-kind"
+                  value={kind}
+                  checked={selected}
+                  onChange={() => setSelectedKind(kind)}
+                  className="sr-only"
+                />
+                <Icon className="size-4 shrink-0" aria-hidden="true" />
+                <span>{label}</span>
+              </label>
+            )
+          })}
+        </div>
+      ) : null}
     </section>
   )
 }

--- a/apps/packages/ui/src/components/Option/Onboarding/FirstSourceMilestonePrompt.tsx
+++ b/apps/packages/ui/src/components/Option/Onboarding/FirstSourceMilestonePrompt.tsx
@@ -65,7 +65,7 @@ export function FirstSourceMilestonePrompt({
                 : isReady
                   ? "Your first source is ready for grounded chat."
                   : isError
-                    ? "Source ingest did not finish. Retry or add a different source."
+                    ? "Source ingest did not finish. Retry when you are ready."
                     : "First chat is working. Add a source next so chat can use your own material."}
             </p>
             {lastSourceLabel ? (
@@ -125,7 +125,7 @@ export function FirstSourceMilestonePrompt({
             return (
               <label
                 key={kind}
-                className={`flex min-h-12 cursor-pointer items-center gap-2 rounded-md border px-3 py-2 text-sm font-medium ${
+                className={`flex min-h-12 cursor-pointer items-center gap-2 rounded-md border px-3 py-2 text-sm font-medium focus-within:outline-none focus-within:ring-2 focus-within:ring-primary focus-within:ring-offset-1 ${
                   selected
                     ? "border-primary bg-primary/10 text-text"
                     : "border-border bg-bg text-text-muted hover:bg-surface2"

--- a/apps/packages/ui/src/components/Option/Onboarding/SetupReadinessPanel.tsx
+++ b/apps/packages/ui/src/components/Option/Onboarding/SetupReadinessPanel.tsx
@@ -93,8 +93,8 @@ const DetailList = ({
         {title}
       </dt>
       <dd className="mt-1 space-y-1">
-        {items.map((item) => (
-          <p key={item} className="text-xs text-text-muted">
+        {items.map((item, index) => (
+          <p key={`${item}-${index}`} className="text-xs text-text-muted">
             {item}
           </p>
         ))}
@@ -160,7 +160,8 @@ export function SetupReadinessPanel({
             const deferrable = isOptionalDeferrable(lane, overlays);
             const blocksFirstChat =
               lane.lane_id === "chat" &&
-              (lane.status === "failed" || lane.status === "blocked");
+              lane.status !== "ready" &&
+              lane.status !== "ready_with_warnings";
             return (
               <div
                 key={lane.lane_id}

--- a/apps/packages/ui/src/components/Option/Onboarding/SetupReadinessPanel.tsx
+++ b/apps/packages/ui/src/components/Option/Onboarding/SetupReadinessPanel.tsx
@@ -1,0 +1,235 @@
+import React from "react";
+
+import type {
+  SetupReadinessLane,
+  SetupReadinessStatusResponse,
+} from "@/services/tldw/setup-readiness";
+
+export type SetupReadinessPanelProps = {
+  status: SetupReadinessStatusResponse | null;
+  loading?: boolean;
+  error?: string | null;
+  onRetry?: () => void;
+};
+
+const REQUIRED_LANES = new Set(["chat", "embeddings_rag", "speech"]);
+const OPTIONAL_LANES = new Set(["embeddings_rag", "speech"]);
+const OPTIONAL_BLOCKING_OVERLAYS = new Set([
+  "downloads_disabled",
+  "package_installs_disabled",
+  "network_unavailable",
+  "remote_setup_blocked",
+]);
+
+const overlayLabels: Record<string, string> = {
+  restart_required: "Restart required",
+  admin_required: "Admin required",
+  requires_admin: "Admin required",
+  remote_setup_blocked: "Remote setup blocked",
+  downloads_disabled: "Downloads disabled",
+  package_installs_disabled: "Package installs disabled",
+  network_unavailable: "Network unavailable",
+};
+
+const humanize = (value: string) =>
+  value.replace(/_/g, " ").replace(/\b\w/g, (letter) => letter.toUpperCase());
+
+const statusCopy = (status: string | undefined) =>
+  (status || "not_configured").replace(/_/g, " ");
+
+const statusTone = (lane: SetupReadinessLane) => {
+  if (lane.status === "ready" || lane.status === "ready_with_warnings") {
+    return "border-success/30 bg-success/10 text-success";
+  }
+  if (lane.status === "failed" || lane.status === "blocked") {
+    return lane.lane_id === "chat"
+      ? "border-danger/30 bg-danger/10 text-danger"
+      : "border-warn/30 bg-warn/10 text-warn";
+  }
+  if (lane.status === "provisioning" || lane.status === "previewed") {
+    return "border-primary/30 bg-primary/10 text-primary";
+  }
+  return "border-border bg-surface2 text-text-muted";
+};
+
+const laneHasDetails = (lane: SetupReadinessLane) =>
+  Boolean(
+    lane.warnings?.length || lane.blockers?.length || lane.consequences?.length,
+  );
+
+const isOptionalDeferrable = (
+  lane: SetupReadinessLane,
+  overlays: string[],
+) => {
+  if (!OPTIONAL_LANES.has(lane.lane_id)) return false;
+  if (lane.status === "not_configured" || lane.status === "skipped") {
+    return true;
+  }
+  return Boolean(
+    lane.status === "blocked" &&
+      overlays.some((overlay) => OPTIONAL_BLOCKING_OVERLAYS.has(overlay)),
+  );
+};
+
+const readinessLanes = (status: SetupReadinessStatusResponse | null) =>
+  (status?.lanes ?? []).filter((lane) => REQUIRED_LANES.has(lane.lane_id));
+
+const mergedOverlays = (status: SetupReadinessStatusResponse | null) =>
+  Array.from(
+    new Set([...(status?.active_overlays ?? []), ...(status?.overlays ?? [])]),
+  );
+
+const DetailList = ({
+  title,
+  items,
+}: {
+  title: string;
+  items?: string[];
+}) => {
+  if (!items?.length) return null;
+  return (
+    <div>
+      <dt className="text-xs font-medium uppercase tracking-normal text-text-muted">
+        {title}
+      </dt>
+      <dd className="mt-1 space-y-1">
+        {items.map((item) => (
+          <p key={item} className="text-xs text-text-muted">
+            {item}
+          </p>
+        ))}
+      </dd>
+    </div>
+  );
+};
+
+export function SetupReadinessPanel({
+  status,
+  loading = false,
+  error = null,
+  onRetry,
+}: SetupReadinessPanelProps) {
+  const lanes = readinessLanes(status);
+  const overlays = mergedOverlays(status);
+  const shouldRender = Boolean(status || loading || error || onRetry);
+
+  if (!shouldRender) return null;
+
+  return (
+    <section
+      aria-label="Setup readiness"
+      data-testid="setup-readiness-panel"
+      className="mb-4 rounded-md border border-border bg-surface px-3 py-3"
+    >
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <div>
+          <h2 className="text-sm font-semibold text-text">Setup readiness</h2>
+          <p className="text-xs text-text-muted">
+            Chat must be ready. RAG and speech can be configured later.
+          </p>
+        </div>
+        {onRetry ? (
+          <button
+            type="button"
+            onClick={onRetry}
+            className="rounded-md border border-border bg-bg px-2.5 py-1.5 text-xs font-medium text-text hover:bg-surface2"
+          >
+            Retry
+          </button>
+        ) : null}
+      </div>
+
+      {loading ? (
+        <p className="mt-3 text-xs text-text-muted">
+          Checking setup readiness...
+        </p>
+      ) : null}
+
+      {error ? (
+        <div
+          role="alert"
+          className="mt-3 rounded-md border border-danger/30 bg-danger/10 px-3 py-2 text-xs text-danger"
+        >
+          {error}
+        </div>
+      ) : null}
+
+      {lanes.length > 0 ? (
+        <div className="mt-3 grid gap-2 md:grid-cols-3">
+          {lanes.map((lane) => {
+            const deferrable = isOptionalDeferrable(lane, overlays);
+            const blocksFirstChat =
+              lane.lane_id === "chat" &&
+              (lane.status === "failed" || lane.status === "blocked");
+            return (
+              <div
+                key={lane.lane_id}
+                data-testid={`setup-readiness-lane-${lane.lane_id}`}
+                className="rounded-md border border-border bg-bg px-3 py-2"
+              >
+                <div className="flex items-start justify-between gap-2">
+                  <div>
+                    <p className="text-sm font-medium text-text">
+                      {lane.label || humanize(lane.lane_id)}
+                    </p>
+                    <p className="mt-0.5 text-xs text-text-muted">
+                      {blocksFirstChat
+                        ? "Blocks first chat"
+                        : deferrable
+                          ? "Deferrable"
+                          : lane.lane_id === "chat"
+                            ? "First-chat lane"
+                            : "Optional lane"}
+                    </p>
+                  </div>
+                  <span
+                    className={`rounded-full border px-2 py-0.5 text-[10px] font-medium ${statusTone(
+                      lane,
+                    )}`}
+                  >
+                    {statusCopy(lane.status)}
+                  </span>
+                </div>
+
+                {laneHasDetails(lane) ? (
+                  <details className="mt-2">
+                    <summary className="cursor-pointer text-xs font-medium text-text-muted hover:text-text">
+                      {lane.label || humanize(lane.lane_id)} details
+                    </summary>
+                    <dl className="mt-2 space-y-2">
+                      <DetailList title="Warnings" items={lane.warnings} />
+                      <DetailList title="Blockers" items={lane.blockers} />
+                      <DetailList
+                        title="Effects"
+                        items={lane.consequences}
+                      />
+                    </dl>
+                  </details>
+                ) : null}
+              </div>
+            );
+          })}
+        </div>
+      ) : status ? (
+        <p className="mt-3 text-xs text-text-muted">
+          Lane readiness is not available yet.
+        </p>
+      ) : null}
+
+      {overlays.length > 0 ? (
+        <div className="mt-3 flex flex-wrap gap-1.5">
+          {overlays.map((overlay) => (
+            <span
+              key={overlay}
+              className="rounded-full border border-warn/30 bg-warn/10 px-2 py-0.5 text-[10px] font-medium text-warn"
+            >
+              {overlayLabels[overlay] || humanize(overlay)}
+            </span>
+          ))}
+        </div>
+      ) : null}
+    </section>
+  );
+}
+
+export default SetupReadinessPanel;

--- a/apps/packages/ui/src/components/Option/Onboarding/UnifiedSetupWizard.tsx
+++ b/apps/packages/ui/src/components/Option/Onboarding/UnifiedSetupWizard.tsx
@@ -404,7 +404,7 @@ export function UnifiedSetupWizard({
         status={setupReadinessStatus}
         loading={setupReadinessLoading}
         error={setupReadinessError}
-        onRetry={refreshSetupReadinessStatus}
+        onRetry={refreshSetupReadiness}
       />
 
       <div className="rounded-md border border-border bg-bg px-4 py-5 shadow-sm md:px-6">

--- a/apps/packages/ui/src/components/Option/Onboarding/UnifiedSetupWizard.tsx
+++ b/apps/packages/ui/src/components/Option/Onboarding/UnifiedSetupWizard.tsx
@@ -6,6 +6,7 @@ import type {
   FirstRunMetadata,
   FirstRunState,
   FirstRunStepUpdateRequest,
+  SetupProviderSaveResponse,
 } from "@/types/setup-onboarding";
 import { SetupPathStep } from "./steps/SetupPathStep";
 import { PrivacySecurityStep } from "./steps/PrivacySecurityStep";
@@ -13,6 +14,8 @@ import { MultiUserExitPanel } from "./steps/MultiUserExitPanel";
 import {
   ProviderSetupStep,
   type ProviderSelection,
+  type ProviderSavedPayloadFingerprintState,
+  type ProviderValidationViewState,
 } from "./steps/ProviderSetupStep";
 import { IngestDefaultsStep } from "./steps/IngestDefaultsStep";
 import { AudioSetupStep } from "./steps/AudioSetupStep";
@@ -57,13 +60,19 @@ const providerSelectionFromState = (
   const data = state?.step_data?.providers;
   const provider = data?.default_provider;
   const model = data?.default_model;
+  const credentialConfigured =
+    data?.default_provider_credential_configured === true;
   if (typeof provider === "string" && typeof model === "string") {
-    return { provider, model };
+    return { provider, model, credential_configured: credentialConfigured };
   }
   const firstChatProvider = state?.first_chat?.provider;
   const firstChatModel = state?.first_chat?.model;
   if (firstChatProvider && firstChatModel) {
-    return { provider: firstChatProvider, model: firstChatModel };
+    return {
+      provider: firstChatProvider,
+      model: firstChatModel,
+      credential_configured: credentialConfigured,
+    };
   }
   return null;
 };
@@ -86,6 +95,7 @@ export function UnifiedSetupWizard({
     saveStep,
     skip,
     saveProvider,
+    validateProvider,
     saveIngestDefaults,
     saveAudioDefaults,
     saveOptionalAdvanced,
@@ -103,6 +113,23 @@ export function UnifiedSetupWizard({
     React.useState<ProviderSelection | null>(() =>
       providerSelectionFromState(initialState),
     );
+  const [providerSavedProviders, setProviderSavedProviders] = React.useState<
+    Record<string, SetupProviderSaveResponse>
+  >({});
+  const [
+    providerSavedPayloadFingerprints,
+    setProviderSavedPayloadFingerprints,
+  ] = React.useState<ProviderSavedPayloadFingerprintState>({});
+  const [providerSavedDefaultProvider, setProviderSavedDefaultProvider] =
+    React.useState<string | null>(() =>
+      providerSelectionFromState(initialState)?.provider ?? null,
+    );
+  const [providerValidationState, setProviderValidationState] = React.useState<
+    Record<string, ProviderValidationViewState>
+  >({});
+  const [providerEditRevisions, setProviderEditRevisions] = React.useState<
+    Record<string, number>
+  >({});
   const [savingStep, setSavingStep] = React.useState(false);
   const [stepError, setStepError] = React.useState<string | null>(null);
 
@@ -206,6 +233,9 @@ export function UnifiedSetupWizard({
             acknowledged: true,
             default_provider: selection.provider,
             default_model: selection.model,
+            default_provider_credential_configured: Boolean(
+              selection.credential_configured,
+            ),
           },
         });
         if (!nextState) return;
@@ -342,7 +372,20 @@ export function UnifiedSetupWizard({
           <ProviderSetupStep
             providers={providerCatalog}
             initialSelection={providerSelection}
+            savedProviders={providerSavedProviders}
+            savedPayloadFingerprints={providerSavedPayloadFingerprints}
+            savedDefaultProvider={providerSavedDefaultProvider}
+            validationState={providerValidationState}
+            providerEditRevisions={providerEditRevisions}
             onSaveProvider={saveProvider}
+            onValidateProvider={validateProvider}
+            onSavedProvidersChange={setProviderSavedProviders}
+            onSavedPayloadFingerprintsChange={
+              setProviderSavedPayloadFingerprints
+            }
+            onSavedDefaultProviderChange={setProviderSavedDefaultProvider}
+            onValidationStateChange={setProviderValidationState}
+            onProviderEditRevisionsChange={setProviderEditRevisions}
             onContinue={handleProviderContinue}
             onBack={() => setStep("privacy_security")}
           />

--- a/apps/packages/ui/src/components/Option/Onboarding/UnifiedSetupWizard.tsx
+++ b/apps/packages/ui/src/components/Option/Onboarding/UnifiedSetupWizard.tsx
@@ -139,6 +139,8 @@ export function UnifiedSetupWizard({
     Record<string, number>
   >({});
   const [savingStep, setSavingStep] = React.useState(false);
+  const [skipPending, setSkipPending] = React.useState(false);
+  const skipPendingRef = React.useRef(false);
   const [stepError, setStepError] = React.useState<string | null>(null);
 
   React.useEffect(() => {
@@ -322,6 +324,9 @@ export function UnifiedSetupWizard({
   );
 
   const handleSkip = React.useCallback(() => {
+    if (skipPendingRef.current) return;
+    skipPendingRef.current = true;
+    setSkipPending(true);
     setStepError(null);
     void skip({ reason: "user_skip" })
       .then((nextState) => {
@@ -332,6 +337,8 @@ export function UnifiedSetupWizard({
         setStepError("Setup skip could not be saved. Try again.");
       })
       .finally(() => {
+        skipPendingRef.current = false;
+        setSkipPending(false);
         void refreshSetupReadiness();
       });
   }, [onStateChange, refreshSetupReadiness, skip]);
@@ -367,9 +374,10 @@ export function UnifiedSetupWizard({
           <button
             type="button"
             onClick={handleSkip}
-            className="rounded-md border border-border bg-surface px-3 py-2 text-sm font-medium text-text hover:bg-surface2"
+            disabled={skipPending}
+            className="rounded-md border border-border bg-surface px-3 py-2 text-sm font-medium text-text hover:bg-surface2 disabled:opacity-50"
           >
-            Skip for now
+            {skipPending ? "Skipping..." : "Skip for now"}
           </button>
         </div>
       </header>
@@ -471,6 +479,11 @@ export function UnifiedSetupWizard({
               void refreshParentState();
             }}
             onBack={() => setStep("provider_setup")}
+            onEditProvider={() => setStep("provider_setup")}
+            onSwitchProvider={() => setStep("provider_setup")}
+            onCheckEndpoint={() => setStep("provider_setup")}
+            onSkip={handleSkip}
+            skipPending={skipPending}
           />
         ) : null}
       </div>

--- a/apps/packages/ui/src/components/Option/Onboarding/UnifiedSetupWizard.tsx
+++ b/apps/packages/ui/src/components/Option/Onboarding/UnifiedSetupWizard.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 
 import { PageAssistLoader } from "@/components/Common/PageAssistLoader";
+import { useSetupReadinessSummary } from "@/hooks/useSetupReadinessSummary";
 import { useSetupOnboarding } from "@/hooks/useSetupOnboarding";
 import type {
   FirstRunMetadata,
@@ -21,6 +22,7 @@ import { IngestDefaultsStep } from "./steps/IngestDefaultsStep";
 import { AudioSetupStep } from "./steps/AudioSetupStep";
 import { OptionalAdvancedStep } from "./steps/OptionalAdvancedStep";
 import { FirstChatStep } from "./steps/FirstChatStep";
+import { SetupReadinessPanel } from "./SetupReadinessPanel";
 
 type WizardStep =
   | "setup_path"
@@ -106,6 +108,12 @@ export function UnifiedSetupWizard({
     initialMetadata,
     autoLoad: !initialState || !initialMetadata,
   });
+  const {
+    status: setupReadinessStatus,
+    loading: setupReadinessLoading,
+    error: setupReadinessError,
+    refresh: refreshSetupReadinessStatus,
+  } = useSetupReadinessSummary();
   const [step, setStep] = React.useState<WizardStep>(() =>
     stepFromState(initialState),
   );
@@ -183,6 +191,12 @@ export function UnifiedSetupWizard({
     return nextState;
   }, [onStateChange, refresh]);
 
+  const refreshSetupReadiness = React.useCallback(() => {
+    void refreshSetupReadinessStatus().catch((err) => {
+      console.warn("Setup readiness summary could not be refreshed", err);
+    });
+  }, [refreshSetupReadinessStatus]);
+
   const handlePathSelect = React.useCallback(
     (path: "docker" | "local" | "multi_user") => {
       if (path === "multi_user") {
@@ -249,28 +263,31 @@ export function UnifiedSetupWizard({
   const saveIngestAndPublish = React.useCallback(
     async (...args: Parameters<typeof saveIngestDefaults>) => {
       const response = await saveIngestDefaults(...args);
+      refreshSetupReadiness();
       await refreshParentState();
       return response;
     },
-    [refreshParentState, saveIngestDefaults],
+    [refreshParentState, refreshSetupReadiness, saveIngestDefaults],
   );
 
   const saveAudioAndPublish = React.useCallback(
     async (...args: Parameters<typeof saveAudioDefaults>) => {
       const response = await saveAudioDefaults(...args);
+      refreshSetupReadiness();
       await refreshParentState();
       return response;
     },
-    [refreshParentState, saveAudioDefaults],
+    [refreshParentState, refreshSetupReadiness, saveAudioDefaults],
   );
 
   const saveAdvancedAndPublish = React.useCallback(
     async (...args: Parameters<typeof saveOptionalAdvanced>) => {
       const response = await saveOptionalAdvanced(...args);
+      refreshSetupReadiness();
       await refreshParentState();
       return response;
     },
-    [refreshParentState, saveOptionalAdvanced],
+    [refreshParentState, refreshSetupReadiness, saveOptionalAdvanced],
   );
 
   const completeAndPublish = React.useCallback(
@@ -282,6 +299,28 @@ export function UnifiedSetupWizard({
     [complete, refreshParentState],
   );
 
+  const saveProviderAndRefreshReadiness = React.useCallback(
+    async (...args: Parameters<typeof saveProvider>) => {
+      try {
+        return await saveProvider(...args);
+      } finally {
+        refreshSetupReadiness();
+      }
+    },
+    [refreshSetupReadiness, saveProvider],
+  );
+
+  const validateProviderAndRefreshReadiness = React.useCallback(
+    async (...args: Parameters<typeof validateProvider>) => {
+      try {
+        return await validateProvider(...args);
+      } finally {
+        refreshSetupReadiness();
+      }
+    },
+    [refreshSetupReadiness, validateProvider],
+  );
+
   const handleSkip = React.useCallback(() => {
     setStepError(null);
     void skip({ reason: "user_skip" })
@@ -291,8 +330,11 @@ export function UnifiedSetupWizard({
       .catch((err) => {
         console.error("Setup skip could not be saved", err);
         setStepError("Setup skip could not be saved. Try again.");
+      })
+      .finally(() => {
+        void refreshSetupReadiness();
       });
-  }, [onStateChange, skip]);
+  }, [onStateChange, refreshSetupReadiness, skip]);
 
   if (loading && !state && !metadata) {
     return (
@@ -350,6 +392,13 @@ export function UnifiedSetupWizard({
         </div>
       ) : null}
 
+      <SetupReadinessPanel
+        status={setupReadinessStatus}
+        loading={setupReadinessLoading}
+        error={setupReadinessError}
+        onRetry={refreshSetupReadinessStatus}
+      />
+
       <div className="rounded-md border border-border bg-bg px-4 py-5 shadow-sm md:px-6">
         {step === "setup_path" ? (
           <SetupPathStep onSelect={handlePathSelect} />
@@ -377,8 +426,8 @@ export function UnifiedSetupWizard({
             savedDefaultProvider={providerSavedDefaultProvider}
             validationState={providerValidationState}
             providerEditRevisions={providerEditRevisions}
-            onSaveProvider={saveProvider}
-            onValidateProvider={validateProvider}
+            onSaveProvider={saveProviderAndRefreshReadiness}
+            onValidateProvider={validateProviderAndRefreshReadiness}
             onSavedProvidersChange={setProviderSavedProviders}
             onSavedPayloadFingerprintsChange={
               setProviderSavedPayloadFingerprints

--- a/apps/packages/ui/src/components/Option/Onboarding/__tests__/FirstChatStep.test.tsx
+++ b/apps/packages/ui/src/components/Option/Onboarding/__tests__/FirstChatStep.test.tsx
@@ -29,6 +29,9 @@ describe("FirstChatStep", () => {
         complete={complete}
         onComplete={onComplete}
         onBack={vi.fn()}
+        onEditProvider={vi.fn()}
+        onSwitchProvider={vi.fn()}
+        onSkip={vi.fn()}
       />,
     );
 
@@ -44,11 +47,13 @@ describe("FirstChatStep", () => {
       status: "failed",
       provider: "openai",
       model: "gpt-4.1-mini",
-      failure_category: "auth",
+      failure_category: "auth_failed",
       message: "Invalid API key",
     });
     const complete = vi.fn();
-    const onBack = vi.fn();
+    const onEditProvider = vi.fn();
+    const onSwitchProvider = vi.fn();
+    const onSkip = vi.fn();
 
     render(
       <FirstChatStep
@@ -57,19 +62,318 @@ describe("FirstChatStep", () => {
         verifyFirstChat={verifyFirstChat}
         complete={complete}
         onComplete={vi.fn()}
-        onBack={onBack}
+        onBack={vi.fn()}
+        onEditProvider={onEditProvider}
+        onSwitchProvider={onSwitchProvider}
+        onSkip={onSkip}
       />,
     );
 
     fireEvent.click(screen.getByRole("button", { name: /send test chat/i }));
 
     await screen.findByText(/invalid api key/i);
+    expect(
+      screen.getByText(/update the provider credentials/i),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/or switch to another provider/i),
+    ).toBeInTheDocument();
     expect(complete).not.toHaveBeenCalled();
-    fireEvent.click(screen.getByRole("button", { name: /back to providers/i }));
-    expect(onBack).toHaveBeenCalled();
+    fireEvent.click(screen.getByRole("button", { name: /edit provider/i }));
+    fireEvent.click(screen.getByRole("button", { name: /switch provider/i }));
+    fireEvent.click(screen.getByRole("button", { name: /skip setup/i }));
+    expect(onEditProvider).toHaveBeenCalled();
+    expect(onSwitchProvider).toHaveBeenCalled();
+    expect(onSkip).toHaveBeenCalled();
   });
 
-  it("reports setup completion errors separately from first chat verification", async () => {
+  it.each(["auth", "authentication_failed", "provider_api_key_invalid"])(
+    "preserves auth recovery copy for %s first chat failure aliases",
+    async (failureCategory) => {
+      const verifyFirstChat = vi.fn().mockResolvedValue({
+        status: "failed",
+        provider: "openai",
+        model: "gpt-4.1-mini",
+        failure_category: failureCategory,
+        message: "Invalid API key",
+      });
+
+      render(
+        <FirstChatStep
+          provider="openai"
+          model="gpt-4.1-mini"
+          verifyFirstChat={verifyFirstChat}
+          complete={vi.fn()}
+          onComplete={vi.fn()}
+          onBack={vi.fn()}
+          onEditProvider={vi.fn()}
+          onSwitchProvider={vi.fn()}
+          onSkip={vi.fn()}
+        />,
+      );
+
+      fireEvent.click(screen.getByRole("button", { name: /send test chat/i }));
+
+      await screen.findByText(/invalid api key/i);
+      expect(screen.getByRole("alert")).toHaveTextContent(
+        /credentials need attention/i,
+      );
+      expect(screen.getByRole("alert")).toHaveTextContent(
+        /update the provider credentials/i,
+      );
+      expect(
+        screen.getByRole("button", { name: /edit provider/i }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: /switch provider/i }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: /skip setup/i }),
+      ).toBeInTheDocument();
+    },
+  );
+
+  it("shows endpoint recovery when the first chat endpoint is unreachable", async () => {
+    const verifyFirstChat = vi.fn().mockResolvedValue({
+      status: "failed",
+      provider: "ollama",
+      model: "llama3.1",
+      failure_category: "local_provider_unreachable",
+      message: "Connection refused",
+    });
+    const onCheckEndpoint = vi.fn();
+
+    render(
+      <FirstChatStep
+        provider="ollama"
+        model="llama3.1"
+        verifyFirstChat={verifyFirstChat}
+        complete={vi.fn()}
+        onComplete={vi.fn()}
+        onBack={vi.fn()}
+        onEditProvider={vi.fn()}
+        onSwitchProvider={vi.fn()}
+        onSkip={vi.fn()}
+        onCheckEndpoint={onCheckEndpoint}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /send test chat/i }));
+
+    await screen.findByText(/connection refused/i);
+    expect(
+      screen.getByText(/check the local endpoint URL and API compatibility/i),
+    ).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: /check endpoint/i }));
+    expect(onCheckEndpoint).toHaveBeenCalled();
+  });
+
+  it.each([
+    {
+      failureCategory: "rate_limited",
+      message: "The provider rate limit was reached.",
+      expectedCopy: /provider limit reached/i,
+      expectedCategory: /category: quota_or_rate_limit/i,
+    },
+    {
+      failureCategory: "network_error",
+      message: "The provider could not be reached.",
+      expectedCopy: /endpoint could not be reached/i,
+      expectedCategory: /category: endpoint_unreachable/i,
+    },
+    {
+      failureCategory: "provider_error",
+      message: "The provider returned an error.",
+      expectedCopy: /provider returned an error/i,
+      expectedCategory: /category: provider_error/i,
+    },
+    {
+      failureCategory: "configuration_error",
+      message: "Provider configuration is incomplete.",
+      expectedCopy: /provider configuration needs attention/i,
+      expectedCategory: /category: configuration_error/i,
+    },
+    {
+      failureCategory: "empty_response",
+      message: "The provider returned an empty chat response.",
+      expectedCopy: /provider returned an empty response/i,
+      expectedCategory: /category: empty_response/i,
+    },
+  ])(
+    "maps backend first-chat failure category $failureCategory to recovery copy",
+    async ({ failureCategory, message, expectedCopy, expectedCategory }) => {
+      const verifyFirstChat = vi.fn().mockResolvedValue({
+        status: "failed",
+        provider: "openai",
+        model: "gpt-4.1-mini",
+        failure_category: failureCategory,
+        message,
+      });
+
+      render(
+        <FirstChatStep
+          provider="openai"
+          model="gpt-4.1-mini"
+          verifyFirstChat={verifyFirstChat}
+          complete={vi.fn()}
+          onComplete={vi.fn()}
+          onBack={vi.fn()}
+          onEditProvider={vi.fn()}
+          onSwitchProvider={vi.fn()}
+          onSkip={vi.fn()}
+        />,
+      );
+
+      fireEvent.click(screen.getByRole("button", { name: /send test chat/i }));
+
+      await screen.findByText(message);
+      expect(screen.getByRole("alert")).toHaveTextContent(expectedCopy);
+      expect(screen.getByRole("alert")).toHaveTextContent(expectedCategory);
+    },
+  );
+
+  it("shows endpoint diagnostics for backend request_invalid first-chat failures", async () => {
+    const verifyFirstChat = vi.fn().mockResolvedValue({
+      status: "failed",
+      provider: "openai_compatible",
+      model: "local-model",
+      failure_category: "request_invalid",
+      message: "The provider rejected the first-chat request.",
+    });
+    const onCheckEndpoint = vi.fn();
+
+    render(
+      <FirstChatStep
+        provider="openai_compatible"
+        model="local-model"
+        verifyFirstChat={verifyFirstChat}
+        complete={vi.fn()}
+        onComplete={vi.fn()}
+        onBack={vi.fn()}
+        onEditProvider={vi.fn()}
+        onSwitchProvider={vi.fn()}
+        onSkip={vi.fn()}
+        onCheckEndpoint={onCheckEndpoint}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /send test chat/i }));
+
+    await screen.findByText(/the provider rejected the first-chat request/i);
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      /endpoint API shape is unsupported/i,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /check endpoint/i }));
+    expect(onCheckEndpoint).toHaveBeenCalled();
+  });
+
+  it("keeps the failed attempt visible while retrying until the new result arrives", async () => {
+    let resolveRetry!: (value: {
+      status: string;
+      provider: string;
+      model: string;
+      response_text: string;
+    }) => void;
+    const retryPromise = new Promise<{
+      status: string;
+      provider: string;
+      model: string;
+      response_text: string;
+    }>((resolve) => {
+      resolveRetry = resolve;
+    });
+    const verifyFirstChat = vi
+      .fn()
+      .mockResolvedValueOnce({
+        status: "failed",
+        provider: "openai",
+        model: "gpt-4.1-mini",
+        failure_category: "auth",
+        message: "Invalid API key",
+      })
+      .mockReturnValueOnce(retryPromise);
+
+    render(
+      <FirstChatStep
+        provider="openai"
+        model="gpt-4.1-mini"
+        verifyFirstChat={verifyFirstChat}
+        complete={vi.fn().mockResolvedValue({
+          success: true,
+          message: "completed",
+          requires_restart: false,
+          install_plan_submitted: false,
+        })}
+        onComplete={vi.fn()}
+        onBack={vi.fn()}
+        onEditProvider={vi.fn()}
+        onSwitchProvider={vi.fn()}
+        onSkip={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /send test chat/i }));
+    await screen.findByText(/invalid api key/i);
+
+    fireEvent.click(screen.getByRole("button", { name: /retry/i }));
+
+    expect(verifyFirstChat).toHaveBeenCalledTimes(2);
+    expect(screen.getByText(/invalid api key/i)).toBeInTheDocument();
+
+    resolveRetry({
+      status: "ready",
+      provider: "openai",
+      model: "gpt-4.1-mini",
+      response_text: "Hello again.",
+    });
+    await screen.findByText("Hello again.");
+    expect(screen.queryByText(/invalid api key/i)).not.toBeInTheDocument();
+  });
+
+  it("does not keep stale categorized copy when retry throws before a response", async () => {
+    const verifyFirstChat = vi
+      .fn()
+      .mockResolvedValueOnce({
+        status: "failed",
+        provider: "openai",
+        model: "gpt-4.1-mini",
+        failure_category: "auth_failed",
+        message: "Invalid API key",
+      })
+      .mockRejectedValueOnce(new Error("Network request failed before response"));
+
+    render(
+      <FirstChatStep
+        provider="openai"
+        model="gpt-4.1-mini"
+        verifyFirstChat={verifyFirstChat}
+        complete={vi.fn()}
+        onComplete={vi.fn()}
+        onBack={vi.fn()}
+        onEditProvider={vi.fn()}
+        onSwitchProvider={vi.fn()}
+        onSkip={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /send test chat/i }));
+    await screen.findByText(/invalid api key/i);
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      /credentials need attention/i,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /retry/i }));
+
+    await screen.findByText(/network request failed before response/i);
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      /first chat did not complete/i,
+    );
+    expect(screen.getByRole("alert")).not.toHaveTextContent(
+      /credentials need attention/i,
+    );
+  });
+
+  it("reports completion state errors separately from first chat verification", async () => {
     const verifyFirstChat = vi.fn().mockResolvedValue({
       status: "ready",
       provider: "openai",
@@ -89,6 +393,9 @@ describe("FirstChatStep", () => {
         complete={complete}
         onComplete={onComplete}
         onBack={vi.fn()}
+        onEditProvider={vi.fn()}
+        onSwitchProvider={vi.fn()}
+        onSkip={vi.fn()}
       />,
     );
 
@@ -96,7 +403,7 @@ describe("FirstChatStep", () => {
 
     await screen.findByText("Hello.");
     expect(await screen.findByRole("alert")).toHaveTextContent(
-      /setup completion failed/i,
+      /setup state could not be completed/i,
     );
     expect(screen.getByRole("alert")).not.toHaveTextContent(
       /first chat failed/i,

--- a/apps/packages/ui/src/components/Option/Onboarding/__tests__/FirstChatStep.test.tsx
+++ b/apps/packages/ui/src/components/Option/Onboarding/__tests__/FirstChatStep.test.tsx
@@ -267,7 +267,7 @@ describe("FirstChatStep", () => {
     expect(onCheckEndpoint).toHaveBeenCalled();
   });
 
-  it("keeps the failed attempt visible while retrying until the new result arrives", async () => {
+  it("clears stale failed attempt details while retrying", async () => {
     let resolveRetry!: (value: {
       status: string;
       provider: string;
@@ -318,7 +318,10 @@ describe("FirstChatStep", () => {
     fireEvent.click(screen.getByRole("button", { name: /retry/i }));
 
     expect(verifyFirstChat).toHaveBeenCalledTimes(2);
-    expect(screen.getByText(/invalid api key/i)).toBeInTheDocument();
+    expect(screen.queryByText(/invalid api key/i)).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(/credentials need attention/i),
+    ).not.toBeInTheDocument();
 
     resolveRetry({
       status: "ready",

--- a/apps/packages/ui/src/components/Option/Onboarding/__tests__/FirstSourceMilestonePrompt.test.tsx
+++ b/apps/packages/ui/src/components/Option/Onboarding/__tests__/FirstSourceMilestonePrompt.test.tsx
@@ -4,22 +4,129 @@ import { fireEvent, render, screen } from "@testing-library/react"
 import { describe, expect, it, vi } from "vitest"
 
 describe("FirstSourceMilestonePrompt", () => {
-  it("offers adding a first source immediately after onboarding completion", async () => {
+  it("defaults to Web URL and adds that source kind", async () => {
     const onAddSource = vi.fn()
     const { FirstSourceMilestonePrompt } = await import(
       "../FirstSourceMilestonePrompt"
     )
 
     render(
-      <FirstSourceMilestonePrompt onAddSource={onAddSource} onDismiss={vi.fn()} />
+      <FirstSourceMilestonePrompt
+        readinessStatus="idle"
+        onAddSource={onAddSource}
+        onDismiss={vi.fn()}
+      />
     )
 
     expect(
       screen.getByRole("heading", { name: /add your first source/i })
     ).toBeInTheDocument()
+    expect(screen.getByRole("radio", { name: /web url/i })).toBeChecked()
     fireEvent.click(screen.getByRole("button", { name: /add source/i }))
 
-    expect(onAddSource).toHaveBeenCalled()
+    expect(onAddSource).toHaveBeenCalledWith("web_url")
+  })
+
+  it("lets users select file upload and paste text source kinds", async () => {
+    const onAddSource = vi.fn()
+    const { FirstSourceMilestonePrompt } = await import(
+      "../FirstSourceMilestonePrompt"
+    )
+
+    render(
+      <FirstSourceMilestonePrompt
+        readinessStatus="idle"
+        onAddSource={onAddSource}
+        onDismiss={vi.fn()}
+      />
+    )
+
+    fireEvent.click(screen.getByRole("radio", { name: /file/i }))
+    fireEvent.click(screen.getByRole("button", { name: /add source/i }))
+    fireEvent.click(screen.getByRole("radio", { name: /paste/i }))
+    fireEvent.click(screen.getByRole("button", { name: /add source/i }))
+
+    expect(onAddSource).toHaveBeenNthCalledWith(1, "file_upload")
+    expect(onAddSource).toHaveBeenNthCalledWith(2, "paste_text")
+  })
+
+  it("shows processing state without the picker", async () => {
+    const { FirstSourceMilestonePrompt } = await import(
+      "../FirstSourceMilestonePrompt"
+    )
+
+    render(
+      <FirstSourceMilestonePrompt
+        readinessStatus="processing"
+        onAddSource={vi.fn()}
+        onDismiss={vi.fn()}
+      />
+    )
+
+    expect(screen.getByText(/processing your source/i)).toBeInTheDocument()
+    expect(screen.queryByRole("radio", { name: /web url/i })).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole("button", { name: /add source/i })
+    ).not.toBeInTheDocument()
+  })
+
+  it("shows retry action after ingest errors", async () => {
+    const onRetry = vi.fn()
+    const { FirstSourceMilestonePrompt } = await import(
+      "../FirstSourceMilestonePrompt"
+    )
+
+    render(
+      <FirstSourceMilestonePrompt
+        readinessStatus="error"
+        errorMessage="Upload failed"
+        onAddSource={vi.fn()}
+        onRetry={onRetry}
+        onDismiss={vi.fn()}
+      />
+    )
+
+    expect(screen.getByText(/upload failed/i)).toBeInTheDocument()
+    fireEvent.click(screen.getByRole("button", { name: /retry/i }))
+
+    expect(onRetry).toHaveBeenCalled()
+  })
+
+  it("shows grounded chat action only when a ready source handler is provided", async () => {
+    const onAskAboutSource = vi.fn()
+    const { FirstSourceMilestonePrompt } = await import(
+      "../FirstSourceMilestonePrompt"
+    )
+
+    const { rerender } = render(
+      <FirstSourceMilestonePrompt
+        readinessStatus="ready"
+        lastSourceLabel="Example article"
+        onAddSource={vi.fn()}
+        onDismiss={vi.fn()}
+      />
+    )
+
+    expect(
+      screen.queryByRole("button", { name: /ask a question about this source/i })
+    ).not.toBeInTheDocument()
+
+    rerender(
+      <FirstSourceMilestonePrompt
+        readinessStatus="ready"
+        lastSourceLabel="Example article"
+        onAddSource={vi.fn()}
+        onAskAboutSource={onAskAboutSource}
+        onDismiss={vi.fn()}
+      />
+    )
+
+    expect(screen.getByText(/example article/i)).toBeInTheDocument()
+    fireEvent.click(
+      screen.getByRole("button", { name: /ask a question about this source/i })
+    )
+
+    expect(onAskAboutSource).toHaveBeenCalled()
   })
 
   it("lets users dismiss the post-onboarding source milestone", async () => {
@@ -29,7 +136,11 @@ describe("FirstSourceMilestonePrompt", () => {
     )
 
     render(
-      <FirstSourceMilestonePrompt onAddSource={vi.fn()} onDismiss={onDismiss} />
+      <FirstSourceMilestonePrompt
+        readinessStatus="idle"
+        onAddSource={vi.fn()}
+        onDismiss={onDismiss}
+      />
     )
 
     fireEvent.click(screen.getByRole("button", { name: /dismiss/i }))

--- a/apps/packages/ui/src/components/Option/Onboarding/__tests__/FirstSourceMilestonePrompt.test.tsx
+++ b/apps/packages/ui/src/components/Option/Onboarding/__tests__/FirstSourceMilestonePrompt.test.tsx
@@ -92,6 +92,51 @@ describe("FirstSourceMilestonePrompt", () => {
     expect(onRetry).toHaveBeenCalled()
   })
 
+  it("does not offer a hidden add-source action in error copy", async () => {
+    const { FirstSourceMilestonePrompt } = await import(
+      "../FirstSourceMilestonePrompt"
+    )
+
+    render(
+      <FirstSourceMilestonePrompt
+        readinessStatus="error"
+        onAddSource={vi.fn()}
+        onRetry={vi.fn()}
+        onDismiss={vi.fn()}
+      />
+    )
+
+    expect(screen.getByText(/source ingest did not finish/i)).toHaveTextContent(
+      /retry/i
+    )
+    expect(screen.getByText(/source ingest did not finish/i)).not.toHaveTextContent(
+      /add a different source/i
+    )
+    expect(
+      screen.queryByRole("button", { name: /add source/i })
+    ).not.toBeInTheDocument()
+  })
+
+  it("exposes a focus-visible ring on source kind cards", async () => {
+    const { FirstSourceMilestonePrompt } = await import(
+      "../FirstSourceMilestonePrompt"
+    )
+
+    render(
+      <FirstSourceMilestonePrompt
+        readinessStatus="idle"
+        onAddSource={vi.fn()}
+        onDismiss={vi.fn()}
+      />
+    )
+
+    const pasteCard = screen
+      .getByRole("radio", { name: /paste/i })
+      .closest("label")
+
+    expect(pasteCard?.className).toContain("focus-within:ring-2")
+  })
+
   it("shows grounded chat action only when a ready source handler is provided", async () => {
     const onAskAboutSource = vi.fn()
     const { FirstSourceMilestonePrompt } = await import(

--- a/apps/packages/ui/src/components/Option/Onboarding/__tests__/ProviderSetupStep.test.tsx
+++ b/apps/packages/ui/src/components/Option/Onboarding/__tests__/ProviderSetupStep.test.tsx
@@ -4,6 +4,93 @@ import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 
 import { ProviderSetupStep } from "../steps/ProviderSetupStep";
+import type {
+  SetupProviderCatalogEntry,
+  SetupProviderSaveRequest,
+} from "@/types/setup-onboarding";
+import type { ProviderSelection } from "../steps/ProviderSetupStep";
+
+const providers: SetupProviderCatalogEntry[] = [
+  {
+    provider_key: "openai",
+    label: "OpenAI",
+    provider_type: "hosted_api_key",
+    supports_preflight: true,
+    recommended_for_first_chat: true,
+  },
+  {
+    provider_key: "ollama",
+    label: "Ollama",
+    provider_type: "local_endpoint",
+    default_base_url: "http://127.0.0.1:11434/v1",
+    supports_preflight: true,
+    recommended_for_first_chat: false,
+  },
+];
+
+const fillDefaultOpenAI = () => {
+  fireEvent.click(screen.getByLabelText(/openai/i));
+  fireEvent.change(screen.getByLabelText(/openai api key/i), {
+    target: { value: "test-api-key-value" },
+  });
+  fireEvent.change(screen.getByLabelText(/default model/i), {
+    target: { value: "gpt-4.1-mini" },
+  });
+};
+
+const deferred = <T,>() => {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((promiseResolve, promiseReject) => {
+    resolve = promiseResolve;
+    reject = promiseReject;
+  });
+
+  return { promise, reject, resolve };
+};
+
+const renderProviderStep = ({
+  onSaveProvider = vi.fn().mockImplementation(async (payload) => ({
+    provider_key: payload.provider_key,
+    status: "saved",
+    masked_api_key: payload.provider_key === "openai" ? "saved-key-present" : null,
+    model: payload.model,
+    make_default: payload.make_default,
+  })),
+  onValidateProvider = vi.fn().mockImplementation(async (payload) => ({
+    provider_key: payload.provider_key,
+    status: "accepted",
+    message: "Provider credentials passed local syntax checks.",
+    models: [],
+    validation_level: "local_syntax",
+    can_gate_first_chat: true,
+  })),
+  onContinue = vi.fn(),
+  providerCatalog = providers,
+  initialSelection = null,
+}: {
+  onSaveProvider?: (payload: SetupProviderSaveRequest) => Promise<any>;
+  onValidateProvider?: (payload: SetupProviderSaveRequest) => Promise<any>;
+  onContinue?: (selection: {
+    provider: string;
+    model: string;
+    credential_configured?: boolean;
+  }) => void;
+  providerCatalog?: SetupProviderCatalogEntry[];
+  initialSelection?: ProviderSelection | null;
+} = {}) => {
+  render(
+    <ProviderSetupStep
+      providers={providerCatalog}
+      initialSelection={initialSelection}
+      onSaveProvider={onSaveProvider}
+      onValidateProvider={onValidateProvider}
+      onContinue={onContinue}
+    />,
+  );
+
+  return { onSaveProvider, onValidateProvider, onContinue };
+};
 
 describe("ProviderSetupStep", () => {
   it("lets users select multiple providers and saves every configured provider", async () => {
@@ -11,38 +98,26 @@ describe("ProviderSetupStep", () => {
       provider_key: payload.provider_key,
       status: "saved",
       masked_api_key:
-        payload.provider_key === "openai" ? "sk-...test" : undefined,
+        payload.provider_key === "openai" ? "saved-key-present" : undefined,
     }));
     const onContinue = vi.fn();
 
-    render(
-      <ProviderSetupStep
-        providers={[
-          {
-            provider_key: "openai",
-            label: "OpenAI",
-            provider_type: "hosted_api_key",
-            supports_preflight: true,
-            recommended_for_first_chat: true,
-          },
-          {
-            provider_key: "ollama",
-            label: "Ollama",
-            provider_type: "local_endpoint",
-            default_base_url: "http://127.0.0.1:11434/v1",
-            supports_preflight: true,
-            recommended_for_first_chat: false,
-          },
-        ]}
-        onSaveProvider={saveProvider}
-        onContinue={onContinue}
-      />,
-    );
+    renderProviderStep({
+      onSaveProvider: saveProvider,
+      onValidateProvider: vi.fn().mockResolvedValue({
+        provider_key: "openai",
+        status: "accepted",
+        models: [],
+        validation_level: "local_syntax",
+        can_gate_first_chat: true,
+      }),
+      onContinue,
+    });
 
     fireEvent.click(screen.getByLabelText(/openai/i));
     fireEvent.click(screen.getByLabelText(/ollama/i));
     fireEvent.change(screen.getByLabelText(/openai api key/i), {
-      target: { value: "sk-test" },
+      target: { value: "test-api-key-value" },
     });
     fireEvent.change(screen.getByLabelText(/ollama base url/i), {
       target: { value: "http://127.0.0.1:11434/v1" },
@@ -50,13 +125,15 @@ describe("ProviderSetupStep", () => {
     fireEvent.change(screen.getByLabelText(/default model/i), {
       target: { value: "gpt-4.1-mini" },
     });
+    fireEvent.click(screen.getByRole("button", { name: /validate openai/i }));
+    await screen.findByText(/first chat verifies/i);
     fireEvent.click(screen.getByRole("button", { name: /save provider/i }));
 
     await waitFor(() =>
       expect(saveProvider).toHaveBeenCalledWith(
         expect.objectContaining({
           provider_key: "openai",
-          api_key: "sk-test",
+          api_key: "test-api-key-value",
           model: "gpt-4.1-mini",
           make_default: true,
         }),
@@ -69,12 +146,13 @@ describe("ProviderSetupStep", () => {
         make_default: false,
       }),
     );
-    expect(screen.getByText(/saved as sk-\.\.\.test/i)).toBeInTheDocument();
+    expect(screen.getByText(/saved as saved-key-present/i)).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole("button", { name: /continue/i }));
     expect(onContinue).toHaveBeenCalledWith({
       provider: "openai",
       model: "gpt-4.1-mini",
+      credential_configured: true,
     });
   });
 
@@ -92,11 +170,566 @@ describe("ProviderSetupStep", () => {
         ]}
         initialSelection={{ provider: "openai", model: "gpt-4.1-mini" }}
         onSaveProvider={vi.fn()}
+        onValidateProvider={vi.fn()}
         onContinue={vi.fn()}
       />,
     );
 
     expect(screen.getByLabelText(/select openai/i)).toBeChecked();
     expect(screen.getByLabelText(/default model/i)).toHaveValue("gpt-4.1-mini");
+  });
+
+  it("keeps continue disabled until the default provider is validated and saved", async () => {
+    const { onContinue } = renderProviderStep();
+
+    fillDefaultOpenAI();
+    expect(screen.getByRole("button", { name: /continue/i })).toBeDisabled();
+
+    fireEvent.click(screen.getByRole("button", { name: /validate openai/i }));
+    await screen.findByText(/first chat verifies/i);
+    expect(screen.getByRole("button", { name: /continue/i })).toBeDisabled();
+
+    fireEvent.click(screen.getByRole("button", { name: /save provider/i }));
+    await screen.findByText(/saved as saved-key-present/i);
+
+    expect(screen.getByRole("button", { name: /continue/i })).toBeEnabled();
+    fireEvent.click(screen.getByRole("button", { name: /continue/i }));
+    expect(onContinue).toHaveBeenCalledWith({
+      provider: "openai",
+      model: "gpt-4.1-mini",
+      credential_configured: true,
+    });
+  });
+
+  it("requires re-saving a reselected default provider after another default was saved", async () => {
+    renderProviderStep({
+      onSaveProvider: vi.fn().mockImplementation(async (payload) => ({
+        provider_key: payload.provider_key,
+        status: "saved",
+        masked_api_key:
+          payload.provider_key === "openai" ? "saved-key-present" : null,
+        base_url: payload.base_url,
+        model: payload.model,
+        make_default: payload.make_default,
+      })),
+      onValidateProvider: vi.fn().mockImplementation(async (payload) => ({
+        provider_key: payload.provider_key,
+        status: payload.provider_key === "ollama" ? "ready" : "accepted",
+        message:
+          payload.provider_key === "ollama"
+            ? "Provider validation is ready."
+            : "Format accepted; first chat verifies the provider.",
+        models: [],
+        validation_level:
+          payload.provider_key === "ollama"
+            ? "live_non_generative"
+            : "local_syntax",
+        can_gate_first_chat: true,
+      })),
+    });
+
+    fillDefaultOpenAI();
+    fireEvent.click(screen.getByRole("button", { name: /validate openai/i }));
+    await screen.findByText(/first chat verifies/i);
+    fireEvent.click(screen.getByRole("button", { name: /save provider/i }));
+    await screen.findByText(/saved as saved-key-present/i);
+    expect(screen.getByRole("button", { name: /continue/i })).toBeEnabled();
+
+    fireEvent.click(screen.getByLabelText(/ollama/i));
+    fireEvent.click(screen.getByLabelText(/select openai/i));
+    fireEvent.change(screen.getByLabelText(/ollama base url/i), {
+      target: { value: "http://127.0.0.1:11434/v1" },
+    });
+    fireEvent.change(screen.getByLabelText(/default model/i), {
+      target: { value: "llama3.1" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /validate ollama/i }));
+    await screen.findByText(/provider validation is ready/i);
+    fireEvent.click(screen.getByRole("button", { name: /save provider/i }));
+    await screen.findByText(/^Saved$/i);
+
+    expect(screen.getByRole("button", { name: /continue/i })).toBeEnabled();
+
+    fireEvent.click(screen.getByLabelText(/openai/i));
+    fireEvent.click(screen.getAllByLabelText(/use as first chat default/i)[0]);
+
+    expect(screen.getByRole("button", { name: /continue/i })).toBeDisabled();
+
+    fireEvent.click(screen.getByRole("button", { name: /save provider/i }));
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: /continue/i })).toBeEnabled(),
+    );
+  });
+
+  it("keeps validation valid after save clears the raw key and shows the masked key", async () => {
+    renderProviderStep();
+
+    fillDefaultOpenAI();
+    fireEvent.click(screen.getByRole("button", { name: /validate openai/i }));
+    await screen.findByText(/first chat verifies/i);
+    fireEvent.click(screen.getByRole("button", { name: /save provider/i }));
+
+    await screen.findByText(/saved as saved-key-present/i);
+    expect(screen.getByLabelText(/openai api key/i)).toHaveValue("");
+    expect(screen.getByRole("button", { name: /continue/i })).toBeEnabled();
+  });
+
+  it("allows accepted validation to satisfy the gate with first-chat-verifies copy", async () => {
+    renderProviderStep({
+      onValidateProvider: vi.fn().mockResolvedValue({
+        provider_key: "openai",
+        status: "accepted",
+        message: "Format accepted; first chat verifies the provider.",
+        models: [],
+        validation_level: "local_syntax",
+        can_gate_first_chat: true,
+      }),
+    });
+
+    fillDefaultOpenAI();
+    fireEvent.click(screen.getByRole("button", { name: /validate openai/i }));
+
+    expect(
+      await screen.findByText(/format accepted; first chat verifies/i),
+    ).toBeInTheDocument();
+  });
+
+  it("keeps continue disabled and shows categorized failure messages", async () => {
+    renderProviderStep({
+      onValidateProvider: vi.fn().mockResolvedValue({
+        provider_key: "openai",
+        status: "failed",
+        failure_category: "auth_failed",
+        message: "Local provider rejected the supplied credentials.",
+        models: [],
+        can_gate_first_chat: false,
+      }),
+    });
+
+    fillDefaultOpenAI();
+    fireEvent.click(screen.getByRole("button", { name: /validate openai/i }));
+
+    expect(await screen.findByText(/auth_failed/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(/rejected the supplied credentials/i),
+    ).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: /save provider/i }));
+    await screen.findByText(/saved as saved-key-present/i);
+    expect(screen.getByRole("button", { name: /continue/i })).toBeDisabled();
+  });
+
+  it("does not gate failed validation even when can_gate_first_chat is true", async () => {
+    renderProviderStep({
+      onValidateProvider: vi.fn().mockResolvedValue({
+        provider_key: "openai",
+        status: "failed",
+        failure_category: "auth_failed",
+        message: "Provider validation failed.",
+        models: [],
+        can_gate_first_chat: true,
+      }),
+    });
+
+    fillDefaultOpenAI();
+    fireEvent.click(screen.getByRole("button", { name: /validate openai/i }));
+    await screen.findByText(/auth_failed/i);
+    fireEvent.click(screen.getByRole("button", { name: /save provider/i }));
+    await screen.findByText(/saved as saved-key-present/i);
+
+    expect(screen.getByRole("button", { name: /continue/i })).toBeDisabled();
+  });
+
+  it("saves non-default selected providers without validating them", async () => {
+    const onValidateProvider = vi.fn().mockResolvedValue({
+      provider_key: "openai",
+      status: "accepted",
+      models: [],
+      validation_level: "local_syntax",
+      can_gate_first_chat: true,
+    });
+    const onSaveProvider = vi.fn().mockImplementation(async (payload) => ({
+      provider_key: payload.provider_key,
+      status: "saved",
+      masked_api_key: payload.provider_key === "openai" ? "saved-key-present" : null,
+      model: payload.model,
+      make_default: payload.make_default,
+    }));
+    renderProviderStep({ onSaveProvider, onValidateProvider });
+
+    fillDefaultOpenAI();
+    fireEvent.click(screen.getByLabelText(/ollama/i));
+    fireEvent.change(screen.getByLabelText(/ollama base url/i), {
+      target: { value: "http://127.0.0.1:11434/v1" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /validate openai/i }));
+    await screen.findByText(/first chat verifies/i);
+    fireEvent.click(screen.getByRole("button", { name: /save provider/i }));
+
+    await waitFor(() => expect(onSaveProvider).toHaveBeenCalledTimes(2));
+    expect(onValidateProvider).toHaveBeenCalledTimes(1);
+    expect(onValidateProvider).toHaveBeenCalledWith(
+      expect.objectContaining({ provider_key: "openai" }),
+    );
+  });
+
+  it("preserves concurrent validation results for multiple providers", async () => {
+    const openaiValidation = deferred<any>();
+    const ollamaValidation = deferred<any>();
+    const onValidateProvider = vi.fn((payload: SetupProviderSaveRequest) => {
+      if (payload.provider_key === "openai") {
+        return openaiValidation.promise;
+      }
+      if (payload.provider_key === "ollama") {
+        return ollamaValidation.promise;
+      }
+      throw new Error(`Unexpected provider ${payload.provider_key}`);
+    });
+    renderProviderStep({ onValidateProvider });
+
+    fillDefaultOpenAI();
+    fireEvent.click(screen.getByLabelText(/ollama/i));
+    fireEvent.change(screen.getByLabelText(/ollama base url/i), {
+      target: { value: "http://127.0.0.1:11434/v1" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /validate openai/i }));
+    await waitFor(() =>
+      expect(screen.getByText(/validating openai/i)).toBeInTheDocument(),
+    );
+    fireEvent.click(screen.getByRole("button", { name: /validate ollama/i }));
+    await waitFor(() => expect(onValidateProvider).toHaveBeenCalledTimes(2));
+
+    ollamaValidation.resolve({
+      provider_key: "ollama",
+      status: "ready",
+      message: "Ollama validation is ready.",
+      models: [],
+      validation_level: "live_non_generative",
+      can_gate_first_chat: true,
+    });
+    await screen.findByText(/ollama validation is ready/i);
+
+    openaiValidation.resolve({
+      provider_key: "openai",
+      status: "accepted",
+      message: "OpenAI format accepted; first chat verifies this provider.",
+      models: [],
+      validation_level: "local_syntax",
+      can_gate_first_chat: true,
+    });
+
+    expect(
+      await screen.findByText(/openai format accepted/i),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/ollama validation is ready/i)).toBeInTheDocument();
+  });
+
+  it("shows discovered models while keeping manual model entry available", async () => {
+    renderProviderStep({
+      onValidateProvider: vi.fn().mockResolvedValue({
+        provider_key: "ollama",
+        status: "ready",
+        message: "Local provider models were discovered.",
+        models: ["llama3.1", "qwen2.5"],
+        validation_level: "live_non_generative",
+        can_gate_first_chat: true,
+      }),
+    });
+
+    fireEvent.click(screen.getByLabelText(/ollama/i));
+    fireEvent.click(screen.getByLabelText(/use as first chat default/i));
+    fireEvent.change(screen.getByLabelText(/default model/i), {
+      target: { value: "manual-local-model" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /validate ollama/i }));
+
+    expect(await screen.findByText("llama3.1")).toBeInTheDocument();
+    expect(screen.getByText("qwen2.5")).toBeInTheDocument();
+    expect(screen.getByLabelText(/default model/i)).toHaveValue(
+      "manual-local-model",
+    );
+  });
+
+  it("uses discovered model selections as real model values", async () => {
+    const onValidateProvider = vi
+      .fn()
+      .mockResolvedValueOnce({
+        provider_key: "ollama",
+        status: "ready",
+        message: "Local provider models were discovered.",
+        models: ["llama3.1", "qwen2.5"],
+        validation_level: "live_non_generative",
+        can_gate_first_chat: true,
+      })
+      .mockResolvedValueOnce({
+        provider_key: "ollama",
+        status: "ready",
+        message: "Provider validation is ready.",
+        models: ["llama3.1", "qwen2.5"],
+        validation_level: "live_non_generative",
+        can_gate_first_chat: true,
+      });
+    const onSaveProvider = vi.fn().mockImplementation(async (payload) => ({
+      provider_key: payload.provider_key,
+      status: "saved",
+      base_url: payload.base_url,
+      model: payload.model,
+      make_default: payload.make_default,
+    }));
+    renderProviderStep({
+      onSaveProvider,
+      onValidateProvider,
+      providerCatalog: [
+        {
+          ...providers[1],
+          model_field: "ollama_model",
+        },
+      ],
+    });
+
+    fireEvent.click(screen.getByLabelText(/ollama/i));
+    fireEvent.change(screen.getByLabelText(/ollama base url/i), {
+      target: { value: "http://127.0.0.1:11434/v1" },
+    });
+    fireEvent.change(screen.getByLabelText(/default model/i), {
+      target: { value: "temporary-discovery-model" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /validate ollama/i }));
+    await screen.findByText("llama3.1");
+
+    fireEvent.click(screen.getByRole("button", { name: "qwen2.5" }));
+    expect(screen.getByRole("button", { name: /continue/i })).toBeDisabled();
+    fireEvent.click(screen.getByRole("button", { name: /validate ollama/i }));
+    await screen.findByText(/provider validation is ready/i);
+    fireEvent.click(screen.getByRole("button", { name: /save provider/i }));
+
+    await waitFor(() =>
+      expect(onSaveProvider).toHaveBeenCalledWith(
+        expect.objectContaining({
+          provider_key: "ollama",
+          model: "qwen2.5",
+        }),
+      ),
+    );
+    expect(onValidateProvider).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        provider_key: "ollama",
+        model: "qwen2.5",
+      }),
+    );
+  });
+
+  it("does not use hosted catalog model field names as default model values", async () => {
+    const onSaveProvider = vi.fn();
+    const onValidateProvider = vi.fn();
+    renderProviderStep({
+      onSaveProvider,
+      onValidateProvider,
+      providerCatalog: [
+        {
+          ...providers[0],
+          model_field: "openai_model",
+        },
+      ],
+    });
+
+    fireEvent.click(screen.getByLabelText(/openai/i));
+    fireEvent.change(screen.getByLabelText(/openai api key/i), {
+      target: { value: "test-api-key-value" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /validate openai/i }));
+
+    expect(onValidateProvider).not.toHaveBeenCalled();
+    expect(onSaveProvider).not.toHaveBeenCalled();
+    expect(
+      screen.getByRole("button", { name: /save provider/i }),
+    ).toBeDisabled();
+    expect(screen.getByRole("button", { name: /continue/i })).toBeDisabled();
+    expect(screen.queryByText("openai_model")).not.toBeInTheDocument();
+  });
+
+  it("does not use local catalog model field names as default model values", async () => {
+    const onSaveProvider = vi.fn();
+    const onValidateProvider = vi.fn();
+    renderProviderStep({
+      onSaveProvider,
+      onValidateProvider,
+      providerCatalog: [
+        {
+          ...providers[1],
+          model_field: "ollama_model",
+        },
+      ],
+    });
+
+    fireEvent.click(screen.getByLabelText(/ollama/i));
+    fireEvent.change(screen.getByLabelText(/ollama base url/i), {
+      target: { value: "http://127.0.0.1:11434/v1" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /validate ollama/i }));
+
+    expect(onValidateProvider).not.toHaveBeenCalled();
+    expect(onSaveProvider).not.toHaveBeenCalled();
+    expect(
+      screen.getByRole("button", { name: /save provider/i }),
+    ).toBeDisabled();
+    expect(screen.getByRole("button", { name: /continue/i })).toBeDisabled();
+    expect(screen.queryByText("ollama_model")).not.toBeInTheDocument();
+  });
+
+  it("invalidates default provider validation when the model changes", async () => {
+    renderProviderStep();
+
+    fillDefaultOpenAI();
+    fireEvent.click(screen.getByRole("button", { name: /validate openai/i }));
+    await screen.findByText(/first chat verifies/i);
+    fireEvent.click(screen.getByRole("button", { name: /save provider/i }));
+    await screen.findByText(/saved as saved-key-present/i);
+    expect(screen.getByRole("button", { name: /continue/i })).toBeEnabled();
+
+    fireEvent.change(screen.getByLabelText(/default model/i), {
+      target: { value: "gpt-4.1" },
+    });
+
+    expect(screen.getByText(/validation changed/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /continue/i })).toBeDisabled();
+  });
+
+  it("invalidates default provider validation when the API key changes after save", async () => {
+    renderProviderStep();
+
+    fillDefaultOpenAI();
+    fireEvent.click(screen.getByRole("button", { name: /validate openai/i }));
+    await screen.findByText(/first chat verifies/i);
+    fireEvent.click(screen.getByRole("button", { name: /save provider/i }));
+    await screen.findByText(/saved as saved-key-present/i);
+    expect(screen.getByLabelText(/openai api key/i)).toHaveValue("");
+    expect(screen.getByRole("button", { name: /continue/i })).toBeEnabled();
+
+    fireEvent.change(screen.getByLabelText(/openai api key/i), {
+      target: { value: "replacement-api-key-value" },
+    });
+
+    expect(screen.getByText(/validation changed/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /continue/i })).toBeDisabled();
+  });
+
+  it("keeps resumed hosted model edits from continuing until the edited payload is saved", async () => {
+    const onSaveProvider = vi.fn().mockImplementation(async (payload) => ({
+      provider_key: payload.provider_key,
+      status: "saved",
+      credential_configured: true,
+      model: payload.model,
+      make_default: payload.make_default,
+    }));
+    const onContinue = vi.fn();
+    renderProviderStep({
+      initialSelection: {
+        provider: "openai",
+        model: "gpt-4.1-mini",
+        credential_configured: true,
+      },
+      onSaveProvider,
+      onContinue,
+    });
+
+    fireEvent.change(screen.getByLabelText(/default model/i), {
+      target: { value: "gpt-4.1" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /validate openai/i }));
+    await screen.findByText(/saved credentials are present/i);
+
+    expect(screen.getByRole("button", { name: /continue/i })).toBeDisabled();
+    expect(onContinue).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole("button", { name: /save provider/i }));
+    await waitFor(() =>
+      expect(onSaveProvider).toHaveBeenCalledWith(
+        expect.objectContaining({
+          provider_key: "openai",
+          api_key: null,
+          model: "gpt-4.1",
+          make_default: true,
+        }),
+      ),
+    );
+
+    expect(screen.getByRole("button", { name: /continue/i })).toBeEnabled();
+    fireEvent.click(screen.getByRole("button", { name: /continue/i }));
+    expect(onContinue).toHaveBeenCalledWith({
+      provider: "openai",
+      model: "gpt-4.1",
+      credential_configured: true,
+    });
+  });
+
+  it("requires saving an API key edit after revalidation before continuing", async () => {
+    const onContinue = vi.fn();
+    renderProviderStep({ onContinue });
+
+    fillDefaultOpenAI();
+    fireEvent.click(screen.getByRole("button", { name: /validate openai/i }));
+    await screen.findByText(/first chat verifies/i);
+    fireEvent.click(screen.getByRole("button", { name: /save provider/i }));
+    await screen.findByText(/saved as saved-key-present/i);
+
+    fireEvent.change(screen.getByLabelText(/openai api key/i), {
+      target: { value: "replacement-api-key-value" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /validate openai/i }));
+    await screen.findByText(/first chat verifies/i);
+
+    expect(screen.getByRole("button", { name: /continue/i })).toBeDisabled();
+
+    fireEvent.click(screen.getByRole("button", { name: /save provider/i }));
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: /continue/i })).toBeEnabled(),
+    );
+    fireEvent.click(screen.getByRole("button", { name: /continue/i }));
+    expect(onContinue).toHaveBeenCalledWith({
+      provider: "openai",
+      model: "gpt-4.1-mini",
+      credential_configured: true,
+    });
+  });
+
+  it("invalidates local default provider validation when the base URL changes", async () => {
+    renderProviderStep({
+      onSaveProvider: vi.fn().mockImplementation(async (payload) => ({
+        provider_key: payload.provider_key,
+        status: "saved",
+        base_url: payload.base_url,
+        model: payload.model,
+        make_default: payload.make_default,
+      })),
+      onValidateProvider: vi.fn().mockResolvedValue({
+        provider_key: "ollama",
+        status: "ready",
+        message: "Provider validation is ready.",
+        models: ["llama3.1"],
+        validation_level: "live_non_generative",
+        can_gate_first_chat: true,
+      }),
+    });
+
+    fireEvent.click(screen.getByLabelText(/ollama/i));
+    fireEvent.click(screen.getByLabelText(/use as first chat default/i));
+    fireEvent.change(screen.getByLabelText(/ollama base url/i), {
+      target: { value: "http://127.0.0.1:11434/v1" },
+    });
+    fireEvent.change(screen.getByLabelText(/default model/i), {
+      target: { value: "llama3.1" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /validate ollama/i }));
+    await screen.findByText(/provider validation is ready/i);
+    fireEvent.click(screen.getByRole("button", { name: /save provider/i }));
+    await screen.findByText(/saved/i);
+    expect(screen.getByRole("button", { name: /continue/i })).toBeEnabled();
+
+    fireEvent.change(screen.getByLabelText(/ollama base url/i), {
+      target: { value: "http://127.0.0.1:11435/v1" },
+    });
+
+    expect(screen.getByText(/validation changed/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /continue/i })).toBeDisabled();
   });
 });

--- a/apps/packages/ui/src/components/Option/Onboarding/__tests__/SetupReadinessPanel.test.tsx
+++ b/apps/packages/ui/src/components/Option/Onboarding/__tests__/SetupReadinessPanel.test.tsx
@@ -96,6 +96,59 @@ describe("SetupReadinessPanel", () => {
     expect(within(speechLane).getByText(/deferrable/i)).toBeInTheDocument();
   });
 
+  it("marks non-ready chat states as blocking first chat", () => {
+    render(
+      <SetupReadinessPanel
+        status={{
+          ...readinessStatus,
+          lanes: [
+            {
+              lane_id: "chat",
+              label: "Chat",
+              status: "not_configured",
+            },
+          ],
+        }}
+      />,
+    );
+
+    const chatLane = screen.getByTestId("setup-readiness-lane-chat");
+
+    expect(within(chatLane).getByText(/blocks first chat/i)).toBeInTheDocument();
+  });
+
+  it("renders duplicate detail messages without React key warnings", () => {
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+
+    render(
+      <SetupReadinessPanel
+        status={{
+          ...readinessStatus,
+          lanes: [
+            {
+              lane_id: "chat",
+              label: "Chat",
+              status: "failed",
+              warnings: [
+                "Retry provider validation.",
+                "Retry provider validation.",
+              ],
+            },
+          ],
+        }}
+      />,
+    );
+
+    expect(
+      consoleError.mock.calls.some((call) =>
+        String(call[0]).includes("Encountered two children with the same key"),
+      ),
+    ).toBe(false);
+    consoleError.mockRestore();
+  });
+
   it("calls retry handler from the retry button", () => {
     const onRetry = vi.fn();
 

--- a/apps/packages/ui/src/components/Option/Onboarding/__tests__/SetupReadinessPanel.test.tsx
+++ b/apps/packages/ui/src/components/Option/Onboarding/__tests__/SetupReadinessPanel.test.tsx
@@ -1,0 +1,134 @@
+// @vitest-environment jsdom
+import React from "react";
+import { fireEvent, render, screen, within } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import type { SetupReadinessStatusResponse } from "@/services/tldw/setup-readiness";
+import { SetupReadinessPanel } from "../SetupReadinessPanel";
+
+const readinessStatus: SetupReadinessStatusResponse = {
+  readiness_status: "ready_with_warnings",
+  lane_ids: ["chat", "embeddings_rag", "speech"],
+  supported_statuses: [],
+  supported_overlays: [],
+  active_overlays: ["restart_required", "downloads_disabled"],
+  overlays: ["network_unavailable"],
+  lanes: [
+    {
+      lane_id: "chat",
+      label: "Chat",
+      status: "ready_with_warnings",
+      warnings: ["Hosted provider key will be verified on first chat."],
+      blockers: [],
+      consequences: [],
+    },
+    {
+      lane_id: "embeddings_rag",
+      label: "Embeddings/RAG",
+      status: "not_configured",
+      warnings: [],
+      blockers: [],
+      consequences: [
+        "RAG search will be limited until embeddings are configured.",
+      ],
+    },
+    {
+      lane_id: "speech",
+      label: "Speech",
+      status: "blocked",
+      warnings: ["Speech bundle needs provisioning."],
+      blockers: ["Package installs are disabled."],
+      consequences: ["Transcription can be configured later."],
+    },
+  ],
+};
+
+describe("SetupReadinessPanel", () => {
+  it("renders backend lane labels and statuses", () => {
+    render(<SetupReadinessPanel status={readinessStatus} />);
+
+    expect(screen.getByText("Chat")).toBeInTheDocument();
+    expect(screen.getByText("Embeddings/RAG")).toBeInTheDocument();
+    expect(screen.getByText("Speech")).toBeInTheDocument();
+    expect(screen.getByText("ready with warnings")).toBeInTheDocument();
+    expect(screen.getByText("not configured")).toBeInTheDocument();
+    expect(screen.getByText("blocked")).toBeInTheDocument();
+  });
+
+  it("shows lane warnings, blockers, and consequences inside compact details", () => {
+    render(<SetupReadinessPanel status={readinessStatus} />);
+
+    const details = screen
+      .getByText(/speech details/i)
+      .closest("details");
+    expect(details).not.toHaveAttribute("open");
+
+    fireEvent.click(screen.getByText(/speech details/i));
+
+    expect(
+      screen.getByText("Speech bundle needs provisioning."),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("Package installs are disabled."),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("Transcription can be configured later."),
+    ).toBeInTheDocument();
+  });
+
+  it("renders overlays with readable labels", () => {
+    render(<SetupReadinessPanel status={readinessStatus} />);
+
+    expect(screen.getByText("Restart required")).toBeInTheDocument();
+    expect(screen.getByText("Downloads disabled")).toBeInTheDocument();
+    expect(screen.getByText("Network unavailable")).toBeInTheDocument();
+  });
+
+  it("marks embeddings and speech as deferrable when optional lanes are unavailable", () => {
+    render(<SetupReadinessPanel status={readinessStatus} />);
+
+    const embeddingsLane = screen.getByTestId(
+      "setup-readiness-lane-embeddings_rag",
+    );
+    const speechLane = screen.getByTestId("setup-readiness-lane-speech");
+
+    expect(within(embeddingsLane).getByText(/deferrable/i)).toBeInTheDocument();
+    expect(within(speechLane).getByText(/deferrable/i)).toBeInTheDocument();
+  });
+
+  it("calls retry handler from the retry button", () => {
+    const onRetry = vi.fn();
+
+    render(
+      <SetupReadinessPanel
+        status={readinessStatus}
+        error="Setup readiness could not be loaded."
+        onRetry={onRetry}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /retry/i }));
+
+    expect(onRetry).toHaveBeenCalledTimes(1);
+  });
+
+  it("handles loading and error states without a readiness payload", () => {
+    render(
+      <SetupReadinessPanel
+        status={null}
+        loading
+        error="Setup readiness could not be loaded."
+      />,
+    );
+
+    expect(screen.getByText(/checking setup readiness/i)).toBeInTheDocument();
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      /setup readiness could not be loaded/i,
+    );
+  });
+
+  it("does not render an empty panel when readiness is unavailable", () => {
+    const { container } = render(<SetupReadinessPanel status={null} />);
+
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/apps/packages/ui/src/components/Option/Onboarding/__tests__/UnifiedSetupWizard.test.tsx
+++ b/apps/packages/ui/src/components/Option/Onboarding/__tests__/UnifiedSetupWizard.test.tsx
@@ -227,6 +227,27 @@ describe("UnifiedSetupWizard", () => {
     ).toBeInTheDocument();
   });
 
+  it("handles setup readiness retry failures through the guarded refresh wrapper", async () => {
+    const consoleWarn = vi
+      .spyOn(console, "warn")
+      .mockImplementation(() => undefined);
+    readinessHookMocks.refresh.mockRejectedValueOnce(
+      new Error("readiness refresh failed"),
+    );
+    const { UnifiedSetupWizard } = await import("../UnifiedSetupWizard");
+
+    render(<UnifiedSetupWizard />);
+
+    fireEvent.click(screen.getByRole("button", { name: /retry/i }));
+
+    await waitFor(() => {
+      expect(consoleWarn).toHaveBeenCalledWith(
+        "Setup readiness summary could not be refreshed",
+        expect.any(Error),
+      );
+    });
+  });
+
   it("shows multi-user exit guidance instead of continuing solo wizard", async () => {
     const { UnifiedSetupWizard } = await import("../UnifiedSetupWizard");
 

--- a/apps/packages/ui/src/components/Option/Onboarding/__tests__/UnifiedSetupWizard.test.tsx
+++ b/apps/packages/ui/src/components/Option/Onboarding/__tests__/UnifiedSetupWizard.test.tsx
@@ -3,6 +3,8 @@ import React from "react";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import type { FirstRunState } from "@/types/setup-onboarding";
+
 const setupHookMocks = vi.hoisted(() => ({
   saveStep: vi.fn(),
   skip: vi.fn(),
@@ -17,6 +19,38 @@ const setupHookMocks = vi.hoisted(() => ({
   complete: vi.fn(),
   refresh: vi.fn(),
 }));
+
+const readinessHookMocks = vi.hoisted(() => ({
+  refresh: vi.fn(),
+}));
+
+const createDeferred = <T,>() => {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+};
+
+const initialStateForCompletedSteps = (
+  completedSteps: string[],
+): FirstRunState => ({
+  status: "in_progress",
+  completed_steps: completedSteps,
+  skipped_steps: [],
+  step_data: {
+    providers: {
+      acknowledged: true,
+      default_provider: "openai",
+      default_model: "gpt-4.1-mini",
+      default_provider_credential_configured: true,
+    },
+  },
+  acknowledged_steps: [],
+  first_chat: { completed: false },
+});
 
 vi.mock("@/hooks/useSetupOnboarding", () => ({
   useSetupOnboarding: () => ({
@@ -67,6 +101,28 @@ vi.mock("@/hooks/useSetupOnboarding", () => ({
     saveOptionalAdvanced: setupHookMocks.saveOptionalAdvanced,
     verifyFirstChat: setupHookMocks.verifyFirstChat,
     complete: setupHookMocks.complete,
+  }),
+}));
+
+vi.mock("@/hooks/useSetupReadinessSummary", () => ({
+  useSetupReadinessSummary: () => ({
+    status: {
+      readiness_status: "ready_with_warnings",
+      lanes: [
+        { lane_id: "chat", label: "Chat", status: "ready" },
+        {
+          lane_id: "embeddings_rag",
+          label: "Embeddings/RAG",
+          status: "not_configured",
+        },
+        { lane_id: "speech", label: "Speech", status: "skipped" },
+      ],
+      active_overlays: [],
+      overlays: [],
+    },
+    loading: false,
+    error: null,
+    refresh: readinessHookMocks.refresh,
   }),
 }));
 
@@ -138,6 +194,12 @@ describe("UnifiedSetupWizard", () => {
       acknowledged_steps: [],
       first_chat: { completed: false },
     });
+    readinessHookMocks.refresh.mockReset().mockResolvedValue({
+      readiness_status: "ready_with_warnings",
+      lanes: [],
+      active_overlays: [],
+      overlays: [],
+    });
   });
 
   afterEach(() => {
@@ -149,6 +211,8 @@ describe("UnifiedSetupWizard", () => {
 
     render(<UnifiedSetupWizard />);
 
+    expect(screen.getByTestId("setup-readiness-panel")).toBeInTheDocument();
+    expect(screen.getByText("Embeddings/RAG")).toBeInTheDocument();
     expect(
       screen.getByRole("heading", { name: /first-time setup/i }),
     ).toBeInTheDocument();
@@ -363,9 +427,15 @@ describe("UnifiedSetupWizard", () => {
         }),
       );
     });
+    await waitFor(() => {
+      expect(readinessHookMocks.refresh).toHaveBeenCalledTimes(1);
+    });
 
     fireEvent.click(screen.getByRole("button", { name: /save provider/i }));
     await screen.findByText(/saved as saved-key-present/i);
+    await waitFor(() => {
+      expect(readinessHookMocks.refresh).toHaveBeenCalledTimes(2);
+    });
     fireEvent.click(screen.getByRole("button", { name: /continue/i }));
 
     await waitFor(() => {
@@ -379,6 +449,215 @@ describe("UnifiedSetupWizard", () => {
         },
       });
     });
+  });
+
+  it("does not keep provider validation or save pending while readiness refresh is unresolved", async () => {
+    const readinessRefreshes: Array<
+      ReturnType<typeof createDeferred<Record<string, unknown>>>
+    > = [];
+    readinessHookMocks.refresh.mockImplementation(() => {
+      const deferred = createDeferred<Record<string, unknown>>();
+      readinessRefreshes.push(deferred);
+      return deferred.promise;
+    });
+    const { UnifiedSetupWizard } = await import("../UnifiedSetupWizard");
+
+    render(
+      <UnifiedSetupWizard
+        initialState={{
+          status: "in_progress",
+          completed_steps: ["setup_path", "privacy_security"],
+          skipped_steps: [],
+          step_data: {},
+          acknowledged_steps: [],
+          first_chat: { completed: false },
+        }}
+      />,
+    );
+
+    fireEvent.click(screen.getByLabelText(/select openai/i));
+    fireEvent.change(screen.getByLabelText(/openai api key/i), {
+      target: { value: "test-api-key-value" },
+    });
+    fireEvent.change(screen.getByLabelText(/default model/i), {
+      target: { value: "gpt-4.1-mini" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /validate openai/i }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /validate openai/i }))
+        .toBeEnabled();
+    });
+    expect(screen.getByText(/first chat verifies/i)).toBeInTheDocument();
+    expect(readinessRefreshes).toHaveLength(1);
+
+    fireEvent.click(screen.getByRole("button", { name: /save provider/i }));
+
+    await screen.findByText(/saved as saved-key-present/i);
+    expect(screen.getByRole("button", { name: /save provider/i })).toBeEnabled();
+    expect(readinessRefreshes).toHaveLength(2);
+
+    for (const deferred of readinessRefreshes) {
+      deferred.resolve({
+        readiness_status: "ready_with_warnings",
+        lanes: [],
+        active_overlays: [],
+        overlays: [],
+      });
+    }
+  });
+
+  it("refreshes readiness after ingest defaults are saved", async () => {
+    const { UnifiedSetupWizard } = await import("../UnifiedSetupWizard");
+
+    render(
+      <UnifiedSetupWizard
+        initialState={initialStateForCompletedSteps([
+          "setup_path",
+          "privacy_security",
+          "providers",
+        ])}
+      />,
+    );
+
+    expect(
+      screen.getByRole("heading", { name: /ingest defaults/i }),
+    ).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: /continue/i }));
+
+    await waitFor(() => {
+      expect(setupHookMocks.saveIngestDefaults).toHaveBeenCalledWith(
+        expect.objectContaining({
+          allow_local_file_ingest: false,
+          chunking_profile: "balanced",
+          metadata_mode: "automatic",
+        }),
+      );
+    });
+    await waitFor(() => {
+      expect(readinessHookMocks.refresh).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("refreshes readiness after audio defaults are saved", async () => {
+    const { UnifiedSetupWizard } = await import("../UnifiedSetupWizard");
+
+    render(
+      <UnifiedSetupWizard
+        initialState={initialStateForCompletedSteps([
+          "setup_path",
+          "privacy_security",
+          "providers",
+          "ingest_defaults",
+        ])}
+      />,
+    );
+
+    expect(
+      screen.getByRole("heading", { name: /audio, stt, and tts/i }),
+    ).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: /continue/i }));
+
+    await waitFor(() => {
+      expect(setupHookMocks.saveAudioDefaults).toHaveBeenCalledWith(
+        expect.objectContaining({
+          mode: "skip",
+          stt_provider: null,
+          tts_provider: null,
+          tts_voice: null,
+        }),
+      );
+    });
+    await waitFor(() => {
+      expect(readinessHookMocks.refresh).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("refreshes readiness after optional advanced choices are saved", async () => {
+    const { UnifiedSetupWizard } = await import("../UnifiedSetupWizard");
+
+    render(
+      <UnifiedSetupWizard
+        initialState={initialStateForCompletedSteps([
+          "setup_path",
+          "privacy_security",
+          "providers",
+          "ingest_defaults",
+          "audio_defaults",
+        ])}
+      />,
+    );
+
+    expect(
+      screen.getByRole("heading", { name: /optional advanced setup/i }),
+    ).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: /continue/i }));
+
+    await waitFor(() => {
+      expect(setupHookMocks.saveOptionalAdvanced).toHaveBeenCalledWith({
+        rag: "defer",
+        storage_paths: "defer",
+      });
+    });
+    await waitFor(() => {
+      expect(readinessHookMocks.refresh).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("does not refresh readiness after first chat completion", async () => {
+    const { UnifiedSetupWizard } = await import("../UnifiedSetupWizard");
+
+    render(
+      <UnifiedSetupWizard
+        initialState={initialStateForCompletedSteps([
+          "setup_path",
+          "privacy_security",
+          "providers",
+          "ingest_defaults",
+          "audio_defaults",
+          "optional_advanced",
+        ])}
+      />,
+    );
+
+    expect(
+      screen.getByRole("heading", { name: /first chat/i }),
+    ).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: /send test chat/i }));
+
+    await waitFor(() => {
+      expect(setupHookMocks.complete).toHaveBeenCalledWith({
+        acknowledged_steps: ["first_chat"],
+      });
+    });
+    await waitFor(() => {
+      expect(setupHookMocks.refresh).toHaveBeenCalledTimes(2);
+    });
+    expect(readinessHookMocks.refresh).not.toHaveBeenCalled();
+  });
+
+  it("refreshes readiness after a failed skip attempt", async () => {
+    setupHookMocks.skip.mockRejectedValueOnce(new Error("skip failed"));
+    const { UnifiedSetupWizard } = await import("../UnifiedSetupWizard");
+
+    render(<UnifiedSetupWizard />);
+    fireEvent.click(screen.getByRole("button", { name: /skip for now/i }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toHaveTextContent(
+        /setup skip could not be saved/i,
+      );
+    });
+    expect(readinessHookMocks.refresh).toHaveBeenCalledTimes(1);
+  });
+
+  it("wires the panel retry action to readiness refresh", async () => {
+    const { UnifiedSetupWizard } = await import("../UnifiedSetupWizard");
+
+    render(<UnifiedSetupWizard />);
+    fireEvent.click(screen.getByRole("button", { name: /retry/i }));
+
+    expect(readinessHookMocks.refresh).toHaveBeenCalledTimes(1);
   });
 
   it("keeps validated provider gate available after back navigation", async () => {

--- a/apps/packages/ui/src/components/Option/Onboarding/__tests__/UnifiedSetupWizard.test.tsx
+++ b/apps/packages/ui/src/components/Option/Onboarding/__tests__/UnifiedSetupWizard.test.tsx
@@ -9,6 +9,7 @@ const setupHookMocks = vi.hoisted(() => ({
   loadProviderCatalog: vi.fn(),
   loadAudioRecommendations: vi.fn(),
   saveProvider: vi.fn(),
+  validateProvider: vi.fn(),
   saveIngestDefaults: vi.fn(),
   saveAudioDefaults: vi.fn(),
   saveOptionalAdvanced: vi.fn(),
@@ -60,6 +61,7 @@ vi.mock("@/hooks/useSetupOnboarding", () => ({
     saveStep: setupHookMocks.saveStep,
     skip: setupHookMocks.skip,
     saveProvider: setupHookMocks.saveProvider,
+    validateProvider: setupHookMocks.validateProvider,
     saveIngestDefaults: setupHookMocks.saveIngestDefaults,
     saveAudioDefaults: setupHookMocks.saveAudioDefaults,
     saveOptionalAdvanced: setupHookMocks.saveOptionalAdvanced,
@@ -75,9 +77,23 @@ describe("UnifiedSetupWizard", () => {
     setupHookMocks.skip.mockReset();
     setupHookMocks.loadProviderCatalog.mockReset().mockResolvedValue([]);
     setupHookMocks.loadAudioRecommendations.mockReset().mockResolvedValue([]);
-    setupHookMocks.saveProvider.mockReset().mockResolvedValue({
+    setupHookMocks.saveProvider
+      .mockReset()
+      .mockImplementation(async (payload) => ({
+        provider_key: payload.provider_key,
+        status: "saved",
+        masked_api_key: payload.api_key ? "saved-key-present" : null,
+        credential_configured: true,
+        model: payload.model,
+        make_default: payload.make_default,
+      }));
+    setupHookMocks.validateProvider.mockReset().mockResolvedValue({
       provider_key: "openai",
-      status: "saved",
+      status: "accepted",
+      message: "Format accepted; first chat verifies the provider.",
+      models: [],
+      validation_level: "local_syntax",
+      can_gate_first_chat: true,
     });
     setupHookMocks.saveIngestDefaults.mockReset().mockResolvedValue({
       status: "saved",
@@ -296,6 +312,7 @@ describe("UnifiedSetupWizard", () => {
               acknowledged: true,
               default_provider: "openai",
               default_model: "gpt-4.1-mini",
+              default_provider_credential_configured: true,
             },
           },
           acknowledged_steps: [],
@@ -309,6 +326,362 @@ describe("UnifiedSetupWizard", () => {
     ).toBeInTheDocument();
     expect(screen.getByLabelText(/select openai/i)).toBeChecked();
     expect(screen.getByLabelText(/default model/i)).toHaveValue("gpt-4.1-mini");
+  });
+
+  it("validates and saves the default provider before recording provider setup progress", async () => {
+    const { UnifiedSetupWizard } = await import("../UnifiedSetupWizard");
+
+    render(
+      <UnifiedSetupWizard
+        initialState={{
+          status: "in_progress",
+          completed_steps: ["setup_path", "privacy_security"],
+          skipped_steps: [],
+          step_data: {},
+          acknowledged_steps: [],
+          first_chat: { completed: false },
+        }}
+      />,
+    );
+
+    fireEvent.click(screen.getByLabelText(/select openai/i));
+    fireEvent.change(screen.getByLabelText(/openai api key/i), {
+      target: { value: "test-api-key-value" },
+    });
+    fireEvent.change(screen.getByLabelText(/default model/i), {
+      target: { value: "gpt-4.1-mini" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /validate openai/i }));
+
+    await waitFor(() => {
+      expect(setupHookMocks.validateProvider).toHaveBeenCalledWith(
+        expect.objectContaining({
+          provider_key: "openai",
+          api_key: "test-api-key-value",
+          model: "gpt-4.1-mini",
+          make_default: true,
+        }),
+      );
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /save provider/i }));
+    await screen.findByText(/saved as saved-key-present/i);
+    fireEvent.click(screen.getByRole("button", { name: /continue/i }));
+
+    await waitFor(() => {
+      expect(setupHookMocks.saveStep).toHaveBeenCalledWith({
+        step: "providers",
+        data: {
+          acknowledged: true,
+          default_provider: "openai",
+          default_model: "gpt-4.1-mini",
+          default_provider_credential_configured: true,
+        },
+      });
+    });
+  });
+
+  it("keeps validated provider gate available after back navigation", async () => {
+    const { UnifiedSetupWizard } = await import("../UnifiedSetupWizard");
+
+    render(
+      <UnifiedSetupWizard
+        initialState={{
+          status: "in_progress",
+          completed_steps: ["setup_path", "privacy_security"],
+          skipped_steps: [],
+          step_data: {},
+          acknowledged_steps: [],
+          first_chat: { completed: false },
+        }}
+      />,
+    );
+
+    fireEvent.click(screen.getByLabelText(/select openai/i));
+    fireEvent.change(screen.getByLabelText(/openai api key/i), {
+      target: { value: "test-api-key-value" },
+    });
+    fireEvent.change(screen.getByLabelText(/default model/i), {
+      target: { value: "gpt-4.1-mini" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /validate openai/i }));
+    await screen.findByText(/first chat verifies/i);
+    fireEvent.click(screen.getByRole("button", { name: /save provider/i }));
+    await screen.findByText(/saved as saved-key-present/i);
+    fireEvent.click(screen.getByRole("button", { name: /continue/i }));
+
+    expect(
+      await screen.findByRole("heading", { name: /ingest defaults/i }),
+    ).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: /back/i }));
+
+    expect(
+      await screen.findByRole("heading", { name: /chat provider/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByLabelText(/openai api key/i)).toHaveValue("");
+    const validateCallsAfterBack =
+      setupHookMocks.validateProvider.mock.calls.length;
+
+    expect(screen.getByRole("button", { name: /continue/i })).toBeEnabled();
+    fireEvent.click(screen.getByRole("button", { name: /continue/i }));
+
+    expect(
+      await screen.findByRole("heading", { name: /ingest defaults/i }),
+    ).toBeInTheDocument();
+    expect(setupHookMocks.validateProvider).toHaveBeenCalledTimes(
+      validateCallsAfterBack,
+    );
+  });
+
+  it("revalidates saved hosted credentials after a model-only edit without re-pasting the key", async () => {
+    const { UnifiedSetupWizard } = await import("../UnifiedSetupWizard");
+    setupHookMocks.validateProvider.mockImplementation(async (payload) => {
+      if (!payload.api_key) {
+        return {
+          provider_key: "openai",
+          status: "failed",
+          failure_category: "provider_api_key_required",
+          message: "Provider API key is required.",
+          models: [],
+          can_gate_first_chat: false,
+        };
+      }
+      return {
+        provider_key: "openai",
+        status: "accepted",
+        message: "Format accepted; first chat verifies the provider.",
+        models: [],
+        validation_level: "local_syntax",
+        can_gate_first_chat: true,
+      };
+    });
+
+    render(
+      <UnifiedSetupWizard
+        initialState={{
+          status: "in_progress",
+          completed_steps: ["setup_path", "privacy_security"],
+          skipped_steps: [],
+          step_data: {},
+          acknowledged_steps: [],
+          first_chat: { completed: false },
+        }}
+      />,
+    );
+
+    fireEvent.click(screen.getByLabelText(/select openai/i));
+    fireEvent.change(screen.getByLabelText(/openai api key/i), {
+      target: { value: "test-api-key-value" },
+    });
+    fireEvent.change(screen.getByLabelText(/default model/i), {
+      target: { value: "gpt-4.1-mini" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /validate openai/i }));
+    await screen.findByText(/first chat verifies/i);
+    fireEvent.click(screen.getByRole("button", { name: /save provider/i }));
+    await screen.findByText(/saved as saved-key-present/i);
+    fireEvent.click(screen.getByRole("button", { name: /continue/i }));
+    expect(
+      await screen.findByRole("heading", { name: /ingest defaults/i }),
+    ).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /back/i }));
+    expect(
+      await screen.findByRole("heading", { name: /chat provider/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByLabelText(/openai api key/i)).toHaveValue("");
+    fireEvent.change(screen.getByLabelText(/default model/i), {
+      target: { value: "gpt-4.1" },
+    });
+    expect(screen.getByRole("button", { name: /continue/i })).toBeDisabled();
+
+    fireEvent.click(screen.getByRole("button", { name: /validate openai/i }));
+    expect(
+      await screen.findByText(/saved credentials are present/i),
+    ).toBeInTheDocument();
+    expect(setupHookMocks.validateProvider).toHaveBeenCalledTimes(1);
+    expect(setupHookMocks.validateProvider).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        provider_key: "openai",
+        api_key: "test-api-key-value",
+      }),
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /save provider/i }));
+    await waitFor(() => {
+      expect(setupHookMocks.saveProvider).toHaveBeenCalledWith(
+        expect.objectContaining({
+          provider_key: "openai",
+          api_key: null,
+          model: "gpt-4.1",
+          make_default: true,
+        }),
+      );
+    });
+
+    expect(screen.getByRole("button", { name: /continue/i })).toBeEnabled();
+    fireEvent.click(screen.getByRole("button", { name: /continue/i }));
+
+    expect(
+      await screen.findByRole("heading", { name: /ingest defaults/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("resumes first chat and revalidates saved hosted credentials after provider edits", async () => {
+    const { UnifiedSetupWizard } = await import("../UnifiedSetupWizard");
+    setupHookMocks.validateProvider.mockImplementation(async (payload) => {
+      if (!payload.api_key) {
+        return {
+          provider_key: "openai",
+          status: "failed",
+          failure_category: "provider_api_key_required",
+          message: "Provider API key is required.",
+          models: [],
+          can_gate_first_chat: false,
+        };
+      }
+      return {
+        provider_key: "openai",
+        status: "accepted",
+        message: "Format accepted; first chat verifies the provider.",
+        models: [],
+        validation_level: "local_syntax",
+        can_gate_first_chat: true,
+      };
+    });
+
+    render(
+      <UnifiedSetupWizard
+        initialState={{
+          status: "in_progress",
+          completed_steps: [
+            "setup_path",
+            "privacy_security",
+            "providers",
+            "ingest_defaults",
+            "audio_defaults",
+            "optional_advanced",
+          ],
+          skipped_steps: [],
+          step_data: {
+            providers: {
+              acknowledged: true,
+              default_provider: "openai",
+              default_model: "gpt-4.1-mini",
+              default_provider_credential_configured: true,
+            },
+          },
+          acknowledged_steps: [],
+          first_chat: { completed: false },
+        }}
+      />,
+    );
+
+    expect(
+      screen.getByRole("heading", { name: /first chat/i }),
+    ).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: /back to providers/i }));
+    expect(
+      await screen.findByRole("heading", { name: /chat provider/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByLabelText(/openai api key/i)).toHaveValue("");
+    fireEvent.change(screen.getByLabelText(/default model/i), {
+      target: { value: "gpt-4.1" },
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /validate openai/i }));
+    expect(
+      await screen.findByText(/saved credentials are present/i),
+    ).toBeInTheDocument();
+    expect(setupHookMocks.validateProvider).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole("button", { name: /save provider/i }));
+    await waitFor(() => {
+      expect(setupHookMocks.saveProvider).toHaveBeenCalledWith(
+        expect.objectContaining({
+          provider_key: "openai",
+          api_key: null,
+          model: "gpt-4.1",
+          make_default: true,
+        }),
+      );
+    });
+    fireEvent.click(screen.getByRole("button", { name: /continue/i }));
+
+    expect(
+      await screen.findByRole("heading", { name: /ingest defaults/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("does not infer saved hosted credentials when resumed state lacks the marker", async () => {
+    const { UnifiedSetupWizard } = await import("../UnifiedSetupWizard");
+    setupHookMocks.validateProvider.mockImplementation(async (payload) => {
+      if (!payload.api_key) {
+        return {
+          provider_key: "openai",
+          status: "failed",
+          failure_category: "provider_api_key_required",
+          message: "Provider API key is required.",
+          models: [],
+          can_gate_first_chat: false,
+        };
+      }
+      return {
+        provider_key: "openai",
+        status: "accepted",
+        message: "Format accepted; first chat verifies the provider.",
+        models: [],
+        validation_level: "local_syntax",
+        can_gate_first_chat: true,
+      };
+    });
+
+    render(
+      <UnifiedSetupWizard
+        initialState={{
+          status: "in_progress",
+          completed_steps: [
+            "setup_path",
+            "privacy_security",
+            "providers",
+            "ingest_defaults",
+            "audio_defaults",
+            "optional_advanced",
+          ],
+          skipped_steps: [],
+          step_data: {
+            providers: {
+              acknowledged: true,
+              default_provider: "openai",
+              default_model: "gpt-4.1-mini",
+            },
+          },
+          acknowledged_steps: [],
+          first_chat: { completed: false },
+        }}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /back to providers/i }));
+    expect(
+      await screen.findByRole("heading", { name: /chat provider/i }),
+    ).toBeInTheDocument();
+    fireEvent.change(screen.getByLabelText(/default model/i), {
+      target: { value: "gpt-4.1" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /validate openai/i }));
+
+    expect(
+      await screen.findByText(/provider_api_key_required/i),
+    ).toBeInTheDocument();
+    expect(setupHookMocks.validateProvider).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider_key: "openai",
+        api_key: null,
+        model: "gpt-4.1",
+      }),
+    );
+    expect(screen.getByRole("button", { name: /continue/i })).toBeDisabled();
   });
 
   it("shows a non-blocking warning when audio recommendations fail to load", async () => {

--- a/apps/packages/ui/src/components/Option/Onboarding/__tests__/UnifiedSetupWizard.test.tsx
+++ b/apps/packages/ui/src/components/Option/Onboarding/__tests__/UnifiedSetupWizard.test.tsx
@@ -892,6 +892,161 @@ describe("UnifiedSetupWizard", () => {
     ).toBeInTheDocument();
   });
 
+  it("routes first-chat recovery actions through provider setup and skip", async () => {
+    setupHookMocks.verifyFirstChat.mockResolvedValue({
+      status: "failed",
+      provider: "openai",
+      model: "gpt-4.1-mini",
+      failure_category: "auth",
+      message: "Invalid API key",
+    });
+    setupHookMocks.skip.mockResolvedValueOnce({
+      status: "skipped",
+      completed_steps: [],
+      skipped_steps: [],
+      step_data: {},
+      acknowledged_steps: [],
+      first_chat: { completed: false },
+      skip_reason: "user_skip",
+    });
+    const onStateChange = vi.fn();
+    const { UnifiedSetupWizard } = await import("../UnifiedSetupWizard");
+
+    const renderFirstChat = () =>
+      render(
+        <UnifiedSetupWizard
+          initialState={initialStateForCompletedSteps([
+            "setup_path",
+            "privacy_security",
+            "providers",
+            "ingest_defaults",
+            "audio_defaults",
+            "optional_advanced",
+          ])}
+          onStateChange={onStateChange}
+        />,
+      );
+
+    const firstRender = renderFirstChat();
+    fireEvent.click(screen.getByRole("button", { name: /send test chat/i }));
+    await screen.findByText(/invalid api key/i);
+    fireEvent.click(screen.getByRole("button", { name: /edit provider/i }));
+    expect(
+      await screen.findByRole("heading", { name: /chat provider/i }),
+    ).toBeInTheDocument();
+    firstRender.unmount();
+
+    const secondRender = renderFirstChat();
+    fireEvent.click(screen.getByRole("button", { name: /send test chat/i }));
+    await screen.findByText(/invalid api key/i);
+    fireEvent.click(screen.getByRole("button", { name: /switch provider/i }));
+    expect(
+      await screen.findByRole("heading", { name: /chat provider/i }),
+    ).toBeInTheDocument();
+    secondRender.unmount();
+
+    renderFirstChat();
+    fireEvent.click(screen.getByRole("button", { name: /send test chat/i }));
+    await screen.findByText(/invalid api key/i);
+    fireEvent.click(screen.getByRole("button", { name: /skip setup/i }));
+
+    await waitFor(() => {
+      expect(setupHookMocks.skip).toHaveBeenCalledWith({
+        reason: "user_skip",
+      });
+      expect(onStateChange).toHaveBeenCalledWith(
+        expect.objectContaining({ status: "skipped" }),
+      );
+    });
+  });
+
+  it("prevents duplicate first-chat recovery skip submissions while skip is pending", async () => {
+    setupHookMocks.verifyFirstChat.mockResolvedValue({
+      status: "failed",
+      provider: "openai",
+      model: "gpt-4.1-mini",
+      failure_category: "auth_failed",
+      message: "Invalid API key",
+    });
+    const deferredSkip = createDeferred<FirstRunState>();
+    setupHookMocks.skip.mockReturnValueOnce(deferredSkip.promise);
+    const onStateChange = vi.fn();
+    const { UnifiedSetupWizard } = await import("../UnifiedSetupWizard");
+
+    render(
+      <UnifiedSetupWizard
+        initialState={initialStateForCompletedSteps([
+          "setup_path",
+          "privacy_security",
+          "providers",
+          "ingest_defaults",
+          "audio_defaults",
+          "optional_advanced",
+        ])}
+        onStateChange={onStateChange}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /send test chat/i }));
+    await screen.findByText(/invalid api key/i);
+
+    const skipButton = screen.getByRole("button", { name: /skip setup/i });
+    fireEvent.click(skipButton);
+    fireEvent.click(skipButton);
+
+    expect(setupHookMocks.skip).toHaveBeenCalledTimes(1);
+    expect(skipButton).toBeDisabled();
+
+    deferredSkip.resolve({
+      status: "skipped",
+      completed_steps: [],
+      skipped_steps: [],
+      step_data: {},
+      acknowledged_steps: [],
+      first_chat: { completed: false },
+      skip_reason: "user_skip",
+    });
+
+    await waitFor(() => {
+      expect(onStateChange).toHaveBeenCalledWith(
+        expect.objectContaining({ status: "skipped" }),
+      );
+    });
+  });
+
+  it("routes first-chat endpoint diagnostics back to provider setup", async () => {
+    setupHookMocks.verifyFirstChat.mockResolvedValueOnce({
+      status: "failed",
+      provider: "openai",
+      model: "gpt-4.1-mini",
+      failure_category: "unsupported_api_shape",
+      message: "The endpoint does not look OpenAI-compatible.",
+    });
+    const { UnifiedSetupWizard } = await import("../UnifiedSetupWizard");
+
+    render(
+      <UnifiedSetupWizard
+        initialState={initialStateForCompletedSteps([
+          "setup_path",
+          "privacy_security",
+          "providers",
+          "ingest_defaults",
+          "audio_defaults",
+          "optional_advanced",
+        ])}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /send test chat/i }));
+    await screen.findByText(/does not look openai-compatible/i);
+    fireEvent.click(screen.getByRole("button", { name: /check endpoint/i }));
+
+    expect(
+      await screen.findByRole("heading", { name: /chat provider/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByLabelText(/select openai/i)).toBeChecked();
+  });
+
   it("does not infer saved hosted credentials when resumed state lacks the marker", async () => {
     const { UnifiedSetupWizard } = await import("../UnifiedSetupWizard");
     setupHookMocks.validateProvider.mockImplementation(async (payload) => {

--- a/apps/packages/ui/src/components/Option/Onboarding/steps/FirstChatStep.tsx
+++ b/apps/packages/ui/src/components/Option/Onboarding/steps/FirstChatStep.tsx
@@ -19,9 +19,128 @@ type FirstChatStepProps = {
   ) => Promise<SetupCompleteResponse>;
   onComplete: () => void;
   onBack: () => void;
+  onEditProvider: () => void;
+  onSwitchProvider: () => void;
+  onSkip: () => void;
+  skipPending?: boolean;
+  onCheckEndpoint?: () => void;
 };
 
 const DEFAULT_FIRST_PROMPT = "Say hello in one short sentence.";
+
+type FirstChatRecoveryCategory =
+  | "auth_failed"
+  | "quota_or_rate_limit"
+  | "endpoint_unreachable"
+  | "unsupported_api_shape"
+  | "model_unavailable"
+  | "configuration_error"
+  | "provider_error"
+  | "empty_response"
+  | "config_write_failed"
+  | "provider_unvalidated"
+  | "unknown";
+
+const FIRST_CHAT_CATEGORY_ALIASES: Record<string, FirstChatRecoveryCategory> = {
+  auth: "auth_failed",
+  auth_failed: "auth_failed",
+  authentication_failed: "auth_failed",
+  provider_api_key_invalid: "auth_failed",
+  rate_limit: "quota_or_rate_limit",
+  rate_limited: "quota_or_rate_limit",
+  quota: "quota_or_rate_limit",
+  quota_exceeded: "quota_or_rate_limit",
+  connection_error: "endpoint_unreachable",
+  network_error: "endpoint_unreachable",
+  timeout: "endpoint_unreachable",
+  timeout_error: "endpoint_unreachable",
+  local_provider_unreachable: "endpoint_unreachable",
+  endpoint_unreachable: "endpoint_unreachable",
+  bad_request: "unsupported_api_shape",
+  invalid_request: "unsupported_api_shape",
+  request_invalid: "unsupported_api_shape",
+  unsupported_api_shape: "unsupported_api_shape",
+  model_not_found: "model_unavailable",
+  model_unavailable: "model_unavailable",
+  configuration_error: "configuration_error",
+  provider_error: "provider_error",
+  server_error: "provider_error",
+  upstream_error: "provider_error",
+  empty_response: "empty_response",
+  provider_unvalidated: "provider_unvalidated",
+  config_write_failed: "config_write_failed",
+};
+
+const normalizeRecoveryCategory = (
+  category?: string | null,
+): FirstChatRecoveryCategory => {
+  if (!category) return "unknown";
+  return FIRST_CHAT_CATEGORY_ALIASES[category] ?? "unknown";
+};
+
+const RECOVERY_COPY: Record<
+  FirstChatRecoveryCategory,
+  { title: string; guidance: string }
+> = {
+  auth_failed: {
+    title: "Credentials need attention",
+    guidance:
+      "Update the provider credentials, then retry the first chat, or switch to another provider.",
+  },
+  quota_or_rate_limit: {
+    title: "Provider limit reached",
+    guidance:
+      "Retry later if this is temporary, or switch provider to keep setup moving.",
+  },
+  endpoint_unreachable: {
+    title: "Endpoint could not be reached",
+    guidance:
+      "Check the local endpoint URL and API compatibility, then retry the first chat.",
+  },
+  unsupported_api_shape: {
+    title: "Endpoint API shape is unsupported",
+    guidance:
+      "Check the local endpoint URL and API compatibility, then retry with an OpenAI-compatible chat endpoint.",
+  },
+  model_unavailable: {
+    title: "Model is unavailable",
+    guidance:
+      "Switch model or provider, or edit the provider details before retrying.",
+  },
+  configuration_error: {
+    title: "Provider configuration needs attention",
+    guidance:
+      "Return to provider setup, confirm the saved provider details, then retry the first chat.",
+  },
+  provider_error: {
+    title: "Provider returned an error",
+    guidance:
+      "Retry if this looks temporary, or switch provider to keep setup moving.",
+  },
+  empty_response: {
+    title: "Provider returned an empty response",
+    guidance:
+      "Retry the first chat. If it happens again, switch model or provider.",
+  },
+  config_write_failed: {
+    title: "Configuration could not be saved",
+    guidance:
+      "Edit provider setup to confirm the saved configuration, then retry the first chat.",
+  },
+  provider_unvalidated: {
+    title: "Provider needs validation",
+    guidance:
+      "Return to provider setup, validate the provider, then retry the first chat.",
+  },
+  unknown: {
+    title: "First chat did not complete",
+    guidance:
+      "Retry the first chat, edit provider settings, or skip setup and diagnose from settings later.",
+  },
+};
+
+const shouldShowCheckEndpoint = (category: FirstChatRecoveryCategory) =>
+  category === "endpoint_unreachable" || category === "unsupported_api_shape";
 
 export function FirstChatStep({
   provider,
@@ -30,17 +149,28 @@ export function FirstChatStep({
   complete,
   onComplete,
   onBack,
+  onEditProvider,
+  onSwitchProvider,
+  onSkip,
+  skipPending = false,
+  onCheckEndpoint,
 }: FirstChatStepProps) {
   const [prompt, setPrompt] = React.useState(DEFAULT_FIRST_PROMPT);
   const [response, setResponse] =
     React.useState<FirstChatVerifyResponse | null>(null);
   const [running, setRunning] = React.useState(false);
-  const [error, setError] = React.useState<string | null>(null);
+  const [verificationError, setVerificationError] = React.useState<
+    string | null
+  >(null);
+  const [requestFailureCategory, setRequestFailureCategory] =
+    React.useState<FirstChatRecoveryCategory | null>(null);
+  const [completionError, setCompletionError] = React.useState<string | null>(
+    null,
+  );
 
   const handleSend = async () => {
     setRunning(true);
-    setError(null);
-    setResponse(null);
+    setCompletionError(null);
     try {
       let verification: FirstChatVerifyResponse;
       try {
@@ -50,12 +180,21 @@ export function FirstChatStep({
           prompt,
         });
       } catch (err) {
-        setError(err instanceof Error ? err.message : "First chat failed.");
+        setRequestFailureCategory("unknown");
+        setVerificationError(
+          err instanceof Error
+            ? err.message
+            : "First chat request failed. Retry, edit provider, or skip setup.",
+        );
         return;
       }
       setResponse(verification);
+      setRequestFailureCategory(null);
+      setVerificationError(null);
       if (verification.status !== "ready") {
-        setError(verification.message || "First chat did not complete.");
+        setVerificationError(
+          verification.message || "First chat did not complete.",
+        );
         return;
       }
       try {
@@ -64,18 +203,32 @@ export function FirstChatStep({
         });
       } catch (err) {
         const detail = err instanceof Error ? err.message : "Try again.";
-        setError(
-          `Setup completion failed after the first chat succeeded. ${detail}`,
+        setCompletionError(
+          `Setup state could not be completed after the first chat succeeded. ${detail}`,
         );
         return;
       }
       onComplete();
     } catch (err) {
-      setError(err instanceof Error ? err.message : "First chat failed.");
+      setRequestFailureCategory("unknown");
+      setVerificationError(
+        err instanceof Error ? err.message : "First chat failed.",
+      );
     } finally {
       setRunning(false);
     }
   };
+
+  const activeFailureCategory =
+    requestFailureCategory ?? response?.failure_category ?? null;
+  const recoveryCategory = normalizeRecoveryCategory(activeFailureCategory);
+  const recoveryCopy = RECOVERY_COPY[recoveryCategory];
+  const hasVerificationFailure =
+    Boolean(verificationError) ||
+    Boolean(response && response.status !== "ready");
+  const failureMessage = verificationError ?? response?.message ?? null;
+  const showCheckEndpoint =
+    Boolean(onCheckEndpoint) && shouldShowCheckEndpoint(recoveryCategory);
 
   return (
     <section aria-labelledby="first-chat-title" className="space-y-5">
@@ -116,15 +269,83 @@ export function FirstChatStep({
         </div>
       ) : null}
 
-      {error ? (
+      {hasVerificationFailure ? (
         <div
           role="alert"
           className="rounded-md border border-danger/40 bg-danger/10 px-4 py-3 text-sm text-text"
         >
-          {response?.failure_category ? (
-            <span className="font-medium">{response.failure_category}: </span>
-          ) : null}
-          {error}
+          <div className="flex flex-wrap items-start justify-between gap-3">
+            <div className="min-w-0">
+              <p className="font-medium">{recoveryCopy.title}</p>
+              <p className="mt-1 text-text-muted">{recoveryCopy.guidance}</p>
+              {failureMessage ? (
+                <p className="mt-2">{failureMessage}</p>
+              ) : null}
+              {activeFailureCategory ? (
+                <p className="mt-2 font-mono text-xs text-text-muted">
+                  Category: {recoveryCategory}
+                </p>
+              ) : null}
+            </div>
+            {running ? (
+              <span className="rounded-full border border-border bg-surface px-2 py-0.5 text-xs font-medium text-text-muted">
+                Retrying
+              </span>
+            ) : null}
+          </div>
+          <div className="mt-3 flex flex-wrap gap-2">
+            <button
+              type="button"
+              onClick={handleSend}
+              disabled={running || !provider || !model}
+              className="rounded-md bg-primary px-3 py-1.5 text-sm font-semibold text-primary-foreground disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              Retry
+            </button>
+            <button
+              type="button"
+              onClick={onEditProvider}
+              disabled={running}
+              className="rounded-md border border-border bg-surface px-3 py-1.5 text-sm font-medium text-text hover:bg-surface2 disabled:opacity-50"
+            >
+              Edit provider
+            </button>
+            <button
+              type="button"
+              onClick={onSwitchProvider}
+              disabled={running}
+              className="rounded-md border border-border bg-surface px-3 py-1.5 text-sm font-medium text-text hover:bg-surface2 disabled:opacity-50"
+            >
+              Switch provider
+            </button>
+            {showCheckEndpoint ? (
+              <button
+                type="button"
+                onClick={onCheckEndpoint}
+                disabled={running}
+                className="rounded-md border border-border bg-surface px-3 py-1.5 text-sm font-medium text-text hover:bg-surface2 disabled:opacity-50"
+              >
+                Check endpoint
+              </button>
+            ) : null}
+            <button
+              type="button"
+              onClick={onSkip}
+              disabled={running || skipPending}
+              className="rounded-md border border-border bg-surface px-3 py-1.5 text-sm font-medium text-text hover:bg-surface2 disabled:opacity-50"
+            >
+              {skipPending ? "Skipping..." : "Skip setup"}
+            </button>
+          </div>
+        </div>
+      ) : null}
+
+      {completionError ? (
+        <div
+          role="alert"
+          className="rounded-md border border-danger/40 bg-danger/10 px-4 py-3 text-sm text-text"
+        >
+          {completionError}
         </div>
       ) : null}
 

--- a/apps/packages/ui/src/components/Option/Onboarding/steps/FirstChatStep.tsx
+++ b/apps/packages/ui/src/components/Option/Onboarding/steps/FirstChatStep.tsx
@@ -170,6 +170,9 @@ export function FirstChatStep({
 
   const handleSend = async () => {
     setRunning(true);
+    setResponse(null);
+    setVerificationError(null);
+    setRequestFailureCategory(null);
     setCompletionError(null);
     try {
       let verification: FirstChatVerifyResponse;

--- a/apps/packages/ui/src/components/Option/Onboarding/steps/ProviderSetupStep.tsx
+++ b/apps/packages/ui/src/components/Option/Onboarding/steps/ProviderSetupStep.tsx
@@ -5,19 +5,42 @@ import type {
   SetupProviderCatalogEntry,
   SetupProviderSaveRequest,
   SetupProviderSaveResponse,
+  SetupProviderValidationResponse,
 } from "@/types/setup-onboarding";
 
 export type ProviderSelection = {
   provider: string;
   model: string;
+  credential_configured?: boolean;
 };
 
 type ProviderSetupStepProps = {
   providers: SetupProviderCatalogEntry[];
   initialSelection?: ProviderSelection | null;
+  savedProviders?: SavedProviderState;
+  savedPayloadFingerprints?: ProviderSavedPayloadFingerprintState;
+  savedDefaultProvider?: string | null;
+  validationState?: ProviderValidationState;
+  providerEditRevisions?: ProviderEditRevisionState;
   onSaveProvider: (
     payload: SetupProviderSaveRequest,
   ) => Promise<SetupProviderSaveResponse>;
+  onValidateProvider: (
+    payload: SetupProviderSaveRequest,
+  ) => Promise<SetupProviderValidationResponse>;
+  onSavedProvidersChange?: React.Dispatch<
+    React.SetStateAction<SavedProviderState>
+  >;
+  onSavedPayloadFingerprintsChange?: React.Dispatch<
+    React.SetStateAction<ProviderSavedPayloadFingerprintState>
+  >;
+  onSavedDefaultProviderChange?: (savedDefaultProvider: string | null) => void;
+  onValidationStateChange?: React.Dispatch<
+    React.SetStateAction<ProviderValidationState>
+  >;
+  onProviderEditRevisionsChange?: React.Dispatch<
+    React.SetStateAction<ProviderEditRevisionState>
+  >;
   onContinue: (selection: ProviderSelection) => void;
   onBack?: () => void;
 };
@@ -27,6 +50,16 @@ type ProviderFormValues = {
   baseUrl: string;
   model: string;
 };
+
+export type ProviderValidationViewState = {
+  fingerprint: string;
+  response: SetupProviderValidationResponse;
+};
+
+export type ProviderSavedPayloadFingerprintState = Record<string, string>;
+type SavedProviderState = Record<string, SetupProviderSaveResponse>;
+type ProviderValidationState = Record<string, ProviderValidationViewState>;
+type ProviderEditRevisionState = Record<string, number>;
 
 const emptyValues: ProviderFormValues = {
   apiKey: "",
@@ -46,10 +79,86 @@ const sortedProviders = (providers: SetupProviderCatalogEntry[]) =>
     return a.label.localeCompare(b.label);
   });
 
+const validationCanGate = (
+  response: SetupProviderValidationResponse | null | undefined,
+) => {
+  const statusCanGate =
+    response?.status === "ready" || response?.status === "accepted";
+  return Boolean(statusCanGate && (response?.can_gate_first_chat ?? true));
+};
+
+const validationStatusCopy = (
+  response: SetupProviderValidationResponse,
+): string => {
+  if (response.status === "failed") {
+    return [
+      response.failure_category,
+      response.message || "Provider validation failed.",
+    ]
+      .filter(Boolean)
+      .join(": ");
+  }
+  if (response.status === "accepted") {
+    if (response.message?.toLowerCase().includes("first chat verifies")) {
+      return response.message;
+    }
+    return "Format accepted; first chat verifies this provider.";
+  }
+  if (response.status === "ready") {
+    return response.message || "Provider validation is ready.";
+  }
+  return response.message || "Provider validation response received.";
+};
+
+const savedHostedCredentialFallbackValidation = (
+  provider: SetupProviderCatalogEntry,
+): SetupProviderValidationResponse => ({
+  provider_key: provider.provider_key,
+  status: "accepted",
+  message: "Saved credentials are present; first chat verifies this provider.",
+  models: [],
+  validation_level: "local_syntax",
+  can_gate_first_chat: true,
+});
+
+const hasBackendConfirmedSavedCredential = (
+  saved: SetupProviderSaveResponse | null | undefined,
+) => Boolean(saved?.credential_configured === true || saved?.masked_api_key);
+
+const initialSavedProvider = (
+  initialSelection: ProviderSelection,
+): SetupProviderSaveResponse => ({
+  provider_key: initialSelection.provider,
+  status: "saved",
+  credential_configured: Boolean(initialSelection.credential_configured),
+  model: initialSelection.model,
+  make_default: true,
+});
+
+const providerValuesEqual = (
+  left: ProviderFormValues | undefined,
+  right: ProviderFormValues,
+) =>
+  Boolean(left) &&
+  left?.apiKey === right.apiKey &&
+  left?.baseUrl === right.baseUrl &&
+  left?.model === right.model;
+
 export function ProviderSetupStep({
   providers,
   initialSelection = null,
+  savedProviders: controlledSavedProviders,
+  savedPayloadFingerprints: controlledSavedPayloadFingerprints,
+  savedDefaultProvider: controlledSavedDefaultProvider,
+  validationState: controlledValidationState,
+  providerEditRevisions: controlledProviderEditRevisions,
   onSaveProvider,
+  onValidateProvider,
+  onSavedProvidersChange,
+  onSavedPayloadFingerprintsChange,
+  onSavedDefaultProviderChange,
+  onValidationStateChange,
+  onProviderEditRevisionsChange,
   onContinue,
   onBack,
 }: ProviderSetupStepProps) {
@@ -76,62 +185,277 @@ export function ProviderSetupStep({
         }
       : {},
   );
-  const [savedProviders, setSavedProviders] = React.useState<
-    Record<string, SetupProviderSaveResponse>
-  >(() =>
-    initialSelection?.provider
-      ? {
-          [initialSelection.provider]: {
-            provider_key: initialSelection.provider,
-            status: "saved",
-            model: initialSelection.model,
-            make_default: true,
-          },
-        }
-      : {},
-  );
+  const [internalSavedProviders, setInternalSavedProviders] =
+    React.useState<SavedProviderState>(() =>
+      initialSelection?.provider
+        ? {
+            [initialSelection.provider]: {
+              provider_key: initialSelection.provider,
+              status: "saved",
+              credential_configured: Boolean(
+                initialSelection.credential_configured,
+              ),
+              model: initialSelection.model,
+              make_default: true,
+            },
+          }
+        : {},
+    );
+  const [
+    internalSavedPayloadFingerprints,
+    setInternalSavedPayloadFingerprints,
+  ] = React.useState<ProviderSavedPayloadFingerprintState>({});
+  const [internalSavedDefaultProvider, setInternalSavedDefaultProvider] =
+    React.useState<string | null>(() => initialSelection?.provider ?? null);
   const [savingProvider, setSavingProvider] = React.useState(false);
+  const [validatingProvider, setValidatingProvider] = React.useState<
+    string | null
+  >(null);
+  const [internalValidationState, setInternalValidationState] =
+    React.useState<ProviderValidationState>({});
+  const [
+    internalProviderEditRevisions,
+    setInternalProviderEditRevisions,
+  ] = React.useState<ProviderEditRevisionState>({});
   const [error, setError] = React.useState<string | null>(null);
+  const savedProviders = controlledSavedProviders ?? internalSavedProviders;
+  const savedPayloadFingerprints =
+    controlledSavedPayloadFingerprints ?? internalSavedPayloadFingerprints;
+  const savedDefaultProvider =
+    controlledSavedDefaultProvider !== undefined
+      ? controlledSavedDefaultProvider
+      : internalSavedDefaultProvider;
+  const validationState = controlledValidationState ?? internalValidationState;
+  const providerEditRevisions =
+    controlledProviderEditRevisions ?? internalProviderEditRevisions;
+
+  const updateSavedProviders = React.useCallback(
+    (updater: React.SetStateAction<SavedProviderState>) => {
+      if (onSavedProvidersChange) {
+        onSavedProvidersChange(updater);
+      } else {
+        setInternalSavedProviders(updater);
+      }
+    },
+    [onSavedProvidersChange],
+  );
+
+  const updateSavedPayloadFingerprints = React.useCallback(
+    (
+      updater: React.SetStateAction<ProviderSavedPayloadFingerprintState>,
+    ) => {
+      if (onSavedPayloadFingerprintsChange) {
+        onSavedPayloadFingerprintsChange(updater);
+      } else {
+        setInternalSavedPayloadFingerprints(updater);
+      }
+    },
+    [onSavedPayloadFingerprintsChange],
+  );
+
+  const updateSavedDefaultProvider = React.useCallback(
+    (next: string | null) => {
+      if (onSavedDefaultProviderChange) {
+        onSavedDefaultProviderChange(next);
+      } else {
+        setInternalSavedDefaultProvider(next);
+      }
+    },
+    [onSavedDefaultProviderChange],
+  );
+
+  const updateValidationState = React.useCallback(
+    (updater: React.SetStateAction<ProviderValidationState>) => {
+      if (onValidationStateChange) {
+        onValidationStateChange(updater);
+      } else {
+        setInternalValidationState(updater);
+      }
+    },
+    [onValidationStateChange],
+  );
+
+  const updateProviderEditRevisions = React.useCallback(
+    (updater: React.SetStateAction<ProviderEditRevisionState>) => {
+      if (onProviderEditRevisionsChange) {
+        onProviderEditRevisionsChange(updater);
+      } else {
+        setInternalProviderEditRevisions(updater);
+      }
+    },
+    [onProviderEditRevisionsChange],
+  );
 
   const currentValues = values[defaultProvider] ?? emptyValues;
   const defaultProviderConfig = orderedProviders.find(
     (provider) => provider.provider_key === defaultProvider,
   );
-  const selectedDefaultModel =
-    currentValues.model.trim() || defaultProviderConfig?.model_field || "";
-  const canContinue = Boolean(
-    defaultProvider && selectedDefaultModel && savedProviders[defaultProvider],
+  const selectedDefaultModel = currentValues.model.trim();
+  const providerFingerprint = React.useCallback(
+    (
+      provider: SetupProviderCatalogEntry,
+      providerValues: ProviderFormValues,
+      model: string | null,
+      savedOverride?: SetupProviderSaveResponse,
+    ) => {
+      const saved = savedOverride ?? savedProviders[provider.provider_key];
+      const baseUrl =
+        provider.provider_type === "local_endpoint"
+          ? providerValues.baseUrl.trim() || provider.default_base_url || ""
+          : "";
+      return JSON.stringify({
+        provider_key: provider.provider_key,
+        base_url: baseUrl,
+        model: model || "",
+        make_default: provider.provider_key === defaultProvider,
+        edit_revision: providerEditRevisions[provider.provider_key] ?? 0,
+        secret_present: Boolean(
+          providerValues.apiKey.trim() ||
+            hasBackendConfirmedSavedCredential(saved),
+        ),
+      });
+    },
+    [defaultProvider, providerEditRevisions, savedProviders],
   );
+  const defaultValidation = defaultProviderConfig
+    ? validationState[defaultProviderConfig.provider_key]
+    : null;
+  const defaultValidationFingerprint = defaultProviderConfig
+    ? providerFingerprint(
+        defaultProviderConfig,
+        currentValues,
+        selectedDefaultModel,
+      )
+    : "";
+  const defaultValidationIsCurrent = Boolean(
+    defaultValidation &&
+      defaultValidation.fingerprint === defaultValidationFingerprint,
+  );
+  const defaultSaveIsCurrent = Boolean(
+    savedPayloadFingerprints[defaultProvider] === defaultValidationFingerprint,
+  );
+  const canContinue = Boolean(
+    defaultProvider &&
+      selectedDefaultModel &&
+      savedProviders[defaultProvider] &&
+      savedDefaultProvider === defaultProvider &&
+      defaultSaveIsCurrent &&
+      defaultValidationIsCurrent &&
+      validationCanGate(defaultValidation?.response),
+  );
+  const initialProviderKey = initialSelection?.provider ?? "";
+  const seededInitialSavedProvider = React.useMemo(
+    () => (initialSelection ? initialSavedProvider(initialSelection) : null),
+    [
+      initialSelection?.credential_configured,
+      initialSelection?.model,
+      initialSelection?.provider,
+    ],
+  );
+  const initialProviderSavedResponse = initialProviderKey
+    ? savedProviders[initialProviderKey]
+    : undefined;
+  const initialProviderSavedFingerprint = initialProviderKey
+    ? savedPayloadFingerprints[initialProviderKey]
+    : undefined;
 
   React.useEffect(() => {
     if (!initialSelection?.provider) return;
-    setSelectedProviders(
-      (current) => new Set([...current, initialSelection.provider]),
-    );
+    setSelectedProviders((current) => {
+      if (current.has(initialSelection.provider)) return current;
+      return new Set([...current, initialSelection.provider]);
+    });
     setDefaultProvider((current) => current || initialSelection.provider);
-    setValues((current) => ({
-      ...current,
-      [initialSelection.provider]: {
+    setValues((current) => {
+      const nextValues = {
         ...emptyValues,
         ...(current[initialSelection.provider] ?? {}),
         model:
           current[initialSelection.provider]?.model || initialSelection.model,
-      },
-    }));
-    setSavedProviders((current) => ({
-      ...current,
-      [initialSelection.provider]: current[initialSelection.provider] ?? {
-        provider_key: initialSelection.provider,
-        status: "saved",
-        model: initialSelection.model,
-        make_default: true,
-      },
-    }));
+      };
+      if (
+        providerValuesEqual(current[initialSelection.provider], nextValues)
+      ) {
+        return current;
+      }
+      return {
+        ...current,
+        [initialSelection.provider]: nextValues,
+      };
+    });
   }, [initialSelection?.model, initialSelection?.provider]);
+
+  React.useEffect(() => {
+    if (!initialSelection?.provider || !seededInitialSavedProvider) return;
+    if (initialProviderSavedResponse) return;
+    updateSavedProviders((current) => {
+      if (current[initialSelection.provider]) return current;
+      return {
+        ...current,
+        [initialSelection.provider]: seededInitialSavedProvider,
+      };
+    });
+  }, [
+    initialProviderSavedResponse,
+    initialSelection?.provider,
+    seededInitialSavedProvider,
+    updateSavedProviders,
+  ]);
+
+  React.useEffect(() => {
+    if (!initialSelection?.provider || !seededInitialSavedProvider) return;
+    if (initialProviderSavedFingerprint) return;
+    if (defaultProvider !== initialSelection.provider) return;
+
+    const provider = orderedProviders.find(
+      (entry) => entry.provider_key === initialSelection.provider,
+    );
+    if (!provider) return;
+
+    const currentProviderValues =
+      values[initialSelection.provider] ?? emptyValues;
+    const savedResponse =
+      initialProviderSavedResponse ?? seededInitialSavedProvider;
+    const savedModel = savedResponse.model || initialSelection.model;
+    const seededStateStillMatchesCurrentPayload =
+      currentProviderValues.model === savedModel &&
+      currentProviderValues.apiKey.trim() === "" &&
+      currentProviderValues.baseUrl.trim() === "" &&
+      (providerEditRevisions[initialSelection.provider] ?? 0) === 0 &&
+      savedResponse.make_default === true;
+    if (!seededStateStillMatchesCurrentPayload) return;
+
+    const fingerprint = providerFingerprint(
+      provider,
+      currentProviderValues,
+      currentProviderValues.model,
+      savedResponse,
+    );
+    updateSavedPayloadFingerprints((current) => {
+      if (current[initialSelection.provider]) return current;
+      return {
+        ...current,
+        [initialSelection.provider]: fingerprint,
+      };
+    });
+  }, [
+    defaultProvider,
+    initialProviderSavedFingerprint,
+    initialProviderSavedResponse,
+    initialSelection?.model,
+    initialSelection?.provider,
+    orderedProviders,
+    providerFingerprint,
+    providerEditRevisions,
+    seededInitialSavedProvider,
+    updateSavedPayloadFingerprints,
+    values,
+  ]);
 
   const updateValues = (
     providerKey: string,
     patch: Partial<ProviderFormValues>,
+    options: { invalidateValidation?: boolean } = {},
   ) => {
     setValues((current) => ({
       ...current,
@@ -141,6 +465,75 @@ export function ProviderSetupStep({
         ...patch,
       },
     }));
+    if (options.invalidateValidation) {
+      updateProviderEditRevisions((current) => ({
+        ...current,
+        [providerKey]: (current[providerKey] ?? 0) + 1,
+      }));
+    }
+  };
+
+  const buildProviderPayload = (
+    provider: SetupProviderCatalogEntry,
+  ): SetupProviderSaveRequest => {
+    const providerValues = values[provider.provider_key] ?? emptyValues;
+    const apiKey = providerValues.apiKey.trim() || null;
+    const baseUrl =
+      provider.provider_type === "local_endpoint"
+        ? providerValues.baseUrl.trim() || provider.default_base_url || null
+        : null;
+    const model =
+      provider.provider_key === defaultProvider
+        ? selectedDefaultModel
+        : providerValues.model.trim() || null;
+
+    return {
+      provider_key: provider.provider_key,
+      api_key: apiKey,
+      base_url: baseUrl,
+      model,
+      make_default: provider.provider_key === defaultProvider,
+    };
+  };
+
+  const validateProvider = async (provider: SetupProviderCatalogEntry) => {
+    if (provider.provider_key === defaultProvider && !selectedDefaultModel) {
+      setError("Default model is required before validation.");
+      return;
+    }
+    setValidatingProvider(provider.provider_key);
+    setError(null);
+    try {
+      const payload = buildProviderPayload(provider);
+      const providerValues = values[provider.provider_key] ?? emptyValues;
+      const saved = savedProviders[provider.provider_key];
+      const response =
+        provider.provider_type === "hosted_api_key" &&
+        saved?.status === "saved" &&
+        hasBackendConfirmedSavedCredential(saved) &&
+        !payload.api_key
+          ? savedHostedCredentialFallbackValidation(provider)
+          : await onValidateProvider(payload);
+      updateValidationState((current) => ({
+        ...current,
+        [provider.provider_key]: {
+          fingerprint: providerFingerprint(
+            provider,
+            providerValues,
+            payload.model || "",
+          ),
+          response,
+        },
+      }));
+    } catch (err) {
+      setError(
+        err instanceof Error
+          ? err.message
+          : "Provider could not be validated.",
+      );
+    } finally {
+      setValidatingProvider(null);
+    }
   };
 
   const toggleProvider = (provider: SetupProviderCatalogEntry) => {
@@ -160,7 +553,9 @@ export function ProviderSetupStep({
   };
 
   const saveConfiguredProviders = async () => {
-    if (!defaultProvider || !defaultProviderConfig) return;
+    if (!defaultProvider || !defaultProviderConfig || !selectedDefaultModel) {
+      return;
+    }
     setSavingProvider(true);
     setError(null);
     try {
@@ -168,16 +563,13 @@ export function ProviderSetupStep({
         selectedProviders.has(provider.provider_key),
       );
       const responses: SetupProviderSaveResponse[] = [];
+      const savedFingerprintEntries: Array<[string, string]> = [];
       for (const provider of selectedProviderEntries) {
+        const payload = buildProviderPayload(provider);
         const providerValues = values[provider.provider_key] ?? emptyValues;
-        const apiKey = providerValues.apiKey.trim() || null;
-        const baseUrl =
-          provider.provider_type === "local_endpoint"
-            ? providerValues.baseUrl.trim() || provider.default_base_url || null
-            : null;
         if (
           provider.provider_type === "hosted_api_key" &&
-          !apiKey &&
+          !payload.api_key &&
           !savedProviders[provider.provider_key]
         ) {
           throw new Error(
@@ -186,37 +578,49 @@ export function ProviderSetupStep({
         }
         if (
           provider.provider_type === "local_endpoint" &&
-          !baseUrl &&
+          !payload.base_url &&
           !savedProviders[provider.provider_key]
         ) {
           throw new Error(
             `${provider.label} base URL is required before saving.`,
           );
         }
-        const model =
-          provider.provider_key === defaultProvider
-            ? selectedDefaultModel
-            : providerValues.model.trim() || null;
-        const response = await onSaveProvider({
-          provider_key: provider.provider_key,
-          api_key: apiKey,
-          base_url: baseUrl,
-          model,
-          make_default: provider.provider_key === defaultProvider,
-        });
+        const response = await onSaveProvider(payload);
         if (response.status === "failed") {
           throw new Error(
             response.message || `${provider.label} could not be saved.`,
           );
         }
         responses.push(response);
+        savedFingerprintEntries.push([
+          response.provider_key,
+          providerFingerprint(
+            provider,
+            providerValues,
+            payload.model || "",
+            response,
+          ),
+        ]);
       }
-      setSavedProviders((current) => ({
+      updateSavedProviders((current) => ({
         ...current,
         ...Object.fromEntries(
           responses.map((response) => [response.provider_key, response]),
         ),
       }));
+      updateSavedPayloadFingerprints((current) => ({
+        ...current,
+        ...Object.fromEntries(savedFingerprintEntries),
+      }));
+      if (
+        responses.some(
+          (response) =>
+            response.provider_key === defaultProvider &&
+            response.status === "saved",
+        )
+      ) {
+        updateSavedDefaultProvider(defaultProvider);
+      }
       for (const response of responses) {
         updateValues(response.provider_key, { apiKey: "" });
       }
@@ -287,6 +691,22 @@ export function ProviderSetupStep({
           const selected = selectedProviders.has(provider.provider_key);
           const providerValues = values[provider.provider_key] ?? emptyValues;
           const saved = savedProviders[provider.provider_key];
+          const payloadModel =
+            provider.provider_key === defaultProvider
+              ? selectedDefaultModel
+              : providerValues.model.trim() || null;
+          const currentFingerprint = providerFingerprint(
+            provider,
+            providerValues,
+            payloadModel,
+          );
+          const validation = validationState[provider.provider_key];
+          const validationIsCurrent =
+            validation?.fingerprint === currentFingerprint;
+          const validationResponse = validationIsCurrent
+            ? validation.response
+            : null;
+          const discoveredModels = validationResponse?.models ?? [];
           return (
             <div
               key={provider.provider_key}
@@ -331,9 +751,13 @@ export function ProviderSetupStep({
                       type="password"
                       value={providerValues.apiKey}
                       onChange={(event) =>
-                        updateValues(provider.provider_key, {
-                          apiKey: event.currentTarget.value,
-                        })
+                        updateValues(
+                          provider.provider_key,
+                          {
+                            apiKey: event.currentTarget.value,
+                          },
+                          { invalidateValidation: true },
+                        )
                       }
                       className="mt-1 w-full rounded-md border border-border bg-bg px-3 py-2 text-sm text-text"
                       placeholder={
@@ -354,9 +778,13 @@ export function ProviderSetupStep({
                           ""
                         }
                         onChange={(event) =>
-                          updateValues(provider.provider_key, {
-                            baseUrl: event.currentTarget.value,
-                          })
+                          updateValues(
+                            provider.provider_key,
+                            {
+                              baseUrl: event.currentTarget.value,
+                            },
+                            { invalidateValidation: true },
+                          )
                         }
                         className="mt-1 w-full rounded-md border border-border bg-bg px-3 py-2 text-sm text-text"
                         placeholder="http://127.0.0.1:11434/v1"
@@ -370,9 +798,13 @@ export function ProviderSetupStep({
                       <input
                         value={providerValues.model}
                         onChange={(event) =>
-                          updateValues(provider.provider_key, {
-                            model: event.currentTarget.value,
-                          })
+                          updateValues(
+                            provider.provider_key,
+                            {
+                              model: event.currentTarget.value,
+                            },
+                            { invalidateValidation: true },
+                          )
                         }
                         className="mt-1 w-full rounded-md border border-border bg-bg px-3 py-2 text-sm text-text"
                         placeholder="Model name"
@@ -389,6 +821,63 @@ export function ProviderSetupStep({
                     />
                     Use as first chat default
                   </label>
+
+                  <div className="space-y-2">
+                    <button
+                      type="button"
+                      onClick={() => void validateProvider(provider)}
+                      disabled={validatingProvider === provider.provider_key}
+                      className="rounded-md border border-border bg-bg px-3 py-2 text-sm font-medium text-text hover:bg-surface2 disabled:cursor-not-allowed disabled:opacity-50"
+                    >
+                      {validatingProvider === provider.provider_key
+                        ? `Validating ${provider.label}...`
+                        : `Validate ${provider.label}`}
+                    </button>
+                    {validationResponse ? (
+                      <p
+                        className={`text-sm ${
+                          validationResponse.status === "failed"
+                            ? "text-danger"
+                            : "text-success"
+                        }`}
+                      >
+                        {validationStatusCopy(validationResponse)}
+                      </p>
+                    ) : validation ? (
+                      <p className="text-sm text-warning">
+                        Provider validation changed. Validate again.
+                      </p>
+                    ) : (
+                      <p className="text-sm text-text-muted">
+                        Validation has not run for this configuration.
+                      </p>
+                    )}
+                    {discoveredModels.length > 0 ? (
+                      <div className="space-y-1">
+                        <p className="text-xs font-medium uppercase tracking-normal text-text-muted">
+                          Discovered models
+                        </p>
+                        <div className="flex flex-wrap gap-2">
+                          {discoveredModels.map((model) => (
+                            <button
+                              key={model}
+                              type="button"
+                              onClick={() =>
+                                updateValues(
+                                  provider.provider_key,
+                                  { model },
+                                  { invalidateValidation: true },
+                                )
+                              }
+                              className="rounded-sm border border-border bg-bg px-2 py-1 text-xs text-text hover:bg-surface2"
+                            >
+                              {model}
+                            </button>
+                          ))}
+                        </div>
+                      </div>
+                    ) : null}
+                  </div>
 
                   {saved ? (
                     <p className="flex items-center gap-2 text-sm text-success">
@@ -436,6 +925,9 @@ export function ProviderSetupStep({
               onContinue({
                 provider: defaultProvider,
                 model: selectedDefaultModel,
+                credential_configured: hasBackendConfirmedSavedCredential(
+                  savedProviders[defaultProvider],
+                ),
               })
             }
             className="rounded-md bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground disabled:cursor-not-allowed disabled:opacity-50"

--- a/apps/packages/ui/src/hooks/__tests__/useSetupReadinessSummary.test.tsx
+++ b/apps/packages/ui/src/hooks/__tests__/useSetupReadinessSummary.test.tsx
@@ -168,6 +168,26 @@ describe("useSetupReadinessSummary", () => {
     expect(readinessMocks.getSetupReadinessProfiles).toHaveBeenCalledTimes(2);
   });
 
+  it("keeps the last readiness payload visible when refresh fails", async () => {
+    readinessMocks.getSetupReadinessStatus
+      .mockResolvedValueOnce(statusPayload)
+      .mockRejectedValueOnce(new Error("temporary readiness outage"));
+    const { useSetupReadinessSummary } = await import(
+      "../useSetupReadinessSummary"
+    );
+
+    const { result } = renderHook(() => useSetupReadinessSummary());
+    await waitFor(() => expect(result.current.status).toEqual(statusPayload));
+
+    await act(async () => {
+      await result.current.refresh();
+    });
+
+    expect(result.current.status).toEqual(statusPayload);
+    expect(result.current.error).toBe("Setup readiness could not be loaded.");
+    expect(result.current.loading).toBe(false);
+  });
+
   it("exposes sanitized fallback error copy on failure", async () => {
     readinessMocks.getSetupReadinessStatus.mockRejectedValueOnce(
       new Error("Traceback: stack secret"),

--- a/apps/packages/ui/src/hooks/__tests__/useSetupReadinessSummary.test.tsx
+++ b/apps/packages/ui/src/hooks/__tests__/useSetupReadinessSummary.test.tsx
@@ -1,0 +1,250 @@
+// @vitest-environment jsdom
+import React from "react";
+import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const readinessMocks = vi.hoisted(() => ({
+  getSetupReadinessProfiles: vi.fn(),
+  getSetupReadinessStatus: vi.fn(),
+}));
+
+vi.mock("@/services/tldw/setup-readiness", () => ({
+  getSetupReadinessProfiles: readinessMocks.getSetupReadinessProfiles,
+  getSetupReadinessStatus: readinessMocks.getSetupReadinessStatus,
+}));
+
+const statusPayload = {
+  readiness_status: "ready_with_warnings",
+  lane_ids: ["chat", "embeddings_rag", "speech"],
+  lanes: [
+    { lane_id: "chat", label: "Chat", status: "ready" },
+    {
+      lane_id: "embeddings_rag",
+      label: "Embeddings/RAG",
+      status: "not_configured",
+    },
+    { lane_id: "speech", label: "Speech", status: "skipped" },
+  ],
+  active_overlays: [],
+  overlays: [],
+};
+
+const profilesPayload = {
+  setup_access: { mode: "first_run" },
+  lane_ids: ["chat", "embeddings_rag", "speech"],
+  lanes: statusPayload.lanes,
+  active_overlays: [],
+  overlays: [],
+  profiles: [],
+};
+
+describe("useSetupReadinessSummary", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    readinessMocks.getSetupReadinessProfiles.mockReset().mockResolvedValue(
+      profilesPayload,
+    );
+    readinessMocks.getSetupReadinessStatus.mockReset().mockResolvedValue(
+      statusPayload,
+    );
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("loads first-run setup readiness status on mount", async () => {
+    const { useSetupReadinessSummary } = await import(
+      "../useSetupReadinessSummary"
+    );
+
+    const { result } = renderHook(() => useSetupReadinessSummary());
+
+    expect(result.current.loading).toBe(true);
+    await waitFor(() => expect(result.current.status).toEqual(statusPayload));
+    expect(readinessMocks.getSetupReadinessStatus).toHaveBeenCalledWith({
+      mode: "first-run",
+    });
+    expect(readinessMocks.getSetupReadinessProfiles).toHaveBeenCalledWith({
+      mode: "first-run",
+    });
+    expect(result.current.loading).toBe(false);
+    expect(result.current.error).toBeNull();
+  });
+
+  it("loads first-run setup readiness status under React StrictMode", async () => {
+    const { useSetupReadinessSummary } = await import(
+      "../useSetupReadinessSummary"
+    );
+    const StrictModeWrapper = ({ children }: { children: React.ReactNode }) => (
+      <React.StrictMode>{children}</React.StrictMode>
+    );
+
+    const { result } = renderHook(() => useSetupReadinessSummary(), {
+      wrapper: StrictModeWrapper,
+    });
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.status).toEqual(statusPayload);
+    expect(result.current.error).toBeNull();
+  });
+
+  it("uses profile lanes when first-run status only reports lane ids", async () => {
+    readinessMocks.getSetupReadinessStatus.mockResolvedValueOnce({
+      readiness_status: "ready_with_warnings",
+      lane_ids: ["chat", "embeddings_rag", "speech"],
+      active_overlays: [],
+      overlays: [],
+    });
+    readinessMocks.getSetupReadinessProfiles.mockResolvedValueOnce({
+      ...profilesPayload,
+      active_overlays: ["downloads_disabled"],
+      overlays: ["network_unavailable"],
+    });
+    const { useSetupReadinessSummary } = await import(
+      "../useSetupReadinessSummary"
+    );
+
+    const { result } = renderHook(() => useSetupReadinessSummary());
+
+    await waitFor(() =>
+      expect(result.current.status?.lanes).toEqual(statusPayload.lanes),
+    );
+    expect(result.current.status).toMatchObject({
+      readiness_status: "ready_with_warnings",
+      lane_ids: ["chat", "embeddings_rag", "speech"],
+      active_overlays: ["downloads_disabled"],
+      overlays: ["network_unavailable"],
+    });
+  });
+
+  it("keeps authoritative status when profile enrichment fails", async () => {
+    const authoritativeStatus = {
+      readiness_status: "ready_with_warnings",
+      lane_ids: ["chat"],
+      active_overlays: [],
+      overlays: [],
+    };
+    readinessMocks.getSetupReadinessStatus.mockResolvedValueOnce(
+      authoritativeStatus,
+    );
+    readinessMocks.getSetupReadinessProfiles.mockRejectedValueOnce(
+      new Error("profile enrichment failed"),
+    );
+    const { useSetupReadinessSummary } = await import(
+      "../useSetupReadinessSummary"
+    );
+
+    const { result } = renderHook(() => useSetupReadinessSummary());
+
+    await waitFor(() =>
+      expect(result.current.status).toEqual(authoritativeStatus),
+    );
+    expect(result.current.error).toBeNull();
+    expect(result.current.loading).toBe(false);
+  });
+
+  it("exposes refresh to reload readiness status", async () => {
+    const refreshedPayload = {
+      ...statusPayload,
+      readiness_status: "ready",
+    };
+    readinessMocks.getSetupReadinessStatus
+      .mockResolvedValueOnce(statusPayload)
+      .mockResolvedValueOnce(refreshedPayload);
+    const { useSetupReadinessSummary } = await import(
+      "../useSetupReadinessSummary"
+    );
+
+    const { result } = renderHook(() => useSetupReadinessSummary());
+    await waitFor(() => expect(result.current.status).toEqual(statusPayload));
+
+    await act(async () => {
+      await result.current.refresh();
+    });
+
+    expect(result.current.status).toEqual(refreshedPayload);
+    expect(readinessMocks.getSetupReadinessStatus).toHaveBeenCalledTimes(2);
+    expect(readinessMocks.getSetupReadinessProfiles).toHaveBeenCalledTimes(2);
+  });
+
+  it("exposes sanitized fallback error copy on failure", async () => {
+    readinessMocks.getSetupReadinessStatus.mockRejectedValueOnce(
+      new Error("Traceback: stack secret"),
+    );
+    const { useSetupReadinessSummary } = await import(
+      "../useSetupReadinessSummary"
+    );
+
+    const { result } = renderHook(() => useSetupReadinessSummary());
+
+    await waitFor(() =>
+      expect(result.current.error).toBe(
+        "Setup readiness could not be loaded.",
+      ),
+    );
+    expect(result.current.status).toBeNull();
+    expect(result.current.loading).toBe(false);
+  });
+
+  it("keeps newer refresh results when older requests resolve later", async () => {
+    let resolveInitial: (value: typeof statusPayload) => void = () => undefined;
+    let resolveOlder: (value: typeof statusPayload) => void = () => undefined;
+    let resolveNewer: (value: typeof statusPayload) => void = () => undefined;
+    const olderPayload = {
+      ...statusPayload,
+      readiness_status: "older_result",
+    };
+    const newerPayload = {
+      ...statusPayload,
+      readiness_status: "newer_result",
+    };
+    readinessMocks.getSetupReadinessStatus
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveInitial = resolve;
+          }),
+      )
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveOlder = resolve;
+          }),
+      )
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveNewer = resolve;
+          }),
+      );
+    const { useSetupReadinessSummary } = await import(
+      "../useSetupReadinessSummary"
+    );
+
+    const { result } = renderHook(() => useSetupReadinessSummary());
+    await act(async () => {
+      resolveInitial(statusPayload);
+    });
+    await waitFor(() => expect(result.current.status).toEqual(statusPayload));
+
+    let olderRefresh: Promise<unknown> = Promise.resolve();
+    let newerRefresh: Promise<unknown> = Promise.resolve();
+    await act(async () => {
+      olderRefresh = result.current.refresh();
+      newerRefresh = result.current.refresh();
+    });
+    await act(async () => {
+      resolveNewer(newerPayload);
+      await newerRefresh;
+    });
+    expect(result.current.status).toEqual(newerPayload);
+
+    await act(async () => {
+      resolveOlder(olderPayload);
+      await olderRefresh;
+    });
+
+    expect(result.current.status).toEqual(newerPayload);
+  });
+});

--- a/apps/packages/ui/src/hooks/useSetupReadinessSummary.ts
+++ b/apps/packages/ui/src/hooks/useSetupReadinessSummary.ts
@@ -1,0 +1,115 @@
+import React from "react";
+
+import {
+  getSetupReadinessProfiles,
+  getSetupReadinessStatus,
+  type SetupReadinessProfilesResponse,
+  type SetupReadinessStatusResponse,
+} from "@/services/tldw/setup-readiness";
+
+const SETUP_READINESS_ERROR = "Setup readiness could not be loaded.";
+
+const hasItems = <T,>(items?: T[]) => Array.isArray(items) && items.length > 0;
+
+const mergeProfileFallbacks = (
+  status: SetupReadinessStatusResponse,
+  profiles: SetupReadinessProfilesResponse,
+): SetupReadinessStatusResponse => {
+  const merged: SetupReadinessStatusResponse = { ...status };
+  if (!hasItems(merged.lane_ids) && hasItems(profiles.lane_ids)) {
+    merged.lane_ids = profiles.lane_ids;
+  }
+  if (!hasItems(merged.lanes) && hasItems(profiles.lanes)) {
+    merged.lanes = profiles.lanes;
+  }
+  if (
+    !hasItems(merged.active_overlays) &&
+    hasItems(profiles.active_overlays)
+  ) {
+    merged.active_overlays = profiles.active_overlays;
+  }
+  if (!hasItems(merged.overlays) && hasItems(profiles.overlays)) {
+    merged.overlays = profiles.overlays;
+  }
+  if (!hasItems(merged.profiles) && hasItems(profiles.profiles)) {
+    merged.profiles = profiles.profiles;
+  }
+  if (
+    !hasItems(merged.supported_statuses) &&
+    hasItems(profiles.supported_statuses)
+  ) {
+    merged.supported_statuses = profiles.supported_statuses;
+  }
+  if (
+    !hasItems(merged.supported_overlays) &&
+    hasItems(profiles.supported_overlays)
+  ) {
+    merged.supported_overlays = profiles.supported_overlays;
+  }
+  return merged;
+};
+
+export const useSetupReadinessSummary = () => {
+  const [status, setStatus] =
+    React.useState<SetupReadinessStatusResponse | null>(null);
+  const [loading, setLoading] = React.useState(true);
+  const [error, setError] = React.useState<string | null>(null);
+  const latestRequestId = React.useRef(0);
+  const mounted = React.useRef(true);
+
+  React.useEffect(() => {
+    mounted.current = true;
+    return () => {
+      mounted.current = false;
+    };
+  }, []);
+
+  const refresh = React.useCallback(async () => {
+    const requestId = latestRequestId.current + 1;
+    latestRequestId.current = requestId;
+    setLoading(true);
+    try {
+      const [statusResult, profilesResult] = await Promise.allSettled([
+        getSetupReadinessStatus({ mode: "first-run" }),
+        getSetupReadinessProfiles({ mode: "first-run" }),
+      ]);
+      if (statusResult.status === "rejected") {
+        throw statusResult.reason;
+      }
+      const nextSummary =
+        profilesResult.status === "fulfilled"
+          ? mergeProfileFallbacks(statusResult.value, profilesResult.value)
+          : statusResult.value;
+      if (mounted.current && latestRequestId.current === requestId) {
+        setStatus(nextSummary);
+        setError(null);
+      }
+      return nextSummary;
+    } catch {
+      if (mounted.current && latestRequestId.current === requestId) {
+        setStatus(null);
+        setError(SETUP_READINESS_ERROR);
+      }
+      return null;
+    } finally {
+      if (mounted.current && latestRequestId.current === requestId) {
+        setLoading(false);
+      }
+    }
+  }, []);
+
+  React.useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  return {
+    status,
+    loading,
+    error,
+    refresh,
+  };
+};
+
+export type UseSetupReadinessSummaryResult = ReturnType<
+  typeof useSetupReadinessSummary
+>;

--- a/apps/packages/ui/src/hooks/useSetupReadinessSummary.ts
+++ b/apps/packages/ui/src/hooks/useSetupReadinessSummary.ts
@@ -87,7 +87,6 @@ export const useSetupReadinessSummary = () => {
       return nextSummary;
     } catch {
       if (mounted.current && latestRequestId.current === requestId) {
-        setStatus(null);
         setError(SETUP_READINESS_ERROR);
       }
       return null;

--- a/apps/packages/ui/src/routes/__tests__/option-index.unified-setup.test.tsx
+++ b/apps/packages/ui/src/routes/__tests__/option-index.unified-setup.test.tsx
@@ -4,6 +4,16 @@ import { MemoryRouter } from "react-router-dom"
 import { fireEvent, render, screen, waitFor } from "@testing-library/react"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
+import {
+  createInitialQuickIngestLastRunSummary,
+  useQuickIngestStore
+} from "@/store/quick-ingest"
+import {
+  createEmptyQuickIngestSession,
+  useQuickIngestSessionStore,
+  type QuickIngestSessionRecord
+} from "@/store/quick-ingest-session"
+
 const routeMocks = vi.hoisted(() => ({
   firstRunState: {
     current: {
@@ -74,6 +84,14 @@ vi.mock("@/components/Option/CompanionHome", () => ({
 }))
 
 vi.mock("@/utils/quick-ingest-open", () => ({
+  isFirstSourceOpenDetail: (detail: any) =>
+    Boolean(
+      detail &&
+        (detail.source === "first_source_milestone" ||
+          detail.firstSource === true)
+    ),
+  isFirstSourceQuickIngestKind: (value: unknown) =>
+    value === "web_url" || value === "file_upload" || value === "paste_text",
   requestQuickIngestOpen: routeMocks.requestQuickIngestOpen
 }))
 
@@ -118,6 +136,33 @@ vi.mock("@/hooks/useSetupOnboarding", () => ({
   })
 }))
 
+const createCompletedFirstRunState = () => ({
+  status: "completed",
+  completed_steps: ["first_chat"],
+  skipped_steps: [],
+  step_data: {},
+  acknowledged_steps: ["first_chat"],
+  first_chat: { completed: true }
+})
+
+const seedQuickIngestSession = (
+  overrides: Partial<QuickIngestSessionRecord>
+) => {
+  const base = createEmptyQuickIngestSession()
+  useQuickIngestSessionStore.setState((state) => ({
+    ...state,
+    session: {
+      ...base,
+      ...overrides,
+      resultSummary: {
+        ...base.resultSummary,
+        ...(overrides.resultSummary || {})
+      }
+    },
+    triggerSummary: { count: 0, label: null, hadFailure: false }
+  }))
+}
+
 describe("OptionIndex unified setup resolver", () => {
   beforeEach(() => {
     window.localStorage.clear()
@@ -148,6 +193,17 @@ describe("OptionIndex unified setup resolver", () => {
         ...(updates as Record<string, unknown>)
       }
     })
+    useQuickIngestStore.setState((state) => ({
+      ...state,
+      queuedCount: 0,
+      hadRecentFailure: false,
+      lastRunSummary: createInitialQuickIngestLastRunSummary()
+    }))
+    useQuickIngestSessionStore.setState((state) => ({
+      ...state,
+      session: null,
+      triggerSummary: { count: 0, label: null, hadFailure: false }
+    }))
   })
 
   it("renders setup in focused shell when backend state is not complete", async () => {
@@ -167,14 +223,7 @@ describe("OptionIndex unified setup resolver", () => {
   })
 
   it("offers the first-source milestone after authenticated media readiness succeeds", async () => {
-    routeMocks.firstRunState.current = {
-      status: "completed",
-      completed_steps: ["first_chat"],
-      skipped_steps: [],
-      step_data: {},
-      acknowledged_steps: ["first_chat"],
-      first_chat: { completed: true }
-    }
+    routeMocks.firstRunState.current = createCompletedFirstRunState()
     const { default: OptionIndex } = await import("../option-index")
 
     render(
@@ -196,21 +245,179 @@ describe("OptionIndex unified setup resolver", () => {
       {
         source: "first_source_milestone",
         preferredPreset: "quick",
-        firstSource: true
+        firstSource: true,
+        firstSourceKind: "web_url"
       },
       { focusTrigger: true }
     )
   })
 
-  it("shows inline API key recovery when setup is complete but media auth is missing", async () => {
-    routeMocks.firstRunState.current = {
-      status: "completed",
-      completed_steps: ["first_chat"],
-      skipped_steps: [],
-      step_data: {},
-      acknowledged_steps: ["first_chat"],
-      first_chat: { completed: true }
+  it("passes the selected first-source kind into quick ingest", async () => {
+    routeMocks.firstRunState.current = createCompletedFirstRunState()
+    const { default: OptionIndex } = await import("../option-index")
+
+    render(
+      <MemoryRouter>
+        <OptionIndex />
+      </MemoryRouter>
+    )
+
+    expect(
+      await screen.findByRole("heading", { name: /add your first source/i })
+    ).toBeInTheDocument()
+    fireEvent.click(screen.getByRole("radio", { name: /file/i }))
+    fireEvent.click(screen.getByRole("button", { name: /add source/i }))
+    fireEvent.click(screen.getByRole("radio", { name: /paste/i }))
+    fireEvent.click(screen.getByRole("button", { name: /add source/i }))
+
+    expect(routeMocks.requestQuickIngestOpen).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        firstSourceKind: "file_upload"
+      }),
+      { focusTrigger: true }
+    )
+    expect(routeMocks.requestQuickIngestOpen).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        firstSourceKind: "paste_text"
+      }),
+      { focusTrigger: true }
+    )
+  })
+
+  it("does not offer source chat before quick ingest returns a ready media id", async () => {
+    routeMocks.firstRunState.current = createCompletedFirstRunState()
+    const { default: OptionIndex } = await import("../option-index")
+
+    render(
+      <MemoryRouter>
+        <OptionIndex />
+      </MemoryRouter>
+    )
+
+    expect(
+      await screen.findByRole("heading", { name: /add your first source/i })
+    ).toBeInTheDocument()
+    expect(
+      screen.queryByRole("button", { name: /ask a question about this source/i })
+    ).not.toBeInTheDocument()
+  })
+
+  it("ignores unrelated quick ingest success when no first-source session owns it", async () => {
+    routeMocks.firstRunState.current = createCompletedFirstRunState()
+    useQuickIngestStore.setState((state) => ({
+      ...state,
+      lastRunSummary: {
+        ...createInitialQuickIngestLastRunSummary(),
+        status: "success",
+        attemptedAt: 1,
+        completedAt: 2,
+        totalCount: 1,
+        successCount: 1,
+        firstMediaId: "unrelated-42",
+        primarySourceLabel: "Unrelated import"
+      }
+    }))
+    const { default: OptionIndex } = await import("../option-index")
+
+    render(
+      <MemoryRouter>
+        <OptionIndex />
+      </MemoryRouter>
+    )
+
+    expect(
+      await screen.findByRole("heading", { name: /add your first source/i })
+    ).toBeInTheDocument()
+    expect(
+      screen.queryByRole("button", { name: /ask a question about this source/i })
+    ).not.toBeInTheDocument()
+  })
+
+  it("uses persisted first-source session result summary after reload", async () => {
+    routeMocks.firstRunState.current = createCompletedFirstRunState()
+    seedQuickIngestSession({
+      lifecycle: "completed",
+      openDetail: {
+        source: "first_source_milestone",
+        preferredPreset: "quick",
+        firstSource: true,
+        firstSourceKind: "file_upload"
+      },
+      resultSummary: {
+        status: "success",
+        attemptedAt: 1,
+        completedAt: 2,
+        totalCount: 1,
+        successCount: 1,
+        failedCount: 0,
+        cancelledCount: 0,
+        firstMediaId: "persisted-42",
+        primarySourceLabel: "Saved PDF",
+        errorMessage: null
+      }
+    })
+    const discussEvents: Array<CustomEvent> = []
+    const listener = (event: Event) => {
+      discussEvents.push(event as CustomEvent)
     }
+    window.addEventListener("tldw:discuss-media", listener)
+    const { default: OptionIndex } = await import("../option-index")
+
+    try {
+      render(
+        <MemoryRouter>
+          <OptionIndex />
+        </MemoryRouter>
+      )
+
+      expect(
+        await screen.findByRole("heading", { name: /add your first source/i })
+      ).toBeInTheDocument()
+
+      fireEvent.click(
+        await screen.findByRole("button", {
+          name: /ask a question about this source/i
+        })
+      )
+
+      expect(discussEvents).toHaveLength(1)
+      expect(discussEvents[0]?.detail).toEqual({
+        mediaId: "persisted-42",
+        title: "Saved PDF",
+        mode: "rag_media"
+      })
+    } finally {
+      window.removeEventListener("tldw:discuss-media", listener)
+    }
+  })
+
+  it("does not show first-source processing for an unrelated processing session", async () => {
+    routeMocks.firstRunState.current = createCompletedFirstRunState()
+    seedQuickIngestSession({
+      lifecycle: "processing",
+      openDetail: { source: "manual" }
+    })
+    const { default: OptionIndex } = await import("../option-index")
+
+    render(
+      <MemoryRouter>
+        <OptionIndex />
+      </MemoryRouter>
+    )
+
+    expect(
+      await screen.findByRole("heading", { name: /add your first source/i })
+    ).toBeInTheDocument()
+    expect(screen.queryByText(/processing your source/i)).not.toBeInTheDocument()
+    expect(
+      screen.getByRole("button", { name: /add source/i })
+    ).toBeInTheDocument()
+  })
+
+  it("shows inline API key recovery when setup is complete but media auth is missing", async () => {
+    routeMocks.firstRunState.current = createCompletedFirstRunState()
     routeMocks.tldwConfig.current = {
       serverUrl: "http://localhost:3000",
       authMode: "single-user"
@@ -232,14 +439,7 @@ describe("OptionIndex unified setup resolver", () => {
   })
 
   it("saves a recovered API key, rechecks readiness, and then shows the first-source milestone", async () => {
-    routeMocks.firstRunState.current = {
-      status: "completed",
-      completed_steps: ["first_chat"],
-      skipped_steps: [],
-      step_data: {},
-      acknowledged_steps: ["first_chat"],
-      first_chat: { completed: true }
-    }
+    routeMocks.firstRunState.current = createCompletedFirstRunState()
     routeMocks.tldwConfig.current = {
       serverUrl: "http://localhost:3000",
       authMode: "single-user"
@@ -273,14 +473,7 @@ describe("OptionIndex unified setup resolver", () => {
   })
 
   it("does not render the first-source CTA while media readiness is still checking", async () => {
-    routeMocks.firstRunState.current = {
-      status: "completed",
-      completed_steps: ["first_chat"],
-      skipped_steps: [],
-      step_data: {},
-      acknowledged_steps: ["first_chat"],
-      first_chat: { completed: true }
-    }
+    routeMocks.firstRunState.current = createCompletedFirstRunState()
     routeMocks.listMedia.mockReturnValue(new Promise(() => undefined))
     const { default: OptionIndex } = await import("../option-index")
 

--- a/apps/packages/ui/src/routes/__tests__/option-index.unified-setup.test.tsx
+++ b/apps/packages/ui/src/routes/__tests__/option-index.unified-setup.test.tsx
@@ -393,6 +393,48 @@ describe("OptionIndex unified setup resolver", () => {
     }
   })
 
+  it("retries first-source ingest with the persisted source kind after reload", async () => {
+    routeMocks.firstRunState.current = createCompletedFirstRunState()
+    seedQuickIngestSession({
+      lifecycle: "completed",
+      openDetail: {
+        source: "first_source_milestone",
+        preferredPreset: "quick",
+        firstSource: true,
+        firstSourceKind: "paste_text"
+      },
+      firstSourceAddMode: "paste_text",
+      resultSummary: {
+        status: "error",
+        attemptedAt: 1,
+        completedAt: 2,
+        totalCount: 1,
+        successCount: 0,
+        failedCount: 1,
+        cancelledCount: 0,
+        firstMediaId: null,
+        primarySourceLabel: "Pasted notes",
+        errorMessage: "Upload failed"
+      }
+    })
+    const { default: OptionIndex } = await import("../option-index")
+
+    render(
+      <MemoryRouter>
+        <OptionIndex />
+      </MemoryRouter>
+    )
+
+    fireEvent.click(await screen.findByRole("button", { name: /retry/i }))
+
+    expect(routeMocks.requestQuickIngestOpen).toHaveBeenCalledWith(
+      expect.objectContaining({
+        firstSourceKind: "paste_text"
+      }),
+      { focusTrigger: true }
+    )
+  })
+
   it("does not show first-source processing for an unrelated processing session", async () => {
     routeMocks.firstRunState.current = createCompletedFirstRunState()
     seedQuickIngestSession({

--- a/apps/packages/ui/src/routes/option-index.tsx
+++ b/apps/packages/ui/src/routes/option-index.tsx
@@ -1,7 +1,10 @@
 import React from "react"
 
 import { PageAssistLoader } from "@/components/Common/PageAssistLoader"
-import { FirstSourceMilestonePrompt } from "@/components/Option/Onboarding/FirstSourceMilestonePrompt"
+import {
+  FirstSourceMilestonePrompt,
+  type FirstSourceKind
+} from "@/components/Option/Onboarding/FirstSourceMilestonePrompt"
 import { PostSetupApiRecovery } from "@/components/Option/Onboarding/PostSetupApiRecovery"
 import { UnifiedSetupWizard } from "@/components/Option/Onboarding/UnifiedSetupWizard"
 import {
@@ -13,7 +16,11 @@ import { usePostOnboardingMediaReadiness } from "@/hooks/usePostOnboardingMediaR
 import { useSetupOnboarding } from "@/hooks/useSetupOnboarding"
 import OptionLayout from "~/components/Layouts/Layout"
 import { isHostedTldwDeployment } from "@/services/tldw/deployment-mode"
-import { requestQuickIngestOpen } from "@/utils/quick-ingest-open"
+import { useQuickIngestSessionStore } from "@/store/quick-ingest-session"
+import {
+  isFirstSourceOpenDetail,
+  requestQuickIngestOpen
+} from "@/utils/quick-ingest-open"
 import { isSetupStatusRequiringWizard } from "./setup-status"
 
 const LazyCompanionHomeShell = React.lazy(() =>
@@ -38,6 +45,34 @@ const readFirstSourceDismissed = () => {
   }
 }
 
+const openFirstSourceQuickIngest = (kind: FirstSourceKind) => {
+  requestQuickIngestOpen(
+    {
+      source: "first_source_milestone",
+      preferredPreset: "quick",
+      firstSource: true,
+      firstSourceKind: kind
+    },
+    { focusTrigger: true }
+  )
+}
+
+const discussFirstSource = (payload: {
+  mediaId: string
+  title: string | null
+}) => {
+  if (typeof window === "undefined") return
+  window.dispatchEvent(
+    new CustomEvent("tldw:discuss-media", {
+      detail: {
+        mediaId: payload.mediaId,
+        title: payload.title || "First source",
+        mode: "rag_media"
+      }
+    })
+  )
+}
+
 const OptionIndex = () => {
   const hostedMode = isHostedTldwDeployment()
   const { phase } = useConnectionState()
@@ -51,6 +86,11 @@ const OptionIndex = () => {
   const [didHydrate, setDidHydrate] = React.useState(false)
   const [firstSourceDismissed, setFirstSourceDismissed] = React.useState(
     readFirstSourceDismissed
+  )
+  const [lastFirstSourceKind, setLastFirstSourceKind] =
+    React.useState<FirstSourceKind>("web_url")
+  const quickIngestSession = useQuickIngestSessionStore(
+    (state) => state.session
   )
 
   React.useEffect(() => {
@@ -134,6 +174,27 @@ const OptionIndex = () => {
 
   const showFirstSourcePrompt =
     shouldCheckPostOnboardingMedia && mediaReadiness.status === "ready"
+  const firstSourceSession = isFirstSourceOpenDetail(
+    quickIngestSession?.openDetail
+  )
+    ? quickIngestSession
+    : null
+  const firstSourceRunSummary = firstSourceSession?.resultSummary ?? null
+  const firstSourceMediaId =
+    firstSourceRunSummary?.status === "success" &&
+    firstSourceRunSummary.firstMediaId
+      ? firstSourceRunSummary.firstMediaId
+      : null
+  const firstSourceAskReady =
+    Boolean(firstSourceMediaId) && mediaReadiness.status === "ready"
+  const firstSourcePromptStatus =
+    firstSourceSession?.lifecycle === "processing"
+      ? "processing"
+      : firstSourceRunSummary?.status === "error"
+        ? "error"
+        : firstSourceAskReady
+          ? "ready"
+          : "idle"
 
   if (
     shouldCheckPostOnboardingMedia &&
@@ -155,16 +216,23 @@ const OptionIndex = () => {
     <OptionLayout>
       {showFirstSourcePrompt ? (
         <FirstSourceMilestonePrompt
-          onAddSource={() => {
-            requestQuickIngestOpen(
-              {
-                source: "first_source_milestone",
-                preferredPreset: "quick",
-                firstSource: true
-              },
-              { focusTrigger: true }
-            )
+          readinessStatus={firstSourcePromptStatus}
+          lastSourceLabel={firstSourceRunSummary?.primarySourceLabel}
+          errorMessage={firstSourceRunSummary?.errorMessage}
+          onAddSource={(kind) => {
+            setLastFirstSourceKind(kind)
+            openFirstSourceQuickIngest(kind)
           }}
+          onRetry={() => openFirstSourceQuickIngest(lastFirstSourceKind)}
+          onAskAboutSource={
+            firstSourceMediaId && firstSourceAskReady
+              ? () =>
+                  discussFirstSource({
+                    mediaId: firstSourceMediaId,
+                    title: firstSourceRunSummary?.primarySourceLabel ?? null
+                  })
+              : undefined
+          }
           onDismiss={dismissFirstSourcePrompt}
         />
       ) : null}

--- a/apps/packages/ui/src/routes/option-index.tsx
+++ b/apps/packages/ui/src/routes/option-index.tsx
@@ -223,7 +223,13 @@ const OptionIndex = () => {
             setLastFirstSourceKind(kind)
             openFirstSourceQuickIngest(kind)
           }}
-          onRetry={() => openFirstSourceQuickIngest(lastFirstSourceKind)}
+          onRetry={() =>
+            openFirstSourceQuickIngest(
+              firstSourceSession?.firstSourceAddMode ??
+                firstSourceSession?.openDetail?.firstSourceKind ??
+                lastFirstSourceKind
+            )
+          }
           onAskAboutSource={
             firstSourceMediaId && firstSourceAskReady
               ? () =>

--- a/apps/packages/ui/src/store/quick-ingest-session.ts
+++ b/apps/packages/ui/src/store/quick-ingest-session.ts
@@ -14,7 +14,11 @@ import type {
   PlaylistQueueMetadata,
 } from "@/components/Common/QuickIngest/types"
 import { DEFAULT_PRESET, DEFAULT_PRESETS } from "@/components/Common/QuickIngest/presets"
-import type { QuickIngestOpenDetail } from "@/utils/quick-ingest-open"
+import {
+  isFirstSourceQuickIngestKind,
+  type FirstSourceQuickIngestKind,
+  type QuickIngestOpenDetail,
+} from "@/utils/quick-ingest-open"
 
 const STORAGE_KEY = "tldw-quick-ingest-session"
 
@@ -104,6 +108,7 @@ export type QuickIngestSessionRecord = {
   processingState: WizardProcessingState
   results: WizardResultItem[]
   openDetail?: QuickIngestOpenDetail | null
+  firstSourceAddMode?: FirstSourceQuickIngestKind | null
   conferenceBatchMetadata?: ConferenceBatchMetadata | null
   badge: QuickIngestSessionBadge
   resultSummary: QuickIngestSessionResultSummary
@@ -502,6 +507,11 @@ const sanitizeSession = (
       session.openDetail && typeof session.openDetail === "object"
         ? session.openDetail
         : null,
+    firstSourceAddMode: isFirstSourceQuickIngestKind(
+      session.firstSourceAddMode
+    )
+      ? session.firstSourceAddMode
+      : null,
     conferenceBatchMetadata: session.conferenceBatchMetadata ?? null,
     badge: {
       queueCount: Math.max(
@@ -553,6 +563,7 @@ export const createEmptyQuickIngestSession = (): QuickIngestSessionRecord => {
     processingState: { ...INITIAL_PROCESSING_STATE },
     results: [],
     openDetail: null,
+    firstSourceAddMode: null,
     conferenceBatchMetadata: null,
     badge: {
       queueCount: 0,

--- a/apps/packages/ui/src/types/setup-onboarding.ts
+++ b/apps/packages/ui/src/types/setup-onboarding.ts
@@ -59,6 +59,7 @@ export type SetupProviderSaveResponse = {
   provider_key: string
   status: "saved" | "failed"
   masked_api_key?: string | null
+  credential_configured?: boolean
   base_url?: string | null
   model?: string | null
   make_default?: boolean
@@ -73,6 +74,8 @@ export type SetupProviderValidationResponse = {
   failure_category?: string | null
   message?: string | null
   models: string[]
+  validation_level?: string | null
+  can_gate_first_chat?: boolean
 }
 
 export type FirstRunMetadata = {

--- a/apps/packages/ui/src/utils/__tests__/quick-ingest-open.test.ts
+++ b/apps/packages/ui/src/utils/__tests__/quick-ingest-open.test.ts
@@ -69,7 +69,8 @@ describe("quick ingest open handoff", () => {
     }
 
     expect(createQuickIngestSessionSeedFromOpenDetail(detail)).toEqual({
-      openDetail: detail
+      openDetail: detail,
+      firstSourceAddMode: null
     })
   })
 
@@ -77,11 +78,13 @@ describe("quick ingest open handoff", () => {
     const detail = {
       source: "first_source_milestone" as const,
       preferredPreset: "quick" as const,
-      firstSource: true
+      firstSource: true,
+      firstSourceKind: "paste_text" as const
     }
 
     expect(createQuickIngestSessionSeedFromOpenDetail(detail)).toMatchObject({
       openDetail: detail,
+      firstSourceAddMode: "paste_text",
       selectedPreset: "quick",
       customBasePreset: "quick",
       presetConfig: {
@@ -106,6 +109,7 @@ describe("quick ingest open handoff", () => {
     } as unknown as QuickIngestOpenDetail
 
     expect(createQuickIngestSessionSeedFromOpenDetail(detail)).toMatchObject({
+      firstSourceAddMode: "web_url",
       selectedPreset: "quick",
       customBasePreset: "quick",
       presetConfig: {

--- a/apps/packages/ui/src/utils/__tests__/quick-ingest-open.test.ts
+++ b/apps/packages/ui/src/utils/__tests__/quick-ingest-open.test.ts
@@ -1,7 +1,8 @@
-import { describe, expect, it } from "vitest"
+import { describe, expect, expectTypeOf, it } from "vitest"
 import {
   buildQuickIngestOpenDetailFromUrl,
   createQuickIngestSessionSeedFromOpenDetail,
+  isFirstSourceOpenDetail,
   isQuickIngestPlaylistPreflightDetail,
   requestQuickIngestOpen
 } from "../quick-ingest-open"
@@ -98,6 +99,32 @@ describe("quick ingest open handoff", () => {
           document: { ocr: false }
         }
       }
+    })
+  })
+
+  it("keeps legacy first-source markers from narrowing to milestone-only source", () => {
+    const detail = {
+      source: "global",
+      firstSource: true,
+      firstSourceKind: "paste_text"
+    } as QuickIngestOpenDetail
+
+    expect(isFirstSourceOpenDetail(detail)).toBe(true)
+    if (isFirstSourceOpenDetail(detail)) {
+      expect(detail.source).toBe("global")
+      const narrowedSource: Exclude<
+        typeof detail.source,
+        "first_source_milestone"
+      > = detail.source
+      expect(narrowedSource).toBe("global")
+      expectTypeOf(detail.source).not.toEqualTypeOf<"first_source_milestone">()
+    }
+
+    expect(createQuickIngestSessionSeedFromOpenDetail(detail)).toMatchObject({
+      openDetail: detail,
+      firstSourceAddMode: "paste_text",
+      selectedPreset: "quick",
+      customBasePreset: "quick"
     })
   })
 

--- a/apps/packages/ui/src/utils/quick-ingest-open.ts
+++ b/apps/packages/ui/src/utils/quick-ingest-open.ts
@@ -15,6 +15,16 @@ export type QuickIngestPlaylistSourceKind =
   | "youtube_watch_playlist"
   | "unknown"
 
+export type FirstSourceQuickIngestKind =
+  | "web_url"
+  | "file_upload"
+  | "paste_text"
+
+export const isFirstSourceQuickIngestKind = (
+  value: unknown
+): value is FirstSourceQuickIngestKind =>
+  value === "web_url" || value === "file_upload" || value === "paste_text"
+
 export type QuickIngestOpenDetail =
   | {
       source: "manual"
@@ -24,6 +34,7 @@ export type QuickIngestOpenDetail =
       source: "first_source_milestone"
       preferredPreset?: Exclude<IngestPreset, "custom">
       firstSource?: boolean
+      firstSourceKind?: FirstSourceQuickIngestKind
       action?: string
     }
   | {
@@ -55,6 +66,7 @@ export type QuickIngestPendingOpenRequest = {
 
 export type QuickIngestSessionSeed = {
   openDetail: QuickIngestOpenDetail
+  firstSourceAddMode?: FirstSourceQuickIngestKind | null
   selectedPreset?: Exclude<IngestPreset, "custom">
   customBasePreset?: Exclude<IngestPreset, "custom">
   presetConfig?: PresetConfig
@@ -216,7 +228,7 @@ const isPreferredPreset = (
   typeof value === "string" &&
   Object.prototype.hasOwnProperty.call(DEFAULT_PRESETS, value)
 
-const isFirstSourceOpenDetail = (
+export const isFirstSourceOpenDetail = (
   detail: QuickIngestOpenDetail | null | undefined
 ): detail is Extract<
   QuickIngestOpenDetail,
@@ -227,6 +239,13 @@ const isFirstSourceOpenDetail = (
     (detail.source === "first_source_milestone" || detail.firstSource === true)
   )
 
+const getFirstSourceAddMode = (
+  detail: QuickIngestOpenDetail
+): FirstSourceQuickIngestKind =>
+  isFirstSourceQuickIngestKind(detail.firstSourceKind)
+    ? detail.firstSourceKind
+    : "web_url"
+
 export const createQuickIngestSessionSeedFromOpenDetail = (
   detail: QuickIngestOpenDetail | null | undefined
 ): QuickIngestSessionSeed | null => {
@@ -236,6 +255,7 @@ export const createQuickIngestSessionSeedFromOpenDetail = (
       : FIRST_SOURCE_PREFERRED_PRESET
     return {
       openDetail: detail,
+      firstSourceAddMode: getFirstSourceAddMode(detail),
       selectedPreset: preferredPreset,
       customBasePreset: preferredPreset,
       presetConfig:
@@ -246,7 +266,7 @@ export const createQuickIngestSessionSeedFromOpenDetail = (
   }
 
   if (isQuickIngestPlaylistPreflightDetail(detail)) {
-    return { openDetail: detail }
+    return { openDetail: detail, firstSourceAddMode: null }
   }
 
   return null

--- a/apps/packages/ui/src/utils/quick-ingest-open.ts
+++ b/apps/packages/ui/src/utils/quick-ingest-open.ts
@@ -72,6 +72,14 @@ export type QuickIngestSessionSeed = {
   presetConfig?: PresetConfig
 }
 
+export type FirstSourceOpenDetail =
+  | Extract<QuickIngestOpenDetail, { source: "first_source_milestone" }>
+  | (QuickIngestOpenDetail & {
+      firstSource: true
+      preferredPreset?: unknown
+      firstSourceKind?: unknown
+    })
+
 type QuickIngestWindow = Window & {
   __tldwPendingQuickIngestOpen?: QuickIngestPendingOpenRequest
 }
@@ -230,17 +238,14 @@ const isPreferredPreset = (
 
 export const isFirstSourceOpenDetail = (
   detail: QuickIngestOpenDetail | null | undefined
-): detail is Extract<
-  QuickIngestOpenDetail,
-  { source: "first_source_milestone" }
-> =>
+): detail is FirstSourceOpenDetail =>
   Boolean(
     detail &&
     (detail.source === "first_source_milestone" || detail.firstSource === true)
   )
 
 const getFirstSourceAddMode = (
-  detail: QuickIngestOpenDetail
+  detail: FirstSourceOpenDetail
 ): FirstSourceQuickIngestKind =>
   isFirstSourceQuickIngestKind(detail.firstSourceKind)
     ? detail.firstSourceKind

--- a/apps/tldw-frontend/e2e/smoke/smoke.setup.ts
+++ b/apps/tldw-frontend/e2e/smoke/smoke.setup.ts
@@ -1,4 +1,4 @@
-import { test as base, expect, Page } from "@playwright/test"
+import { test as base, expect, Page, type Route } from "@playwright/test"
 import { resolveE2eApiKey } from "../utils/e2e-auth"
 
 /**
@@ -110,6 +110,87 @@ export const AUTH_CONFIG = {
   serverUrl: SMOKE_SERVER_URL,
   apiKey: resolveE2eApiKey({ serverUrl: SMOKE_SERVER_URL }),
   allowOffline: process.env.TLDW_E2E_ALLOW_OFFLINE !== "0"
+}
+
+const fulfillSmokeJson = async (
+  route: Route,
+  status: number,
+  body: unknown
+): Promise<void> => {
+  await route.fulfill({
+    status,
+    contentType: "application/json",
+    headers: {
+      "access-control-allow-origin": "*",
+      "access-control-allow-headers": "*",
+      "access-control-allow-methods": "GET,POST,OPTIONS"
+    },
+    body: JSON.stringify(body)
+  })
+}
+
+async function stubCompletedFirstRunSetup(page: Page): Promise<void> {
+  await page.route(/\/api\/v1\/setup\/first-run\/(?:state|metadata)(?:\?.*)?$/, async (route) => {
+    const request = route.request()
+    const method = request.method().toUpperCase()
+    const path = new URL(request.url()).pathname
+
+    if (method === "OPTIONS") {
+      await route.fulfill({
+        status: 204,
+        headers: {
+          "access-control-allow-origin": "*",
+          "access-control-allow-headers": "*",
+          "access-control-allow-methods": "GET,POST,OPTIONS"
+        }
+      })
+      return
+    }
+
+    if (method !== "GET") {
+      await route.fallback()
+      return
+    }
+
+    if (path === "/api/v1/setup/first-run/state") {
+      await fulfillSmokeJson(route, 200, {
+        status: "completed",
+        current_step: null,
+        completed_steps: ["first_chat"],
+        skipped_steps: [],
+        step_data: {},
+        acknowledged_steps: ["first_chat"],
+        first_chat: {
+          completed: true,
+          provider: "openai",
+          model: "gpt-4.1-mini",
+          response_id: "smoke-first-chat",
+          completed_at: "2026-06-01T12:00:00Z"
+        },
+        skip_reason: null,
+        created_at: "2026-06-01T12:00:00Z",
+        updated_at: "2026-06-01T12:00:00Z",
+        completed_at: "2026-06-01T12:00:00Z"
+      })
+      return
+    }
+
+    await fulfillSmokeJson(route, 200, {
+      auth_mode: "single_user",
+      bundled_single_user_auth_available: true,
+      manual_auth_required: false,
+      setup_required: false,
+      setup_completed: true,
+      remote_setup_enabled: false,
+      connection: {
+        frontend_origin: "http://localhost:3000",
+        api_origin: SMOKE_SERVER_URL,
+        browser_access: "local"
+      },
+      setup_paths: [],
+      multi_user_exit: { guide_path: "/Docs/AuthNZ/Multi_User_Setup.md" }
+    })
+  })
 }
 
 type SeedAuthOverrides = {
@@ -351,6 +432,7 @@ export async function seedAuth(
     },
     cfg
   )
+  await stubCompletedFirstRunSetup(page)
 }
 
 /**

--- a/apps/tldw-frontend/e2e/workflows/onboarding-ingestion-first.spec.ts
+++ b/apps/tldw-frontend/e2e/workflows/onboarding-ingestion-first.spec.ts
@@ -1,14 +1,12 @@
 import fs from "node:fs"
 import path from "node:path"
-import type { Page } from "@playwright/test"
+import type { Page, Route } from "@playwright/test"
 import {
   test,
   expect,
   assertNoCriticalErrors,
-  skipIfServerUnavailable,
 } from "../utils/fixtures"
-import { TEST_CONFIG, dismissConnectionModals, waitForConnection } from "../utils/helpers"
-import { openQuickIngestDialog } from "../utils/journey-helpers"
+import { TEST_CONFIG, dismissConnectionModals } from "../utils/helpers"
 
 type ViewportTarget = {
   label: "desktop" | "mobile"
@@ -23,19 +21,6 @@ type OnboardingEvidenceStep = {
   note: string
 }
 
-function sanitizeEvidenceTag(rawTag: string): string {
-  const normalized = rawTag.trim().replace(/[^a-zA-Z0-9._-]/g, "_")
-  return normalized.length > 0 ? normalized : "local"
-}
-
-function defaultEvidenceTag(): string {
-  return new Date().toISOString().slice(0, 10).replace(/-/g, "_")
-}
-
-function formatEvidenceDate(tag: string): string | null {
-  return /^\d{4}_\d{2}_\d{2}$/.test(tag) ? tag.split("_").join("-") : null
-}
-
 const EVIDENCE_TAG = sanitizeEvidenceTag(
   process.env.TLDW_ONBOARDING_EVIDENCE_TAG || defaultEvidenceTag()
 )
@@ -48,6 +33,19 @@ const VIEWPORTS: ViewportTarget[] = [
   { label: "desktop", width: 1440, height: 900 },
   { label: "mobile", width: 375, height: 812 },
 ]
+
+function sanitizeEvidenceTag(rawTag: string): string {
+  const normalized = rawTag.trim().replace(/[^a-zA-Z0-9._-]/g, "_")
+  return normalized.length > 0 ? normalized : "local"
+}
+
+function defaultEvidenceTag(): string {
+  return new Date().toISOString().slice(0, 10).replace(/-/g, "_")
+}
+
+function formatEvidenceDate(tag: string): string | null {
+  return /^\d{4}_\d{2}_\d{2}$/.test(tag) ? tag.split("_").join("-") : null
+}
 
 function ensureEvidenceDirectory(): void {
   fs.mkdirSync(EVIDENCE_DIR, { recursive: true })
@@ -90,7 +88,7 @@ function writeEvidenceReadme(): void {
   const mobileRows = readViewportEvidence("mobile")
   const evidenceDate = formatEvidenceDate(EVIDENCE_TAG)
   const markdown = [
-    "# M4.3 Onboarding Ingestion-First Evidence",
+    "# M4.3 Onboarding First-Source Evidence",
     "",
     `Evidence Tag: ${EVIDENCE_TAG}`,
     evidenceDate ? `Date: ${evidenceDate}` : null,
@@ -133,96 +131,176 @@ async function captureStep(
   })
 }
 
-async function assertCardOrder(page: Page) {
-  const ingest = page.getByTestId("onboarding-success-ingest")
-  const media = page.getByTestId("onboarding-success-media")
-  const chat = page.getByTestId("onboarding-success-chat")
-  const [ingestBox, mediaBox, chatBox] = await Promise.all([
-    ingest.boundingBox(),
-    media.boundingBox(),
-    chat.boundingBox(),
-  ])
-  expect(ingestBox).toBeTruthy()
-  expect(mediaBox).toBeTruthy()
-  expect(chatBox).toBeTruthy()
-  expect((ingestBox?.y ?? 0) < (mediaBox?.y ?? 0)).toBeTruthy()
-  expect((mediaBox?.y ?? 0) < (chatBox?.y ?? 0)).toBeTruthy()
+async function json(route: Route, body: unknown, status = 200): Promise<void> {
+  await route.fulfill({
+    status,
+    contentType: "application/json",
+    headers: {
+      "access-control-allow-origin": "*",
+      "access-control-allow-headers": "*",
+      "access-control-allow-methods": "GET,POST,OPTIONS",
+    },
+    body: JSON.stringify(body),
+  })
 }
 
-async function clearOnboardingBlockingOverlays(page: Page): Promise<void> {
-  const splash = page.getByRole("dialog", { name: "Splash screen" }).first()
-  if (await splash.isVisible().catch(() => false)) {
-    await splash.click({ force: true })
-    await splash.waitFor({ state: "hidden", timeout: 5_000 }).catch(() => {})
-  }
-  await dismissConnectionModals(page)
-}
+async function installCompletedFirstRunApi(page: Page): Promise<void> {
+  await page.route(/\/api\/v1\/setup\/first-run\/(?:state|metadata)(?:\?.*)?$/, async (route) => {
+    const request = route.request()
+    const method = request.method().toUpperCase()
+    const pathName = new URL(request.url()).pathname
 
-async function openOnboardingSuccessScreen(
-  page: Page
-): Promise<"connected-now" | "already-connected"> {
-  await page.goto("/", { waitUntil: "domcontentloaded" })
-
-  const connect = page.getByTestId("onboarding-connect")
-  const success = page.getByTestId("onboarding-success-screen")
-
-  await Promise.race([
-    connect.waitFor({ state: "visible", timeout: 25_000 }),
-    success.waitFor({ state: "visible", timeout: 25_000 }),
-  ])
-
-  await clearOnboardingBlockingOverlays(page)
-
-  const alreadyConnected = await success.isVisible().catch(() => false)
-  if (alreadyConnected) {
-    return "already-connected"
-  }
-
-  const needsConnect = await connect.isVisible().catch(() => false)
-  if (needsConnect) {
-    await clearOnboardingBlockingOverlays(page)
-    await connect.click()
-  }
-
-  await expect(success).toBeVisible({ timeout: 30_000 })
-  return needsConnect ? "connected-now" : "already-connected"
-}
-
-async function ensureOnboardingSuccessScreen(page: Page): Promise<void> {
-  const success = page.getByTestId("onboarding-success-screen")
-  const isVisible = await success.isVisible().catch(() => false)
-  if (isVisible) return
-  await openOnboardingSuccessScreen(page)
-}
-
-async function clickOnboardingCtaAndExpectRoute(
-  page: Page,
-  ctaTestId: string,
-  expectedUrl: RegExp
-): Promise<void> {
-  const cta = page.getByTestId(ctaTestId)
-  let lastError: unknown
-
-  for (let attempt = 0; attempt < 2; attempt += 1) {
-    await clearOnboardingBlockingOverlays(page)
-    await expect(cta).toBeVisible({ timeout: 15_000 })
-    await cta.click()
-    try {
-      await expect(page).toHaveURL(expectedUrl, { timeout: 15_000 })
+    if (method === "OPTIONS") {
+      await route.fulfill({
+        status: 204,
+        headers: {
+          "access-control-allow-origin": "*",
+          "access-control-allow-headers": "*",
+          "access-control-allow-methods": "GET,POST,OPTIONS",
+        },
+      })
       return
-    } catch (error) {
-      lastError = error
     }
-  }
 
-  throw lastError
+    if (method !== "GET") {
+      await route.fallback()
+      return
+    }
+
+    if (pathName === "/api/v1/setup/first-run/state") {
+      await json(route, {
+        status: "completed",
+        current_step: null,
+        completed_steps: ["first_chat"],
+        skipped_steps: [],
+        step_data: {},
+        acknowledged_steps: ["first_chat"],
+        first_chat: {
+          completed: true,
+          provider: "openai",
+          model: "gpt-4.1-mini",
+          response_id: "chatcmpl-first-source-e2e",
+          completed_at: "2026-06-01T12:00:00Z",
+        },
+        skip_reason: null,
+        created_at: "2026-06-01T12:00:00Z",
+        updated_at: "2026-06-01T12:00:00Z",
+        completed_at: "2026-06-01T12:00:00Z",
+      })
+      return
+    }
+
+    await json(route, {
+      auth_mode: "single_user",
+      bundled_single_user_auth_available: true,
+      manual_auth_required: false,
+      setup_required: false,
+      setup_completed: true,
+      remote_setup_enabled: false,
+      connection: {
+        frontend_origin: "http://localhost:8080",
+        api_origin: TEST_CONFIG.serverUrl,
+        browser_access: "local",
+      },
+      setup_paths: [],
+      multi_user_exit: { guide_path: "/Docs/AuthNZ/Multi_User_Setup.md" },
+    })
+  })
+
+  await page.route(/\/api\/v1\/media(?:\?.*)?$/, async (route) => {
+    if (route.request().method().toUpperCase() !== "GET") {
+      await route.fallback()
+      return
+    }
+    await json(route, { items: [], total: 0, page: 1, results_per_page: 1 })
+  })
 }
 
-test.describe("Onboarding Ingestion-First Journey", () => {
+async function closeQuickIngestIfOpen(page: Page): Promise<void> {
+  const dialog = page.getByRole("dialog").filter({ hasText: /quick ingest/i }).first()
+  if (!(await dialog.isVisible().catch(() => false))) return
+  const closeButton = dialog.locator(".ant-modal-close").first()
+  if (await closeButton.isVisible().catch(() => false)) {
+    await closeButton.click()
+  } else {
+    await page.keyboard.press("Escape")
+  }
+  await expect(dialog).toBeHidden({ timeout: 10_000 })
+}
+
+async function setFirstSourceSessionState(
+  page: Page,
+  state:
+    | { lifecycle: "processing" }
+    | {
+        lifecycle: "completed"
+        resultStatus: "error" | "success"
+        firstMediaId?: string | null
+        label: string
+        errorMessage?: string | null
+      }
+): Promise<void> {
+  await page.evaluate((nextState) => {
+    type QuickIngestSessionApi = {
+      session?: {
+        id: string
+        resultSummary: Record<string, unknown>
+      } | null
+      createDraftSession: (seed: Record<string, unknown>) => {
+        id: string
+        resultSummary: Record<string, unknown>
+      }
+      upsertSession: (patch: Record<string, unknown>) => void
+    }
+    const store = (
+      window as Window & {
+        __tldw_useQuickIngestSessionStore?: {
+          getState?: () => QuickIngestSessionApi
+        }
+      }
+    ).__tldw_useQuickIngestSessionStore
+    const api = store?.getState?.()
+    if (!api) return
+    const openDetail = {
+      source: "first_source_milestone",
+      preferredPreset: "quick",
+      firstSource: true,
+      firstSourceKind: "paste_text",
+    }
+    const session = api.session || api.createDraftSession({
+      openDetail,
+      firstSourceAddMode: "paste_text",
+    })
+    api.upsertSession({
+      id: session.id,
+      openDetail,
+      firstSourceAddMode: "paste_text",
+      lifecycle: nextState.lifecycle,
+      resultSummary:
+        nextState.lifecycle === "completed"
+          ? {
+              status: nextState.resultStatus,
+              attemptedAt: Date.now(),
+              completedAt: Date.now(),
+              totalCount: 1,
+              successCount: nextState.resultStatus === "success" ? 1 : 0,
+              failedCount: nextState.resultStatus === "error" ? 1 : 0,
+              cancelledCount: 0,
+              firstMediaId: nextState.firstMediaId || null,
+              primarySourceLabel: nextState.label,
+              errorMessage: nextState.errorMessage || null,
+            }
+          : session.resultSummary,
+    })
+  }, state)
+}
+
+test.describe("Onboarding First-Source Journey", () => {
   test.describe.configure({ timeout: 120_000 })
 
   test.beforeEach(async ({ authedPage }) => {
     ensureEvidenceDirectory()
+    await installCompletedFirstRunApi(authedPage)
     await authedPage.addInitScript((cfg) => {
       try {
         localStorage.setItem(
@@ -230,24 +308,21 @@ test.describe("Onboarding Ingestion-First Journey", () => {
           JSON.stringify({
             serverUrl: cfg.serverUrl,
             authMode: "single-user",
-            // lgtm[js/clear-text-storage-of-sensitive-data] synthetic CI key only
             apiKey: cfg.apiKey,
           })
         )
       } catch {}
       try {
-        localStorage.removeItem("__tldw_first_run_complete")
+        localStorage.removeItem("tldw:first-source-milestone-dismissed")
       } catch {}
     }, TEST_CONFIG)
   })
 
   for (const viewport of VIEWPORTS) {
-    test(`connects then guides ingest -> verify -> chat (${viewport.label})`, async ({
+    test(`guides first source after first-chat completion (${viewport.label})`, async ({
       authedPage,
-      serverInfo,
       diagnostics,
     }) => {
-      skipIfServerUnavailable(serverInfo)
       const evidenceRows: OnboardingEvidenceStep[] = []
 
       await authedPage.setViewportSize({
@@ -255,146 +330,84 @@ test.describe("Onboarding Ingestion-First Journey", () => {
         height: viewport.height,
       })
 
-      const initialConnectState = await openOnboardingSuccessScreen(authedPage)
+      await authedPage.goto("/", { waitUntil: "domcontentloaded" })
+      await dismissConnectionModals(authedPage)
+      await expect(
+        authedPage.getByRole("heading", { name: /add your first source/i })
+      ).toBeVisible({ timeout: 30_000 })
+      await expect(
+        authedPage.getByRole("radio", { name: /web url/i })
+      ).toBeChecked()
+      await expect(
+        authedPage.getByRole("button", { name: /ask a question about this source/i })
+      ).toHaveCount(0)
       await captureStep(
         authedPage,
         evidenceRows,
         viewport.label,
-        "01-setup-connect",
-        initialConnectState === "connected-now"
-          ? "Connected via home onboarding."
-          : "Onboarding success already visible from prior connected state."
+        "01-first-source-idle",
+        "Completed first chat now guides the next milestone: add a first source."
       )
 
-      await expect(authedPage.getByTestId("onboarding-success-screen")).toHaveAttribute(
-        "data-ingest-status",
-        "idle"
-      )
-      await expect(authedPage.getByTestId("onboarding-ingest-status")).toContainText(
-        "Start"
-      )
-      await expect(authedPage.getByTestId("onboarding-success-ingest")).toBeVisible()
-      await expect(authedPage.getByTestId("onboarding-success-media")).toBeVisible()
-      await expect(authedPage.getByTestId("onboarding-success-chat")).toBeVisible()
-      await assertCardOrder(authedPage)
+      await authedPage.getByText("Paste", { exact: true }).click()
+      await authedPage.getByRole("button", { name: /add source/i }).click()
+      await expect(
+        authedPage.getByRole("textbox", { name: /pasted text input/i })
+      ).toBeVisible({ timeout: 20_000 })
       await captureStep(
         authedPage,
         evidenceRows,
         viewport.label,
-        "02-success-idle",
-        "Idle onboarding recommendation state with CTA ordering."
+        "02-paste-source-entry",
+        "Paste text choice opens Quick Ingest directly in paste mode."
       )
+      await closeQuickIngestIfOpen(authedPage)
 
-      await authedPage.evaluate(() => {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const store = (window as any).__tldw_useQuickIngestStore
-        store?.getState?.().recordRunSuccess({
-          totalCount: 1,
-          successCount: 1,
-          failedCount: 0,
-          firstMediaId: "m4-e2e-media-id",
-          primarySourceLabel: "https://example.com/m4-e2e"
-        })
-      })
-      await expect(authedPage.getByTestId("onboarding-success-screen")).toHaveAttribute(
-        "data-ingest-status",
-        "success"
-      )
-      await expect(authedPage.getByTestId("onboarding-ingest-status")).toContainText(
-        "Completed"
-      )
-      await expect(authedPage.getByTestId("onboarding-success-media")).toContainText(
-        "successful item"
-      )
-      await assertCardOrder(authedPage)
-      await captureStep(
-        authedPage,
-        evidenceRows,
-        viewport.label,
-        "03-success-post-ingest",
-        "Post-ingest recommendation state prioritizes media verification."
-      )
-
-      await clickOnboardingCtaAndExpectRoute(
-        authedPage,
-        "onboarding-success-media",
-        /\/media(?:[/?#].*)?$/
-      )
-      await captureStep(
-        authedPage,
-        evidenceRows,
-        viewport.label,
-        "04-media-route",
-        "Media verification route reached from onboarding CTA."
-      )
-
-      await openOnboardingSuccessScreen(authedPage)
-
-      await clickOnboardingCtaAndExpectRoute(
-        authedPage,
-        "onboarding-success-ingest",
-        /\/media(?:[/?#].*)?$/
-      )
-      await waitForConnection(authedPage)
-      const inlineQuickIngest = authedPage.getByRole("heading", {
-        name: /get started.*ingest your first content/i,
-      })
-      const hasInlineQuickIngest = await inlineQuickIngest
-        .waitFor({ state: "visible", timeout: 15_000 })
-        .then(() => true)
-        .catch(() => false)
-      const quickIngestDialog = hasInlineQuickIngest
-        ? null
-        : await openQuickIngestDialog(authedPage, 20_000)
-      await captureStep(
-        authedPage,
-        evidenceRows,
-        viewport.label,
-        "05-quick-ingest-modal",
-        hasInlineQuickIngest
-          ? "Onboarding ingest CTA routes to Media, where the inline Quick Ingest surface is visible."
-          : "Onboarding ingest CTA routes to Media, where Quick Ingest remains reachable."
-      )
-
-      if (quickIngestDialog) {
-        const quickIngestClose = quickIngestDialog
-          .locator(".ant-modal-close")
-          .first()
-        if (await quickIngestClose.isVisible().catch(() => false)) {
-          await quickIngestClose.evaluate((el: HTMLElement) => el.click())
-        } else {
-          await authedPage.keyboard.press("Escape")
-        }
-        await expect(quickIngestDialog).toBeHidden({ timeout: 10_000 })
-      }
-
-      await expect(authedPage).toHaveURL(/\/media(?:[/?#].*)?$/, {
-        timeout: 20_000,
-      })
-      await openOnboardingSuccessScreen(authedPage)
-
-      await authedPage.evaluate(() => {
-        try {
-          localStorage.setItem("__tldw_first_run_complete", "true")
-        } catch {
-          // Non-blocking; CTA should still handle completion in-app.
-        }
-      })
-
-      await clickOnboardingCtaAndExpectRoute(
-        authedPage,
-        "onboarding-success-chat",
-        /\/chat(?:[/?#].*)?$/
-      )
-      await expect(authedPage.getByTestId("chat-input")).toBeVisible({
-        timeout: 15_000,
+      await setFirstSourceSessionState(authedPage, { lifecycle: "processing" })
+      await expect(authedPage.getByText(/processing your source/i)).toBeVisible({
+        timeout: 10_000,
       })
       await captureStep(
         authedPage,
         evidenceRows,
         viewport.label,
-        "06-chat-route",
-        "Chat route reached from onboarding CTA."
+        "03-source-processing",
+        "Prompt remains inline while the first source is processing."
+      )
+
+      await setFirstSourceSessionState(authedPage, {
+        lifecycle: "completed",
+        resultStatus: "error",
+        label: "Pasted notes",
+        errorMessage: "Upload failed",
+      })
+      await expect(authedPage.getByText(/upload failed/i)).toBeVisible({
+        timeout: 10_000,
+      })
+      await expect(authedPage.getByRole("button", { name: /retry/i })).toBeVisible()
+      await captureStep(
+        authedPage,
+        evidenceRows,
+        viewport.label,
+        "04-source-error",
+        "Failed first-source ingest offers inline retry without claiming grounded chat is ready."
+      )
+
+      await setFirstSourceSessionState(authedPage, {
+        lifecycle: "completed",
+        resultStatus: "success",
+        firstMediaId: "m4-e2e-media-id",
+        label: "Pasted notes",
+      })
+      await expect(
+        authedPage.getByRole("button", { name: /ask a question about this source/i })
+      ).toBeVisible({ timeout: 10_000 })
+      await captureStep(
+        authedPage,
+        evidenceRows,
+        viewport.label,
+        "05-source-ready",
+        "Grounded chat action appears only after a successful first-source media id exists."
       )
 
       writeViewportEvidence(viewport.label, evidenceRows)

--- a/apps/tldw-frontend/e2e/workflows/unified-first-run-onboarding.spec.ts
+++ b/apps/tldw-frontend/e2e/workflows/unified-first-run-onboarding.spec.ts
@@ -221,6 +221,18 @@ async function installUnifiedFirstRunApi(
       return;
     }
 
+    if (path === '/api/v1/setup/first-run/providers/validate' && method === 'POST') {
+      const body = requestJson(route);
+      await json(route, {
+        provider_key: body.provider_key,
+        status: 'accepted',
+        validation_level: 'local_syntax',
+        can_gate_first_chat: true,
+        models: [],
+      });
+      return;
+    }
+
     if (path === '/api/v1/setup/first-run/ingest-defaults' && method === 'POST') {
       const body = requestJson(route);
       setupMutations.push({ path, body });
@@ -408,6 +420,8 @@ test.describe('unified first-run onboarding', () => {
     await page.getByLabel(/select openai/i).check();
     await page.getByLabel(/openai api key/i).fill('sk-test-onboarding');
     await page.getByLabel(/default model/i).fill('gpt-4.1-mini');
+    await page.getByRole('button', { name: /validate openai/i }).click();
+    await expect(page.getByText(/first chat verifies this provider/i)).toBeVisible();
     await page.getByRole('button', { name: /save provider/i }).click();
     await expect(page.getByText(/saved as sk-\.\.\.test/i)).toBeVisible();
     await page.getByRole('button', { name: /^continue$/i }).click();
@@ -427,6 +441,16 @@ test.describe('unified first-run onboarding', () => {
     await page.getByRole('button', { name: /send test chat/i }).click();
 
     await expect(page.getByRole('heading', { name: /add your first source/i })).toBeVisible();
+    await expect(page.getByRole('radio', { name: /web url/i })).toBeChecked();
+    await page.getByRole('button', { name: /add source/i }).click();
+    const firstSourceDetail = await page.evaluate(
+      () => (window as any).__tldwPendingQuickIngestOpen?.detail
+    );
+    expect(firstSourceDetail).toMatchObject({
+      source: 'first_source_milestone',
+      firstSource: true,
+      firstSourceKind: 'web_url',
+    });
     expect(mock.firstChatRequests).toHaveLength(1);
     expect(mock.firstChatRequests[0]).toMatchObject({
       provider: 'openai',

--- a/backlog/tasks/task-583 - Design-onboarding-confidence-flow-follow-up.md
+++ b/backlog/tasks/task-583 - Design-onboarding-confidence-flow-follow-up.md
@@ -1,0 +1,52 @@
+---
+id: TASK-583
+title: Design onboarding confidence flow follow-up
+status: In Progress
+labels:
+- onboarding
+- webui
+- setup
+priority: High
+documentation:
+- Docs/superpowers/specs/2026-06-01-onboarding-confidence-flow-design.md
+- Docs/superpowers/plans/2026-06-01-onboarding-confidence-flow-implementation-plan.md
+modified_files:
+- Docs/superpowers/specs/2026-06-01-onboarding-confidence-flow-design.md
+- Docs/superpowers/plans/2026-06-01-onboarding-confidence-flow-implementation-plan.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Design the next unified solo onboarding follow-up PR: manual provider validation, setup readiness panel, inline first-chat recovery, and first-source guided milestone. Start from latest dev and do not rebase the stale unified-solo-onboarding worktree wholesale.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Design spec captures the approved four-stage order: provider validation, readiness panel, first-chat recovery, first-source milestone.
+- [ ] #2 Spec explicitly preserves current dev readiness architecture and avoids resurrecting stale branch deletions.
+- [ ] #3 Spec defines staged commits/tasks and test expectations for the eventual one-PR implementation.
+- [ ] #4 Backlog task references the written spec and records review/verification status.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+['Design spec written and marked ready for user review.', 'Local review completed against approved sequence: provider validation, readiness panel, first-chat recovery, first-source milestone.', 'Subagent spec review not run because available subagent tooling is restricted to explicit user-requested delegation in this session.', 'Verification: git diff --cached --check passed for staged documentation/task changes.', 'Bandit: skipped because this commit changes only documentation and Backlog task metadata.', 'Follow-up review found and addressed validation-gate deadlock for syntax-only hosted providers by distinguishing ready vs accepted validation results.', 'Follow-up review found and addressed first-source readiness risk by requiring queryable/source readiness before offering a grounded question.', 'Follow-up review narrowed provider save semantics so persistence status is not overloaded with validation status.', 'Implementation plan written with four staged commits, exact touched files, TDD steps, focused verification commands, UAT checklist, and cleanup requirements.', 'Plan review subagent not run because available subagent tooling requires explicit user-requested delegation in this session.', 'Local plan review adjusted execution details: validate-first happy path preserves validation across safe key clearing, first-source ask action must not overclaim readiness, and exact verification commands now keep venv/workdir requirements explicit.']
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-584 - Implement-onboarding-confidence-flow-follow-up.md
+++ b/backlog/tasks/task-584 - Implement-onboarding-confidence-flow-follow-up.md
@@ -19,6 +19,8 @@ modified_files:
 - apps/packages/ui/src/hooks/__tests__/useSetupReadinessSummary.test.tsx
 - apps/packages/ui/src/components/Option/Onboarding/UnifiedSetupWizard.tsx
 - apps/packages/ui/src/components/Option/Onboarding/__tests__/UnifiedSetupWizard.test.tsx
+- apps/packages/ui/src/components/Option/Onboarding/steps/FirstChatStep.tsx
+- apps/packages/ui/src/components/Option/Onboarding/__tests__/FirstChatStep.test.tsx
 ---
 
 ## Description
@@ -31,7 +33,7 @@ Implement the approved onboarding confidence flow plan as one PR with four stage
 <!-- AC:BEGIN -->
 - [x] #1 Default first-chat provider requires manual validation and save before continuing; non-default providers can be saved unverified.
 - [x] #2 Setup readiness panel uses existing readiness APIs/types and remains non-blocking for optional lanes.
-- [ ] #3 First-chat failures render inline recovery actions: retry, edit provider, switch provider, skip setup, and endpoint recovery where relevant.
+- [x] #3 First-chat failures render inline recovery actions: retry, edit provider, switch provider, skip setup, and endpoint recovery where relevant.
 - [ ] #4 Post-onboarding first-source milestone offers Web URL, File upload, and Paste text, and only offers grounded chat after source readiness is confirmed.
 - [ ] #5 Focused backend, frontend, E2E, Bandit, and diff verification are recorded before PR closeout.
 <!-- AC:END -->
@@ -221,4 +223,37 @@ Task 2 StrictMode quality fix:
 - GREEN focused frontend: same hook command passed, 1 file / 7 tests.
 - Required frontend suite: `bun run test:run ../packages/ui/src/hooks/__tests__/useSetupReadinessSummary.test.tsx ../packages/ui/src/components/Option/Onboarding/__tests__/SetupReadinessPanel.test.tsx ../packages/ui/src/components/Option/Onboarding/__tests__/UnifiedSetupWizard.test.tsx --reporter=dot` from `apps/tldw-frontend` passed, 3 files / 35 tests.
 - Backend files were not touched; Bandit not required.
+
+Task 3 first-chat recovery actions:
+- FirstChatStep now normalizes first-chat failure aliases into recovery categories and renders inline category-specific recovery copy without navigating away on failure.
+- Failure responses keep the failed attempt visible while retrying until a new result replaces it.
+- Recovery actions are explicit and compact: Retry, Edit provider, Switch provider, Skip setup, and Check endpoint for endpoint/API-shape failures when available.
+- Completion-state errors after a successful model response now use separate copy so they do not imply the model response failed.
+- UnifiedSetupWizard wires Edit provider, Switch provider, and Check endpoint back to provider setup while preserving the current provider selection; Skip setup uses the existing skip handler.
+- RED frontend: `bun run test:run ../packages/ui/src/components/Option/Onboarding/__tests__/FirstChatStep.test.tsx ../packages/ui/src/components/Option/Onboarding/__tests__/UnifiedSetupWizard.test.tsx --reporter=dot` from `apps/tldw-frontend` failed on missing categorized recovery copy/buttons, retry persistence, endpoint action, and completion-state copy.
+- GREEN frontend: same focused command passed, 2 files / 28 tests.
+- Task 2/3 adjacency frontend: `bun run test:run ../packages/ui/src/hooks/__tests__/useSetupReadinessSummary.test.tsx ../packages/ui/src/components/Option/Onboarding/__tests__/SetupReadinessPanel.test.tsx ../packages/ui/src/components/Option/Onboarding/__tests__/FirstChatStep.test.tsx ../packages/ui/src/components/Option/Onboarding/__tests__/UnifiedSetupWizard.test.tsx --reporter=dot` from `apps/tldw-frontend` passed, 4 files / 42 tests.
+- Backend files were not touched; Bandit not required for Task 3.
+Task 3 spec-fix worker:
+- Added backend `auth_failed` first-chat failure category to the FirstChatStep auth recovery normalization path.
+- Updated first-chat recovery coverage so backend `failure_category: "auth_failed"` shows credential-specific auth copy and recovery actions.
+- Added alias coverage preserving `auth`, `authentication_failed`, and `provider_api_key_invalid` auth recovery behavior.
+- Focused frontend verification: `bun run test:run ../packages/ui/src/components/Option/Onboarding/__tests__/FirstChatStep.test.tsx ../packages/ui/src/components/Option/Onboarding/__tests__/UnifiedSetupWizard.test.tsx --reporter=dot` from `apps/tldw-frontend` passed, 2 files / 31 tests.
+- `git diff --check` passed before staging. Backend files were not touched; Bandit not required.
+Task 3 backend-category spec fix:
+- Added explicit recovery mappings for backend first-chat failure categories `rate_limited`, `network_error`, `provider_error`, `request_invalid`, and `configuration_error`.
+- `request_invalid` now lands in the endpoint/API-shape recovery path so the Check endpoint action remains available for compatible endpoint diagnostics.
+- Added regressions proving backend categories render specific recovery copy instead of falling through to unknown.
+- RED frontend: `bun run test:run ../packages/ui/src/components/Option/Onboarding/__tests__/FirstChatStep.test.tsx --reporter=dot` from `apps/tldw-frontend` failed, 5 failed / 8 passed, because the backend categories rendered `Category: unknown`.
+- GREEN frontend: same focused command passed, 1 file / 13 tests.
+Task 3 quality fix:
+- Added recovery handling for backend `empty_response` so the UI gives specific empty-response guidance instead of unknown fallback.
+- Added request-exception failure state so a retry that throws before receiving a backend response does not keep stale recovery category/copy from the previous failed response.
+- RED frontend: `bun run test:run ../packages/ui/src/components/Option/Onboarding/__tests__/FirstChatStep.test.tsx --reporter=dot` from `apps/tldw-frontend` failed, 2 failed / 13 passed, on `empty_response` unknown fallback and stale auth copy after retry exception.
+- GREEN frontend: same focused command passed, 1 file / 15 tests.
+Task 3 duplicate skip quality fix:
+- Added wizard-level skip pending state and a synchronous ref guard so recovery Skip setup and header Skip for now cannot submit duplicate skip mutations while the backend request is in flight.
+- FirstChatStep now receives skip pending state and disables/renames the recovery skip button while skipping.
+- RED frontend: `bun run test:run ../packages/ui/src/components/Option/Onboarding/__tests__/UnifiedSetupWizard.test.tsx -t "prevents duplicate first-chat recovery skip submissions while skip is pending" --reporter=dot` from `apps/tldw-frontend` failed because skip was called twice and the second call threw on undefined `.then`.
+- GREEN frontend: same targeted command passed, 1 passed / 23 skipped.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->

--- a/backlog/tasks/task-584 - Implement-onboarding-confidence-flow-follow-up.md
+++ b/backlog/tasks/task-584 - Implement-onboarding-confidence-flow-follow-up.md
@@ -2,29 +2,23 @@
 id: TASK-584
 title: Implement onboarding confidence flow follow-up
 status: In Progress
+assignee: []
+created_date: ''
+updated_date: 2026-06-01 06:14
 labels:
 - onboarding
 - webui
 - setup
-priority: High
+dependencies: []
 documentation:
 - Docs/superpowers/specs/2026-06-01-onboarding-confidence-flow-design.md
 - Docs/superpowers/plans/2026-06-01-onboarding-confidence-flow-implementation-plan.md
+priority: high
 modified_files:
-- tldw_Server_API/app/api/v1/endpoints/setup.py
-- tldw_Server_API/app/api/v1/schemas/setup_schemas.py
-- tldw_Server_API/app/core/Setup/first_run_state.py
-- tldw_Server_API/app/core/Setup/setup_manager.py
-- tldw_Server_API/app/core/Setup/provider_validation.py
-- tldw_Server_API/tests/Setup/test_first_run_state.py
-- tldw_Server_API/tests/Setup/test_setup_provider_validation.py
-- tldw_Server_API/tests/integration/test_unified_first_run_setup_api.py
-- apps/packages/ui/src/types/setup-onboarding.ts
-- apps/packages/ui/src/components/Option/Onboarding/steps/ProviderSetupStep.tsx
+- apps/packages/ui/src/hooks/useSetupReadinessSummary.ts
+- apps/packages/ui/src/hooks/__tests__/useSetupReadinessSummary.test.tsx
 - apps/packages/ui/src/components/Option/Onboarding/UnifiedSetupWizard.tsx
-- apps/packages/ui/src/components/Option/Onboarding/__tests__/ProviderSetupStep.test.tsx
 - apps/packages/ui/src/components/Option/Onboarding/__tests__/UnifiedSetupWizard.test.tsx
-- backlog/tasks/task-584 - Implement-onboarding-confidence-flow-follow-up.md
 ---
 
 ## Description
@@ -36,7 +30,7 @@ Implement the approved onboarding confidence flow plan as one PR with four stage
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
 - [x] #1 Default first-chat provider requires manual validation and save before continuing; non-default providers can be saved unverified.
-- [ ] #2 Setup readiness panel uses existing readiness APIs/types and remains non-blocking for optional lanes.
+- [x] #2 Setup readiness panel uses existing readiness APIs/types and remains non-blocking for optional lanes.
 - [ ] #3 First-chat failures render inline recovery actions: retry, edit provider, switch provider, skip setup, and endpoint recovery where relevant.
 - [ ] #4 Post-onboarding first-source milestone offers Web URL, File upload, and Paste text, and only offers grounded chat after source readiness is confirmed.
 - [ ] #5 Focused backend, frontend, E2E, Bandit, and diff verification are recorded before PR closeout.
@@ -44,6 +38,7 @@ Implement the approved onboarding confidence flow plan as one PR with four stage
 
 ## Implementation Notes
 
+<!-- SECTION:NOTES:BEGIN -->
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
 - Implementation task opened before code edits per AGENTS.md. Controller will dispatch Task 1 provider validation gate implementer first, then run spec and code-quality reviews before moving to Task 2.
 - Task 1 provider validation gate implemented:
@@ -156,11 +151,37 @@ Implement the approved onboarding confidence flow plan as one PR with four stage
 - Task 1 final backend test expectation fix:
   - Updated `test_first_run_provider_validate_returns_typed_response_without_token_echo` to assert the full provider validation response schema, including `validation_level` and `can_gate_first_chat`, after the final spec review found the stale exact response assertion.
   - Focused backend suite: `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest -q tldw_Server_API/tests/Setup/test_first_run_state.py tldw_Server_API/tests/Setup/test_setup_provider_validation.py tldw_Server_API/tests/integration/test_unified_first_run_setup_api.py` passed, `134 passed, 5 warnings`.
+- Task 2 setup readiness panel implemented:
+  - Added `useSetupReadinessSummary` as a thin first-run wrapper around `getSetupReadinessStatus({ mode: "first-run" })`.
+  - The hook loads on mount, exposes `status`, `loading`, sanitized fallback `error`, and `refresh`, and ignores stale refresh results when a newer request has already resolved.
+  - Added `SetupReadinessPanel` for the wizard shell using existing readiness response/lane types and backend lane labels/statuses.
+  - The panel renders compact Chat, Embeddings/RAG, and Speech lanes, readable overlay labels, collapsed warnings/blockers/effects details, and retry/loading/error states.
+  - Chat failed/blocked state is presented as first-chat blocking; Embeddings/RAG and Speech remain visibly deferrable for not configured, skipped, and overlay-blocked optional states.
+  - `UnifiedSetupWizard` now renders the readiness panel below the shell header and above the active step card.
+  - Wizard setup-changing actions refresh the readiness summary after provider validation/save, ingest defaults save, audio defaults save, optional advanced save, setup completion, and skip attempts.
+  - Backend files were not touched, so Bandit was not rerun for Task 2.
+- Task 2 verification:
+  - RED frontend: `bun run test:run ../packages/ui/src/hooks/__tests__/useSetupReadinessSummary.test.tsx ../packages/ui/src/components/Option/Onboarding/__tests__/SetupReadinessPanel.test.tsx ../packages/ui/src/components/Option/Onboarding/__tests__/UnifiedSetupWizard.test.tsx --reporter=dot` from `apps/tldw-frontend` failed on missing hook/panel modules and missing wizard readiness rendering/refresh wiring.
+  - GREEN frontend: same focused command passed, `25 passed`.
+  - Post-cleanup frontend: same focused command passed, `25 passed`.
+  - `git diff --check` passed.
+  - `git diff --cached --check` passed.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+Task 2 spec-fix worker: useSetupReadinessSummary now fetches first-run status and profiles together, preserving status fields while filling missing lanes, lane ids, supported metadata, profiles, and active/other overlays from profiles when the status payload is empty. Added hook regression coverage for status-without-lanes plus profiles-with-lanes producing panel-ready lanes.
+
+Task 2 spec-fix worker: added wizard readiness refresh wiring coverage for ingest defaults save, audio defaults save, optional advanced save, first-chat completion, failed skip attempts, and the SetupReadinessPanel retry button. No backend files changed; Bandit not required.
+
+Task 2 spec-fix verification: RED hook focused run failed before implementation because getSetupReadinessProfiles was not called and status-without-lanes left lanes undefined. GREEN hook focused run passed, 5 passed. Requested focused frontend run from apps/tldw-frontend passed: 3 files, 32 tests.
+<!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+<!-- SECTION:FINAL_SUMMARY:END -->
 
 <!-- SECTION:FINAL_SUMMARY:END -->
 
@@ -173,3 +194,31 @@ Implement the approved onboarding confidence flow plan as one PR with four stage
 - [ ] #5 Final summary added
 - [ ] #6 Known skips or blockers documented
 <!-- DOD:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Task 2 code-quality fix:
+- useSetupReadinessSummary now treats first-run readiness status as authoritative and only fails when the status request fails; profile enrichment is best-effort and profile failures keep the successful status visible with no hook error.
+- UnifiedSetupWizard no longer refreshes first-run readiness after terminal setup completion, avoiding a transient readiness error during route handoff; parent first-run state refresh/onComplete behavior remains covered.
+- Added regressions for status-success/profile-failure and completion without readiness refresh.
+- Focused frontend verification: `bun run test:run ../packages/ui/src/hooks/__tests__/useSetupReadinessSummary.test.tsx ../packages/ui/src/components/Option/Onboarding/__tests__/SetupReadinessPanel.test.tsx ../packages/ui/src/components/Option/Onboarding/__tests__/UnifiedSetupWizard.test.tsx --reporter=dot` from `apps/tldw-frontend` passed, 3 files / 33 tests.
+- Backend files were not touched; Bandit not required.
+
+Task 2 quality fix:
+- Made UnifiedSetupWizard readiness refresh fire-and-forget after setup-changing provider validate/save, ingest defaults save, audio defaults save, optional advanced save, and skip attempts so primary button promises settle from their own action results instead of waiting for readiness status/profile requests.
+- Kept SetupReadinessPanel retry explicitly wired to the readiness refresh action and preserved no readiness refresh after terminal first-chat completion.
+- Added a deferred-readiness regression proving provider validation and provider save UI settle while readiness refresh promises remain unresolved.
+- RED frontend: `bun run test:run ../packages/ui/src/components/Option/Onboarding/__tests__/UnifiedSetupWizard.test.tsx -t "does not keep provider validation or save pending while readiness refresh is unresolved" --reporter=dot` from `apps/tldw-frontend` failed because the Validate button remained pending on unresolved readiness.
+- GREEN frontend: same targeted regression command passed, 1 passed / 20 skipped.
+- Focused frontend verification: `bun run test:run ../packages/ui/src/hooks/__tests__/useSetupReadinessSummary.test.tsx ../packages/ui/src/components/Option/Onboarding/__tests__/SetupReadinessPanel.test.tsx ../packages/ui/src/components/Option/Onboarding/__tests__/UnifiedSetupWizard.test.tsx --reporter=dot` from `apps/tldw-frontend` passed, 3 files / 34 tests.
+- `git diff --check` passed before staging. `git diff --cached --check` passed after staging. Backend files were not touched; Bandit not required.
+Task 2 StrictMode quality fix:
+- Reset the `useSetupReadinessSummary` mounted guard during effect setup so React StrictMode setup-cleanup-setup cycles do not leave the hook permanently unmounted.
+- Added hook regression coverage rendering under `<React.StrictMode>` and asserting readiness reaches loaded state.
+- Preserved request-id stale result handling, best-effort profile fallback, and status-authoritative error semantics.
+- RED frontend: `bun run test:run ../packages/ui/src/hooks/__tests__/useSetupReadinessSummary.test.tsx --reporter=dot` from `apps/tldw-frontend` failed on the StrictMode regression with loading stuck true after an initial test-wrapper import fix.
+- GREEN focused frontend: same hook command passed, 1 file / 7 tests.
+- Required frontend suite: `bun run test:run ../packages/ui/src/hooks/__tests__/useSetupReadinessSummary.test.tsx ../packages/ui/src/components/Option/Onboarding/__tests__/SetupReadinessPanel.test.tsx ../packages/ui/src/components/Option/Onboarding/__tests__/UnifiedSetupWizard.test.tsx --reporter=dot` from `apps/tldw-frontend` passed, 3 files / 35 tests.
+- Backend files were not touched; Bandit not required.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->

--- a/backlog/tasks/task-584 - Implement-onboarding-confidence-flow-follow-up.md
+++ b/backlog/tasks/task-584 - Implement-onboarding-confidence-flow-follow-up.md
@@ -1,0 +1,175 @@
+---
+id: TASK-584
+title: Implement onboarding confidence flow follow-up
+status: In Progress
+labels:
+- onboarding
+- webui
+- setup
+priority: High
+documentation:
+- Docs/superpowers/specs/2026-06-01-onboarding-confidence-flow-design.md
+- Docs/superpowers/plans/2026-06-01-onboarding-confidence-flow-implementation-plan.md
+modified_files:
+- tldw_Server_API/app/api/v1/endpoints/setup.py
+- tldw_Server_API/app/api/v1/schemas/setup_schemas.py
+- tldw_Server_API/app/core/Setup/first_run_state.py
+- tldw_Server_API/app/core/Setup/setup_manager.py
+- tldw_Server_API/app/core/Setup/provider_validation.py
+- tldw_Server_API/tests/Setup/test_first_run_state.py
+- tldw_Server_API/tests/Setup/test_setup_provider_validation.py
+- tldw_Server_API/tests/integration/test_unified_first_run_setup_api.py
+- apps/packages/ui/src/types/setup-onboarding.ts
+- apps/packages/ui/src/components/Option/Onboarding/steps/ProviderSetupStep.tsx
+- apps/packages/ui/src/components/Option/Onboarding/UnifiedSetupWizard.tsx
+- apps/packages/ui/src/components/Option/Onboarding/__tests__/ProviderSetupStep.test.tsx
+- apps/packages/ui/src/components/Option/Onboarding/__tests__/UnifiedSetupWizard.test.tsx
+- backlog/tasks/task-584 - Implement-onboarding-confidence-flow-follow-up.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement the approved onboarding confidence flow plan as one PR with four staged commits: provider validation gate, setup readiness panel, first-chat recovery actions, and first-source guided milestone. Use current dev contracts, preserve backend-authoritative setup/readiness state, and do not replay stale unified-solo-onboarding worktree changes.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Default first-chat provider requires manual validation and save before continuing; non-default providers can be saved unverified.
+- [ ] #2 Setup readiness panel uses existing readiness APIs/types and remains non-blocking for optional lanes.
+- [ ] #3 First-chat failures render inline recovery actions: retry, edit provider, switch provider, skip setup, and endpoint recovery where relevant.
+- [ ] #4 Post-onboarding first-source milestone offers Web URL, File upload, and Paste text, and only offers grounded chat after source readiness is confirmed.
+- [ ] #5 Focused backend, frontend, E2E, Bandit, and diff verification are recorded before PR closeout.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+- Implementation task opened before code edits per AGENTS.md. Controller will dispatch Task 1 provider validation gate implementer first, then run spec and code-quality reviews before moving to Task 2.
+- Task 1 provider validation gate implemented:
+  - Backend validation responses now include non-secret `validation_level` and `can_gate_first_chat` metadata.
+  - Hosted providers return `accepted` with `local_syntax` gate metadata after local syntax/presence checks.
+  - Local OpenAI-compatible `/models` validation returns `ready` with `live_non_generative` gate metadata and discovered models.
+  - Native Kobold endpoint shape validation returns `ready` with `live_endpoint_shape` gate metadata.
+  - Failed validation keeps `can_gate_first_chat` false by schema default.
+  - Frontend provider setup now requires the default provider to be manually validated and saved before Continue is enabled.
+  - Non-default selected providers can still be saved without validation.
+  - Editing default provider API key, base URL, or model invalidates the stored validation result via a non-secret fingerprint.
+  - Validation fingerprints use provider key, local base URL, selected model, a non-secret user-edit revision, and secret-present boolean only.
+  - Validation state is transient; raw API keys are cleared after save while masked saved-key state can preserve validation validity.
+  - Local model discovery renders model choices while preserving manual model entry.
+- Task 1 spec compliance fix:
+  - Added a non-secret per-provider edit revision that increments only for user-initiated API key, base URL, and model edits.
+  - Save-induced raw API key clearing does not increment the edit revision, so validated-and-saved masked key state remains current.
+  - Added regression coverage for API key edits after save and local endpoint base URL edits invalidating validation.
+- Task 1 back-navigation fix:
+  - Lifted the provider setup cache to `UnifiedSetupWizard` so saved provider responses, validation responses, and non-secret edit revisions survive normal step unmount/remount.
+  - Back navigation from ingest defaults to provider setup now keeps a validated-and-saved hosted default provider eligible to continue without re-pasting the raw API key.
+  - Validation cache remains frontend-local/transient and contains no raw secrets.
+  - Added wizard-level regression coverage for validate/save/continue/back/continue without revalidation.
+- Task 1 saved hosted revalidation fix:
+  - Added a manual-only hosted validation fallback for saved providers with a masked saved-key marker and no raw API key in the form.
+  - Model-only edits still stale validation and require the user to click Validate again before Continue.
+  - Revalidation after save records an `accepted` local-syntax result with first-chat-verifies copy without sending or storing raw secrets.
+  - Local endpoints and unsaved hosted providers still use the backend validation path.
+- Task 1 no-secret hosted save/resume fix:
+  - Added backend support for hosted model/default saves without a raw API key when the provider already has a non-placeholder configured secret.
+  - Added a sanitized `credential_configured` save response marker so the UI can preserve saved-key presence without raw secrets or fake masked strings.
+  - Frontend validation fingerprints and saved-hosted fallback now use `credential_configured` or a real `masked_api_key` as the non-secret credential marker.
+  - Provider setup progress records `default_provider_credential_configured` and resumed first-chat back navigation can seed a saved hosted provider marker before manual revalidation.
+- Task 1 review fix:
+  - First-run step redaction now preserves the exact boolean `default_provider_credential_configured` marker while still redacting secret-like credential, token, API key, password, and auth fields.
+  - Unified setup resume no longer infers saved hosted credentials from completed provider steps or first-chat state; hosted saved-credential fallback requires an explicit persisted marker, a real masked key, or an actual save response marker.
+  - Saved-hosted validation fallback remains manual-only and constrained to hosted providers that are already saved, have backend-confirmed credential presence, and have no raw API key typed.
+  - Provider validation gating now requires `ready` or `accepted` status and honors `can_gate_first_chat` only as an additional positive gate flag.
+  - Default model selection no longer falls back to catalog config field names such as `openai_model` or `ollama_model`; validation/save require a real typed or discovered model value.
+- Task 1 verification:
+  - RED backend: `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tldw_Server_API/tests/Setup/test_setup_provider_validation.py -q` failed with 3 expected missing metadata attribute failures.
+  - GREEN backend: same pytest command passed, `25 passed, 5 warnings`.
+  - RED frontend: package-local Vitest run failed on missing Validate action / validation gate behavior.
+  - GREEN frontend: `bunx vitest run src/components/Option/Onboarding/__tests__/ProviderSetupStep.test.tsx src/components/Option/Onboarding/__tests__/UnifiedSetupWizard.test.tsx` from `apps/packages/ui` passed, `19 passed`.
+  - Requested root-level `bunx vitest run apps/packages/ui/src/components/Option/Onboarding/__tests__/ProviderSetupStep.test.tsx apps/packages/ui/src/components/Option/Onboarding/__tests__/UnifiedSetupWizard.test.tsx` fails before tests because temp `bunx` Vitest cannot resolve `jsdom`; the repo-local UI command above was used for functional verification.
+  - Bandit: `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m bandit -r tldw_Server_API/app/api/v1/schemas/setup_schemas.py tldw_Server_API/app/core/Setup/provider_validation.py -f json -o /tmp/bandit_task584_task1.json` passed with 0 results.
+- Task 1 fix verification:
+  - RED frontend: `bunx vitest run src/components/Option/Onboarding/__tests__/ProviderSetupStep.test.tsx src/components/Option/Onboarding/__tests__/UnifiedSetupWizard.test.tsx` from `apps/packages/ui` failed on the new API-key edit invalidation regression while the new base URL invalidation regression passed.
+  - GREEN frontend: same package-local Vitest command passed, `21 passed`.
+  - Backend not rerun for the spec compliance fix because backend files were not touched.
+- Task 1 back-navigation fix verification:
+  - RED frontend: same package-local Vitest command failed on the new back-navigation regression because Continue was disabled after returning from ingest defaults.
+  - GREEN frontend: same package-local Vitest command passed, `22 passed`.
+  - Backend not rerun for the back-navigation fix because backend files were not touched.
+- Task 1 saved hosted revalidation fix verification:
+  - RED frontend: same package-local Vitest command failed on the new validate/save/continue/back/change-model/validate regression with `provider_api_key_required` and Continue disabled.
+  - GREEN frontend: same package-local Vitest command passed, `23 passed`.
+  - Backend not rerun for the saved hosted revalidation fix because backend files were not touched.
+- Task 1 no-secret hosted save/resume fix verification:
+  - RED backend: `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tldw_Server_API/tests/Setup/test_setup_provider_validation.py -q` failed on the new configured-secret hosted save regression with `provider_api_key_required`.
+  - RED frontend: package-local focused Vitest command failed on post-save model save and resumed first-chat provider edit regressions.
+  - GREEN backend: same pytest command passed, `27 passed, 6 warnings`.
+  - GREEN frontend: same package-local focused Vitest command passed, `24 passed`.
+  - Bandit: `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m bandit -r tldw_Server_API/app/api/v1/endpoints/setup.py tldw_Server_API/app/api/v1/schemas/setup_schemas.py tldw_Server_API/app/core/Setup/setup_manager.py -f json -o /tmp/bandit_task584_task1_no_secret_save.json` passed with 0 results.
+- Task 1 review fix verification:
+  - RED backend: `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tldw_Server_API/tests/Setup/test_first_run_state.py tldw_Server_API/tests/Setup/test_setup_provider_validation.py -q` failed because `default_provider_credential_configured` was redacted to `********`.
+  - RED frontend: package-local focused Vitest command failed on permissive failed-response gating, catalog `model_field` fallback, and resumed saved-credential inference without an explicit marker.
+  - GREEN backend: same focused backend pytest command passed, `49 passed, 6 warnings`.
+  - GREEN frontend: `bunx vitest run src/components/Option/Onboarding/__tests__/ProviderSetupStep.test.tsx src/components/Option/Onboarding/__tests__/UnifiedSetupWizard.test.tsx` from `apps/packages/ui` passed, `29 passed`.
+  - Bandit: `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m bandit -r tldw_Server_API/app/core/Setup/first_run_state.py -f json -o /tmp/bandit_task584_task1_redaction_fix.json` passed with 0 results.
+- Task 1 commit status: amended existing Task 1 commit as `feat: validate onboarding providers before first chat`.
+- Task 1 recovery review fix:
+  - Kept the RED regressions for resumed hosted model edits and post-save API key edits requiring Save again after validation.
+  - Added saved-payload fingerprints to the provider setup cache so Continue requires the current default provider payload to match both the current validation fingerprint and the current saved fingerprint.
+  - Fingerprints remain non-secret: provider key, effective local base URL, selected model, make_default, edit revision, and secret-present state only.
+  - Replaced loop-prone initial saved-state seeding with guarded effects that only hydrate missing initial saved fingerprints when the current form still matches the backend-confirmed saved selection and no user edit revision exists.
+  - Backend was not touched; Bandit/backend tests not rerun for this recovery.
+- Task 1 recovery verification:
+  - `bun run test:run ../packages/ui/src/components/Option/Onboarding/__tests__/ProviderSetupStep.test.tsx ../packages/ui/src/components/Option/Onboarding/__tests__/UnifiedSetupWizard.test.tsx --reporter=dot` from `apps/tldw-frontend` passed, `31 passed`.
+  - `git diff --check` passed.
+  - `git diff --cached --check` passed.
+- Task 1 default-churn review fix:
+  - Added explicit `savedDefaultProvider` provider-step state, lifted through `UnifiedSetupWizard`, so Continue requires the current default provider to also be the last successfully saved default provider.
+  - Preserved the existing saved payload fingerprint and transient validation gates; raw secrets are still cleared after save and are not stored in the new state.
+  - Added regression coverage for saving OpenAI as default, saving Ollama as the new default after deselecting OpenAI, then reselecting OpenAI; Continue stays disabled until OpenAI is saved again as default.
+- Task 1 default-churn verification:
+  - RED frontend: `bun run test:run ../packages/ui/src/components/Option/Onboarding/__tests__/ProviderSetupStep.test.tsx --reporter=dot` from `apps/tldw-frontend` failed on the new default-churn regression because Continue was enabled after reselecting the stale OpenAI default.
+  - GREEN frontend: `bun run test:run ../packages/ui/src/components/Option/Onboarding/__tests__/ProviderSetupStep.test.tsx --reporter=dot` from `apps/tldw-frontend` passed, `18 passed`.
+  - Focused frontend: `bun run test:run ../packages/ui/src/components/Option/Onboarding/__tests__/ProviderSetupStep.test.tsx ../packages/ui/src/components/Option/Onboarding/__tests__/UnifiedSetupWizard.test.tsx --reporter=dot` from `apps/tldw-frontend` passed, `32 passed`.
+  - Backend was not touched; backend tests and Bandit were not rerun.
+- Task 1 backend review-fix provider marker:
+  - Allowed exact providers-step `default_provider_credential_configured` boolean marker through setup endpoint state validation and public-state projection.
+  - Kept real credential-like provider step data rejected; added endpoint regression coverage for `provider_credential` rejection.
+  - RED endpoint: `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tldw_Server_API/tests/integration/test_unified_first_run_setup_api.py::test_first_run_state_persists_provider_credential_configured_marker -q` failed with 400 before the fix.
+  - GREEN focused endpoint: same marker test plus `test_first_run_state_rejects_real_provider_credential_step_data` passed, `2 passed`.
+  - Required backend suite: `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tldw_Server_API/tests/integration/test_unified_first_run_setup_api.py::test_first_run_state_persists_provider_credential_configured_marker tldw_Server_API/tests/integration/test_unified_first_run_setup_api.py::test_first_run_state_rejects_real_provider_credential_step_data tldw_Server_API/tests/Setup/test_first_run_state.py tldw_Server_API/tests/Setup/test_setup_provider_validation.py -q` passed, `51 passed, 3 warnings`.
+  - Bandit production scope: `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m bandit -r tldw_Server_API/app/api/v1/endpoints/setup.py -f json -o /tmp/bandit_task584_task1_provider_marker_app.json` passed with 0 results. Including the integration test file separately returned baseline pytest assert findings plus an existing test secret-string fixture warning, so production scope result is the recorded security gate.
+  - `git diff --check` passed before staging.
+- Task 1 frontend concurrency review fix:
+  - Provider setup controlled object-state callbacks now accept and forward `React.SetStateAction` values so functional updates resolve against the latest parent/internal state instead of render-captured snapshots.
+  - Applied the same pass-through functional-update pattern to validation state, saved providers, saved payload fingerprints, and provider edit revisions; saved default provider remains direct assignment.
+  - Added a regression with deferred concurrent OpenAI/Ollama validation promises resolved out of order, asserting both validation entries remain visible.
+  - Backend was not touched; backend tests and Bandit were not rerun.
+- Task 1 frontend concurrency review verification:
+  - RED frontend: `bun run test:run ../packages/ui/src/components/Option/Onboarding/__tests__/ProviderSetupStep.test.tsx --reporter=dot` from `apps/tldw-frontend` failed on the new concurrent-validation regression because Ollama's earlier validation entry was overwritten by OpenAI's later result.
+  - GREEN frontend: same ProviderSetupStep focused command passed, `19 passed`.
+  - Required focused frontend: `bun run test:run ../packages/ui/src/components/Option/Onboarding/__tests__/ProviderSetupStep.test.tsx ../packages/ui/src/components/Option/Onboarding/__tests__/UnifiedSetupWizard.test.tsx --reporter=dot` from `apps/tldw-frontend` passed, `33 passed`.
+  - `git diff --check` passed.
+  - `git diff --cached --check` passed.
+- Task 1 final backend test expectation fix:
+  - Updated `test_first_run_provider_validate_returns_typed_response_without_token_echo` to assert the full provider validation response schema, including `validation_level` and `can_gate_first_chat`, after the final spec review found the stale exact response assertion.
+  - Focused backend suite: `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest -q tldw_Server_API/tests/Setup/test_first_run_state.py tldw_Server_API/tests/Setup/test_setup_provider_validation.py tldw_Server_API/tests/integration/test_unified_first_run_setup_api.py` passed, `134 passed, 5 warnings`.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-584 - Implement-onboarding-confidence-flow-follow-up.md
+++ b/backlog/tasks/task-584 - Implement-onboarding-confidence-flow-follow-up.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-584
 title: Implement onboarding confidence flow follow-up
-status: In Progress
+status: Done
 assignee: []
 created_date: ''
-updated_date: 2026-06-01 06:14
+updated_date: 2026-06-01 15:28
 labels:
 - onboarding
 - webui
@@ -17,10 +17,41 @@ priority: high
 modified_files:
 - apps/packages/ui/src/hooks/useSetupReadinessSummary.ts
 - apps/packages/ui/src/hooks/__tests__/useSetupReadinessSummary.test.tsx
+- apps/packages/ui/src/components/Option/Onboarding/SetupReadinessPanel.tsx
+- apps/packages/ui/src/components/Option/Onboarding/__tests__/SetupReadinessPanel.test.tsx
 - apps/packages/ui/src/components/Option/Onboarding/UnifiedSetupWizard.tsx
 - apps/packages/ui/src/components/Option/Onboarding/__tests__/UnifiedSetupWizard.test.tsx
+- apps/packages/ui/src/components/Option/Onboarding/steps/ProviderSetupStep.tsx
+- apps/packages/ui/src/components/Option/Onboarding/__tests__/ProviderSetupStep.test.tsx
 - apps/packages/ui/src/components/Option/Onboarding/steps/FirstChatStep.tsx
 - apps/packages/ui/src/components/Option/Onboarding/__tests__/FirstChatStep.test.tsx
+- apps/packages/ui/src/components/Option/Onboarding/FirstSourceMilestonePrompt.tsx
+- apps/packages/ui/src/components/Option/Onboarding/__tests__/FirstSourceMilestonePrompt.test.tsx
+- apps/packages/ui/src/routes/option-index.tsx
+- apps/packages/ui/src/routes/__tests__/option-index.unified-setup.test.tsx
+- apps/packages/ui/src/utils/quick-ingest-open.ts
+- apps/packages/ui/src/utils/__tests__/quick-ingest-open.test.ts
+- apps/packages/ui/src/store/quick-ingest-session.ts
+- apps/packages/ui/src/components/Common/QuickIngest/IngestWizardContext.tsx
+- apps/packages/ui/src/components/Common/QuickIngest/AddContentStep.tsx
+- apps/packages/ui/src/components/Common/QuickIngest/QueueTab/FileDropZone.tsx
+- apps/packages/ui/src/components/Common/QuickIngestWizardModal.tsx
+- apps/packages/ui/src/components/Common/QuickIngest/__tests__/QuickIngestWizardModal.integration.test.tsx
+- apps/packages/ui/src/components/Common/QuickIngest/__tests__/QuickIngestWizardModal.session.test.tsx
+- apps/tldw-frontend/e2e/workflows/unified-first-run-onboarding.spec.ts
+- tldw_Server_API/app/api/v1/endpoints/setup.py
+- tldw_Server_API/app/api/v1/schemas/setup_schemas.py
+- tldw_Server_API/app/core/Setup/provider_validation.py
+- tldw_Server_API/app/core/Setup/setup_manager.py
+- tldw_Server_API/app/core/Setup/first_run_state.py
+- tldw_Server_API/tests/Setup/test_setup_provider_validation.py
+- tldw_Server_API/tests/Setup/test_setup_first_chat_completion.py
+- tldw_Server_API/tests/Setup/test_first_run_state.py
+- tldw_Server_API/tests/integration/test_unified_first_run_setup_api.py
+- Docs/superpowers/specs/2026-06-01-onboarding-confidence-flow-design.md
+- Docs/superpowers/plans/2026-06-01-onboarding-confidence-flow-implementation-plan.md
+references:
+- https://github.com/rmusser01/tldw_server/pull/2214
 ---
 
 ## Description
@@ -34,8 +65,8 @@ Implement the approved onboarding confidence flow plan as one PR with four stage
 - [x] #1 Default first-chat provider requires manual validation and save before continuing; non-default providers can be saved unverified.
 - [x] #2 Setup readiness panel uses existing readiness APIs/types and remains non-blocking for optional lanes.
 - [x] #3 First-chat failures render inline recovery actions: retry, edit provider, switch provider, skip setup, and endpoint recovery where relevant.
-- [ ] #4 Post-onboarding first-source milestone offers Web URL, File upload, and Paste text, and only offers grounded chat after source readiness is confirmed.
-- [ ] #5 Focused backend, frontend, E2E, Bandit, and diff verification are recorded before PR closeout.
+- [x] #4 Post-onboarding first-source milestone offers Web URL, File upload, and Paste text, and only offers grounded chat after source readiness is confirmed.
+- [x] #5 Focused backend, frontend, E2E, Bandit, and diff verification are recorded before PR closeout.
 <!-- AC:END -->
 
 ## Implementation Notes
@@ -168,92 +199,44 @@ Implement the approved onboarding confidence flow plan as one PR with four stage
   - Post-cleanup frontend: same focused command passed, `25 passed`.
   - `git diff --check` passed.
   - `git diff --cached --check` passed.
+- Task 2 spec and quality fixes:
+  - `useSetupReadinessSummary` now fetches first-run status and profiles together, keeps first-run status authoritative, treats profile enrichment as best-effort, and handles React StrictMode effect setup/cleanup correctly.
+  - Wizard readiness refreshes are fire-and-forget after setup-changing provider/default actions, so primary buttons are not blocked by readiness refresh latency.
+  - Added coverage for status-without-lanes profile enrichment, profile failure fallback, retry wiring, skipped completion refresh, deferred readiness refresh, and StrictMode loading behavior.
+  - Focused frontend verification for the final Task 2 state passed from `apps/tldw-frontend`, 3 files / 35 tests.
+- Task 3 first-chat recovery actions:
+  - `FirstChatStep` normalizes backend failure aliases and categories into recovery buckets, keeps failed attempts visible across retries, and shows explicit actions for retry, edit provider, switch provider, skip setup, and endpoint checks where relevant.
+  - Added backend category coverage for `auth_failed`, `rate_limited`, `network_error`, `provider_error`, `request_invalid`, `configuration_error`, and `empty_response`.
+  - Added request-exception handling so thrown retry attempts do not leave stale previous failure copy, and added a wizard-level pending guard to prevent duplicate skip submissions.
+  - Focused frontend verification for Task 3 passed from `apps/tldw-frontend`, including FirstChatStep and UnifiedSetupWizard recovery coverage.
+- Task 4 first-source guided milestone:
+  - `FirstSourceMilestonePrompt` offers Web URL, File upload, and Paste text, and shows idle, processing, error, and ready states before grounded chat is offered.
+  - OptionIndex scopes first-source state to durable quick-ingest sessions with first-source open detail and no longer unlocks grounded chat from unrelated global quick-ingest success or processing state.
+  - Quick ingest now persists the first-source add mode, preserves first-source open detail during wizard sync, focuses the selected URL/file/paste entry, and queues pasted text as a `text/plain` `pasted-text.txt` file.
+  - RED coverage failed first on missing picker/metadata/ready states, unrelated global quick-ingest leakage, ignored persisted first-source summaries, missing add-mode handoff, lost first-source open detail, and paste mode routing through URL input.
+  - GREEN coverage passed for the targeted Task 4 suites, then the broader focused onboarding frontend suite passed from `apps/tldw-frontend`, 11 files / 155 tests.
+- Final closeout verification after rebase:
+  - `bun run test:run ../packages/ui/src/hooks/__tests__/useSetupReadinessSummary.test.tsx ../packages/ui/src/components/Option/Onboarding/__tests__/SetupReadinessPanel.test.tsx ../packages/ui/src/components/Option/Onboarding/__tests__/ProviderSetupStep.test.tsx ../packages/ui/src/components/Option/Onboarding/__tests__/FirstChatStep.test.tsx ../packages/ui/src/components/Option/Onboarding/__tests__/FirstSourceMilestonePrompt.test.tsx ../packages/ui/src/components/Option/Onboarding/__tests__/UnifiedSetupWizard.test.tsx ../packages/ui/src/routes/__tests__/option-index.unified-setup.test.tsx ../packages/ui/src/utils/__tests__/quick-ingest-open.test.ts ../packages/ui/src/hooks/__tests__/usePostOnboardingMediaReadiness.test.tsx ../packages/ui/src/components/Common/QuickIngest/__tests__/QuickIngestWizardModal.integration.test.tsx ../packages/ui/src/components/Common/QuickIngest/__tests__/QuickIngestWizardModal.session.test.tsx --reporter=dot` passed, 11 files / 155 tests.
+  - `bun run e2e:pw e2e/workflows/unified-first-run-onboarding.spec.ts --project=chromium --reporter=line` passed, 3 tests, with the local Next test server run outside the sandbox after sandbox port binding failed earlier.
+  - `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tldw_Server_API/tests/Setup/test_setup_provider_validation.py tldw_Server_API/tests/Setup/test_setup_first_chat_completion.py tldw_Server_API/tests/Setup/test_first_run_state.py tldw_Server_API/tests/integration/test_unified_first_run_setup_api.py -q` passed, 143 tests.
+  - `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m bandit -r tldw_Server_API/app/api/v1/endpoints/setup.py tldw_Server_API/app/api/v1/schemas/setup_schemas.py tldw_Server_API/app/core/Setup/provider_validation.py tldw_Server_API/app/core/Setup/setup_manager.py tldw_Server_API/app/core/Setup/first_run_state.py -f json -o /tmp/bandit_task584_onboarding_confidence_flow.json` reported 0 results.
+  - `git diff --check origin/dev..HEAD` and final unstaged `git diff --check` passed.
+- PR opened as draft for review: https://github.com/rmusser01/tldw_server/pull/2214. Human-written Change summary is still required before marking ready or merging per repo policy.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
-
-Task 2 spec-fix worker: useSetupReadinessSummary now fetches first-run status and profiles together, preserving status fields while filling missing lanes, lane ids, supported metadata, profiles, and active/other overlays from profiles when the status payload is empty. Added hook regression coverage for status-without-lanes plus profiles-with-lanes producing panel-ready lanes.
-
-Task 2 spec-fix worker: added wizard readiness refresh wiring coverage for ingest defaults save, audio defaults save, optional advanced save, first-chat completion, failed skip attempts, and the SetupReadinessPanel retry button. No backend files changed; Bandit not required.
-
-Task 2 spec-fix verification: RED hook focused run failed before implementation because getSetupReadinessProfiles was not called and status-without-lanes left lanes undefined. GREEN hook focused run passed, 5 passed. Requested focused frontend run from apps/tldw-frontend passed: 3 files, 32 tests.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-<!-- SECTION:FINAL_SUMMARY:BEGIN -->
-
-<!-- SECTION:FINAL_SUMMARY:END -->
-<!-- SECTION:FINAL_SUMMARY:END -->
-
+Implemented the onboarding confidence flow follow-up as a rebased four-stage feature branch: provider validation before first chat, a backend-readiness panel inside the setup shell, inline first-chat recovery actions, and a post-onboarding first-source milestone integrated with quick ingest. Final verification after rebase: focused frontend onboarding/quick-ingest suite passed (11 files / 155 tests), focused unified first-run E2E passed (3 tests), focused backend setup/first-run suite passed (143 tests), Bandit on touched backend setup paths reported 0 results, and git diff whitespace checks passed. No known blockers remain.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->
-
-## Implementation Notes
-
-<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
-Task 2 code-quality fix:
-- useSetupReadinessSummary now treats first-run readiness status as authoritative and only fails when the status request fails; profile enrichment is best-effort and profile failures keep the successful status visible with no hook error.
-- UnifiedSetupWizard no longer refreshes first-run readiness after terminal setup completion, avoiding a transient readiness error during route handoff; parent first-run state refresh/onComplete behavior remains covered.
-- Added regressions for status-success/profile-failure and completion without readiness refresh.
-- Focused frontend verification: `bun run test:run ../packages/ui/src/hooks/__tests__/useSetupReadinessSummary.test.tsx ../packages/ui/src/components/Option/Onboarding/__tests__/SetupReadinessPanel.test.tsx ../packages/ui/src/components/Option/Onboarding/__tests__/UnifiedSetupWizard.test.tsx --reporter=dot` from `apps/tldw-frontend` passed, 3 files / 33 tests.
-- Backend files were not touched; Bandit not required.
-
-Task 2 quality fix:
-- Made UnifiedSetupWizard readiness refresh fire-and-forget after setup-changing provider validate/save, ingest defaults save, audio defaults save, optional advanced save, and skip attempts so primary button promises settle from their own action results instead of waiting for readiness status/profile requests.
-- Kept SetupReadinessPanel retry explicitly wired to the readiness refresh action and preserved no readiness refresh after terminal first-chat completion.
-- Added a deferred-readiness regression proving provider validation and provider save UI settle while readiness refresh promises remain unresolved.
-- RED frontend: `bun run test:run ../packages/ui/src/components/Option/Onboarding/__tests__/UnifiedSetupWizard.test.tsx -t "does not keep provider validation or save pending while readiness refresh is unresolved" --reporter=dot` from `apps/tldw-frontend` failed because the Validate button remained pending on unresolved readiness.
-- GREEN frontend: same targeted regression command passed, 1 passed / 20 skipped.
-- Focused frontend verification: `bun run test:run ../packages/ui/src/hooks/__tests__/useSetupReadinessSummary.test.tsx ../packages/ui/src/components/Option/Onboarding/__tests__/SetupReadinessPanel.test.tsx ../packages/ui/src/components/Option/Onboarding/__tests__/UnifiedSetupWizard.test.tsx --reporter=dot` from `apps/tldw-frontend` passed, 3 files / 34 tests.
-- `git diff --check` passed before staging. `git diff --cached --check` passed after staging. Backend files were not touched; Bandit not required.
-Task 2 StrictMode quality fix:
-- Reset the `useSetupReadinessSummary` mounted guard during effect setup so React StrictMode setup-cleanup-setup cycles do not leave the hook permanently unmounted.
-- Added hook regression coverage rendering under `<React.StrictMode>` and asserting readiness reaches loaded state.
-- Preserved request-id stale result handling, best-effort profile fallback, and status-authoritative error semantics.
-- RED frontend: `bun run test:run ../packages/ui/src/hooks/__tests__/useSetupReadinessSummary.test.tsx --reporter=dot` from `apps/tldw-frontend` failed on the StrictMode regression with loading stuck true after an initial test-wrapper import fix.
-- GREEN focused frontend: same hook command passed, 1 file / 7 tests.
-- Required frontend suite: `bun run test:run ../packages/ui/src/hooks/__tests__/useSetupReadinessSummary.test.tsx ../packages/ui/src/components/Option/Onboarding/__tests__/SetupReadinessPanel.test.tsx ../packages/ui/src/components/Option/Onboarding/__tests__/UnifiedSetupWizard.test.tsx --reporter=dot` from `apps/tldw-frontend` passed, 3 files / 35 tests.
-- Backend files were not touched; Bandit not required.
-
-Task 3 first-chat recovery actions:
-- FirstChatStep now normalizes first-chat failure aliases into recovery categories and renders inline category-specific recovery copy without navigating away on failure.
-- Failure responses keep the failed attempt visible while retrying until a new result replaces it.
-- Recovery actions are explicit and compact: Retry, Edit provider, Switch provider, Skip setup, and Check endpoint for endpoint/API-shape failures when available.
-- Completion-state errors after a successful model response now use separate copy so they do not imply the model response failed.
-- UnifiedSetupWizard wires Edit provider, Switch provider, and Check endpoint back to provider setup while preserving the current provider selection; Skip setup uses the existing skip handler.
-- RED frontend: `bun run test:run ../packages/ui/src/components/Option/Onboarding/__tests__/FirstChatStep.test.tsx ../packages/ui/src/components/Option/Onboarding/__tests__/UnifiedSetupWizard.test.tsx --reporter=dot` from `apps/tldw-frontend` failed on missing categorized recovery copy/buttons, retry persistence, endpoint action, and completion-state copy.
-- GREEN frontend: same focused command passed, 2 files / 28 tests.
-- Task 2/3 adjacency frontend: `bun run test:run ../packages/ui/src/hooks/__tests__/useSetupReadinessSummary.test.tsx ../packages/ui/src/components/Option/Onboarding/__tests__/SetupReadinessPanel.test.tsx ../packages/ui/src/components/Option/Onboarding/__tests__/FirstChatStep.test.tsx ../packages/ui/src/components/Option/Onboarding/__tests__/UnifiedSetupWizard.test.tsx --reporter=dot` from `apps/tldw-frontend` passed, 4 files / 42 tests.
-- Backend files were not touched; Bandit not required for Task 3.
-Task 3 spec-fix worker:
-- Added backend `auth_failed` first-chat failure category to the FirstChatStep auth recovery normalization path.
-- Updated first-chat recovery coverage so backend `failure_category: "auth_failed"` shows credential-specific auth copy and recovery actions.
-- Added alias coverage preserving `auth`, `authentication_failed`, and `provider_api_key_invalid` auth recovery behavior.
-- Focused frontend verification: `bun run test:run ../packages/ui/src/components/Option/Onboarding/__tests__/FirstChatStep.test.tsx ../packages/ui/src/components/Option/Onboarding/__tests__/UnifiedSetupWizard.test.tsx --reporter=dot` from `apps/tldw-frontend` passed, 2 files / 31 tests.
-- `git diff --check` passed before staging. Backend files were not touched; Bandit not required.
-Task 3 backend-category spec fix:
-- Added explicit recovery mappings for backend first-chat failure categories `rate_limited`, `network_error`, `provider_error`, `request_invalid`, and `configuration_error`.
-- `request_invalid` now lands in the endpoint/API-shape recovery path so the Check endpoint action remains available for compatible endpoint diagnostics.
-- Added regressions proving backend categories render specific recovery copy instead of falling through to unknown.
-- RED frontend: `bun run test:run ../packages/ui/src/components/Option/Onboarding/__tests__/FirstChatStep.test.tsx --reporter=dot` from `apps/tldw-frontend` failed, 5 failed / 8 passed, because the backend categories rendered `Category: unknown`.
-- GREEN frontend: same focused command passed, 1 file / 13 tests.
-Task 3 quality fix:
-- Added recovery handling for backend `empty_response` so the UI gives specific empty-response guidance instead of unknown fallback.
-- Added request-exception failure state so a retry that throws before receiving a backend response does not keep stale recovery category/copy from the previous failed response.
-- RED frontend: `bun run test:run ../packages/ui/src/components/Option/Onboarding/__tests__/FirstChatStep.test.tsx --reporter=dot` from `apps/tldw-frontend` failed, 2 failed / 13 passed, on `empty_response` unknown fallback and stale auth copy after retry exception.
-- GREEN frontend: same focused command passed, 1 file / 15 tests.
-Task 3 duplicate skip quality fix:
-- Added wizard-level skip pending state and a synchronous ref guard so recovery Skip setup and header Skip for now cannot submit duplicate skip mutations while the backend request is in flight.
-- FirstChatStep now receives skip pending state and disables/renames the recovery skip button while skipping.
-- RED frontend: `bun run test:run ../packages/ui/src/components/Option/Onboarding/__tests__/UnifiedSetupWizard.test.tsx -t "prevents duplicate first-chat recovery skip submissions while skip is pending" --reporter=dot` from `apps/tldw-frontend` failed because skip was called twice and the second call threw on undefined `.then`.
-- GREEN frontend: same targeted command passed, 1 passed / 23 skipped.
-<!-- SECTION:IMPLEMENTATION_NOTES:END -->

--- a/backlog/tasks/task-584 - Implement-onboarding-confidence-flow-follow-up.md
+++ b/backlog/tasks/task-584 - Implement-onboarding-confidence-flow-follow-up.md
@@ -35,9 +35,12 @@ modified_files:
 - apps/packages/ui/src/components/Common/QuickIngest/IngestWizardContext.tsx
 - apps/packages/ui/src/components/Common/QuickIngest/AddContentStep.tsx
 - apps/packages/ui/src/components/Common/QuickIngest/QueueTab/FileDropZone.tsx
+- apps/packages/ui/src/components/Common/QuickIngest/__tests__/FileDropZone.acceptance.test.tsx
 - apps/packages/ui/src/components/Common/QuickIngestWizardModal.tsx
 - apps/packages/ui/src/components/Common/QuickIngest/__tests__/QuickIngestWizardModal.integration.test.tsx
 - apps/packages/ui/src/components/Common/QuickIngest/__tests__/QuickIngestWizardModal.session.test.tsx
+- apps/tldw-frontend/e2e/smoke/smoke.setup.ts
+- apps/tldw-frontend/e2e/workflows/onboarding-ingestion-first.spec.ts
 - apps/tldw-frontend/e2e/workflows/unified-first-run-onboarding.spec.ts
 - tldw_Server_API/app/api/v1/endpoints/setup.py
 - tldw_Server_API/app/api/v1/schemas/setup_schemas.py
@@ -222,13 +225,30 @@ Implement the approved onboarding confidence flow plan as one PR with four stage
   - `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m bandit -r tldw_Server_API/app/api/v1/endpoints/setup.py tldw_Server_API/app/api/v1/schemas/setup_schemas.py tldw_Server_API/app/core/Setup/provider_validation.py tldw_Server_API/app/core/Setup/setup_manager.py tldw_Server_API/app/core/Setup/first_run_state.py -f json -o /tmp/bandit_task584_onboarding_confidence_flow.json` reported 0 results.
   - `git diff --check origin/dev..HEAD` and final unstaged `git diff --check` passed.
 - PR opened as draft for review: https://github.com/rmusser01/tldw_server/pull/2214. Human-written Change summary is still required before marking ready or merging per repo policy.
+- PR review follow-up after rebase:
+  - Rebased `codex/onboarding-confidence-flow` on latest `origin/dev`.
+  - Setup readiness refresh now preserves the last known status on refresh failure, labels non-ready chat states as first-chat blockers, avoids duplicate detail keys, and guards wizard retry refresh failures.
+  - First-chat retry clears stale response/error/category state before a new attempt.
+  - First-source recovery copy no longer points users to a hidden Add Source action, radio choices expose a keyboard focus ring, and retry after reload uses the persisted first-source add mode.
+  - Quick ingest preserves raw pasted-text whitespace, clears persisted first-source mode on reset, and file-drop autofocus is one-shot across disabled toggles.
+  - The first-source quick-ingest open-detail guard now has an honest predicate type for legacy `firstSource: true` markers instead of narrowing them to milestone-only source details.
+  - Backend first-run provider save handling now preserves existing hosted provider keys without overwriting secrets, reports existing local endpoint token configuration, and keeps rejected raw provider credentials out of persisted first-run state.
+  - Smoke and first-source E2E fixtures were updated to match the completed first-run app shell and current first-source milestone flow.
+- PR review follow-up verification:
+  - Focused frontend review suite: `bun run test:run ../packages/ui/src/hooks/__tests__/useSetupReadinessSummary.test.tsx ../packages/ui/src/components/Option/Onboarding/__tests__/SetupReadinessPanel.test.tsx ../packages/ui/src/components/Option/Onboarding/__tests__/FirstChatStep.test.tsx ../packages/ui/src/components/Option/Onboarding/__tests__/FirstSourceMilestonePrompt.test.tsx ../packages/ui/src/components/Option/Onboarding/__tests__/UnifiedSetupWizard.test.tsx ../packages/ui/src/routes/__tests__/option-index.unified-setup.test.tsx ../packages/ui/src/components/Common/QuickIngest/__tests__/FileDropZone.acceptance.test.tsx ../packages/ui/src/components/Common/QuickIngest/__tests__/QuickIngestWizardModal.integration.test.tsx ../packages/ui/src/components/Common/QuickIngest/__tests__/QuickIngestWizardModal.session.test.tsx --reporter=dot` passed, 9 files / 139 tests.
+  - Expanded frontend review suite with quick-ingest open-detail guard coverage: `bun run test:run ../packages/ui/src/hooks/__tests__/useSetupReadinessSummary.test.tsx ../packages/ui/src/components/Option/Onboarding/__tests__/SetupReadinessPanel.test.tsx ../packages/ui/src/components/Option/Onboarding/__tests__/FirstChatStep.test.tsx ../packages/ui/src/components/Option/Onboarding/__tests__/FirstSourceMilestonePrompt.test.tsx ../packages/ui/src/components/Option/Onboarding/__tests__/UnifiedSetupWizard.test.tsx ../packages/ui/src/routes/__tests__/option-index.unified-setup.test.tsx ../packages/ui/src/utils/__tests__/quick-ingest-open.test.ts ../packages/ui/src/components/Common/QuickIngest/__tests__/FileDropZone.acceptance.test.tsx ../packages/ui/src/components/Common/QuickIngest/__tests__/QuickIngestWizardModal.integration.test.tsx ../packages/ui/src/components/Common/QuickIngest/__tests__/QuickIngestWizardModal.session.test.tsx --reporter=dot` passed, 10 files / 146 tests.
+  - Stage 6 interaction smoke: `bun run e2e:smoke:interaction:stage1 --project=chromium --reporter=line` passed, 2 tests, after rerunning outside the sandbox because the sandboxed server could not bind `0.0.0.0:8080`.
+  - Onboarding first-source E2E: `bun run e2e:onboarding --project=chromium --reporter=line` passed, 2 tests, after rerunning outside the sandbox for the same port-binding restriction.
+  - Focused backend setup suite: `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tldw_Server_API/tests/Setup/test_setup_provider_validation.py tldw_Server_API/tests/Setup/test_setup_first_chat_completion.py tldw_Server_API/tests/Setup/test_first_run_state.py tldw_Server_API/tests/integration/test_unified_first_run_setup_api.py -q` passed, 145 tests with 5 warnings.
+  - Bandit production scope: `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m bandit -r tldw_Server_API/app/api/v1/endpoints/setup.py -f json -o /tmp/bandit_task584_pr2214_review_fixes.json` reported 0 results.
+  - `git diff --check` passed after the final review-fix edits.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Implemented the onboarding confidence flow follow-up as a rebased four-stage feature branch: provider validation before first chat, a backend-readiness panel inside the setup shell, inline first-chat recovery actions, and a post-onboarding first-source milestone integrated with quick ingest. Final verification after rebase: focused frontend onboarding/quick-ingest suite passed (11 files / 155 tests), focused unified first-run E2E passed (3 tests), focused backend setup/first-run suite passed (143 tests), Bandit on touched backend setup paths reported 0 results, and git diff whitespace checks passed. No known blockers remain.
+Implemented the onboarding confidence flow follow-up as a rebased four-stage feature branch: provider validation before first chat, a backend-readiness panel inside the setup shell, inline first-chat recovery actions, and a post-onboarding first-source milestone integrated with quick ingest. PR review feedback was addressed after rebasing on latest `origin/dev`, including readiness refresh resilience, first-chat retry state cleanup, first-source recovery/focus/retry fixes, quick-ingest paste/autofocus/session/type-guard cleanup fixes, hosted/local provider credential handling fixes, and refreshed smoke/first-source E2E coverage. Final verification after review fixes: expanded frontend review suite passed (10 files / 146 tests), Stage 6 smoke passed (2 tests), first-source onboarding E2E passed (2 tests), focused backend setup suite passed (145 tests, 5 warnings), Bandit on touched production setup endpoint code reported 0 results, and git diff whitespace checks passed. No known blockers remain.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/tldw_Server_API/app/api/v1/endpoints/setup.py
+++ b/tldw_Server_API/app/api/v1/endpoints/setup.py
@@ -128,6 +128,9 @@ _SUSPICIOUS_SETUP_DETAIL_RE = re.compile(
 )
 _SANITIZED_SETUP_DETAIL_MESSAGE = "Internal setup diagnostics were suppressed."
 UNSUPPORTED_FIRST_RUN_STEP_DATA_DETAIL = "unsupported_first_run_step_data"
+_FIRST_RUN_NON_SECRET_BOOLEAN_STEP_DATA_KEYS = {
+    "providers": frozenset({"default_provider_credential_configured"}),
+}
 _FIRST_RUN_STEP_DATA_ALLOWED_KEYS = {
     "setup_path": frozenset(
         {
@@ -148,7 +151,14 @@ _FIRST_RUN_STEP_DATA_ALLOWED_KEYS = {
             "selected_options",
         }
     ),
-    "providers": frozenset({"acknowledged", "default_provider", "default_model"}),
+    "providers": frozenset(
+        {
+            "acknowledged",
+            "default_provider",
+            "default_model",
+            *_FIRST_RUN_NON_SECRET_BOOLEAN_STEP_DATA_KEYS["providers"],
+        }
+    ),
     "ingest_defaults": frozenset(
         {
             "acknowledged",
@@ -329,7 +339,14 @@ def _is_unsafe_public_step_data_key(key: object) -> bool:
 
 
 def _is_explicitly_allowed_unsafe_named_step_key(step: str, key: object) -> bool:
-    return step == "optional_advanced" and key == "values"
+    return (step == "optional_advanced" and key == "values") or (
+        key in _FIRST_RUN_NON_SECRET_BOOLEAN_STEP_DATA_KEYS.get(step, frozenset())
+    )
+
+
+def _is_valid_non_secret_boolean_step_data(step: str, data: dict[str, Any]) -> bool:
+    keys = _FIRST_RUN_NON_SECRET_BOOLEAN_STEP_DATA_KEYS.get(step, frozenset()) & data.keys()
+    return all(isinstance(data[key], bool) for key in keys)
 
 
 def _is_unsafe_public_step_data_value(value: object) -> bool:
@@ -441,6 +458,11 @@ def _validated_public_first_run_step_data(step: str, data: dict[str, Any]) -> di
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=UNSUPPORTED_FIRST_RUN_STEP_DATA_DETAIL,
         )
+    if not _is_valid_non_secret_boolean_step_data(step, data):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=UNSUPPORTED_FIRST_RUN_STEP_DATA_DETAIL,
+        )
     if step == "ingest_defaults":
         _validate_ingest_allowed_local_roots(data)
     if not all(
@@ -470,6 +492,11 @@ def _public_first_run_step_data(step: str, data: dict[str, Any]) -> dict[str, An
         if key not in allowed_keys:
             continue
         if step == "ingest_defaults" and key == "allowed_local_roots":
+            continue
+        if (
+            key in _FIRST_RUN_NON_SECRET_BOOLEAN_STEP_DATA_KEYS.get(step, frozenset())
+            and not isinstance(value, bool)
+        ):
             continue
         if _is_unsafe_public_step_data_key(key) and not _is_explicitly_allowed_unsafe_named_step_key(step, key):
             continue
@@ -1053,14 +1080,16 @@ async def save_first_run_provider(
     entry = get_setup_provider_entry(provider_key)
     if entry is None:
         raise HTTPException(status.HTTP_400_BAD_REQUEST, detail="unknown_setup_provider")
-    if (
-        entry.provider_type is SetupProviderType.HOSTED_API_KEY
-        and entry.api_key_field
-        and (payload.api_key is None or not payload.api_key.strip())
-    ):
-        raise HTTPException(status.HTTP_400_BAD_REQUEST, detail="provider_api_key_required")
-    if entry.provider_type is SetupProviderType.HOSTED_API_KEY and payload.api_key is not None:
-        payload = payload.model_copy(update={"api_key": payload.api_key.strip()})
+    credential_configured = False
+    if entry.provider_type is SetupProviderType.HOSTED_API_KEY and entry.api_key_field:
+        normalized_api_key = payload.api_key.strip() if payload.api_key is not None else ""
+        if normalized_api_key:
+            payload = payload.model_copy(update={"api_key": normalized_api_key})
+            credential_configured = True
+        elif setup_manager.is_secret_configured(entry.config_section, entry.api_key_field):
+            credential_configured = True
+        else:
+            raise HTTPException(status.HTTP_400_BAD_REQUEST, detail="provider_api_key_required")
 
     updates = _provider_config_updates(payload)
     if not updates:
@@ -1083,6 +1112,7 @@ async def save_first_run_provider(
             provider_key=provider_key,
             status=SetupProviderSaveStatus.FAILED,
             masked_api_key=mask_secret(payload.api_key) if payload.api_key is not None else None,
+            credential_configured=False,
             base_url=payload.base_url,
             model=payload.model,
             make_default=payload.make_default,
@@ -1095,6 +1125,7 @@ async def save_first_run_provider(
             provider_key=provider_key,
             status=SetupProviderSaveStatus.SAVED,
             masked_api_key=mask_secret(payload.api_key) if payload.api_key is not None else None,
+            credential_configured=credential_configured,
             base_url=payload.base_url,
             model=payload.model,
             make_default=payload.make_default,
@@ -1107,6 +1138,7 @@ async def save_first_run_provider(
         provider_key=provider_key,
         status=SetupProviderSaveStatus.SAVED,
         masked_api_key=mask_secret(payload.api_key) if payload.api_key is not None else None,
+        credential_configured=credential_configured,
         base_url=payload.base_url,
         model=payload.model,
         make_default=payload.make_default,

--- a/tldw_Server_API/app/api/v1/endpoints/setup.py
+++ b/tldw_Server_API/app/api/v1/endpoints/setup.py
@@ -804,6 +804,11 @@ def _refresh_runtime_config_cache(context: str) -> bool:
     return True
 
 
+async def _is_secret_configured(section: str, key: str) -> bool:
+    """Return whether a setup secret is configured without blocking the event loop."""
+    return await asyncio.to_thread(setup_manager.is_secret_configured, section, key)
+
+
 def _sanitize_setup_payload(value: Any) -> Any:
     if isinstance(value, str):
         return _SANITIZED_SETUP_DETAIL_MESSAGE if _SUSPICIOUS_SETUP_DETAIL_RE.search(value) else value
@@ -1081,15 +1086,18 @@ async def save_first_run_provider(
     if entry is None:
         raise HTTPException(status.HTTP_400_BAD_REQUEST, detail="unknown_setup_provider")
     credential_configured = False
-    if entry.provider_type is SetupProviderType.HOSTED_API_KEY and entry.api_key_field:
+    if entry.api_key_field:
         normalized_api_key = payload.api_key.strip() if payload.api_key is not None else ""
         if normalized_api_key:
             payload = payload.model_copy(update={"api_key": normalized_api_key})
             credential_configured = True
-        elif setup_manager.is_secret_configured(entry.config_section, entry.api_key_field):
+        elif await _is_secret_configured(entry.config_section, entry.api_key_field):
+            payload = payload.model_copy(update={"api_key": None})
             credential_configured = True
-        else:
+        elif entry.provider_type is SetupProviderType.HOSTED_API_KEY:
             raise HTTPException(status.HTTP_400_BAD_REQUEST, detail="provider_api_key_required")
+        elif payload.api_key is not None:
+            payload = payload.model_copy(update={"api_key": None})
 
     updates = _provider_config_updates(payload)
     if not updates:

--- a/tldw_Server_API/app/api/v1/schemas/setup_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/setup_schemas.py
@@ -174,6 +174,7 @@ class SetupProviderSaveResponse(BaseModel):
     provider_key: str
     status: SetupProviderSaveStatus
     masked_api_key: str | None = None
+    credential_configured: bool = False
     base_url: str | None = None
     model: str | None = None
     make_default: bool = False
@@ -190,6 +191,8 @@ class SetupProviderValidationResponse(BaseModel):
     failure_category: str | None = None
     message: str | None = None
     models: list[str] = Field(default_factory=list)
+    validation_level: str | None = None
+    can_gate_first_chat: bool = False
 
 
 class SetupCompleteRequest(BaseModel):

--- a/tldw_Server_API/app/core/Setup/first_run_state.py
+++ b/tldw_Server_API/app/core/Setup/first_run_state.py
@@ -53,6 +53,11 @@ SECRET_KEY_MARKERS = (
 SENSITIVE_TOKEN_KEY_PREFIXES = frozenset({"access", "api", "auth", "bearer", "private", "refresh", "secret", "session"})
 TOKEN_KEY_MARKER = "".join(("tok", "en"))
 REDACTION_PLACEHOLDER = "********"
+NON_SECRET_BOOLEAN_STEP_MARKERS = frozenset(
+    {
+        "default_provider_credential_configured",
+    }
+)
 
 
 class FirstRunState(FirstRunStateResponse):
@@ -157,10 +162,18 @@ def _is_sensitive_key(key: object) -> bool:
     return False
 
 
+def _is_non_secret_step_marker(key: object, value: Any) -> bool:
+    return str(key) in NON_SECRET_BOOLEAN_STEP_MARKERS and isinstance(value, bool)
+
+
 def _redact_secret_step_data(value: Any) -> Any:
     if isinstance(value, Mapping):
         return {
-            key: REDACTION_PLACEHOLDER if _is_sensitive_key(key) else _redact_secret_step_data(item)
+            key: item
+            if _is_non_secret_step_marker(key, item)
+            else REDACTION_PLACEHOLDER
+            if _is_sensitive_key(key)
+            else _redact_secret_step_data(item)
             for key, item in value.items()
         }
     if isinstance(value, list):

--- a/tldw_Server_API/app/core/Setup/provider_validation.py
+++ b/tldw_Server_API/app/core/Setup/provider_validation.py
@@ -163,6 +163,8 @@ def validate_hosted_provider_credentials(
         provider_key=provider_key,
         status=VALIDATION_STATUS_ACCEPTED,
         message="Provider credentials passed local syntax checks.",
+        validation_level="local_syntax",
+        can_gate_first_chat=True,
     )
 
 
@@ -226,6 +228,8 @@ async def validate_local_openai_endpoint(
         provider_key=payload.provider_key,
         status=VALIDATION_STATUS_READY,
         models=model_ids,
+        validation_level="live_non_generative",
+        can_gate_first_chat=True,
     )
 
 
@@ -292,4 +296,6 @@ async def validate_native_kobold_endpoint(
     return SetupProviderValidationResponse(
         provider_key=payload.provider_key,
         status=VALIDATION_STATUS_READY,
+        validation_level="live_endpoint_shape",
+        can_gate_first_chat=True,
     )

--- a/tldw_Server_API/app/core/Setup/setup_manager.py
+++ b/tldw_Server_API/app/core/Setup/setup_manager.py
@@ -448,6 +448,19 @@ def _is_placeholder(value: str) -> bool:
     return value.strip() in PLACEHOLDER_VALUES
 
 
+def is_secret_configured(section: str, key: str) -> bool:
+    """Return True when a secret config field has a non-placeholder value."""
+    if not section or not key:
+        return False
+
+    parser = _load_config_parser()
+    if not parser.has_option(section, key):
+        return False
+
+    value = parser.get(section, key, fallback="")
+    return bool(value.strip()) and not _is_placeholder(value)
+
+
 def get_setup_flags(config: ConfigParser | None = None) -> dict[str, bool]:
     """Return the setup enablement and completion flags."""
     parser = config or _load_config_parser()

--- a/tldw_Server_API/tests/Setup/test_first_run_state.py
+++ b/tldw_Server_API/tests/Setup/test_first_run_state.py
@@ -94,6 +94,33 @@ def test_step_data_secrets_are_redacted_before_persistence(tmp_path: Path):
     assert state.step_data["providers"]["acknowledged"] is True
 
 
+def test_provider_credential_configured_marker_survives_redaction(tmp_path: Path):
+    path = tmp_path / "first_run_state.json"
+    store = FirstRunStateStore(path)
+
+    store.update_step(
+        "providers",
+        {
+            "acknowledged": True,
+            "default_provider": "openai",
+            "default_model": "gpt-4.1-mini",
+            "default_provider_credential_configured": True,
+            "provider_credential": "raw-secret",
+            "api_token": "raw-token",
+        },
+    )
+
+    state = FirstRunStateStore(path).load()
+    provider_data = state.step_data["providers"]
+    serialized_step_data = json.dumps(state.step_data)
+
+    assert provider_data["default_provider_credential_configured"] is True
+    assert provider_data["provider_credential"] == "********"
+    assert provider_data["api_token"] == "********"
+    assert "raw-secret" not in serialized_step_data
+    assert "raw-token" not in serialized_step_data
+
+
 def test_complete_requires_first_chat_success(tmp_path: Path):
     store = FirstRunStateStore(tmp_path / "first_run_state.json")
 

--- a/tldw_Server_API/tests/Setup/test_setup_provider_validation.py
+++ b/tldw_Server_API/tests/Setup/test_setup_provider_validation.py
@@ -1,5 +1,11 @@
+from configparser import ConfigParser
+
 import httpx
 import pytest
+from fastapi import HTTPException
+
+from tldw_Server_API.app.api.v1.endpoints import setup as setup_endpoint
+from tldw_Server_API.app.api.v1.schemas.setup_schemas import SetupProviderSaveRequest
 
 from tldw_Server_API.app.core.Setup import provider_validation
 from tldw_Server_API.app.core.Setup.provider_validation import (
@@ -57,6 +63,14 @@ def _fail_client_creation():
     pytest.fail("disallowed local provider endpoint should be rejected before httpx client creation")
 
 
+def _config_with_openai_key(raw_key: str) -> ConfigParser:
+    parser = ConfigParser()
+    parser.optionxform = str
+    parser.add_section("API")
+    parser.set("API", "openai_api_key", raw_key)
+    return parser
+
+
 @pytest.mark.asyncio
 async def test_unreachable_local_endpoint_maps_to_unreachable(monkeypatch):
     fake_client = _FakeAsyncClient(error=TimeoutError("raw timeout details"))
@@ -96,6 +110,28 @@ async def test_openai_models_shape_maps_to_ready(monkeypatch):
     assert response.status == "ready"
     assert response.models == ["local-model"]
     assert fake_client.requests == [("http://127.0.0.1:11434/v1/models", {})]
+
+
+@pytest.mark.asyncio
+async def test_openai_models_shape_ready_can_gate_first_chat(monkeypatch):
+    fake_client = _FakeAsyncClient(
+        response=_FakeResponse(
+            200,
+            {"object": "list", "data": [{"id": "local-model", "object": "model"}]},
+        )
+    )
+    monkeypatch.setattr(provider_validation, "_create_validation_client", lambda: fake_client)
+
+    response = await validate_local_openai_endpoint(
+        LocalEndpointValidationRequest(
+            provider_key="ollama",
+            base_url="http://127.0.0.1:11434/v1",
+        )
+    )
+
+    assert response.status == "ready"
+    assert response.validation_level == "live_non_generative"
+    assert response.can_gate_first_chat is True
 
 
 @pytest.mark.asyncio
@@ -387,6 +423,8 @@ def test_hosted_provider_validation_accepts_plausible_openai_key_without_echo():
 
     assert response.status == "accepted"
     assert response.failure_category is None
+    assert response.validation_level == "local_syntax"
+    assert response.can_gate_first_chat is True
     assert raw_key not in response.model_dump_json()
 
 
@@ -399,6 +437,7 @@ def test_hosted_provider_validation_rejects_malformed_openai_key_without_echo():
 
     assert response.status == "failed"
     assert response.failure_category == "provider_api_key_invalid"
+    assert response.can_gate_first_chat is False
     assert raw_key not in response.model_dump_json()
 
 
@@ -409,3 +448,77 @@ def test_hosted_provider_validation_accepts_other_hosted_nonblank_key():
 
     assert response.status == "accepted"
     assert response.failure_category is None
+
+
+@pytest.mark.asyncio
+async def test_hosted_provider_save_uses_existing_key_for_model_update_without_echo(
+    monkeypatch,
+):
+    raw_existing_key = "configured-provider-key"
+    updates_seen = []
+    monkeypatch.setattr(
+        setup_endpoint.setup_manager,
+        "_load_config_parser",
+        lambda: _config_with_openai_key(raw_existing_key),
+    )
+    monkeypatch.setattr(
+        setup_endpoint.setup_manager,
+        "update_config",
+        lambda updates: updates_seen.append(updates),
+    )
+    monkeypatch.setattr(
+        setup_endpoint,
+        "_refresh_runtime_config_cache",
+        lambda _context: True,
+    )
+
+    response = await setup_endpoint.save_first_run_provider(
+        SetupProviderSaveRequest(
+            provider_key="openai",
+            model="gpt-4.1",
+            make_default=True,
+        )
+    )
+
+    assert response.status == "saved"
+    assert response.credential_configured is True
+    assert response.masked_api_key is None
+    assert response.model == "gpt-4.1"
+    assert raw_existing_key not in response.model_dump_json()
+    assert updates_seen == [
+        {
+            "API": {
+                "openai_model": "gpt-4.1",
+                "default_api": "openai",
+            }
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_hosted_provider_save_without_raw_key_rejects_missing_existing_key(
+    monkeypatch,
+):
+    def fail_update_config(_updates):
+        pytest.fail(
+            "hosted provider save without configured credentials must not write config"
+        )
+
+    monkeypatch.setattr(
+        setup_endpoint.setup_manager,
+        "_load_config_parser",
+        lambda: _config_with_openai_key("your_api_key_here"),
+    )
+    monkeypatch.setattr(setup_endpoint.setup_manager, "update_config", fail_update_config)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await setup_endpoint.save_first_run_provider(
+            SetupProviderSaveRequest(
+                provider_key="openai",
+                model="gpt-4.1",
+                make_default=True,
+            )
+        )
+
+    assert exc_info.value.status_code == 400
+    assert exc_info.value.detail == "provider_api_key_required"

--- a/tldw_Server_API/tests/integration/test_unified_first_run_setup_api.py
+++ b/tldw_Server_API/tests/integration/test_unified_first_run_setup_api.py
@@ -265,6 +265,43 @@ def test_first_run_provider_save_rejects_blank_hosted_api_key_without_config_wri
     assert "openai_api_key" not in config_text
 
 
+def test_first_run_provider_save_keeps_existing_hosted_key_on_blank_update(
+    monkeypatch,
+    tmp_path,
+    setup_client,
+):
+    state_path = tmp_path / "first_run_state.json"
+    config_path = tmp_path / "config.txt"
+    config_path.write_text(
+        "[API]\ndefault_api = openai\nopenai_api_key = sk-existing-secret\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(setup_endpoint, "FIRST_RUN_STATE_PATH", state_path, raising=False)
+    monkeypatch.setattr(setup_endpoint.setup_manager, "get_config_file_path", lambda: config_path)
+    _setup_needs_setup(monkeypatch)
+
+    response = setup_client.post(
+        "/api/v1/setup/first-run/providers",
+        json={
+            "provider_key": "openai",
+            "api_key": "   ",
+            "model": "gpt-4.1-mini",
+            "make_default": True,
+        },
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["status"] == "saved"
+    assert body["credential_configured"] is True
+    assert body["masked_api_key"] is None
+    parser = ConfigParser()
+    parser.optionxform = str
+    parser.read(config_path, encoding="utf-8")
+    assert parser.get("API", "openai_api_key") == "sk-existing-secret"
+    assert parser.get("API", "openai_model") == "gpt-4.1-mini"
+
+
 def test_first_run_provider_save_writes_kobold_runtime_endpoint_key(
     monkeypatch,
     tmp_path,
@@ -294,6 +331,44 @@ def test_first_run_provider_save_writes_kobold_runtime_endpoint_key(
     assert "default_api = kobold" in config_text
     assert "kobold_api_IP = http://127.0.0.1:5001/api/v1/generate" in config_text
     assert "kobold_openai_api_IP" not in config_text
+
+
+def test_first_run_provider_save_marks_existing_local_endpoint_key_configured(
+    monkeypatch,
+    tmp_path,
+    setup_client,
+):
+    state_path = tmp_path / "first_run_state.json"
+    config_path = tmp_path / "config.txt"
+    config_path.write_text(
+        "[API]\ndefault_api = openai\n\n"
+        "[Local-API]\n"
+        "ollama_api_key = local-existing-token\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(setup_endpoint, "FIRST_RUN_STATE_PATH", state_path, raising=False)
+    monkeypatch.setattr(setup_endpoint.setup_manager, "get_config_file_path", lambda: config_path)
+    _setup_needs_setup(monkeypatch)
+
+    response = setup_client.post(
+        "/api/v1/setup/first-run/providers",
+        json={
+            "provider_key": "ollama",
+            "base_url": "http://127.0.0.1:11434/v1",
+            "model": "llama3.1",
+        },
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["status"] == "saved"
+    assert body["credential_configured"] is True
+    assert body["masked_api_key"] is None
+    parser = ConfigParser()
+    parser.optionxform = str
+    parser.read(config_path, encoding="utf-8")
+    assert parser.get("Local-API", "ollama_api_key") == "local-existing-token"
+    assert parser.get("Local-API", "ollama_api_IP") == "http://127.0.0.1:11434/v1"
 
 
 def test_completed_setup_rejects_provider_save_through_first_run_write_guard(
@@ -1766,6 +1841,8 @@ def test_first_run_state_rejects_unsupported_public_step_data(
 
     assert response.status_code == 400
     assert response.json()["detail"] == "unsupported_first_run_step_data"
+    if state_path.exists():
+        assert "raw-provider-secret" not in state_path.read_text(encoding="utf-8")
     state_response = setup_client.get("/api/v1/setup/first-run/state")
     assert state_response.status_code == 200
     assert "sk-raw" not in str(state_response.json())
@@ -1908,6 +1985,8 @@ def test_first_run_state_rejects_real_provider_credential_step_data(
 
     assert response.status_code == 400
     assert response.json()["detail"] == "unsupported_first_run_step_data"
+    if state_path.exists():
+        assert "raw-provider-secret" not in state_path.read_text(encoding="utf-8")
     state_response = setup_client.get("/api/v1/setup/first-run/state")
     assert state_response.status_code == 200
     assert "raw-provider-secret" not in str(state_response.json())

--- a/tldw_Server_API/tests/integration/test_unified_first_run_setup_api.py
+++ b/tldw_Server_API/tests/integration/test_unified_first_run_setup_api.py
@@ -1029,6 +1029,8 @@ def test_first_run_provider_validate_returns_typed_response_without_token_echo(
         "failure_category": None,
         "message": None,
         "models": ["local-model"],
+        "validation_level": None,
+        "can_gate_first_chat": False,
     }
     assert raw_token not in str(body)
 
@@ -1849,6 +1851,66 @@ def test_first_run_state_persists_allowed_public_step_data(
     assert providers_data["acknowledged"] is True
     assert providers_data["default_provider"] == "openai"
     assert providers_data["default_model"] == "gpt-4.1-mini"
+
+
+def test_first_run_state_persists_provider_credential_configured_marker(
+    monkeypatch,
+    tmp_path,
+    setup_client,
+):
+    state_path = tmp_path / "first_run_state.json"
+    monkeypatch.setattr(setup_endpoint, "FIRST_RUN_STATE_PATH", state_path, raising=False)
+    _setup_needs_setup(monkeypatch)
+
+    response = setup_client.post(
+        "/api/v1/setup/first-run/state",
+        json={
+            "step": "providers",
+            "data": {
+                "acknowledged": True,
+                "default_provider": "openai",
+                "default_model": "gpt-4.1-mini",
+                "default_provider_credential_configured": True,
+            },
+        },
+    )
+
+    assert response.status_code == 200
+    providers_data = response.json()["step_data"]["providers"]
+    assert providers_data["default_provider_credential_configured"] is True
+
+    state_response = setup_client.get("/api/v1/setup/first-run/state")
+    assert state_response.status_code == 200
+    persisted_provider_data = state_response.json()["step_data"]["providers"]
+    assert persisted_provider_data["default_provider_credential_configured"] is True
+
+
+def test_first_run_state_rejects_real_provider_credential_step_data(
+    monkeypatch,
+    tmp_path,
+    setup_client,
+):
+    state_path = tmp_path / "first_run_state.json"
+    monkeypatch.setattr(setup_endpoint, "FIRST_RUN_STATE_PATH", state_path, raising=False)
+    _setup_needs_setup(monkeypatch)
+
+    response = setup_client.post(
+        "/api/v1/setup/first-run/state",
+        json={
+            "step": "providers",
+            "data": {
+                "acknowledged": True,
+                "default_provider": "openai",
+                "provider_credential": "raw-provider-secret",
+            },
+        },
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "unsupported_first_run_step_data"
+    state_response = setup_client.get("/api/v1/setup/first-run/state")
+    assert state_response.status_code == 200
+    assert "raw-provider-secret" not in str(state_response.json())
 
 
 def test_first_run_state_get_projects_only_public_step_data(


### PR DESCRIPTION
## Scope

- Adds provider validation metadata and default-provider gating before first chat.
- Adds a setup readiness panel inside the focused onboarding shell.
- Adds inline first-chat recovery actions for retry/edit/switch/skip/endpoint paths.
- Adds the post-onboarding first-source milestone with durable quick-ingest state and Web URL, File upload, and Paste text paths.

## Verification

- `bun run test:run ../packages/ui/src/hooks/__tests__/useSetupReadinessSummary.test.tsx ../packages/ui/src/components/Option/Onboarding/__tests__/SetupReadinessPanel.test.tsx ../packages/ui/src/components/Option/Onboarding/__tests__/ProviderSetupStep.test.tsx ../packages/ui/src/components/Option/Onboarding/__tests__/FirstChatStep.test.tsx ../packages/ui/src/components/Option/Onboarding/__tests__/FirstSourceMilestonePrompt.test.tsx ../packages/ui/src/components/Option/Onboarding/__tests__/UnifiedSetupWizard.test.tsx ../packages/ui/src/routes/__tests__/option-index.unified-setup.test.tsx ../packages/ui/src/utils/__tests__/quick-ingest-open.test.ts ../packages/ui/src/hooks/__tests__/usePostOnboardingMediaReadiness.test.tsx ../packages/ui/src/components/Common/QuickIngest/__tests__/QuickIngestWizardModal.integration.test.tsx ../packages/ui/src/components/Common/QuickIngest/__tests__/QuickIngestWizardModal.session.test.tsx --reporter=dot`
- `bun run e2e:pw e2e/workflows/unified-first-run-onboarding.spec.ts --project=chromium --reporter=line`
- `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tldw_Server_API/tests/Setup/test_setup_provider_validation.py tldw_Server_API/tests/Setup/test_setup_first_chat_completion.py tldw_Server_API/tests/Setup/test_first_run_state.py tldw_Server_API/tests/integration/test_unified_first_run_setup_api.py -q`
- `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m bandit -r tldw_Server_API/app/api/v1/endpoints/setup.py tldw_Server_API/app/api/v1/schemas/setup_schemas.py tldw_Server_API/app/core/Setup/provider_validation.py tldw_Server_API/app/core/Setup/setup_manager.py tldw_Server_API/app/core/Setup/first_run_state.py -f json -o /tmp/bandit_task584_onboarding_confidence_flow.json`
- `git diff --check origin/dev..HEAD`

## Merge note

This PR was materially authored by Codex. Per `Docs/superpowers/AI_GENERATED_PR_CHANGE_SUMMARY_POLICY_2026_04_17.md`, a human-written Change summary explaining what changed and why is required before this PR is marked ready or merged. Codex intentionally has not supplied that human summary.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Strengthens first‑run onboarding so the first chat reliably succeeds, then guides the user to add a first source. Adds provider validation with gating, a compact setup readiness panel, inline first‑chat recovery, and a guided handoff into quick ingest with source‑kind presets.

- New Features
  - Provider validation before first chat: “Validate” returns `validation_level`, `can_gate_first_chat`, and `credential_configured`; persist non‑secret `default_provider_credential_configured` with redaction; enforce default‑provider gating.
  - Setup readiness panel: compact lanes/overlays via `useSetupReadinessSummary` (profiles+status merge with fallback and retry); visible during the wizard without blocking.
  - Inline first‑chat recovery: map failures (auth, quota, endpoint, unsupported shape, model unavailable, config write, provider unvalidated, etc.) to actions (retry, edit provider, switch provider, check endpoint, skip).
  - First‑source milestone and quick ingest: user picks Web URL, File, or Paste; pass `firstSourceKind` to quick ingest; session tracks `firstSourceAddMode`; preserve `openDetail` during wizard/session sync; `FileDropZone` supports `autoFocus`.

- Bug Fixes
  - Hosted provider save keeps existing API key on blank updates; validation endpoints consistently return `validation_level`.
  - Preserve first‑source open detail while syncing wizard state; drop stale playlist preflight seeds; `FileDropZone` autofocuses only once when disabled state toggles.

<sup>Written for commit a8827f28ec31b564935d8fc77d926e40f00ef69b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2214?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

