### PR TITLE
Expose external runtime tools through MCP gateway

### DIFF
--- a/Docs/superpowers/plans/2026-06-02-mcp-gateway-external-runtime-adapter-plan.md
+++ b/Docs/superpowers/plans/2026-06-02-mcp-gateway-external-runtime-adapter-plan.md
@@ -1,0 +1,420 @@
+# MCP Gateway External Runtime Adapter Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Expose active standalone external MCP runtime virtual tools through the gateway `GatewayRuntime` protocol so HTTP, WebSocket, and stdio transports can list and call them.
+
+**Architecture:** Add a small package-owned adapter that composes an optional base `GatewayRuntime` with `GatewayExternalRuntimeManager`. Keep transport code unchanged: JSON-RPC still delegates to `GatewayRuntime`, while `ProfileAwareGatewayRuntime` enriches delegated call contexts with the already-derived effective policy so the external manager can enforce external-server grants, credential grants, and audit behavior.
+
+**Tech Stack:** Python 3.11, asyncio, package-local MCP Unified gateway/federation contracts, pytest, Ruff, Bandit.
+
+---
+
+## Scope And Constraints
+
+Backlog: `TASK-589`
+
+In scope:
+
+- Convert active `VirtualExternalTool` rows into normal gateway tool descriptors.
+- Dispatch `tools/call` for external virtual tool names to `GatewayExternalRuntimeManager.execute_virtual_tool()`.
+- Preserve profile policy enforcement by having `ProfileAwareGatewayRuntime` pass the resolved `EffectivePolicy` into downstream context metadata.
+- Preserve base runtime behavior when an injected base runtime handles local tools/resources/prompts/modules.
+
+Out of scope:
+
+- Durable daemon-control CLI commands.
+- A client-facing stdio serve loop.
+- Real package-manager install/update execution.
+- New external process policy rules beyond existing process-policy enforcement.
+- Broad packaging/extras metadata changes.
+
+## File Structure
+
+- Create: `mcp_unified/gateway/external_runtime_adapter.py`
+  - `ExternalRuntimeGatewayRuntime`
+  - virtual-tool descriptor conversion
+  - context policy extraction
+  - federated result conversion to MCP tool-call JSON
+- Modify: `mcp_unified/gateway/profile_runtime.py`
+  - add a package-private metadata key for effective policy
+  - enrich delegated call contexts after profile policy is resolved
+- Modify: `mcp_unified/gateway/__init__.py`
+  - lazy/public export for the adapter and policy metadata key if useful
+- Create: `tldw_Server_API/app/core/MCP_unified/tests/test_gateway_external_runtime_adapter.py`
+  - focused adapter and profile-context integration tests
+- Modify: `tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py`
+  - package export/import-boundary coverage
+- Modify: `Docs/superpowers/plans/2026-06-02-mcp-gateway-external-runtime-adapter-plan.md`
+  - execution evidence and status updates
+- Modify: `backlog/tasks/task-589 - Expose-MCP-external-runtime-tools-through-gateway-runtime.md`
+  - acceptance criteria, verification, final summary
+
+Baseline evidence before this plan: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_gateway_cli_package.py -q` passed with `63 passed, 4 warnings`.
+
+## Task 1: Adapter Red Tests
+
+**Files:**
+- Create: `tldw_Server_API/app/core/MCP_unified/tests/test_gateway_external_runtime_adapter.py`
+
+- [x] **Step 1: Write test doubles**
+
+Create an in-memory external registry store, a recording transport, and a small base gateway runtime. Reuse `ExternalServerDefinition`, `ExternalToolDefinition`, and `ExternalToolCallResult` from package models.
+
+- [x] **Step 2: Add a listing test**
+
+Assert that an adapter with a base runtime and a started external runtime returns both local and external tools:
+
+```python
+async def test_external_runtime_gateway_lists_base_and_external_tools():
+    store = InMemoryExternalRegistryStore([_server("research")])
+    transport = RecordingTransport(
+        tools=[
+            ExternalToolDefinition(
+                name="search",
+                description="Search papers",
+                input_schema={"type": "object", "properties": {"query": {"type": "string"}}},
+                metadata={"capability": "research.search", "annotations": {"readOnlyHint": True}},
+            )
+        ]
+    )
+    manager = GatewayExternalRuntimeManager(
+        external_registry_store=store,
+        transport_factory=lambda _server: transport,
+    )
+    await manager.start_server("research")
+
+    runtime = ExternalRuntimeGatewayRuntime(
+        base_runtime=BaseGatewayRuntime(),
+        external_runtime_manager=manager,
+    )
+    tools = await runtime.list_tools(GatewayRequestContext(request_id="list"))
+
+    assert [tool["name"] for tool in tools] == ["local.echo", "ext.research.search"]
+    external = tools[1]
+    assert external["inputSchema"]["properties"]["query"]["type"] == "string"
+    assert external["metadata"]["external_server_id"] == "research"
+    assert external["metadata"]["upstream_tool_name"] == "search"
+    assert external["metadata"]["source"] == "external_runtime"
+```
+
+- [x] **Step 3: Add an execution dispatch test**
+
+Assert local names delegate to the base runtime and external names call `execute_virtual_tool()` with a copy of arguments and the context actor id:
+
+```python
+result = await runtime.call_tool(
+    "ext.research.search",
+    {"query": "mcp"},
+    GatewayRequestContext(
+        request_id="call",
+        user_id="user-1",
+        metadata={EFFECTIVE_POLICY_METADATA_KEY: {"external_server_grants": [{"server_id": "research"}]}},
+    ),
+)
+
+assert result == {
+    "content": {"matches": ["paper-1"]},
+    "isError": False,
+    "metadata": {
+        "server_id": "research",
+        "upstream_tool_name": "search",
+        "virtual_tool_name": "ext.research.search",
+    },
+}
+assert transport.calls[0][0] == "search"
+```
+
+- [x] **Step 4: Add a missing external tool fallback test**
+
+Assert `ExternalRuntimeGatewayRuntime` delegates unknown/non-external names to the base runtime when one is configured, and raises `ValueError` for unknown names when no base runtime is available.
+
+- [x] **Step 5: Verify red**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_gateway_external_runtime_adapter.py -q
+```
+
+Expected: fail because `mcp_unified.gateway.external_runtime_adapter` does not exist.
+
+Evidence: RED failed during collection with `ModuleNotFoundError: No module named 'mcp_unified.gateway.external_runtime_adapter'`.
+
+## Task 2: Adapter Implementation
+
+**Files:**
+- Create: `mcp_unified/gateway/external_runtime_adapter.py`
+- Modify: `mcp_unified/gateway/__init__.py`
+
+- [x] **Step 1: Add the adapter skeleton**
+
+Implement:
+
+```python
+class ExternalRuntimeGatewayRuntime:
+    name = "mcp-unified-gateway"
+    version = "0.1.0"
+
+    def __init__(
+        self,
+        *,
+        external_runtime_manager: GatewayExternalRuntimeManager,
+        base_runtime: GatewayRuntime | None = None,
+        name: str | None = None,
+        version: str | None = None,
+    ) -> None: ...
+```
+
+Resolve `name` and `version` from explicit values, then `base_runtime`, then stable defaults.
+
+- [x] **Step 2: Convert virtual tools to gateway descriptors**
+
+Map `VirtualExternalTool` to:
+
+```python
+{
+    "name": virtual_tool.virtual_name,
+    "description": virtual_tool.description,
+    "inputSchema": copy.deepcopy(virtual_tool.input_schema),
+    "metadata": {
+        **copy.deepcopy(virtual_tool.metadata),
+        "source": "external_runtime",
+        "external_server_id": virtual_tool.server_id,
+        "upstream_tool_name": virtual_tool.upstream_tool_name,
+        "is_write": virtual_tool.is_write,
+    },
+}
+```
+
+Do not mutate the `VirtualExternalTool` returned by the manager.
+
+- [x] **Step 3: Implement local/external tool dispatch**
+
+`call_tool()` should:
+
+- route names currently returned by `list_virtual_tools()` to `execute_virtual_tool()`
+- pass `effective_policy` from `context.metadata[EFFECTIVE_POLICY_METADATA_KEY]`
+- pass `actor_id=context.user_id`
+- pass the original context to the external manager
+- delegate all other names to `base_runtime.call_tool()` when configured
+- raise `ValueError("Unknown gateway tool: <name>")` when no route exists
+
+- [x] **Step 4: Convert federated results**
+
+Convert `FederatedToolResult` into MCP tool-call JSON:
+
+```python
+{
+    "content": copy.deepcopy(result.content),
+    "isError": result.is_error,
+    "metadata": {
+        **copy.deepcopy(result.metadata),
+        "server_id": result.server_id,
+        "upstream_tool_name": result.upstream_tool_name,
+        "virtual_tool_name": result.virtual_tool_name,
+    },
+}
+```
+
+- [x] **Step 5: Delegate non-tool methods**
+
+For resources, prompts, modules, and module health, delegate to `base_runtime` when available. Return empty lists or empty health details when no base runtime exists.
+
+- [x] **Step 6: Export lazily**
+
+Update `mcp_unified/gateway/__init__.py` so `ExternalRuntimeGatewayRuntime` can be imported without eager FastAPI imports.
+
+- [x] **Step 7: Run green adapter tests**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_gateway_external_runtime_adapter.py -q
+```
+
+Expected: adapter tests pass.
+
+Evidence: adapter tests passed with `5 passed, 4 warnings`.
+
+## Task 3: Profile Policy Context Integration
+
+**Files:**
+- Modify: `mcp_unified/gateway/profile_runtime.py`
+- Modify: `tldw_Server_API/app/core/MCP_unified/tests/test_gateway_external_runtime_adapter.py`
+
+- [x] **Step 1: Add a red profile integration test**
+
+Build a profile with:
+
+```python
+MCPProfile(
+    id="researcher",
+    name="Researcher",
+    policy_document=ProfilePolicy(allowed_tools=["ext.research.search"]),
+    external_server_grants=[{"server_id": "research"}],
+    credential_grants=[{"server_id": "research", "credential_slots": ["api_key"]}],
+)
+```
+
+Use `ProfileAwareGatewayRuntime(ExternalRuntimeGatewayRuntime(...), profile_store=store, default_profile_id="researcher")` and assert:
+
+- `tools/list` includes `ext.research.search`
+- `tools/call` succeeds for the external tool
+- the external manager receives effective policy grants
+- a required credential slot is satisfied through the profile credential grant
+
+- [x] **Step 2: Add a red profile denial test**
+
+Use the same started external server but a profile without `external_server_grants`. Assert the profile gate may list the tool if allowed by tool name, but `tools/call` fails with `FederationPolicyDenied`/JSON-RPC policy denial reason `external_server_not_granted`.
+
+- [x] **Step 3: Add context enrichment helper**
+
+In `profile_runtime.py`, add:
+
+```python
+EFFECTIVE_POLICY_METADATA_KEY = "_gateway_effective_policy"
+```
+
+After `call_tool()` obtains a resolved `EffectivePolicyResult`, create a new `GatewayRequestContext` with copied metadata plus the JSON-safe effective policy data. Do not mutate the incoming context.
+
+- [x] **Step 4: Run profile integration tests**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_gateway_external_runtime_adapter.py -q
+```
+
+Expected: all adapter and profile-context tests pass.
+
+Evidence: covered by the adapter test file pass with `5 passed, 4 warnings`.
+
+## Task 4: JSON-RPC And Boundary Coverage
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/MCP_unified/tests/test_gateway_external_runtime_adapter.py`
+- Modify: `tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py`
+- Modify: `tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py`
+
+- [x] **Step 1: Add a JSON-RPC smoke test**
+
+Use `handle_jsonrpc()` or `create_gateway_app()` with `ProfileAwareGatewayRuntime(ExternalRuntimeGatewayRuntime(...))` and assert `tools/list` and `tools/call` return the external tool through the existing JSON-RPC path.
+
+- [x] **Step 2: Add export/import-boundary tests**
+
+Assert:
+
+- importing `mcp_unified.gateway.ExternalRuntimeGatewayRuntime` works
+- importing `mcp_unified.gateway.external_runtime_adapter` does not import `tldw_Server_API`
+- importing the adapter does not require FastAPI
+
+- [x] **Step 3: Run focused package tests**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest \
+  tldw_Server_API/app/core/MCP_unified/tests/test_gateway_external_runtime_adapter.py \
+  tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py \
+  tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py \
+  -q
+```
+
+Expected: focused package tests pass.
+
+Evidence: adapter plus runtime package-boundary tests passed with `18 passed, 4 warnings`.
+
+## Task 5: Verification And Handoff
+
+**Files:**
+- Modify: `Docs/superpowers/plans/2026-06-02-mcp-gateway-external-runtime-adapter-plan.md`
+- Modify: `backlog/tasks/task-589 - Expose-MCP-external-runtime-tools-through-gateway-runtime.md`
+
+- [x] **Step 1: Run compatibility tests**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest \
+  tldw_Server_API/app/core/MCP_unified/tests/test_gateway_external_runtime_adapter.py \
+  tldw_Server_API/app/core/MCP_unified/tests/test_gateway_external_runtime.py \
+  tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py \
+  tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py \
+  tldw_Server_API/app/core/MCP_unified/tests/test_federation_shell_contracts.py \
+  -q
+```
+
+Expected: focused adapter, manager, gateway, boundary, and federation tests pass.
+
+Evidence: focused MCP compatibility suite passed with `201 passed, 5 warnings`.
+
+- [x] **Step 2: Run lint/security/whitespace checks**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m ruff check \
+  mcp_unified/gateway \
+  tldw_Server_API/app/core/MCP_unified/tests/test_gateway_external_runtime_adapter.py
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r \
+  mcp_unified/gateway/external_runtime_adapter.py \
+  mcp_unified/gateway/profile_runtime.py \
+  -f json -o /tmp/bandit_mcp_gateway_external_runtime_adapter.json
+git diff --check
+```
+
+Expected: Ruff passes, Bandit reports no findings for touched package files, and diff check passes.
+
+Evidence: Ruff reported `All checks passed!`; Bandit JSON at `/tmp/bandit_mcp_gateway_external_runtime_adapter.json` had `0` results; `git diff --check` exited cleanly.
+
+- [x] **Step 3: Update plan and Backlog task**
+
+Record test evidence, Bandit output path, known deferrals, and final summary in this plan and `TASK-589`.
+
+- [ ] **Step 4: Commit and open PR**
+
+Stage only this worktree's task, plan, source, and test changes. Commit with:
+
+```bash
+git commit -m "feat: expose external runtime tools through gateway"
+```
+
+Push `codex/mcp-gateway-external-runtime-adapter` and open a PR against `dev`.
+
+## Final Verification Before PR
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest \
+  tldw_Server_API/app/core/MCP_unified/tests/test_gateway_external_runtime_adapter.py \
+  tldw_Server_API/app/core/MCP_unified/tests/test_gateway_external_runtime.py \
+  tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py \
+  tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py \
+  tldw_Server_API/app/core/MCP_unified/tests/test_federation_shell_contracts.py \
+  -q
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m ruff check \
+  mcp_unified/gateway \
+  tldw_Server_API/app/core/MCP_unified/tests/test_gateway_external_runtime_adapter.py
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r \
+  mcp_unified/gateway/external_runtime_adapter.py \
+  mcp_unified/gateway/profile_runtime.py \
+  -f json -o /tmp/bandit_mcp_gateway_external_runtime_adapter.json
+git diff --check
+git status --short --branch
+```
+
+Expected:
+
+- focused pytest suite passes
+- Ruff passes
+- Bandit JSON reports no findings for touched package code
+- `git diff --check` passes
+- branch is clean after commit
+
+## Deliberate Deferrals
+
+- The client-facing stdio serve loop remains deferred until there is a concrete gateway runtime factory to launch from configuration.
+- Durable lifecycle CLI control remains deferred until there is a daemon-control client.
+- Package installer execution remains disabled by default and out of this adapter scope.

--- a/backlog/tasks/task-589 - Expose-MCP-external-runtime-tools-through-gateway-runtime.md
+++ b/backlog/tasks/task-589 - Expose-MCP-external-runtime-tools-through-gateway-runtime.md
@@ -15,6 +15,7 @@ modified_files:
 - mcp_unified/gateway/external_runtime.py
 - mcp_unified/gateway/__init__.py
 - tldw_Server_API/app/core/MCP_unified/tests/test_gateway_external_runtime_adapter.py
+- tldw_Server_API/app/core/MCP_unified/tests/test_gateway_external_runtime.py
 - tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py
 - Docs/superpowers/plans/2026-06-02-mcp-gateway-external-runtime-adapter-plan.md
 ---
@@ -44,7 +45,7 @@ Docs/superpowers/plans/2026-06-02-mcp-gateway-external-runtime-adapter-plan.md
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Added a package-owned ExternalRuntimeGatewayRuntime adapter that exposes active GatewayExternalRuntimeManager virtual tools through GatewayRuntime tools/list and tools/call. ProfileAwareGatewayRuntime now copies resolved effective policy data into delegated request context metadata so external server grants and credential grants reach the external runtime manager without mutating the original context. Also fixed adjacent installer timeout/error wrapping regressions covered by existing tests. Verification: focused MCP pytest suite passed with 201 passed and 5 warnings; Ruff reported All checks passed; Bandit JSON at /tmp/bandit_mcp_gateway_external_runtime_adapter.json reported 0 results; git diff --check passed.
+PR #2219 review follow-up complete. Rebased on current origin/dev (already up to date). Addressed Gemini defensive-null findings by defaulting nullable external input schemas to {}, reading request metadata through safe fallbacks in the adapter/profile runtime, and covering metadata=None regressions. Addressed Qodo findings by adding a direct GatewayExternalRuntimeManager.has_virtual_tool() ownership check for call routing, removing the adapter's call-time list/sort/deep-copy scan, restoring timeout traceback logging, and adding sanitized traceback-frame diagnostics plus sanitized exception causes for installer operation failures without exposing do-not-leak secret text in public payloads/log arguments. Verification: targeted RED tests failed before fixes; targeted follow-up tests now pass; focused MCP suite reports 206 passed, 5 warnings; Ruff reports All checks passed; Bandit on touched gateway code reports 0 findings; git diff --check is clean.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-589 - Expose-MCP-external-runtime-tools-through-gateway-runtime.md
+++ b/backlog/tasks/task-589 - Expose-MCP-external-runtime-tools-through-gateway-runtime.md
@@ -1,0 +1,58 @@
+---
+id: TASK-589
+title: Expose MCP external runtime tools through gateway runtime
+status: Done
+labels:
+- mcp-unified
+- gateway
+- external-runtime
+priority: medium
+documentation:
+- Docs/superpowers/plans/2026-06-02-mcp-gateway-external-runtime-adapter-plan.md
+modified_files:
+- mcp_unified/gateway/external_runtime_adapter.py
+- mcp_unified/gateway/profile_runtime.py
+- mcp_unified/gateway/external_runtime.py
+- mcp_unified/gateway/__init__.py
+- tldw_Server_API/app/core/MCP_unified/tests/test_gateway_external_runtime_adapter.py
+- tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py
+- Docs/superpowers/plans/2026-06-02-mcp-gateway-external-runtime-adapter-plan.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Adapt GatewayExternalRuntimeManager into the standalone gateway GatewayRuntime surface so active external virtual tools can be listed and executed through tools/list and tools/call with profile policy, credential brokering, and audit behavior preserved. Keep transport serving and package installer execution out of scope.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Docs/superpowers/plans/2026-06-02-mcp-gateway-external-runtime-adapter-plan.md
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Added a package-owned ExternalRuntimeGatewayRuntime adapter that exposes active GatewayExternalRuntimeManager virtual tools through GatewayRuntime tools/list and tools/call. ProfileAwareGatewayRuntime now copies resolved effective policy data into delegated request context metadata so external server grants and credential grants reach the external runtime manager without mutating the original context. Also fixed adjacent installer timeout/error wrapping regressions covered by existing tests. Verification: focused MCP pytest suite passed with 201 passed and 5 warnings; Ruff reported All checks passed; Bandit JSON at /tmp/bandit_mcp_gateway_external_runtime_adapter.json reported 0 results; git diff --check passed.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-589 - Expose-MCP-external-runtime-tools-through-gateway-runtime.md
+++ b/backlog/tasks/task-589 - Expose-MCP-external-runtime-tools-through-gateway-runtime.md
@@ -28,6 +28,12 @@ Adapt GatewayExternalRuntimeManager into the standalone gateway GatewayRuntime s
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
+- [x] #1 External virtual tools are exposed through GatewayRuntime tools/list descriptors with external metadata and safe nullable schema defaults.
+- [x] #2 GatewayRuntime tools/call dispatches active external virtual tool names through GatewayExternalRuntimeManager while preserving local base-runtime delegation.
+- [x] #3 ProfileAwareGatewayRuntime forwards resolved effective policy metadata without mutating the original GatewayRequestContext, including metadata=None callers.
+- [x] #4 External runtime call routing uses a direct virtual-tool membership check instead of list/sort/deep-copy catalog scans.
+- [x] #5 Installer timeout and operation failures retain sanitized diagnostic context without exposing secret-looking values in public payloads or test log arguments.
+- [x] #6 Focused MCP tests, Ruff, Bandit, and diff hygiene checks are recorded and passing.
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -50,10 +56,10 @@ PR #2219 review follow-up complete. Rebased on current origin/dev (already up to
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->

--- a/mcp_unified/gateway/__init__.py
+++ b/mcp_unified/gateway/__init__.py
@@ -31,6 +31,7 @@ if TYPE_CHECKING:
         GatewayExternalRuntimeError,
         GatewayExternalRuntimeManager,
     )
+    from .external_runtime_adapter import ExternalRuntimeGatewayRuntime
     from .fastapi import create_gateway_app, create_gateway_router
 
 __all__ = [
@@ -40,6 +41,7 @@ __all__ = [
     "GatewayExternalRuntimeLifecycleConfig",
     "GatewayExternalRuntimeError",
     "GatewayExternalRuntimeManager",
+    "ExternalRuntimeGatewayRuntime",
     "GatewayProfileBootstrap",
     "GatewayProfileBootstrapConfig",
     "GatewayProfileManagementError",
@@ -81,4 +83,8 @@ def __getattr__(name: str) -> Any:
             "GatewayExternalRuntimeError": GatewayExternalRuntimeError,
             "GatewayExternalRuntimeManager": GatewayExternalRuntimeManager,
         }[name]
+    if name == "ExternalRuntimeGatewayRuntime":
+        from .external_runtime_adapter import ExternalRuntimeGatewayRuntime
+
+        return ExternalRuntimeGatewayRuntime
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/mcp_unified/gateway/external_runtime.py
+++ b/mcp_unified/gateway/external_runtime.py
@@ -793,7 +793,7 @@ class GatewayExternalRuntimeManager:
                 timeout=self._installer_status_timeout_seconds,
             )
         except asyncio.TimeoutError:
-            logger.opt(exception=True).error(
+            logger.error(
                 "External installer status timed out server_id={!r}",
                 server.id,
             )
@@ -846,7 +846,7 @@ class GatewayExternalRuntimeManager:
                 f"External server {operation} failed",
                 reason_code=failure_reason_code,
                 server_id=server.id,
-            ) from exc
+            ) from None
         return self._installer_payload(
             payload,
             server=server,

--- a/mcp_unified/gateway/external_runtime.py
+++ b/mcp_unified/gateway/external_runtime.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import inspect
+import traceback
 from collections.abc import Callable, Iterable
 from copy import deepcopy
 from datetime import datetime, timezone
@@ -441,6 +442,12 @@ class GatewayExternalRuntimeManager:
                 for name in sorted(self._virtual_tools)
             ]
 
+    async def has_virtual_tool(self, virtual_tool_name: str) -> bool:
+        """Return whether an active virtual tool exists without copying the catalog."""
+
+        async with self._lock:
+            return virtual_tool_name in self._virtual_tools
+
     async def install_server(
         self,
         server_id: str,
@@ -793,7 +800,7 @@ class GatewayExternalRuntimeManager:
                 timeout=self._installer_status_timeout_seconds,
             )
         except asyncio.TimeoutError:
-            logger.error(
+            logger.opt(exception=True).error(
                 "External installer status timed out server_id={!r}",
                 server.id,
             )
@@ -804,10 +811,12 @@ class GatewayExternalRuntimeManager:
                 "error_type": "TimeoutError",
             }
         except Exception as exc:  # noqa: BLE001 - installer adapters are optional.
+            traceback_frames = self._traceback_frames(exc)
             logger.error(
-                "External installer status failed server_id={!r} error_type={!r}",
+                "External installer status failed server_id={!r} error_type={!r} traceback_frames={!r}",
                 server.id,
                 type(exc).__name__,
+                traceback_frames,
             )
             return {
                 "available": False,
@@ -836,17 +845,19 @@ class GatewayExternalRuntimeManager:
         try:
             payload = await callback()
         except Exception as exc:  # noqa: BLE001 - installer adapters define failures.
+            traceback_frames = self._traceback_frames(exc)
             logger.error(
-                "External installer operation failed operation={!r} server_id={!r} error_type={!r}",
+                "External installer operation failed operation={!r} server_id={!r} error_type={!r} traceback_frames={!r}",
                 operation,
                 server.id,
                 type(exc).__name__,
+                traceback_frames,
             )
             raise GatewayExternalRuntimeError(
                 f"External server {operation} failed",
                 reason_code=failure_reason_code,
                 server_id=server.id,
-            ) from None
+            ) from self._sanitized_exception_cause(exc)
         return self._installer_payload(
             payload,
             server=server,
@@ -1350,6 +1361,25 @@ class GatewayExternalRuntimeManager:
         message = str(exc).strip()
         error_type = type(exc).__name__
         return f"{error_type}: {message}" if message else error_type
+
+    @staticmethod
+    def _traceback_frames(exc: BaseException) -> list[dict[str, Any]]:
+        """Return traceback frame locations without exception messages or source text."""
+
+        return [
+            {
+                "function": frame.name,
+                "line": frame.lineno,
+                "path": frame.filename,
+            }
+            for frame in traceback.extract_tb(exc.__traceback__)
+        ]
+
+    @staticmethod
+    def _sanitized_exception_cause(exc: BaseException) -> RuntimeError:
+        """Return a chainable cause that preserves error type without secret text."""
+
+        return RuntimeError(type(exc).__name__)
 
     @staticmethod
     def _virtual_tool_name(server_id: str, tool_name: str) -> str:

--- a/mcp_unified/gateway/external_runtime_adapter.py
+++ b/mcp_unified/gateway/external_runtime_adapter.py
@@ -63,7 +63,7 @@ class ExternalRuntimeGatewayRuntime:
     ) -> dict[str, Any]:
         """Execute an external virtual tool or delegate to the base runtime."""
 
-        if await self._has_external_tool(name):
+        if await self._external_runtime_manager.has_virtual_tool(name):
             try:
                 result = await self._external_runtime_manager.execute_virtual_tool(
                     name,
@@ -136,15 +136,6 @@ class ExternalRuntimeGatewayRuntime:
             return {"modules": []}
         return await self._base_runtime.get_modules_health(context)
 
-    async def _has_external_tool(self, name: str) -> bool:
-        """Return whether the active external runtime owns this tool name."""
-
-        return any(
-            virtual_tool.virtual_name == name
-            for virtual_tool in await self._external_runtime_manager.list_virtual_tools()
-        )
-
-
 def _virtual_tool_descriptor(virtual_tool: VirtualExternalTool) -> dict[str, Any]:
     """Convert one virtual external tool into a gateway tool descriptor."""
 
@@ -160,7 +151,7 @@ def _virtual_tool_descriptor(virtual_tool: VirtualExternalTool) -> dict[str, Any
     return {
         "name": virtual_tool.virtual_name,
         "description": virtual_tool.description,
-        "inputSchema": deepcopy(virtual_tool.input_schema),
+        "inputSchema": deepcopy(virtual_tool.input_schema or {}),
         "metadata": metadata,
     }
 
@@ -168,7 +159,7 @@ def _virtual_tool_descriptor(virtual_tool: VirtualExternalTool) -> dict[str, Any
 def _effective_policy_from_context(context: GatewayRequestContext) -> Any:
     """Return the profile-derived effective policy stored in request metadata."""
 
-    value = context.metadata.get(EFFECTIVE_POLICY_METADATA_KEY)
+    value = (context.metadata or {}).get(EFFECTIVE_POLICY_METADATA_KEY)
     if hasattr(value, "model_dump"):
         return value.model_dump(mode="json")
     if isinstance(value, Mapping):

--- a/mcp_unified/gateway/external_runtime_adapter.py
+++ b/mcp_unified/gateway/external_runtime_adapter.py
@@ -1,0 +1,199 @@
+"""Gateway runtime adapter for active external MCP runtime tools."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from copy import deepcopy
+from typing import Any
+
+from mcp_unified.federation.models import (
+    FederatedToolResult,
+    FederationPolicyDenied,
+    VirtualExternalTool,
+)
+
+from .external_runtime import GatewayExternalRuntimeManager
+from .profile_runtime import EFFECTIVE_POLICY_METADATA_KEY
+from .runtime import GatewayPolicyDenied, GatewayRequestContext, GatewayRuntime
+
+
+class ExternalRuntimeGatewayRuntime:
+    """Expose active external runtime virtual tools through `GatewayRuntime`."""
+
+    def __init__(
+        self,
+        *,
+        external_runtime_manager: GatewayExternalRuntimeManager,
+        base_runtime: GatewayRuntime | None = None,
+        name: str | None = None,
+        version: str | None = None,
+    ) -> None:
+        """Store runtime dependencies and resolve public identity metadata."""
+
+        self._external_runtime_manager = external_runtime_manager
+        self._base_runtime = base_runtime
+        self.name = (
+            name
+            or str(getattr(base_runtime, "name", "") or "")
+            or "mcp-unified-gateway"
+        )
+        self.version = (
+            version
+            or str(getattr(base_runtime, "version", "") or "")
+            or "0.1.0"
+        )
+
+    async def list_tools(self, context: GatewayRequestContext) -> list[dict[str, Any]]:
+        """Return local tools followed by active external virtual tools."""
+
+        tools: list[dict[str, Any]] = []
+        if self._base_runtime is not None:
+            tools.extend(await self._base_runtime.list_tools(context))
+        tools.extend(
+            _virtual_tool_descriptor(virtual_tool)
+            for virtual_tool in await self._external_runtime_manager.list_virtual_tools()
+        )
+        return tools
+
+    async def call_tool(
+        self,
+        name: str,
+        arguments: dict[str, Any],
+        context: GatewayRequestContext,
+    ) -> dict[str, Any]:
+        """Execute an external virtual tool or delegate to the base runtime."""
+
+        if await self._has_external_tool(name):
+            try:
+                result = await self._external_runtime_manager.execute_virtual_tool(
+                    name,
+                    deepcopy(arguments or {}),
+                    effective_policy=_effective_policy_from_context(context),
+                    actor_id=context.user_id,
+                    context=context,
+                )
+            except FederationPolicyDenied as exc:
+                raise GatewayPolicyDenied(
+                    str(exc),
+                    reason_code=exc.reason_code,
+                    provenance=deepcopy(exc.payload),
+                ) from exc
+            return _federated_result_payload(result)
+
+        if self._base_runtime is not None:
+            return await self._base_runtime.call_tool(name, arguments, context)
+
+        raise ValueError(f"Unknown gateway tool: {name}")
+
+    async def list_resources(self, context: GatewayRequestContext) -> list[dict[str, Any]]:
+        """Delegate resource listing to the base runtime when available."""
+
+        if self._base_runtime is None:
+            return []
+        return await self._base_runtime.list_resources(context)
+
+    async def read_resource(
+        self,
+        uri: str,
+        context: GatewayRequestContext,
+    ) -> dict[str, Any]:
+        """Delegate resource reads to the base runtime when available."""
+
+        if self._base_runtime is None:
+            raise ValueError(f"Unknown gateway resource: {uri}")
+        return await self._base_runtime.read_resource(uri, context)
+
+    async def list_prompts(self, context: GatewayRequestContext) -> list[dict[str, Any]]:
+        """Delegate prompt listing to the base runtime when available."""
+
+        if self._base_runtime is None:
+            return []
+        return await self._base_runtime.list_prompts(context)
+
+    async def get_prompt(
+        self,
+        name: str,
+        arguments: dict[str, Any],
+        context: GatewayRequestContext,
+    ) -> dict[str, Any]:
+        """Delegate prompt reads to the base runtime when available."""
+
+        if self._base_runtime is None:
+            raise ValueError(f"Unknown gateway prompt: {name}")
+        return await self._base_runtime.get_prompt(name, arguments, context)
+
+    async def list_modules(self, context: GatewayRequestContext) -> list[dict[str, Any]]:
+        """Delegate module listing to the base runtime when available."""
+
+        if self._base_runtime is None:
+            return []
+        return await self._base_runtime.list_modules(context)
+
+    async def get_modules_health(self, context: GatewayRequestContext) -> dict[str, Any]:
+        """Delegate module health to the base runtime when available."""
+
+        if self._base_runtime is None:
+            return {"modules": []}
+        return await self._base_runtime.get_modules_health(context)
+
+    async def _has_external_tool(self, name: str) -> bool:
+        """Return whether the active external runtime owns this tool name."""
+
+        return any(
+            virtual_tool.virtual_name == name
+            for virtual_tool in await self._external_runtime_manager.list_virtual_tools()
+        )
+
+
+def _virtual_tool_descriptor(virtual_tool: VirtualExternalTool) -> dict[str, Any]:
+    """Convert one virtual external tool into a gateway tool descriptor."""
+
+    metadata = deepcopy(virtual_tool.metadata or {})
+    metadata.update(
+        {
+            "external_server_id": virtual_tool.server_id,
+            "is_write": virtual_tool.is_write,
+            "source": "external_runtime",
+            "upstream_tool_name": virtual_tool.upstream_tool_name,
+        }
+    )
+    return {
+        "name": virtual_tool.virtual_name,
+        "description": virtual_tool.description,
+        "inputSchema": deepcopy(virtual_tool.input_schema),
+        "metadata": metadata,
+    }
+
+
+def _effective_policy_from_context(context: GatewayRequestContext) -> Any:
+    """Return the profile-derived effective policy stored in request metadata."""
+
+    value = context.metadata.get(EFFECTIVE_POLICY_METADATA_KEY)
+    if hasattr(value, "model_dump"):
+        return value.model_dump(mode="json")
+    if isinstance(value, Mapping):
+        return deepcopy(dict(value))
+    return deepcopy(value)
+
+
+def _federated_result_payload(result: FederatedToolResult) -> dict[str, Any]:
+    """Convert a federated external result into gateway tool-call JSON."""
+
+    metadata = deepcopy(result.metadata or {})
+    metadata.update(
+        {
+            "server_id": result.server_id,
+            "upstream_tool_name": result.upstream_tool_name,
+            "virtual_tool_name": result.virtual_tool_name,
+        }
+    )
+    return {
+        "content": deepcopy(result.content),
+        "isError": result.is_error,
+        "metadata": metadata,
+    }
+
+
+__all__ = [
+    "ExternalRuntimeGatewayRuntime",
+]

--- a/mcp_unified/gateway/profile_runtime.py
+++ b/mcp_unified/gateway/profile_runtime.py
@@ -16,6 +16,8 @@ from mcp_unified.profiles.resolver import StoreBackedProfileResolver
 
 from .runtime import GatewayPolicyDenied, GatewayRequestContext, GatewayRuntime
 
+EFFECTIVE_POLICY_METADATA_KEY = "_gateway_effective_policy"
+
 
 class GatewayProfileResolver(Protocol):
     """Structured profile resolver needed by the profile-aware gateway runtime."""
@@ -113,7 +115,11 @@ class ProfileAwareGatewayRuntime:
                 policy_result,
                 message=f"Gateway profile denied tool execution: {policy_result.reason_code}",
             )
-        return await self._backend.call_tool(name, arguments, context)
+        return await self._backend.call_tool(
+            name,
+            arguments,
+            _context_with_effective_policy(context, policy_result.policy),
+        )
 
     async def list_resources(self, context: GatewayRequestContext) -> list[dict[str, Any]]:
         """Delegate resource discovery unchanged for this profile slice."""
@@ -202,6 +208,34 @@ def _context_profile_id(context: GatewayRequestContext) -> str | None:
         if isinstance(value, str) and value.strip():
             return value.strip()
     return None
+
+
+def _context_with_effective_policy(
+    context: GatewayRequestContext,
+    policy: Any,
+) -> GatewayRequestContext:
+    """Return a copy of the context carrying resolved effective policy data."""
+
+    if policy is None:
+        return context
+    metadata = dict(context.metadata)
+    metadata[EFFECTIVE_POLICY_METADATA_KEY] = _json_safe_model(policy)
+    return GatewayRequestContext(
+        request_id=context.request_id,
+        client_id=context.client_id,
+        user_id=context.user_id,
+        metadata=metadata,
+    )
+
+
+def _json_safe_model(value: Any) -> Any:
+    """Dump pydantic models to JSON-safe mappings with v1/v2 compatibility."""
+
+    if hasattr(value, "model_dump"):
+        return value.model_dump(mode="json")
+    if hasattr(value, "dict"):
+        return value.dict()
+    return value
 
 
 def _tool_name(tool: Any) -> str | None:

--- a/mcp_unified/gateway/profile_runtime.py
+++ b/mcp_unified/gateway/profile_runtime.py
@@ -203,8 +203,9 @@ class ProfileAwareGatewayRuntime:
 def _context_profile_id(context: GatewayRequestContext) -> str | None:
     """Return an explicit profile id from transport metadata, if present."""
 
+    metadata = context.metadata or {}
     for key in ("profile_id", "profileId", "mcp_profile", "mcp-profile"):
-        value = context.metadata.get(key)
+        value = metadata.get(key)
         if isinstance(value, str) and value.strip():
             return value.strip()
     return None
@@ -218,7 +219,7 @@ def _context_with_effective_policy(
 
     if policy is None:
         return context
-    metadata = dict(context.metadata)
+    metadata = dict(context.metadata or {})
     metadata[EFFECTIVE_POLICY_METADATA_KEY] = _json_safe_model(policy)
     return GatewayRequestContext(
         request_id=context.request_id,

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_external_runtime.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_external_runtime.py
@@ -1010,6 +1010,23 @@ async def test_external_runtime_unknown_virtual_tool_reports_not_found() -> None
 
 
 @pytest.mark.asyncio
+async def test_external_runtime_has_virtual_tool_uses_active_catalog() -> None:
+    store = InMemoryExternalRegistryStore([_server()])
+    transport = RecordingExternalTransport(
+        server_id="research",
+        tools=[ExternalToolDefinition(name="search")],
+    )
+    manager = GatewayExternalRuntimeManager(
+        external_registry_store=store,
+        transport_factory=lambda _server: transport,
+    )
+    await manager.start_server("research")
+
+    assert await manager.has_virtual_tool("ext.research.search") is True
+    assert await manager.has_virtual_tool("ext.research.missing") is False
+
+
+@pytest.mark.asyncio
 async def test_external_runtime_execution_wraps_transport_call_errors() -> None:
     audit = RecordingAuditStore()
     store = InMemoryExternalRegistryStore([_server()])
@@ -1245,12 +1262,13 @@ async def test_external_runtime_installer_status_failure_is_row_scoped(
     }
     assert "do-not-leak" not in json.dumps(rows, sort_keys=True)
     assert fake_logger.opt_calls == []
-    assert fake_logger.error_calls == [
-        (
-            "External installer status failed server_id={!r} error_type={!r}",
-            ("research", "RuntimeError"),
-        )
-    ]
+    assert len(fake_logger.error_calls) == 1
+    message, args = fake_logger.error_calls[0]
+    assert message == "External installer status failed server_id={!r} error_type={!r} traceback_frames={!r}"
+    assert args[:2] == ("research", "RuntimeError")
+    frame_functions = [frame["function"] for frame in args[2]]
+    assert frame_functions[0] == "_installer_status"
+    assert frame_functions[-1] == "get_status"
     assert "do-not-leak" not in json.dumps(fake_logger.error_calls, sort_keys=True)
 
 
@@ -1276,7 +1294,7 @@ async def test_external_runtime_installer_status_timeout_is_row_scoped(
         "server_id": "research",
         "error_type": "TimeoutError",
     }
-    assert fake_logger.opt_calls == []
+    assert fake_logger.opt_calls == [{"exception": True}]
     assert fake_logger.error_calls == [
         (
             "External installer status timed out server_id={!r}",
@@ -1405,27 +1423,34 @@ async def test_external_runtime_installer_operation_failures_are_wrapped(
     assert install_exc.value.reason_code == "external_server_install_failed"
     assert install_exc.value.server_id == "research"
     assert str(install_exc.value) == "External server install failed"
-    assert install_exc.value.__cause__ is None
-    assert install_exc.value.__suppress_context__ is True
+    assert install_exc.value.__cause__ is not None
+    assert str(install_exc.value.__cause__) == "RuntimeError"
+    assert "do-not-leak" not in str(install_exc.value.__cause__)
     assert update_exc.value.reason_code == "external_server_update_failed"
     assert update_exc.value.server_id == "research"
     assert str(update_exc.value) == "External server update failed"
-    assert update_exc.value.__cause__ is None
-    assert update_exc.value.__suppress_context__ is True
+    assert update_exc.value.__cause__ is not None
+    assert str(update_exc.value.__cause__) == "RuntimeError"
+    assert "do-not-leak" not in str(update_exc.value.__cause__)
     public_payloads = {
         "install": install_exc.value.to_payload(),
         "update": update_exc.value.to_payload(),
     }
     assert "do-not-leak" not in json.dumps(public_payloads, sort_keys=True)
     assert fake_logger.opt_calls == []
-    assert fake_logger.error_calls == [
-        (
-            "External installer operation failed operation={!r} server_id={!r} error_type={!r}",
-            ("install", "research", "RuntimeError"),
-        ),
-        (
-            "External installer operation failed operation={!r} server_id={!r} error_type={!r}",
-            ("update", "research", "RuntimeError"),
-        ),
-    ]
+    assert len(fake_logger.error_calls) == 2
+    for expected_operation, expected_function, error_call in (
+        ("install", "install_server", fake_logger.error_calls[0]),
+        ("update", "update_server", fake_logger.error_calls[1]),
+    ):
+        message, args = error_call
+        assert message == (
+            "External installer operation failed operation={!r} server_id={!r} "
+            "error_type={!r} traceback_frames={!r}"
+        )
+        assert args[:3] == (expected_operation, "research", "RuntimeError")
+        assert [frame["function"] for frame in args[3]] == [
+            "_installer_operation_payload",
+            expected_function,
+        ]
     assert "do-not-leak" not in json.dumps(fake_logger.error_calls, sort_keys=True)

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_external_runtime_adapter.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_external_runtime_adapter.py
@@ -7,6 +7,8 @@ from mcp_unified.federation.models import (
     BrokeredExternalCredential,
     ExternalToolCallResult,
     ExternalToolDefinition,
+    FederatedToolResult,
+    VirtualExternalTool,
 )
 from mcp_unified.federation.transports import FakeExternalTransport
 from mcp_unified.gateway.external_runtime import GatewayExternalRuntimeManager
@@ -16,7 +18,7 @@ from mcp_unified.gateway.profile_runtime import (
     EFFECTIVE_POLICY_METADATA_KEY,
     ProfileAwareGatewayRuntime,
 )
-from mcp_unified.gateway.runtime import GatewayRequestContext
+from mcp_unified.gateway.runtime import GatewayPolicyDenied, GatewayRequestContext
 from mcp_unified.profiles.models import MCPProfile, ProfilePolicy
 from mcp_unified.profiles.store import InMemoryProfileStore
 from mcp_unified.storage.models import ExternalServerDefinition
@@ -159,6 +161,58 @@ class RecordingCredentialBroker:
         return self.result.copy()
 
 
+class NullableVirtualToolManager:
+    """Minimal manager fake that returns nullable virtual tool fields."""
+
+    async def list_virtual_tools(self) -> list[VirtualExternalTool]:
+        """Return one virtual tool with nullable schema and metadata values."""
+
+        return [
+            VirtualExternalTool(
+                virtual_name="ext.null.search",
+                server_id="null-server",
+                upstream_tool_name="search",
+                input_schema=None,  # type: ignore[arg-type]
+                metadata=None,  # type: ignore[arg-type]
+            )
+        ]
+
+
+class DirectRoutingVirtualToolManager:
+    """Manager fake that fails if tool calls route through full discovery."""
+
+    def __init__(self) -> None:
+        self.has_calls: list[str] = []
+        self.execute_calls: list[tuple[str, dict[str, Any]]] = []
+
+    async def list_virtual_tools(self) -> list[VirtualExternalTool]:
+        """Reject call-time discovery scans."""
+
+        raise AssertionError("call_tool should not list virtual tools for routing")
+
+    async def has_virtual_tool(self, name: str) -> bool:
+        """Return whether the fake external catalog owns the requested name."""
+
+        self.has_calls.append(name)
+        return name == "ext.fast.search"
+
+    async def execute_virtual_tool(
+        self,
+        virtual_tool_name: str,
+        arguments: dict[str, Any],
+        **_kwargs: Any,
+    ) -> FederatedToolResult:
+        """Record direct execution and return a gateway-compatible result."""
+
+        self.execute_calls.append((virtual_tool_name, dict(arguments)))
+        return FederatedToolResult(
+            content={"matches": ["paper-1"]},
+            server_id="fast",
+            upstream_tool_name="search",
+            virtual_tool_name=virtual_tool_name,
+        )
+
+
 def _server(
     server_id: str = "research",
     *,
@@ -245,6 +299,20 @@ async def test_external_runtime_gateway_lists_base_and_external_tools() -> None:
     assert external["metadata"]["is_write"] is False
 
 
+async def test_external_runtime_gateway_defaults_nullable_input_schema() -> None:
+    """Nullable upstream schemas should still expose a JSON object descriptor."""
+
+    runtime = ExternalRuntimeGatewayRuntime(
+        external_runtime_manager=NullableVirtualToolManager(),  # type: ignore[arg-type]
+    )
+
+    tools = await runtime.list_tools(GatewayRequestContext(request_id="list-nullable"))
+
+    assert tools[0]["name"] == "ext.null.search"
+    assert tools[0]["inputSchema"] == {}
+    assert tools[0]["metadata"]["external_server_id"] == "null-server"
+
+
 async def test_external_runtime_gateway_dispatches_external_and_local_tools() -> None:
     """External names call the manager while local names still use the base runtime."""
 
@@ -277,6 +345,42 @@ async def test_external_runtime_gateway_dispatches_external_and_local_tools() ->
     assert transport.calls == [("search", {"query": "mcp"})]
     assert local["content"][0]["text"] == "hello"
     assert base_runtime.calls[0][0] == "local.echo"
+
+
+async def test_external_runtime_gateway_routes_calls_without_full_tool_listing() -> None:
+    """Call routing should use a direct manager membership check."""
+
+    manager = DirectRoutingVirtualToolManager()
+    base_runtime = BaseGatewayRuntime()
+    runtime = ExternalRuntimeGatewayRuntime(
+        external_runtime_manager=manager,  # type: ignore[arg-type]
+        base_runtime=base_runtime,
+    )
+    context = GatewayRequestContext(request_id="direct-route")
+
+    external = await runtime.call_tool("ext.fast.search", {"query": "mcp"}, context)
+    local = await runtime.call_tool("local.echo", {"query": "hello"}, context)
+
+    assert external["content"] == {"matches": ["paper-1"]}
+    assert local["content"][0]["text"] == "hello"
+    assert manager.has_calls == ["ext.fast.search", "local.echo"]
+    assert manager.execute_calls == [("ext.fast.search", {"query": "mcp"})]
+    assert base_runtime.calls[0][0] == "local.echo"
+
+
+async def test_external_runtime_gateway_handles_missing_context_metadata() -> None:
+    """Missing metadata should not crash effective-policy extraction."""
+
+    runtime, _transport = await _started_runtime()
+    context = GatewayRequestContext(
+        request_id="call-null-metadata",
+        metadata=None,  # type: ignore[arg-type]
+    )
+
+    with pytest.raises(GatewayPolicyDenied) as exc_info:
+        await runtime.call_tool("ext.research.search", {"query": "mcp"}, context)
+
+    assert exc_info.value.reason_code == "external_server_not_granted"
 
 
 async def test_external_runtime_gateway_unknown_tool_without_base_fails() -> None:
@@ -333,6 +437,36 @@ async def test_profile_runtime_passes_external_grants_to_adapter() -> None:
         {"server_id": "research", "credential_slots": ["api_key"]}
     ]
     assert EFFECTIVE_POLICY_METADATA_KEY not in context.metadata
+
+
+async def test_profile_runtime_enriches_context_with_missing_metadata() -> None:
+    """Profile policy metadata enrichment should tolerate a null metadata mapping."""
+
+    base_runtime = BaseGatewayRuntime()
+    profile_store = InMemoryProfileStore()
+    await profile_store.upsert_profile(
+        MCPProfile(
+            id="researcher",
+            name="Researcher",
+            policy_document=ProfilePolicy(allowed_tools=["local.echo"]),
+        )
+    )
+    runtime = ProfileAwareGatewayRuntime(
+        base_runtime,
+        profile_store=profile_store,
+        default_profile_id="researcher",
+    )
+    context = GatewayRequestContext(
+        request_id="profile-null-metadata",
+        metadata=None,  # type: ignore[arg-type]
+    )
+
+    result = await runtime.call_tool("local.echo", {"query": "hello"}, context)
+
+    assert result["content"][0]["text"] == "hello"
+    delegated_context = base_runtime.calls[0][2]
+    assert delegated_context.metadata[EFFECTIVE_POLICY_METADATA_KEY]["profile_id"] == "researcher"
+    assert context.metadata is None
 
 
 async def test_jsonrpc_maps_external_policy_denial_to_policy_error() -> None:

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_external_runtime_adapter.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_external_runtime_adapter.py
@@ -1,0 +1,373 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from mcp_unified.federation.models import (
+    BrokeredExternalCredential,
+    ExternalToolCallResult,
+    ExternalToolDefinition,
+)
+from mcp_unified.federation.transports import FakeExternalTransport
+from mcp_unified.gateway.external_runtime import GatewayExternalRuntimeManager
+from mcp_unified.gateway.external_runtime_adapter import ExternalRuntimeGatewayRuntime
+from mcp_unified.gateway.jsonrpc import handle_jsonrpc
+from mcp_unified.gateway.profile_runtime import (
+    EFFECTIVE_POLICY_METADATA_KEY,
+    ProfileAwareGatewayRuntime,
+)
+from mcp_unified.gateway.runtime import GatewayRequestContext
+from mcp_unified.profiles.models import MCPProfile, ProfilePolicy
+from mcp_unified.profiles.store import InMemoryProfileStore
+from mcp_unified.storage.models import ExternalServerDefinition
+
+
+class InMemoryExternalRegistryStore:
+    """Copy-isolated external registry store for adapter tests."""
+
+    def __init__(self, servers: list[ExternalServerDefinition] | None = None) -> None:
+        self.servers = {
+            server.id: server.model_copy(deep=True)
+            for server in servers or ()
+        }
+
+    async def get_server(self, server_id: str) -> ExternalServerDefinition | None:
+        """Return one server definition by id."""
+
+        server = self.servers.get(server_id)
+        return None if server is None else server.model_copy(deep=True)
+
+    async def list_servers(self) -> list[ExternalServerDefinition]:
+        """Return runtime-compatible server rows."""
+
+        return await self.list_server_definitions()
+
+    async def list_server_definitions(
+        self,
+        *,
+        enabled: bool | None = None,
+    ) -> list[ExternalServerDefinition]:
+        """Return typed server definitions matching the enabled filter."""
+
+        rows = [
+            server
+            for server in self.servers.values()
+            if enabled is None or server.enabled is enabled
+        ]
+        return [
+            server.model_copy(deep=True)
+            for server in sorted(rows, key=lambda item: item.id)
+        ]
+
+
+class BaseGatewayRuntime:
+    """Small local gateway runtime used to prove delegation behavior."""
+
+    name = "base-gateway"
+    version = "1.2.3"
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, dict[str, Any], GatewayRequestContext]] = []
+
+    async def list_tools(self, context: GatewayRequestContext) -> list[dict[str, Any]]:
+        """Return one local tool descriptor."""
+
+        del context
+        return [
+            {
+                "name": "local.echo",
+                "description": "Echo a query.",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {"query": {"type": "string"}},
+                },
+                "metadata": {"source": "base"},
+            }
+        ]
+
+    async def call_tool(
+        self,
+        name: str,
+        arguments: dict[str, Any],
+        context: GatewayRequestContext,
+    ) -> dict[str, Any]:
+        """Record a local tool call and return a simple text response."""
+
+        self.calls.append((name, dict(arguments), context))
+        return {"content": [{"type": "text", "text": arguments["query"]}]}
+
+    async def list_resources(self, context: GatewayRequestContext) -> list[dict[str, Any]]:
+        """Return no local resources."""
+
+        del context
+        return []
+
+    async def read_resource(
+        self,
+        uri: str,
+        context: GatewayRequestContext,
+    ) -> dict[str, Any]:
+        """Reject local resource reads in this fake runtime."""
+
+        del context
+        raise ValueError(f"Unknown local resource: {uri}")
+
+    async def list_prompts(self, context: GatewayRequestContext) -> list[dict[str, Any]]:
+        """Return no local prompts."""
+
+        del context
+        return []
+
+    async def get_prompt(
+        self,
+        name: str,
+        arguments: dict[str, Any],
+        context: GatewayRequestContext,
+    ) -> dict[str, Any]:
+        """Reject local prompt reads in this fake runtime."""
+
+        del arguments, context
+        raise ValueError(f"Unknown local prompt: {name}")
+
+    async def list_modules(self, context: GatewayRequestContext) -> list[dict[str, Any]]:
+        """Return no local modules."""
+
+        del context
+        return []
+
+    async def get_modules_health(self, context: GatewayRequestContext) -> dict[str, Any]:
+        """Return empty local health."""
+
+        del context
+        return {"modules": []}
+
+
+class RecordingCredentialBroker:
+    """Credential broker fake that records resolution requests."""
+
+    def __init__(self, result: BrokeredExternalCredential) -> None:
+        self.result = result
+        self.calls: list[dict[str, Any]] = []
+
+    async def resolve_external_credential(
+        self,
+        **kwargs: Any,
+    ) -> BrokeredExternalCredential:
+        """Record one credential lookup and return a copied credential."""
+
+        self.calls.append(dict(kwargs))
+        return self.result.copy()
+
+
+def _server(
+    server_id: str = "research",
+    *,
+    credential_slots: list[str] | None = None,
+) -> ExternalServerDefinition:
+    """Build a valid non-spawning stdio server definition for tests."""
+
+    return ExternalServerDefinition(
+        id=server_id,
+        name=server_id.title(),
+        transport="stdio",
+        command=["python", "-m", "fake_mcp_server"],
+        enabled=True,
+        credential_slots=credential_slots or [],
+    )
+
+
+def _search_tool() -> ExternalToolDefinition:
+    """Return one read-only external search tool definition."""
+
+    return ExternalToolDefinition(
+        name="search",
+        description="Search papers.",
+        input_schema={
+            "type": "object",
+            "properties": {"query": {"type": "string"}},
+        },
+        metadata={
+            "capability": "research.search",
+            "annotations": {"readOnlyHint": True},
+        },
+    )
+
+
+async def _started_runtime(
+    *,
+    base_runtime: BaseGatewayRuntime | None = None,
+    credential_slots: list[str] | None = None,
+    credential_broker: RecordingCredentialBroker | None = None,
+) -> tuple[ExternalRuntimeGatewayRuntime, FakeExternalTransport]:
+    """Create an adapter around a started external runtime manager."""
+
+    transport = FakeExternalTransport(
+        server_id="research",
+        tools=[_search_tool()],
+        results={
+            "search": ExternalToolCallResult(
+                content={"matches": ["paper-1"]},
+                metadata={"transport": "fake"},
+            )
+        },
+    )
+    manager = GatewayExternalRuntimeManager(
+        external_registry_store=InMemoryExternalRegistryStore(
+            [_server(credential_slots=credential_slots)]
+        ),
+        transport_factory=lambda _server: transport,
+        credential_broker=credential_broker,
+    )
+    await manager.start_server("research")
+    return (
+        ExternalRuntimeGatewayRuntime(
+            base_runtime=base_runtime,
+            external_runtime_manager=manager,
+        ),
+        transport,
+    )
+
+
+async def test_external_runtime_gateway_lists_base_and_external_tools() -> None:
+    """External virtual tools should appear beside base gateway tools."""
+
+    runtime, _transport = await _started_runtime(base_runtime=BaseGatewayRuntime())
+
+    tools = await runtime.list_tools(GatewayRequestContext(request_id="list"))
+
+    assert [tool["name"] for tool in tools] == ["local.echo", "ext.research.search"]
+    external = tools[1]
+    assert external["description"] == "Search papers."
+    assert external["inputSchema"]["properties"]["query"]["type"] == "string"
+    assert external["metadata"]["external_server_id"] == "research"
+    assert external["metadata"]["upstream_tool_name"] == "search"
+    assert external["metadata"]["source"] == "external_runtime"
+    assert external["metadata"]["is_write"] is False
+
+
+async def test_external_runtime_gateway_dispatches_external_and_local_tools() -> None:
+    """External names call the manager while local names still use the base runtime."""
+
+    base_runtime = BaseGatewayRuntime()
+    runtime, transport = await _started_runtime(base_runtime=base_runtime)
+    context = GatewayRequestContext(
+        request_id="call",
+        user_id="user-1",
+        metadata={
+            EFFECTIVE_POLICY_METADATA_KEY: {
+                "profile_id": "researcher",
+                "external_server_grants": [{"server_id": "research"}],
+            }
+        },
+    )
+
+    external = await runtime.call_tool("ext.research.search", {"query": "mcp"}, context)
+    local = await runtime.call_tool("local.echo", {"query": "hello"}, context)
+
+    assert external == {
+        "content": {"matches": ["paper-1"]},
+        "isError": False,
+        "metadata": {
+            "server_id": "research",
+            "transport": "fake",
+            "upstream_tool_name": "search",
+            "virtual_tool_name": "ext.research.search",
+        },
+    }
+    assert transport.calls == [("search", {"query": "mcp"})]
+    assert local["content"][0]["text"] == "hello"
+    assert base_runtime.calls[0][0] == "local.echo"
+
+
+async def test_external_runtime_gateway_unknown_tool_without_base_fails() -> None:
+    """An adapter without a base runtime should fail closed for unknown names."""
+
+    runtime, _transport = await _started_runtime()
+
+    with pytest.raises(ValueError, match="Unknown gateway tool"):
+        await runtime.call_tool(
+            "missing.tool",
+            {},
+            GatewayRequestContext(request_id="missing"),
+        )
+
+
+async def test_profile_runtime_passes_external_grants_to_adapter() -> None:
+    """Resolved profile grants should reach the external runtime manager."""
+
+    broker = RecordingCredentialBroker(
+        BrokeredExternalCredential(
+            headers={"Authorization": "Bearer test"},
+            metadata={"credential_mode": "brokered_ephemeral"},
+        )
+    )
+    adapter, transport = await _started_runtime(
+        credential_slots=["api_key"],
+        credential_broker=broker,
+    )
+    profile_store = InMemoryProfileStore()
+    await profile_store.upsert_profile(
+        MCPProfile(
+            id="researcher",
+            name="Researcher",
+            policy_document=ProfilePolicy(allowed_tools=["ext.research.search"]),
+            external_server_grants=[{"server_id": "research"}],
+            credential_grants=[
+                {"server_id": "research", "credential_slots": ["api_key"]}
+            ],
+        )
+    )
+    runtime = ProfileAwareGatewayRuntime(
+        adapter,
+        profile_store=profile_store,
+        default_profile_id="researcher",
+    )
+    context = GatewayRequestContext(request_id="profile-call", user_id="user-1")
+
+    result = await runtime.call_tool("ext.research.search", {"query": "mcp"}, context)
+
+    assert result["content"] == {"matches": ["paper-1"]}
+    assert transport.runtime_auth_seen is not None
+    assert broker.calls[0]["effective_policy"]["profile_id"] == "researcher"
+    assert broker.calls[0]["effective_policy"]["credential_grants"] == [
+        {"server_id": "research", "credential_slots": ["api_key"]}
+    ]
+    assert EFFECTIVE_POLICY_METADATA_KEY not in context.metadata
+
+
+async def test_jsonrpc_maps_external_policy_denial_to_policy_error() -> None:
+    """External grant denial should surface as JSON-RPC policy denial."""
+
+    adapter, _transport = await _started_runtime()
+    profile_store = InMemoryProfileStore()
+    await profile_store.upsert_profile(
+        MCPProfile(
+            id="researcher",
+            name="Researcher",
+            policy_document=ProfilePolicy(allowed_tools=["ext.research.search"]),
+        )
+    )
+    runtime = ProfileAwareGatewayRuntime(
+        adapter,
+        profile_store=profile_store,
+        default_profile_id="researcher",
+    )
+
+    response = await handle_jsonrpc(
+        runtime,
+        {
+            "jsonrpc": "2.0",
+            "method": "tools/call",
+            "params": {
+                "name": "ext.research.search",
+                "arguments": {"query": "mcp"},
+            },
+            "id": "denied",
+        },
+        path="/mcp",
+    )
+
+    assert not isinstance(response, list)
+    assert response.error is not None
+    assert response.error.code == -32001
+    assert response.error.data["reason_code"] == "external_server_not_granted"

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import ast
 import importlib
+import subprocess
+import sys
 from datetime import datetime
 from pathlib import Path
 
@@ -124,11 +126,16 @@ def test_gateway_external_runtime_exports_are_package_owned() -> None:
     """Gateway runtime exports must resolve without host package imports."""
     package_gateway = importlib.import_module("mcp_unified.gateway")
     package_config = importlib.import_module("mcp_unified.gateway.config")
+    package_adapter = importlib.import_module("mcp_unified.gateway.external_runtime_adapter")
     package_lifecycle = importlib.import_module("mcp_unified.gateway.lifecycle")
     package_runtime = importlib.import_module("mcp_unified.gateway.external_runtime")
 
     assert package_gateway.GatewayExternalRuntimeManager is package_runtime.GatewayExternalRuntimeManager
     assert package_gateway.GatewayExternalRuntimeError is package_runtime.GatewayExternalRuntimeError
+    assert (
+        package_gateway.ExternalRuntimeGatewayRuntime
+        is package_adapter.ExternalRuntimeGatewayRuntime
+    )
     assert (
         package_gateway.GatewayExternalRuntimeBootstrapConfig
         is package_config.GatewayExternalRuntimeBootstrapConfig
@@ -137,6 +144,27 @@ def test_gateway_external_runtime_exports_are_package_owned() -> None:
         package_gateway.GatewayExternalRuntimeLifecycleConfig
         is package_lifecycle.GatewayExternalRuntimeLifecycleConfig
     )
+
+
+def test_gateway_external_runtime_adapter_import_does_not_import_fastapi_transport() -> None:
+    """Importing the external runtime adapter must not require FastAPI helpers."""
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            (
+                "import sys; "
+                "import mcp_unified.gateway.external_runtime_adapter; "
+                "print('mcp_unified.gateway.fastapi' in sys.modules)"
+            ),
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.stdout.strip() == "False"
 
 
 def test_federation_installer_contracts_are_public_exports() -> None:


### PR DESCRIPTION
## Summary
- Adds `ExternalRuntimeGatewayRuntime` so active external virtual tools are exposed through the package gateway runtime and JSON-RPC transports.
- Passes profile effective-policy decisions into backend runtime context metadata without mutating the original request context.
- Keeps adjacent external-runtime installer error handling from leaking exception context while preserving diagnostics.

## Test Plan
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_gateway_external_runtime_adapter.py tldw_Server_API/app/core/MCP_unified/tests/test_gateway_external_runtime.py tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py tldw_Server_API/app/core/MCP_unified/tests/test_federation_shell_contracts.py -q` -> 201 passed
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m ruff check mcp_unified/gateway tldw_Server_API/app/core/MCP_unified/tests/test_gateway_external_runtime_adapter.py tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py` -> All checks passed
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r mcp_unified/gateway/external_runtime_adapter.py mcp_unified/gateway/profile_runtime.py mcp_unified/gateway/external_runtime.py -f json -o /tmp/bandit_mcp_gateway_external_runtime_adapter.json` -> 0 findings
- `git diff --check` -> clean

## Change Summary Requirement
Per repo policy, this AI-authored PR still needs a human-written Change summary before merge.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Exposes active external MCP runtime tools through the gateway so clients can list and call them over JSON‑RPC without changing transport code. Injects profile effective policy into request metadata so external grants and credentials are enforced. Addresses TASK-589.

- New Features
  - Added `ExternalRuntimeGatewayRuntime` to list and call external virtual tools, merged with base runtime tools.
  - Introduced `GatewayExternalRuntimeManager.has_virtual_tool()` for direct routing; converts federated results to gateway JSON.
  - Lazily exports `ExternalRuntimeGatewayRuntime` from `mcp_unified.gateway`.

- Bug Fixes
  - Safely handle nullable external tool `input_schema`/`metadata` and missing context metadata.
  - `ProfileAwareGatewayRuntime` adds effective policy under `"_gateway_effective_policy"` without mutating the original context.
  - Installer errors now include traceback frame locations and sanitized chained causes; no secret text leaks; adapter import stays independent of FastAPI.

<sup>Written for commit 4193696d7aa2b8e9c759f83d7c20f5e4736489b5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2219?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

