### PR TITLE
Add Companion Home header and launcher shortcuts

### DIFF
--- a/apps/packages/ui/src/components/Layouts/ChatHeader.tsx
+++ b/apps/packages/ui/src/components/Layouts/ChatHeader.tsx
@@ -4,6 +4,7 @@ import { Tooltip, Input } from "antd"
 import {
   Bell,
   CogIcon,
+  House,
   Menu,
   Moon,
   Search,
@@ -27,6 +28,7 @@ type ChatHeaderProps = {
   onTitleCommit: (value: string) => void | Promise<void>
   onToggleSidebar?: () => void
   sidebarCollapsed?: boolean
+  onOpenCompanionHome: () => void
   onOpenCommandPalette: () => void
   onOpenShortcutsModal: () => void
   onOpenSettings: () => void
@@ -64,6 +66,7 @@ export function ChatHeader({
   onTitleCommit,
   onToggleSidebar,
   sidebarCollapsed = false,
+  onOpenCompanionHome,
   onOpenCommandPalette,
   onOpenShortcutsModal,
   onOpenSettings,
@@ -95,6 +98,9 @@ export function ChatHeader({
   const shortcutsToggleLabel = shortcutsExpanded
     ? toText(t("option:header.hideShortcuts", "Hide shortcuts"))
     : toText(t("option:header.showShortcuts", "Show shortcuts"))
+  const companionHomeLabel = toText(
+    t("option:header.companionHome", "Companion Home")
+  )
   const canEditTitle =
     showChatTitle && !temporaryChat && historyId && historyId !== "temp"
   const isDarkTheme = themeMode !== "light"
@@ -145,6 +151,18 @@ export function ChatHeader({
             <span className="text-sm font-medium">
               {toText(t("common:pageAssist", "tldw Assistant"))}
             </span>
+            <Tooltip title={companionHomeLabel}>
+              <button
+                type="button"
+                onClick={onOpenCompanionHome}
+                aria-label={companionHomeLabel}
+                className={`inline-flex items-center justify-center rounded-md p-1.5 text-text-muted hover:bg-surface2 hover:text-text ${focusRingClasses}`}
+                title={companionHomeLabel}
+                data-testid="chat-header-companion-home"
+              >
+                <House className="size-4" aria-hidden="true" />
+              </button>
+            </Tooltip>
             <Tooltip title={shortcutsToggleLabel}>
               <button
                 type="button"

--- a/apps/packages/ui/src/components/Layouts/Header.tsx
+++ b/apps/packages/ui/src/components/Layouts/Header.tsx
@@ -114,6 +114,10 @@ export const Header: React.FC<Props> = ({
     window.dispatchEvent(new CustomEvent("tldw:open-shortcuts-modal"))
   }, [])
 
+  const openCompanionHome = React.useCallback(() => {
+    navigate("/")
+  }, [navigate])
+
   const toggleHeaderShortcuts = React.useCallback((next?: boolean) => {
     void setHeaderShortcutsExpanded((prev) =>
       typeof next === "boolean" ? next : !prev
@@ -355,6 +359,7 @@ export const Header: React.FC<Props> = ({
         onTitleCommit={handleTitleCommit}
         onToggleSidebar={onToggleSidebar}
         sidebarCollapsed={sidebarCollapsed}
+        onOpenCompanionHome={openCompanionHome}
         onOpenCommandPalette={openCommandPalette}
         onOpenShortcutsModal={openShortcutsModal}
         onOpenShareModal={

--- a/apps/packages/ui/src/components/Layouts/HeaderShortcuts.tsx
+++ b/apps/packages/ui/src/components/Layouts/HeaderShortcuts.tsx
@@ -489,6 +489,7 @@ export function HeaderShortcuts({
                         <NavLink
                           key={ri.item.id}
                           to={ri.item.to}
+                          end
                           onClick={(e) => {
                             e.preventDefault()
                             navigateTo(ri.item.to)
@@ -572,6 +573,7 @@ export function HeaderShortcuts({
                           <NavLink
                             key={ri.item.id}
                             to={ri.item.to}
+                            end
                             onClick={(e) => {
                               e.preventDefault()
                               navigateTo(ri.item.to)

--- a/apps/packages/ui/src/components/Layouts/HeaderShortcuts.tsx
+++ b/apps/packages/ui/src/components/Layouts/HeaderShortcuts.tsx
@@ -584,10 +584,11 @@ export function HeaderShortcuts({
                             aria-selected={isSelected}
                             className={cn(
                               "flex w-full items-center gap-1.5 rounded-md border px-2 py-1.5 text-xs transition-colors sm:w-auto sm:text-sm",
-                              isCurrentRoute && "border-border bg-surface text-text",
-                              isSelected
+                              isCurrentRoute
                                 ? "border-border bg-surface text-text"
-                                : "border-transparent text-text-muted hover:border-border hover:bg-surface"
+                                : isSelected
+                                  ? "border-focus/60 bg-surface2 text-text"
+                                  : "border-transparent text-text-muted hover:border-border hover:bg-surface"
                             )}
                           >
                             <Icon className="h-4 w-4 shrink-0" aria-hidden="true" />

--- a/apps/packages/ui/src/components/Layouts/HeaderShortcuts.tsx
+++ b/apps/packages/ui/src/components/Layouts/HeaderShortcuts.tsx
@@ -26,6 +26,9 @@ import { useConnectionActions } from "@/hooks/useConnectionState"
 const ALL_CATEGORY = "__all__"
 const META_LABEL = isMac ? "\u2318" : "Ctrl+"
 
+const isCurrentShortcutRoute = (pathname: string, item: HeaderShortcutItem) =>
+  pathname === item.to
+
 /* ------------------------------------------------------------------ */
 /*  Types                                                              */
 /* ------------------------------------------------------------------ */
@@ -477,9 +480,10 @@ export function HeaderShortcuts({
                       const globalIdx = flatItems.indexOf(ri)
                       const isSelected = globalIdx === selectedIndex
                       const Icon = ri.item.icon
-                      const isCurrentRoute =
-                        location.pathname === ri.item.to ||
-                        (ri.item.to === "/" && location.pathname === "/chat")
+                      const isCurrentRoute = isCurrentShortcutRoute(
+                        location.pathname,
+                        ri.item
+                      )
 
                       return (
                         <NavLink
@@ -559,9 +563,10 @@ export function HeaderShortcuts({
                         const globalIdx = flatItems.indexOf(ri)
                         const isSelected = globalIdx === selectedIndex
                         const Icon = ri.item.icon
-                        const isCurrentRoute =
-                          location.pathname === ri.item.to ||
-                          (ri.item.to === "/" && location.pathname === "/chat")
+                        const isCurrentRoute = isCurrentShortcutRoute(
+                          location.pathname,
+                          ri.item
+                        )
 
                         return (
                           <NavLink

--- a/apps/packages/ui/src/components/Layouts/__tests__/ChatHeader.test.tsx
+++ b/apps/packages/ui/src/components/Layouts/__tests__/ChatHeader.test.tsx
@@ -111,7 +111,9 @@ describe("ChatHeader shortcut toggle", () => {
     const homeButton = screen.getByRole("button", { name: "Companion Home" })
     const signpostButton = screen.getByRole("button", { name: "Show shortcuts" })
     const headerBrand = homeButton.closest(".flex.items-center.gap-2.text-text")
-    const headerButtons = Array.from(headerBrand?.querySelectorAll("button") ?? [])
+    const headerButtons: HTMLElement[] = Array.from(
+      headerBrand?.querySelectorAll("button") ?? []
+    )
 
     expect(headerBrand).toBeTruthy()
     expect(headerBrand).toContainElement(homeButton)

--- a/apps/packages/ui/src/components/Layouts/__tests__/ChatHeader.test.tsx
+++ b/apps/packages/ui/src/components/Layouts/__tests__/ChatHeader.test.tsx
@@ -53,6 +53,7 @@ const createProps = (overrides: Partial<React.ComponentProps<typeof ChatHeader>>
   onTitleCommit: vi.fn(),
   onToggleSidebar: vi.fn(),
   sidebarCollapsed: false,
+  onOpenCompanionHome: vi.fn(),
   onOpenCommandPalette: vi.fn(),
   onOpenShortcutsModal: vi.fn(),
   onOpenSettings: vi.fn(),
@@ -103,12 +104,33 @@ describe("ChatHeader shortcut toggle", () => {
     )
   })
 
+  it("shows a Companion Home button immediately before the signpost shortcut toggle", () => {
+    const props = createProps()
+    render(<ChatHeader {...props} />)
+
+    const homeButton = screen.getByRole("button", { name: "Companion Home" })
+    const signpostButton = screen.getByRole("button", { name: "Show shortcuts" })
+    const headerBrand = homeButton.closest(".flex.items-center.gap-2.text-text")
+    const headerButtons = Array.from(headerBrand?.querySelectorAll("button") ?? [])
+
+    expect(headerBrand).toBeTruthy()
+    expect(headerBrand).toContainElement(homeButton)
+    expect(headerBrand).toContainElement(signpostButton)
+    expect(headerButtons.indexOf(signpostButton)).toBe(
+      headerButtons.indexOf(homeButton) + 1
+    )
+
+    fireEvent.click(homeButton)
+    expect(props.onOpenCompanionHome).toHaveBeenCalledTimes(1)
+  })
+
   it("applies focus-visible ring classes to key header controls", () => {
     const props = createProps()
     render(<ChatHeader {...props} />)
 
     const controls = [
       screen.getByRole("button", { name: "Collapse sidebar" }),
+      screen.getByRole("button", { name: "Companion Home" }),
       screen.getByRole("button", { name: "Show shortcuts" }),
       screen.getByRole("button", { name: "New saved chat" }),
       screen.getByRole("button", { name: "Temporary chat (not saved)" }),

--- a/apps/packages/ui/src/components/Layouts/__tests__/HeaderShortcuts.test.tsx
+++ b/apps/packages/ui/src/components/Layouts/__tests__/HeaderShortcuts.test.tsx
@@ -436,8 +436,6 @@ describe("HeaderShortcuts launcher modal", () => {
     const companionHome = getShortcutLink(legacySheet, "Companion Home")
     const chat = getShortcutLink(legacySheet, "Chat")
 
-    fireEvent.mouseEnter(chat)
-
     expect(companionHome).not.toHaveClass("border-border")
     expect(companionHome).not.toHaveAttribute("aria-current")
     expect(chat).toHaveClass("border-border")
@@ -456,9 +454,9 @@ describe("HeaderShortcuts launcher modal", () => {
     const companionHome = getShortcutLink(legacySheet, "Companion Home")
     const chat = getShortcutLink(legacySheet, "Chat")
 
-    fireEvent.mouseEnter(chat)
-
+    expect(companionHome).not.toHaveClass("border-border")
     expect(companionHome).not.toHaveAttribute("aria-current")
+    expect(chat).not.toHaveClass("border-border")
     expect(chat).not.toHaveAttribute("aria-current")
   })
 

--- a/apps/packages/ui/src/components/Layouts/__tests__/HeaderShortcuts.test.tsx
+++ b/apps/packages/ui/src/components/Layouts/__tests__/HeaderShortcuts.test.tsx
@@ -217,7 +217,24 @@ describe("HeaderShortcuts launcher modal", () => {
     const chat = getShortcutLink(listbox, "Chat")
 
     expect(companionHome.className).not.toContain("border-primary")
+    expect(companionHome).not.toHaveAttribute("aria-current")
     expect(chat.className).toContain("border-primary")
+    expect(chat).toHaveAttribute("aria-current", "page")
+  })
+
+  it("does not expose Chat as current in the launcher on nested chat routes", () => {
+    renderWithRouter(
+      <HeaderShortcuts expanded={true} onExpandedChange={vi.fn()} />,
+      "/chat/thread/1"
+    )
+
+    const listbox = screen.getByRole("listbox", { name: "Pages" })
+    const companionHome = getShortcutLink(listbox, "Companion Home")
+    const chat = getShortcutLink(listbox, "Chat")
+
+    expect(companionHome).not.toHaveAttribute("aria-current")
+    expect(chat.className).not.toContain("border-primary")
+    expect(chat).not.toHaveAttribute("aria-current")
   })
 
   it("marks Companion Home as current in the launcher on the home route", () => {
@@ -230,6 +247,7 @@ describe("HeaderShortcuts launcher modal", () => {
     const companionHome = getShortcutLink(listbox, "Companion Home")
 
     expect(companionHome.className).toContain("border-primary")
+    expect(companionHome).toHaveAttribute("aria-current", "page")
   })
 
   it("does not show Content Review in the launcher modal", () => {
@@ -421,7 +439,27 @@ describe("HeaderShortcuts launcher modal", () => {
     fireEvent.mouseEnter(chat)
 
     expect(companionHome).not.toHaveClass("border-border")
+    expect(companionHome).not.toHaveAttribute("aria-current")
     expect(chat).toHaveClass("border-border")
+    expect(chat).toHaveAttribute("aria-current", "page")
+  })
+
+  it("does not expose Chat as current in the legacy sheet on nested chat routes", () => {
+    mockState.launcherView = "legacy"
+
+    renderWithRouter(
+      <HeaderShortcuts expanded={true} onExpandedChange={vi.fn()} />,
+      "/chat/thread/1"
+    )
+
+    const legacySheet = screen.getByRole("listbox", { name: "Legacy sheet" })
+    const companionHome = getShortcutLink(legacySheet, "Companion Home")
+    const chat = getShortcutLink(legacySheet, "Chat")
+
+    fireEvent.mouseEnter(chat)
+
+    expect(companionHome).not.toHaveAttribute("aria-current")
+    expect(chat).not.toHaveAttribute("aria-current")
   })
 
   it("marks Companion Home as current in the legacy sheet on the home route", () => {
@@ -439,6 +477,8 @@ describe("HeaderShortcuts launcher modal", () => {
     fireEvent.mouseEnter(chat)
 
     expect(companionHome).toHaveClass("border-border")
+    expect(companionHome).toHaveAttribute("aria-current", "page")
+    expect(chat).not.toHaveAttribute("aria-current")
   })
 
   it("opens in persisted legacy view mode when preference is set", () => {

--- a/apps/packages/ui/src/components/Layouts/__tests__/HeaderShortcuts.test.tsx
+++ b/apps/packages/ui/src/components/Layouts/__tests__/HeaderShortcuts.test.tsx
@@ -4,6 +4,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 import { MemoryRouter } from "react-router-dom"
 import { HeaderShortcuts } from "../HeaderShortcuts"
 import { getHeaderShortcutItems } from "../header-shortcut-items"
+import { HEADER_SHORTCUT_IDS } from "@/services/settings/ui-settings"
 
 const mockState = vi.hoisted(() => ({
   expanded: false,
@@ -16,21 +17,7 @@ const mockState = vi.hoisted(() => ({
 const mockUseSetting = vi.hoisted(() => vi.fn())
 const mockT = vi.hoisted(() => (key: string, fallback?: string) => fallback ?? key)
 
-const ALL_SHORTCUT_IDS = [
-  "chat", "chat-workspace", "prompts", "prompt-studio", "characters",
-  "chat-dictionaries", "world-books", "deep-research", "research-workspace",
-  "knowledge-qa", "media", "document-workspace",
-  "repo2txt",
-  "multi-item-review", "collections",
-  "watchlists", "integrations", "mcp-hub", "scheduled-tasks", "notes", "chatbooks-playground", "flashcards",
-  "quizzes", "evaluations", "chunking-playground",
-  "stt-playground", "tts-playground", "audiobook-studio",
-  "workflows", "writing-playground", "acp-playground",
-  "skills", "kanban-playground",
-  "model-playground", "data-tables",
-  "admin-server", "admin-integrations", "documentation", "moderation-review", "moderation-rules",
-  "admin-llamacpp", "admin-mlx", "settings"
-]
+const ALL_SHORTCUT_IDS = [...HEADER_SHORTCUT_IDS]
 
 /* ------------------------------------------------------------------ */
 /*  Mocks                                                              */
@@ -68,6 +55,15 @@ vi.mock("@/services/settings/ui-settings", async (importOriginal) => {
 
 const renderWithRouter = (ui: React.ReactElement, initialRoute = "/") =>
   render(<MemoryRouter initialEntries={[initialRoute]}>{ui}</MemoryRouter>)
+
+const getShortcutLink = (
+  container: HTMLElement,
+  label: string
+): HTMLAnchorElement => {
+  const link = within(container).getByText(label).closest("a")
+  expect(link).toBeTruthy()
+  return link as HTMLAnchorElement
+}
 
 /* ------------------------------------------------------------------ */
 /*  Tests                                                              */
@@ -187,11 +183,53 @@ describe("HeaderShortcuts launcher modal", () => {
       <HeaderShortcuts expanded={true} onExpandedChange={vi.fn()} />
     )
     // Items should be visible
+    expect(screen.getByText("Companion Home")).toBeInTheDocument()
     expect(screen.getByText("Chat")).toBeInTheDocument()
     expect(screen.getByText("Prompts")).toBeInTheDocument()
     expect(screen.getByText("Deep Research")).toBeInTheDocument()
     expect(screen.getByText("Repo2Txt")).toBeInTheDocument()
     expect(screen.getByText("Settings")).toBeInTheDocument()
+  })
+
+  it("lists Companion Home in the current launcher view and targets home", () => {
+    renderWithRouter(
+      <HeaderShortcuts expanded={true} onExpandedChange={vi.fn()} />,
+      "/chat"
+    )
+
+    const nav = screen.getByLabelText("Categories")
+    expect(within(nav).getByText("Start")).toBeInTheDocument()
+
+    const listbox = screen.getByRole("listbox", { name: "Pages" })
+    const companionHome = getShortcutLink(listbox, "Companion Home")
+
+    expect(companionHome).toHaveAttribute("href", "/")
+  })
+
+  it("does not mark Companion Home as current in the launcher while on the chat route", () => {
+    renderWithRouter(
+      <HeaderShortcuts expanded={true} onExpandedChange={vi.fn()} />,
+      "/chat"
+    )
+
+    const listbox = screen.getByRole("listbox", { name: "Pages" })
+    const companionHome = getShortcutLink(listbox, "Companion Home")
+    const chat = getShortcutLink(listbox, "Chat")
+
+    expect(companionHome.className).not.toContain("border-primary")
+    expect(chat.className).toContain("border-primary")
+  })
+
+  it("marks Companion Home as current in the launcher on the home route", () => {
+    renderWithRouter(
+      <HeaderShortcuts expanded={true} onExpandedChange={vi.fn()} />,
+      "/"
+    )
+
+    const listbox = screen.getByRole("listbox", { name: "Pages" })
+    const companionHome = getShortcutLink(listbox, "Companion Home")
+
+    expect(companionHome.className).toContain("border-primary")
   })
 
   it("does not show Content Review in the launcher modal", () => {
@@ -352,6 +390,55 @@ describe("HeaderShortcuts launcher modal", () => {
     fireEvent.click(screen.getByRole("button", { name: "Current view" }))
     expect(screen.getByLabelText("Categories")).toBeInTheDocument()
     expect(mockState.setLauncherView).toHaveBeenCalledWith("current")
+  })
+
+  it("lists Companion Home in the legacy sheet view", () => {
+    mockState.launcherView = "legacy"
+
+    renderWithRouter(
+      <HeaderShortcuts expanded={true} onExpandedChange={vi.fn()} />,
+      "/chat"
+    )
+
+    const legacySheet = screen.getByRole("listbox", { name: "Legacy sheet" })
+    const companionHome = getShortcutLink(legacySheet, "Companion Home")
+
+    expect(companionHome).toHaveAttribute("href", "/")
+  })
+
+  it("does not mark Companion Home as current in the legacy sheet while on the chat route", () => {
+    mockState.launcherView = "legacy"
+
+    renderWithRouter(
+      <HeaderShortcuts expanded={true} onExpandedChange={vi.fn()} />,
+      "/chat"
+    )
+
+    const legacySheet = screen.getByRole("listbox", { name: "Legacy sheet" })
+    const companionHome = getShortcutLink(legacySheet, "Companion Home")
+    const chat = getShortcutLink(legacySheet, "Chat")
+
+    fireEvent.mouseEnter(chat)
+
+    expect(companionHome).not.toHaveClass("border-border")
+    expect(chat).toHaveClass("border-border")
+  })
+
+  it("marks Companion Home as current in the legacy sheet on the home route", () => {
+    mockState.launcherView = "legacy"
+
+    renderWithRouter(
+      <HeaderShortcuts expanded={true} onExpandedChange={vi.fn()} />,
+      "/"
+    )
+
+    const legacySheet = screen.getByRole("listbox", { name: "Legacy sheet" })
+    const companionHome = getShortcutLink(legacySheet, "Companion Home")
+    const chat = getShortcutLink(legacySheet, "Chat")
+
+    fireEvent.mouseEnter(chat)
+
+    expect(companionHome).toHaveClass("border-border")
   })
 
   it("opens in persisted legacy view mode when preference is set", () => {

--- a/apps/packages/ui/src/components/Layouts/__tests__/header-shortcut-items.hosted.test.ts
+++ b/apps/packages/ui/src/components/Layouts/__tests__/header-shortcut-items.hosted.test.ts
@@ -6,6 +6,25 @@ describe("header shortcut items hosted mode", () => {
     vi.doUnmock("@/services/tldw/deployment-mode")
   })
 
+  it("keeps Companion Home discoverable in hosted mode", async () => {
+    vi.doMock("@/services/tldw/deployment-mode", () => ({
+      isHostedTldwDeployment: () => true,
+    }))
+
+    const mod = await import("../header-shortcut-items")
+    const shortcutItems = mod.getHeaderShortcutItems()
+
+    expect(shortcutItems).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: "companion-home",
+          to: "/",
+          labelDefault: "Companion Home"
+        })
+      ])
+    )
+  })
+
   it("uses dedicated account and billing shortcut ids in hosted mode", async () => {
     vi.doMock("@/services/tldw/deployment-mode", () => ({
       isHostedTldwDeployment: () => true,

--- a/apps/packages/ui/src/components/Layouts/__tests__/persona-shortcut-defaults.test.ts
+++ b/apps/packages/ui/src/components/Layouts/__tests__/persona-shortcut-defaults.test.ts
@@ -6,8 +6,13 @@ import {
 } from "../header-shortcut-items"
 
 describe("persona shortcut defaults", () => {
+  it("keeps Companion Home first in the shared shortcut IDs", () => {
+    expect(HEADER_SHORTCUT_IDS[0]).toBe("companion-home")
+  })
+
   it("family persona includes safety tools", () => {
     const shortcuts = getDefaultShortcutsForPersona("family")
+    expect(shortcuts).toContain("companion-home")
     expect(shortcuts).toContain("family-guardrails")
     expect(shortcuts).toContain("moderation-review")
     expect(shortcuts).toContain("moderation-rules")
@@ -18,6 +23,7 @@ describe("persona shortcut defaults", () => {
 
   it("researcher persona includes research tools", () => {
     const shortcuts = getDefaultShortcutsForPersona("researcher")
+    expect(shortcuts).toContain("companion-home")
     expect(shortcuts).toContain("deep-research")
     expect(shortcuts).toContain("knowledge-qa")
     expect(shortcuts).toContain("media")
@@ -69,6 +75,7 @@ describe("persona shortcut defaults", () => {
     for (const persona of ["explorer", "default"] as const) {
       const shortcuts = PERSONA_SHORTCUT_DEFAULTS[persona]
       expect(shortcuts).toHaveLength(HEADER_SHORTCUT_IDS.length)
+      expect(shortcuts).toContain("companion-home")
     }
   })
 })

--- a/apps/packages/ui/src/components/Layouts/header-shortcut-items.ts
+++ b/apps/packages/ui/src/components/Layouts/header-shortcut-items.ts
@@ -16,6 +16,7 @@ import {
   Gauge,
   GitCompare,
   Headphones,
+  House,
   Kanban,
   Layers,
   LayoutGrid,
@@ -74,6 +75,22 @@ export type HeaderShortcutGroup = {
 }
 
 const BASE_HEADER_SHORTCUT_GROUPS: HeaderShortcutGroup[] = [
+  {
+    id: "start",
+    titleKey: "option:header.groupStart",
+    titleDefault: "Start",
+    items: [
+      {
+        id: "companion-home",
+        to: "/",
+        icon: House,
+        labelKey: "option:header.companionHome",
+        labelDefault: "Companion Home",
+        descriptionKey: "option:header.companionHomeDesc",
+        descriptionDefault: "Open the main Companion Home workspace"
+      }
+    ]
+  },
   {
     id: "chat-persona",
     titleKey: "option:header.groupChatPersona",
@@ -529,6 +546,7 @@ const BASE_HEADER_SHORTCUT_GROUPS: HeaderShortcutGroup[] = [
 ]
 
 const HOSTED_VISIBLE_SHORTCUT_PATHS = new Set([
+  "/",
   "/chat",
   CHAT_WORKSPACE_PATH,
   "/knowledge",
@@ -622,6 +640,7 @@ export const PERSONA_SHORTCUT_DEFAULTS: Record<
   HeaderShortcutId[]
 > = {
   family: [
+    "companion-home",
     "chat",
     "media",
     "family-guardrails",
@@ -631,6 +650,7 @@ export const PERSONA_SHORTCUT_DEFAULTS: Record<
     "settings"
   ],
   researcher: [
+    "companion-home",
     "chat",
     "prompts",
     "deep-research",

--- a/apps/packages/ui/src/services/__tests__/ui-settings.header-shortcuts.test.ts
+++ b/apps/packages/ui/src/services/__tests__/ui-settings.header-shortcuts.test.ts
@@ -20,6 +20,10 @@ describe("header shortcut defaults", () => {
     expect(DEFAULT_HEADER_SHORTCUT_SELECTION).toContain("sources")
   })
 
+  it("includes Companion Home first in the default selection", () => {
+    expect(DEFAULT_HEADER_SHORTCUT_SELECTION[0]).toBe("companion-home")
+  })
+
   it("includes the integrations control-plane shortcuts in the default selection", () => {
     expect(DEFAULT_HEADER_SHORTCUT_SELECTION).toContain("integrations")
     expect(DEFAULT_HEADER_SHORTCUT_SELECTION).toContain("scheduled-tasks")
@@ -46,6 +50,17 @@ describe("header shortcut defaults", () => {
     )
 
     expect(normalized).not.toContain("sources")
+  })
+
+  it("adds Companion Home to persisted filtered selections", () => {
+    const normalized = normalizeSettingValue(
+      HEADER_SHORTCUT_SELECTION_SETTING,
+      ["chat", "settings"]
+    )
+
+    expect(normalized).toEqual(
+      expect.arrayContaining(["companion-home", "chat", "settings"])
+    )
   })
 
   it("adds the integrations control-plane shortcuts to persisted legacy selections", () => {

--- a/apps/packages/ui/src/services/__tests__/ui-settings.header-shortcuts.test.ts
+++ b/apps/packages/ui/src/services/__tests__/ui-settings.header-shortcuts.test.ts
@@ -43,6 +43,20 @@ describe("header shortcut defaults", () => {
     expect(normalized).toContain("sources")
   })
 
+  it("adds Sources to legacy full-default selections missing Companion Home and Sources", () => {
+    const legacyFullDefaultSelection = DEFAULT_HEADER_SHORTCUT_SELECTION.filter(
+      (id) => id !== "companion-home" && id !== "sources"
+    )
+
+    const normalized = normalizeSettingValue(
+      HEADER_SHORTCUT_SELECTION_SETTING,
+      legacyFullDefaultSelection
+    )
+
+    expect(normalized).toContain("companion-home")
+    expect(normalized).toContain("sources")
+  })
+
   it("does not add Sources to custom persisted selections", () => {
     const normalized = normalizeSettingValue(
       HEADER_SHORTCUT_SELECTION_SETTING,

--- a/apps/packages/ui/src/services/settings/ui-settings.ts
+++ b/apps/packages/ui/src/services/settings/ui-settings.ts
@@ -502,11 +502,11 @@ const coerceHeaderShortcutSelection = (
       }
     }
   }
-  if (hasExactHeaderShortcutIds(unique, HEADER_SHORTCUT_IDS_WITHOUT_SOURCES)) {
-    unique.add("sources")
-  }
   for (const requiredId of required) {
     unique.add(requiredId)
+  }
+  if (hasExactHeaderShortcutIds(unique, HEADER_SHORTCUT_IDS_WITHOUT_SOURCES)) {
+    unique.add("sources")
   }
   return HEADER_SHORTCUT_IDS.filter((id) => unique.has(id))
 }

--- a/apps/packages/ui/src/services/settings/ui-settings.ts
+++ b/apps/packages/ui/src/services/settings/ui-settings.ts
@@ -406,6 +406,7 @@ export const PERSONA_BUDDY_SHELL_ENABLED_SETTING = defineSetting(
 export const SIDEBAR_SHORTCUT_MAX_COUNT = 15
 
 export const HEADER_SHORTCUT_IDS = [
+  "companion-home",
   "chat",
   "chat-workspace",
   "prompts",
@@ -464,6 +465,7 @@ export const DEFAULT_HEADER_SHORTCUT_SELECTION = [
 ] as HeaderShortcutId[]
 
 const REQUIRED_HEADER_SHORTCUT_IDS: HeaderShortcutId[] = [
+  "companion-home",
   "workflows",
   "acp-playground",
   "integrations",

--- a/backlog/tasks/task-499 - Implement-Companion-Home-header-and-launcher-shortcuts.md
+++ b/backlog/tasks/task-499 - Implement-Companion-Home-header-and-launcher-shortcuts.md
@@ -72,6 +72,15 @@ Verification:
 - Red check: `bunx vitest run src/components/Layouts/__tests__/HeaderShortcuts.test.tsx` from `apps/packages/ui` failed before production changes with 2 expected active-state failures.
 - Green check: `bunx vitest run src/components/Layouts/__tests__/HeaderShortcuts.test.tsx` from `apps/packages/ui`: 30 tests passed.
 - Bandit: not applicable for this Task 3 frontend-only TypeScript/TSX touched scope.
+Task 3 quality review follow-up complete:
+- Added exact `aria-current` regression coverage for current launcher and legacy sheet links, including `/chat/thread/1` not marking Chat current.
+- Added direct `aria-current` assertions for `/chat` Chat current state and `/` Companion Home current state.
+- Added `end` to both launcher `NavLink` instances so React Router current semantics match the exact route helper and visual active styling.
+
+Verification:
+- Red check: `bunx vitest run src/components/Layouts/__tests__/HeaderShortcuts.test.tsx` from `apps/packages/ui` failed before production changes with 2 expected nested-route `aria-current` failures.
+- Green check: `bunx vitest run src/components/Layouts/__tests__/HeaderShortcuts.test.tsx` from `apps/packages/ui`: 32 tests passed.
+- Bandit: not applicable for this frontend-only TypeScript/TSX and Backlog markdown touched scope.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-499 - Implement-Companion-Home-header-and-launcher-shortcuts.md
+++ b/backlog/tasks/task-499 - Implement-Companion-Home-header-and-launcher-shortcuts.md
@@ -6,6 +6,11 @@ modified_files:
 - apps/packages/ui/src/components/Layouts/ChatHeader.tsx
 - apps/packages/ui/src/components/Layouts/Header.tsx
 - apps/packages/ui/src/components/Layouts/__tests__/ChatHeader.test.tsx
+- apps/packages/ui/src/components/Layouts/header-shortcut-items.ts
+- apps/packages/ui/src/services/settings/ui-settings.ts
+- apps/packages/ui/src/services/__tests__/ui-settings.header-shortcuts.test.ts
+- apps/packages/ui/src/components/Layouts/__tests__/header-shortcut-items.hosted.test.ts
+- apps/packages/ui/src/components/Layouts/__tests__/persona-shortcut-defaults.test.ts
 ---
 
 ## Description

--- a/backlog/tasks/task-499 - Implement-Companion-Home-header-and-launcher-shortcuts.md
+++ b/backlog/tasks/task-499 - Implement-Companion-Home-header-and-launcher-shortcuts.md
@@ -11,6 +11,8 @@ modified_files:
 - apps/packages/ui/src/services/__tests__/ui-settings.header-shortcuts.test.ts
 - apps/packages/ui/src/components/Layouts/__tests__/header-shortcut-items.hosted.test.ts
 - apps/packages/ui/src/components/Layouts/__tests__/persona-shortcut-defaults.test.ts
+- apps/packages/ui/src/components/Layouts/HeaderShortcuts.tsx
+- apps/packages/ui/src/components/Layouts/__tests__/HeaderShortcuts.test.tsx
 ---
 
 ## Description
@@ -50,6 +52,26 @@ Verification:
 - `bunx vitest run src/components/Layouts/__tests__/ChatHeader.test.tsx` from `apps/packages/ui`: 11 tests passed.
 - `git diff --check`: passed with no output.
 - Bandit: not applicable for this Task 1 frontend-only TypeScript/TSX touched scope.
+
+Task 2 (Shortcut Metadata And Persisted Selection) complete:
+- Added Companion Home shortcut metadata with id `companion-home`, target `/`, House icon, Start group placement, and hosted-mode visibility.
+- Added `companion-home` to header shortcut ids, required shortcut ids, and persona shortcut expectations so persisted filtered selections still expose it.
+- Added focused coverage for default/coerced shortcut selection, hosted shortcut visibility, and persona defaults.
+
+Verification:
+- `bunx vitest run src/services/__tests__/ui-settings.header-shortcuts.test.ts src/components/Layouts/__tests__/header-shortcut-items.hosted.test.ts src/components/Layouts/__tests__/persona-shortcut-defaults.test.ts` from `apps/packages/ui`: 18 tests passed.
+- Bandit: not applicable for this Task 2 frontend-only TypeScript/TS touched scope.
+
+Task 3 (Launcher Rendering And Active Route Behavior) complete:
+- Derived HeaderShortcuts test selection from shared `HEADER_SHORTCUT_IDS` so launcher tests include `companion-home`.
+- Added current launcher coverage for Companion Home listing, home target, `/chat` non-current state, Chat current state, and `/` current state.
+- Added legacy sheet coverage for Companion Home listing, `/chat` non-current state after moving selection away from Companion Home, and `/` current state.
+- Replaced the duplicated `/` to `/chat` active alias with a shared exact-route helper used by both launcher rendering branches.
+
+Verification:
+- Red check: `bunx vitest run src/components/Layouts/__tests__/HeaderShortcuts.test.tsx` from `apps/packages/ui` failed before production changes with 2 expected active-state failures.
+- Green check: `bunx vitest run src/components/Layouts/__tests__/HeaderShortcuts.test.tsx` from `apps/packages/ui`: 30 tests passed.
+- Bandit: not applicable for this Task 3 frontend-only TypeScript/TSX touched scope.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-499 - Implement-Companion-Home-header-and-launcher-shortcuts.md
+++ b/backlog/tasks/task-499 - Implement-Companion-Home-header-and-launcher-shortcuts.md
@@ -1,0 +1,51 @@
+---
+id: TASK-499
+title: Implement Companion Home header and launcher shortcuts
+status: In Progress
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement the approved Companion Home shortcut design.
+
+Spec: Docs/superpowers/specs/2026-06-01-companion-home-header-shortcut-design.md
+Plan: Docs/superpowers/plans/2026-06-01-companion-home-header-shortcut-implementation-plan.md
+
+Scope:
+- Add a Companion Home header icon button immediately left of the signpost shortcut button, navigating to `/`.
+- Add a Companion Home shortcut/listing to the page directory and legacy sheet modal.
+- Preserve existing persisted header shortcut selections by forcing Companion Home into coerced selection IDs.
+- Keep `/` active state exact so `/chat` does not mark Companion Home current.
+
+Verification:
+- Focused Vitest coverage for ChatHeader, HeaderShortcuts, header shortcut item hosting, persona defaults, and UI settings shortcut coercion.
+- TypeScript check for the UI package.
+- Bandit noted as not applicable to frontend-only touched scope unless Python files become touched.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-499 - Implement-Companion-Home-header-and-launcher-shortcuts.md
+++ b/backlog/tasks/task-499 - Implement-Companion-Home-header-and-launcher-shortcuts.md
@@ -37,6 +37,12 @@ Verification:
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
+- [x] Companion Home appears as a header icon immediately left of the page-directory signpost control and navigates to `/`.
+- [x] Companion Home is listed in both the current page launcher and legacy sheet views with the `/` target.
+- [x] Persisted shortcut selections are coerced so existing users receive Companion Home without losing their saved visible shortcuts.
+- [x] Legacy full-default shortcut selections still receive the Sources backfill even when they predate both Companion Home and Sources.
+- [x] Route-current state is exact: `/` marks Companion Home current, while `/chat` and nested chat routes do not.
+- [x] Focused regression tests and PR review follow-up verification are recorded.
 <!-- AC:END -->
 
 ## Implementation Notes
@@ -50,11 +56,13 @@ PR #2215 dev rebase follow-up complete:
 - Resolved the `HeaderShortcuts.test.tsx` conflict by keeping the shared `HEADER_SHORTCUT_IDS` test selection instead of a stale hard-coded shortcut list.
 - Force-pushed the rebased branch with lease and retargeted PR #2215 from `main` to `dev`.
 - Replied to and resolved the outdated Gemini Dockerfile `.env` parser review thread after verifying `Dockerfiles/entrypoints/tldw-app-first-run.sh` is no longer in the current PR diff.
+- After `dev` advanced again, rebased the PR branch onto the refreshed `origin/dev` tip and force-pushed the updated branch.
+- Addressed Cubic review comments by adding legacy migration coverage for selections missing both `companion-home` and `sources`, moving required shortcut injection before the Sources backfill check, and filling this task's Acceptance Criteria section.
 
 Rebase verification:
-- `bunx vitest run src/services/__tests__/ui-settings.header-shortcuts.test.ts` from `apps/packages/ui`: 9 tests passed after conflict resolution.
+- `bunx vitest run src/services/__tests__/ui-settings.header-shortcuts.test.ts` from `apps/packages/ui`: 10 tests passed after the Cubic migration follow-up.
 - `bunx vitest run src/components/Layouts/__tests__/HeaderShortcuts.test.tsx` from `apps/packages/ui`: 30 tests passed after conflict resolution.
-- `bunx vitest run src/components/Layouts/__tests__/ChatHeader.test.tsx src/components/Layouts/__tests__/HeaderShortcuts.test.tsx src/components/Layouts/__tests__/header-shortcut-items.hosted.test.ts src/components/Layouts/__tests__/persona-shortcut-defaults.test.ts src/services/__tests__/ui-settings.header-shortcuts.test.ts` from `apps/packages/ui`: 5 files passed, 68 tests passed.
+- `bunx vitest run src/components/Layouts/__tests__/ChatHeader.test.tsx src/components/Layouts/__tests__/HeaderShortcuts.test.tsx src/components/Layouts/__tests__/header-shortcut-items.hosted.test.ts src/components/Layouts/__tests__/persona-shortcut-defaults.test.ts src/services/__tests__/ui-settings.header-shortcuts.test.ts` from `apps/packages/ui`: 5 files passed, 69 tests passed.
 - `git diff --check origin/dev..HEAD`: passed.
 - `NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit --project tsconfig.json` from `apps/packages/ui`: fails on existing package-wide unrelated errors in QuickIngest, Layout shell override test, setup onboarding test, and quick-ingest utils; none are in the touched Companion Home files.
 - Bandit: not applicable; touched scope remains frontend TypeScript/TSX tests and Backlog markdown only.
@@ -114,7 +122,7 @@ What changed:
 - Made legacy sheet keyboard-selection styling distinct from route-current styling so the initially selected Companion Home row does not visually read as current on `/chat`.
 
 Verification:
-- `bunx vitest run src/components/Layouts/__tests__/ChatHeader.test.tsx src/components/Layouts/__tests__/HeaderShortcuts.test.tsx src/components/Layouts/__tests__/header-shortcut-items.hosted.test.ts src/components/Layouts/__tests__/persona-shortcut-defaults.test.ts src/services/__tests__/ui-settings.header-shortcuts.test.ts` from `apps/packages/ui`: 5 files passed, 68 tests passed after the `origin/dev` rebase.
+- `bunx vitest run src/components/Layouts/__tests__/ChatHeader.test.tsx src/components/Layouts/__tests__/HeaderShortcuts.test.tsx src/components/Layouts/__tests__/header-shortcut-items.hosted.test.ts src/components/Layouts/__tests__/persona-shortcut-defaults.test.ts src/services/__tests__/ui-settings.header-shortcuts.test.ts` from `apps/packages/ui`: 5 files passed, 69 tests passed after the `origin/dev` rebase and Cubic follow-up.
 - `git diff --check origin/dev..HEAD`: passed.
 - `NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit --project tsconfig.json` from `apps/packages/ui`: fails on existing package-wide unrelated errors; the remaining diagnostics are outside the touched Companion Home files.
 - Bandit: not applicable; touched scope is frontend TypeScript/TSX tests and Backlog markdown only.

--- a/backlog/tasks/task-499 - Implement-Companion-Home-header-and-launcher-shortcuts.md
+++ b/backlog/tasks/task-499 - Implement-Companion-Home-header-and-launcher-shortcuts.md
@@ -2,6 +2,10 @@
 id: TASK-499
 title: Implement Companion Home header and launcher shortcuts
 status: In Progress
+modified_files:
+- apps/packages/ui/src/components/Layouts/ChatHeader.tsx
+- apps/packages/ui/src/components/Layouts/Header.tsx
+- apps/packages/ui/src/components/Layouts/__tests__/ChatHeader.test.tsx
 ---
 
 ## Description
@@ -31,7 +35,16 @@ Verification:
 ## Implementation Notes
 
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Task 1 (Header Button Contract) complete:
+- Added ChatHeader onOpenCompanionHome callback contract.
+- Rendered a Companion Home House icon button immediately before the signpost shortcut toggle with the same header icon focus-ring treatment.
+- Wired Header to navigate to `/` through useNavigate.
+- Added focused ChatHeader coverage for accessible name, DOM/tab order, callback invocation, and focus-ring classes.
 
+Verification:
+- `bunx vitest run src/components/Layouts/__tests__/ChatHeader.test.tsx` from `apps/packages/ui`: 11 tests passed.
+- `git diff --check`: passed with no output.
+- Bandit: not applicable for this Task 1 frontend-only TypeScript/TSX touched scope.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-499 - Implement-Companion-Home-header-and-launcher-shortcuts.md
+++ b/backlog/tasks/task-499 - Implement-Companion-Home-header-and-launcher-shortcuts.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-499
 title: Implement Companion Home header and launcher shortcuts
-status: In Progress
+status: Done
 modified_files:
 - apps/packages/ui/src/components/Layouts/ChatHeader.tsx
 - apps/packages/ui/src/components/Layouts/Header.tsx
@@ -86,15 +86,32 @@ Verification:
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Implemented Companion Home in the shared header and launcher surfaces.
 
+What changed:
+- Added a Companion Home House icon button in `ChatHeader`, immediately before the signpost/page-directory button, wired through `Header` to navigate to `/`.
+- Added `companion-home` as the first shared header shortcut ID and as a required ID so old persisted filtered selections are coerced forward.
+- Added Companion Home to shortcut metadata with `/` target, Start group placement, House icon, hosted-mode visibility, and persona/default coverage.
+- Updated current launcher and legacy sheet active-state logic to use exact route matching, including `NavLink end`, so `/chat` and nested chat routes do not mark Companion Home or Chat incorrectly.
+
+Verification:
+- `bunx vitest run src/components/Layouts/__tests__/ChatHeader.test.tsx src/components/Layouts/__tests__/HeaderShortcuts.test.tsx src/components/Layouts/__tests__/header-shortcut-items.hosted.test.ts src/components/Layouts/__tests__/persona-shortcut-defaults.test.ts src/services/__tests__/ui-settings.header-shortcuts.test.ts` from `apps/packages/ui`: 5 files passed, 61 tests passed.
+- `git diff --check 4e682bea9f..HEAD`: passed.
+- `bunx tsc --noEmit --project tsconfig.json` from `apps/packages/ui`: fails on existing package-wide unrelated errors; the touched-file `ChatHeader.test.tsx` type error found during verification was fixed, and the remaining diagnostics are outside the touched Companion Home files.
+- Bandit: not applicable; touched scope is frontend TypeScript/TSX tests and Backlog markdown only.
+- Browser smoke: Next dev server on `http://127.0.0.1:8080` with seeded local auth showed one Companion Home button immediately before the signpost button, page directory listing included Companion Home with `/` href, and clicking Companion Home navigated from `/chat` to `/`.
+
+Known skips/blockers:
+- Full UI package TypeScript remains blocked by pre-existing unrelated errors outside this change.
+- Browser plugin was available but its in-app viewport rendered the mobile route without the target desktop header, so desktop smoke used a headless Playwright fallback.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->

--- a/backlog/tasks/task-499 - Implement-Companion-Home-header-and-launcher-shortcuts.md
+++ b/backlog/tasks/task-499 - Implement-Companion-Home-header-and-launcher-shortcuts.md
@@ -42,6 +42,24 @@ Verification:
 ## Implementation Notes
 
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Reopened on 2026-06-01 to rebase PR #2215 onto latest dev and address PR review/check comments.
+
+PR #2215 dev rebase follow-up complete:
+- Rebased the Companion Home commits onto `origin/dev` with a narrowed `git rebase --onto origin/dev 4e682bea9f` after a broad rebase attempted to replay unrelated commits.
+- Resolved the `ui-settings.header-shortcuts.test.ts` conflict by preserving both the new Sources migration tests from `dev` and the Companion Home required-selection test.
+- Resolved the `HeaderShortcuts.test.tsx` conflict by keeping the shared `HEADER_SHORTCUT_IDS` test selection instead of a stale hard-coded shortcut list.
+- Force-pushed the rebased branch with lease and retargeted PR #2215 from `main` to `dev`.
+- Replied to and resolved the outdated Gemini Dockerfile `.env` parser review thread after verifying `Dockerfiles/entrypoints/tldw-app-first-run.sh` is no longer in the current PR diff.
+
+Rebase verification:
+- `bunx vitest run src/services/__tests__/ui-settings.header-shortcuts.test.ts` from `apps/packages/ui`: 9 tests passed after conflict resolution.
+- `bunx vitest run src/components/Layouts/__tests__/HeaderShortcuts.test.tsx` from `apps/packages/ui`: 30 tests passed after conflict resolution.
+- `bunx vitest run src/components/Layouts/__tests__/ChatHeader.test.tsx src/components/Layouts/__tests__/HeaderShortcuts.test.tsx src/components/Layouts/__tests__/header-shortcut-items.hosted.test.ts src/components/Layouts/__tests__/persona-shortcut-defaults.test.ts src/services/__tests__/ui-settings.header-shortcuts.test.ts` from `apps/packages/ui`: 5 files passed, 68 tests passed.
+- `git diff --check origin/dev..HEAD`: passed.
+- `NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit --project tsconfig.json` from `apps/packages/ui`: fails on existing package-wide unrelated errors in QuickIngest, Layout shell override test, setup onboarding test, and quick-ingest utils; none are in the touched Companion Home files.
+- Bandit: not applicable; touched scope remains frontend TypeScript/TSX tests and Backlog markdown only.
+- PR review threads: GraphQL showed the Gemini Dockerfile thread as `isOutdated: true`; after the scope reply, `resolveReviewThread` returned `isResolved: true`.
+
 Task 1 (Header Button Contract) complete:
 - Added ChatHeader onOpenCompanionHome callback contract.
 - Rendered a Companion Home House icon button immediately before the signpost shortcut toggle with the same header icon focus-ring treatment.
@@ -96,11 +114,12 @@ What changed:
 - Made legacy sheet keyboard-selection styling distinct from route-current styling so the initially selected Companion Home row does not visually read as current on `/chat`.
 
 Verification:
-- `bunx vitest run src/components/Layouts/__tests__/ChatHeader.test.tsx src/components/Layouts/__tests__/HeaderShortcuts.test.tsx src/components/Layouts/__tests__/header-shortcut-items.hosted.test.ts src/components/Layouts/__tests__/persona-shortcut-defaults.test.ts src/services/__tests__/ui-settings.header-shortcuts.test.ts` from `apps/packages/ui`: 5 files passed, 61 tests passed.
-- `git diff --check 4e682bea9f..HEAD`: passed.
-- `bunx tsc --noEmit --project tsconfig.json` from `apps/packages/ui`: fails on existing package-wide unrelated errors; the touched-file `ChatHeader.test.tsx` type error found during verification was fixed, and the remaining diagnostics are outside the touched Companion Home files.
+- `bunx vitest run src/components/Layouts/__tests__/ChatHeader.test.tsx src/components/Layouts/__tests__/HeaderShortcuts.test.tsx src/components/Layouts/__tests__/header-shortcut-items.hosted.test.ts src/components/Layouts/__tests__/persona-shortcut-defaults.test.ts src/services/__tests__/ui-settings.header-shortcuts.test.ts` from `apps/packages/ui`: 5 files passed, 68 tests passed after the `origin/dev` rebase.
+- `git diff --check origin/dev..HEAD`: passed.
+- `NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit --project tsconfig.json` from `apps/packages/ui`: fails on existing package-wide unrelated errors; the remaining diagnostics are outside the touched Companion Home files.
 - Bandit: not applicable; touched scope is frontend TypeScript/TSX tests and Backlog markdown only.
 - Browser smoke: Next dev server on `http://127.0.0.1:8080` with seeded local auth showed one Companion Home button immediately before the signpost button, page directory listing included Companion Home with `/` href, and clicking Companion Home navigated from `/chat` to `/`.
+- PR #2215 is based on `dev`; the stale Gemini Dockerfile review thread was replied to and resolved.
 
 Known skips/blockers:
 - Full UI package TypeScript remains blocked by pre-existing unrelated errors outside this change.

--- a/backlog/tasks/task-499 - Implement-Companion-Home-header-and-launcher-shortcuts.md
+++ b/backlog/tasks/task-499 - Implement-Companion-Home-header-and-launcher-shortcuts.md
@@ -93,6 +93,7 @@ What changed:
 - Added `companion-home` as the first shared header shortcut ID and as a required ID so old persisted filtered selections are coerced forward.
 - Added Companion Home to shortcut metadata with `/` target, Start group placement, House icon, hosted-mode visibility, and persona/default coverage.
 - Updated current launcher and legacy sheet active-state logic to use exact route matching, including `NavLink end`, so `/chat` and nested chat routes do not mark Companion Home or Chat incorrectly.
+- Made legacy sheet keyboard-selection styling distinct from route-current styling so the initially selected Companion Home row does not visually read as current on `/chat`.
 
 Verification:
 - `bunx vitest run src/components/Layouts/__tests__/ChatHeader.test.tsx src/components/Layouts/__tests__/HeaderShortcuts.test.tsx src/components/Layouts/__tests__/header-shortcut-items.hosted.test.ts src/components/Layouts/__tests__/persona-shortcut-defaults.test.ts src/services/__tests__/ui-settings.header-shortcuts.test.ts` from `apps/packages/ui`: 5 files passed, 61 tests passed.


### PR DESCRIPTION
## Summary
- Add a Companion Home header icon button immediately before the page-directory signpost, wired to navigate to `/`.
- Add Companion Home to shared page-directory metadata, hosted visibility, persona defaults, and required persisted shortcut selection.
- Make launcher and legacy sheet current-route semantics exact, including distinct legacy selection styling so `/chat` does not visually mark Companion Home current.

## Test Plan
- [x] `cd apps/packages/ui && bunx vitest run src/components/Layouts/__tests__/ChatHeader.test.tsx src/components/Layouts/__tests__/HeaderShortcuts.test.tsx src/components/Layouts/__tests__/header-shortcut-items.hosted.test.ts src/components/Layouts/__tests__/persona-shortcut-defaults.test.ts src/services/__tests__/ui-settings.header-shortcuts.test.ts`
- [x] `git diff --check 4e682bea9f..HEAD`
- [x] Browser smoke on `http://127.0.0.1:8080` with seeded local auth: verified Home button order, page directory listing, `/` href, and `/chat` -> `/` navigation.
- [ ] `cd apps/packages/ui && bunx tsc --noEmit --project tsconfig.json` fails on existing unrelated package-wide errors outside touched Companion Home files; a touched-file error found during verification was fixed.
- [x] Bandit not applicable: frontend TypeScript/TSX and markdown-only touched scope.

## Change summary
This PR was materially authored by AI. Per project policy, a human maintainer must replace or supplement this section with their own explanation of what changed and why before merge.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Companion Home header button and integrates `companion-home` across launcher shortcuts with exact route matching. Home is easy to find, and `/chat` and nested chat routes no longer mark the wrong page active; legacy selections are upgraded to include Home and Sources.

- **New Features**
  - Header: Added a House icon button before the signpost that navigates to `/`.
  - Launcher: Added “Companion Home” in a Start group; uses exact-route detection and `NavLink` `end` for correct `aria-current` (including nested chat routes); legacy sheet selection styling is distinct from “current”.
  - Settings: Added `companion-home` to `HEADER_SHORTCUT_IDS`, first in `DEFAULT_HEADER_SHORTCUT_SELECTION`, coerced into persisted selections, and included in persona defaults.
  - Hosted: Companion Home remains visible in hosted mode.

- **Bug Fixes**
  - Settings: Preserved the `sources` backfill for legacy selections while injecting required `companion-home`, ensuring both are added during migration.

<sup>Written for commit d2a6f5e65ed424ec23b888b83c21047dd90107e9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2215?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

