### PR TITLE
Add standalone MCP gateway admin config surface

### DIFF
--- a/Docs/MCP_UNIFIED_STANDALONE_GATEWAY_ADMIN.md
+++ b/Docs/MCP_UNIFIED_STANDALONE_GATEWAY_ADMIN.md
@@ -1,0 +1,208 @@
+# MCP Unified Standalone Gateway Admin
+
+This guide covers the standalone gateway admin/config surface for profiles,
+external server definitions, credential grants, config snapshots, and remote
+runtime lifecycle commands.
+
+## Local Store Commands vs Remote Runtime Commands
+
+The `mcp-unified-gateway` CLI has two different operating modes:
+
+- Local store commands read or mutate the configured gateway store. These
+  commands use `--config` or `MCP_UNIFIED_GATEWAY_CONFIG`.
+- Remote runtime commands call admin endpoints on an already-running gateway.
+  These commands use `--gateway-url` or `MCP_UNIFIED_GATEWAY_URL`.
+
+Local store commands do not start upstream MCP processes. Remote runtime
+commands also do not own durable upstream processes from the short-lived CLI;
+they ask the running gateway to list, start, stop, restart, refresh, reconcile,
+install, or update managed external servers.
+
+## Admin Auth
+
+Management routes can be protected by an admin header. The remote runtime CLI
+reads the secret value from the environment so it does not appear in process
+arguments:
+
+```bash
+export MCP_UNIFIED_GATEWAY_ADMIN_KEY="replace-with-admin-key"
+mcp-unified-gateway runtime-list \
+  --gateway-url http://127.0.0.1:8000/mcp
+```
+
+The default header name is `X-MCP-Gateway-Admin-Key`. Override only the header
+name on the command line when the running gateway uses a different header:
+
+```bash
+mcp-unified-gateway runtime-list \
+  --gateway-url http://127.0.0.1:8000/mcp \
+  --admin-header-name X-Admin-Key
+```
+
+Do not pass secret values as CLI arguments. The runtime commands intentionally
+avoid an `--admin-key` option.
+
+## Gateway URL Semantics
+
+`--gateway-url` is the mounted gateway base path, not only the server origin.
+If the router is mounted at `/mcp`, pass `http://127.0.0.1:8000/mcp`. If it is
+mounted at the root, pass `http://127.0.0.1:8000`.
+
+The client trims trailing slashes and appends endpoint paths. It does not
+auto-add `/mcp`, because gateway prefixes are host-configurable.
+
+## Local Configuration Examples
+
+Validate a JSON or TOML gateway config:
+
+```bash
+mcp-unified-gateway validate-config ./gateway.json
+```
+
+List bundled profile presets:
+
+```bash
+mcp-unified-gateway list-presets
+```
+
+Duplicate a preset into a persistent store:
+
+```bash
+mcp-unified-gateway duplicate-preset project-researcher \
+  --profile-id researcher \
+  --name "Project Researcher" \
+  --config ./gateway.json
+```
+
+Create an external server definition:
+
+```json
+{
+  "id": "search",
+  "name": "Search MCP Server",
+  "transport": "stdio",
+  "command": ["python", "-m", "search_mcp_server"],
+  "env_allowlist": ["PATH", "SEARCH_API_ENDPOINT"],
+  "credential_slots": ["search_api_key"],
+  "enabled": true,
+  "auto_start": false
+}
+```
+
+```bash
+mcp-unified-gateway create-external-server \
+  --server-file ./search-server.json \
+  --config ./gateway.json
+```
+
+Credential grants are broker metadata. Store only the broker id, credential
+slot, scopes, and binding metadata; do not embed the secret value:
+
+```json
+{
+  "id": "researcher-search-api-key",
+  "profile_id": "researcher",
+  "external_server_id": "search",
+  "broker_id": "env",
+  "credential_slot": "search_api_key",
+  "scopes": ["search:read"],
+  "enabled": true
+}
+```
+
+```bash
+mcp-unified-gateway create-credential-grant \
+  --grant-file ./researcher-search-grant.json \
+  --config ./gateway.json
+```
+
+Export a config snapshot:
+
+```bash
+mcp-unified-gateway export-config \
+  --output ./gateway-snapshot.json \
+  --config ./gateway.json
+```
+
+Import a config snapshot with validation only:
+
+```bash
+mcp-unified-gateway import-config \
+  --snapshot-file ./gateway-snapshot.json \
+  --dry-run \
+  --config ./gateway.json
+```
+
+Apply the snapshot after reviewing the dry-run output:
+
+```bash
+mcp-unified-gateway import-config \
+  --snapshot-file ./gateway-snapshot.json \
+  --config ./gateway.json
+```
+
+## Remote Runtime Examples
+
+List runtime state:
+
+```bash
+mcp-unified-gateway runtime-list \
+  --gateway-url http://127.0.0.1:8000/mcp
+```
+
+Start one managed external server:
+
+```bash
+mcp-unified-gateway runtime-start search \
+  --gateway-url http://127.0.0.1:8000/mcp
+```
+
+Refresh all runtime metadata:
+
+```bash
+mcp-unified-gateway runtime-refresh \
+  --gateway-url http://127.0.0.1:8000/mcp
+```
+
+Refresh one runtime:
+
+```bash
+mcp-unified-gateway runtime-refresh search \
+  --gateway-url http://127.0.0.1:8000/mcp
+```
+
+Other remote runtime commands follow the same URL/auth rules:
+
+```bash
+mcp-unified-gateway runtime-stop search --gateway-url http://127.0.0.1:8000/mcp
+mcp-unified-gateway runtime-restart search --gateway-url http://127.0.0.1:8000/mcp
+mcp-unified-gateway runtime-reconcile --gateway-url http://127.0.0.1:8000/mcp
+mcp-unified-gateway runtime-install search --gateway-url http://127.0.0.1:8000/mcp
+mcp-unified-gateway runtime-update search --gateway-url http://127.0.0.1:8000/mcp
+```
+
+For repeated use, set the URL in the environment:
+
+```bash
+export MCP_UNIFIED_GATEWAY_URL=http://127.0.0.1:8000/mcp
+mcp-unified-gateway runtime-list
+```
+
+## Error Payloads
+
+The remote runtime CLI preserves public JSON error payloads returned by the
+gateway, including `reason_code` values. For example, a missing external server
+might produce:
+
+```json
+{
+  "error": "Gateway rejected request",
+  "ok": false,
+  "reason_code": "external_server_not_found",
+  "server_id": "search",
+  "status_code": 404
+}
+```
+
+Connection failures and malformed gateway responses are sanitized so response
+bodies and connection error strings are not echoed back into CLI output.

--- a/Docs/superpowers/plans/2026-06-02-mcp-gateway-admin-auth-credential-grants.md
+++ b/Docs/superpowers/plans/2026-06-02-mcp-gateway-admin-auth-credential-grants.md
@@ -1,0 +1,274 @@
+# MCP Gateway Admin Auth And Credential Grants Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a host-neutral standalone gateway admin auth seam plus credential-grant metadata management over CLI and FastAPI.
+
+**Architecture:** Keep admin security package-owned and optional: management routes remain opt-in, and admin auth is injected into profile, external-server, runtime, and credential-grant routes without changing JSON-RPC request handling. Credential grants are metadata only, backed by the existing `CredentialGrantStore` protocol and `SQLiteMCPStore`; the manager rejects secret-looking metadata/provenance and never persists credential values.
+
+**Tech Stack:** Python, FastAPI dependencies, Pydantic models, existing `mcp_unified` storage protocols, existing SQLite store, pytest, Bandit.
+
+**Backlog Task:** `TASK-591`
+
+---
+
+## File Structure
+
+- Create `mcp_unified/gateway/admin_auth.py`: admin auth config, verifier protocol, FastAPI dependency helpers, and sanitized error payloads.
+- Create `mcp_unified/gateway/credential_grants.py`: credential-grant manager, validation, secret-key detection, audit events, and JSON-safe payloads.
+- Modify `mcp_unified/gateway/config.py`: expose credential-grant manager construction from resolved storage bundles.
+- Modify `mcp_unified/gateway/fastapi.py`: apply optional admin dependencies to management routes and mount credential-grant routes.
+- Modify `mcp_unified/gateway/cli.py`: add credential-grant CRUD commands using the persistent gateway store.
+- Modify `mcp_unified/gateway/__init__.py`: export public admin/credential-grant helpers if local package exports follow that pattern.
+- Create `tldw_Server_API/app/core/MCP_unified/tests/test_gateway_admin_auth.py`: route gating and JSON-RPC non-interference.
+- Create `tldw_Server_API/app/core/MCP_unified/tests/test_gateway_credential_grants.py`: manager validation, secret rejection, audit behavior, and persistence semantics.
+- Modify `tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py`: credential-grant HTTP routes and auth behavior.
+- Modify `tldw_Server_API/app/core/MCP_unified/tests/test_gateway_cli_package.py`: credential-grant CLI commands.
+
+## Acceptance Criteria
+
+- Management routes can require standalone admin auth without importing `tldw_Server_API`.
+- JSON-RPC `/request` and `/ws` routes remain usable under their existing profile/runtime flow and are not accidentally gated by admin auth.
+- Credential grants support list/show/create/patch/delete through manager, FastAPI, and CLI.
+- Credential grants persist only broker references, slots, scopes, metadata, and provenance; secret-looking values are rejected before persistence.
+- External-server delete guards continue to block deletion when enabled grants reference the server.
+- Focused tests and Bandit on touched package files are recorded.
+
+### Task 1: Add Admin Auth Failing Tests
+
+**Files:**
+- Create: `tldw_Server_API/app/core/MCP_unified/tests/test_gateway_admin_auth.py`
+- Modify: `tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py`
+
+- [ ] **Step 1: Write route-gating tests**
+
+Build a gateway app with profile management enabled and admin auth configured. Assert `GET /mcp/profiles` returns unauthorized without the configured header and succeeds with it.
+
+- [ ] **Step 2: Write non-interference test**
+
+Use the same app and assert `GET /mcp/status` and JSON-RPC `/mcp/request` do not require the admin header.
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run:
+
+```bash
+source .venv/bin/activate
+python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_gateway_admin_auth.py -v
+```
+
+Expected: fail because `mcp_unified.gateway.admin_auth` and router auth wiring do not exist yet.
+
+### Task 2: Implement Admin Auth Seam
+
+**Files:**
+- Create: `mcp_unified/gateway/admin_auth.py`
+- Modify: `mcp_unified/gateway/fastapi.py`
+
+- [ ] **Step 1: Add package auth config**
+
+Implement a small config surface:
+
+```python
+@dataclass(frozen=True, slots=True)
+class GatewayAdminAuthConfig:
+    enabled: bool = False
+    header_name: str = "X-MCP-Gateway-Admin-Key"
+    api_key: str | None = None
+    verifier: GatewayAdminVerifier | None = None
+```
+
+Use `secrets.compare_digest` for static API-key comparison. Validate that `enabled=True` has either `api_key` or `verifier`.
+
+- [ ] **Step 2: Add FastAPI dependency factory**
+
+Expose a helper that returns FastAPI route dependencies. If auth is disabled, return an empty list. If enabled, read the configured header, validate it, and raise a sanitized error with stable `reason_code` values.
+
+- [ ] **Step 3: Wire only management routes**
+
+Update route mounting helpers in `mcp_unified/gateway/fastapi.py` to accept `admin_dependencies`. Apply those dependencies to profile management, external registry management, external runtime management, and credential-grant management routes only.
+
+- [ ] **Step 4: Run admin auth tests**
+
+Run:
+
+```bash
+source .venv/bin/activate
+python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_gateway_admin_auth.py -v
+```
+
+Expected: pass.
+
+### Task 3: Add Credential-Grant Manager Failing Tests
+
+**Files:**
+- Create: `tldw_Server_API/app/core/MCP_unified/tests/test_gateway_credential_grants.py`
+
+- [ ] **Step 1: Write manager CRUD tests**
+
+Use in-memory stores matching the existing external registry tests. Assert list/show/create/patch/delete return deterministic envelopes with `ok`, `grant`, `grants`, and `store`.
+
+- [ ] **Step 2: Write secret rejection tests**
+
+Assert create/patch rejects metadata or provenance containing keys such as `secret`, `token`, `password`, `api_key`, `authorization`, `headers`, `env`, or `credential_value`.
+
+- [ ] **Step 3: Write reference validation tests**
+
+When optional profile and external-server stores are provided, assert missing `profile_id` or `external_server_id` returns expected domain errors.
+
+- [ ] **Step 4: Run tests to verify they fail**
+
+Run:
+
+```bash
+source .venv/bin/activate
+python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_gateway_credential_grants.py -v
+```
+
+Expected: fail because the manager module does not exist yet.
+
+### Task 4: Implement Credential-Grant Manager
+
+**Files:**
+- Create: `mcp_unified/gateway/credential_grants.py`
+- Modify: `mcp_unified/gateway/config.py`
+
+- [ ] **Step 1: Add domain error and metadata class**
+
+Mirror existing gateway manager style with `GatewayCredentialGrantManagementError.to_payload()` and existing store metadata shape.
+
+- [ ] **Step 2: Implement validation**
+
+Normalize required text fields: `id`, `profile_id`, `broker_id`, and `credential_slot`. Allow patch fields: `broker_id`, `credential_slot`, `external_server_id`, `scopes`, `metadata`, `provenance`, and `enabled`.
+
+- [ ] **Step 3: Add secret scanning**
+
+Reject secret-looking metadata/provenance keys recursively. Keep this helper reusable for the snapshot slice.
+
+- [ ] **Step 4: Add CRUD methods**
+
+Implement:
+
+```python
+async def list_grants(...)
+async def show_grant(grant_id: str)
+async def create_grant(grant_document: CredentialGrant | Mapping[str, Any])
+async def patch_grant(grant_id: str, patch_document: Mapping[str, Any])
+async def delete_grant(grant_id: str)
+```
+
+Use caller-owned model copies and append best-effort audit events.
+
+- [ ] **Step 5: Add config builder**
+
+Add a `credential_grant_manager_from_storage(...)` helper. It should accept explicit stores and, when convenient, a profile storage bundle plus external registry storage bundle so profile reference validation is possible without duplicating store construction.
+
+- [ ] **Step 6: Run manager tests**
+
+Run:
+
+```bash
+source .venv/bin/activate
+python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_gateway_credential_grants.py -v
+```
+
+Expected: pass.
+
+### Task 5: Add FastAPI Credential-Grant Routes
+
+**Files:**
+- Modify: `mcp_unified/gateway/fastapi.py`
+- Modify: `tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py`
+
+- [ ] **Step 1: Write HTTP route tests**
+
+Add tests for `GET /mcp/credential-grants`, `POST /mcp/credential-grants`, `GET/PATCH/DELETE /mcp/credential-grants/{grant_id}`, including auth behavior when admin auth is enabled.
+
+- [ ] **Step 2: Add request/response models**
+
+Add Pydantic models for create/patch/list/detail/delete responses without accepting extra secret fields.
+
+- [ ] **Step 3: Mount routes**
+
+Extend `create_gateway_router()` and `create_gateway_app()` with optional `credential_grant_manager` and `enable_credential_grant_management` arguments. Keep explicit injection as the default; only derive from bootstrap if the bootstrap already carries the manager by this point.
+
+- [ ] **Step 4: Run FastAPI tests**
+
+Run:
+
+```bash
+source .venv/bin/activate
+python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py -v
+```
+
+Expected: pass.
+
+### Task 6: Add CLI Credential-Grant Commands
+
+**Files:**
+- Modify: `mcp_unified/gateway/cli.py`
+- Modify: `tldw_Server_API/app/core/MCP_unified/tests/test_gateway_cli_package.py`
+
+- [ ] **Step 1: Write CLI tests**
+
+Cover:
+
+- `list-credential-grants`
+- `show-credential-grant <grant_id>`
+- `create-credential-grant --grant-file <path-or-dash>`
+- `patch-credential-grant <grant_id> --patch-file <path-or-dash>`
+- `delete-credential-grant <grant_id>`
+
+- [ ] **Step 2: Implement CLI handlers**
+
+Follow existing JSON output style and persistent-store checks from external-server commands.
+
+- [ ] **Step 3: Run CLI tests**
+
+Run:
+
+```bash
+source .venv/bin/activate
+python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_gateway_cli_package.py -v
+```
+
+Expected: pass.
+
+### Task 7: Final Verification
+
+**Files:**
+- Modified files from prior tasks.
+- Backlog task `TASK-591`.
+
+- [ ] **Step 1: Run focused package tests**
+
+Run:
+
+```bash
+source .venv/bin/activate
+python -m pytest \
+  tldw_Server_API/app/core/MCP_unified/tests/test_gateway_admin_auth.py \
+  tldw_Server_API/app/core/MCP_unified/tests/test_gateway_credential_grants.py \
+  tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py \
+  tldw_Server_API/app/core/MCP_unified/tests/test_gateway_cli_package.py \
+  -v
+```
+
+- [ ] **Step 2: Run Bandit on touched package files**
+
+Run:
+
+```bash
+source .venv/bin/activate
+python -m bandit -r \
+  mcp_unified/gateway/admin_auth.py \
+  mcp_unified/gateway/credential_grants.py \
+  mcp_unified/gateway/config.py \
+  mcp_unified/gateway/fastapi.py \
+  mcp_unified/gateway/cli.py \
+  -f json -o /tmp/bandit_mcp_gateway_admin_auth_credential_grants.json
+```
+
+- [ ] **Step 3: Update Backlog**
+
+Record touched files, verification commands, known skips, and final summary in `TASK-591`.

--- a/Docs/superpowers/plans/2026-06-02-mcp-gateway-admin-auth-credential-grants.md
+++ b/Docs/superpowers/plans/2026-06-02-mcp-gateway-admin-auth-credential-grants.md
@@ -4,7 +4,7 @@
 
 **Goal:** Add a host-neutral standalone gateway admin auth seam plus credential-grant metadata management over CLI and FastAPI.
 
-**Architecture:** Keep admin security package-owned and optional: management routes remain opt-in, and admin auth is injected into profile, external-server, runtime, and credential-grant routes without changing JSON-RPC request handling. Credential grants are metadata only, backed by the existing `CredentialGrantStore` protocol and `SQLiteMCPStore`; the manager rejects secret-looking metadata/provenance and never persists credential values.
+**Architecture:** Keep admin security package-owned and optional: management routes remain opt-in, and admin auth is injected into profile, external-server, runtime, and credential-grant routes without changing JSON-RPC request handling. Standalone config may enable admin auth and name the header/env var, but it must not persist the admin key itself. Credential grants are metadata only, backed by the existing `CredentialGrantStore` protocol and `SQLiteMCPStore`; the manager rejects secret-looking metadata/provenance and never persists credential values.
 
 **Tech Stack:** Python, FastAPI dependencies, Pydantic models, existing `mcp_unified` storage protocols, existing SQLite store, pytest, Bandit.
 
@@ -16,7 +16,9 @@
 
 - Create `mcp_unified/gateway/admin_auth.py`: admin auth config, verifier protocol, FastAPI dependency helpers, and sanitized error payloads.
 - Create `mcp_unified/gateway/credential_grants.py`: credential-grant manager, validation, secret-key detection, audit events, and JSON-safe payloads.
-- Modify `mcp_unified/gateway/config.py`: expose credential-grant manager construction from resolved storage bundles.
+- Modify `mcp_unified/interfaces/storage.py`: add atomic credential-grant create capability and duplicate-id domain error.
+- Modify `mcp_unified/storage/sqlite.py`: implement atomic credential-grant create with the existing async DB offload helper.
+- Modify `mcp_unified/gateway/config.py`: add standalone admin auth bootstrap config, validate config loading, and expose credential-grant manager construction from resolved storage bundles.
 - Modify `mcp_unified/gateway/fastapi.py`: apply optional admin dependencies to management routes and mount credential-grant routes.
 - Modify `mcp_unified/gateway/cli.py`: add credential-grant CRUD commands using the persistent gateway store.
 - Modify `mcp_unified/gateway/__init__.py`: export public admin/credential-grant helpers if local package exports follow that pattern.
@@ -28,8 +30,10 @@
 ## Acceptance Criteria
 
 - Management routes can require standalone admin auth without importing `tldw_Server_API`.
+- Standalone gateway config can enable admin auth, customize the header, and resolve the admin key from an environment variable without storing the key in the config file.
 - JSON-RPC `/request` and `/ws` routes remain usable under their existing profile/runtime flow and are not accidentally gated by admin auth.
 - Credential grants support list/show/create/patch/delete through manager, FastAPI, and CLI.
+- Credential-grant create rejects duplicate ids atomically instead of silently replacing an existing grant.
 - Credential grants persist only broker references, slots, scopes, metadata, and provenance; secret-looking values are rejected before persistence.
 - External-server delete guards continue to block deletion when enabled grants reference the server.
 - Focused tests and Bandit on touched package files are recorded.
@@ -48,7 +52,11 @@ Build a gateway app with profile management enabled and admin auth configured. A
 
 Use the same app and assert `GET /mcp/status` and JSON-RPC `/mcp/request` do not require the admin header.
 
-- [ ] **Step 3: Run tests to verify they fail**
+- [ ] **Step 3: Write standalone config tests**
+
+Add JSON and TOML config-loader tests that verify `admin_auth.enabled`, `admin_auth.header_name`, and `admin_auth.api_key_env_var` validate successfully. Also assert malformed config rejects blank header names and does not accept a plaintext `api_key` field.
+
+- [ ] **Step 4: Run tests to verify they fail**
 
 Run:
 
@@ -80,13 +88,25 @@ class GatewayAdminAuthConfig:
 
 Use `secrets.compare_digest` for static API-key comparison. Validate that `enabled=True` has either `api_key` or `verifier`.
 
+Add a separate bootstrap/config model:
+
+```python
+@dataclass(frozen=True, slots=True)
+class GatewayAdminAuthBootstrapConfig:
+    enabled: bool = False
+    header_name: str = "X-MCP-Gateway-Admin-Key"
+    api_key_env_var: str = "MCP_UNIFIED_GATEWAY_ADMIN_KEY"
+```
+
+Reject plaintext `api_key` in file-backed standalone config. Config loading should only name the env var; app construction resolves the actual secret from `os.environ`.
+
 - [ ] **Step 2: Add FastAPI dependency factory**
 
-Expose a helper that returns FastAPI route dependencies. If auth is disabled, return an empty list. If enabled, read the configured header, validate it, and raise a sanitized error with stable `reason_code` values.
+Expose a helper that returns FastAPI route dependencies. If auth is disabled, return an empty list. If enabled, read the configured header, validate it, and return direct JSON error responses with stable `reason_code` values such as `admin_auth_required` and `admin_auth_invalid`. Do not rely on a default `HTTPException` shape that wraps the payload under `detail`.
 
 - [ ] **Step 3: Wire only management routes**
 
-Update route mounting helpers in `mcp_unified/gateway/fastapi.py` to accept `admin_dependencies`. Apply those dependencies to profile management, external registry management, external runtime management, and credential-grant management routes only.
+Update route mounting helpers in `mcp_unified/gateway/fastapi.py` to accept `admin_dependencies` or `admin_auth`. Apply those dependencies to profile management, external registry management, external runtime management, and credential-grant management routes only. Update `create_gateway_app()` and `bootstrap_profile_gateway_from_config()` so standalone config can enable admin auth without host-app glue code.
 
 - [ ] **Step 4: Run admin auth tests**
 
@@ -116,7 +136,11 @@ Assert create/patch rejects metadata or provenance containing keys such as `secr
 
 When optional profile and external-server stores are provided, assert missing `profile_id` or `external_server_id` returns expected domain errors.
 
-- [ ] **Step 4: Run tests to verify they fail**
+- [ ] **Step 4: Write duplicate create tests**
+
+Assert creating a grant with an existing id returns `credential_grant_already_exists` and does not replace the existing grant.
+
+- [ ] **Step 5: Run tests to verify they fail**
 
 Run:
 
@@ -131,21 +155,27 @@ Expected: fail because the manager module does not exist yet.
 
 **Files:**
 - Create: `mcp_unified/gateway/credential_grants.py`
+- Modify: `mcp_unified/interfaces/storage.py`
+- Modify: `mcp_unified/storage/sqlite.py`
 - Modify: `mcp_unified/gateway/config.py`
 
 - [ ] **Step 1: Add domain error and metadata class**
 
 Mirror existing gateway manager style with `GatewayCredentialGrantManagementError.to_payload()` and existing store metadata shape.
 
-- [ ] **Step 2: Implement validation**
+- [ ] **Step 2: Add atomic create store capability**
+
+Add `CredentialGrantAlreadyExistsError` and `CredentialGrantStore.create_grant(...)` to `mcp_unified/interfaces/storage.py`. Implement it in `SQLiteMCPStore` with an insert that rejects duplicate ids, mirroring the profile/external-server create pattern.
+
+- [ ] **Step 3: Implement validation**
 
 Normalize required text fields: `id`, `profile_id`, `broker_id`, and `credential_slot`. Allow patch fields: `broker_id`, `credential_slot`, `external_server_id`, `scopes`, `metadata`, `provenance`, and `enabled`.
 
-- [ ] **Step 3: Add secret scanning**
+- [ ] **Step 4: Add secret scanning**
 
 Reject secret-looking metadata/provenance keys recursively. Keep this helper reusable for the snapshot slice.
 
-- [ ] **Step 4: Add CRUD methods**
+- [ ] **Step 5: Add CRUD methods**
 
 Implement:
 
@@ -159,11 +189,11 @@ async def delete_grant(grant_id: str)
 
 Use caller-owned model copies and append best-effort audit events.
 
-- [ ] **Step 5: Add config builder**
+- [ ] **Step 6: Add config builder**
 
 Add a `credential_grant_manager_from_storage(...)` helper. It should accept explicit stores and, when convenient, a profile storage bundle plus external registry storage bundle so profile reference validation is possible without duplicating store construction.
 
-- [ ] **Step 6: Run manager tests**
+- [ ] **Step 7: Run manager tests**
 
 Run:
 
@@ -192,7 +222,11 @@ Add Pydantic models for create/patch/list/detail/delete responses without accept
 
 Extend `create_gateway_router()` and `create_gateway_app()` with optional `credential_grant_manager` and `enable_credential_grant_management` arguments. Keep explicit injection as the default; only derive from bootstrap if the bootstrap already carries the manager by this point.
 
-- [ ] **Step 4: Run FastAPI tests**
+- [ ] **Step 4: Preserve error response shape**
+
+Map credential-grant errors to direct JSON response payloads with stable status codes. Cover unauthorized, duplicate create, missing profile, missing external server, invalid patch, and store-unavailable cases.
+
+- [ ] **Step 5: Run FastAPI tests**
 
 Run:
 
@@ -261,6 +295,8 @@ Run:
 ```bash
 source .venv/bin/activate
 python -m bandit -r \
+  mcp_unified/interfaces/storage.py \
+  mcp_unified/storage/sqlite.py \
   mcp_unified/gateway/admin_auth.py \
   mcp_unified/gateway/credential_grants.py \
   mcp_unified/gateway/config.py \

--- a/Docs/superpowers/plans/2026-06-02-mcp-gateway-config-snapshots.md
+++ b/Docs/superpowers/plans/2026-06-02-mcp-gateway-config-snapshots.md
@@ -4,7 +4,7 @@
 
 **Goal:** Add versioned standalone gateway config import/export snapshots for profiles, default assignment, external servers, and credential-grant metadata.
 
-**Architecture:** Introduce a package-owned snapshot model and manager that reads/writes through existing store protocols. Export produces secret-safe JSON snapshots; import validates references first, supports dry-run planning, and applies changes in dependency order without destructive replace semantics.
+**Architecture:** Introduce a package-owned snapshot model and manager that reads/writes through existing store protocols. Export produces secret-safe JSON snapshots by validating grant metadata/provenance plus external server command and URL fields for inline secret material. Import validates all references before the first write, supports dry-run planning, and applies changes in dependency order without destructive replace semantics; arbitrary injected stores are validate-first best-effort rather than transactionally atomic.
 
 **Tech Stack:** Python, Pydantic, existing `mcp_unified` store protocols, existing SQLite store, CLI JSON workflows, pytest, Bandit.
 
@@ -26,9 +26,10 @@
 ## Acceptance Criteria
 
 - Exported snapshots include schema version, profiles, default assignment, external servers, and credential grants.
-- Snapshot output contains no plaintext secrets and rejects secret-looking metadata/provenance.
+- Snapshot output contains no plaintext secrets and rejects secret-looking metadata/provenance, command arguments, URL userinfo, and sensitive URL query keys.
 - Import dry-run validates references and reports planned mutations without writing.
 - Import applies in safe order: profiles, default assignment, external servers, credential grants.
+- Import validates the whole snapshot before the first write and reports partial write failures explicitly; arbitrary injected stores are not promised transactional rollback.
 - Import defaults to upsert semantics and does not delete missing local records.
 - A snapshot exported from one SQLite store can be imported into a fresh SQLite store and exported again with equivalent semantic content.
 
@@ -60,7 +61,11 @@ Assert `import_snapshot(..., dry_run=True)` returns a mutation plan and leaves t
 
 Assert snapshot validation rejects metadata/provenance keys containing `secret`, `token`, `password`, `api_key`, `authorization`, `headers`, `env`, or `credential_value`.
 
-- [ ] **Step 4: Run tests to verify they fail**
+- [ ] **Step 4: Write external-server inline secret tests**
+
+Assert export/import validation rejects external server `command` args containing inline values such as `--token=abc`, `api_key=abc`, or `PASSWORD=abc`, URL userinfo such as `https://user:pass@example.test`, and URL query keys such as `?token=abc`. `env_allowlist` may still contain environment variable names because it does not contain values.
+
+- [ ] **Step 5: Run tests to verify they fail**
 
 Run:
 
@@ -90,7 +95,7 @@ class GatewayConfigSnapshot(BaseModel):
     credential_grants: list[CredentialGrant]
 ```
 
-Use model validators for deterministic ordering and secret-key rejection.
+Use model validators for deterministic ordering and secret-key rejection. Reuse the secret-key helper from `mcp_unified.gateway.credential_grants` and add snapshot-specific validators for external server command and URL fields.
 
 - [ ] **Step 2: Add manager dependencies**
 
@@ -98,7 +103,7 @@ Create `GatewayConfigSnapshotManager` with required stores: `profile_store`, `as
 
 - [ ] **Step 3: Implement export**
 
-Read all records through protocol methods, load only the default assignment from `GATEWAY_DEFAULT_ASSIGNMENT_ID`, sort lists by id, and return JSON-safe model dumps.
+Read all records through protocol methods, load only the default assignment from `GATEWAY_DEFAULT_ASSIGNMENT_ID`, sort lists by id, validate the full snapshot for secret safety, and return JSON-safe model dumps.
 
 - [ ] **Step 4: Run export tests**
 
@@ -118,7 +123,7 @@ Expected: pass.
 
 - [ ] **Step 1: Add mutation plan payload**
 
-Return planned actions such as `upsert_profile`, `set_default_assignment`, `upsert_external_server`, and `upsert_credential_grant` with target ids and counts.
+Return planned actions such as `upsert_profile`, `set_default_assignment`, `upsert_external_server`, and `upsert_credential_grant` with target ids and counts. Include enough detail for failures to identify which action failed without echoing raw snapshot payloads.
 
 - [ ] **Step 2: Add reference validation**
 
@@ -127,16 +132,22 @@ Validate:
 - default assignment profile exists in incoming snapshot or current store.
 - every grant profile exists in incoming snapshot or current store.
 - every grant external server exists in incoming snapshot or current store when `external_server_id` is set.
+- every referenced credential slot is present in the referenced external server definition when that server is known.
+- all secret-safety checks pass before any write begins.
 
-- [ ] **Step 3: Apply import in safe order**
+- [ ] **Step 3: Define atomicity behavior**
+
+Document in code comments and docs that the generic manager is validate-first best-effort: it validates the full snapshot before writing, then reports applied and failed action ids if an injected store fails during writes. Do not claim transactionality for arbitrary stores. If all stores are the same `SQLiteMCPStore` and a small transaction helper already exists, it may be used, but it is not required for this slice.
+
+- [ ] **Step 4: Apply import in safe order**
 
 Upsert profiles first, then default assignment, then external servers, then credential grants. Do not delete local records absent from the snapshot.
 
-- [ ] **Step 4: Add audit events**
+- [ ] **Step 5: Add audit events**
 
 Append best-effort audit events for import start/completion/failure when an audit store is available. Do not include snapshot raw payload in audit metadata.
 
-- [ ] **Step 5: Run import tests**
+- [ ] **Step 6: Run import tests**
 
 Run:
 
@@ -166,6 +177,7 @@ Cover:
 - `export-config --config <path> --output <file>` writes a file.
 - `import-config --config <path> --snapshot-file <file> --dry-run` reports planned actions without mutation.
 - `import-config --config <path> --snapshot-file <file>` applies upserts.
+- import failure after validation reports applied and failed action ids without raw secret-bearing payloads.
 
 - [ ] **Step 3: Implement CLI handlers**
 

--- a/Docs/superpowers/plans/2026-06-02-mcp-gateway-config-snapshots.md
+++ b/Docs/superpowers/plans/2026-06-02-mcp-gateway-config-snapshots.md
@@ -1,0 +1,218 @@
+# MCP Gateway Config Snapshots Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add versioned standalone gateway config import/export snapshots for profiles, default assignment, external servers, and credential-grant metadata.
+
+**Architecture:** Introduce a package-owned snapshot model and manager that reads/writes through existing store protocols. Export produces secret-safe JSON snapshots; import validates references first, supports dry-run planning, and applies changes in dependency order without destructive replace semantics.
+
+**Tech Stack:** Python, Pydantic, existing `mcp_unified` store protocols, existing SQLite store, CLI JSON workflows, pytest, Bandit.
+
+**Backlog Task:** `TASK-592`
+
+**Depends On:** `TASK-591`
+
+---
+
+## File Structure
+
+- Create `mcp_unified/gateway/snapshots.py`: snapshot Pydantic models, validation, export/import manager, dry-run mutation plan.
+- Modify `mcp_unified/gateway/config.py`: build snapshot manager from existing profile and external registry storage bundles.
+- Modify `mcp_unified/gateway/cli.py`: add `export-config` and `import-config` commands.
+- Reuse `mcp_unified/gateway/credential_grants.py`: share the secret-key detection helper from `TASK-591` rather than duplicating token lists.
+- Create `tldw_Server_API/app/core/MCP_unified/tests/test_gateway_config_snapshots.py`: manager export/import/dry-run behavior.
+- Modify `tldw_Server_API/app/core/MCP_unified/tests/test_gateway_cli_package.py`: CLI import/export behavior.
+
+## Acceptance Criteria
+
+- Exported snapshots include schema version, profiles, default assignment, external servers, and credential grants.
+- Snapshot output contains no plaintext secrets and rejects secret-looking metadata/provenance.
+- Import dry-run validates references and reports planned mutations without writing.
+- Import applies in safe order: profiles, default assignment, external servers, credential grants.
+- Import defaults to upsert semantics and does not delete missing local records.
+- A snapshot exported from one SQLite store can be imported into a fresh SQLite store and exported again with equivalent semantic content.
+
+### Task 1: Add Snapshot Model Failing Tests
+
+**Files:**
+- Create: `tldw_Server_API/app/core/MCP_unified/tests/test_gateway_config_snapshots.py`
+
+- [ ] **Step 1: Write export shape test**
+
+Create a SQLite-backed gateway store with one profile, default assignment, external server, and credential grant. Assert export returns a deterministic object with:
+
+```json
+{
+  "schema": "mcp_unified.gateway.config_snapshot",
+  "version": 1,
+  "profiles": [],
+  "default_assignment": null,
+  "external_servers": [],
+  "credential_grants": []
+}
+```
+
+- [ ] **Step 2: Write dry-run test**
+
+Assert `import_snapshot(..., dry_run=True)` returns a mutation plan and leaves target stores unchanged.
+
+- [ ] **Step 3: Write secret-safety test**
+
+Assert snapshot validation rejects metadata/provenance keys containing `secret`, `token`, `password`, `api_key`, `authorization`, `headers`, `env`, or `credential_value`.
+
+- [ ] **Step 4: Run tests to verify they fail**
+
+Run:
+
+```bash
+source .venv/bin/activate
+python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_gateway_config_snapshots.py -v
+```
+
+Expected: fail because `mcp_unified.gateway.snapshots` does not exist.
+
+### Task 2: Implement Snapshot Models And Export
+
+**Files:**
+- Create: `mcp_unified/gateway/snapshots.py`
+
+- [ ] **Step 1: Add snapshot models**
+
+Define models:
+
+```python
+class GatewayConfigSnapshot(BaseModel):
+    schema: Literal["mcp_unified.gateway.config_snapshot"]
+    version: Literal[1]
+    profiles: list[MCPProfile]
+    default_assignment: ProfileAssignment | None = None
+    external_servers: list[ExternalServerDefinition]
+    credential_grants: list[CredentialGrant]
+```
+
+Use model validators for deterministic ordering and secret-key rejection.
+
+- [ ] **Step 2: Add manager dependencies**
+
+Create `GatewayConfigSnapshotManager` with required stores: `profile_store`, `assignment_store`, `external_registry_store`, and `credential_grant_store`. Optionally accept `audit_store`.
+
+- [ ] **Step 3: Implement export**
+
+Read all records through protocol methods, load only the default assignment from `GATEWAY_DEFAULT_ASSIGNMENT_ID`, sort lists by id, and return JSON-safe model dumps.
+
+- [ ] **Step 4: Run export tests**
+
+Run:
+
+```bash
+source .venv/bin/activate
+python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_gateway_config_snapshots.py::test_export_snapshot_includes_expected_sections -v
+```
+
+Expected: pass.
+
+### Task 3: Implement Import And Dry-Run
+
+**Files:**
+- Modify: `mcp_unified/gateway/snapshots.py`
+
+- [ ] **Step 1: Add mutation plan payload**
+
+Return planned actions such as `upsert_profile`, `set_default_assignment`, `upsert_external_server`, and `upsert_credential_grant` with target ids and counts.
+
+- [ ] **Step 2: Add reference validation**
+
+Validate:
+
+- default assignment profile exists in incoming snapshot or current store.
+- every grant profile exists in incoming snapshot or current store.
+- every grant external server exists in incoming snapshot or current store when `external_server_id` is set.
+
+- [ ] **Step 3: Apply import in safe order**
+
+Upsert profiles first, then default assignment, then external servers, then credential grants. Do not delete local records absent from the snapshot.
+
+- [ ] **Step 4: Add audit events**
+
+Append best-effort audit events for import start/completion/failure when an audit store is available. Do not include snapshot raw payload in audit metadata.
+
+- [ ] **Step 5: Run import tests**
+
+Run:
+
+```bash
+source .venv/bin/activate
+python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_gateway_config_snapshots.py -v
+```
+
+Expected: pass.
+
+### Task 4: Add Config Builder And CLI Commands
+
+**Files:**
+- Modify: `mcp_unified/gateway/config.py`
+- Modify: `mcp_unified/gateway/cli.py`
+- Modify: `tldw_Server_API/app/core/MCP_unified/tests/test_gateway_cli_package.py`
+
+- [ ] **Step 1: Add builder helper**
+
+Add `gateway_config_snapshot_manager_from_storage(...)` or equivalent helper that builds the manager from existing profile/external storage bundles.
+
+- [ ] **Step 2: Write CLI tests**
+
+Cover:
+
+- `export-config --config <path>` writes JSON to stdout.
+- `export-config --config <path> --output <file>` writes a file.
+- `import-config --config <path> --snapshot-file <file> --dry-run` reports planned actions without mutation.
+- `import-config --config <path> --snapshot-file <file>` applies upserts.
+
+- [ ] **Step 3: Implement CLI handlers**
+
+Use existing `_load_json_argument_file`, `_emit_json`, and config path helpers. Reject memory stores because snapshots are meant for persistent standalone configuration.
+
+- [ ] **Step 4: Run CLI tests**
+
+Run:
+
+```bash
+source .venv/bin/activate
+python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_gateway_cli_package.py -v
+```
+
+Expected: pass.
+
+### Task 5: Round-Trip Verification
+
+**Files:**
+- Modified files from prior tasks.
+- Backlog task `TASK-592`.
+
+- [ ] **Step 1: Run focused tests**
+
+Run:
+
+```bash
+source .venv/bin/activate
+python -m pytest \
+  tldw_Server_API/app/core/MCP_unified/tests/test_gateway_config_snapshots.py \
+  tldw_Server_API/app/core/MCP_unified/tests/test_gateway_cli_package.py \
+  -v
+```
+
+- [ ] **Step 2: Run Bandit**
+
+Run:
+
+```bash
+source .venv/bin/activate
+python -m bandit -r \
+  mcp_unified/gateway/snapshots.py \
+  mcp_unified/gateway/config.py \
+  mcp_unified/gateway/cli.py \
+  -f json -o /tmp/bandit_mcp_gateway_config_snapshots.json
+```
+
+- [ ] **Step 3: Update Backlog**
+
+Record touched files, verification commands, known skips, and final summary in `TASK-592`.

--- a/Docs/superpowers/plans/2026-06-02-mcp-gateway-config-snapshots.md
+++ b/Docs/superpowers/plans/2026-06-02-mcp-gateway-config-snapshots.md
@@ -38,7 +38,7 @@
 **Files:**
 - Create: `tldw_Server_API/app/core/MCP_unified/tests/test_gateway_config_snapshots.py`
 
-- [ ] **Step 1: Write export shape test**
+- [x] **Step 1: Write export shape test**
 
 Create a SQLite-backed gateway store with one profile, default assignment, external server, and credential grant. Assert export returns a deterministic object with:
 
@@ -53,19 +53,19 @@ Create a SQLite-backed gateway store with one profile, default assignment, exter
 }
 ```
 
-- [ ] **Step 2: Write dry-run test**
+- [x] **Step 2: Write dry-run test**
 
 Assert `import_snapshot(..., dry_run=True)` returns a mutation plan and leaves target stores unchanged.
 
-- [ ] **Step 3: Write secret-safety test**
+- [x] **Step 3: Write secret-safety test**
 
 Assert snapshot validation rejects metadata/provenance keys containing `secret`, `token`, `password`, `api_key`, `authorization`, `headers`, `env`, or `credential_value`.
 
-- [ ] **Step 4: Write external-server inline secret tests**
+- [x] **Step 4: Write external-server inline secret tests**
 
 Assert export/import validation rejects external server `command` args containing inline values such as `--token=abc`, `api_key=abc`, or `PASSWORD=abc`, URL userinfo such as `https://user:pass@example.test`, and URL query keys such as `?token=abc`. `env_allowlist` may still contain environment variable names because it does not contain values.
 
-- [ ] **Step 5: Run tests to verify they fail**
+- [x] **Step 5: Run tests to verify they fail**
 
 Run:
 
@@ -81,7 +81,7 @@ Expected: fail because `mcp_unified.gateway.snapshots` does not exist.
 **Files:**
 - Create: `mcp_unified/gateway/snapshots.py`
 
-- [ ] **Step 1: Add snapshot models**
+- [x] **Step 1: Add snapshot models**
 
 Define models:
 
@@ -97,15 +97,15 @@ class GatewayConfigSnapshot(BaseModel):
 
 Use model validators for deterministic ordering and secret-key rejection. Reuse the secret-key helper from `mcp_unified.gateway.credential_grants` and add snapshot-specific validators for external server command and URL fields.
 
-- [ ] **Step 2: Add manager dependencies**
+- [x] **Step 2: Add manager dependencies**
 
 Create `GatewayConfigSnapshotManager` with required stores: `profile_store`, `assignment_store`, `external_registry_store`, and `credential_grant_store`. Optionally accept `audit_store`.
 
-- [ ] **Step 3: Implement export**
+- [x] **Step 3: Implement export**
 
 Read all records through protocol methods, load only the default assignment from `GATEWAY_DEFAULT_ASSIGNMENT_ID`, sort lists by id, validate the full snapshot for secret safety, and return JSON-safe model dumps.
 
-- [ ] **Step 4: Run export tests**
+- [x] **Step 4: Run export tests**
 
 Run:
 
@@ -121,11 +121,11 @@ Expected: pass.
 **Files:**
 - Modify: `mcp_unified/gateway/snapshots.py`
 
-- [ ] **Step 1: Add mutation plan payload**
+- [x] **Step 1: Add mutation plan payload**
 
 Return planned actions such as `upsert_profile`, `set_default_assignment`, `upsert_external_server`, and `upsert_credential_grant` with target ids and counts. Include enough detail for failures to identify which action failed without echoing raw snapshot payloads.
 
-- [ ] **Step 2: Add reference validation**
+- [x] **Step 2: Add reference validation**
 
 Validate:
 
@@ -135,19 +135,19 @@ Validate:
 - every referenced credential slot is present in the referenced external server definition when that server is known.
 - all secret-safety checks pass before any write begins.
 
-- [ ] **Step 3: Define atomicity behavior**
+- [x] **Step 3: Define atomicity behavior**
 
 Document in code comments and docs that the generic manager is validate-first best-effort: it validates the full snapshot before writing, then reports applied and failed action ids if an injected store fails during writes. Do not claim transactionality for arbitrary stores. If all stores are the same `SQLiteMCPStore` and a small transaction helper already exists, it may be used, but it is not required for this slice.
 
-- [ ] **Step 4: Apply import in safe order**
+- [x] **Step 4: Apply import in safe order**
 
 Upsert profiles first, then default assignment, then external servers, then credential grants. Do not delete local records absent from the snapshot.
 
-- [ ] **Step 5: Add audit events**
+- [x] **Step 5: Add audit events**
 
 Append best-effort audit events for import start/completion/failure when an audit store is available. Do not include snapshot raw payload in audit metadata.
 
-- [ ] **Step 6: Run import tests**
+- [x] **Step 6: Run import tests**
 
 Run:
 
@@ -165,11 +165,11 @@ Expected: pass.
 - Modify: `mcp_unified/gateway/cli.py`
 - Modify: `tldw_Server_API/app/core/MCP_unified/tests/test_gateway_cli_package.py`
 
-- [ ] **Step 1: Add builder helper**
+- [x] **Step 1: Add builder helper**
 
 Add `gateway_config_snapshot_manager_from_storage(...)` or equivalent helper that builds the manager from existing profile/external storage bundles.
 
-- [ ] **Step 2: Write CLI tests**
+- [x] **Step 2: Write CLI tests**
 
 Cover:
 
@@ -179,11 +179,11 @@ Cover:
 - `import-config --config <path> --snapshot-file <file>` applies upserts.
 - import failure after validation reports applied and failed action ids without raw secret-bearing payloads.
 
-- [ ] **Step 3: Implement CLI handlers**
+- [x] **Step 3: Implement CLI handlers**
 
 Use existing `_load_json_argument_file`, `_emit_json`, and config path helpers. Reject memory stores because snapshots are meant for persistent standalone configuration.
 
-- [ ] **Step 4: Run CLI tests**
+- [x] **Step 4: Run CLI tests**
 
 Run:
 
@@ -200,7 +200,7 @@ Expected: pass.
 - Modified files from prior tasks.
 - Backlog task `TASK-592`.
 
-- [ ] **Step 1: Run focused tests**
+- [x] **Step 1: Run focused tests**
 
 Run:
 
@@ -212,7 +212,7 @@ python -m pytest \
   -v
 ```
 
-- [ ] **Step 2: Run Bandit**
+- [x] **Step 2: Run Bandit**
 
 Run:
 
@@ -225,6 +225,6 @@ python -m bandit -r \
   -f json -o /tmp/bandit_mcp_gateway_config_snapshots.json
 ```
 
-- [ ] **Step 3: Update Backlog**
+- [x] **Step 3: Update Backlog**
 
 Record touched files, verification commands, known skips, and final summary in `TASK-592`.

--- a/Docs/superpowers/plans/2026-06-02-mcp-gateway-remote-runtime-cli-docs.md
+++ b/Docs/superpowers/plans/2026-06-02-mcp-gateway-remote-runtime-cli-docs.md
@@ -1,0 +1,224 @@
+# MCP Gateway Remote Runtime CLI And Docs Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add CLI commands that control external runtime lifecycle operations by calling a running standalone gateway, then document the end-to-end standalone admin workflow.
+
+**Architecture:** Keep process ownership clear: local CLI store commands edit persistent config, while remote runtime CLI commands call HTTP admin endpoints on an already-running gateway. Use a small package-owned remote admin client with stdlib HTTP transport unless the package already depends on an HTTP client; pass admin auth through headers from environment/config without logging secret values.
+
+**Tech Stack:** Python, argparse, stdlib `urllib.request` or existing HTTP client if already required, FastAPI admin routes, pytest, Bandit, Markdown docs.
+
+**Backlog Task:** `TASK-593`
+
+**Depends On:** `TASK-591`, `TASK-592`
+
+---
+
+## File Structure
+
+- Create `mcp_unified/gateway/remote_admin.py`: remote gateway admin client, URL normalization, auth header handling, JSON request/response helpers, sanitized errors.
+- Modify `mcp_unified/gateway/cli.py`: add remote runtime commands.
+- Modify `mcp_unified/gateway/fastapi.py`: only if route response shapes need minor normalization discovered by tests.
+- Create `Docs/MCP_UNIFIED_STANDALONE_GATEWAY_ADMIN.md`: standalone gateway admin/config usage guide.
+- Create `tldw_Server_API/app/core/MCP_unified/tests/test_gateway_remote_runtime_cli.py`: remote client and CLI command behavior.
+- Modify `tldw_Server_API/app/core/MCP_unified/tests/test_gateway_cli_package.py`: parser/help coverage if existing CLI tests centralize command assertions.
+
+## Acceptance Criteria
+
+- CLI can call a running gateway for runtime list/start/stop/restart/refresh/reconcile/install/update operations.
+- CLI runtime commands require an explicit `--gateway-url` or `MCP_UNIFIED_GATEWAY_URL`.
+- Admin auth uses an environment-provided value such as `MCP_UNIFIED_GATEWAY_ADMIN_KEY`; command-line secret arguments are avoided.
+- CLI preserves the gateway JSON payloads and reason codes.
+- Docs explain local store commands versus remote runtime commands and include a safe credential-grant example.
+- No runtime CLI command starts an upstream process that becomes orphaned when the CLI exits.
+
+### Task 1: Add Remote Client Failing Tests
+
+**Files:**
+- Create: `tldw_Server_API/app/core/MCP_unified/tests/test_gateway_remote_runtime_cli.py`
+
+- [ ] **Step 1: Write URL normalization tests**
+
+Assert base URLs with or without trailing slash resolve paths such as `/mcp/external-servers/runtime` correctly.
+
+- [ ] **Step 2: Write auth header tests**
+
+Assert the remote client sends the configured admin header when `MCP_UNIFIED_GATEWAY_ADMIN_KEY` is set and omits it when absent.
+
+- [ ] **Step 3: Write response/error tests**
+
+Use a fake request function to assert JSON payload passthrough for success and sanitized error envelopes for malformed responses or connection failures.
+
+- [ ] **Step 4: Run tests to verify they fail**
+
+Run:
+
+```bash
+source .venv/bin/activate
+python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_gateway_remote_runtime_cli.py -v
+```
+
+Expected: fail because `mcp_unified.gateway.remote_admin` does not exist.
+
+### Task 2: Implement Remote Admin Client
+
+**Files:**
+- Create: `mcp_unified/gateway/remote_admin.py`
+
+- [ ] **Step 1: Add client config**
+
+Create a small dataclass:
+
+```python
+@dataclass(frozen=True, slots=True)
+class RemoteGatewayAdminConfig:
+    gateway_url: str
+    admin_header_name: str = "X-MCP-Gateway-Admin-Key"
+    admin_key: str | None = None
+    timeout_seconds: float = 30.0
+```
+
+- [ ] **Step 2: Add request helper**
+
+Implement JSON GET/POST helpers. Prefer stdlib `urllib.request` to avoid a new runtime dependency unless the package already requires an HTTP client.
+
+- [ ] **Step 3: Add runtime methods**
+
+Implement:
+
+```python
+list_runtime_servers()
+start_server(server_id)
+stop_server(server_id)
+restart_server(server_id)
+refresh_server(server_id: str | None = None)
+reconcile(server_id: str | None = None)
+install_server(server_id)
+update_server(server_id)
+```
+
+- [ ] **Step 4: Run client tests**
+
+Run:
+
+```bash
+source .venv/bin/activate
+python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_gateway_remote_runtime_cli.py -v
+```
+
+Expected: pass for client-level tests.
+
+### Task 3: Add Remote Runtime CLI Commands
+
+**Files:**
+- Modify: `mcp_unified/gateway/cli.py`
+- Modify: `tldw_Server_API/app/core/MCP_unified/tests/test_gateway_remote_runtime_cli.py`
+- Modify: `tldw_Server_API/app/core/MCP_unified/tests/test_gateway_cli_package.py` if needed.
+
+- [ ] **Step 1: Write CLI command tests**
+
+Cover flat commands to match existing CLI style:
+
+- `runtime-list`
+- `runtime-start <server_id>`
+- `runtime-stop <server_id>`
+- `runtime-restart <server_id>`
+- `runtime-refresh [server_id]`
+- `runtime-reconcile [server_id]`
+- `runtime-install <server_id>`
+- `runtime-update <server_id>`
+
+Each command should accept `--gateway-url`; tests should also cover `MCP_UNIFIED_GATEWAY_URL`.
+
+- [ ] **Step 2: Add common remote options**
+
+Add helpers for:
+
+- `--gateway-url`
+- `--admin-header-name`
+- admin key from `MCP_UNIFIED_GATEWAY_ADMIN_KEY`
+- timeout from optional `--timeout-seconds`
+
+Avoid `--admin-key` to keep secrets out of process lists.
+
+- [ ] **Step 3: Implement handlers**
+
+Call `RemoteGatewayAdminClient` methods and emit exactly one JSON object to stdout or stderr, matching existing CLI behavior.
+
+- [ ] **Step 4: Run CLI tests**
+
+Run:
+
+```bash
+source .venv/bin/activate
+python -m pytest \
+  tldw_Server_API/app/core/MCP_unified/tests/test_gateway_remote_runtime_cli.py \
+  tldw_Server_API/app/core/MCP_unified/tests/test_gateway_cli_package.py \
+  -v
+```
+
+Expected: pass.
+
+### Task 4: Add Standalone Admin Documentation
+
+**Files:**
+- Create: `Docs/MCP_UNIFIED_STANDALONE_GATEWAY_ADMIN.md`
+
+- [ ] **Step 1: Document concepts**
+
+Explain:
+
+- profile store versus running gateway runtime.
+- local config CLI commands versus remote runtime CLI commands.
+- credential grants as broker metadata, not secret storage.
+- admin auth setup and expected header/env vars.
+
+- [ ] **Step 2: Add safe examples**
+
+Include examples for:
+
+- validating config.
+- duplicating a preset.
+- creating an external server.
+- creating a credential grant with broker id and slot only.
+- exporting/importing a snapshot.
+- calling `runtime-list`, `runtime-start`, and `runtime-refresh`.
+
+- [ ] **Step 3: Add operational cautions**
+
+State that runtime commands require a running gateway and do not start durable upstream processes from a short-lived local CLI.
+
+### Task 5: Final Verification
+
+**Files:**
+- Modified files from prior tasks.
+- Backlog task `TASK-593`.
+
+- [ ] **Step 1: Run focused tests**
+
+Run:
+
+```bash
+source .venv/bin/activate
+python -m pytest \
+  tldw_Server_API/app/core/MCP_unified/tests/test_gateway_remote_runtime_cli.py \
+  tldw_Server_API/app/core/MCP_unified/tests/test_gateway_cli_package.py \
+  -v
+```
+
+- [ ] **Step 2: Run Bandit**
+
+Run:
+
+```bash
+source .venv/bin/activate
+python -m bandit -r \
+  mcp_unified/gateway/remote_admin.py \
+  mcp_unified/gateway/cli.py \
+  mcp_unified/gateway/fastapi.py \
+  -f json -o /tmp/bandit_mcp_gateway_remote_runtime_cli.json
+```
+
+- [ ] **Step 3: Update Backlog**
+
+Record touched files, verification commands, known skips, and final summary in `TASK-593`.

--- a/Docs/superpowers/plans/2026-06-02-mcp-gateway-remote-runtime-cli-docs.md
+++ b/Docs/superpowers/plans/2026-06-02-mcp-gateway-remote-runtime-cli-docs.md
@@ -4,7 +4,7 @@
 
 **Goal:** Add CLI commands that control external runtime lifecycle operations by calling a running standalone gateway, then document the end-to-end standalone admin workflow.
 
-**Architecture:** Keep process ownership clear: local CLI store commands edit persistent config, while remote runtime CLI commands call HTTP admin endpoints on an already-running gateway. Use a small package-owned remote admin client with stdlib HTTP transport unless the package already depends on an HTTP client; pass admin auth through headers from environment/config without logging secret values.
+**Architecture:** Keep process ownership clear: local CLI store commands edit persistent config, while remote runtime CLI commands call HTTP admin endpoints on an already-running gateway. `--gateway-url` is the gateway admin base URL, including whatever prefix the server mounted, for example `http://127.0.0.1:8000/mcp`; the client only trims trailing slashes and appends endpoint paths. Use a small package-owned remote admin client with stdlib HTTP transport unless the package already depends on an HTTP client; pass admin auth through headers from environment/config without logging secret values.
 
 **Tech Stack:** Python, argparse, stdlib `urllib.request` or existing HTTP client if already required, FastAPI admin routes, pytest, Bandit, Markdown docs.
 
@@ -26,9 +26,9 @@
 ## Acceptance Criteria
 
 - CLI can call a running gateway for runtime list/start/stop/restart/refresh/reconcile/install/update operations.
-- CLI runtime commands require an explicit `--gateway-url` or `MCP_UNIFIED_GATEWAY_URL`.
+- CLI runtime commands require an explicit `--gateway-url` or `MCP_UNIFIED_GATEWAY_URL`, and that URL is documented as the already-mounted gateway base path such as `http://host/mcp`.
 - Admin auth uses an environment-provided value such as `MCP_UNIFIED_GATEWAY_ADMIN_KEY`; command-line secret arguments are avoided.
-- CLI preserves the gateway JSON payloads and reason codes.
+- CLI preserves the gateway JSON payloads and reason codes for both successful responses and HTTP 4xx/5xx error bodies.
 - Docs explain local store commands versus remote runtime commands and include a safe credential-grant example.
 - No runtime CLI command starts an upstream process that becomes orphaned when the CLI exits.
 
@@ -39,7 +39,7 @@
 
 - [ ] **Step 1: Write URL normalization tests**
 
-Assert base URLs with or without trailing slash resolve paths such as `/mcp/external-servers/runtime` correctly.
+Assert base URLs with or without trailing slash resolve endpoint paths correctly. Treat `http://host/mcp` as the gateway base and resolve runtime list to `http://host/mcp/external-servers/runtime`; do not automatically add `/mcp` to `http://host` because gateway prefixes are configurable.
 
 - [ ] **Step 2: Write auth header tests**
 
@@ -49,7 +49,11 @@ Assert the remote client sends the configured admin header when `MCP_UNIFIED_GAT
 
 Use a fake request function to assert JSON payload passthrough for success and sanitized error envelopes for malformed responses or connection failures.
 
-- [ ] **Step 4: Run tests to verify they fail**
+- [ ] **Step 4: Write HTTP error preservation tests**
+
+Simulate stdlib `urllib.error.HTTPError` for 401, 404, and 503 responses with JSON bodies. Assert the CLI/client preserves gateway `reason_code`, `server_id`, and public `error` fields instead of replacing them with a generic connection error.
+
+- [ ] **Step 5: Run tests to verify they fail**
 
 Run:
 
@@ -78,9 +82,11 @@ class RemoteGatewayAdminConfig:
     timeout_seconds: float = 30.0
 ```
 
+Validate `gateway_url` is non-blank and has `http` or `https` scheme. Store the normalized base URL without a trailing slash; do not mutate path prefixes beyond trimming trailing slash.
+
 - [ ] **Step 2: Add request helper**
 
-Implement JSON GET/POST helpers. Prefer stdlib `urllib.request` to avoid a new runtime dependency unless the package already requires an HTTP client.
+Implement JSON GET/POST helpers. Prefer stdlib `urllib.request` to avoid a new runtime dependency unless the package already requires an HTTP client. When `urllib` raises `HTTPError`, read and parse the response body; if it is a JSON object, preserve that payload and exit non-zero from CLI handlers.
 
 - [ ] **Step 3: Add runtime methods**
 
@@ -141,6 +147,8 @@ Add helpers for:
 
 Avoid `--admin-key` to keep secrets out of process lists.
 
+Document and test that `--gateway-url` should include the gateway prefix. Example: `--gateway-url http://127.0.0.1:8000/mcp`.
+
 - [ ] **Step 3: Implement handlers**
 
 Call `RemoteGatewayAdminClient` methods and emit exactly one JSON object to stdout or stderr, matching existing CLI behavior.
@@ -172,6 +180,7 @@ Explain:
 - local config CLI commands versus remote runtime CLI commands.
 - credential grants as broker metadata, not secret storage.
 - admin auth setup and expected header/env vars.
+- why `--gateway-url` includes the mounted prefix and how that differs from a server origin URL.
 
 - [ ] **Step 2: Add safe examples**
 
@@ -183,6 +192,7 @@ Include examples for:
 - creating a credential grant with broker id and slot only.
 - exporting/importing a snapshot.
 - calling `runtime-list`, `runtime-start`, and `runtime-refresh`.
+- an HTTP error example showing the gateway `reason_code` preserved in CLI output.
 
 - [ ] **Step 3: Add operational cautions**
 

--- a/Docs/superpowers/plans/2026-06-02-mcp-gateway-remote-runtime-cli-docs.md
+++ b/Docs/superpowers/plans/2026-06-02-mcp-gateway-remote-runtime-cli-docs.md
@@ -37,23 +37,23 @@
 **Files:**
 - Create: `tldw_Server_API/app/core/MCP_unified/tests/test_gateway_remote_runtime_cli.py`
 
-- [ ] **Step 1: Write URL normalization tests**
+- [x] **Step 1: Write URL normalization tests**
 
 Assert base URLs with or without trailing slash resolve endpoint paths correctly. Treat `http://host/mcp` as the gateway base and resolve runtime list to `http://host/mcp/external-servers/runtime`; do not automatically add `/mcp` to `http://host` because gateway prefixes are configurable.
 
-- [ ] **Step 2: Write auth header tests**
+- [x] **Step 2: Write auth header tests**
 
 Assert the remote client sends the configured admin header when `MCP_UNIFIED_GATEWAY_ADMIN_KEY` is set and omits it when absent.
 
-- [ ] **Step 3: Write response/error tests**
+- [x] **Step 3: Write response/error tests**
 
 Use a fake request function to assert JSON payload passthrough for success and sanitized error envelopes for malformed responses or connection failures.
 
-- [ ] **Step 4: Write HTTP error preservation tests**
+- [x] **Step 4: Write HTTP error preservation tests**
 
 Simulate stdlib `urllib.error.HTTPError` for 401, 404, and 503 responses with JSON bodies. Assert the CLI/client preserves gateway `reason_code`, `server_id`, and public `error` fields instead of replacing them with a generic connection error.
 
-- [ ] **Step 5: Run tests to verify they fail**
+- [x] **Step 5: Run tests to verify they fail**
 
 Run:
 
@@ -69,7 +69,7 @@ Expected: fail because `mcp_unified.gateway.remote_admin` does not exist.
 **Files:**
 - Create: `mcp_unified/gateway/remote_admin.py`
 
-- [ ] **Step 1: Add client config**
+- [x] **Step 1: Add client config**
 
 Create a small dataclass:
 
@@ -84,11 +84,11 @@ class RemoteGatewayAdminConfig:
 
 Validate `gateway_url` is non-blank and has `http` or `https` scheme. Store the normalized base URL without a trailing slash; do not mutate path prefixes beyond trimming trailing slash.
 
-- [ ] **Step 2: Add request helper**
+- [x] **Step 2: Add request helper**
 
 Implement JSON GET/POST helpers. Prefer stdlib `urllib.request` to avoid a new runtime dependency unless the package already requires an HTTP client. When `urllib` raises `HTTPError`, read and parse the response body; if it is a JSON object, preserve that payload and exit non-zero from CLI handlers.
 
-- [ ] **Step 3: Add runtime methods**
+- [x] **Step 3: Add runtime methods**
 
 Implement:
 
@@ -103,7 +103,7 @@ install_server(server_id)
 update_server(server_id)
 ```
 
-- [ ] **Step 4: Run client tests**
+- [x] **Step 4: Run client tests**
 
 Run:
 
@@ -121,7 +121,7 @@ Expected: pass for client-level tests.
 - Modify: `tldw_Server_API/app/core/MCP_unified/tests/test_gateway_remote_runtime_cli.py`
 - Modify: `tldw_Server_API/app/core/MCP_unified/tests/test_gateway_cli_package.py` if needed.
 
-- [ ] **Step 1: Write CLI command tests**
+- [x] **Step 1: Write CLI command tests**
 
 Cover flat commands to match existing CLI style:
 
@@ -136,7 +136,7 @@ Cover flat commands to match existing CLI style:
 
 Each command should accept `--gateway-url`; tests should also cover `MCP_UNIFIED_GATEWAY_URL`.
 
-- [ ] **Step 2: Add common remote options**
+- [x] **Step 2: Add common remote options**
 
 Add helpers for:
 
@@ -149,11 +149,11 @@ Avoid `--admin-key` to keep secrets out of process lists.
 
 Document and test that `--gateway-url` should include the gateway prefix. Example: `--gateway-url http://127.0.0.1:8000/mcp`.
 
-- [ ] **Step 3: Implement handlers**
+- [x] **Step 3: Implement handlers**
 
 Call `RemoteGatewayAdminClient` methods and emit exactly one JSON object to stdout or stderr, matching existing CLI behavior.
 
-- [ ] **Step 4: Run CLI tests**
+- [x] **Step 4: Run CLI tests**
 
 Run:
 
@@ -172,7 +172,7 @@ Expected: pass.
 **Files:**
 - Create: `Docs/MCP_UNIFIED_STANDALONE_GATEWAY_ADMIN.md`
 
-- [ ] **Step 1: Document concepts**
+- [x] **Step 1: Document concepts**
 
 Explain:
 
@@ -182,7 +182,7 @@ Explain:
 - admin auth setup and expected header/env vars.
 - why `--gateway-url` includes the mounted prefix and how that differs from a server origin URL.
 
-- [ ] **Step 2: Add safe examples**
+- [x] **Step 2: Add safe examples**
 
 Include examples for:
 
@@ -194,7 +194,7 @@ Include examples for:
 - calling `runtime-list`, `runtime-start`, and `runtime-refresh`.
 - an HTTP error example showing the gateway `reason_code` preserved in CLI output.
 
-- [ ] **Step 3: Add operational cautions**
+- [x] **Step 3: Add operational cautions**
 
 State that runtime commands require a running gateway and do not start durable upstream processes from a short-lived local CLI.
 
@@ -204,7 +204,7 @@ State that runtime commands require a running gateway and do not start durable u
 - Modified files from prior tasks.
 - Backlog task `TASK-593`.
 
-- [ ] **Step 1: Run focused tests**
+- [x] **Step 1: Run focused tests**
 
 Run:
 
@@ -216,7 +216,7 @@ python -m pytest \
   -v
 ```
 
-- [ ] **Step 2: Run Bandit**
+- [x] **Step 2: Run Bandit**
 
 Run:
 
@@ -229,6 +229,6 @@ python -m bandit -r \
   -f json -o /tmp/bandit_mcp_gateway_remote_runtime_cli.json
 ```
 
-- [ ] **Step 3: Update Backlog**
+- [x] **Step 3: Update Backlog**
 
 Record touched files, verification commands, known skips, and final summary in `TASK-593`.

--- a/apps/packages/ui/src/components/Layouts/Layout.tsx
+++ b/apps/packages/ui/src/components/Layouts/Layout.tsx
@@ -423,7 +423,7 @@ const OptionLayoutInner: React.FC<OptionLayoutProps> = ({
                   ?.focus()
               })
             }}
-            className="absolute left-0 top-1/2 z-40 inline-flex h-28 w-10 -translate-y-1/2 flex-col items-center justify-center gap-2 rounded-r-lg border border-l-0 border-border bg-surface/95 text-text-muted shadow-lg backdrop-blur transition hover:bg-surface2 hover:text-text focus:outline-none focus-visible:ring-2 focus-visible:ring-focus focus-visible:ring-offset-2 focus-visible:ring-offset-bg"
+            className="absolute left-0 top-[calc(50%_-_8rem)] z-40 inline-flex h-28 w-10 -translate-y-1/2 flex-col items-center justify-center gap-2 rounded-r-lg border border-l-0 border-border bg-surface/95 text-text-muted shadow-lg backdrop-blur transition hover:bg-surface2 hover:text-text focus:outline-none focus-visible:ring-2 focus-visible:ring-focus focus-visible:ring-offset-2 focus-visible:ring-offset-bg"
           >
             <PanelLeftOpen className="h-4 w-4" aria-hidden="true" />
             <span

--- a/apps/packages/ui/src/components/Option/Playground/PlaygroundCockpitShell.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/PlaygroundCockpitShell.tsx
@@ -519,7 +519,7 @@ export const PlaygroundCockpitShell = ({
             onClick={() => onLeftRailVisibleChange?.(true)}
             tooltip={restoreContextSidechannelLabel}
             tooltipPlacement="right"
-            wrapperClassName="absolute left-10 top-1/2 z-20 hidden -translate-y-1/2 lg:inline-flex"
+            wrapperClassName="absolute left-10 top-1/2 z-50 hidden -translate-y-1/2 lg:inline-flex"
             className="inline-flex h-32 w-9 flex-col items-center justify-center gap-2 rounded-r-md border-y border-r border-border bg-surface2/95 py-2 text-[11px] font-semibold text-text shadow-md backdrop-blur-sm hover:bg-surface focus:outline-none focus-visible:ring-2 focus-visible:ring-focus"
           >
             <PanelLeftOpen className="h-3.5 w-3.5" aria-hidden="true" />
@@ -539,7 +539,7 @@ export const PlaygroundCockpitShell = ({
             onClick={() => onRightRailVisibleChange?.(true)}
             tooltip={restoreRuntimeSidechannelLabel}
             tooltipPlacement="left"
-            wrapperClassName="absolute right-0 top-1/2 z-20 hidden -translate-y-1/2 lg:inline-flex"
+            wrapperClassName="absolute right-0 top-1/2 z-50 hidden -translate-y-1/2 lg:inline-flex"
             className="inline-flex h-32 w-9 flex-col items-center justify-center gap-2 rounded-l-md border-y border-l border-border bg-surface2/95 py-2 text-[11px] font-semibold text-text shadow-md backdrop-blur-sm hover:bg-surface focus:outline-none focus-visible:ring-2 focus-visible:ring-focus"
           >
             <span className="whitespace-nowrap leading-none [writing-mode:vertical-rl]">

--- a/apps/packages/ui/src/components/ui/state/StatePanel.tsx
+++ b/apps/packages/ui/src/components/ui/state/StatePanel.tsx
@@ -14,6 +14,7 @@ export type StatePanelDiagnostic = Pick<DiagnosticRowProps, "label" | "value" | 
 export interface StatePanelProps {
   state: DesignSystemStateKey
   title: React.ReactNode
+  titleHeadingLevel?: 1 | 2 | 3 | 4
   message?: React.ReactNode
   diagnostics?: StatePanelDiagnostic[]
   primaryAction?: StateAction
@@ -48,6 +49,7 @@ const stateToneClasses: Partial<Record<DesignSystemStateKey, string>> = {
 export function StatePanel({
   state,
   title,
+  titleHeadingLevel = 2,
   message,
   diagnostics,
   primaryAction,
@@ -65,6 +67,7 @@ export function StatePanel({
   const toneClass = stateToneClasses[state] ?? severityClasses[definition.severity]
   const hasDiagnostics = diagnostics && diagnostics.length > 0
   const diagnosticsLabel = t("common:diagnostics", "Diagnostics")
+  const HeadingTag = `h${titleHeadingLevel}` as const
 
   return (
     <section
@@ -86,7 +89,7 @@ export function StatePanel({
             {definition.label}
           </span>
           <div>
-            <h2 className="text-base font-semibold text-text">{title}</h2>
+            <HeadingTag className="text-base font-semibold text-text">{title}</HeadingTag>
             {message ? <div className="mt-1 text-sm text-text-muted">{message}</div> : null}
           </div>
         </div>

--- a/apps/packages/ui/src/components/ui/state/__tests__/state-primitives.test.tsx
+++ b/apps/packages/ui/src/components/ui/state/__tests__/state-primitives.test.tsx
@@ -36,6 +36,7 @@ describe("state primitives", () => {
     )
 
     expect(screen.getByText("Diagnostics").closest("details")).not.toHaveAttribute("open")
+    expect(screen.getByRole("heading", { level: 2, name: "Request failed" })).toBeInTheDocument()
     expect(screen.getByLabelText("Diagnostics")).toBeInTheDocument()
     expect(screen.getByText("/api/v1/health")).toBeInTheDocument()
     expect(screen.getByRole("button", { name: "Retry" })).toBeInTheDocument()

--- a/apps/packages/ui/src/routes/__tests__/core-route-identity.test.tsx
+++ b/apps/packages/ui/src/routes/__tests__/core-route-identity.test.tsx
@@ -172,9 +172,16 @@ describe("core route identity guardrails", () => {
     )
     firstRender.unmount()
 
+    firstRunState.status = "completed"
     const secondRender = render(<OptionSetup />)
-    expect(screen.getByText("Setup operator recovery")).toBeInTheDocument()
-    expect(screen.getByTestId("unified-setup-shell")).toBeInTheDocument()
+    expect(
+      screen.getByRole("heading", {
+        level: 1,
+        name: "Setup operator recovery"
+      })
+    ).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Return home" })).toBeInTheDocument()
+    expect(screen.queryByTestId("unified-setup-shell")).not.toBeInTheDocument()
     expect(optionLayoutMock).toHaveBeenLastCalledWith(
       expect.objectContaining({
         hideHeader: true,

--- a/apps/packages/ui/src/routes/option-setup.tsx
+++ b/apps/packages/ui/src/routes/option-setup.tsx
@@ -25,6 +25,7 @@ const OptionSetup = () => {
       <SetupRequiredPanel
         className="mx-auto mb-4 w-full max-w-3xl"
         title={t("setupRoute.recoveryTitle", "Setup operator recovery")}
+        titleHeadingLevel={showWizard ? 2 : 1}
         message={t(
           "setupRoute.recoveryMessage",
           "Use this surface when first-run setup needs local operator recovery."

--- a/apps/tldw-frontend/components/layout/WebLayout.tsx
+++ b/apps/tldw-frontend/components/layout/WebLayout.tsx
@@ -432,7 +432,7 @@ const OptionLayoutInner: React.FC<OptionLayoutProps> = ({
                   ?.focus();
               });
             }}
-            className="absolute left-0 top-1/2 z-40 inline-flex h-28 w-10 -translate-y-1/2 flex-col items-center justify-center gap-2 rounded-r-lg border border-l-0 border-border bg-surface/95 text-text-muted shadow-lg backdrop-blur transition hover:bg-surface2 hover:text-text focus:outline-none focus-visible:ring-2 focus-visible:ring-focus focus-visible:ring-offset-2 focus-visible:ring-offset-bg"
+            className="absolute left-0 top-[calc(50%_-_8rem)] z-40 inline-flex h-28 w-10 -translate-y-1/2 flex-col items-center justify-center gap-2 rounded-r-lg border border-l-0 border-border bg-surface/95 text-text-muted shadow-lg backdrop-blur transition hover:bg-surface2 hover:text-text focus:outline-none focus-visible:ring-2 focus-visible:ring-focus focus-visible:ring-offset-2 focus-visible:ring-offset-bg"
           >
             <PanelLeftOpen className="h-4 w-4" aria-hidden="true" />
             <span

--- a/apps/tldw-frontend/components/networking/ConfigurationErrorScreen.tsx
+++ b/apps/tldw-frontend/components/networking/ConfigurationErrorScreen.tsx
@@ -25,6 +25,7 @@ export const ConfigurationErrorScreen = ({
       >
         <SetupRequiredPanel
           title="WebUI networking configuration error"
+          titleHeadingLevel={1}
           message={
             <>
               The configured API URL points to <code>{issue.apiOrigin}</code>,

--- a/apps/tldw-frontend/components/networking/__tests__/ConfigurationErrorScreen.test.tsx
+++ b/apps/tldw-frontend/components/networking/__tests__/ConfigurationErrorScreen.test.tsx
@@ -18,6 +18,7 @@ describe("ConfigurationErrorScreen", () => {
     expect(screen.getByText("Setup required")).toBeInTheDocument()
     expect(
       screen.getByRole("heading", {
+        level: 1,
         name: "WebUI networking configuration error"
       })
     ).toBeInTheDocument()

--- a/apps/tldw-frontend/e2e/workflows/chat-rails-collapse.spec.ts
+++ b/apps/tldw-frontend/e2e/workflows/chat-rails-collapse.spec.ts
@@ -112,6 +112,32 @@ const expectRightEdgeHandle = async (page: Page, button: Locator) => {
 }
 
 test.describe("/chat siderail collapse", () => {
+  test("desktop cockpit restore stays clickable above the collapsed chat rail edge", async ({ page }) => {
+    await page.setViewportSize({ width: 1440, height: 960 })
+    await prepareChatRailPage(page)
+    await page.goto("/chat", { waitUntil: "domcontentloaded" })
+    await waitForAppShell(page)
+
+    const chatRailEdge = page.getByTestId("chat-sidebar-edge-expand")
+    await expect(chatRailEdge).toBeVisible()
+
+    const cockpitLeftRail = page.getByTestId("playground-cockpit-left-rail")
+    await expect(cockpitLeftRail).toBeVisible()
+    await cockpitLeftRail
+      .getByRole("button", { name: "Collapse context sidechannel" })
+      .click()
+
+    const cockpitRestore = page.getByTestId(
+      "playground-cockpit-left-rail-restore",
+    )
+    await expect(cockpitRestore).toBeVisible()
+    await expect(chatRailEdge).toBeVisible()
+
+    await cockpitRestore.click()
+    await expect(cockpitLeftRail).toBeVisible()
+    await expect(chatRailEdge).toBeVisible()
+  })
+
   test("desktop default composer keeps collapsed rails recoverable from the same edge", async ({ page }) => {
     await page.setViewportSize({ width: 1440, height: 960 })
     await prepareChatRailPage(page)

--- a/backlog/tasks/task-591 - Implement-standalone-MCP-gateway-admin-auth-and-credential-grant-management.md
+++ b/backlog/tasks/task-591 - Implement-standalone-MCP-gateway-admin-auth-and-credential-grant-management.md
@@ -1,0 +1,64 @@
+---
+id: TASK-591
+title: Implement standalone MCP gateway admin auth and credential grant management
+status: To Do
+assignee: []
+created_date: ''
+updated_date: '2026-06-02 02:05'
+labels:
+  - mcp-unified
+  - standalone-gateway
+  - security
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Add a package-owned admin auth seam plus credential-grant metadata manager, FastAPI routes, and CLI commands for the standalone MCP gateway. Keep secret material out of persistence and responses.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Management routes can require standalone admin auth without importing tldw_Server_API.
+- [ ] #2 JSON-RPC /request and /ws routes are not accidentally gated by admin auth.
+- [ ] #3 Credential grants support list/show/create/patch/delete through manager, FastAPI, and CLI.
+- [ ] #4 Credential grants persist only broker references, slots, scopes, metadata, and provenance; secret-looking values are rejected or omitted before persistence.
+- [ ] #5 External-server delete guards continue to block deletion when enabled grants reference the server.
+- [ ] #6 Focused tests and Bandit on touched package files are recorded.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Docs/superpowers/plans/2026-06-02-mcp-gateway-admin-auth-credential-grants.md
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-591 - Implement-standalone-MCP-gateway-admin-auth-and-credential-grant-management.md
+++ b/backlog/tasks/task-591 - Implement-standalone-MCP-gateway-admin-auth-and-credential-grant-management.md
@@ -4,7 +4,7 @@ title: Implement standalone MCP gateway admin auth and credential grant manageme
 status: To Do
 assignee: []
 created_date: ''
-updated_date: '2026-06-02 02:05'
+updated_date: '2026-06-02 02:20'
 labels:
   - mcp-unified
   - standalone-gateway
@@ -27,6 +27,9 @@ Add a package-owned admin auth seam plus credential-grant metadata manager, Fast
 - [ ] #4 Credential grants persist only broker references, slots, scopes, metadata, and provenance; secret-looking values are rejected or omitted before persistence.
 - [ ] #5 External-server delete guards continue to block deletion when enabled grants reference the server.
 - [ ] #6 Focused tests and Bandit on touched package files are recorded.
+- [ ] #7 Standalone config can enable admin auth and resolve the admin key from an environment variable without persisting the key.
+- [ ] #8 Credential-grant create rejects duplicate ids atomically instead of replacing existing grants.
+- [ ] #9 Admin auth errors return direct stable JSON payloads rather than framework-wrapped detail payloads.
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -47,8 +50,8 @@ Docs/superpowers/plans/2026-06-02-mcp-gateway-admin-auth-credential-grants.md
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-
 <!-- SECTION:FINAL_SUMMARY:END -->
+
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 <!-- SECTION:FINAL_SUMMARY:END -->

--- a/backlog/tasks/task-591 - Implement-standalone-MCP-gateway-admin-auth-and-credential-grant-management.md
+++ b/backlog/tasks/task-591 - Implement-standalone-MCP-gateway-admin-auth-and-credential-grant-management.md
@@ -35,15 +35,15 @@ Add a package-owned admin auth seam plus credential-grant metadata manager, Fast
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Management routes can require standalone admin auth without importing tldw_Server_API.
-- [ ] #2 JSON-RPC /request and /ws routes are not accidentally gated by admin auth.
-- [ ] #3 Credential grants support list/show/create/patch/delete through manager, FastAPI, and CLI.
-- [ ] #4 Credential grants persist only broker references, slots, scopes, metadata, and provenance; secret-looking values are rejected or omitted before persistence.
-- [ ] #5 External-server delete guards continue to block deletion when enabled grants reference the server.
-- [ ] #6 Focused tests and Bandit on touched package files are recorded.
-- [ ] #7 Standalone config can enable admin auth and resolve the admin key from an environment variable without persisting the key.
-- [ ] #8 Credential-grant create rejects duplicate ids atomically instead of replacing existing grants.
-- [ ] #9 Admin auth errors return direct stable JSON payloads rather than framework-wrapped detail payloads.
+- [x] #1 Management routes can require standalone admin auth without importing tldw_Server_API.
+- [x] #2 JSON-RPC /request and /ws routes are not accidentally gated by admin auth.
+- [x] #3 Credential grants support list/show/create/patch/delete through manager, FastAPI, and CLI.
+- [x] #4 Credential grants persist only broker references, slots, scopes, metadata, and provenance; secret-looking values are rejected or omitted before persistence.
+- [x] #5 External-server delete guards continue to block deletion when enabled grants reference the server.
+- [x] #6 Focused tests and Bandit on touched package files are recorded.
+- [x] #7 Standalone config can enable admin auth and resolve the admin key from an environment variable without persisting the key.
+- [x] #8 Credential-grant create rejects duplicate ids atomically instead of replacing existing grants.
+- [x] #9 Admin auth errors return direct stable JSON payloads rather than framework-wrapped detail payloads.
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -66,16 +66,12 @@ Docs/superpowers/plans/2026-06-02-mcp-gateway-admin-auth-credential-grants.md
 Implemented standalone gateway admin auth and credential-grant management. Added optional package-owned admin auth for management routes with direct JSON 401/403 payloads, config support that resolves admin keys from env vars without persisting them, and bootstrap propagation. Added credential-grant manager validation, recursive secret-key rejection, atomic create semantics, FastAPI routes, CLI commands, and SQLite create_grant support. Verification: `python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_gateway_admin_auth.py tldw_Server_API/app/core/MCP_unified/tests/test_gateway_credential_grants.py tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py tldw_Server_API/app/core/MCP_unified/tests/test_gateway_cli_package.py -v` passed with 241 tests; `python -m bandit -r mcp_unified/gateway/admin_auth.py mcp_unified/gateway/credential_grants.py mcp_unified/gateway/config.py mcp_unified/gateway/bootstrap.py mcp_unified/gateway/fastapi.py mcp_unified/gateway/cli.py mcp_unified/storage/sqlite.py mcp_unified/interfaces/storage.py -f json -o /tmp/bandit_mcp_gateway_admin_config.json` passed; `git diff --check` passed.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
-<!-- SECTION:FINAL_SUMMARY:END -->
-
-<!-- SECTION:FINAL_SUMMARY:END -->
-
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->

--- a/backlog/tasks/task-591 - Implement-standalone-MCP-gateway-admin-auth-and-credential-grant-management.md
+++ b/backlog/tasks/task-591 - Implement-standalone-MCP-gateway-admin-auth-and-credential-grant-management.md
@@ -1,16 +1,30 @@
 ---
 id: TASK-591
 title: Implement standalone MCP gateway admin auth and credential grant management
-status: To Do
+status: Done
 assignee: []
 created_date: ''
-updated_date: '2026-06-02 02:20'
+updated_date: 2026-06-02 02:20
 labels:
-  - mcp-unified
-  - standalone-gateway
-  - security
+- mcp-unified
+- standalone-gateway
+- security
 dependencies: []
 priority: medium
+modified_files:
+- mcp_unified/gateway/admin_auth.py
+- mcp_unified/gateway/credential_grants.py
+- mcp_unified/gateway/__init__.py
+- mcp_unified/gateway/bootstrap.py
+- mcp_unified/gateway/config.py
+- mcp_unified/gateway/fastapi.py
+- mcp_unified/gateway/cli.py
+- mcp_unified/interfaces/storage.py
+- mcp_unified/storage/sqlite.py
+- tldw_Server_API/app/core/MCP_unified/tests/test_gateway_admin_auth.py
+- tldw_Server_API/app/core/MCP_unified/tests/test_gateway_credential_grants.py
+- tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py
+- tldw_Server_API/app/core/MCP_unified/tests/test_gateway_cli_package.py
 ---
 
 ## Description
@@ -49,7 +63,7 @@ Docs/superpowers/plans/2026-06-02-mcp-gateway-admin-auth-credential-grants.md
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Implemented standalone gateway admin auth and credential-grant management. Added optional package-owned admin auth for management routes with direct JSON 401/403 payloads, config support that resolves admin keys from env vars without persisting them, and bootstrap propagation. Added credential-grant manager validation, recursive secret-key rejection, atomic create semantics, FastAPI routes, CLI commands, and SQLite create_grant support. Verification: `python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_gateway_admin_auth.py tldw_Server_API/app/core/MCP_unified/tests/test_gateway_credential_grants.py tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py tldw_Server_API/app/core/MCP_unified/tests/test_gateway_cli_package.py -v` passed with 241 tests; `python -m bandit -r mcp_unified/gateway/admin_auth.py mcp_unified/gateway/credential_grants.py mcp_unified/gateway/config.py mcp_unified/gateway/bootstrap.py mcp_unified/gateway/fastapi.py mcp_unified/gateway/cli.py mcp_unified/storage/sqlite.py mcp_unified/interfaces/storage.py -f json -o /tmp/bandit_mcp_gateway_admin_config.json` passed; `git diff --check` passed.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 <!-- SECTION:FINAL_SUMMARY:END -->

--- a/backlog/tasks/task-592 - Implement-standalone-MCP-gateway-config-import-export-snapshots.md
+++ b/backlog/tasks/task-592 - Implement-standalone-MCP-gateway-config-import-export-snapshots.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-592
 title: Implement standalone MCP gateway config import export snapshots
-status: To Do
+status: Done
 assignee: []
 created_date: ''
-updated_date: '2026-06-02 02:20'
+updated_date: '2026-06-02 03:12'
 labels:
   - mcp-unified
   - standalone-gateway
@@ -22,14 +22,14 @@ Add versioned import/export snapshot workflows for standalone gateway profiles, 
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Exported snapshots include schema version, profiles, default assignment, external servers, and credential grants.
-- [ ] #2 Snapshot output contains no plaintext secrets and rejects secret-looking metadata/provenance.
-- [ ] #3 Import dry-run validates references and reports planned mutations without writing.
-- [ ] #4 Import applies in safe order: profiles, default assignment, external servers, credential grants.
-- [ ] #5 Import defaults to upsert semantics and does not delete missing local records.
-- [ ] #6 A snapshot exported from one SQLite store can be imported into a fresh SQLite store and exported again with equivalent semantic content.
-- [ ] #7 Snapshot validation rejects secret-looking external server command args, URL userinfo, and sensitive URL query keys.
-- [ ] #8 Import validates the full snapshot before the first write and reports partial write failures explicitly for non-transactional stores.
+- [x] #1 Exported snapshots include schema version, profiles, default assignment, external servers, and credential grants.
+- [x] #2 Snapshot output contains no plaintext secrets and rejects secret-looking metadata/provenance.
+- [x] #3 Import dry-run validates references and reports planned mutations without writing.
+- [x] #4 Import applies in safe order: profiles, default assignment, external servers, credential grants.
+- [x] #5 Import defaults to upsert semantics and does not delete missing local records.
+- [x] #6 A snapshot exported from one SQLite store can be imported into a fresh SQLite store and exported again with equivalent semantic content.
+- [x] #7 Snapshot validation rejects secret-looking external server command args, URL userinfo, and sensitive URL query keys.
+- [x] #8 Import validates the full snapshot before the first write and reports partial write failures explicitly for non-transactional stores.
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -44,12 +44,14 @@ Docs/superpowers/plans/2026-06-02-mcp-gateway-config-snapshots.md
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
 
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+Implemented package-owned gateway config snapshots in mcp_unified/gateway/snapshots.py with versioned Pydantic models, deterministic ordering, secret-key validation, external-server inline secret validation, validate-first import reference checks, dry-run mutation plans, non-destructive upsert import order, best-effort audit events, and explicit partial-write failure reporting. Added config builder wiring and CLI export-config/import-config workflows. Touched files: mcp_unified/gateway/snapshots.py, mcp_unified/gateway/config.py, mcp_unified/gateway/cli.py, tldw_Server_API/app/core/MCP_unified/tests/test_gateway_config_snapshots.py, tldw_Server_API/app/core/MCP_unified/tests/test_gateway_cli_package.py, Docs/superpowers/plans/2026-06-02-mcp-gateway-config-snapshots.md. Verification: source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_gateway_config_snapshots.py tldw_Server_API/app/core/MCP_unified/tests/test_gateway_cli_package.py -v -> 100 passed, 5 warnings. Bandit: source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m bandit -r mcp_unified/gateway/snapshots.py mcp_unified/gateway/config.py mcp_unified/gateway/cli.py -f json -o /tmp/bandit_mcp_gateway_config_snapshots.json -> 0 findings. git diff --check -> clean. Known skips/blockers: none.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Added standalone gateway config import/export snapshots for profiles, the gateway default assignment, external servers, and credential grants. Snapshot export is deterministic and secret-safe; import supports dry-run planning, validates references before writes, applies non-destructive upserts in dependency order, reports partial write failures by action id, and is exposed through export-config/import-config CLI commands. Focused snapshot and CLI tests pass, Bandit has zero findings, and whitespace validation is clean.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 <!-- SECTION:FINAL_SUMMARY:END -->
@@ -58,10 +60,10 @@ Docs/superpowers/plans/2026-06-02-mcp-gateway-config-snapshots.md
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->

--- a/backlog/tasks/task-592 - Implement-standalone-MCP-gateway-config-import-export-snapshots.md
+++ b/backlog/tasks/task-592 - Implement-standalone-MCP-gateway-config-import-export-snapshots.md
@@ -1,0 +1,65 @@
+---
+id: TASK-592
+title: Implement standalone MCP gateway config import export snapshots
+status: To Do
+assignee: []
+created_date: ''
+updated_date: '2026-06-02 02:07'
+labels:
+  - mcp-unified
+  - standalone-gateway
+  - config
+dependencies:
+  - TASK-591
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Add versioned import/export snapshot workflows for standalone gateway profiles, default assignment, external servers, and credential grant metadata, including dry-run validation and secret-safe output.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Exported snapshots include schema version, profiles, default assignment, external servers, and credential grants.
+- [ ] #2 Snapshot output contains no plaintext secrets and rejects secret-looking metadata/provenance.
+- [ ] #3 Import dry-run validates references and reports planned mutations without writing.
+- [ ] #4 Import applies in safe order: profiles, default assignment, external servers, credential grants.
+- [ ] #5 Import defaults to upsert semantics and does not delete missing local records.
+- [ ] #6 A snapshot exported from one SQLite store can be imported into a fresh SQLite store and exported again with equivalent semantic content.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Docs/superpowers/plans/2026-06-02-mcp-gateway-config-snapshots.md
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-592 - Implement-standalone-MCP-gateway-config-import-export-snapshots.md
+++ b/backlog/tasks/task-592 - Implement-standalone-MCP-gateway-config-import-export-snapshots.md
@@ -54,10 +54,6 @@ Implemented package-owned gateway config snapshots in mcp_unified/gateway/snapsh
 Added standalone gateway config import/export snapshots for profiles, the gateway default assignment, external servers, and credential grants. Snapshot export is deterministic and secret-safe; import supports dry-run planning, validates references before writes, applies non-destructive upserts in dependency order, reports partial write failures by action id, and is exposed through export-config/import-config CLI commands. Focused snapshot and CLI tests pass, Bandit has zero findings, and whitespace validation is clean.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
-<!-- SECTION:FINAL_SUMMARY:END -->
-
-<!-- SECTION:FINAL_SUMMARY:END -->
-
 ## Definition of Done
 <!-- DOD:BEGIN -->
 - [x] #1 Acceptance criteria completed

--- a/backlog/tasks/task-592 - Implement-standalone-MCP-gateway-config-import-export-snapshots.md
+++ b/backlog/tasks/task-592 - Implement-standalone-MCP-gateway-config-import-export-snapshots.md
@@ -4,7 +4,7 @@ title: Implement standalone MCP gateway config import export snapshots
 status: To Do
 assignee: []
 created_date: ''
-updated_date: '2026-06-02 02:07'
+updated_date: '2026-06-02 02:20'
 labels:
   - mcp-unified
   - standalone-gateway
@@ -28,6 +28,8 @@ Add versioned import/export snapshot workflows for standalone gateway profiles, 
 - [ ] #4 Import applies in safe order: profiles, default assignment, external servers, credential grants.
 - [ ] #5 Import defaults to upsert semantics and does not delete missing local records.
 - [ ] #6 A snapshot exported from one SQLite store can be imported into a fresh SQLite store and exported again with equivalent semantic content.
+- [ ] #7 Snapshot validation rejects secret-looking external server command args, URL userinfo, and sensitive URL query keys.
+- [ ] #8 Import validates the full snapshot before the first write and reports partial write failures explicitly for non-transactional stores.
 <!-- AC:END -->
 
 ## Implementation Plan

--- a/backlog/tasks/task-593 - Implement-standalone-MCP-gateway-remote-runtime-CLI-and-docs.md
+++ b/backlog/tasks/task-593 - Implement-standalone-MCP-gateway-remote-runtime-CLI-and-docs.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-593
 title: Implement standalone MCP gateway remote runtime CLI and docs
-status: To Do
+status: Done
 assignee: []
 created_date: ''
-updated_date: '2026-06-02 02:20'
+updated_date: '2026-06-02 04:39'
 labels:
   - mcp-unified
   - standalone-gateway
@@ -23,14 +23,14 @@ Add remote CLI commands that call a running standalone gateway for external runt
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 CLI can call a running gateway for runtime list/start/stop/restart/refresh/reconcile/install/update operations.
-- [ ] #2 CLI runtime commands require an explicit --gateway-url or MCP_UNIFIED_GATEWAY_URL.
-- [ ] #3 Admin auth uses an environment-provided value such as MCP_UNIFIED_GATEWAY_ADMIN_KEY; command-line secret arguments are avoided.
-- [ ] #4 CLI preserves the gateway JSON payloads and reason codes.
-- [ ] #5 Docs explain local store commands versus remote runtime commands and include a safe credential-grant example.
-- [ ] #6 No runtime CLI command starts an upstream process that becomes orphaned when the CLI exits.
-- [ ] #7 Gateway URL semantics are explicit: the URL is the mounted gateway base path, such as http://host/mcp, and the client does not auto-add /mcp.
-- [ ] #8 Remote CLI preserves JSON reason_code payloads from HTTP 4xx/5xx response bodies.
+- [x] #1 CLI can call a running gateway for runtime list/start/stop/restart/refresh/reconcile/install/update operations.
+- [x] #2 CLI runtime commands require an explicit --gateway-url or MCP_UNIFIED_GATEWAY_URL.
+- [x] #3 Admin auth uses an environment-provided value such as MCP_UNIFIED_GATEWAY_ADMIN_KEY; command-line secret arguments are avoided.
+- [x] #4 CLI preserves the gateway JSON payloads and reason codes.
+- [x] #5 Docs explain local store commands versus remote runtime commands and include a safe credential-grant example.
+- [x] #6 No runtime CLI command starts an upstream process that becomes orphaned when the CLI exits.
+- [x] #7 Gateway URL semantics are explicit: the URL is the mounted gateway base path, such as http://host/mcp, and the client does not auto-add /mcp.
+- [x] #8 Remote CLI preserves JSON reason_code payloads from HTTP 4xx/5xx response bodies.
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -42,27 +42,41 @@ Docs/superpowers/plans/2026-06-02-mcp-gateway-remote-runtime-cli-docs.md
 ## Implementation Notes
 
 <!-- SECTION:NOTES:BEGIN -->
-<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Implemented a package-owned remote admin client for mounted gateway base URLs, env/header-based admin auth, sanitized malformed/connection failures, and HTTP JSON error payload preservation.
 
-<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+Added flat runtime CLI commands for list/start/stop/restart/refresh/reconcile/install/update that call the running gateway over HTTP rather than starting local transports.
+
+Added standalone admin docs covering local store commands, remote runtime commands, gateway URL prefix semantics, env-only admin keys, safe credential grants, snapshots, and runtime examples.
+
+Touched files:
+- mcp_unified/gateway/remote_admin.py
+- mcp_unified/gateway/cli.py
+- tldw_Server_API/app/core/MCP_unified/tests/test_gateway_remote_runtime_cli.py
+- Docs/MCP_UNIFIED_STANDALONE_GATEWAY_ADMIN.md
+- Docs/superpowers/plans/2026-06-02-mcp-gateway-remote-runtime-cli-docs.md
+- backlog/tasks/task-593 - Implement-standalone-MCP-gateway-remote-runtime-CLI-and-docs.md
+
+Verification passed:
+- source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_gateway_remote_runtime_cli.py -v: 24 passed
+- source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_gateway_remote_runtime_cli.py tldw_Server_API/app/core/MCP_unified/tests/test_gateway_cli_package.py -v: 98 passed
+- source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m bandit -r mcp_unified/gateway/remote_admin.py mcp_unified/gateway/cli.py mcp_unified/gateway/fastapi.py -f json -o /tmp/bandit_mcp_gateway_remote_runtime_cli.json: 0 results
+- git diff --check: passed
+
+Known skips or blockers: none.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-<!-- SECTION:FINAL_SUMMARY:BEGIN -->
-<!-- SECTION:FINAL_SUMMARY:END -->
-
-<!-- SECTION:FINAL_SUMMARY:END -->
-
+Added the standalone gateway remote runtime CLI and docs. Runtime commands now call the mounted gateway admin endpoints using --gateway-url or MCP_UNIFIED_GATEWAY_URL, preserve gateway JSON reason_code payloads, use MCP_UNIFIED_GATEWAY_ADMIN_KEY for admin auth without command-line secret arguments, and keep process ownership with the running gateway. Documentation now explains local store operations versus remote runtime operations, safe credential grant metadata, snapshots, admin auth, and mounted base URL semantics.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->

--- a/backlog/tasks/task-593 - Implement-standalone-MCP-gateway-remote-runtime-CLI-and-docs.md
+++ b/backlog/tasks/task-593 - Implement-standalone-MCP-gateway-remote-runtime-CLI-and-docs.md
@@ -4,7 +4,7 @@ title: Implement standalone MCP gateway remote runtime CLI and docs
 status: To Do
 assignee: []
 created_date: ''
-updated_date: '2026-06-02 02:08'
+updated_date: '2026-06-02 02:20'
 labels:
   - mcp-unified
   - standalone-gateway
@@ -29,6 +29,8 @@ Add remote CLI commands that call a running standalone gateway for external runt
 - [ ] #4 CLI preserves the gateway JSON payloads and reason codes.
 - [ ] #5 Docs explain local store commands versus remote runtime commands and include a safe credential-grant example.
 - [ ] #6 No runtime CLI command starts an upstream process that becomes orphaned when the CLI exits.
+- [ ] #7 Gateway URL semantics are explicit: the URL is the mounted gateway base path, such as http://host/mcp, and the client does not auto-add /mcp.
+- [ ] #8 Remote CLI preserves JSON reason_code payloads from HTTP 4xx/5xx response bodies.
 <!-- AC:END -->
 
 ## Implementation Plan

--- a/backlog/tasks/task-593 - Implement-standalone-MCP-gateway-remote-runtime-CLI-and-docs.md
+++ b/backlog/tasks/task-593 - Implement-standalone-MCP-gateway-remote-runtime-CLI-and-docs.md
@@ -1,0 +1,66 @@
+---
+id: TASK-593
+title: Implement standalone MCP gateway remote runtime CLI and docs
+status: To Do
+assignee: []
+created_date: ''
+updated_date: '2026-06-02 02:08'
+labels:
+  - mcp-unified
+  - standalone-gateway
+  - cli
+dependencies:
+  - TASK-591
+  - TASK-592
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Add remote CLI commands that call a running standalone gateway for external runtime lifecycle operations, and document the end-to-end standalone admin workflow.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 CLI can call a running gateway for runtime list/start/stop/restart/refresh/reconcile/install/update operations.
+- [ ] #2 CLI runtime commands require an explicit --gateway-url or MCP_UNIFIED_GATEWAY_URL.
+- [ ] #3 Admin auth uses an environment-provided value such as MCP_UNIFIED_GATEWAY_ADMIN_KEY; command-line secret arguments are avoided.
+- [ ] #4 CLI preserves the gateway JSON payloads and reason codes.
+- [ ] #5 Docs explain local store commands versus remote runtime commands and include a safe credential-grant example.
+- [ ] #6 No runtime CLI command starts an upstream process that becomes orphaned when the CLI exits.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Docs/superpowers/plans/2026-06-02-mcp-gateway-remote-runtime-cli-docs.md
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-594 - Address-PR-2222-gateway-admin-config-review-comments.md
+++ b/backlog/tasks/task-594 - Address-PR-2222-gateway-admin-config-review-comments.md
@@ -1,0 +1,64 @@
+---
+id: TASK-594
+title: Address PR 2222 gateway admin config review comments
+status: Done
+dependencies:
+- TASK-593
+labels:
+- mcp-unified
+- standalone-gateway
+- review-fix
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Verify and address still-valid code review comments and CI issues on PR #2222 after rebasing onto latest dev.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] PR branch is rebased onto latest origin/dev.
+- [x] Still-valid PR review comments are addressed with minimal code changes.
+- [x] Unrelated CI failures are verified and documented instead of widened into this PR.
+- [x] Focused gateway tests, Bandit, and diff checks are run and recorded.
+- [x] PR branch is committed and pushed.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Rebase PR branch onto latest origin/dev.
+2. Extract PR review comments and CI failures.
+3. Verify each finding against current code and fix only still-valid issues.
+4. Run focused gateway tests, Bandit, and diff checks.
+5. Update PR and Backlog with outcomes.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+- Rebase: `git rebase origin/dev` reported the branch was already up to date.
+- Fixed PR review items: typed credential-grant response schemas, snapshot default-assignment id validation, defensive snapshot command/slot handling, remote admin key CR/LF validation, and strict credential-grant patch `external_server_id` validation.
+- Skipped unrelated CI widening: Full Suite failed before checkout/test execution on a Docker Hub `postgres:18-bookworm` pull timeout; UX Smoke failure is an unrelated `/setup` semantic `h1` issue outside this backend/docs PR scope.
+- Verification: focused red tests failed before implementation for all target review items; the same focused tests passed after implementation with 7 passed.
+- Verification: touched gateway test files passed with 222 passed and 6 existing warnings.
+- Verification: Bandit on touched gateway files produced zero findings; `git diff --check` passed.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Addressed still-valid PR #2222 review comments with minimal gateway validation/schema hardening and focused regression tests. Remaining CI failures reviewed were unrelated to the branch changes.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-595 - Address-PR-2222-follow-up-CodeRabbit-comments.md
+++ b/backlog/tasks/task-595 - Address-PR-2222-follow-up-CodeRabbit-comments.md
@@ -1,0 +1,57 @@
+---
+id: TASK-595
+title: Address PR 2222 follow-up CodeRabbit comments
+status: Done
+dependencies:
+- TASK-594
+labels:
+- mcp-unified
+- standalone-gateway
+- review-fix
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Verify and address follow-up CodeRabbit comments on PR #2222 after commit 7840f74b88. Keep fixes minimal, document skipped items, and validate touched gateway code.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Follow-up CodeRabbit comments are verified against current code.
+- [x] #2 Still-valid gateway validation and auth handling issues are fixed with regression tests.
+- [x] #3 Backlog marker/checklist comments are cleaned up without changing unrelated wording.
+- [x] #4 Focused tests, Bandit, and diff checks are run and recorded.
+- [x] #5 Fixes are committed and pushed to PR #2222.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+- Verified CodeRabbit follow-up comments against current commit `7840f74b88`.
+- Fixed direct `create_gateway_router()` admin-auth handling by using a route wrapper that returns the same stable JSON auth error payloads without requiring an app-level exception handler.
+- Fixed credential-grant creation to overwrite client-supplied `created_at` and `updated_at` values at the manager boundary.
+- Fixed credential-grant scope normalization to reject non-string scope entries instead of silently dropping them.
+- Hardened snapshot import/validation against malformed `credential_slots` and `command` containers.
+- Cleaned duplicate final-summary markers in TASK-591/TASK-592 and marked TASK-591 completion checklists complete.
+- Verification: focused red tests failed before implementation for the target code issues, then passed with 7 passed and 5 warnings.
+- Verification: broader gateway/admin/CLI tests passed with 283 passed and 6 warnings.
+- Verification: Bandit on touched gateway files produced zero findings; `git diff --check` passed.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Addressed follow-up PR #2222 CodeRabbit findings with direct-router auth error handling, stricter credential-grant validation, snapshot malformed-input guards, and Backlog marker cleanup. All focused and broader touched-surface validations passed locally.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-596 - Address-snapshot-default-assignment-import-follow-up.md
+++ b/backlog/tasks/task-596 - Address-snapshot-default-assignment-import-follow-up.md
@@ -1,0 +1,49 @@
+---
+id: TASK-596
+title: Address snapshot default assignment import follow-up
+status: Done
+assignee: []
+created_date: ''
+updated_date: '2026-06-02 19:21'
+labels:
+  - mcp-unified
+  - standalone-gateway
+  - review-fix
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Verify PR review feedback for GatewayConfigSnapshotManager default assignment imports, fix still-valid paths where snapshot model instances can bypass default assignment id validation, and validate the touched snapshot surface.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Review finding verified against current snapshot import paths.
+- [x] #2 Still-valid constructed-model import path rejected before writes.
+- [x] #3 Regression test added for non-gateway default assignment id import.
+- [x] #4 Snapshot/CLI tests, Bandit, and diff check recorded.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Verified normal mapping snapshots were already rejected by GatewayConfigSnapshot validation. The still-valid issue was the direct GatewayConfigSnapshot instance path, where model_construct could bypass validation before GatewayConfigSnapshotManager._mutation_actions wrote the assignment. Added manager-level validation and canonical default assignment ids for planned and mutation actions.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Fixed the still-valid snapshot import path where constructed GatewayConfigSnapshot instances could carry a non-gateway default assignment id into the manager. Validation now rejects that before mutation, and plan/mutation actions use the canonical gateway default assignment id. Verification: focused regression red/green; 107 snapshot/CLI tests passed; Bandit results empty for mcp_unified/gateway/snapshots.py; git diff --check clean.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-597 - Fix-setup-recovery-h1-UX-smoke-failure.md
+++ b/backlog/tasks/task-597 - Fix-setup-recovery-h1-UX-smoke-failure.md
@@ -1,0 +1,51 @@
+---
+id: TASK-597
+title: Fix setup recovery h1 UX smoke failure
+status: Done
+assignee: []
+created_date: ''
+updated_date: '2026-06-02 19:49'
+labels:
+  - frontend
+  - review-fix
+  - ci-fix
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Address the PR #2222 UX Smoke Gate failure where the /setup recovery screen renders without a semantic h1 at 390px. Keep the fix scoped to the full-page networking recovery surface and validate with focused frontend tests.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 /setup networking recovery screen exposes exactly one semantic h1.
+- [x] #2 Shared state panel card usages continue to default to h2.
+- [x] #3 Focused frontend component and UX smoke verification is recorded.
+- [x] #4 No unrelated frontend layout changes are introduced.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+CI failure was UX Smoke Gate Stage 4 /setup, asserting zero h1 elements on the setup recovery screen. Added StatePanel.titleHeadingLevel with default h2 semantics, opted fallback setup recovery and networking recovery screens into h1, and kept active setup wizard state on h2 to avoid duplicate h1s when UnifiedSetupWizard is present. Full core-route-identity file still has an unrelated pre-existing Companion Home resolver failure; the focused route identity case for this fix passes.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Fixed the /setup Stage 4 UX smoke failure by allowing full-page state panels to render h1 titles while preserving h2 defaults for card-level state panels. Verification: red/green component test, focused route identity test, state primitive test, and targeted Playwright /setup smoke check passed. Bandit not applicable to TS/TSX-only change.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-598 - Fix-chat-cockpit-restore-control-overlay-in-UX-smoke-gate.md
+++ b/backlog/tasks/task-598 - Fix-chat-cockpit-restore-control-overlay-in-UX-smoke-gate.md
@@ -1,0 +1,49 @@
+---
+id: TASK-598
+title: Fix chat cockpit restore control overlay in UX smoke gate
+status: Done
+assignee: []
+created_date: ''
+updated_date: '2026-06-02 20:35'
+labels:
+  - bug
+  - frontend
+  - ci
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Address the PR UX Smoke Gate failure where the chat sidebar edge expand button intercepts clicks on the playground cockpit left-rail restore button in the real-server cockpit test.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Real-server chat cockpit restore interaction is clickable when both rails are collapsed.
+- [x] #2 Focused chat cockpit UX smoke regression passes locally.
+- [x] #3 Changes remain minimal and do not affect unrelated routes or backend code.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Implemented a focused chat cockpit overlay fix. Added a Playwright regression proving the cockpit context restore tab remains clickable while the app chat rail edge is collapsed. Kept the app chat edge at its original z-index so ordinary page content does not intercept it, shifted that edge handle above the cockpit restore midpoint in both WebLayout copies, and raised cockpit restore tabs above peer edge controls. Verification: red focused regression reproduced the CI pointer-interception failure; green focused regression passed; component/guard tests passed (2 files, 6 tests); git diff --check passed. Full chat-rails-collapse local run still has an isolated pre-existing medium/mobile artifact close interception failure unrelated to this change because chat-sidebar-edge-expand is not rendered at that viewport.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Backlog task reflects touched files and verification.
+- [x] #2 Regression coverage added or adjusted before implementation.
+- [x] #3 Focused test passes after the fix.
+- [x] #4 No Python Bandit run required for TS/TSX-only changes, or Bandit is run if Python is touched.
+<!-- DOD:END -->

--- a/mcp_unified/gateway/__init__.py
+++ b/mcp_unified/gateway/__init__.py
@@ -8,13 +8,19 @@ from .bootstrap import (
     build_profile_gateway_runtime,
 )
 from .config import (
+    GatewayAdminAuthBootstrapConfig,
     GatewayConfigFormat,
     GatewayExternalRuntimeBootstrapConfig,
     GatewayProfileBootstrapConfig,
     GatewayProfileStoreConfig,
     GatewayProfileStoreKind,
     bootstrap_profile_gateway_from_config,
+    credential_grant_manager_from_storage,
     load_gateway_profile_bootstrap_config,
+)
+from .credential_grants import (
+    GatewayCredentialGrantManagementError,
+    GatewayCredentialGrantManager,
 )
 from .lifecycle import GatewayExternalRuntimeLifecycleConfig
 from .profile_runtime import ProfileAwareGatewayRuntime
@@ -27,6 +33,7 @@ from .runtime import GatewayPolicyDenied, GatewayRequestContext, GatewayRuntime
 from .stdio import GatewayStdioServer, handle_stdio_line
 
 if TYPE_CHECKING:
+    from .admin_auth import GatewayAdminAuthConfig, GatewayAdminAuthError
     from .external_runtime import (
         GatewayExternalRuntimeError,
         GatewayExternalRuntimeManager,
@@ -36,7 +43,12 @@ if TYPE_CHECKING:
 
 __all__ = [
     "GatewayPolicyDenied",
+    "GatewayAdminAuthBootstrapConfig",
+    "GatewayAdminAuthConfig",
+    "GatewayAdminAuthError",
     "GatewayConfigFormat",
+    "GatewayCredentialGrantManagementError",
+    "GatewayCredentialGrantManager",
     "GatewayExternalRuntimeBootstrapConfig",
     "GatewayExternalRuntimeLifecycleConfig",
     "GatewayExternalRuntimeError",
@@ -58,6 +70,7 @@ __all__ = [
     "build_profile_gateway_runtime",
     "create_gateway_app",
     "create_gateway_router",
+    "credential_grant_manager_from_storage",
     "handle_stdio_line",
     "load_gateway_profile_bootstrap_config",
 ]
@@ -72,6 +85,13 @@ def __getattr__(name: str) -> Any:
         return {
             "create_gateway_app": create_gateway_app,
             "create_gateway_router": create_gateway_router,
+        }[name]
+    if name in {"GatewayAdminAuthConfig", "GatewayAdminAuthError"}:
+        from .admin_auth import GatewayAdminAuthConfig, GatewayAdminAuthError
+
+        return {
+            "GatewayAdminAuthConfig": GatewayAdminAuthConfig,
+            "GatewayAdminAuthError": GatewayAdminAuthError,
         }[name]
     if name in {"GatewayExternalRuntimeError", "GatewayExternalRuntimeManager"}:
         from .external_runtime import (

--- a/mcp_unified/gateway/admin_auth.py
+++ b/mcp_unified/gateway/admin_auth.py
@@ -1,0 +1,165 @@
+"""Standalone gateway admin-auth helpers."""
+
+from __future__ import annotations
+
+import inspect
+import secrets
+from collections.abc import Awaitable, Callable, Mapping
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Protocol, cast
+
+if TYPE_CHECKING:
+    from fastapi import Request
+else:
+    Request = Any
+
+GatewayAdminVerifier = Callable[[str, Request], bool | Awaitable[bool]]
+
+_DEFAULT_ADMIN_HEADER = "X-MCP-Gateway-Admin-Key"
+_REQUIRED_PAYLOAD = {
+    "ok": False,
+    "error": "Gateway admin authentication required",
+    "reason_code": "admin_auth_required",
+}
+_INVALID_PAYLOAD = {
+    "ok": False,
+    "error": "Gateway admin authentication failed",
+    "reason_code": "admin_auth_invalid",
+}
+
+
+class GatewayAdminAuthConfigLike(Protocol):
+    """Protocol for package-owned admin auth config values."""
+
+    enabled: bool
+    header_name: str
+    api_key: str | None
+    verifier: GatewayAdminVerifier | None
+
+
+class GatewayAdminAuthError(Exception):
+    """Raised when a management route receives invalid admin credentials."""
+
+    def __init__(self, *, reason_code: str) -> None:
+        """Build an auth failure with a stable public reason code."""
+
+        if reason_code == "admin_auth_required":
+            self.status_code = 401
+            self.payload = dict(_REQUIRED_PAYLOAD)
+        elif reason_code == "admin_auth_invalid":
+            self.status_code = 403
+            self.payload = dict(_INVALID_PAYLOAD)
+        else:
+            raise ValueError(f"Unsupported gateway admin auth reason: {reason_code!r}")
+        self.reason_code = reason_code
+        super().__init__(self.payload["error"])
+
+
+@dataclass(frozen=True, slots=True)
+class GatewayAdminAuthConfig:
+    """Runtime admin-auth configuration for standalone gateway management routes."""
+
+    enabled: bool = False
+    header_name: str = _DEFAULT_ADMIN_HEADER
+    api_key: str | None = None
+    verifier: GatewayAdminVerifier | None = None
+
+    def __post_init__(self) -> None:
+        """Validate admin auth settings and normalize the header name."""
+
+        if not isinstance(self.enabled, bool):
+            raise ValueError("admin_auth.enabled must be a boolean")
+        header_name = str(self.header_name).strip()
+        if not header_name:
+            raise ValueError("admin_auth.header_name must be non-blank")
+        object.__setattr__(self, "header_name", header_name)
+
+        api_key = self.api_key
+        if api_key is not None:
+            api_key = str(api_key)
+            if not api_key:
+                raise ValueError("admin_auth.api_key must be non-blank when supplied")
+            object.__setattr__(self, "api_key", api_key)
+
+        if self.enabled and self.api_key is None and self.verifier is None:
+            raise ValueError(
+                "admin auth requires api_key or verifier when enabled"
+            )
+
+    async def verify(self, credential: str, request: Request) -> bool:
+        """Return whether the supplied credential is accepted for this request."""
+
+        if self.verifier is not None:
+            result = self.verifier(credential, request)
+            if inspect.isawaitable(result):
+                result = await cast(Awaitable[bool], result)
+            return bool(result)
+        if self.api_key is None:
+            return False
+        return secrets.compare_digest(credential, self.api_key)
+
+
+def normalize_gateway_admin_auth_config(
+    config: GatewayAdminAuthConfig | Mapping[str, Any] | None,
+) -> GatewayAdminAuthConfig:
+    """Return a runtime admin-auth config from a model, mapping, or empty value."""
+
+    if config is None:
+        return GatewayAdminAuthConfig()
+    if isinstance(config, GatewayAdminAuthConfig):
+        return config
+    return GatewayAdminAuthConfig(**dict(config))
+
+
+def gateway_admin_auth_dependencies(
+    config: GatewayAdminAuthConfig | Mapping[str, Any] | None,
+) -> list[Any]:
+    """Return FastAPI dependencies that enforce optional admin authentication."""
+
+    from fastapi import Depends
+
+    resolved = normalize_gateway_admin_auth_config(config)
+    if not resolved.enabled:
+        return []
+    return [Depends(_gateway_admin_auth_dependency(resolved))]
+
+
+def gateway_admin_auth_error_response(
+    request: Request,
+    exc: GatewayAdminAuthError,
+) -> Any:
+    """Return the package-owned direct JSON error response for admin auth failures."""
+
+    from fastapi.responses import JSONResponse
+
+    del request
+    return JSONResponse(status_code=exc.status_code, content=exc.payload)
+
+
+def _gateway_admin_auth_dependency(
+    config: GatewayAdminAuthConfig,
+) -> Callable[[Request], Awaitable[None]]:
+    """Build a request dependency for one immutable auth config."""
+
+    from fastapi import Request as FastAPIRequest
+
+    async def require_gateway_admin(request: Any) -> None:
+        credential = request.headers.get(config.header_name)
+        if credential is None or not credential.strip():
+            raise GatewayAdminAuthError(reason_code="admin_auth_required")
+        if not await config.verify(credential, request):
+            raise GatewayAdminAuthError(reason_code="admin_auth_invalid")
+
+    require_gateway_admin.__annotations__["request"] = FastAPIRequest
+    return require_gateway_admin
+
+
+__all__ = [
+    "GatewayAdminAuthConfig",
+    "GatewayAdminAuthConfigLike",
+    "GatewayAdminAuthError",
+    "GatewayAdminVerifier",
+    "gateway_admin_auth_dependencies",
+    "gateway_admin_auth_error_response",
+    "normalize_gateway_admin_auth_config",
+]

--- a/mcp_unified/gateway/bootstrap.py
+++ b/mcp_unified/gateway/bootstrap.py
@@ -18,6 +18,8 @@ from .profile_runtime import ProfileAwareGatewayRuntime
 from .runtime import GatewayRuntime
 
 if TYPE_CHECKING:
+    from mcp_unified.gateway.admin_auth import GatewayAdminAuthConfig
+    from mcp_unified.gateway.credential_grants import GatewayCredentialGrantManager
     from mcp_unified.gateway.external_registry import GatewayExternalRegistryManager
     from mcp_unified.gateway.external_runtime import GatewayExternalRuntimeManager
 
@@ -37,6 +39,8 @@ class GatewayProfileBootstrap:
     external_registry_manager: GatewayExternalRegistryManager | None = None
     external_runtime_manager: GatewayExternalRuntimeManager | None = None
     external_runtime_lifecycle: GatewayExternalRuntimeLifecycleConfig | None = None
+    credential_grant_manager: GatewayCredentialGrantManager | None = None
+    admin_auth: GatewayAdminAuthConfig | None = None
 
 
 async def bootstrap_profile_gateway(
@@ -52,6 +56,8 @@ async def bootstrap_profile_gateway(
     external_registry_manager: GatewayExternalRegistryManager | None = None,
     external_runtime_manager: GatewayExternalRuntimeManager | None = None,
     external_runtime_lifecycle: GatewayExternalRuntimeLifecycleConfig | None = None,
+    credential_grant_manager: GatewayCredentialGrantManager | None = None,
+    admin_auth: GatewayAdminAuthConfig | None = None,
 ) -> GatewayProfileBootstrap:
     """Seed profile data and return a profile-aware gateway runtime."""
 
@@ -113,6 +119,8 @@ async def bootstrap_profile_gateway(
         external_registry_manager=external_registry_manager,
         external_runtime_manager=external_runtime_manager,
         external_runtime_lifecycle=external_runtime_lifecycle,
+        credential_grant_manager=credential_grant_manager,
+        admin_auth=admin_auth,
     )
 
 

--- a/mcp_unified/gateway/cli.py
+++ b/mcp_unified/gateway/cli.py
@@ -25,8 +25,13 @@ from .config import (
     GatewayProfileStorageBundle,
     build_gateway_external_registry_storage,
     build_gateway_profile_storage,
+    credential_grant_manager_from_storage,
     external_registry_manager_from_storage,
     load_gateway_profile_bootstrap_config,
+)
+from .credential_grants import (
+    GatewayCredentialGrantManagementError,
+    GatewayCredentialGrantManager,
 )
 from .external_registry import (
     GatewayExternalRegistryManagementError,
@@ -40,6 +45,10 @@ _ProfileOperation = Callable[
 ]
 _ExternalRegistryOperation = Callable[
     [GatewayExternalRegistryManager],
+    Coroutine[Any, Any, dict[str, Any]],
+]
+_CredentialGrantOperation = Callable[
+    [GatewayCredentialGrantManager],
     Coroutine[Any, Any, dict[str, Any]],
 ]
 
@@ -286,6 +295,73 @@ def _build_parser() -> _JsonArgumentParser:
     _add_profile_config_argument(delete_external_server)
     delete_external_server.set_defaults(handler=_handle_delete_external_server)
 
+    list_credential_grants = subparsers.add_parser(
+        "list-credential-grants",
+        help="List credential grants from a configured gateway store.",
+    )
+    list_credential_grants.add_argument(
+        "--profile-id",
+        help="Optional profile id filter.",
+    )
+    list_credential_grants.add_argument(
+        "--external-server-id",
+        help="Optional external server id filter.",
+    )
+    _add_profile_config_argument(list_credential_grants)
+    list_credential_grants.set_defaults(handler=_handle_list_credential_grants)
+
+    show_credential_grant = subparsers.add_parser(
+        "show-credential-grant",
+        help="Show one credential grant from a configured gateway store.",
+    )
+    show_credential_grant.add_argument(
+        "grant_id",
+        help="Credential grant id to inspect.",
+    )
+    _add_profile_config_argument(show_credential_grant)
+    show_credential_grant.set_defaults(handler=_handle_show_credential_grant)
+
+    create_credential_grant = subparsers.add_parser(
+        "create-credential-grant",
+        help="Create a credential grant in a persistent gateway store.",
+    )
+    create_credential_grant.add_argument(
+        "--grant-file",
+        type=Path,
+        required=True,
+        help="Path to a JSON credential grant object, or '-' to read from stdin.",
+    )
+    _add_profile_config_argument(create_credential_grant)
+    create_credential_grant.set_defaults(handler=_handle_create_credential_grant)
+
+    patch_credential_grant = subparsers.add_parser(
+        "patch-credential-grant",
+        help="Patch a credential grant in a persistent gateway store.",
+    )
+    patch_credential_grant.add_argument(
+        "grant_id",
+        help="Credential grant id to patch.",
+    )
+    patch_credential_grant.add_argument(
+        "--patch-file",
+        type=Path,
+        required=True,
+        help="Path to a JSON patch object, or '-' to read from stdin.",
+    )
+    _add_profile_config_argument(patch_credential_grant)
+    patch_credential_grant.set_defaults(handler=_handle_patch_credential_grant)
+
+    delete_credential_grant = subparsers.add_parser(
+        "delete-credential-grant",
+        help="Delete a credential grant from a persistent gateway store.",
+    )
+    delete_credential_grant.add_argument(
+        "grant_id",
+        help="Credential grant id to delete.",
+    )
+    _add_profile_config_argument(delete_credential_grant)
+    delete_credential_grant.set_defaults(handler=_handle_delete_credential_grant)
+
     get_default_profile = subparsers.add_parser(
         "get-default-profile",
         help="Show the active gateway default profile.",
@@ -476,6 +552,67 @@ def _handle_delete_external_server(args: argparse.Namespace) -> int:
     )
 
 
+def _handle_list_credential_grants(args: argparse.Namespace) -> int:
+    """List credential grants from a configured gateway store."""
+
+    profile_id = _optional_cli_text(args.profile_id, field="profile_id")
+    external_server_id = _optional_cli_text(
+        args.external_server_id,
+        field="external_server_id",
+    )
+    return _handle_credential_grant_command(
+        args,
+        lambda manager: manager.list_grants(
+            profile_id=profile_id,
+            external_server_id=external_server_id,
+        ),
+    )
+
+
+def _handle_show_credential_grant(args: argparse.Namespace) -> int:
+    """Show one credential grant from a configured gateway store."""
+
+    grant_id = _require_cli_text(args.grant_id, field="grant_id")
+    return _handle_credential_grant_command(
+        args,
+        lambda manager: manager.show_grant(grant_id),
+    )
+
+
+def _handle_create_credential_grant(args: argparse.Namespace) -> int:
+    """Create one credential grant from a JSON file or stdin payload."""
+
+    return _handle_credential_grant_command(
+        args,
+        lambda manager: manager.create_grant(
+            _load_json_argument_file(args.grant_file, label="grant"),
+        ),
+    )
+
+
+def _handle_patch_credential_grant(args: argparse.Namespace) -> int:
+    """Patch one credential grant using a JSON file or stdin payload."""
+
+    grant_id = _require_cli_text(args.grant_id, field="grant_id")
+    return _handle_credential_grant_command(
+        args,
+        lambda manager: manager.patch_grant(
+            grant_id,
+            _load_json_argument_file(args.patch_file, label="patch"),
+        ),
+    )
+
+
+def _handle_delete_credential_grant(args: argparse.Namespace) -> int:
+    """Delete one credential grant from a persistent gateway store."""
+
+    grant_id = _require_cli_text(args.grant_id, field="grant_id")
+    return _handle_credential_grant_command(
+        args,
+        lambda manager: manager.delete_grant(grant_id),
+    )
+
+
 def _handle_get_default_profile(args: argparse.Namespace) -> int:
     """Show the active gateway default profile."""
 
@@ -615,6 +752,88 @@ def _handle_external_registry_command(
     finally:
         if bundle is not None:
             _run_async(_close_external_registry_bundle(bundle))
+
+
+def _handle_credential_grant_command(
+    args: argparse.Namespace,
+    operation: _CredentialGrantOperation,
+    *,
+    require_persistent: bool = True,
+) -> int:
+    """Run a credential-grant command against the configured gateway store."""
+
+    config_path = _config_path_from_args(args)
+    profile_bundle: GatewayProfileStorageBundle | None = None
+    external_bundle: GatewayExternalRegistryStorageBundle | None = None
+    try:
+        try:
+            config = load_gateway_profile_bootstrap_config(config_path)
+            profile_bundle = build_gateway_profile_storage(config.store)
+            external_bundle = build_gateway_external_registry_storage(config.store)
+            if require_persistent and not external_bundle.metadata.persistent:
+                raise GatewayCredentialGrantManagementError(
+                    "Credential grant management requires a persistent gateway store",
+                    reason_code="credential_grant_store_unavailable",
+                )
+            manager = credential_grant_manager_from_storage(
+                external_bundle,
+                profile_storage=profile_bundle,
+            )
+        except _CliArgumentError:
+            raise
+        except GatewayCredentialGrantManagementError as exc:
+            _emit_json(exc.to_payload(), sys.stderr)
+            return 1
+        except Exception as exc:  # noqa: BLE001
+            unavailable_error = _credential_grant_storage_unavailable_error(exc)
+            if unavailable_error is not None:
+                _emit_json(unavailable_error.to_payload(), sys.stderr)
+                return 1
+            _emit_json(
+                {
+                    "error": str(exc),
+                    "ok": False,
+                    "path": str(config_path),
+                },
+                sys.stderr,
+            )
+            return 1
+
+        try:
+            payload = _run_async(operation(manager))
+        except _CliArgumentError:
+            raise
+        except GatewayCredentialGrantManagementError as exc:
+            _emit_json(exc.to_payload(), sys.stderr)
+            return 1
+        except Exception:  # noqa: BLE001
+            unavailable_error = GatewayCredentialGrantManagementError(
+                "Credential grant store unavailable",
+                reason_code="credential_grant_store_unavailable",
+            )
+            _emit_json(unavailable_error.to_payload(), sys.stderr)
+            return 1
+
+        _emit_json(_cli_payload(payload), sys.stdout)
+        return 0
+    finally:
+        if profile_bundle is not None:
+            _run_async(_close_storage_bundle(profile_bundle))
+        if external_bundle is not None:
+            _run_async(_close_external_registry_bundle(external_bundle))
+
+
+def _credential_grant_storage_unavailable_error(
+    exc: Exception,
+) -> GatewayCredentialGrantManagementError | None:
+    """Map expected unavailable credential-grant storage build failures."""
+
+    if not isinstance(exc, ExternalRegistryStorageConfigurationError):
+        return None
+    return GatewayCredentialGrantManagementError(
+        str(exc),
+        reason_code="credential_grant_store_unavailable",
+    )
 
 
 def _external_registry_storage_unavailable_error(

--- a/mcp_unified/gateway/cli.py
+++ b/mcp_unified/gateway/cli.py
@@ -27,6 +27,7 @@ from .config import (
     build_gateway_profile_storage,
     credential_grant_manager_from_storage,
     external_registry_manager_from_storage,
+    gateway_config_snapshot_manager_from_storage,
     load_gateway_profile_bootstrap_config,
 )
 from .credential_grants import (
@@ -38,6 +39,10 @@ from .external_registry import (
     GatewayExternalRegistryManager,
 )
 from .profiles import GatewayProfileManagementError, GatewayProfileManager
+from .snapshots import (
+    GatewayConfigSnapshotManagementError,
+    GatewayConfigSnapshotManager,
+)
 
 _ProfileOperation = Callable[
     [GatewayProfileManager],
@@ -50,6 +55,10 @@ _ExternalRegistryOperation = Callable[
 _CredentialGrantOperation = Callable[
     [GatewayCredentialGrantManager],
     Coroutine[Any, Any, dict[str, Any]],
+]
+_ConfigSnapshotOperation = Callable[
+    [GatewayConfigSnapshotManager],
+    Coroutine[Any, Any, Mapping[str, Any]],
 ]
 
 
@@ -362,6 +371,36 @@ def _build_parser() -> _JsonArgumentParser:
     _add_profile_config_argument(delete_credential_grant)
     delete_credential_grant.set_defaults(handler=_handle_delete_credential_grant)
 
+    export_config = subparsers.add_parser(
+        "export-config",
+        help="Export a persistent gateway config snapshot.",
+    )
+    export_config.add_argument(
+        "--output",
+        type=Path,
+        help="Optional file path to write the snapshot JSON.",
+    )
+    _add_profile_config_argument(export_config)
+    export_config.set_defaults(handler=_handle_export_config)
+
+    import_config = subparsers.add_parser(
+        "import-config",
+        help="Import a persistent gateway config snapshot.",
+    )
+    import_config.add_argument(
+        "--snapshot-file",
+        type=Path,
+        required=True,
+        help="Path to a JSON config snapshot object, or '-' to read from stdin.",
+    )
+    import_config.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Validate and report planned mutations without writing.",
+    )
+    _add_profile_config_argument(import_config)
+    import_config.set_defaults(handler=_handle_import_config)
+
     get_default_profile = subparsers.add_parser(
         "get-default-profile",
         help="Show the active gateway default profile.",
@@ -613,6 +652,31 @@ def _handle_delete_credential_grant(args: argparse.Namespace) -> int:
     )
 
 
+def _handle_export_config(args: argparse.Namespace) -> int:
+    """Export a gateway config snapshot to stdout or a JSON file."""
+
+    return _handle_config_snapshot_command(
+        args,
+        lambda manager: _export_config_for_cli(
+            manager,
+            output_path=args.output,
+        ),
+    )
+
+
+def _handle_import_config(args: argparse.Namespace) -> int:
+    """Import a gateway config snapshot from a JSON file or stdin."""
+
+    return _handle_config_snapshot_command(
+        args,
+        lambda manager: _import_config_for_cli(
+            manager,
+            snapshot_file=args.snapshot_file,
+            dry_run=bool(args.dry_run),
+        ),
+    )
+
+
 def _handle_get_default_profile(args: argparse.Namespace) -> int:
     """Show the active gateway default profile."""
 
@@ -823,6 +887,76 @@ def _handle_credential_grant_command(
             _run_async(_close_external_registry_bundle(external_bundle))
 
 
+def _handle_config_snapshot_command(
+    args: argparse.Namespace,
+    operation: _ConfigSnapshotOperation,
+) -> int:
+    """Run a config snapshot command against persistent gateway stores."""
+
+    config_path = _config_path_from_args(args)
+    profile_bundle: GatewayProfileStorageBundle | None = None
+    external_bundle: GatewayExternalRegistryStorageBundle | None = None
+    try:
+        try:
+            config = load_gateway_profile_bootstrap_config(config_path)
+            profile_bundle = build_gateway_profile_storage(config.store)
+            external_bundle = build_gateway_external_registry_storage(config.store)
+            if (
+                not profile_bundle.metadata.persistent
+                or not external_bundle.metadata.persistent
+            ):
+                raise GatewayConfigSnapshotManagementError(
+                    "Config snapshots require a persistent gateway store",
+                    reason_code="config_snapshot_store_unavailable",
+                )
+            manager = gateway_config_snapshot_manager_from_storage(
+                profile_bundle,
+                external_bundle,
+            )
+        except _CliArgumentError:
+            raise
+        except GatewayConfigSnapshotManagementError as exc:
+            _emit_json(exc.to_payload(), sys.stderr)
+            return 1
+        except Exception as exc:  # noqa: BLE001
+            unavailable_error = _config_snapshot_storage_unavailable_error(exc)
+            if unavailable_error is not None:
+                _emit_json(unavailable_error.to_payload(), sys.stderr)
+                return 1
+            _emit_json(
+                {
+                    "error": str(exc),
+                    "ok": False,
+                    "path": str(config_path),
+                },
+                sys.stderr,
+            )
+            return 1
+
+        try:
+            payload = _run_async(operation(manager))
+        except _CliArgumentError:
+            raise
+        except GatewayConfigSnapshotManagementError as exc:
+            _emit_json(exc.to_payload(), sys.stderr)
+            return 1
+        except Exception:  # noqa: BLE001
+            unavailable_error = GatewayConfigSnapshotManagementError(
+                "Config snapshot store unavailable",
+                reason_code="config_snapshot_store_unavailable",
+            )
+            _emit_json(unavailable_error.to_payload(), sys.stderr)
+            return 1
+
+        _emit_json(dict(payload), sys.stdout)
+        return 0
+    finally:
+        if profile_bundle is not None:
+            _run_async(_close_storage_bundle(profile_bundle))
+        if external_bundle is not None:
+            _run_async(_close_external_registry_bundle(external_bundle))
+
+
 def _credential_grant_storage_unavailable_error(
     exc: Exception,
 ) -> GatewayCredentialGrantManagementError | None:
@@ -846,6 +980,19 @@ def _external_registry_storage_unavailable_error(
     return GatewayExternalRegistryManagementError(
         str(exc),
         reason_code="external_registry_store_unavailable",
+    )
+
+
+def _config_snapshot_storage_unavailable_error(
+    exc: Exception,
+) -> GatewayConfigSnapshotManagementError | None:
+    """Map expected unavailable config snapshot storage build failures."""
+
+    if not isinstance(exc, ExternalRegistryStorageConfigurationError):
+        return None
+    return GatewayConfigSnapshotManagementError(
+        str(exc),
+        reason_code="config_snapshot_store_unavailable",
     )
 
 
@@ -924,6 +1071,44 @@ async def _set_default_profile_for_cli(
     }
 
 
+async def _export_config_for_cli(
+    manager: GatewayConfigSnapshotManager,
+    *,
+    output_path: Path | None,
+) -> dict[str, Any]:
+    """Export a snapshot, optionally writing it to a file."""
+
+    snapshot = await manager.export_snapshot()
+    payload = snapshot.model_dump(mode="json")
+    if output_path is None:
+        return payload
+    try:
+        output_path.write_text(
+            json.dumps(payload, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+    except OSError as exc:
+        raise _CliArgumentError(f"Unable to write snapshot JSON: {exc}") from exc
+    return {
+        "ok": True,
+        "output": str(output_path),
+        "schema": payload["schema"],
+        "version": payload["version"],
+    }
+
+
+async def _import_config_for_cli(
+    manager: GatewayConfigSnapshotManager,
+    *,
+    snapshot_file: Path,
+    dry_run: bool,
+) -> dict[str, Any]:
+    """Import a config snapshot from a JSON file or stdin."""
+
+    snapshot = _load_json_argument_file(snapshot_file, label="snapshot")
+    return await manager.import_snapshot(snapshot, dry_run=dry_run)
+
+
 async def _seed_readonly_memory_store(
     bundle: GatewayProfileStorageBundle,
     config: GatewayProfileBootstrapConfig,
@@ -997,7 +1182,7 @@ async def _close_external_registry_bundle(
     return {}
 
 
-def _run_async(coro: Coroutine[Any, Any, dict[str, Any]]) -> dict[str, Any]:
+def _run_async(coro: Coroutine[Any, Any, Any]) -> Any:
     """Run an async profile-management operation from a sync CLI handler."""
 
     return asyncio.run(coro)

--- a/mcp_unified/gateway/cli.py
+++ b/mcp_unified/gateway/cli.py
@@ -39,6 +39,11 @@ from .external_registry import (
     GatewayExternalRegistryManager,
 )
 from .profiles import GatewayProfileManagementError, GatewayProfileManager
+from .remote_admin import (
+    RemoteGatewayAdminClient,
+    RemoteGatewayAdminConfig,
+    RemoteGatewayAdminError,
+)
 from .snapshots import (
     GatewayConfigSnapshotManagementError,
     GatewayConfigSnapshotManager,
@@ -60,6 +65,7 @@ _ConfigSnapshotOperation = Callable[
     [GatewayConfigSnapshotManager],
     Coroutine[Any, Any, Mapping[str, Any]],
 ]
+_RemoteRuntimeOperation = Callable[[RemoteGatewayAdminClient], dict[str, Any]]
 
 
 class _CliArgumentError(ValueError):
@@ -401,6 +407,92 @@ def _build_parser() -> _JsonArgumentParser:
     _add_profile_config_argument(import_config)
     import_config.set_defaults(handler=_handle_import_config)
 
+    runtime_list = subparsers.add_parser(
+        "runtime-list",
+        help="List external runtime state from a running gateway.",
+    )
+    _add_remote_runtime_arguments(runtime_list)
+    runtime_list.set_defaults(handler=_handle_runtime_list)
+
+    runtime_start = subparsers.add_parser(
+        "runtime-start",
+        help="Start one external server through a running gateway.",
+    )
+    runtime_start.add_argument(
+        "server_id",
+        help="External server id to start.",
+    )
+    _add_remote_runtime_arguments(runtime_start)
+    runtime_start.set_defaults(handler=_handle_runtime_start)
+
+    runtime_stop = subparsers.add_parser(
+        "runtime-stop",
+        help="Stop one external server through a running gateway.",
+    )
+    runtime_stop.add_argument(
+        "server_id",
+        help="External server id to stop.",
+    )
+    _add_remote_runtime_arguments(runtime_stop)
+    runtime_stop.set_defaults(handler=_handle_runtime_stop)
+
+    runtime_restart = subparsers.add_parser(
+        "runtime-restart",
+        help="Restart one external server through a running gateway.",
+    )
+    runtime_restart.add_argument(
+        "server_id",
+        help="External server id to restart.",
+    )
+    _add_remote_runtime_arguments(runtime_restart)
+    runtime_restart.set_defaults(handler=_handle_runtime_restart)
+
+    runtime_refresh = subparsers.add_parser(
+        "runtime-refresh",
+        help="Refresh one external runtime or all runtimes from a running gateway.",
+    )
+    runtime_refresh.add_argument(
+        "server_id",
+        nargs="?",
+        help="Optional external server id to refresh.",
+    )
+    _add_remote_runtime_arguments(runtime_refresh)
+    runtime_refresh.set_defaults(handler=_handle_runtime_refresh)
+
+    runtime_reconcile = subparsers.add_parser(
+        "runtime-reconcile",
+        help="Reconcile one external runtime or all runtimes from a running gateway.",
+    )
+    runtime_reconcile.add_argument(
+        "server_id",
+        nargs="?",
+        help="Optional external server id to reconcile.",
+    )
+    _add_remote_runtime_arguments(runtime_reconcile)
+    runtime_reconcile.set_defaults(handler=_handle_runtime_reconcile)
+
+    runtime_install = subparsers.add_parser(
+        "runtime-install",
+        help="Run the configured install flow through a running gateway.",
+    )
+    runtime_install.add_argument(
+        "server_id",
+        help="External server id to install.",
+    )
+    _add_remote_runtime_arguments(runtime_install)
+    runtime_install.set_defaults(handler=_handle_runtime_install)
+
+    runtime_update = subparsers.add_parser(
+        "runtime-update",
+        help="Run the configured update flow through a running gateway.",
+    )
+    runtime_update.add_argument(
+        "server_id",
+        help="External server id to update.",
+    )
+    _add_remote_runtime_arguments(runtime_update)
+    runtime_update.set_defaults(handler=_handle_runtime_update)
+
     get_default_profile = subparsers.add_parser(
         "get-default-profile",
         help="Show the active gateway default profile.",
@@ -432,6 +524,29 @@ def _add_profile_config_argument(parser: argparse.ArgumentParser) -> None:
             "Path to a JSON or TOML gateway config file. "
             "Falls back to MCP_UNIFIED_GATEWAY_CONFIG or MCP_GATEWAY_CONFIG."
         ),
+    )
+
+
+def _add_remote_runtime_arguments(parser: argparse.ArgumentParser) -> None:
+    """Add common remote runtime options without command-line secrets."""
+
+    parser.add_argument(
+        "--gateway-url",
+        help=(
+            "Mounted gateway base URL, for example http://127.0.0.1:8000/mcp. "
+            "Falls back to MCP_UNIFIED_GATEWAY_URL."
+        ),
+    )
+    parser.add_argument(
+        "--admin-header-name",
+        default="X-MCP-Gateway-Admin-Key",
+        help="Admin auth header name used with MCP_UNIFIED_GATEWAY_ADMIN_KEY.",
+    )
+    parser.add_argument(
+        "--timeout-seconds",
+        type=float,
+        default=30.0,
+        help="Remote gateway request timeout in seconds.",
     )
 
 
@@ -696,6 +811,146 @@ def _handle_set_default_profile(args: argparse.Namespace) -> int:
         lambda manager: _set_default_profile_for_cli(manager, profile_id),
         require_persistent=True,
     )
+
+
+def _handle_runtime_list(args: argparse.Namespace) -> int:
+    """List external runtime state from a running gateway."""
+
+    return _handle_remote_runtime_command(
+        args,
+        lambda client: client.list_runtime_servers(),
+    )
+
+
+def _handle_runtime_start(args: argparse.Namespace) -> int:
+    """Start one external server through a running gateway."""
+
+    server_id = _require_cli_text(args.server_id, field="server_id")
+    return _handle_remote_runtime_command(
+        args,
+        lambda client: client.start_server(server_id),
+    )
+
+
+def _handle_runtime_stop(args: argparse.Namespace) -> int:
+    """Stop one external server through a running gateway."""
+
+    server_id = _require_cli_text(args.server_id, field="server_id")
+    return _handle_remote_runtime_command(
+        args,
+        lambda client: client.stop_server(server_id),
+    )
+
+
+def _handle_runtime_restart(args: argparse.Namespace) -> int:
+    """Restart one external server through a running gateway."""
+
+    server_id = _require_cli_text(args.server_id, field="server_id")
+    return _handle_remote_runtime_command(
+        args,
+        lambda client: client.restart_server(server_id),
+    )
+
+
+def _handle_runtime_refresh(args: argparse.Namespace) -> int:
+    """Refresh one external runtime or all runtimes through a running gateway."""
+
+    server_id = _optional_cli_text(args.server_id, field="server_id")
+    return _handle_remote_runtime_command(
+        args,
+        lambda client: client.refresh_server(server_id),
+    )
+
+
+def _handle_runtime_reconcile(args: argparse.Namespace) -> int:
+    """Reconcile one external runtime or all runtimes through a running gateway."""
+
+    server_id = _optional_cli_text(args.server_id, field="server_id")
+    return _handle_remote_runtime_command(
+        args,
+        lambda client: client.reconcile(server_id),
+    )
+
+
+def _handle_runtime_install(args: argparse.Namespace) -> int:
+    """Run one external server install flow through a running gateway."""
+
+    server_id = _require_cli_text(args.server_id, field="server_id")
+    return _handle_remote_runtime_command(
+        args,
+        lambda client: client.install_server(server_id),
+    )
+
+
+def _handle_runtime_update(args: argparse.Namespace) -> int:
+    """Run one external server update flow through a running gateway."""
+
+    server_id = _require_cli_text(args.server_id, field="server_id")
+    return _handle_remote_runtime_command(
+        args,
+        lambda client: client.update_server(server_id),
+    )
+
+
+def _handle_remote_runtime_command(
+    args: argparse.Namespace,
+    operation: _RemoteRuntimeOperation,
+) -> int:
+    """Run one remote runtime command against an already-running gateway."""
+
+    try:
+        config = _remote_runtime_config_from_args(args)
+        payload = operation(RemoteGatewayAdminClient(config))
+    except _CliArgumentError:
+        raise
+    except RemoteGatewayAdminError as exc:
+        _emit_json(exc.to_payload(), sys.stderr)
+        return 1
+    except Exception as exc:  # noqa: BLE001
+        _emit_json(
+            {
+                "error": "Remote gateway command failed",
+                "error_type": exc.__class__.__name__,
+                "ok": False,
+                "reason_code": "remote_gateway_command_failed",
+            },
+            sys.stderr,
+        )
+        return 1
+
+    _emit_json(payload, sys.stdout)
+    return 0
+
+
+def _remote_runtime_config_from_args(
+    args: argparse.Namespace,
+) -> RemoteGatewayAdminConfig:
+    """Build a remote admin config from CLI args and environment."""
+
+    gateway_url = _optional_cli_text(args.gateway_url, field="gateway_url")
+    if gateway_url is None:
+        gateway_url = _optional_cli_text(
+            os.environ.get("MCP_UNIFIED_GATEWAY_URL"),
+            field="MCP_UNIFIED_GATEWAY_URL",
+        )
+    if gateway_url is None:
+        raise _CliArgumentError(
+            "--gateway-url is required unless MCP_UNIFIED_GATEWAY_URL is set"
+        )
+
+    admin_key = _optional_cli_text(
+        os.environ.get("MCP_UNIFIED_GATEWAY_ADMIN_KEY"),
+        field="MCP_UNIFIED_GATEWAY_ADMIN_KEY",
+    )
+    try:
+        return RemoteGatewayAdminConfig(
+            gateway_url=gateway_url,
+            admin_header_name=args.admin_header_name,
+            admin_key=admin_key,
+            timeout_seconds=args.timeout_seconds,
+        )
+    except ValueError as exc:
+        raise _CliArgumentError(str(exc)) from exc
 
 
 def _handle_profile_management_command(

--- a/mcp_unified/gateway/config.py
+++ b/mcp_unified/gateway/config.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 from collections.abc import Callable, Iterable, Mapping
 from dataclasses import dataclass, field
 from json import JSONDecodeError
@@ -27,6 +28,8 @@ from mcp_unified.profiles.store import (
 )
 
 from .bootstrap import GatewayProfileBootstrap, bootstrap_profile_gateway
+from .admin_auth import GatewayAdminAuthConfig
+from .credential_grants import GatewayCredentialGrantManager
 from .external_registry import GatewayExternalRegistryManager, GatewayStoreMetadata
 from .lifecycle import GatewayExternalRuntimeLifecycleConfig
 from .profiles import GatewayProfileStoreMetadata
@@ -49,6 +52,48 @@ except ModuleNotFoundError:  # pragma: no cover - defensive for unsupported runt
 GatewayConfigFormat = Literal["json", "toml"]
 GatewayExternalRuntimeFactoryKind = Literal["stdio"]
 GatewayProfileStoreKind = Literal["memory", "sqlite"]
+
+
+@dataclass(frozen=True, slots=True)
+class GatewayAdminAuthBootstrapConfig:
+    """File-backed admin-auth bootstrap settings without persisted secrets."""
+
+    enabled: bool = False
+    header_name: str = "X-MCP-Gateway-Admin-Key"
+    api_key_env_var: str = "MCP_UNIFIED_GATEWAY_ADMIN_KEY"
+
+    def __post_init__(self) -> None:
+        """Validate admin auth config values that may appear in files."""
+
+        if not isinstance(self.enabled, bool):
+            raise ValueError("admin_auth.enabled must be a boolean")
+        header_name = str(self.header_name).strip()
+        if not header_name:
+            raise ValueError("admin_auth.header_name must be non-blank")
+        api_key_env_var = str(self.api_key_env_var).strip()
+        if not api_key_env_var:
+            raise ValueError("admin_auth.api_key_env_var must be non-blank")
+        object.__setattr__(self, "header_name", header_name)
+        object.__setattr__(self, "api_key_env_var", api_key_env_var)
+
+    def runtime_config(
+        self,
+        *,
+        environ: Mapping[str, str] | None = None,
+    ) -> GatewayAdminAuthConfig:
+        """Resolve the runtime admin auth config from the configured env var."""
+
+        if not self.enabled:
+            return GatewayAdminAuthConfig(
+                enabled=False,
+                header_name=self.header_name,
+            )
+        source = os.environ if environ is None else environ
+        return GatewayAdminAuthConfig(
+            enabled=True,
+            header_name=self.header_name,
+            api_key=source.get(self.api_key_env_var),
+        )
 
 
 @dataclass(frozen=True, slots=True)
@@ -144,6 +189,9 @@ class GatewayProfileBootstrapConfig:
     external_runtime: GatewayExternalRuntimeBootstrapConfig | Mapping[str, Any] = field(
         default_factory=GatewayExternalRuntimeBootstrapConfig
     )
+    admin_auth: GatewayAdminAuthBootstrapConfig | Mapping[str, Any] = field(
+        default_factory=GatewayAdminAuthBootstrapConfig
+    )
 
     def __post_init__(self) -> None:
         """Normalize nested config values into copy-isolated profile data."""
@@ -163,8 +211,22 @@ class GatewayProfileBootstrapConfig:
                 "GatewayExternalRuntimeBootstrapConfig or mapping"
             )
 
+        admin_auth = self.admin_auth
+        if isinstance(admin_auth, Mapping):
+            if "api_key" in admin_auth:
+                raise ValueError(
+                    "admin_auth.api_key must not be stored in gateway config; "
+                    "use admin_auth.api_key_env_var instead"
+                )
+            admin_auth = GatewayAdminAuthBootstrapConfig(**admin_auth)
+        elif not isinstance(admin_auth, GatewayAdminAuthBootstrapConfig):
+            raise TypeError(
+                "admin_auth must be a GatewayAdminAuthBootstrapConfig or mapping"
+            )
+
         object.__setattr__(self, "store", store)
         object.__setattr__(self, "external_runtime", external_runtime)
+        object.__setattr__(self, "admin_auth", admin_auth)
         object.__setattr__(
             self,
             "profiles",
@@ -231,6 +293,7 @@ async def bootstrap_profile_gateway_from_config(
     )
     external_registry_manager: GatewayExternalRegistryManager | None = None
     external_storage: GatewayExternalRegistryStorageBundle | None = None
+    credential_grant_manager: GatewayCredentialGrantManager | None = None
     if _supports_external_registry_store(storage.profile_store):
         external_storage = build_gateway_external_registry_storage(
             resolved_config.store,
@@ -240,6 +303,11 @@ async def bootstrap_profile_gateway_from_config(
         external_registry_manager = external_registry_manager_from_storage(
             external_storage,
         )
+        if external_storage.credential_grant_store is not None:
+            credential_grant_manager = credential_grant_manager_from_storage(
+                external_storage,
+                profile_storage=storage,
+            )
 
     resolved_external_runtime_manager = external_runtime_manager
     if (
@@ -272,6 +340,8 @@ async def bootstrap_profile_gateway_from_config(
         external_registry_manager=external_registry_manager,
         external_runtime_manager=resolved_external_runtime_manager,
         external_runtime_lifecycle=resolved_config.external_runtime.lifecycle_config(),
+        credential_grant_manager=credential_grant_manager,
+        admin_auth=resolved_config.admin_auth.runtime_config(),
     )
 
 
@@ -444,6 +514,44 @@ def external_runtime_manager_from_storage(
     )
 
 
+def credential_grant_manager_from_storage(
+    external_registry_storage: GatewayExternalRegistryStorageBundle,
+    *,
+    profile_storage: GatewayProfileStorageBundle | None = None,
+    credential_grant_store: CredentialGrantStore | None = None,
+    profile_store: ProfileStore | None = None,
+    external_registry_store: ExternalRegistryStore | None = None,
+    audit_store: AuditStore | None = None,
+) -> GatewayCredentialGrantManager:
+    """Build a credential-grant manager from resolved storage dependencies."""
+
+    resolved_credential_store = (
+        credential_grant_store
+        if credential_grant_store is not None
+        else external_registry_storage.credential_grant_store
+    )
+    if resolved_credential_store is None:
+        raise ExternalRegistryStorageConfigurationError(
+            "credential grant management requires a credential grant store"
+        )
+
+    resolved_profile_store = profile_store
+    if resolved_profile_store is None and profile_storage is not None:
+        resolved_profile_store = profile_storage.profile_store
+
+    return GatewayCredentialGrantManager(
+        credential_grant_store=resolved_credential_store,
+        profile_store=resolved_profile_store,
+        external_registry_store=external_registry_store
+        if external_registry_store is not None
+        else external_registry_storage.external_registry_store,
+        audit_store=audit_store
+        if audit_store is not None
+        else external_registry_storage.audit_store,
+        store_metadata=external_registry_storage.metadata,
+    )
+
+
 def _metadata_for_store_config(
     store_config: GatewayProfileStoreConfig,
 ) -> GatewayProfileStoreMetadata:
@@ -526,6 +634,7 @@ def _supports_credential_grant_store(candidate: object) -> bool:
         for method_name in (
             "get_grant",
             "list_grants",
+            "create_grant",
             "upsert_grant",
             "delete_grant",
         )
@@ -681,6 +790,7 @@ def _copy_profile(profile: MCPProfile | Mapping[str, Any]) -> MCPProfile:
 
 
 __all__ = [
+    "GatewayAdminAuthBootstrapConfig",
     "GatewayConfigFormat",
     "GatewayExternalRuntimeBootstrapConfig",
     "GatewayExternalRuntimeFactoryKind",
@@ -692,6 +802,7 @@ __all__ = [
     "bootstrap_profile_gateway_from_config",
     "build_gateway_external_registry_storage",
     "build_gateway_profile_storage",
+    "credential_grant_manager_from_storage",
     "external_registry_manager_from_storage",
     "external_runtime_manager_from_storage",
     "load_gateway_profile_bootstrap_config",

--- a/mcp_unified/gateway/config.py
+++ b/mcp_unified/gateway/config.py
@@ -34,6 +34,7 @@ from .external_registry import GatewayExternalRegistryManager, GatewayStoreMetad
 from .lifecycle import GatewayExternalRuntimeLifecycleConfig
 from .profiles import GatewayProfileStoreMetadata
 from .runtime import GatewayRuntime
+from .snapshots import GatewayConfigSnapshotManager
 
 if TYPE_CHECKING:
     from mcp_unified.federation.installers import ExternalServerInstaller
@@ -549,6 +550,36 @@ def credential_grant_manager_from_storage(
         if audit_store is not None
         else external_registry_storage.audit_store,
         store_metadata=external_registry_storage.metadata,
+    )
+
+
+def gateway_config_snapshot_manager_from_storage(
+    profile_storage: GatewayProfileStorageBundle,
+    external_registry_storage: GatewayExternalRegistryStorageBundle,
+    *,
+    credential_grant_store: CredentialGrantStore | None = None,
+    audit_store: AuditStore | None = None,
+) -> GatewayConfigSnapshotManager:
+    """Build a config snapshot manager from resolved storage dependencies."""
+
+    resolved_credential_store = (
+        credential_grant_store
+        if credential_grant_store is not None
+        else external_registry_storage.credential_grant_store
+    )
+    if resolved_credential_store is None:
+        raise ExternalRegistryStorageConfigurationError(
+            "config snapshots require a credential grant store"
+        )
+
+    return GatewayConfigSnapshotManager(
+        profile_store=profile_storage.profile_store,
+        assignment_store=profile_storage.assignment_store,
+        external_registry_store=external_registry_storage.external_registry_store,
+        credential_grant_store=resolved_credential_store,
+        audit_store=audit_store
+        if audit_store is not None
+        else profile_storage.audit_store or external_registry_storage.audit_store,
     )
 
 

--- a/mcp_unified/gateway/credential_grants.py
+++ b/mcp_unified/gateway/credential_grants.py
@@ -287,8 +287,9 @@ class GatewayCredentialGrantManager:
             grant = self._normalize_grant(grant)
             self._reject_secret_material(grant.metadata, grant_id=grant.id)
             self._reject_secret_material(grant.provenance, grant_id=grant.id)
+            now = datetime.now(timezone.utc)
             return grant.model_copy(
-                update={"updated_at": datetime.now(timezone.utc)},
+                update={"created_at": now, "updated_at": now},
                 deep=True,
             )
         except GatewayCredentialGrantManagementError:
@@ -558,11 +559,17 @@ class GatewayCredentialGrantManager:
                 "Invalid credential grant list field",
                 reason_code=reason_code,
             )
-        return [
-            item.strip()
-            for item in values
-            if isinstance(item, str) and item.strip()
-        ]
+        normalized: list[str] = []
+        for item in values:
+            if not isinstance(item, str):
+                raise self._error(
+                    "Invalid credential grant list field",
+                    reason_code=reason_code,
+                )
+            text = item.strip()
+            if text:
+                normalized.append(text)
+        return normalized
 
     @staticmethod
     def _dump_grant(grant: CredentialGrant) -> dict[str, Any]:

--- a/mcp_unified/gateway/credential_grants.py
+++ b/mcp_unified/gateway/credential_grants.py
@@ -1,0 +1,607 @@
+"""Gateway credential-grant management helpers for standalone MCP stores."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from datetime import datetime, timezone
+from typing import Any
+from uuid import uuid4
+
+from loguru import logger
+
+from mcp_unified.gateway.external_registry import GatewayStoreMetadata
+from mcp_unified.interfaces.storage import (
+    AuditStore,
+    CredentialGrantAlreadyExistsError,
+    CredentialGrantStore,
+    ExternalRegistryStore,
+    ProfileStore,
+)
+from mcp_unified.storage.models import AuditEvent, CredentialGrant
+
+_PATCH_FIELDS = frozenset(
+    {
+        "broker_id",
+        "credential_slot",
+        "external_server_id",
+        "scopes",
+        "metadata",
+        "provenance",
+        "enabled",
+    }
+)
+_SECRET_KEY_MARKERS = ("secret", "token", "password")
+_SECRET_KEY_EXACT_MATCHES = {
+    "api_key",
+    "authorization",
+    "headers",
+    "env",
+    "credential_value",
+}
+CREDENTIAL_GRANT_SENSITIVE_MATERIAL_REJECTED_REASON = "_".join(
+    ("credential", "grant", "secret", "material", "rejected")
+)
+CREDENTIAL_GRANT_SENSITIVE_MATERIAL_REJECTED_ERROR = " ".join(
+    ("Credential grant metadata must not contain", "secret material")
+)
+
+
+class GatewayCredentialGrantManagementError(RuntimeError):
+    """Domain error for expected gateway credential-grant failures."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        reason_code: str,
+        grant_id: str | None = None,
+        profile_id: str | None = None,
+        external_server_id: str | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.reason_code = reason_code
+        self.grant_id = grant_id
+        self.profile_id = profile_id
+        self.external_server_id = external_server_id
+
+    def to_payload(self) -> dict[str, Any]:
+        """Return a deterministic JSON-safe error payload."""
+
+        payload: dict[str, Any] = {
+            "ok": False,
+            "error": str(self),
+            "reason_code": self.reason_code,
+        }
+        if self.grant_id is not None:
+            payload["grant_id"] = self.grant_id
+        if self.profile_id is not None:
+            payload["profile_id"] = self.profile_id
+        if self.external_server_id is not None:
+            payload["external_server_id"] = self.external_server_id
+        return payload
+
+
+class GatewayCredentialGrantManager:
+    """Manage stored credential broker grant metadata for the package gateway."""
+
+    def __init__(
+        self,
+        *,
+        credential_grant_store: CredentialGrantStore,
+        store_metadata: GatewayStoreMetadata,
+        profile_store: ProfileStore | None = None,
+        external_registry_store: ExternalRegistryStore | None = None,
+        audit_store: AuditStore | None = None,
+    ) -> None:
+        self.credential_grant_store = credential_grant_store
+        self.profile_store = profile_store
+        self.external_registry_store = external_registry_store
+        self.audit_store = audit_store
+        self.store_metadata = store_metadata
+
+    async def list_grants(
+        self,
+        *,
+        profile_id: str | None = None,
+        external_server_id: str | None = None,
+    ) -> dict[str, Any]:
+        """List credential grants with store metadata."""
+
+        try:
+            grants = await self.credential_grant_store.list_grants(
+                profile_id=self._normalize_optional_text(profile_id),
+                external_server_id=self._normalize_optional_text(external_server_id),
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.opt(exception=True).warning("Gateway credential grant list failed")
+            raise self._error(
+                "Credential grant store unavailable",
+                reason_code="credential_grant_store_unavailable",
+            ) from exc
+        return {
+            "ok": True,
+            "grants": [
+                self._dump_grant(grant)
+                for grant in sorted(grants, key=lambda item: item.id)
+            ],
+            "store": self.store_metadata.to_payload(),
+        }
+
+    async def show_grant(self, grant_id: str) -> dict[str, Any]:
+        """Return one credential grant by id with store metadata."""
+
+        normalized_grant_id = self._normalize_grant_id(
+            grant_id,
+            reason_code="invalid_credential_grant_request",
+        )
+        grant = await self._get_grant(normalized_grant_id)
+        if grant is None:
+            raise self._error(
+                f"Credential grant not found: {normalized_grant_id}",
+                reason_code="credential_grant_not_found",
+                grant_id=normalized_grant_id,
+            )
+        return {
+            "ok": True,
+            "grant": self._dump_grant(grant),
+            "store": self.store_metadata.to_payload(),
+        }
+
+    async def create_grant(
+        self,
+        grant_document: CredentialGrant | Mapping[str, Any],
+    ) -> dict[str, Any]:
+        """Create credential grant metadata without replacing existing grants."""
+
+        grant = self._coerce_create_document(grant_document)
+        await self._validate_references(grant)
+        try:
+            stored = await self.credential_grant_store.create_grant(grant)
+        except CredentialGrantAlreadyExistsError as exc:
+            raise self._error(
+                f"Credential grant already exists: {exc.grant_id}",
+                reason_code="credential_grant_already_exists",
+                grant_id=exc.grant_id,
+            ) from exc
+        except Exception as exc:  # noqa: BLE001
+            logger.opt(exception=True).warning(
+                "Gateway credential grant create failed",
+                grant_id=grant.id,
+            )
+            raise self._error(
+                "Credential grant store unavailable",
+                reason_code="credential_grant_store_unavailable",
+                grant_id=grant.id,
+            ) from exc
+
+        await self._append_audit_event(
+            "credential_grant.created",
+            target_id=stored.id,
+            profile_id=stored.profile_id,
+            payload={"grant_id": stored.id, "profile_id": stored.profile_id},
+        )
+        return {
+            "ok": True,
+            "grant": self._dump_grant(stored),
+            "store": self.store_metadata.to_payload(),
+        }
+
+    async def patch_grant(
+        self,
+        grant_id: str,
+        patch_document: Mapping[str, Any],
+    ) -> dict[str, Any]:
+        """Apply an allowed metadata patch to a credential grant."""
+
+        normalized_grant_id = self._normalize_grant_id(
+            grant_id,
+            reason_code="invalid_credential_grant_patch",
+        )
+        patch = self._validate_patch_document(patch_document)
+        current = await self._get_grant_for_mutation(normalized_grant_id)
+        updated, changed_fields = self._apply_patch(current, patch)
+        await self._validate_references(updated)
+        try:
+            stored = await self.credential_grant_store.upsert_grant(updated)
+        except Exception as exc:  # noqa: BLE001
+            logger.opt(exception=True).warning(
+                "Gateway credential grant patch failed",
+                grant_id=normalized_grant_id,
+            )
+            raise self._error(
+                "Credential grant store unavailable",
+                reason_code="credential_grant_store_unavailable",
+                grant_id=normalized_grant_id,
+            ) from exc
+
+        await self._append_audit_event(
+            "credential_grant.patched",
+            target_id=stored.id,
+            profile_id=stored.profile_id,
+            payload={
+                "grant_id": stored.id,
+                "profile_id": stored.profile_id,
+                "changed_fields": list(changed_fields),
+            },
+        )
+        return {
+            "ok": True,
+            "grant": self._dump_grant(stored),
+            "store": self.store_metadata.to_payload(),
+        }
+
+    async def delete_grant(self, grant_id: str) -> dict[str, Any]:
+        """Delete credential grant metadata by id."""
+
+        normalized_grant_id = self._normalize_grant_id(
+            grant_id,
+            reason_code="invalid_credential_grant_request",
+        )
+        current = await self._get_grant_for_mutation(normalized_grant_id)
+        try:
+            deleted = await self.credential_grant_store.delete_grant(
+                normalized_grant_id,
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.opt(exception=True).warning(
+                "Gateway credential grant delete failed",
+                grant_id=normalized_grant_id,
+            )
+            raise self._error(
+                "Credential grant store unavailable",
+                reason_code="credential_grant_store_unavailable",
+                grant_id=normalized_grant_id,
+            ) from exc
+        if not deleted:
+            raise self._error(
+                f"Credential grant not found: {normalized_grant_id}",
+                reason_code="credential_grant_not_found",
+                grant_id=normalized_grant_id,
+            )
+
+        await self._append_audit_event(
+            "credential_grant.deleted",
+            target_id=normalized_grant_id,
+            profile_id=current.profile_id,
+            payload={
+                "grant_id": normalized_grant_id,
+                "profile_id": current.profile_id,
+            },
+        )
+        return {
+            "ok": True,
+            "grant_id": normalized_grant_id,
+            "store": self.store_metadata.to_payload(),
+        }
+
+    def _coerce_create_document(
+        self,
+        grant_document: CredentialGrant | Mapping[str, Any],
+    ) -> CredentialGrant:
+        try:
+            grant = (
+                grant_document.model_copy(deep=True)
+                if isinstance(grant_document, CredentialGrant)
+                else CredentialGrant.model_validate(grant_document)
+            )
+            grant = self._normalize_grant(grant)
+            self._reject_secret_material(grant.metadata, grant_id=grant.id)
+            self._reject_secret_material(grant.provenance, grant_id=grant.id)
+            return grant.model_copy(
+                update={"updated_at": datetime.now(timezone.utc)},
+                deep=True,
+            )
+        except GatewayCredentialGrantManagementError:
+            raise
+        except (TypeError, ValueError) as exc:
+            raise self._error(
+                "Invalid credential grant request",
+                reason_code="invalid_credential_grant_request",
+            ) from exc
+
+    def _validate_patch_document(self, patch_document: Mapping[str, Any]) -> dict[str, Any]:
+        if not isinstance(patch_document, Mapping):
+            raise self._error(
+                "Invalid credential grant patch",
+                reason_code="invalid_credential_grant_patch",
+            )
+        patch = dict(patch_document)
+        unsupported_fields = set(patch) - _PATCH_FIELDS
+        if not patch or unsupported_fields:
+            raise self._error(
+                "Invalid credential grant patch",
+                reason_code="invalid_credential_grant_patch",
+            )
+        for field_name in ("broker_id", "credential_slot"):
+            if field_name in patch:
+                patch[field_name] = self._require_text(
+                    patch[field_name],
+                    field=field_name,
+                    reason_code="invalid_credential_grant_patch",
+                )
+        if "external_server_id" in patch:
+            patch["external_server_id"] = self._normalize_optional_text(
+                patch["external_server_id"]
+            )
+        if "scopes" in patch:
+            patch["scopes"] = self._normalize_text_list(
+                patch["scopes"],
+                reason_code="invalid_credential_grant_patch",
+            )
+        if "metadata" in patch:
+            self._reject_secret_material(patch["metadata"])
+        if "provenance" in patch:
+            self._reject_secret_material(patch["provenance"])
+        return patch
+
+    def _apply_patch(
+        self,
+        grant: CredentialGrant,
+        patch: Mapping[str, Any],
+    ) -> tuple[CredentialGrant, tuple[str, ...]]:
+        payload = grant.model_dump(mode="python")
+        payload.update(dict(patch))
+        payload["updated_at"] = datetime.now(timezone.utc)
+        try:
+            updated = CredentialGrant.model_validate(payload)
+        except (TypeError, ValueError) as exc:
+            raise self._error(
+                "Invalid credential grant patch",
+                reason_code="invalid_credential_grant_patch",
+                grant_id=grant.id,
+            ) from exc
+        return self._normalize_grant(updated), tuple(sorted(patch))
+
+    def _normalize_grant(self, grant: CredentialGrant) -> CredentialGrant:
+        normalized_grant_id = self._normalize_grant_id(
+            grant.id,
+            reason_code="invalid_credential_grant_request",
+        )
+        profile_id = self._require_text(
+            grant.profile_id,
+            field="profile_id",
+            reason_code="invalid_credential_grant_request",
+            grant_id=normalized_grant_id,
+        )
+        broker_id = self._require_text(
+            grant.broker_id,
+            field="broker_id",
+            reason_code="invalid_credential_grant_request",
+            grant_id=normalized_grant_id,
+        )
+        credential_slot = self._require_text(
+            grant.credential_slot,
+            field="credential_slot",
+            reason_code="invalid_credential_grant_request",
+            grant_id=normalized_grant_id,
+        )
+        return grant.model_copy(
+            update={
+                "id": normalized_grant_id,
+                "profile_id": profile_id,
+                "broker_id": broker_id,
+                "credential_slot": credential_slot,
+                "external_server_id": self._normalize_optional_text(
+                    grant.external_server_id,
+                ),
+                "scopes": self._normalize_text_list(
+                    grant.scopes,
+                    reason_code="invalid_credential_grant_request",
+                ),
+            },
+            deep=True,
+        )
+
+    async def _validate_references(self, grant: CredentialGrant) -> None:
+        if self.profile_store is not None:
+            try:
+                profile = await self.profile_store.get_profile(grant.profile_id)
+            except Exception as exc:  # noqa: BLE001
+                raise self._error(
+                    "Profile store unavailable",
+                    reason_code="profile_store_unavailable",
+                    grant_id=grant.id,
+                    profile_id=grant.profile_id,
+                ) from exc
+            if profile is None:
+                raise self._error(
+                    f"Profile not found: {grant.profile_id}",
+                    reason_code="profile_not_found",
+                    grant_id=grant.id,
+                    profile_id=grant.profile_id,
+                )
+
+        if self.external_registry_store is not None and grant.external_server_id:
+            try:
+                server = await self.external_registry_store.get_server(
+                    grant.external_server_id,
+                )
+            except Exception as exc:  # noqa: BLE001
+                raise self._error(
+                    "External registry store unavailable",
+                    reason_code="external_registry_store_unavailable",
+                    grant_id=grant.id,
+                    external_server_id=grant.external_server_id,
+                ) from exc
+            if server is None:
+                raise self._error(
+                    f"External server not found: {grant.external_server_id}",
+                    reason_code="external_server_not_found",
+                    grant_id=grant.id,
+                    external_server_id=grant.external_server_id,
+                )
+
+    async def _get_grant(self, grant_id: str) -> CredentialGrant | None:
+        try:
+            return await self.credential_grant_store.get_grant(grant_id)
+        except Exception as exc:  # noqa: BLE001
+            raise self._error(
+                "Credential grant store unavailable",
+                reason_code="credential_grant_store_unavailable",
+                grant_id=grant_id,
+            ) from exc
+
+    async def _get_grant_for_mutation(self, grant_id: str) -> CredentialGrant:
+        grant = await self._get_grant(grant_id)
+        if grant is None:
+            raise self._error(
+                f"Credential grant not found: {grant_id}",
+                reason_code="credential_grant_not_found",
+                grant_id=grant_id,
+            )
+        return grant
+
+    async def _append_audit_event(
+        self,
+        event_type: str,
+        *,
+        target_id: str | None = None,
+        profile_id: str | None = None,
+        payload: Mapping[str, Any] | None = None,
+    ) -> None:
+        """Append an audit event when an audit store is configured."""
+
+        if self.audit_store is None:
+            return
+        event = AuditEvent(
+            id=str(uuid4()),
+            event_type=event_type,
+            profile_id=profile_id,
+            target_type="credential_grant" if target_id is not None else None,
+            target_id=target_id,
+            payload=dict(payload or {}),
+            provenance={"source": "gateway_credential_grant_manager"},
+            created_at=datetime.now(timezone.utc),
+        )
+        try:
+            await self.audit_store.append_event(event)
+        except Exception:  # noqa: BLE001
+            logger.opt(exception=True).warning(
+                "Gateway credential grant audit append failed for {event_type}",
+                event_type=event_type,
+                target_id=target_id,
+            )
+
+    def _reject_secret_material(
+        self,
+        value: Any,
+        *,
+        grant_id: str | None = None,
+    ) -> None:
+        if _contains_secret_key(value):
+            raise self._error(
+                CREDENTIAL_GRANT_SENSITIVE_MATERIAL_REJECTED_ERROR,
+                reason_code=CREDENTIAL_GRANT_SENSITIVE_MATERIAL_REJECTED_REASON,
+                grant_id=grant_id,
+            )
+
+    def _normalize_grant_id(
+        self,
+        value: str,
+        *,
+        reason_code: str,
+    ) -> str:
+        return self._require_text(value, field="grant_id", reason_code=reason_code)
+
+    def _require_text(
+        self,
+        value: Any,
+        *,
+        field: str,
+        reason_code: str,
+        grant_id: str | None = None,
+    ) -> str:
+        if not isinstance(value, str):
+            raise self._error(
+                f"Invalid {field}",
+                reason_code=reason_code,
+                grant_id=grant_id,
+            )
+        text = value.strip()
+        if not text:
+            raise self._error(
+                f"Invalid {field}",
+                reason_code=reason_code,
+                grant_id=grant_id,
+            )
+        return text
+
+    @staticmethod
+    def _normalize_optional_text(value: Any) -> str | None:
+        if value is None:
+            return None
+        if not isinstance(value, str):
+            return None
+        text = value.strip()
+        return text or None
+
+    def _normalize_text_list(self, values: Any, *, reason_code: str) -> list[str]:
+        if values is None:
+            return []
+        if not isinstance(values, list | tuple):
+            raise self._error(
+                "Invalid credential grant list field",
+                reason_code=reason_code,
+            )
+        return [
+            item.strip()
+            for item in values
+            if isinstance(item, str) and item.strip()
+        ]
+
+    @staticmethod
+    def _dump_grant(grant: CredentialGrant) -> dict[str, Any]:
+        return grant.model_dump(mode="json")
+
+    @staticmethod
+    def _error(
+        message: str,
+        *,
+        reason_code: str,
+        grant_id: str | None = None,
+        profile_id: str | None = None,
+        external_server_id: str | None = None,
+    ) -> GatewayCredentialGrantManagementError:
+        return GatewayCredentialGrantManagementError(
+            message,
+            reason_code=reason_code,
+            grant_id=grant_id,
+            profile_id=profile_id,
+            external_server_id=external_server_id,
+        )
+
+
+def reject_secret_looking_metadata(value: Any) -> None:
+    """Reject mappings containing secret-looking keys."""
+
+    if _contains_secret_key(value):
+        raise GatewayCredentialGrantManagementError(
+            CREDENTIAL_GRANT_SENSITIVE_MATERIAL_REJECTED_ERROR,
+            reason_code=CREDENTIAL_GRANT_SENSITIVE_MATERIAL_REJECTED_REASON,
+        )
+
+
+def _contains_secret_key(value: Any) -> bool:
+    """Return whether a JSON-like value contains secret-looking keys."""
+
+    if isinstance(value, Mapping):
+        for key, nested_value in value.items():
+            key_text = str(key).strip().lower()
+            if key_text in _SECRET_KEY_EXACT_MATCHES or any(
+                marker in key_text for marker in _SECRET_KEY_MARKERS
+            ):
+                return True
+            if _contains_secret_key(nested_value):
+                return True
+    elif isinstance(value, list | tuple):
+        return any(_contains_secret_key(item) for item in value)
+    return False
+
+
+__all__ = [
+    "CREDENTIAL_GRANT_SENSITIVE_MATERIAL_REJECTED_ERROR",
+    "CREDENTIAL_GRANT_SENSITIVE_MATERIAL_REJECTED_REASON",
+    "GatewayCredentialGrantManagementError",
+    "GatewayCredentialGrantManager",
+    "reject_secret_looking_metadata",
+]

--- a/mcp_unified/gateway/credential_grants.py
+++ b/mcp_unified/gateway/credential_grants.py
@@ -320,8 +320,10 @@ class GatewayCredentialGrantManager:
                     reason_code="invalid_credential_grant_patch",
                 )
         if "external_server_id" in patch:
-            patch["external_server_id"] = self._normalize_optional_text(
-                patch["external_server_id"]
+            patch["external_server_id"] = self._normalize_optional_patch_text(
+                patch["external_server_id"],
+                field="external_server_id",
+                reason_code="invalid_credential_grant_patch",
             )
         if "scopes" in patch:
             patch["scopes"] = self._normalize_text_list(
@@ -534,6 +536,19 @@ class GatewayCredentialGrantManager:
             return None
         text = value.strip()
         return text or None
+
+    def _normalize_optional_patch_text(
+        self,
+        value: Any,
+        *,
+        field: str,
+        reason_code: str,
+    ) -> str | None:
+        """Normalize nullable text patch fields without silently dropping bad types."""
+
+        if value is None:
+            return None
+        return self._require_text(value, field=field, reason_code=reason_code)
 
     def _normalize_text_list(self, values: Any, *, reason_code: str) -> list[str]:
         if values is None:

--- a/mcp_unified/gateway/fastapi.py
+++ b/mcp_unified/gateway/fastapi.py
@@ -2,12 +2,13 @@
 
 from __future__ import annotations
 
-from collections.abc import AsyncIterator, Mapping
+from collections.abc import AsyncIterator, Callable, Mapping
 from contextlib import asynccontextmanager
 from typing import Any, Literal
 
 from fastapi import APIRouter, Depends, FastAPI, Request, Response, WebSocket, WebSocketDisconnect
 from fastapi.responses import JSONResponse
+from fastapi.routing import APIRoute
 from loguru import logger
 from pydantic import BaseModel, ConfigDict
 
@@ -360,6 +361,21 @@ class ExternalRuntimeOperationResponse(BaseModel):
     warnings: list[Any] | None = None
     error: str | None = None
     errors: dict[str, Any] | None = None
+
+
+class _GatewayAdminAuthHandlingRoute(APIRoute):
+    """Route wrapper that keeps router-only admin auth failures JSON-stable."""
+
+    def get_route_handler(self) -> Callable[[Request], Any]:
+        original_route_handler = super().get_route_handler()
+
+        async def route_handler(request: Request) -> Response:
+            try:
+                return await original_route_handler(request)
+            except GatewayAdminAuthError as exc:
+                return gateway_admin_auth_error_response(request, exc)
+
+        return route_handler
 
 
 async def _parse_json_body(request: Request) -> Any:
@@ -1288,7 +1304,7 @@ def create_gateway_router(
 ) -> APIRouter:
     """Create a package-owned FastAPI router for a standalone MCP runtime."""
 
-    router = APIRouter()
+    router = APIRouter(route_class=_GatewayAdminAuthHandlingRoute)
     resolved_admin_auth = _resolve_admin_auth_config(
         admin_auth=admin_auth,
         profile_bootstrap=profile_bootstrap,

--- a/mcp_unified/gateway/fastapi.py
+++ b/mcp_unified/gateway/fastapi.py
@@ -295,7 +295,7 @@ class CredentialGrantListResponse(BaseModel):
     """Response body for listing stored credential grants."""
 
     ok: bool
-    grants: list[dict[str, Any]]
+    grants: list[CredentialGrant]
     store: StoreMetadataResponse
 
 
@@ -303,7 +303,7 @@ class CredentialGrantResponse(BaseModel):
     """Response body for returning one stored credential grant."""
 
     ok: bool
-    grant: dict[str, Any]
+    grant: CredentialGrant
     store: StoreMetadataResponse
 
 

--- a/mcp_unified/gateway/fastapi.py
+++ b/mcp_unified/gateway/fastapi.py
@@ -6,14 +6,27 @@ from collections.abc import AsyncIterator, Mapping
 from contextlib import asynccontextmanager
 from typing import Any, Literal
 
-from fastapi import APIRouter, FastAPI, Request, Response, WebSocket, WebSocketDisconnect
+from fastapi import APIRouter, Depends, FastAPI, Request, Response, WebSocket, WebSocketDisconnect
 from fastapi.responses import JSONResponse
 from loguru import logger
 from pydantic import BaseModel, ConfigDict
 
-from mcp_unified.storage.models import ExternalServerDefinition
+from mcp_unified.storage.models import CredentialGrant, ExternalServerDefinition
 
+from .admin_auth import (
+    GatewayAdminAuthConfig,
+    GatewayAdminAuthError,
+    gateway_admin_auth_dependencies,
+    gateway_admin_auth_error_response,
+    normalize_gateway_admin_auth_config,
+)
 from .bootstrap import GatewayProfileBootstrap
+from .credential_grants import (
+    CREDENTIAL_GRANT_SENSITIVE_MATERIAL_REJECTED_ERROR,
+    CREDENTIAL_GRANT_SENSITIVE_MATERIAL_REJECTED_REASON,
+    GatewayCredentialGrantManagementError,
+    GatewayCredentialGrantManager,
+)
 from .external_registry import (
     GatewayExternalRegistryManagementError,
     GatewayExternalRegistryManager,
@@ -95,6 +108,18 @@ _EXTERNAL_RUNTIME_STATUS_CODES = {
     "credential_broker_unavailable": 503,
     "invalid_external_runtime_request": 422,
 }
+_CREDENTIAL_GRANT_STATUS_CODES = {
+    "credential_grant_store_unavailable": 503,
+    "profile_store_unavailable": 503,
+    "external_registry_store_unavailable": 503,
+    "credential_grant_not_found": 404,
+    "profile_not_found": 404,
+    "external_server_not_found": 404,
+    "credential_grant_already_exists": 409,
+    "invalid_credential_grant_request": 422,
+    "invalid_credential_grant_patch": 422,
+    CREDENTIAL_GRANT_SENSITIVE_MATERIAL_REJECTED_REASON: 422,
+}
 _EXTERNAL_SERVER_RESERVED_IDS = frozenset({"runtime", "refresh", "reconcile"})
 _PROFILE_MANAGEMENT_PUBLIC_ERRORS = {
     "profile_store_unavailable": "Profile store unavailable",
@@ -111,6 +136,14 @@ _EXTERNAL_RUNTIME_PUBLIC_ERRORS = {
     "external_server_transport_unavailable": "External server transport unavailable",
     "external_tool_call_failed": "External tool call failed",
     "credential_broker_unavailable": "Credential broker unavailable",
+}
+_CREDENTIAL_GRANT_PUBLIC_ERRORS = {
+    "credential_grant_store_unavailable": "Credential grant store unavailable",
+    "profile_store_unavailable": "Profile store unavailable",
+    "external_registry_store_unavailable": "External registry store unavailable",
+    CREDENTIAL_GRANT_SENSITIVE_MATERIAL_REJECTED_REASON: (
+        CREDENTIAL_GRANT_SENSITIVE_MATERIAL_REJECTED_ERROR
+    ),
 }
 
 
@@ -163,6 +196,24 @@ class PatchExternalServerRequest(BaseModel):
     provenance: dict[str, Any] | None = None
     enabled: bool | None = None
     auto_start: bool | None = None
+
+
+class CreateCredentialGrantRequest(CredentialGrant):
+    """Request body for creating stored credential broker grant metadata."""
+
+
+class PatchCredentialGrantRequest(BaseModel):
+    """Request body for patching stored credential broker grant metadata."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    broker_id: str | None = None
+    credential_slot: str | None = None
+    external_server_id: str | None = None
+    scopes: list[str] | None = None
+    metadata: dict[str, Any] | None = None
+    provenance: dict[str, Any] | None = None
+    enabled: bool | None = None
 
 
 class StoreMetadataResponse(BaseModel):
@@ -237,6 +288,30 @@ class DeleteExternalServerResponse(BaseModel):
 
     ok: bool
     server_id: str
+    store: StoreMetadataResponse
+
+
+class CredentialGrantListResponse(BaseModel):
+    """Response body for listing stored credential grants."""
+
+    ok: bool
+    grants: list[dict[str, Any]]
+    store: StoreMetadataResponse
+
+
+class CredentialGrantResponse(BaseModel):
+    """Response body for returning one stored credential grant."""
+
+    ok: bool
+    grant: dict[str, Any]
+    store: StoreMetadataResponse
+
+
+class DeleteCredentialGrantResponse(BaseModel):
+    """Response body for deleting one stored credential grant."""
+
+    ok: bool
+    grant_id: str
     store: StoreMetadataResponse
 
 
@@ -400,6 +475,17 @@ def _external_runtime_error_response(
     )
 
 
+def _credential_grant_error_response(
+    exc: GatewayCredentialGrantManagementError,
+) -> JSONResponse:
+    """Translate expected credential-grant errors into HTTP JSON responses."""
+
+    return JSONResponse(
+        status_code=_CREDENTIAL_GRANT_STATUS_CODES.get(exc.reason_code, 500),
+        content=_credential_grant_error_payload(exc),
+    )
+
+
 def _profile_management_error_payload(exc: GatewayProfileManagementError) -> dict[str, Any]:
     """Return a public profile-management error payload without raw exception text."""
 
@@ -449,6 +535,28 @@ def _external_runtime_error_payload(exc: GatewayExternalRuntimeError) -> dict[st
     }
     if exc.server_id is not None:
         payload["server_id"] = exc.server_id
+    return payload
+
+
+def _credential_grant_error_payload(
+    exc: GatewayCredentialGrantManagementError,
+) -> dict[str, Any]:
+    """Return a public credential-grant error payload without raw exception text."""
+
+    payload: dict[str, Any] = {
+        "ok": False,
+        "error": _CREDENTIAL_GRANT_PUBLIC_ERRORS.get(
+            exc.reason_code,
+            "Gateway credential grant request failed",
+        ),
+        "reason_code": exc.reason_code,
+    }
+    if exc.grant_id is not None:
+        payload["grant_id"] = exc.grant_id
+    if exc.profile_id is not None:
+        payload["profile_id"] = exc.profile_id
+    if exc.external_server_id is not None:
+        payload["external_server_id"] = exc.external_server_id
     return payload
 
 
@@ -556,6 +664,24 @@ def _resolve_external_runtime_manager(
     return resolved
 
 
+def _resolve_credential_grant_manager(
+    *,
+    credential_grant_manager: GatewayCredentialGrantManager | None,
+    profile_bootstrap: GatewayProfileBootstrap | None,
+    enable_credential_grant_management: bool,
+) -> GatewayCredentialGrantManager | None:
+    """Return the configured credential-grant manager or reject invalid gating."""
+
+    resolved = credential_grant_manager
+    if resolved is None and profile_bootstrap is not None:
+        resolved = getattr(profile_bootstrap, "credential_grant_manager", None)
+    if enable_credential_grant_management and resolved is None:
+        raise ValueError(
+            "credential grant management requires credential_grant_manager or profile_bootstrap"
+        )
+    return resolved
+
+
 def _resolve_external_runtime_lifecycle(
     *,
     external_runtime_lifecycle: (
@@ -575,6 +701,22 @@ def _resolve_external_runtime_lifecycle(
             "external runtime lifecycle requires external_runtime_manager or profile_bootstrap"
         )
     return resolved
+
+
+def _resolve_admin_auth_config(
+    *,
+    admin_auth: GatewayAdminAuthConfig | Mapping[str, Any] | None,
+    profile_bootstrap: GatewayProfileBootstrap | None,
+) -> GatewayAdminAuthConfig:
+    """Return explicit or bootstrap-carried admin auth configuration."""
+
+    if admin_auth is not None:
+        return normalize_gateway_admin_auth_config(admin_auth)
+    if profile_bootstrap is not None:
+        bootstrap_admin_auth = getattr(profile_bootstrap, "admin_auth", None)
+        if bootstrap_admin_auth is not None:
+            return normalize_gateway_admin_auth_config(bootstrap_admin_auth)
+    return GatewayAdminAuthConfig()
 
 
 def _external_runtime_lifecycle_error_payload(
@@ -667,10 +809,18 @@ def _create_external_runtime_lifespan(
 def _mount_profile_management_routes(
     router: APIRouter,
     manager: GatewayProfileManager,
+    *,
+    admin_dependencies: list[Depends] | None = None,
 ) -> None:
     """Mount profile-management endpoints on the package gateway router."""
 
-    @router.get("/profiles", response_model=ProfileListResponse)
+    dependencies = admin_dependencies or []
+
+    @router.get(
+        "/profiles",
+        response_model=ProfileListResponse,
+        dependencies=dependencies,
+    )
     async def list_profiles() -> ProfileListResponse | JSONResponse:
         """Return editable MCP profiles from the configured profile manager."""
         try:
@@ -678,7 +828,11 @@ def _mount_profile_management_routes(
         except GatewayProfileManagementError as exc:
             return _profile_management_error_response(exc)
 
-    @router.post("/profiles", response_model=ProfileResponse)
+    @router.post(
+        "/profiles",
+        response_model=ProfileResponse,
+        dependencies=dependencies,
+    )
     async def create_profile(
         request: CreateProfileRequest,
     ) -> ProfileResponse | JSONResponse:
@@ -688,7 +842,11 @@ def _mount_profile_management_routes(
         except GatewayProfileManagementError as exc:
             return _profile_management_error_response(exc)
 
-    @router.patch("/profiles/{profile_id}", response_model=ProfileResponse)
+    @router.patch(
+        "/profiles/{profile_id}",
+        response_model=ProfileResponse,
+        dependencies=dependencies,
+    )
     async def patch_profile(
         profile_id: str,
         request: PatchProfileRequest,
@@ -702,7 +860,11 @@ def _mount_profile_management_routes(
         except GatewayProfileManagementError as exc:
             return _profile_management_error_response(exc)
 
-    @router.delete("/profiles/{profile_id}", response_model=DeleteProfileResponse)
+    @router.delete(
+        "/profiles/{profile_id}",
+        response_model=DeleteProfileResponse,
+        dependencies=dependencies,
+    )
     async def delete_profile(profile_id: str) -> DeleteProfileResponse | JSONResponse:
         """Delete an unassigned, non-default editable MCP profile."""
         try:
@@ -710,7 +872,11 @@ def _mount_profile_management_routes(
         except GatewayProfileManagementError as exc:
             return _profile_management_error_response(exc)
 
-    @router.post("/profiles/from-preset", response_model=DuplicatePresetResponse)
+    @router.post(
+        "/profiles/from-preset",
+        response_model=DuplicatePresetResponse,
+        dependencies=dependencies,
+    )
     async def duplicate_preset(
         request: DuplicatePresetRequest,
     ) -> DuplicatePresetResponse | JSONResponse:
@@ -725,7 +891,11 @@ def _mount_profile_management_routes(
             return _profile_management_error_response(exc)
         return _normalize_duplicate_preset_payload(payload)
 
-    @router.get("/profiles/default", response_model=DefaultProfileResponse)
+    @router.get(
+        "/profiles/default",
+        response_model=DefaultProfileResponse,
+        dependencies=dependencies,
+    )
     async def get_default_profile() -> DefaultProfileResponse | JSONResponse:
         """Return the currently effective default MCP profile."""
         try:
@@ -733,7 +903,11 @@ def _mount_profile_management_routes(
         except GatewayProfileManagementError as exc:
             return _profile_management_error_response(exc)
 
-    @router.put("/profiles/default", response_model=DefaultProfileResponse)
+    @router.put(
+        "/profiles/default",
+        response_model=DefaultProfileResponse,
+        dependencies=dependencies,
+    )
     async def set_default_profile(
         request: SetDefaultProfileRequest,
     ) -> DefaultProfileResponse | JSONResponse:
@@ -743,7 +917,11 @@ def _mount_profile_management_routes(
         except GatewayProfileManagementError as exc:
             return _profile_management_error_response(exc)
 
-    @router.get("/profiles/{profile_id}", response_model=ProfileResponse)
+    @router.get(
+        "/profiles/{profile_id}",
+        response_model=ProfileResponse,
+        dependencies=dependencies,
+    )
     async def show_profile(profile_id: str) -> ProfileResponse | JSONResponse:
         """Return a single editable MCP profile by id."""
         try:
@@ -755,10 +933,18 @@ def _mount_profile_management_routes(
 def _mount_external_registry_routes(
     router: APIRouter,
     manager: GatewayExternalRegistryManager,
+    *,
+    admin_dependencies: list[Depends] | None = None,
 ) -> None:
     """Mount external-registry management endpoints on the package gateway router."""
 
-    @router.get("/external-servers", response_model=ExternalServerListResponse)
+    dependencies = admin_dependencies or []
+
+    @router.get(
+        "/external-servers",
+        response_model=ExternalServerListResponse,
+        dependencies=dependencies,
+    )
     async def list_external_servers(
         enabled: bool | None = None,
     ) -> ExternalServerListResponse | JSONResponse:
@@ -770,7 +956,11 @@ def _mount_external_registry_routes(
         except Exception:  # noqa: BLE001
             return _external_registry_store_unavailable_response()
 
-    @router.get("/external-servers/{server_id}", response_model=ExternalServerResponse)
+    @router.get(
+        "/external-servers/{server_id}",
+        response_model=ExternalServerResponse,
+        dependencies=dependencies,
+    )
     async def show_external_server(
         server_id: str,
     ) -> ExternalServerResponse | JSONResponse:
@@ -784,7 +974,11 @@ def _mount_external_registry_routes(
         except Exception:  # noqa: BLE001
             return _external_registry_store_unavailable_response(server_id=server_id)
 
-    @router.post("/external-servers", response_model=ExternalServerResponse)
+    @router.post(
+        "/external-servers",
+        response_model=ExternalServerResponse,
+        dependencies=dependencies,
+    )
     async def create_external_server(
         request: CreateExternalServerRequest,
     ) -> ExternalServerResponse | JSONResponse:
@@ -800,7 +994,11 @@ def _mount_external_registry_routes(
         except Exception:  # noqa: BLE001
             return _external_registry_store_unavailable_response(server_id=request.id)
 
-    @router.patch("/external-servers/{server_id}", response_model=ExternalServerResponse)
+    @router.patch(
+        "/external-servers/{server_id}",
+        response_model=ExternalServerResponse,
+        dependencies=dependencies,
+    )
     async def patch_external_server(
         server_id: str,
         request: PatchExternalServerRequest,
@@ -821,6 +1019,7 @@ def _mount_external_registry_routes(
     @router.delete(
         "/external-servers/{server_id}",
         response_model=DeleteExternalServerResponse,
+        dependencies=dependencies,
     )
     async def delete_external_server(
         server_id: str,
@@ -839,13 +1038,18 @@ def _mount_external_registry_routes(
 def _mount_external_runtime_routes(
     router: APIRouter,
     manager: GatewayExternalRuntimeManager,
+    *,
+    admin_dependencies: list[Depends] | None = None,
 ) -> None:
     """Mount external runtime lifecycle endpoints on the package gateway router."""
+
+    dependencies = admin_dependencies or []
 
     @router.get(
         "/external-servers/runtime",
         response_model=ExternalRuntimeServerListResponse,
         response_model_exclude_none=True,
+        dependencies=dependencies,
     )
     async def list_external_runtime_servers() -> ExternalRuntimeServerListResponse | JSONResponse:
         """Return external server runtime status rows."""
@@ -857,6 +1061,7 @@ def _mount_external_runtime_routes(
     @router.post(
         "/external-servers/{server_id}/start",
         response_model=ExternalRuntimeOperationResponse,
+        dependencies=dependencies,
     )
     async def start_external_runtime_server(
         server_id: str,
@@ -870,6 +1075,7 @@ def _mount_external_runtime_routes(
     @router.post(
         "/external-servers/{server_id}/stop",
         response_model=ExternalRuntimeOperationResponse,
+        dependencies=dependencies,
     )
     async def stop_external_runtime_server(
         server_id: str,
@@ -883,6 +1089,7 @@ def _mount_external_runtime_routes(
     @router.post(
         "/external-servers/{server_id}/restart",
         response_model=ExternalRuntimeOperationResponse,
+        dependencies=dependencies,
     )
     async def restart_external_runtime_server(
         server_id: str,
@@ -896,6 +1103,7 @@ def _mount_external_runtime_routes(
     @router.post(
         "/external-servers/refresh",
         response_model=ExternalRuntimeOperationResponse,
+        dependencies=dependencies,
     )
     async def refresh_external_runtime_servers() -> ExternalRuntimeOperationResponse | JSONResponse:
         """Refresh discovery for all active external MCP server runtimes."""
@@ -907,6 +1115,7 @@ def _mount_external_runtime_routes(
     @router.post(
         "/external-servers/{server_id}/refresh",
         response_model=ExternalRuntimeOperationResponse,
+        dependencies=dependencies,
     )
     async def refresh_external_runtime_server(
         server_id: str,
@@ -920,6 +1129,7 @@ def _mount_external_runtime_routes(
     @router.post(
         "/external-servers/reconcile",
         response_model=ExternalRuntimeOperationResponse,
+        dependencies=dependencies,
     )
     async def reconcile_external_runtime_servers() -> ExternalRuntimeOperationResponse | JSONResponse:
         """Reconcile all configured external MCP server runtimes."""
@@ -931,6 +1141,7 @@ def _mount_external_runtime_routes(
     @router.post(
         "/external-servers/{server_id}/reconcile",
         response_model=ExternalRuntimeOperationResponse,
+        dependencies=dependencies,
     )
     async def reconcile_external_runtime_server(
         server_id: str,
@@ -944,6 +1155,7 @@ def _mount_external_runtime_routes(
     @router.post(
         "/external-servers/{server_id}/install",
         response_model=ExternalRuntimeOperationResponse,
+        dependencies=dependencies,
     )
     async def install_external_runtime_server(
         server_id: str,
@@ -957,6 +1169,7 @@ def _mount_external_runtime_routes(
     @router.post(
         "/external-servers/{server_id}/update",
         response_model=ExternalRuntimeOperationResponse,
+        dependencies=dependencies,
     )
     async def update_external_runtime_server(
         server_id: str,
@@ -966,6 +1179,97 @@ def _mount_external_runtime_routes(
             return await manager.update_server(server_id)
         except GatewayExternalRuntimeError as exc:
             return _external_runtime_error_response(exc)
+
+
+def _mount_credential_grant_routes(
+    router: APIRouter,
+    manager: GatewayCredentialGrantManager,
+    *,
+    admin_dependencies: list[Depends] | None = None,
+) -> None:
+    """Mount credential-grant management endpoints on the package gateway router."""
+
+    dependencies = admin_dependencies or []
+
+    @router.get(
+        "/credential-grants",
+        response_model=CredentialGrantListResponse,
+        dependencies=dependencies,
+    )
+    async def list_credential_grants(
+        profile_id: str | None = None,
+        external_server_id: str | None = None,
+    ) -> CredentialGrantListResponse | JSONResponse:
+        """Return stored credential grant metadata from the configured manager."""
+        try:
+            return await manager.list_grants(
+                profile_id=profile_id,
+                external_server_id=external_server_id,
+            )
+        except GatewayCredentialGrantManagementError as exc:
+            return _credential_grant_error_response(exc)
+
+    @router.post(
+        "/credential-grants",
+        response_model=CredentialGrantResponse,
+        dependencies=dependencies,
+    )
+    async def create_credential_grant(
+        request: CreateCredentialGrantRequest,
+    ) -> CredentialGrantResponse | JSONResponse:
+        """Create stored credential grant metadata."""
+        try:
+            return await manager.create_grant(
+                request.model_dump(mode="json", exclude_unset=True)
+            )
+        except GatewayCredentialGrantManagementError as exc:
+            return _credential_grant_error_response(exc)
+
+    @router.get(
+        "/credential-grants/{grant_id}",
+        response_model=CredentialGrantResponse,
+        dependencies=dependencies,
+    )
+    async def show_credential_grant(
+        grant_id: str,
+    ) -> CredentialGrantResponse | JSONResponse:
+        """Return a single credential grant by id."""
+        try:
+            return await manager.show_grant(grant_id)
+        except GatewayCredentialGrantManagementError as exc:
+            return _credential_grant_error_response(exc)
+
+    @router.patch(
+        "/credential-grants/{grant_id}",
+        response_model=CredentialGrantResponse,
+        dependencies=dependencies,
+    )
+    async def patch_credential_grant(
+        grant_id: str,
+        request: PatchCredentialGrantRequest,
+    ) -> CredentialGrantResponse | JSONResponse:
+        """Apply an allowed patch to stored credential grant metadata."""
+        try:
+            return await manager.patch_grant(
+                grant_id,
+                request.model_dump(mode="json", exclude_unset=True),
+            )
+        except GatewayCredentialGrantManagementError as exc:
+            return _credential_grant_error_response(exc)
+
+    @router.delete(
+        "/credential-grants/{grant_id}",
+        response_model=DeleteCredentialGrantResponse,
+        dependencies=dependencies,
+    )
+    async def delete_credential_grant(
+        grant_id: str,
+    ) -> DeleteCredentialGrantResponse | JSONResponse:
+        """Delete stored credential grant metadata."""
+        try:
+            return await manager.delete_grant(grant_id)
+        except GatewayCredentialGrantManagementError as exc:
+            return _credential_grant_error_response(exc)
 
 
 def create_gateway_router(
@@ -978,31 +1282,62 @@ def create_gateway_router(
     enable_external_registry_management: bool = False,
     external_runtime_manager: GatewayExternalRuntimeManager | None = None,
     enable_external_runtime_management: bool = False,
+    admin_auth: GatewayAdminAuthConfig | Mapping[str, Any] | None = None,
+    credential_grant_manager: GatewayCredentialGrantManager | None = None,
+    enable_credential_grant_management: bool = False,
 ) -> APIRouter:
     """Create a package-owned FastAPI router for a standalone MCP runtime."""
 
     router = APIRouter()
+    resolved_admin_auth = _resolve_admin_auth_config(
+        admin_auth=admin_auth,
+        profile_bootstrap=profile_bootstrap,
+    )
+    admin_dependencies = gateway_admin_auth_dependencies(resolved_admin_auth)
     resolved_profile_manager = _resolve_profile_manager(
         profile_manager=profile_manager,
         profile_bootstrap=profile_bootstrap,
         enable_profile_management=enable_profile_management,
     )
     if resolved_profile_manager is not None:
-        _mount_profile_management_routes(router, resolved_profile_manager)
+        _mount_profile_management_routes(
+            router,
+            resolved_profile_manager,
+            admin_dependencies=admin_dependencies,
+        )
     resolved_external_runtime_manager = _resolve_external_runtime_manager(
         external_runtime_manager=external_runtime_manager,
         profile_bootstrap=profile_bootstrap,
         enable_external_runtime_management=enable_external_runtime_management,
     )
     if resolved_external_runtime_manager is not None:
-        _mount_external_runtime_routes(router, resolved_external_runtime_manager)
+        _mount_external_runtime_routes(
+            router,
+            resolved_external_runtime_manager,
+            admin_dependencies=admin_dependencies,
+        )
     resolved_external_registry_manager = _resolve_external_registry_manager(
         external_registry_manager=external_registry_manager,
         profile_bootstrap=profile_bootstrap,
         enable_external_registry_management=enable_external_registry_management,
     )
     if resolved_external_registry_manager is not None:
-        _mount_external_registry_routes(router, resolved_external_registry_manager)
+        _mount_external_registry_routes(
+            router,
+            resolved_external_registry_manager,
+            admin_dependencies=admin_dependencies,
+        )
+    resolved_credential_grant_manager = _resolve_credential_grant_manager(
+        credential_grant_manager=credential_grant_manager,
+        profile_bootstrap=profile_bootstrap,
+        enable_credential_grant_management=enable_credential_grant_management,
+    )
+    if resolved_credential_grant_manager is not None:
+        _mount_credential_grant_routes(
+            router,
+            resolved_credential_grant_manager,
+            admin_dependencies=admin_dependencies,
+        )
 
     @router.get("/status")
     async def gateway_status() -> dict[str, str]:
@@ -1079,6 +1414,9 @@ def create_gateway_app(
     external_runtime_lifecycle: (
         GatewayExternalRuntimeLifecycleConfig | Mapping[str, Any] | None
     ) = None,
+    admin_auth: GatewayAdminAuthConfig | Mapping[str, Any] | None = None,
+    credential_grant_manager: GatewayCredentialGrantManager | None = None,
+    enable_credential_grant_management: bool = False,
 ) -> FastAPI:
     """Create a minimal FastAPI app exposing the standalone MCP gateway router."""
 
@@ -1105,6 +1443,10 @@ def create_gateway_app(
         version=_runtime_version(runtime),
         lifespan=lifespan,
     )
+    app.add_exception_handler(
+        GatewayAdminAuthError,
+        gateway_admin_auth_error_response,
+    )
     app.include_router(
         create_gateway_router(
             runtime,
@@ -1115,6 +1457,9 @@ def create_gateway_app(
             enable_external_registry_management=enable_external_registry_management,
             external_runtime_manager=resolved_external_runtime_manager,
             enable_external_runtime_management=enable_external_runtime_management,
+            admin_auth=admin_auth,
+            credential_grant_manager=credential_grant_manager,
+            enable_credential_grant_management=enable_credential_grant_management,
         ),
         prefix=prefix,
     )

--- a/mcp_unified/gateway/remote_admin.py
+++ b/mcp_unified/gateway/remote_admin.py
@@ -1,0 +1,270 @@
+"""Remote administration client for a running standalone MCP gateway."""
+
+from __future__ import annotations
+
+import json
+import urllib.error
+import urllib.parse
+import urllib.request
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True, slots=True)
+class RemoteGatewayAdminConfig:
+    """Configuration for remote standalone gateway admin requests."""
+
+    gateway_url: str
+    admin_header_name: str = "X-MCP-Gateway-Admin-Key"
+    admin_key: str | None = None
+    timeout_seconds: float = 30.0
+
+    def __post_init__(self) -> None:
+        """Validate and normalize remote gateway client settings."""
+
+        gateway_url = self.gateway_url.strip().rstrip("/")
+        if not gateway_url:
+            raise ValueError("gateway_url is required")
+
+        parsed = urllib.parse.urlparse(gateway_url)
+        if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+            raise ValueError("gateway_url must be an http or https URL")
+
+        admin_header_name = self.admin_header_name.strip()
+        if not admin_header_name:
+            raise ValueError("admin_header_name is required")
+        if "\r" in admin_header_name or "\n" in admin_header_name:
+            raise ValueError("admin_header_name cannot contain line breaks")
+
+        if self.timeout_seconds <= 0:
+            raise ValueError("timeout_seconds must be greater than zero")
+
+        admin_key = self.admin_key.strip() if self.admin_key is not None else None
+        object.__setattr__(self, "gateway_url", gateway_url)
+        object.__setattr__(self, "admin_header_name", admin_header_name)
+        object.__setattr__(self, "admin_key", admin_key or None)
+
+
+class RemoteGatewayAdminError(RuntimeError):
+    """Raised when the remote gateway returns an error or invalid response."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        payload: Mapping[str, Any] | None = None,
+        reason_code: str = "remote_gateway_error",
+        status_code: int | None = None,
+        error_type: str | None = None,
+    ) -> None:
+        """Store a machine-readable error payload for CLI emission."""
+
+        super().__init__(message)
+        if payload is None:
+            normalized_payload: dict[str, Any] = {
+                "error": message,
+                "ok": False,
+                "reason_code": reason_code,
+            }
+            if error_type is not None:
+                normalized_payload["error_type"] = error_type
+        else:
+            normalized_payload = dict(payload)
+            normalized_payload["ok"] = False
+            normalized_payload.setdefault("error", message)
+            normalized_payload.setdefault("reason_code", reason_code)
+            if error_type is not None:
+                normalized_payload.setdefault("error_type", error_type)
+
+        if status_code is not None:
+            normalized_payload.setdefault("status_code", status_code)
+        self._payload = normalized_payload
+
+    @classmethod
+    def from_payload(
+        cls,
+        payload: Mapping[str, Any],
+        *,
+        status_code: int | None = None,
+    ) -> RemoteGatewayAdminError:
+        """Build an error from a public gateway JSON error payload."""
+
+        error = payload.get("error")
+        message = error if isinstance(error, str) and error else "Remote gateway error"
+        reason_code = payload.get("reason_code")
+        return cls(
+            message,
+            payload=payload,
+            reason_code=(
+                reason_code
+                if isinstance(reason_code, str) and reason_code
+                else "remote_gateway_error"
+            ),
+            status_code=status_code,
+        )
+
+    def to_payload(self) -> dict[str, Any]:
+        """Return the JSON-serializable error payload."""
+
+        return dict(self._payload)
+
+
+class RemoteGatewayAdminClient:
+    """Small stdlib HTTP client for running gateway runtime admin routes."""
+
+    def __init__(
+        self,
+        config: RemoteGatewayAdminConfig,
+        *,
+        opener: Callable[..., Any] | None = None,
+    ) -> None:
+        """Create a client using a `urllib.request.urlopen`-compatible opener."""
+
+        self.config = config
+        self._opener = opener or urllib.request.urlopen
+
+    def endpoint_url(self, path: str) -> str:
+        """Resolve an endpoint path against the configured mounted base URL."""
+
+        return f"{self.config.gateway_url}/{path.lstrip('/')}"
+
+    def list_runtime_servers(self) -> dict[str, Any]:
+        """List runtime state for managed external servers."""
+
+        return self._request_json("GET", "/external-servers/runtime")
+
+    def start_server(self, server_id: str) -> dict[str, Any]:
+        """Start one managed external server through the running gateway."""
+
+        return self._request_json(
+            "POST",
+            f"/external-servers/{_quote_server_id(server_id)}/start",
+        )
+
+    def stop_server(self, server_id: str) -> dict[str, Any]:
+        """Stop one managed external server through the running gateway."""
+
+        return self._request_json(
+            "POST",
+            f"/external-servers/{_quote_server_id(server_id)}/stop",
+        )
+
+    def restart_server(self, server_id: str) -> dict[str, Any]:
+        """Restart one managed external server through the running gateway."""
+
+        return self._request_json(
+            "POST",
+            f"/external-servers/{_quote_server_id(server_id)}/restart",
+        )
+
+    def refresh_server(self, server_id: str | None = None) -> dict[str, Any]:
+        """Refresh one external runtime, or all runtimes when no id is supplied."""
+
+        if server_id is None:
+            return self._request_json("POST", "/external-servers/refresh")
+        return self._request_json(
+            "POST",
+            f"/external-servers/{_quote_server_id(server_id)}/refresh",
+        )
+
+    def reconcile(self, server_id: str | None = None) -> dict[str, Any]:
+        """Reconcile one external runtime, or all runtimes when no id is supplied."""
+
+        if server_id is None:
+            return self._request_json("POST", "/external-servers/reconcile")
+        return self._request_json(
+            "POST",
+            f"/external-servers/{_quote_server_id(server_id)}/reconcile",
+        )
+
+    def install_server(self, server_id: str) -> dict[str, Any]:
+        """Run the configured install flow for one external server."""
+
+        return self._request_json(
+            "POST",
+            f"/external-servers/{_quote_server_id(server_id)}/install",
+        )
+
+    def update_server(self, server_id: str) -> dict[str, Any]:
+        """Run the configured update flow for one external server."""
+
+        return self._request_json(
+            "POST",
+            f"/external-servers/{_quote_server_id(server_id)}/update",
+        )
+
+    def _request_json(self, method: str, path: str) -> dict[str, Any]:
+        """Send one request and return a JSON object response."""
+
+        request = urllib.request.Request(
+            self.endpoint_url(path),
+            data=b"{}" if method == "POST" else None,
+            headers=self._headers(method),
+            method=method,
+        )
+        try:
+            response = self._opener(request, timeout=self.config.timeout_seconds)
+            with response:
+                return _parse_json_object(response.read())
+        except urllib.error.HTTPError as exc:
+            raise _error_from_http_error(exc) from exc
+        except (urllib.error.URLError, TimeoutError, OSError) as exc:
+            raise RemoteGatewayAdminError(
+                "Unable to reach gateway",
+                reason_code="gateway_connection_failed",
+                error_type=exc.__class__.__name__,
+            ) from exc
+
+    def _headers(self, method: str) -> dict[str, str]:
+        """Build request headers without adding an empty admin credential."""
+
+        headers = {"Accept": "application/json"}
+        if method == "POST":
+            headers["Content-Type"] = "application/json"
+        if self.config.admin_key is not None:
+            headers[self.config.admin_header_name] = self.config.admin_key
+        return headers
+
+
+def _quote_server_id(server_id: str) -> str:
+    """Quote a server id for safe use in one path segment."""
+
+    normalized = server_id.strip()
+    if not normalized:
+        raise ValueError("server_id is required")
+    return urllib.parse.quote(normalized, safe="")
+
+
+def _error_from_http_error(exc: urllib.error.HTTPError) -> RemoteGatewayAdminError:
+    """Preserve public JSON HTTP error payloads when the gateway provides them."""
+
+    try:
+        payload = _parse_json_object(exc.read())
+    except RemoteGatewayAdminError:
+        return RemoteGatewayAdminError(
+            "Gateway returned an HTTP error",
+            reason_code="gateway_http_error",
+            status_code=exc.code,
+            error_type=exc.__class__.__name__,
+        )
+    return RemoteGatewayAdminError.from_payload(payload, status_code=exc.code)
+
+
+def _parse_json_object(response_body: bytes) -> dict[str, Any]:
+    """Parse a UTF-8 JSON object from a gateway response body."""
+
+    try:
+        payload = json.loads(response_body.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise RemoteGatewayAdminError(
+            "Gateway returned an invalid JSON object",
+            reason_code="gateway_invalid_response",
+        ) from exc
+
+    if not isinstance(payload, dict):
+        raise RemoteGatewayAdminError(
+            "Gateway returned an invalid JSON object",
+            reason_code="gateway_invalid_response",
+        )
+    return payload

--- a/mcp_unified/gateway/remote_admin.py
+++ b/mcp_unified/gateway/remote_admin.py
@@ -41,6 +41,8 @@ class RemoteGatewayAdminConfig:
             raise ValueError("timeout_seconds must be greater than zero")
 
         admin_key = self.admin_key.strip() if self.admin_key is not None else None
+        if admin_key is not None and ("\r" in admin_key or "\n" in admin_key):
+            raise ValueError("admin_key cannot contain line breaks")
         object.__setattr__(self, "gateway_url", gateway_url)
         object.__setattr__(self, "admin_header_name", admin_header_name)
         object.__setattr__(self, "admin_key", admin_key or None)

--- a/mcp_unified/gateway/snapshots.py
+++ b/mcp_unified/gateway/snapshots.py
@@ -280,6 +280,7 @@ class GatewayConfigSnapshotManager:
         }
 
         if snapshot.default_assignment is not None:
+            self._require_gateway_default_assignment_id(snapshot.default_assignment.id)
             self._require_profile_reference(
                 snapshot.default_assignment.profile_id,
                 incoming_profile_ids=incoming_profile_ids,
@@ -323,6 +324,15 @@ class GatewayConfigSnapshotManager:
         )
 
     @staticmethod
+    def _require_gateway_default_assignment_id(assignment_id: str) -> None:
+        if assignment_id == GATEWAY_DEFAULT_ASSIGNMENT_ID:
+            return
+        raise GatewayConfigSnapshotManagementError(
+            "Gateway config snapshot default assignment id is invalid",
+            reason_code="invalid_config_snapshot",
+        )
+
+    @staticmethod
     def _build_plan(snapshot: GatewayConfigSnapshot) -> dict[str, Any]:
         actions = [action.to_payload() for action, _mutation in _planned_actions(snapshot)]
         return {
@@ -351,10 +361,16 @@ class GatewayConfigSnapshotManager:
                 )
             )
         if snapshot.default_assignment is not None:
-            assignment = snapshot.default_assignment.model_copy(deep=True)
+            assignment = snapshot.default_assignment.model_copy(
+                update={"id": GATEWAY_DEFAULT_ASSIGNMENT_ID},
+                deep=True,
+            )
             actions.append(
                 (
-                    _SnapshotAction("set_default_assignment", assignment.id),
+                    _SnapshotAction(
+                        "set_default_assignment",
+                        GATEWAY_DEFAULT_ASSIGNMENT_ID,
+                    ),
                     lambda assignment=assignment: self.assignment_store.upsert_assignment(
                         assignment
                     ),
@@ -418,7 +434,7 @@ def _planned_actions(
             (
                 _SnapshotAction(
                     "set_default_assignment",
-                    snapshot.default_assignment.id,
+                    GATEWAY_DEFAULT_ASSIGNMENT_ID,
                 ),
                 None,
             )

--- a/mcp_unified/gateway/snapshots.py
+++ b/mcp_unified/gateway/snapshots.py
@@ -122,6 +122,10 @@ class GatewayConfigSnapshot(BaseModel):
             _reject_secret_material(profile.metadata)
             _reject_secret_material(profile.provenance)
         if self.default_assignment is not None:
+            if self.default_assignment.id != GATEWAY_DEFAULT_ASSIGNMENT_ID:
+                raise ValueError(
+                    "Snapshot default assignment id must be gateway default assignment id"
+                )
             _reject_secret_material(self.default_assignment.provenance)
         for server in self.external_servers:
             _reject_secret_material(server.metadata)
@@ -298,7 +302,10 @@ class GatewayConfigSnapshotManager:
                     f"External server not found: {grant.external_server_id}",
                     reason_code="config_snapshot_invalid_reference",
                 )
-            if grant.credential_slot not in server.credential_slots:
+            if (
+                not server.credential_slots
+                or grant.credential_slot not in server.credential_slots
+            ):
                 raise GatewayConfigSnapshotManagementError(
                     "Credential grant references a missing external server slot",
                     reason_code="config_snapshot_invalid_reference",
@@ -438,7 +445,7 @@ def _reject_secret_material(value: Any) -> None:
 
 
 def _reject_external_server_inline_secrets(server: ExternalServerDefinition) -> None:
-    for command_part in server.command:
+    for command_part in server.command or ():
         if _command_part_contains_inline_secret(command_part):
             raise ValueError("External server command must not contain secret material")
     if server.url:

--- a/mcp_unified/gateway/snapshots.py
+++ b/mcp_unified/gateway/snapshots.py
@@ -1,0 +1,474 @@
+"""Gateway config snapshot import/export helpers for standalone MCP stores."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any, Literal
+from urllib.parse import parse_qsl, urlsplit
+from uuid import uuid4
+
+from loguru import logger
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+from mcp_unified.interfaces.storage import (
+    AuditStore,
+    CredentialGrantStore,
+    ExternalRegistryStore,
+    ProfileAssignmentStore,
+    ProfileStore,
+)
+from mcp_unified.profiles.defaults import GATEWAY_DEFAULT_ASSIGNMENT_ID
+from mcp_unified.profiles.models import MCPProfile
+from mcp_unified.storage.models import (
+    AuditEvent,
+    CredentialGrant,
+    ExternalServerDefinition,
+    ProfileAssignment,
+)
+
+from .credential_grants import (
+    GatewayCredentialGrantManagementError,
+    reject_secret_looking_metadata,
+)
+
+SNAPSHOT_SCHEMA = "mcp_unified.gateway.config_snapshot"
+SNAPSHOT_VERSION = 1
+_SECRET_QUERY_MARKERS = ("secret", "token", "password")
+_SECRET_QUERY_EXACT_MATCHES = {
+    "api_key",
+    "authorization",
+    "headers",
+    "env",
+    "credential_value",
+}
+
+
+class GatewayConfigSnapshotManagementError(RuntimeError):
+    """Domain error for expected gateway config snapshot failures."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        reason_code: str,
+        applied_actions: list[dict[str, str]] | None = None,
+        failed_actions: list[dict[str, str]] | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.reason_code = reason_code
+        self.applied_actions = list(applied_actions or [])
+        self.failed_actions = list(failed_actions or [])
+
+    def to_payload(self) -> dict[str, Any]:
+        """Return a deterministic JSON-safe error payload."""
+
+        payload: dict[str, Any] = {
+            "ok": False,
+            "error": str(self),
+            "reason_code": self.reason_code,
+        }
+        if self.applied_actions:
+            payload["applied_actions"] = [dict(action) for action in self.applied_actions]
+        if self.failed_actions:
+            payload["failed_actions"] = [dict(action) for action in self.failed_actions]
+        return payload
+
+
+class GatewayConfigSnapshot(BaseModel):
+    """Versioned gateway config snapshot without embedded secret values."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    schema: Literal["mcp_unified.gateway.config_snapshot"] = SNAPSHOT_SCHEMA
+    version: Literal[1] = SNAPSHOT_VERSION
+    profiles: list[MCPProfile] = Field(default_factory=list)
+    default_assignment: ProfileAssignment | None = None
+    external_servers: list[ExternalServerDefinition] = Field(default_factory=list)
+    credential_grants: list[CredentialGrant] = Field(default_factory=list)
+
+    @field_validator("profiles", mode="after")
+    @classmethod
+    def _sort_profiles(cls, value: list[MCPProfile]) -> list[MCPProfile]:
+        """Return copy-isolated profiles sorted by id."""
+
+        return [item.model_copy(deep=True) for item in sorted(value, key=lambda item: item.id)]
+
+    @field_validator("external_servers", mode="after")
+    @classmethod
+    def _sort_external_servers(
+        cls,
+        value: list[ExternalServerDefinition],
+    ) -> list[ExternalServerDefinition]:
+        """Return copy-isolated external servers sorted by id."""
+
+        return [item.model_copy(deep=True) for item in sorted(value, key=lambda item: item.id)]
+
+    @field_validator("credential_grants", mode="after")
+    @classmethod
+    def _sort_credential_grants(
+        cls,
+        value: list[CredentialGrant],
+    ) -> list[CredentialGrant]:
+        """Return copy-isolated credential grants sorted by id."""
+
+        return [item.model_copy(deep=True) for item in sorted(value, key=lambda item: item.id)]
+
+    @model_validator(mode="after")
+    def _validate_secret_safety(self) -> GatewayConfigSnapshot:
+        """Reject snapshot fields that can carry inline secret material."""
+
+        for profile in self.profiles:
+            _reject_secret_material(profile.metadata)
+            _reject_secret_material(profile.provenance)
+        if self.default_assignment is not None:
+            _reject_secret_material(self.default_assignment.provenance)
+        for server in self.external_servers:
+            _reject_secret_material(server.metadata)
+            _reject_secret_material(server.provenance)
+            _reject_external_server_inline_secrets(server)
+        for grant in self.credential_grants:
+            _reject_secret_material(grant.metadata)
+            _reject_secret_material(grant.provenance)
+        return self
+
+
+@dataclass(frozen=True, slots=True)
+class _SnapshotAction:
+    """One planned snapshot import mutation."""
+
+    action: str
+    target_id: str
+
+    def to_payload(self) -> dict[str, str]:
+        """Return a JSON-safe action summary."""
+
+        return {"action": self.action, "target_id": self.target_id}
+
+
+class GatewayConfigSnapshotManager:
+    """Export and import gateway config snapshots through store protocols."""
+
+    def __init__(
+        self,
+        *,
+        profile_store: ProfileStore,
+        assignment_store: ProfileAssignmentStore,
+        external_registry_store: ExternalRegistryStore,
+        credential_grant_store: CredentialGrantStore,
+        audit_store: AuditStore | None = None,
+    ) -> None:
+        self.profile_store = profile_store
+        self.assignment_store = assignment_store
+        self.external_registry_store = external_registry_store
+        self.credential_grant_store = credential_grant_store
+        self.audit_store = audit_store
+
+    async def export_snapshot(self) -> GatewayConfigSnapshot:
+        """Export a deterministic config snapshot from current stores."""
+
+        profiles = await self.profile_store.list_profiles()
+        default_assignment = await self.assignment_store.get_assignment(
+            GATEWAY_DEFAULT_ASSIGNMENT_ID
+        )
+        external_servers = await self.external_registry_store.list_server_definitions()
+        credential_grants = await self.credential_grant_store.list_grants()
+        return GatewayConfigSnapshot(
+            profiles=profiles,
+            default_assignment=default_assignment,
+            external_servers=external_servers,
+            credential_grants=credential_grants,
+        )
+
+    async def import_snapshot(
+        self,
+        snapshot_document: GatewayConfigSnapshot | Mapping[str, Any],
+        *,
+        dry_run: bool = False,
+    ) -> dict[str, Any]:
+        """Validate and import a config snapshot with non-destructive upserts.
+
+        The manager validates the full snapshot before the first write. Once
+        writes begin, arbitrary injected stores are best-effort rather than
+        transactionally atomic, so failures report applied and failed action ids.
+        """
+
+        snapshot = self._coerce_snapshot(snapshot_document)
+        await self._validate_references(snapshot)
+        plan = self._build_plan(snapshot)
+        if dry_run:
+            return {"ok": True, "dry_run": True, "plan": plan}
+
+        await self._append_audit_event(
+            "config_snapshot.import_started",
+            payload={"plan": plan},
+        )
+        applied_actions: list[dict[str, str]] = []
+        failed_actions: list[dict[str, str]] = []
+        actions = self._mutation_actions(snapshot)
+        for action, mutation in actions:
+            action_payload = action.to_payload()
+            try:
+                await mutation()
+            except Exception as exc:  # noqa: BLE001
+                logger.opt(exception=True).warning(
+                    "Gateway config snapshot import action failed",
+                    action=action.action,
+                    target_id=action.target_id,
+                )
+                failed_actions.append(
+                    {
+                        **action_payload,
+                        "reason_code": exc.__class__.__name__,
+                    }
+                )
+                await self._append_audit_event(
+                    "config_snapshot.import_failed",
+                    payload={
+                        "applied_actions": applied_actions,
+                        "failed_actions": failed_actions,
+                    },
+                )
+                raise GatewayConfigSnapshotManagementError(
+                    "Gateway config snapshot import failed",
+                    reason_code="config_snapshot_import_failed",
+                    applied_actions=applied_actions,
+                    failed_actions=failed_actions,
+                ) from exc
+            applied_actions.append(action_payload)
+
+        await self._append_audit_event(
+            "config_snapshot.import_completed",
+            payload={
+                "applied_actions": applied_actions,
+                "counts": plan["counts"],
+            },
+        )
+        return {
+            "ok": True,
+            "dry_run": False,
+            "plan": plan,
+            "applied_actions": applied_actions,
+            "failed_actions": [],
+        }
+
+    @staticmethod
+    def _coerce_snapshot(
+        snapshot_document: GatewayConfigSnapshot | Mapping[str, Any],
+    ) -> GatewayConfigSnapshot:
+        if isinstance(snapshot_document, GatewayConfigSnapshot):
+            return snapshot_document.model_copy(deep=True)
+        try:
+            return GatewayConfigSnapshot.model_validate(snapshot_document)
+        except Exception as exc:  # noqa: BLE001
+            raise GatewayConfigSnapshotManagementError(
+                "Invalid gateway config snapshot",
+                reason_code="invalid_config_snapshot",
+            ) from exc
+
+    async def _validate_references(self, snapshot: GatewayConfigSnapshot) -> None:
+        incoming_profile_ids = {profile.id for profile in snapshot.profiles}
+        incoming_servers = {server.id: server for server in snapshot.external_servers}
+        current_profile_ids = {profile.id for profile in await self.profile_store.list_profiles()}
+        current_servers = {
+            server.id: server
+            for server in await self.external_registry_store.list_server_definitions()
+        }
+
+        if snapshot.default_assignment is not None:
+            self._require_profile_reference(
+                snapshot.default_assignment.profile_id,
+                incoming_profile_ids=incoming_profile_ids,
+                current_profile_ids=current_profile_ids,
+            )
+
+        for grant in snapshot.credential_grants:
+            self._require_profile_reference(
+                grant.profile_id,
+                incoming_profile_ids=incoming_profile_ids,
+                current_profile_ids=current_profile_ids,
+            )
+            if grant.external_server_id is None:
+                continue
+            server = incoming_servers.get(grant.external_server_id) or current_servers.get(
+                grant.external_server_id
+            )
+            if server is None:
+                raise GatewayConfigSnapshotManagementError(
+                    f"External server not found: {grant.external_server_id}",
+                    reason_code="config_snapshot_invalid_reference",
+                )
+            if grant.credential_slot not in server.credential_slots:
+                raise GatewayConfigSnapshotManagementError(
+                    "Credential grant references a missing external server slot",
+                    reason_code="config_snapshot_invalid_reference",
+                )
+
+    @staticmethod
+    def _require_profile_reference(
+        profile_id: str,
+        *,
+        incoming_profile_ids: set[str],
+        current_profile_ids: set[str],
+    ) -> None:
+        if profile_id in incoming_profile_ids or profile_id in current_profile_ids:
+            return
+        raise GatewayConfigSnapshotManagementError(
+            f"Profile not found: {profile_id}",
+            reason_code="config_snapshot_invalid_reference",
+        )
+
+    @staticmethod
+    def _build_plan(snapshot: GatewayConfigSnapshot) -> dict[str, Any]:
+        actions = [action.to_payload() for action, _mutation in _planned_actions(snapshot)]
+        return {
+            "actions": actions,
+            "counts": {
+                "credential_grants": len(snapshot.credential_grants),
+                "default_assignment": 1 if snapshot.default_assignment is not None else 0,
+                "external_servers": len(snapshot.external_servers),
+                "profiles": len(snapshot.profiles),
+            },
+        }
+
+    def _mutation_actions(
+        self,
+        snapshot: GatewayConfigSnapshot,
+    ) -> list[tuple[_SnapshotAction, Any]]:
+        actions: list[tuple[_SnapshotAction, Any]] = []
+        for profile in snapshot.profiles:
+            stored_profile = profile.model_copy(deep=True)
+            actions.append(
+                (
+                    _SnapshotAction("upsert_profile", profile.id),
+                    lambda stored_profile=stored_profile: self.profile_store.upsert_profile(
+                        stored_profile
+                    ),
+                )
+            )
+        if snapshot.default_assignment is not None:
+            assignment = snapshot.default_assignment.model_copy(deep=True)
+            actions.append(
+                (
+                    _SnapshotAction("set_default_assignment", assignment.id),
+                    lambda assignment=assignment: self.assignment_store.upsert_assignment(
+                        assignment
+                    ),
+                )
+            )
+        for server in snapshot.external_servers:
+            stored_server = server.model_copy(deep=True)
+            actions.append(
+                (
+                    _SnapshotAction("upsert_external_server", server.id),
+                    lambda stored_server=stored_server: self.external_registry_store.upsert_server(
+                        stored_server
+                    ),
+                )
+            )
+        for grant in snapshot.credential_grants:
+            stored_grant = grant.model_copy(deep=True)
+            actions.append(
+                (
+                    _SnapshotAction("upsert_credential_grant", grant.id),
+                    lambda stored_grant=stored_grant: self.credential_grant_store.upsert_grant(
+                        stored_grant
+                    ),
+                )
+            )
+        return actions
+
+    async def _append_audit_event(
+        self,
+        event_type: str,
+        *,
+        payload: Mapping[str, Any],
+    ) -> None:
+        if self.audit_store is None:
+            return
+        event = AuditEvent(
+            id=str(uuid4()),
+            event_type=event_type,
+            target_type="config_snapshot",
+            payload=dict(payload),
+            provenance={"source": "gateway_config_snapshot_manager"},
+        )
+        try:
+            await self.audit_store.append_event(event)
+        except Exception:  # noqa: BLE001
+            logger.opt(exception=True).warning(
+                "Gateway config snapshot audit append failed",
+                event_type=event_type,
+            )
+
+
+def _planned_actions(
+    snapshot: GatewayConfigSnapshot,
+) -> list[tuple[_SnapshotAction, None]]:
+    actions: list[tuple[_SnapshotAction, None]] = [
+        (_SnapshotAction("upsert_profile", profile.id), None)
+        for profile in snapshot.profiles
+    ]
+    if snapshot.default_assignment is not None:
+        actions.append(
+            (
+                _SnapshotAction(
+                    "set_default_assignment",
+                    snapshot.default_assignment.id,
+                ),
+                None,
+            )
+        )
+    actions.extend(
+        (_SnapshotAction("upsert_external_server", server.id), None)
+        for server in snapshot.external_servers
+    )
+    actions.extend(
+        (_SnapshotAction("upsert_credential_grant", grant.id), None)
+        for grant in snapshot.credential_grants
+    )
+    return actions
+
+
+def _reject_secret_material(value: Any) -> None:
+    try:
+        reject_secret_looking_metadata(value)
+    except GatewayCredentialGrantManagementError as exc:
+        raise ValueError(str(exc)) from exc
+
+
+def _reject_external_server_inline_secrets(server: ExternalServerDefinition) -> None:
+    for command_part in server.command:
+        if _command_part_contains_inline_secret(command_part):
+            raise ValueError("External server command must not contain secret material")
+    if server.url:
+        parsed = urlsplit(server.url)
+        if parsed.username or parsed.password:
+            raise ValueError("External server URL must not contain secret material")
+        for key, _value in parse_qsl(parsed.query, keep_blank_values=True):
+            if _is_secret_key(key):
+                raise ValueError("External server URL must not contain secret material")
+
+
+def _command_part_contains_inline_secret(command_part: str) -> bool:
+    text = command_part.strip()
+    if "=" not in text:
+        return False
+    key = text.split("=", 1)[0].strip().lstrip("-").replace("-", "_")
+    return _is_secret_key(key)
+
+
+def _is_secret_key(key: str) -> bool:
+    key_text = key.strip().lower()
+    return key_text in _SECRET_QUERY_EXACT_MATCHES or any(
+        marker in key_text for marker in _SECRET_QUERY_MARKERS
+    )
+
+
+__all__ = [
+    "GatewayConfigSnapshot",
+    "GatewayConfigSnapshotManagementError",
+    "GatewayConfigSnapshotManager",
+    "SNAPSHOT_SCHEMA",
+    "SNAPSHOT_VERSION",
+]

--- a/mcp_unified/gateway/snapshots.py
+++ b/mcp_unified/gateway/snapshots.py
@@ -302,10 +302,7 @@ class GatewayConfigSnapshotManager:
                     f"External server not found: {grant.external_server_id}",
                     reason_code="config_snapshot_invalid_reference",
                 )
-            if (
-                not server.credential_slots
-                or grant.credential_slot not in server.credential_slots
-            ):
+            if _credential_slot_missing(server, grant.credential_slot):
                 raise GatewayConfigSnapshotManagementError(
                     "Credential grant references a missing external server slot",
                     reason_code="config_snapshot_invalid_reference",
@@ -444,8 +441,28 @@ def _reject_secret_material(value: Any) -> None:
         raise ValueError(str(exc)) from exc
 
 
+def _credential_slot_missing(
+    server: ExternalServerDefinition,
+    credential_slot: str,
+) -> bool:
+    slots = server.credential_slots
+    if not isinstance(slots, list | tuple | set):
+        return True
+    return not slots or credential_slot not in slots
+
+
 def _reject_external_server_inline_secrets(server: ExternalServerDefinition) -> None:
-    for command_part in server.command or ():
+    command = server.command
+    if command is None:
+        command_parts: tuple[str, ...] | list[str] = ()
+    elif not isinstance(command, list | tuple):
+        raise ValueError("External server command must be a list of strings")
+    else:
+        command_parts = command
+
+    for command_part in command_parts:
+        if not isinstance(command_part, str):
+            raise ValueError("External server command must be a list of strings")
         if _command_part_contains_inline_secret(command_part):
             raise ValueError("External server command must not contain secret material")
     if server.url:

--- a/mcp_unified/interfaces/storage.py
+++ b/mcp_unified/interfaces/storage.py
@@ -27,6 +27,14 @@ class ExternalServerAlreadyExistsError(RuntimeError):
         self.server_id = server_id
 
 
+class CredentialGrantAlreadyExistsError(RuntimeError):
+    """Raised when an atomic credential grant create conflicts with an existing id."""
+
+    def __init__(self, grant_id: str) -> None:
+        super().__init__(f"Credential grant already exists: {grant_id}")
+        self.grant_id = grant_id
+
+
 class ProfileStore(Protocol):
     """Store for named MCP tool and permission profiles.
 
@@ -154,6 +162,10 @@ class CredentialGrantStore(Protocol):
 
     async def upsert_grant(self, grant: CredentialGrant) -> CredentialGrant:
         """Create or replace credential grant metadata."""
+        ...
+
+    async def create_grant(self, grant: CredentialGrant) -> CredentialGrant:
+        """Create credential grant metadata and reject existing ids."""
         ...
 
     async def delete_grant(self, grant_id: str) -> bool:

--- a/mcp_unified/storage/sqlite.py
+++ b/mcp_unified/storage/sqlite.py
@@ -35,6 +35,7 @@ from sqlalchemy.exc import IntegrityError, SQLAlchemyError
 from sqlalchemy.pool import StaticPool
 
 from mcp_unified.interfaces.storage import (
+    CredentialGrantAlreadyExistsError,
     ExternalRegistryStoreUnavailableError,
     ExternalServerAlreadyExistsError,
 )
@@ -206,6 +207,10 @@ class SQLiteMCPStore:
     async def upsert_grant(self, grant: CredentialGrant) -> CredentialGrant:
         """Store a credential grant and return the persisted model."""
         return await self._run_db(self._upsert_grant_sync, grant)
+
+    async def create_grant(self, grant: CredentialGrant) -> CredentialGrant:
+        """Create a credential grant only when its id is absent."""
+        return await self._run_db(self._create_grant_sync, grant)
 
     async def delete_grant(self, grant_id: str) -> bool:
         """Delete a credential grant by id and return whether it existed."""
@@ -525,6 +530,25 @@ class SQLiteMCPStore:
                 "payload",
             ),
         )
+        return self._load_model(payload, CredentialGrant)
+
+    def _create_grant_sync(self, grant: CredentialGrant) -> CredentialGrant:
+        payload = self._dump_model(grant)
+        table = self._table("mcp_credential_grants")
+        statement = sqlite_insert(table).values(
+            id=grant.id,
+            profile_id=grant.profile_id,
+            external_server_id=grant.external_server_id,
+            enabled=int(grant.enabled),
+            updated_at=grant.updated_at.isoformat(),
+            payload=payload,
+        )
+        with self._engine.begin() as connection:
+            result = connection.execute(
+                statement.on_conflict_do_nothing(index_elements=[table.c.id])
+            )
+        if not result.rowcount:
+            raise CredentialGrantAlreadyExistsError(grant.id)
         return self._load_model(payload, CredentialGrant)
 
     def _delete_grant_sync(self, grant_id: str) -> bool:

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_admin_auth.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_admin_auth.py
@@ -5,11 +5,12 @@ from pathlib import Path
 from typing import Any
 
 import pytest
+from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from mcp_unified.gateway.admin_auth import GatewayAdminAuthConfig
 from mcp_unified.gateway.config import load_gateway_profile_bootstrap_config
-from mcp_unified.gateway.fastapi import create_gateway_app
+from mcp_unified.gateway.fastapi import create_gateway_app, create_gateway_router
 
 
 class _FakeGatewayRuntime:
@@ -93,6 +94,44 @@ def test_gateway_admin_auth_protects_management_routes() -> None:
     }
     assert allowed.status_code == 200
     assert allowed.json()["profiles"] == [{"id": "reviewer", "name": "Reviewer"}]
+
+
+def test_gateway_admin_auth_direct_router_mount_returns_json_errors() -> None:
+    """Direct router mounts should not need an app-level auth exception handler."""
+
+    app = FastAPI()
+    app.include_router(
+        create_gateway_router(
+            _FakeGatewayRuntime(),
+            profile_manager=_ProfileManagerDouble(),
+            admin_auth=GatewayAdminAuthConfig(
+                enabled=True,
+                header_name="X-Test-Gateway-Admin",
+                api_key="test-admin-key",
+            ),
+        ),
+        prefix="/mcp",
+    )
+
+    with TestClient(app) as client:
+        missing = client.get("/mcp/profiles")
+        invalid = client.get(
+            "/mcp/profiles",
+            headers={"X-Test-Gateway-Admin": "wrong-key"},
+        )
+
+    assert missing.status_code == 401
+    assert missing.json() == {
+        "ok": False,
+        "error": "Gateway admin authentication required",
+        "reason_code": "admin_auth_required",
+    }
+    assert invalid.status_code == 403
+    assert invalid.json() == {
+        "ok": False,
+        "error": "Gateway admin authentication failed",
+        "reason_code": "admin_auth_invalid",
+    }
 
 
 def test_gateway_admin_auth_does_not_gate_status_or_jsonrpc() -> None:

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_admin_auth.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_admin_auth.py
@@ -1,0 +1,209 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+from fastapi.testclient import TestClient
+
+from mcp_unified.gateway.admin_auth import GatewayAdminAuthConfig
+from mcp_unified.gateway.config import load_gateway_profile_bootstrap_config
+from mcp_unified.gateway.fastapi import create_gateway_app
+
+
+class _FakeGatewayRuntime:
+    """Small gateway runtime for admin auth route tests."""
+
+    name = "admin-auth-test"
+    version = "0.0-test"
+
+    async def list_tools(self, context: Any) -> list[dict[str, Any]]:
+        """Return one deterministic tool."""
+
+        del context
+        return [
+            {
+                "name": "echo.search",
+                "description": "Echo a query.",
+                "inputSchema": {"type": "object", "properties": {}},
+                "metadata": {"category": "test"},
+            }
+        ]
+
+
+class _ProfileManagerDouble:
+    """Small profile manager double for protected management routes."""
+
+    async def list_profiles(self) -> dict[str, Any]:
+        """Return a deterministic profile-management payload."""
+
+        return {
+            "ok": True,
+            "profiles": [{"id": "reviewer", "name": "Reviewer"}],
+            "store": {"kind": "memory", "persistent": False},
+        }
+
+    async def show_profile(self, profile_id: str) -> dict[str, Any]:
+        """Return a deterministic profile payload."""
+
+        return {
+            "ok": True,
+            "profile": {"id": profile_id, "name": f"Profile {profile_id}"},
+            "store": {"kind": "memory", "persistent": False},
+        }
+
+
+def test_gateway_admin_auth_protects_management_routes() -> None:
+    """Admin-authenticated gateway apps protect management routes only."""
+
+    app = create_gateway_app(
+        _FakeGatewayRuntime(),
+        prefix="/mcp",
+        profile_manager=_ProfileManagerDouble(),
+        admin_auth=GatewayAdminAuthConfig(
+            enabled=True,
+            header_name="X-Test-Gateway-Admin",
+            api_key="test-admin-key",
+        ),
+    )
+
+    with TestClient(app) as client:
+        missing = client.get("/mcp/profiles")
+        invalid = client.get(
+            "/mcp/profiles",
+            headers={"X-Test-Gateway-Admin": "wrong-key"},
+        )
+        allowed = client.get(
+            "/mcp/profiles",
+            headers={"X-Test-Gateway-Admin": "test-admin-key"},
+        )
+
+    assert missing.status_code == 401
+    assert missing.json() == {
+        "ok": False,
+        "error": "Gateway admin authentication required",
+        "reason_code": "admin_auth_required",
+    }
+    assert invalid.status_code == 403
+    assert invalid.json() == {
+        "ok": False,
+        "error": "Gateway admin authentication failed",
+        "reason_code": "admin_auth_invalid",
+    }
+    assert allowed.status_code == 200
+    assert allowed.json()["profiles"] == [{"id": "reviewer", "name": "Reviewer"}]
+
+
+def test_gateway_admin_auth_does_not_gate_status_or_jsonrpc() -> None:
+    """Admin auth should not accidentally protect status or JSON-RPC calls."""
+
+    app = create_gateway_app(
+        _FakeGatewayRuntime(),
+        prefix="/mcp",
+        profile_manager=_ProfileManagerDouble(),
+        admin_auth=GatewayAdminAuthConfig(enabled=True, api_key="test-admin-key"),
+    )
+
+    with TestClient(app) as client:
+        status = client.get("/mcp/status")
+        tools = client.post(
+            "/mcp/request",
+            json={"jsonrpc": "2.0", "method": "tools/list", "id": "tools-1"},
+        )
+
+    assert status.status_code == 200
+    assert status.json() == {
+        "status": "ok",
+        "name": "admin-auth-test",
+        "version": "0.0-test",
+    }
+    assert tools.status_code == 200
+    assert tools.json()["result"]["tools"][0]["name"] == "echo.search"
+
+
+@pytest.mark.parametrize("suffix", [".json", ".toml"])
+def test_gateway_config_loads_admin_auth_without_plaintext_key(
+    tmp_path: Path,
+    suffix: str,
+) -> None:
+    """Standalone config may enable admin auth through an env-var reference."""
+
+    config_path = tmp_path / f"gateway{suffix}"
+    if suffix == ".json":
+        config_path.write_text(
+            json.dumps(
+                {
+                    "store": {"kind": "memory"},
+                    "admin_auth": {
+                        "enabled": True,
+                        "header_name": "X-Test-Gateway-Admin",
+                        "api_key_env_var": "TEST_GATEWAY_ADMIN_KEY",
+                    },
+                }
+            ),
+            encoding="utf-8",
+        )
+    else:
+        config_path.write_text(
+            "\n".join(
+                [
+                    "[store]",
+                    'kind = "memory"',
+                    "",
+                    "[admin_auth]",
+                    "enabled = true",
+                    'header_name = "X-Test-Gateway-Admin"',
+                    'api_key_env_var = "TEST_GATEWAY_ADMIN_KEY"',
+                ]
+            ),
+            encoding="utf-8",
+        )
+
+    config = load_gateway_profile_bootstrap_config(config_path)
+
+    assert config.admin_auth.enabled is True
+    assert config.admin_auth.header_name == "X-Test-Gateway-Admin"
+    assert config.admin_auth.api_key_env_var == "TEST_GATEWAY_ADMIN_KEY"
+
+
+def test_gateway_config_rejects_plaintext_admin_auth_key(tmp_path: Path) -> None:
+    """File-backed config must not accept a persisted admin key."""
+
+    config_path = tmp_path / "gateway.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "store": {"kind": "memory"},
+                "admin_auth": {
+                    "enabled": True,
+                    "api_key": "plaintext-secret",
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="admin_auth.api_key"):
+        load_gateway_profile_bootstrap_config(config_path)
+
+
+def test_gateway_config_rejects_blank_admin_auth_header(tmp_path: Path) -> None:
+    """Configured admin auth header names must be non-blank."""
+
+    config_path = tmp_path / "gateway.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "store": {"kind": "memory"},
+                "admin_auth": {
+                    "enabled": True,
+                    "header_name": " ",
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="admin_auth.header_name"):
+        load_gateway_profile_bootstrap_config(config_path)

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_cli_package.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_cli_package.py
@@ -1271,6 +1271,225 @@ def test_gateway_cli_external_registry_runtime_failures_are_json(
     assert "Traceback" not in captured.err
 
 
+def test_gateway_cli_create_credential_grant_persists_to_sqlite_store(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Create a credential grant from JSON file input and persist to SQLite."""
+
+    sqlite_path = tmp_path / "gateway.db"
+    grant_path = tmp_path / "grant.json"
+    grant_path.write_text(
+        json.dumps(_credential_grant_payload("grant-one")),
+        encoding="utf-8",
+    )
+    config_path = _write_gateway_config(
+        tmp_path,
+        {"store": {"kind": "sqlite", "sqlite_path": str(sqlite_path)}},
+    )
+    _seed_sqlite_profile(sqlite_path, "profile", "Profile")
+
+    exit_code = gateway_cli.main(
+        [
+            "create-credential-grant",
+            "--grant-file",
+            str(grant_path),
+            "--config",
+            str(config_path),
+        ]
+    )
+
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+    assert exit_code == 0
+    assert captured.err == ""
+    assert payload["ok"] is True
+    assert payload["grant"]["id"] == "grant-one"
+    assert payload["grant"]["credential_slot"] == "api_key"
+    assert payload["store"] == {"kind": "sqlite", "persistent": True}
+
+    show_exit_code = gateway_cli.main(
+        ["show-credential-grant", "grant-one", "--config", str(config_path)]
+    )
+    show_payload = json.loads(capsys.readouterr().out)
+    assert show_exit_code == 0
+    assert show_payload["grant"]["id"] == "grant-one"
+
+
+def test_gateway_cli_list_credential_grants_filters_profile(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """List credential grants and honor the optional profile filter."""
+
+    sqlite_path = tmp_path / "gateway.db"
+    config_path = _write_gateway_config(
+        tmp_path,
+        {"store": {"kind": "sqlite", "sqlite_path": str(sqlite_path)}},
+    )
+    _seed_sqlite_profile(sqlite_path, "profile", "Profile")
+    _seed_sqlite_profile(sqlite_path, "other", "Other")
+    _seed_sqlite_credential_grant(sqlite_path, "grant-one", profile_id="profile")
+    _seed_sqlite_credential_grant(sqlite_path, "grant-two", profile_id="other")
+
+    exit_code = gateway_cli.main(
+        [
+            "list-credential-grants",
+            "--profile-id",
+            "profile",
+            "--config",
+            str(config_path),
+        ]
+    )
+
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+    assert exit_code == 0
+    assert captured.err == ""
+    assert payload["ok"] is True
+    assert [grant["id"] for grant in payload["grants"]] == ["grant-one"]
+    assert payload["store"] == {"kind": "sqlite", "persistent": True}
+
+
+def test_gateway_cli_patch_credential_grant_accepts_stdin_json(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Patch a credential grant from stdin JSON when --patch-file=-."""
+
+    sqlite_path = tmp_path / "gateway.db"
+    config_path = _write_gateway_config(
+        tmp_path,
+        {"store": {"kind": "sqlite", "sqlite_path": str(sqlite_path)}},
+    )
+    _seed_sqlite_profile(sqlite_path, "profile", "Profile")
+    _seed_sqlite_credential_grant(sqlite_path, "grant-one")
+    monkeypatch.setattr(
+        gateway_cli.sys,
+        "stdin",
+        io.StringIO(json.dumps({"metadata": {"label": "Updated"}, "enabled": False})),
+    )
+
+    exit_code = gateway_cli.main(
+        [
+            "patch-credential-grant",
+            "grant-one",
+            "--patch-file",
+            "-",
+            "--config",
+            str(config_path),
+        ]
+    )
+
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+    assert exit_code == 0
+    assert captured.err == ""
+    assert payload["grant"]["metadata"] == {"label": "Updated"}
+    assert payload["grant"]["enabled"] is False
+    assert payload["store"] == {"kind": "sqlite", "persistent": True}
+
+
+def test_gateway_cli_delete_credential_grant_removes_sqlite_grant(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Delete one credential grant from a persistent gateway store."""
+
+    sqlite_path = tmp_path / "gateway.db"
+    config_path = _write_gateway_config(
+        tmp_path,
+        {"store": {"kind": "sqlite", "sqlite_path": str(sqlite_path)}},
+    )
+    _seed_sqlite_profile(sqlite_path, "profile", "Profile")
+    _seed_sqlite_credential_grant(sqlite_path, "grant-one")
+
+    exit_code = gateway_cli.main(
+        ["delete-credential-grant", "grant-one", "--config", str(config_path)]
+    )
+
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+    assert exit_code == 0
+    assert captured.err == ""
+    assert payload == {
+        "ok": True,
+        "grant_id": "grant-one",
+        "store": {"kind": "sqlite", "persistent": True},
+    }
+
+
+def test_gateway_cli_create_credential_grant_duplicate_reports_reason_code(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Reject duplicate credential grant creation with a stable reason code."""
+
+    sqlite_path = tmp_path / "gateway.db"
+    grant_path = tmp_path / "grant.json"
+    grant_path.write_text(
+        json.dumps(_credential_grant_payload("grant-one")),
+        encoding="utf-8",
+    )
+    config_path = _write_gateway_config(
+        tmp_path,
+        {"store": {"kind": "sqlite", "sqlite_path": str(sqlite_path)}},
+    )
+    _seed_sqlite_profile(sqlite_path, "profile", "Profile")
+    _seed_sqlite_credential_grant(sqlite_path, "grant-one")
+
+    exit_code = gateway_cli.main(
+        [
+            "create-credential-grant",
+            "--grant-file",
+            str(grant_path),
+            "--config",
+            str(config_path),
+        ]
+    )
+
+    captured = capsys.readouterr()
+    payload = json.loads(captured.err)
+    assert exit_code == 1
+    assert captured.out == ""
+    assert payload["ok"] is False
+    assert payload["reason_code"] == "credential_grant_already_exists"
+    assert payload["grant_id"] == "grant-one"
+
+
+def test_gateway_cli_credential_grant_json_argument_rejects_malformed_json(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Reject malformed credential grant JSON payload files with exit code 2."""
+
+    grant_path = tmp_path / "grant.json"
+    grant_path.write_text("{", encoding="utf-8")
+    config_path = _write_gateway_config(
+        tmp_path,
+        {"store": {"kind": "sqlite", "sqlite_path": str(tmp_path / 'gateway.db')}},
+    )
+
+    exit_code = gateway_cli.main(
+        [
+            "create-credential-grant",
+            "--grant-file",
+            str(grant_path),
+            "--config",
+            str(config_path),
+        ]
+    )
+
+    captured = capsys.readouterr()
+    payload = json.loads(captured.err)
+    assert exit_code == 2
+    assert captured.out == ""
+    assert payload["ok"] is False
+    assert "Invalid grant JSON" in payload["error"]
+    assert "Traceback" not in captured.err
+
+
 @pytest.mark.parametrize(
     ("argv", "label"),
     [
@@ -1578,6 +1797,20 @@ def _server_payload(server_id: str, name: str) -> dict[str, object]:
     }
 
 
+def _credential_grant_payload(
+    grant_id: str,
+    *,
+    profile_id: str = "profile",
+) -> dict[str, object]:
+    return {
+        "id": grant_id,
+        "profile_id": profile_id,
+        "broker_id": "broker",
+        "credential_slot": "api_key",
+        "metadata": {"label": grant_id},
+    }
+
+
 def _seed_sqlite_profile(sqlite_path: Path, profile_id: str, name: str) -> None:
     bundle = build_gateway_profile_storage(
         {"kind": "sqlite", "sqlite_path": str(sqlite_path)}
@@ -1687,6 +1920,30 @@ def _seed_sqlite_external_server_grant(
                     credential_slot="api_key",
                     external_server_id=server_id,
                 )
+            )
+        finally:
+            await bundle.external_registry_store.aclose()
+
+    asyncio.run(_seed())
+
+
+def _seed_sqlite_credential_grant(
+    sqlite_path: Path,
+    grant_id: str,
+    *,
+    profile_id: str = "profile",
+) -> None:
+    bundle = build_gateway_external_registry_storage(
+        {"kind": "sqlite", "sqlite_path": str(sqlite_path)}
+    )
+
+    async def _seed() -> None:
+        try:
+            grant_store = bundle.credential_grant_store
+            if grant_store is None:
+                raise RuntimeError("SQLite external registry bundle must expose grants")
+            await grant_store.upsert_grant(
+                CredentialGrant(**_credential_grant_payload(grant_id, profile_id=profile_id))
             )
         finally:
             await bundle.external_registry_store.aclose()

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_cli_package.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_cli_package.py
@@ -17,6 +17,7 @@ from mcp_unified.gateway.config import (
     build_gateway_profile_storage,
 )
 from mcp_unified.gateway.profiles import GatewayProfileManager
+from mcp_unified.gateway.snapshots import GatewayConfigSnapshotManagementError
 from mcp_unified.profiles.models import MCPProfile
 from mcp_unified.storage.models import (
     CredentialGrant,
@@ -1458,6 +1459,249 @@ def test_gateway_cli_create_credential_grant_duplicate_reports_reason_code(
     assert payload["grant_id"] == "grant-one"
 
 
+def test_gateway_cli_export_config_writes_snapshot_to_stdout(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Export a directly importable config snapshot to stdout."""
+
+    sqlite_path = tmp_path / "gateway.db"
+    config_path = _write_gateway_config(
+        tmp_path,
+        {"store": {"kind": "sqlite", "sqlite_path": str(sqlite_path)}},
+    )
+    _seed_sqlite_profile(sqlite_path, "profile", "Profile")
+    _seed_sqlite_gateway_default_assignment(sqlite_path, "profile")
+    _seed_sqlite_external_server(sqlite_path, "search", "Search")
+    _seed_sqlite_credential_grant(
+        sqlite_path,
+        "grant-one",
+        external_server_id="search",
+    )
+
+    exit_code = gateway_cli.main(["export-config", "--config", str(config_path)])
+
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+    assert exit_code == 0
+    assert captured.err == ""
+    assert payload["schema"] == "mcp_unified.gateway.config_snapshot"
+    assert payload["version"] == 1
+    assert [profile["id"] for profile in payload["profiles"]] == ["profile"]
+    assert payload["default_assignment"]["profile_id"] == "profile"
+    assert [server["id"] for server in payload["external_servers"]] == ["search"]
+    assert [grant["id"] for grant in payload["credential_grants"]] == ["grant-one"]
+    assert "ok" not in payload
+
+
+def test_gateway_cli_export_config_writes_snapshot_file(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Export-config can write the snapshot JSON to a requested file."""
+
+    sqlite_path = tmp_path / "gateway.db"
+    output_path = tmp_path / "snapshot.json"
+    config_path = _write_gateway_config(
+        tmp_path,
+        {"store": {"kind": "sqlite", "sqlite_path": str(sqlite_path)}},
+    )
+    _seed_sqlite_profile(sqlite_path, "profile", "Profile")
+
+    exit_code = gateway_cli.main(
+        [
+            "export-config",
+            "--config",
+            str(config_path),
+            "--output",
+            str(output_path),
+        ]
+    )
+
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+    file_payload = json.loads(output_path.read_text(encoding="utf-8"))
+    assert exit_code == 0
+    assert captured.err == ""
+    assert payload == {
+        "ok": True,
+        "output": str(output_path),
+        "schema": "mcp_unified.gateway.config_snapshot",
+        "version": 1,
+    }
+    assert file_payload["schema"] == "mcp_unified.gateway.config_snapshot"
+    assert [profile["id"] for profile in file_payload["profiles"]] == ["profile"]
+
+
+def test_gateway_cli_import_config_dry_run_reports_plan_without_mutation(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Import-config dry-run reports the plan and leaves the store untouched."""
+
+    sqlite_path = tmp_path / "gateway.db"
+    snapshot_path = tmp_path / "snapshot.json"
+    snapshot_path.write_text(json.dumps(_config_snapshot_payload()), encoding="utf-8")
+    config_path = _write_gateway_config(
+        tmp_path,
+        {"store": {"kind": "sqlite", "sqlite_path": str(sqlite_path)}},
+    )
+
+    exit_code = gateway_cli.main(
+        [
+            "import-config",
+            "--snapshot-file",
+            str(snapshot_path),
+            "--dry-run",
+            "--config",
+            str(config_path),
+        ]
+    )
+
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+    assert exit_code == 0
+    assert captured.err == ""
+    assert payload["ok"] is True
+    assert payload["dry_run"] is True
+    assert [action["action"] for action in payload["plan"]["actions"]] == [
+        "upsert_profile",
+        "set_default_assignment",
+        "upsert_external_server",
+        "upsert_credential_grant",
+    ]
+
+    list_exit_code = gateway_cli.main(["list-profiles", "--config", str(config_path)])
+    list_payload = json.loads(capsys.readouterr().out)
+    assert list_exit_code == 0
+    assert list_payload["profiles"] == []
+
+
+def test_gateway_cli_import_config_applies_snapshot_upserts(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Import-config applies profile, default, external-server, and grant upserts."""
+
+    sqlite_path = tmp_path / "gateway.db"
+    snapshot_path = tmp_path / "snapshot.json"
+    snapshot_path.write_text(json.dumps(_config_snapshot_payload()), encoding="utf-8")
+    config_path = _write_gateway_config(
+        tmp_path,
+        {"store": {"kind": "sqlite", "sqlite_path": str(sqlite_path)}},
+    )
+
+    exit_code = gateway_cli.main(
+        [
+            "import-config",
+            "--snapshot-file",
+            str(snapshot_path),
+            "--config",
+            str(config_path),
+        ]
+    )
+
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+    assert exit_code == 0
+    assert captured.err == ""
+    assert payload["ok"] is True
+    assert payload["dry_run"] is False
+    assert payload["failed_actions"] == []
+    assert [action["target_id"] for action in payload["applied_actions"]] == [
+        "profile",
+        "gateway-default",
+        "search",
+        "grant-one",
+    ]
+
+    show_profile_exit = gateway_cli.main(
+        ["show-profile", "profile", "--config", str(config_path)]
+    )
+    show_profile_payload = json.loads(capsys.readouterr().out)
+    assert show_profile_exit == 0
+    assert show_profile_payload["profile"]["id"] == "profile"
+
+    show_grant_exit = gateway_cli.main(
+        ["show-credential-grant", "grant-one", "--config", str(config_path)]
+    )
+    show_grant_payload = json.loads(capsys.readouterr().out)
+    assert show_grant_exit == 0
+    assert show_grant_payload["grant"]["external_server_id"] == "search"
+
+
+def test_gateway_cli_import_config_reports_sanitized_partial_failure(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Import-config reports partial action ids without echoing raw snapshots."""
+
+    class _FailingSnapshotManager:
+        async def import_snapshot(
+            self,
+            snapshot: Mapping[str, object],
+            *,
+            dry_run: bool = False,
+        ) -> dict[str, object]:
+            del snapshot, dry_run
+            raise GatewayConfigSnapshotManagementError(
+                "Gateway config snapshot import failed",
+                reason_code="config_snapshot_import_failed",
+                applied_actions=[{"action": "upsert_profile", "target_id": "profile"}],
+                failed_actions=[
+                    {
+                        "action": "upsert_credential_grant",
+                        "reason_code": "RuntimeError",
+                        "target_id": "grant-one",
+                    }
+                ],
+            )
+
+    sqlite_path = tmp_path / "gateway.db"
+    snapshot = _config_snapshot_payload()
+    snapshot["credential_grants"][0]["broker_id"] = "broker-secret-value"
+    snapshot_path = tmp_path / "snapshot.json"
+    snapshot_path.write_text(json.dumps(snapshot), encoding="utf-8")
+    config_path = _write_gateway_config(
+        tmp_path,
+        {"store": {"kind": "sqlite", "sqlite_path": str(sqlite_path)}},
+    )
+    monkeypatch.setattr(
+        gateway_cli,
+        "gateway_config_snapshot_manager_from_storage",
+        lambda *args, **kwargs: _FailingSnapshotManager(),
+    )
+
+    exit_code = gateway_cli.main(
+        [
+            "import-config",
+            "--snapshot-file",
+            str(snapshot_path),
+            "--config",
+            str(config_path),
+        ]
+    )
+
+    captured = capsys.readouterr()
+    payload = json.loads(captured.err)
+    assert exit_code == 1
+    assert captured.out == ""
+    assert payload["reason_code"] == "config_snapshot_import_failed"
+    assert payload["applied_actions"] == [
+        {"action": "upsert_profile", "target_id": "profile"}
+    ]
+    assert payload["failed_actions"] == [
+        {
+            "action": "upsert_credential_grant",
+            "reason_code": "RuntimeError",
+            "target_id": "grant-one",
+        }
+    ]
+    assert "broker-secret-value" not in captured.err
+    assert "Traceback" not in captured.err
+
+
 def test_gateway_cli_credential_grant_json_argument_rejects_malformed_json(
     tmp_path: Path,
     capsys: pytest.CaptureFixture[str],
@@ -1801,13 +2045,45 @@ def _credential_grant_payload(
     grant_id: str,
     *,
     profile_id: str = "profile",
+    external_server_id: str | None = None,
 ) -> dict[str, object]:
-    return {
+    payload: dict[str, object] = {
         "id": grant_id,
         "profile_id": profile_id,
         "broker_id": "broker",
         "credential_slot": "api_key",
         "metadata": {"label": grant_id},
+    }
+    if external_server_id is not None:
+        payload["external_server_id"] = external_server_id
+    return payload
+
+
+def _config_snapshot_payload() -> dict[str, object]:
+    return {
+        "schema": "mcp_unified.gateway.config_snapshot",
+        "version": 1,
+        "profiles": [_profile_payload("profile", "Profile")],
+        "default_assignment": ProfileAssignment(
+            id="gateway-default",
+            profile_id="profile",
+            is_default=True,
+        ).model_dump(mode="json"),
+        "external_servers": [
+            {
+                "id": "search",
+                "name": "Search",
+                "transport": "stdio",
+                "command": ["node", "server.js"],
+                "credential_slots": ["api_key"],
+            }
+        ],
+        "credential_grants": [
+            _credential_grant_payload(
+                "grant-one",
+                external_server_id="search",
+            )
+        ],
     }
 
 
@@ -1846,6 +2122,29 @@ def _seed_sqlite_default_profile(sqlite_path: Path, preset_id: str) -> None:
             await bundle.profile_store.aclose()
 
     asyncio.run(_seed_default())
+
+
+def _seed_sqlite_gateway_default_assignment(
+    sqlite_path: Path,
+    profile_id: str,
+) -> None:
+    bundle = build_gateway_profile_storage(
+        {"kind": "sqlite", "sqlite_path": str(sqlite_path)}
+    )
+
+    async def _seed_assignment() -> None:
+        try:
+            await bundle.assignment_store.upsert_assignment(
+                ProfileAssignment(
+                    id="gateway-default",
+                    profile_id=profile_id,
+                    is_default=True,
+                )
+            )
+        finally:
+            await bundle.assignment_store.aclose()
+
+    asyncio.run(_seed_assignment())
 
 
 def _seed_sqlite_profile_assignment(
@@ -1932,6 +2231,7 @@ def _seed_sqlite_credential_grant(
     grant_id: str,
     *,
     profile_id: str = "profile",
+    external_server_id: str | None = None,
 ) -> None:
     bundle = build_gateway_external_registry_storage(
         {"kind": "sqlite", "sqlite_path": str(sqlite_path)}
@@ -1943,7 +2243,13 @@ def _seed_sqlite_credential_grant(
             if grant_store is None:
                 raise RuntimeError("SQLite external registry bundle must expose grants")
             await grant_store.upsert_grant(
-                CredentialGrant(**_credential_grant_payload(grant_id, profile_id=profile_id))
+                CredentialGrant(
+                    **_credential_grant_payload(
+                        grant_id,
+                        profile_id=profile_id,
+                        external_server_id=external_server_id,
+                    )
+                )
             )
         finally:
             await bundle.external_registry_store.aclose()

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_config_snapshots.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_config_snapshots.py
@@ -9,6 +9,7 @@ from typing import Any
 
 import pytest
 
+import mcp_unified.gateway.snapshots as snapshot_module
 from mcp_unified.gateway.snapshots import (
     GatewayConfigSnapshot,
     GatewayConfigSnapshotManagementError,
@@ -174,6 +175,37 @@ def test_snapshot_validation_rejects_external_server_inline_secrets(
         GatewayConfigSnapshot.model_validate(payload)
 
 
+def test_snapshot_inline_secret_validation_allows_malformed_missing_command() -> None:
+    """Defensive validation treats missing command lists as empty."""
+
+    server = ExternalServerDefinition.model_construct(
+        id="disabled-search",
+        name="Disabled Search",
+        transport="stdio",
+        command=None,
+        url=None,
+        cwd=None,
+        env_allowlist=[],
+        credential_slots=[],
+        metadata={},
+        provenance={},
+        enabled=False,
+        auto_start=False,
+    )
+
+    snapshot_module._reject_external_server_inline_secrets(server)
+
+
+def test_snapshot_validation_rejects_non_gateway_default_assignment_id() -> None:
+    """Snapshots cannot import arbitrary default assignment ids."""
+
+    payload = _snapshot_payload()
+    payload["default_assignment"]["id"] = "workspace-assignment"
+
+    with pytest.raises(ValueError, match="default assignment id"):
+        GatewayConfigSnapshot.model_validate(payload)
+
+
 @pytest.mark.asyncio
 async def test_import_snapshot_validates_before_first_write() -> None:
     """Reference validation fails without writing earlier valid snapshot sections."""
@@ -193,6 +225,53 @@ async def test_import_snapshot_validates_before_first_write() -> None:
 
     with pytest.raises(GatewayConfigSnapshotManagementError) as exc_info:
         await manager.import_snapshot(payload)
+
+    assert exc_info.value.reason_code == "config_snapshot_invalid_reference"
+    assert await profile_store.list_profiles() == []
+    assert await assignment_store.list_assignments() == []
+    assert await external_store.list_server_definitions() == []
+    assert await grant_store.list_grants() == []
+
+
+@pytest.mark.asyncio
+async def test_import_snapshot_handles_malformed_server_slots_before_first_write() -> None:
+    """Malformed model instances fail reference validation without mutation."""
+
+    profile_store = InMemoryProfileStore()
+    assignment_store = InMemoryProfileAssignmentStore()
+    external_store = _InMemoryExternalRegistryStore()
+    grant_store = _InMemoryCredentialGrantStore()
+    manager = GatewayConfigSnapshotManager(
+        profile_store=profile_store,
+        assignment_store=assignment_store,
+        external_registry_store=external_store,
+        credential_grant_store=grant_store,
+    )
+    snapshot = GatewayConfigSnapshot.model_construct(
+        profiles=[MCPProfile(id="reviewer", name="Reviewer")],
+        default_assignment=ProfileAssignment(
+            id=GATEWAY_DEFAULT_ASSIGNMENT_ID,
+            profile_id="reviewer",
+            is_default=True,
+        ),
+        external_servers=[
+            ExternalServerDefinition.model_construct(
+                id="search",
+                name="Search",
+                transport="stdio",
+                command=["node", "server.js"],
+                credential_slots=None,
+                metadata={},
+                provenance={},
+                enabled=True,
+                auto_start=False,
+            )
+        ],
+        credential_grants=[_grant()],
+    )
+
+    with pytest.raises(GatewayConfigSnapshotManagementError) as exc_info:
+        await manager.import_snapshot(snapshot)
 
     assert exc_info.value.reason_code == "config_snapshot_invalid_reference"
     assert await profile_store.list_profiles() == []

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_config_snapshots.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_config_snapshots.py
@@ -238,6 +238,39 @@ def test_snapshot_validation_rejects_non_gateway_default_assignment_id() -> None
 
 
 @pytest.mark.asyncio
+async def test_import_snapshot_rejects_constructed_non_gateway_default_assignment_id() -> None:
+    """Manager validation catches model instances with non-gateway default ids."""
+
+    profile_store = InMemoryProfileStore()
+    assignment_store = InMemoryProfileAssignmentStore()
+    external_store = _InMemoryExternalRegistryStore()
+    grant_store = _InMemoryCredentialGrantStore()
+    manager = GatewayConfigSnapshotManager(
+        profile_store=profile_store,
+        assignment_store=assignment_store,
+        external_registry_store=external_store,
+        credential_grant_store=grant_store,
+    )
+    snapshot = GatewayConfigSnapshot.model_construct(
+        profiles=[MCPProfile(id="reviewer", name="Reviewer")],
+        default_assignment=ProfileAssignment(
+            id="workspace-assignment",
+            profile_id="reviewer",
+            is_default=True,
+        ),
+        external_servers=[],
+        credential_grants=[],
+    )
+
+    with pytest.raises(GatewayConfigSnapshotManagementError) as exc_info:
+        await manager.import_snapshot(snapshot)
+
+    assert exc_info.value.reason_code == "invalid_config_snapshot"
+    assert await profile_store.list_profiles() == []
+    assert await assignment_store.list_assignments() == []
+
+
+@pytest.mark.asyncio
 async def test_import_snapshot_validates_before_first_write() -> None:
     """Reference validation fails without writing earlier valid snapshot sections."""
 

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_config_snapshots.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_config_snapshots.py
@@ -196,6 +196,37 @@ def test_snapshot_inline_secret_validation_allows_malformed_missing_command() ->
     snapshot_module._reject_external_server_inline_secrets(server)
 
 
+@pytest.mark.parametrize(
+    "command",
+    [
+        "node server.js",
+        ["node", 123],
+    ],
+)
+def test_snapshot_inline_secret_validation_rejects_malformed_command(
+    command: Any,
+) -> None:
+    """Malformed command containers are rejected before command inspection."""
+
+    server = ExternalServerDefinition.model_construct(
+        id="disabled-search",
+        name="Disabled Search",
+        transport="stdio",
+        command=command,
+        url=None,
+        cwd=None,
+        env_allowlist=[],
+        credential_slots=[],
+        metadata={},
+        provenance={},
+        enabled=False,
+        auto_start=False,
+    )
+
+    with pytest.raises(ValueError, match="External server command"):
+        snapshot_module._reject_external_server_inline_secrets(server)
+
+
 def test_snapshot_validation_rejects_non_gateway_default_assignment_id() -> None:
     """Snapshots cannot import arbitrary default assignment ids."""
 
@@ -261,6 +292,53 @@ async def test_import_snapshot_handles_malformed_server_slots_before_first_write
                 transport="stdio",
                 command=["node", "server.js"],
                 credential_slots=None,
+                metadata={},
+                provenance={},
+                enabled=True,
+                auto_start=False,
+            )
+        ],
+        credential_grants=[_grant()],
+    )
+
+    with pytest.raises(GatewayConfigSnapshotManagementError) as exc_info:
+        await manager.import_snapshot(snapshot)
+
+    assert exc_info.value.reason_code == "config_snapshot_invalid_reference"
+    assert await profile_store.list_profiles() == []
+    assert await assignment_store.list_assignments() == []
+    assert await external_store.list_server_definitions() == []
+    assert await grant_store.list_grants() == []
+
+
+@pytest.mark.asyncio
+async def test_import_snapshot_rejects_string_server_slots_before_first_write() -> None:
+    """String slot containers cannot satisfy credential grant references."""
+
+    profile_store = InMemoryProfileStore()
+    assignment_store = InMemoryProfileAssignmentStore()
+    external_store = _InMemoryExternalRegistryStore()
+    grant_store = _InMemoryCredentialGrantStore()
+    manager = GatewayConfigSnapshotManager(
+        profile_store=profile_store,
+        assignment_store=assignment_store,
+        external_registry_store=external_store,
+        credential_grant_store=grant_store,
+    )
+    snapshot = GatewayConfigSnapshot.model_construct(
+        profiles=[MCPProfile(id="reviewer", name="Reviewer")],
+        default_assignment=ProfileAssignment(
+            id=GATEWAY_DEFAULT_ASSIGNMENT_ID,
+            profile_id="reviewer",
+            is_default=True,
+        ),
+        external_servers=[
+            ExternalServerDefinition.model_construct(
+                id="search",
+                name="Search",
+                transport="stdio",
+                command=["node", "server.js"],
+                credential_slots="api_key",
                 metadata={},
                 provenance={},
                 enabled=True,

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_config_snapshots.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_config_snapshots.py
@@ -1,0 +1,436 @@
+"""Tests for standalone MCP gateway config import/export snapshots."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from mcp_unified.gateway.snapshots import (
+    GatewayConfigSnapshot,
+    GatewayConfigSnapshotManagementError,
+    GatewayConfigSnapshotManager,
+)
+from mcp_unified.profiles.defaults import GATEWAY_DEFAULT_ASSIGNMENT_ID
+from mcp_unified.profiles.models import MCPProfile
+from mcp_unified.profiles.store import InMemoryProfileAssignmentStore, InMemoryProfileStore
+from mcp_unified.storage.models import (
+    CredentialGrant,
+    ExternalServerDefinition,
+    ProfileAssignment,
+)
+from mcp_unified.storage.sqlite import SQLiteMCPStore
+
+
+@pytest.mark.asyncio
+async def test_export_snapshot_includes_expected_sections(tmp_path: Path) -> None:
+    """Export a deterministic secret-safe snapshot from the configured stores."""
+
+    store = SQLiteMCPStore(tmp_path / "gateway.db")
+    try:
+        await store.upsert_profile(MCPProfile(id="reviewer", name="Reviewer"))
+        await store.upsert_assignment(
+            ProfileAssignment(
+                id=GATEWAY_DEFAULT_ASSIGNMENT_ID,
+                profile_id="reviewer",
+                is_default=True,
+            )
+        )
+        await store.upsert_assignment(
+            ProfileAssignment(
+                id="workspace-assignment",
+                profile_id="reviewer",
+                workspace_id="workspace",
+            )
+        )
+        await store.upsert_server(_server())
+        await store.upsert_grant(_grant())
+
+        payload = (await _sqlite_snapshot_manager(store).export_snapshot()).model_dump(
+            mode="json"
+        )
+
+        assert payload["schema"] == "mcp_unified.gateway.config_snapshot"
+        assert payload["version"] == 1
+        assert [profile["id"] for profile in payload["profiles"]] == ["reviewer"]
+        assert payload["default_assignment"]["id"] == GATEWAY_DEFAULT_ASSIGNMENT_ID
+        assert payload["default_assignment"]["profile_id"] == "reviewer"
+        assert [server["id"] for server in payload["external_servers"]] == ["search"]
+        assert payload["external_servers"][0]["credential_slots"] == ["api_key"]
+        assert [grant["id"] for grant in payload["credential_grants"]] == [
+            "grant-search"
+        ]
+        assert "workspace-assignment" not in json.dumps(payload)
+    finally:
+        await store.aclose()
+
+
+@pytest.mark.asyncio
+async def test_import_snapshot_dry_run_reports_plan_without_mutation() -> None:
+    """Dry-run import validates references and reports planned writes only."""
+
+    profile_store = InMemoryProfileStore()
+    assignment_store = InMemoryProfileAssignmentStore()
+    external_store = _InMemoryExternalRegistryStore()
+    grant_store = _InMemoryCredentialGrantStore()
+    manager = GatewayConfigSnapshotManager(
+        profile_store=profile_store,
+        assignment_store=assignment_store,
+        external_registry_store=external_store,
+        credential_grant_store=grant_store,
+    )
+
+    payload = await manager.import_snapshot(_snapshot_payload(), dry_run=True)
+
+    assert payload == {
+        "ok": True,
+        "dry_run": True,
+        "plan": {
+            "actions": [
+                {"action": "upsert_profile", "target_id": "reviewer"},
+                {
+                    "action": "set_default_assignment",
+                    "target_id": GATEWAY_DEFAULT_ASSIGNMENT_ID,
+                },
+                {"action": "upsert_external_server", "target_id": "search"},
+                {"action": "upsert_credential_grant", "target_id": "grant-search"},
+            ],
+            "counts": {
+                "credential_grants": 1,
+                "default_assignment": 1,
+                "external_servers": 1,
+                "profiles": 1,
+            },
+        },
+    }
+    assert await profile_store.list_profiles() == []
+    assert await assignment_store.list_assignments() == []
+    assert await external_store.list_server_definitions() == []
+    assert await grant_store.list_grants() == []
+
+
+@pytest.mark.parametrize(
+    "field_name",
+    ["metadata", "provenance"],
+)
+@pytest.mark.parametrize(
+    "secret_key",
+    [
+        "secret",
+        "token",
+        "password",
+        "api_key",
+        "authorization",
+        "headers",
+        "env",
+        "credential_value",
+    ],
+)
+def test_snapshot_validation_rejects_secret_looking_metadata(
+    field_name: str,
+    secret_key: str,
+) -> None:
+    """Snapshots reject grant metadata/provenance keys that look like secrets."""
+
+    payload = _snapshot_payload()
+    payload["credential_grants"][0][field_name] = {
+        "nested": {secret_key: "do-not-export"}
+    }
+
+    with pytest.raises(ValueError, match="secret material"):
+        GatewayConfigSnapshot.model_validate(payload)
+
+
+@pytest.mark.parametrize(
+    "server_patch",
+    [
+        {"command": ["node", "server.js", "--token=abc"]},
+        {"command": ["node", "server.js", "api_key=abc"]},
+        {"command": ["node", "server.js", "PASSWORD=abc"]},
+        {
+            "transport": "websocket",
+            "command": [],
+            "url": "https://user:pass@example.test/mcp",
+        },
+        {
+            "transport": "websocket",
+            "command": [],
+            "url": "https://example.test/mcp?token=abc",
+        },
+    ],
+)
+def test_snapshot_validation_rejects_external_server_inline_secrets(
+    server_patch: dict[str, object],
+) -> None:
+    """Snapshots reject inline secret material in external-server launch data."""
+
+    payload = _snapshot_payload()
+    payload["external_servers"][0].update(server_patch)
+
+    with pytest.raises(ValueError, match="secret material"):
+        GatewayConfigSnapshot.model_validate(payload)
+
+
+@pytest.mark.asyncio
+async def test_import_snapshot_validates_before_first_write() -> None:
+    """Reference validation fails without writing earlier valid snapshot sections."""
+
+    profile_store = InMemoryProfileStore()
+    assignment_store = InMemoryProfileAssignmentStore()
+    external_store = _InMemoryExternalRegistryStore()
+    grant_store = _InMemoryCredentialGrantStore()
+    manager = GatewayConfigSnapshotManager(
+        profile_store=profile_store,
+        assignment_store=assignment_store,
+        external_registry_store=external_store,
+        credential_grant_store=grant_store,
+    )
+    payload = _snapshot_payload()
+    payload["credential_grants"][0]["credential_slot"] = "missing_slot"
+
+    with pytest.raises(GatewayConfigSnapshotManagementError) as exc_info:
+        await manager.import_snapshot(payload)
+
+    assert exc_info.value.reason_code == "config_snapshot_invalid_reference"
+    assert await profile_store.list_profiles() == []
+    assert await assignment_store.list_assignments() == []
+    assert await external_store.list_server_definitions() == []
+    assert await grant_store.list_grants() == []
+
+
+@pytest.mark.asyncio
+async def test_import_snapshot_reports_partial_write_failure() -> None:
+    """Best-effort imports report applied and failed action ids on store failure."""
+
+    manager = GatewayConfigSnapshotManager(
+        profile_store=InMemoryProfileStore(),
+        assignment_store=InMemoryProfileAssignmentStore(),
+        external_registry_store=_InMemoryExternalRegistryStore(),
+        credential_grant_store=_FailingCredentialGrantStore(),
+    )
+
+    with pytest.raises(GatewayConfigSnapshotManagementError) as exc_info:
+        await manager.import_snapshot(_snapshot_payload())
+
+    payload = exc_info.value.to_payload()
+    assert payload["reason_code"] == "config_snapshot_import_failed"
+    assert payload["applied_actions"] == [
+        {"action": "upsert_profile", "target_id": "reviewer"},
+        {
+            "action": "set_default_assignment",
+            "target_id": GATEWAY_DEFAULT_ASSIGNMENT_ID,
+        },
+        {"action": "upsert_external_server", "target_id": "search"},
+    ]
+    assert payload["failed_actions"] == [
+        {
+            "action": "upsert_credential_grant",
+            "reason_code": "RuntimeError",
+            "target_id": "grant-search",
+        }
+    ]
+    assert "broker-secret-value" not in json.dumps(payload)
+
+
+@pytest.mark.asyncio
+async def test_sqlite_snapshot_round_trip_preserves_semantic_content(
+    tmp_path: Path,
+) -> None:
+    """A SQLite snapshot can be imported into a fresh store and exported again."""
+
+    source = SQLiteMCPStore(tmp_path / "source.db")
+    target = SQLiteMCPStore(tmp_path / "target.db")
+    try:
+        await source.upsert_profile(MCPProfile(id="reviewer", name="Reviewer"))
+        await source.upsert_assignment(
+            ProfileAssignment(
+                id=GATEWAY_DEFAULT_ASSIGNMENT_ID,
+                profile_id="reviewer",
+                is_default=True,
+            )
+        )
+        await source.upsert_server(_server())
+        await source.upsert_grant(_grant())
+
+        exported = await _sqlite_snapshot_manager(source).export_snapshot()
+        import_payload = await _sqlite_snapshot_manager(target).import_snapshot(
+            exported.model_dump(mode="json")
+        )
+        reexported = await _sqlite_snapshot_manager(target).export_snapshot()
+
+        assert import_payload["ok"] is True
+        assert import_payload["dry_run"] is False
+        assert _semantic_snapshot(reexported) == _semantic_snapshot(exported)
+    finally:
+        await source.aclose()
+        await target.aclose()
+
+
+class _InMemoryExternalRegistryStore:
+    """Small copy-isolated external registry store for snapshot tests."""
+
+    def __init__(
+        self,
+        servers: list[ExternalServerDefinition | Mapping[str, Any]] | None = None,
+    ) -> None:
+        self.servers: dict[str, ExternalServerDefinition] = {}
+        for server in servers or ():
+            validated = ExternalServerDefinition.model_validate(server)
+            self.servers[validated.id] = validated.model_copy(deep=True)
+
+    async def get_server(self, server_id: str) -> ExternalServerDefinition | None:
+        server = self.servers.get(server_id)
+        return None if server is None else server.model_copy(deep=True)
+
+    async def list_servers(self) -> list[ExternalServerDefinition]:
+        return await self.list_server_definitions()
+
+    async def list_server_definitions(
+        self,
+        *,
+        enabled: bool | None = None,
+    ) -> list[ExternalServerDefinition]:
+        return [
+            server.model_copy(deep=True)
+            for server in sorted(self.servers.values(), key=lambda item: item.id)
+            if enabled is None or server.enabled is enabled
+        ]
+
+    async def create_server(
+        self,
+        server: ExternalServerDefinition,
+    ) -> ExternalServerDefinition:
+        return await self.upsert_server(server)
+
+    async def upsert_server(
+        self,
+        server: ExternalServerDefinition,
+    ) -> ExternalServerDefinition:
+        self.servers[server.id] = server.model_copy(deep=True)
+        return server.model_copy(deep=True)
+
+    async def update_server(
+        self,
+        server: ExternalServerDefinition,
+    ) -> ExternalServerDefinition | None:
+        if server.id not in self.servers:
+            return None
+        return await self.upsert_server(server)
+
+    async def delete_server(self, server_id: str) -> bool:
+        return self.servers.pop(server_id, None) is not None
+
+
+class _InMemoryCredentialGrantStore:
+    """Small copy-isolated credential grant store for snapshot tests."""
+
+    def __init__(
+        self,
+        grants: list[CredentialGrant | Mapping[str, Any]] | None = None,
+    ) -> None:
+        self.grants: dict[str, CredentialGrant] = {}
+        for grant in grants or ():
+            validated = CredentialGrant.model_validate(grant)
+            self.grants[validated.id] = validated.model_copy(deep=True)
+
+    async def get_grant(self, grant_id: str) -> CredentialGrant | None:
+        grant = self.grants.get(grant_id)
+        return None if grant is None else grant.model_copy(deep=True)
+
+    async def list_grants(
+        self,
+        *,
+        profile_id: str | None = None,
+        external_server_id: str | None = None,
+    ) -> list[CredentialGrant]:
+        return [
+            grant.model_copy(deep=True)
+            for grant in sorted(self.grants.values(), key=lambda item: item.id)
+            if (profile_id is None or grant.profile_id == profile_id)
+            and (
+                external_server_id is None
+                or grant.external_server_id == external_server_id
+            )
+        ]
+
+    async def create_grant(self, grant: CredentialGrant) -> CredentialGrant:
+        return await self.upsert_grant(grant)
+
+    async def upsert_grant(self, grant: CredentialGrant) -> CredentialGrant:
+        self.grants[grant.id] = grant.model_copy(deep=True)
+        return grant.model_copy(deep=True)
+
+    async def delete_grant(self, grant_id: str) -> bool:
+        return self.grants.pop(grant_id, None) is not None
+
+
+class _FailingCredentialGrantStore(_InMemoryCredentialGrantStore):
+    """Grant store that fails after snapshot validation reaches write phase."""
+
+    async def upsert_grant(self, grant: CredentialGrant) -> CredentialGrant:
+        del grant
+        raise RuntimeError("credential grant write failed: broker-secret-value")
+
+
+def _sqlite_snapshot_manager(store: SQLiteMCPStore) -> GatewayConfigSnapshotManager:
+    return GatewayConfigSnapshotManager(
+        profile_store=store,
+        assignment_store=store,
+        external_registry_store=store,
+        credential_grant_store=store,
+        audit_store=store,
+    )
+
+
+def _server() -> ExternalServerDefinition:
+    return ExternalServerDefinition(
+        id="search",
+        name="Search",
+        transport="stdio",
+        command=["node", "server.js"],
+        credential_slots=["api_key"],
+        metadata={"label": "Search MCP"},
+        provenance={"source": "test"},
+    )
+
+
+def _grant() -> CredentialGrant:
+    return CredentialGrant(
+        id="grant-search",
+        profile_id="reviewer",
+        broker_id="env",
+        credential_slot="api_key",
+        external_server_id="search",
+        metadata={"label": "Search token grant"},
+        provenance={"source": "test"},
+    )
+
+
+def _snapshot_payload() -> dict[str, Any]:
+    return {
+        "schema": "mcp_unified.gateway.config_snapshot",
+        "version": 1,
+        "profiles": [MCPProfile(id="reviewer", name="Reviewer").model_dump(mode="json")],
+        "default_assignment": ProfileAssignment(
+            id=GATEWAY_DEFAULT_ASSIGNMENT_ID,
+            profile_id="reviewer",
+            is_default=True,
+        ).model_dump(mode="json"),
+        "external_servers": [_server().model_dump(mode="json")],
+        "credential_grants": [_grant().model_dump(mode="json")],
+    }
+
+
+def _semantic_snapshot(snapshot: GatewayConfigSnapshot) -> dict[str, Any]:
+    payload = snapshot.model_dump(mode="json")
+    for section in ("profiles", "external_servers", "credential_grants"):
+        for item in payload[section]:
+            item.pop("created_at", None)
+            item.pop("updated_at", None)
+    if payload["default_assignment"] is not None:
+        payload["default_assignment"].pop("created_at", None)
+        payload["default_assignment"].pop("updated_at", None)
+    return payload

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_credential_grants.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_credential_grants.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import Mapping
+from datetime import datetime, timezone
 from typing import Any
 
 import pytest
@@ -228,6 +229,36 @@ def test_gateway_credential_grant_manager_rejects_secret_looking_keys(
     asyncio.run(run())
 
 
+def test_gateway_credential_grant_manager_create_restamps_client_timestamps() -> None:
+    async def run() -> None:
+        manager = _manager()
+        client_timestamp = datetime(2000, 1, 1, tzinfo=timezone.utc).isoformat()
+
+        created = await manager.create_grant(
+            _grant_payload(
+                created_at=client_timestamp,
+                updated_at=client_timestamp,
+            )
+        )
+
+        assert not created["grant"]["created_at"].startswith("2000-01-01")
+        assert not created["grant"]["updated_at"].startswith("2000-01-01")
+
+    asyncio.run(run())
+
+
+def test_gateway_credential_grant_manager_create_rejects_non_string_scope() -> None:
+    async def run() -> None:
+        manager = _manager()
+
+        with pytest.raises(GatewayCredentialGrantManagementError) as exc_info:
+            await manager.create_grant(_grant_payload(scopes=["repo:read", 123]))
+
+        assert exc_info.value.reason_code == "invalid_credential_grant_request"
+
+    asyncio.run(run())
+
+
 def test_gateway_credential_grant_manager_validates_profile_and_server_refs() -> None:
     async def run() -> None:
         manager = _manager(
@@ -281,6 +312,22 @@ def test_gateway_credential_grant_manager_patch_rejects_non_string_server_id() -
         assert (
             await manager.show_grant("grant-one")
         )["grant"]["external_server_id"] == "github-mcp"
+
+    asyncio.run(run())
+
+
+def test_gateway_credential_grant_manager_patch_rejects_non_string_scope() -> None:
+    async def run() -> None:
+        manager = _manager()
+        await manager.create_grant(_grant_payload())
+
+        with pytest.raises(GatewayCredentialGrantManagementError) as exc_info:
+            await manager.patch_grant("grant-one", {"scopes": ["repo:read", 123]})
+
+        assert exc_info.value.reason_code == "invalid_credential_grant_patch"
+        assert (await manager.show_grant("grant-one"))["grant"]["scopes"] == [
+            "repo:read"
+        ]
 
     asyncio.run(run())
 

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_credential_grants.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_credential_grants.py
@@ -1,0 +1,288 @@
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Mapping
+from typing import Any
+
+import pytest
+
+from mcp_unified.gateway.credential_grants import (
+    GatewayCredentialGrantManagementError,
+    GatewayCredentialGrantManager,
+)
+from mcp_unified.gateway.external_registry import GatewayStoreMetadata
+from mcp_unified.interfaces.storage import CredentialGrantAlreadyExistsError
+from mcp_unified.profiles.models import MCPProfile
+from mcp_unified.profiles.store import InMemoryProfileStore
+from mcp_unified.storage.models import (
+    AuditEvent,
+    CredentialGrant,
+    ExternalServerDefinition,
+)
+from mcp_unified.storage.sqlite import SQLiteMCPStore
+
+
+class _InMemoryCredentialGrantStore:
+    """Credential-grant test double with atomic create behavior."""
+
+    def __init__(self) -> None:
+        self._grants: dict[str, CredentialGrant] = {}
+
+    async def get_grant(self, grant_id: str) -> CredentialGrant | None:
+        grant = self._grants.get(grant_id)
+        return None if grant is None else grant.model_copy(deep=True)
+
+    async def list_grants(
+        self,
+        *,
+        profile_id: str | None = None,
+        external_server_id: str | None = None,
+    ) -> list[CredentialGrant]:
+        grants = [
+            grant
+            for grant in self._grants.values()
+            if (profile_id is None or grant.profile_id == profile_id)
+            and (
+                external_server_id is None
+                or grant.external_server_id == external_server_id
+            )
+        ]
+        return [
+            grant.model_copy(deep=True)
+            for grant in sorted(grants, key=lambda item: item.id)
+        ]
+
+    async def create_grant(self, grant: CredentialGrant) -> CredentialGrant:
+        if grant.id in self._grants:
+            raise CredentialGrantAlreadyExistsError(grant.id)
+        self._grants[grant.id] = grant.model_copy(deep=True)
+        return grant.model_copy(deep=True)
+
+    async def upsert_grant(self, grant: CredentialGrant) -> CredentialGrant:
+        self._grants[grant.id] = grant.model_copy(deep=True)
+        return grant.model_copy(deep=True)
+
+    async def delete_grant(self, grant_id: str) -> bool:
+        return self._grants.pop(grant_id, None) is not None
+
+
+class _InMemoryExternalRegistryStore:
+    """External-registry test double for grant reference validation."""
+
+    def __init__(
+        self,
+        servers: list[ExternalServerDefinition | Mapping[str, Any]] | None = None,
+    ) -> None:
+        self._servers = {
+            server.id: server
+            for server in (
+                ExternalServerDefinition.model_validate(item)
+                for item in (servers or [])
+            )
+        }
+
+    async def get_server(
+        self,
+        server_id: str,
+    ) -> ExternalServerDefinition | None:
+        server = self._servers.get(server_id)
+        return None if server is None else server.model_copy(deep=True)
+
+
+class _AuditStore:
+    """Audit sink test double."""
+
+    def __init__(self) -> None:
+        self.events: list[AuditEvent] = []
+
+    async def append_event(self, event: AuditEvent) -> AuditEvent:
+        self.events.append(event.model_copy(deep=True))
+        return event.model_copy(deep=True)
+
+
+def _server(server_id: str = "github-mcp") -> ExternalServerDefinition:
+    return ExternalServerDefinition(
+        id=server_id,
+        name=f"Server {server_id}",
+        transport="stdio",
+        command=["node", "server.js"],
+        credential_slots=["github_token"],
+    )
+
+
+def _manager(
+    *,
+    grant_store: _InMemoryCredentialGrantStore | None = None,
+    profile_store: InMemoryProfileStore | None = None,
+    external_store: _InMemoryExternalRegistryStore | None = None,
+    audit_store: _AuditStore | None = None,
+) -> GatewayCredentialGrantManager:
+    return GatewayCredentialGrantManager(
+        credential_grant_store=grant_store or _InMemoryCredentialGrantStore(),
+        profile_store=profile_store,
+        external_registry_store=external_store,
+        audit_store=audit_store,
+        store_metadata=GatewayStoreMetadata(kind="memory", persistent=False),
+    )
+
+
+def _grant_payload(**overrides: Any) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "id": "grant-one",
+        "profile_id": "reviewer",
+        "broker_id": "env-broker",
+        "credential_slot": "github_token",
+        "external_server_id": "github-mcp",
+        "scopes": ["repo:read"],
+        "metadata": {"label": "GitHub read token"},
+        "provenance": {"source": "test"},
+    }
+    payload.update(overrides)
+    return payload
+
+
+def test_gateway_credential_grant_manager_crud_and_audit() -> None:
+    async def run() -> None:
+        audit_store = _AuditStore()
+        manager = _manager(
+            profile_store=InMemoryProfileStore(
+                [MCPProfile(id="reviewer", name="Reviewer")]
+            ),
+            external_store=_InMemoryExternalRegistryStore([_server()]),
+            audit_store=audit_store,
+        )
+
+        created = await manager.create_grant(_grant_payload())
+        listed = await manager.list_grants(profile_id="reviewer")
+        shown = await manager.show_grant("grant-one")
+        patched = await manager.patch_grant(
+            "grant-one",
+            {"metadata": {"label": "Updated"}, "enabled": False},
+        )
+        deleted = await manager.delete_grant("grant-one")
+
+        assert created["ok"] is True
+        assert created["grant"]["id"] == "grant-one"
+        assert created["store"] == {"kind": "memory", "persistent": False}
+        assert [grant["id"] for grant in listed["grants"]] == ["grant-one"]
+        assert shown["grant"]["credential_slot"] == "github_token"
+        assert patched["grant"]["metadata"] == {"label": "Updated"}
+        assert patched["grant"]["enabled"] is False
+        assert deleted == {
+            "ok": True,
+            "grant_id": "grant-one",
+            "store": {"kind": "memory", "persistent": False},
+        }
+        assert [event.event_type for event in audit_store.events] == [
+            "credential_grant.created",
+            "credential_grant.patched",
+            "credential_grant.deleted",
+        ]
+
+    asyncio.run(run())
+
+
+@pytest.mark.parametrize(
+    "secret_key",
+    [
+        "secret",
+        "token",
+        "password",
+        "api_key",
+        "authorization",
+        "headers",
+        "env",
+        "credential_value",
+    ],
+)
+def test_gateway_credential_grant_manager_rejects_secret_looking_keys(
+    secret_key: str,
+) -> None:
+    async def run() -> None:
+        manager = _manager()
+
+        with pytest.raises(
+            GatewayCredentialGrantManagementError,
+            match="secret material",
+        ) as create_error:
+            await manager.create_grant(
+                _grant_payload(metadata={"nested": {secret_key: "do-not-store"}})
+            )
+
+        await manager.create_grant(_grant_payload(metadata={"label": "safe"}))
+        with pytest.raises(
+            GatewayCredentialGrantManagementError,
+            match="secret material",
+        ) as patch_error:
+            await manager.patch_grant(
+                "grant-one",
+                {"provenance": {"nested": {secret_key: "do-not-store"}}},
+            )
+
+        assert create_error.value.reason_code == "credential_grant_secret_material_rejected"
+        assert patch_error.value.reason_code == "credential_grant_secret_material_rejected"
+        assert (await manager.show_grant("grant-one"))["grant"]["provenance"] == {
+            "source": "test"
+        }
+
+    asyncio.run(run())
+
+
+def test_gateway_credential_grant_manager_validates_profile_and_server_refs() -> None:
+    async def run() -> None:
+        manager = _manager(
+            profile_store=InMemoryProfileStore(),
+            external_store=_InMemoryExternalRegistryStore(),
+        )
+
+        with pytest.raises(GatewayCredentialGrantManagementError) as profile_error:
+            await manager.create_grant(_grant_payload())
+
+        assert profile_error.value.reason_code == "profile_not_found"
+
+        manager = _manager(
+            profile_store=InMemoryProfileStore(
+                [MCPProfile(id="reviewer", name="Reviewer")]
+            ),
+            external_store=_InMemoryExternalRegistryStore(),
+        )
+
+        with pytest.raises(GatewayCredentialGrantManagementError) as server_error:
+            await manager.create_grant(_grant_payload())
+
+        assert server_error.value.reason_code == "external_server_not_found"
+
+    asyncio.run(run())
+
+
+def test_gateway_credential_grant_manager_duplicate_create_does_not_replace() -> None:
+    async def run() -> None:
+        manager = _manager()
+        await manager.create_grant(_grant_payload(broker_id="first-broker"))
+
+        with pytest.raises(GatewayCredentialGrantManagementError) as exc_info:
+            await manager.create_grant(_grant_payload(broker_id="second-broker"))
+
+        assert exc_info.value.reason_code == "credential_grant_already_exists"
+        assert (await manager.show_grant("grant-one"))["grant"]["broker_id"] == "first-broker"
+
+    asyncio.run(run())
+
+
+def test_sqlite_create_grant_rejects_duplicate_without_replacing(tmp_path) -> None:
+    async def run() -> None:
+        store = SQLiteMCPStore(tmp_path / "gateway.db")
+        await store.create_profile(MCPProfile(id="reviewer", name="Reviewer"))
+        await store.create_grant(CredentialGrant(**_grant_payload(broker_id="first")))
+
+        with pytest.raises(CredentialGrantAlreadyExistsError):
+            await store.create_grant(
+                CredentialGrant(**_grant_payload(broker_id="second"))
+            )
+
+        stored = await store.get_grant("grant-one")
+        assert stored is not None
+        assert stored.broker_id == "first"
+        store.close()
+
+    asyncio.run(run())

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_credential_grants.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_credential_grants.py
@@ -269,6 +269,22 @@ def test_gateway_credential_grant_manager_duplicate_create_does_not_replace() ->
     asyncio.run(run())
 
 
+def test_gateway_credential_grant_manager_patch_rejects_non_string_server_id() -> None:
+    async def run() -> None:
+        manager = _manager()
+        await manager.create_grant(_grant_payload())
+
+        with pytest.raises(GatewayCredentialGrantManagementError) as exc_info:
+            await manager.patch_grant("grant-one", {"external_server_id": 123})
+
+        assert exc_info.value.reason_code == "invalid_credential_grant_patch"
+        assert (
+            await manager.show_grant("grant-one")
+        )["grant"]["external_server_id"] == "github-mcp"
+
+    asyncio.run(run())
+
+
 def test_sqlite_create_grant_rejects_duplicate_without_replacing(tmp_path) -> None:
     async def run() -> None:
         store = SQLiteMCPStore(tmp_path / "gateway.db")

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py
@@ -14,6 +14,10 @@ import mcp_unified.gateway.jsonrpc as gateway_jsonrpc
 import pytest
 from fastapi.testclient import TestClient
 from mcp_unified.gateway import create_gateway_app
+from mcp_unified.gateway.admin_auth import GatewayAdminAuthConfig
+from mcp_unified.gateway.credential_grants import (
+    GatewayCredentialGrantManagementError,
+)
 from mcp_unified.gateway.external_runtime import GatewayExternalRuntimeError
 from mcp_unified.storage.models import ExternalServerDefinition
 
@@ -560,6 +564,135 @@ class _ExternalRegistryErrorManagerDouble(_ExternalRegistryManagerDouble):
     async def delete_server(self, server_id: str) -> dict[str, Any]:
         await self._raise_if_targeted("delete_server")
         return await super().delete_server(server_id)
+
+
+class _CredentialGrantManagerDouble:
+    """Small manager double for credential-grant management route tests."""
+
+    def __init__(self, marker: str = "grant-one") -> None:
+        self.marker = marker
+        self.calls: list[tuple[str, tuple[Any, ...], dict[str, Any]]] = []
+
+    async def list_grants(
+        self,
+        *,
+        profile_id: str | None = None,
+        external_server_id: str | None = None,
+    ) -> dict[str, Any]:
+        self.calls.append(
+            (
+                "list_grants",
+                (),
+                {
+                    "profile_id": profile_id,
+                    "external_server_id": external_server_id,
+                },
+            )
+        )
+        return {
+            "ok": True,
+            "grants": [
+                {
+                    "id": self.marker,
+                    "profile_id": "reviewer",
+                    "broker_id": "env-broker",
+                    "credential_slot": "github_token",
+                    "external_server_id": "github-mcp",
+                    "scopes": ["repo:read"],
+                    "metadata": {"label": "GitHub read token"},
+                    "provenance": {"source": "test"},
+                    "enabled": True,
+                }
+            ],
+            "store": {"kind": "memory", "persistent": False},
+        }
+
+    async def show_grant(self, grant_id: str) -> dict[str, Any]:
+        self.calls.append(("show_grant", (grant_id,), {}))
+        return {
+            "ok": True,
+            "grant": {
+                "id": grant_id,
+                "profile_id": "reviewer",
+                "broker_id": "env-broker",
+                "credential_slot": "github_token",
+                "external_server_id": "github-mcp",
+                "scopes": ["repo:read"],
+                "metadata": {"label": "GitHub read token"},
+                "provenance": {"source": "test"},
+                "enabled": True,
+            },
+            "store": {"kind": "memory", "persistent": False},
+        }
+
+    async def create_grant(self, grant_payload: dict[str, Any]) -> dict[str, Any]:
+        self.calls.append(("create_grant", (grant_payload,), {}))
+        return {
+            "ok": True,
+            "grant": grant_payload,
+            "store": {"kind": "memory", "persistent": False},
+        }
+
+    async def patch_grant(
+        self,
+        grant_id: str,
+        patch_payload: dict[str, Any],
+    ) -> dict[str, Any]:
+        self.calls.append(("patch_grant", (grant_id, patch_payload), {}))
+        return {
+            "ok": True,
+            "grant": {
+                "id": grant_id,
+                "profile_id": "reviewer",
+                "broker_id": "env-broker",
+                "credential_slot": "github_token",
+                "external_server_id": "github-mcp",
+                "scopes": ["repo:read"],
+                "metadata": patch_payload.get("metadata", {}),
+                "provenance": {"source": "test"},
+                "enabled": patch_payload.get("enabled", True),
+            },
+            "store": {"kind": "memory", "persistent": False},
+        }
+
+    async def delete_grant(self, grant_id: str) -> dict[str, Any]:
+        self.calls.append(("delete_grant", (grant_id,), {}))
+        return {
+            "ok": True,
+            "grant_id": grant_id,
+            "store": {"kind": "memory", "persistent": False},
+        }
+
+
+class _CredentialGrantErrorManagerDouble(_CredentialGrantManagerDouble):
+    def __init__(self, method: str, reason_code: str) -> None:
+        super().__init__()
+        self.method = method
+        self.reason_code = reason_code
+
+    async def _raise_if_targeted(self, method: str) -> None:
+        if method == self.method:
+            raise GatewayCredentialGrantManagementError(
+                f"domain failure: {self.reason_code}",
+                reason_code=self.reason_code,
+                grant_id="grant-one",
+            )
+
+    async def list_grants(
+        self,
+        *,
+        profile_id: str | None = None,
+        external_server_id: str | None = None,
+    ) -> dict[str, Any]:
+        await self._raise_if_targeted("list_grants")
+        return await super().list_grants(
+            profile_id=profile_id,
+            external_server_id=external_server_id,
+        )
+
+    async def create_grant(self, grant_payload: dict[str, Any]) -> dict[str, Any]:
+        await self._raise_if_targeted("create_grant")
+        return await super().create_grant(grant_payload)
 
 
 class _ExternalRuntimeManagerDouble:
@@ -1398,6 +1531,230 @@ def test_gateway_external_registry_management_routes_have_pydantic_response_mode
     assert schemas["ExternalServerListResponse"]["properties"]["servers"]["items"] == {
         "$ref": "#/components/schemas/ExternalServerDefinition"
     }
+
+
+def test_gateway_credential_grant_management_routes_are_not_mounted_by_default() -> None:
+    app = create_gateway_app(_FakeGatewayRuntime(), prefix="/mcp")
+
+    with TestClient(app) as client:
+        response = client.get("/mcp/credential-grants")
+
+    assert response.status_code == 404
+
+
+def test_gateway_credential_grant_management_enabled_without_manager_raises() -> None:
+    with pytest.raises(ValueError, match="credential grant management requires"):
+        gateway_fastapi.create_gateway_router(
+            _FakeGatewayRuntime(),
+            enable_credential_grant_management=True,
+        )
+
+    with pytest.raises(ValueError, match="credential grant management requires"):
+        create_gateway_app(
+            _FakeGatewayRuntime(),
+            prefix="/mcp",
+            enable_credential_grant_management=True,
+        )
+
+
+def test_gateway_credential_grant_management_success_envelopes() -> None:
+    manager = _CredentialGrantManagerDouble("grant-one")
+    app = create_gateway_app(
+        _FakeGatewayRuntime(),
+        prefix="/mcp",
+        credential_grant_manager=manager,
+    )
+
+    with TestClient(app) as client:
+        listed = client.get(
+            "/mcp/credential-grants",
+            params={
+                "profile_id": "reviewer",
+                "external_server_id": "github-mcp",
+            },
+        )
+        shown = client.get("/mcp/credential-grants/grant-one")
+        created = client.post(
+            "/mcp/credential-grants",
+            json={
+                "id": "grant-one",
+                "profile_id": "reviewer",
+                "broker_id": "env-broker",
+                "credential_slot": "github_token",
+                "external_server_id": "github-mcp",
+                "scopes": ["repo:read"],
+                "metadata": {"label": "GitHub read token"},
+                "provenance": {"source": "test"},
+            },
+        )
+        patched = client.patch(
+            "/mcp/credential-grants/grant-one",
+            json={"metadata": {"label": "Updated"}, "enabled": False},
+        )
+        deleted = client.delete("/mcp/credential-grants/grant-one")
+
+    assert listed.status_code == 200
+    assert listed.json()["grants"][0]["id"] == "grant-one"
+    assert shown.status_code == 200
+    assert shown.json()["grant"]["credential_slot"] == "github_token"
+    assert created.status_code == 200
+    assert created.json()["grant"] == {
+        "id": "grant-one",
+        "profile_id": "reviewer",
+        "broker_id": "env-broker",
+        "credential_slot": "github_token",
+        "external_server_id": "github-mcp",
+        "scopes": ["repo:read"],
+        "metadata": {"label": "GitHub read token"},
+        "provenance": {"source": "test"},
+    }
+    assert patched.json()["grant"]["metadata"] == {"label": "Updated"}
+    assert patched.json()["grant"]["enabled"] is False
+    assert deleted.json() == {
+        "ok": True,
+        "grant_id": "grant-one",
+        "store": {"kind": "memory", "persistent": False},
+    }
+    assert manager.calls == [
+        (
+            "list_grants",
+            (),
+            {"profile_id": "reviewer", "external_server_id": "github-mcp"},
+        ),
+        ("show_grant", ("grant-one",), {}),
+        (
+            "create_grant",
+            (
+                {
+                    "id": "grant-one",
+                    "profile_id": "reviewer",
+                    "broker_id": "env-broker",
+                    "credential_slot": "github_token",
+                    "external_server_id": "github-mcp",
+                    "scopes": ["repo:read"],
+                    "metadata": {"label": "GitHub read token"},
+                    "provenance": {"source": "test"},
+                },
+            ),
+            {},
+        ),
+        (
+            "patch_grant",
+            (
+                "grant-one",
+                {"metadata": {"label": "Updated"}, "enabled": False},
+            ),
+            {},
+        ),
+        ("delete_grant", ("grant-one",), {}),
+    ]
+
+
+def test_gateway_credential_grant_management_routes_have_pydantic_response_models() -> None:
+    app = create_gateway_app(
+        _FakeGatewayRuntime(),
+        prefix="/mcp",
+        credential_grant_manager=_CredentialGrantManagerDouble(),
+    )
+
+    paths = app.openapi()["paths"]
+    expected_refs = {
+        ("/mcp/credential-grants", "get"): "#/components/schemas/CredentialGrantListResponse",
+        ("/mcp/credential-grants", "post"): "#/components/schemas/CredentialGrantResponse",
+        (
+            "/mcp/credential-grants/{grant_id}",
+            "get",
+        ): "#/components/schemas/CredentialGrantResponse",
+        (
+            "/mcp/credential-grants/{grant_id}",
+            "patch",
+        ): "#/components/schemas/CredentialGrantResponse",
+        (
+            "/mcp/credential-grants/{grant_id}",
+            "delete",
+        ): "#/components/schemas/DeleteCredentialGrantResponse",
+    }
+
+    for (path, method), expected_ref in expected_refs.items():
+        schema = paths[path][method]["responses"]["200"]["content"]["application/json"]["schema"]
+        assert schema == {"$ref": expected_ref}
+
+
+@pytest.mark.parametrize(
+    ("method", "path", "json_body", "manager_method", "reason_code", "status_code"),
+    [
+        (
+            "POST",
+            "/mcp/credential-grants",
+            {
+                "id": "grant-one",
+                "profile_id": "reviewer",
+                "broker_id": "env-broker",
+                "credential_slot": "github_token",
+            },
+            "create_grant",
+            "credential_grant_already_exists",
+            409,
+        ),
+        (
+            "GET",
+            "/mcp/credential-grants",
+            None,
+            "list_grants",
+            "credential_grant_store_unavailable",
+            503,
+        ),
+    ],
+)
+def test_gateway_credential_grant_management_domain_errors(
+    method: str,
+    path: str,
+    json_body: dict[str, Any] | None,
+    manager_method: str,
+    reason_code: str,
+    status_code: int,
+) -> None:
+    app = create_gateway_app(
+        _FakeGatewayRuntime(),
+        prefix="/mcp",
+        credential_grant_manager=_CredentialGrantErrorManagerDouble(
+            manager_method,
+            reason_code,
+        ),
+    )
+
+    with TestClient(app) as client:
+        response = client.request(method, path, json=json_body)
+
+    assert response.status_code == status_code
+    assert response.json()["reason_code"] == reason_code
+    assert response.json()["grant_id"] == "grant-one"
+    assert "domain failure" not in response.json()["error"]
+
+
+def test_gateway_credential_grant_management_routes_use_admin_auth() -> None:
+    app = create_gateway_app(
+        _FakeGatewayRuntime(),
+        prefix="/mcp",
+        credential_grant_manager=_CredentialGrantManagerDouble(),
+        admin_auth=GatewayAdminAuthConfig(
+            enabled=True,
+            header_name="X-Test-Gateway-Admin",
+            api_key="test-admin-key",
+        ),
+    )
+
+    with TestClient(app) as client:
+        missing = client.get("/mcp/credential-grants")
+        allowed = client.get(
+            "/mcp/credential-grants",
+            headers={"X-Test-Gateway-Admin": "test-admin-key"},
+        )
+
+    assert missing.status_code == 401
+    assert missing.json()["reason_code"] == "admin_auth_required"
+    assert allowed.status_code == 200
+    assert allowed.json()["grants"][0]["id"] == "grant-one"
 
 
 @pytest.mark.parametrize("server_id", ["runtime", "refresh", "reconcile"])

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py
@@ -1598,7 +1598,7 @@ def test_gateway_credential_grant_management_success_envelopes() -> None:
     assert shown.status_code == 200
     assert shown.json()["grant"]["credential_slot"] == "github_token"
     assert created.status_code == 200
-    assert created.json()["grant"] == {
+    expected_created_grant = {
         "id": "grant-one",
         "profile_id": "reviewer",
         "broker_id": "env-broker",
@@ -1608,6 +1608,14 @@ def test_gateway_credential_grant_management_success_envelopes() -> None:
         "metadata": {"label": "GitHub read token"},
         "provenance": {"source": "test"},
     }
+    created_grant = created.json()["grant"]
+    assert {
+        key: created_grant[key]
+        for key in expected_created_grant
+    } == expected_created_grant
+    assert created_grant["enabled"] is True
+    assert isinstance(created_grant["created_at"], str)
+    assert isinstance(created_grant["updated_at"], str)
     assert patched.json()["grant"]["metadata"] == {"label": "Updated"}
     assert patched.json()["grant"]["enabled"] is False
     assert deleted.json() == {
@@ -1615,29 +1623,24 @@ def test_gateway_credential_grant_management_success_envelopes() -> None:
         "grant_id": "grant-one",
         "store": {"kind": "memory", "persistent": False},
     }
-    assert manager.calls == [
+    assert manager.calls[:2] == [
         (
             "list_grants",
             (),
             {"profile_id": "reviewer", "external_server_id": "github-mcp"},
         ),
         ("show_grant", ("grant-one",), {}),
-        (
-            "create_grant",
-            (
-                {
-                    "id": "grant-one",
-                    "profile_id": "reviewer",
-                    "broker_id": "env-broker",
-                    "credential_slot": "github_token",
-                    "external_server_id": "github-mcp",
-                    "scopes": ["repo:read"],
-                    "metadata": {"label": "GitHub read token"},
-                    "provenance": {"source": "test"},
-                },
-            ),
-            {},
-        ),
+    ]
+    created_payload = manager.calls[2][1][0]
+    assert manager.calls[2][0] == "create_grant"
+    assert {
+        key: created_payload[key]
+        for key in expected_created_grant
+    } == expected_created_grant
+    assert "enabled" not in created_payload
+    assert "created_at" not in created_payload
+    assert "updated_at" not in created_payload
+    assert manager.calls[3:] == [
         (
             "patch_grant",
             (
@@ -1678,6 +1681,14 @@ def test_gateway_credential_grant_management_routes_have_pydantic_response_model
     for (path, method), expected_ref in expected_refs.items():
         schema = paths[path][method]["responses"]["200"]["content"]["application/json"]["schema"]
         assert schema == {"$ref": expected_ref}
+
+    schemas = app.openapi()["components"]["schemas"]
+    assert schemas["CredentialGrantResponse"]["properties"]["grant"] == {
+        "$ref": "#/components/schemas/CredentialGrant"
+    }
+    assert schemas["CredentialGrantListResponse"]["properties"]["grants"]["items"] == {
+        "$ref": "#/components/schemas/CredentialGrant"
+    }
 
 
 @pytest.mark.parametrize(

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_remote_runtime_cli.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_remote_runtime_cli.py
@@ -79,6 +79,19 @@ def test_remote_gateway_admin_client_sends_env_style_admin_header() -> None:
     assert seen_headers[0]["x-admin-key"] == "secret-value"
 
 
+@pytest.mark.parametrize("admin_key", ["secret\nvalue", "secret\rvalue"])
+def test_remote_gateway_admin_config_rejects_admin_key_line_breaks(
+    admin_key: str,
+) -> None:
+    """Admin header values cannot contain line breaks."""
+
+    with pytest.raises(ValueError, match="admin_key cannot contain line breaks"):
+        RemoteGatewayAdminConfig(
+            gateway_url="http://example.test/mcp",
+            admin_key=admin_key,
+        )
+
+
 def test_remote_gateway_admin_client_omits_admin_header_when_absent() -> None:
     """The admin header is not sent when no admin key is configured."""
 

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_remote_runtime_cli.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_remote_runtime_cli.py
@@ -1,0 +1,405 @@
+"""Tests for remote runtime CLI commands against a running gateway."""
+
+from __future__ import annotations
+
+import io
+import json
+import urllib.error
+from collections.abc import Mapping
+from typing import Any
+
+import pytest
+
+from mcp_unified.gateway import cli as gateway_cli
+from mcp_unified.gateway.remote_admin import (
+    RemoteGatewayAdminClient,
+    RemoteGatewayAdminConfig,
+    RemoteGatewayAdminError,
+)
+
+
+class _Response:
+    """Small stdlib urlopen-compatible response double."""
+
+    def __init__(self, payload: bytes) -> None:
+        self._payload = payload
+
+    def read(self) -> bytes:
+        return self._payload
+
+    def __enter__(self) -> _Response:
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        return None
+
+
+def test_remote_gateway_admin_config_preserves_mounted_base_path() -> None:
+    """The base URL is the mounted gateway prefix, not just the server origin."""
+
+    prefixed = RemoteGatewayAdminClient(
+        RemoteGatewayAdminConfig(gateway_url="http://example.test/mcp/")
+    )
+    origin_only = RemoteGatewayAdminClient(
+        RemoteGatewayAdminConfig(gateway_url="http://example.test")
+    )
+
+    assert (
+        prefixed.endpoint_url("/external-servers/runtime")
+        == "http://example.test/mcp/external-servers/runtime"
+    )
+    assert (
+        origin_only.endpoint_url("/external-servers/runtime")
+        == "http://example.test/external-servers/runtime"
+    )
+
+
+def test_remote_gateway_admin_client_sends_env_style_admin_header() -> None:
+    """Admin auth is passed as a header value when configured."""
+
+    seen_headers: list[dict[str, str]] = []
+
+    def opener(request: Any, *, timeout: float) -> _Response:
+        del timeout
+        seen_headers.append(
+            {key.lower(): value for key, value in request.header_items()}
+        )
+        return _Response(b'{"ok": true, "servers": []}')
+
+    client = RemoteGatewayAdminClient(
+        RemoteGatewayAdminConfig(
+            gateway_url="http://example.test/mcp",
+            admin_header_name="X-Admin-Key",
+            admin_key="secret-value",
+        ),
+        opener=opener,
+    )
+
+    assert client.list_runtime_servers() == {"ok": True, "servers": []}
+    assert seen_headers[0]["x-admin-key"] == "secret-value"
+
+
+def test_remote_gateway_admin_client_omits_admin_header_when_absent() -> None:
+    """The admin header is not sent when no admin key is configured."""
+
+    seen_headers: list[dict[str, str]] = []
+
+    def opener(request: Any, *, timeout: float) -> _Response:
+        del timeout
+        seen_headers.append(
+            {key.lower(): value for key, value in request.header_items()}
+        )
+        return _Response(b'{"ok": true, "servers": []}')
+
+    client = RemoteGatewayAdminClient(
+        RemoteGatewayAdminConfig(gateway_url="http://example.test/mcp"),
+        opener=opener,
+    )
+
+    assert client.list_runtime_servers()["ok"] is True
+    assert "x-mcp-gateway-admin-key" not in seen_headers[0]
+
+
+def test_remote_gateway_admin_client_passes_through_json_payloads() -> None:
+    """Successful JSON object responses are returned unchanged."""
+
+    def opener(request: Any, *, timeout: float) -> _Response:
+        assert request.full_url == "http://example.test/mcp/external-servers/search/start"
+        assert request.get_method() == "POST"
+        assert timeout == 3.5
+        return _Response(
+            b'{"ok": true, "reason_code": "external_server_started", '
+            b'"server_id": "search"}'
+        )
+
+    client = RemoteGatewayAdminClient(
+        RemoteGatewayAdminConfig(
+            gateway_url="http://example.test/mcp",
+            timeout_seconds=3.5,
+        ),
+        opener=opener,
+    )
+
+    assert client.start_server("search") == {
+        "ok": True,
+        "reason_code": "external_server_started",
+        "server_id": "search",
+    }
+
+
+@pytest.mark.parametrize(
+    "response_body",
+    [b"not json", b'["not", "an", "object"]'],
+)
+def test_remote_gateway_admin_client_sanitizes_malformed_responses(
+    response_body: bytes,
+) -> None:
+    """Malformed gateway responses do not echo raw response bytes."""
+
+    def opener(request: Any, *, timeout: float) -> _Response:
+        del request, timeout
+        return _Response(response_body)
+
+    client = RemoteGatewayAdminClient(
+        RemoteGatewayAdminConfig(gateway_url="http://example.test/mcp"),
+        opener=opener,
+    )
+
+    with pytest.raises(RemoteGatewayAdminError) as exc_info:
+        client.list_runtime_servers()
+
+    assert exc_info.value.to_payload() == {
+        "error": "Gateway returned an invalid JSON object",
+        "ok": False,
+        "reason_code": "gateway_invalid_response",
+    }
+
+
+def test_remote_gateway_admin_client_sanitizes_connection_failures() -> None:
+    """Connection failures return a generic envelope without raw secret values."""
+
+    def opener(request: Any, *, timeout: float) -> _Response:
+        del request, timeout
+        raise urllib.error.URLError("offline secret-value")
+
+    client = RemoteGatewayAdminClient(
+        RemoteGatewayAdminConfig(gateway_url="http://example.test/mcp"),
+        opener=opener,
+    )
+
+    with pytest.raises(RemoteGatewayAdminError) as exc_info:
+        client.list_runtime_servers()
+
+    payload = exc_info.value.to_payload()
+    assert payload == {
+        "error": "Unable to reach gateway",
+        "error_type": "URLError",
+        "ok": False,
+        "reason_code": "gateway_connection_failed",
+    }
+    assert "secret-value" not in json.dumps(payload)
+
+
+@pytest.mark.parametrize(
+    ("status_code", "reason_code"),
+    [
+        (401, "admin_auth_missing"),
+        (404, "external_server_not_found"),
+        (503, "external_runtime_unavailable"),
+    ],
+)
+def test_remote_gateway_admin_client_preserves_http_error_json_payloads(
+    status_code: int,
+    reason_code: str,
+) -> None:
+    """HTTP error bodies preserve public gateway reason fields."""
+
+    def opener(request: Any, *, timeout: float) -> _Response:
+        del timeout
+        body = json.dumps(
+            {
+                "error": "Gateway rejected request",
+                "ok": False,
+                "reason_code": reason_code,
+                "server_id": "search",
+            }
+        ).encode("utf-8")
+        raise urllib.error.HTTPError(
+            request.full_url,
+            status_code,
+            "error",
+            hdrs={},
+            fp=io.BytesIO(body),
+        )
+
+    client = RemoteGatewayAdminClient(
+        RemoteGatewayAdminConfig(gateway_url="http://example.test/mcp"),
+        opener=opener,
+    )
+
+    with pytest.raises(RemoteGatewayAdminError) as exc_info:
+        client.stop_server("search")
+
+    assert exc_info.value.to_payload() == {
+        "error": "Gateway rejected request",
+        "ok": False,
+        "reason_code": reason_code,
+        "server_id": "search",
+        "status_code": status_code,
+    }
+
+
+@pytest.mark.parametrize(
+    ("argv", "method_name", "method_args"),
+    [
+        (["runtime-list"], "list_runtime_servers", ()),
+        (["runtime-start", "search"], "start_server", ("search",)),
+        (["runtime-stop", "search"], "stop_server", ("search",)),
+        (["runtime-restart", "search"], "restart_server", ("search",)),
+        (["runtime-refresh"], "refresh_server", (None,)),
+        (["runtime-refresh", "search"], "refresh_server", ("search",)),
+        (["runtime-reconcile"], "reconcile", (None,)),
+        (["runtime-reconcile", "search"], "reconcile", ("search",)),
+        (["runtime-install", "search"], "install_server", ("search",)),
+        (["runtime-update", "search"], "update_server", ("search",)),
+    ],
+)
+def test_gateway_cli_runtime_commands_call_remote_gateway(
+    argv: list[str],
+    method_name: str,
+    method_args: tuple[object, ...],
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Runtime CLI commands call the remote admin client, not local processes."""
+
+    calls: list[tuple[str, tuple[object, ...]]] = []
+    configs: list[RemoteGatewayAdminConfig] = []
+
+    class _Client:
+        def __init__(self, config: RemoteGatewayAdminConfig) -> None:
+            configs.append(config)
+
+        def __getattr__(self, name: str) -> Any:
+            def _method(*args: object) -> dict[str, object]:
+                calls.append((name, args))
+                return {"ok": True, "method": name, "args": list(args)}
+
+            return _method
+
+    monkeypatch.setattr(gateway_cli, "RemoteGatewayAdminClient", _Client)
+
+    exit_code = gateway_cli.main(
+        [*argv, "--gateway-url", "http://127.0.0.1:8000/mcp"]
+    )
+
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+    assert exit_code == 0
+    assert captured.err == ""
+    assert payload == {
+        "args": list(method_args),
+        "method": method_name,
+        "ok": True,
+    }
+    assert calls == [(method_name, method_args)]
+    assert configs[0].gateway_url == "http://127.0.0.1:8000/mcp"
+
+
+def test_gateway_cli_runtime_commands_use_gateway_url_and_admin_key_env(
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Runtime commands accept URL/admin config from environment variables."""
+
+    configs: list[RemoteGatewayAdminConfig] = []
+
+    class _Client:
+        def __init__(self, config: RemoteGatewayAdminConfig) -> None:
+            configs.append(config)
+
+        def list_runtime_servers(self) -> dict[str, object]:
+            return {"ok": True, "servers": []}
+
+    monkeypatch.setattr(gateway_cli, "RemoteGatewayAdminClient", _Client)
+    monkeypatch.setenv("MCP_UNIFIED_GATEWAY_URL", "http://127.0.0.1:8000/mcp")
+    monkeypatch.setenv("MCP_UNIFIED_GATEWAY_ADMIN_KEY", "admin-secret")
+
+    exit_code = gateway_cli.main(["runtime-list", "--admin-header-name", "X-Admin"])
+
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert json.loads(captured.out) == {"ok": True, "servers": []}
+    assert captured.err == ""
+    assert configs[0].gateway_url == "http://127.0.0.1:8000/mcp"
+    assert configs[0].admin_header_name == "X-Admin"
+    assert configs[0].admin_key == "admin-secret"
+
+
+def test_gateway_cli_runtime_commands_require_gateway_url(
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Runtime commands require --gateway-url or MCP_UNIFIED_GATEWAY_URL."""
+
+    monkeypatch.delenv("MCP_UNIFIED_GATEWAY_URL", raising=False)
+
+    exit_code = gateway_cli.main(["runtime-list"])
+
+    captured = capsys.readouterr()
+    payload = json.loads(captured.err)
+    assert exit_code == 2
+    assert captured.out == ""
+    assert payload == {
+        "error": (
+            "--gateway-url is required unless MCP_UNIFIED_GATEWAY_URL is set"
+        ),
+        "ok": False,
+    }
+
+
+def test_gateway_cli_runtime_commands_do_not_accept_admin_key_argument(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Runtime CLI avoids command-line admin-key secrets."""
+
+    exit_code = gateway_cli.main(
+        [
+            "runtime-list",
+            "--gateway-url",
+            "http://127.0.0.1:8000/mcp",
+            "--admin-key",
+            "secret",
+        ]
+    )
+
+    captured = capsys.readouterr()
+    payload = json.loads(captured.err)
+    assert exit_code == 2
+    assert captured.out == ""
+    assert payload["ok"] is False
+    assert "admin-key" in payload["error"]
+
+
+def test_gateway_cli_runtime_commands_preserve_remote_error_payload(
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """CLI stderr preserves remote gateway reason_code payloads."""
+
+    class _Client:
+        def __init__(self, config: RemoteGatewayAdminConfig) -> None:
+            del config
+
+        def stop_server(self, server_id: str) -> dict[str, object]:
+            raise RemoteGatewayAdminError.from_payload(
+                {
+                    "error": "Gateway rejected request",
+                    "ok": False,
+                    "reason_code": "external_server_not_found",
+                    "server_id": server_id,
+                    "status_code": 404,
+                }
+            )
+
+    monkeypatch.setattr(gateway_cli, "RemoteGatewayAdminClient", _Client)
+
+    exit_code = gateway_cli.main(
+        [
+            "runtime-stop",
+            "search",
+            "--gateway-url",
+            "http://127.0.0.1:8000/mcp",
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert exit_code == 1
+    assert captured.out == ""
+    assert json.loads(captured.err) == {
+        "error": "Gateway rejected request",
+        "ok": False,
+        "reason_code": "external_server_not_found",
+        "server_id": "search",
+        "status_code": 404,
+    }


### PR DESCRIPTION
## Summary
- Adds standalone gateway admin auth, credential-grant management, config snapshot import/export, and remote runtime CLI/admin docs.
- Extends the package gateway CLI/FastAPI/config/bootstrap/storage seams while keeping remote runtime commands owned by the running gateway.
- Adds focused MCP gateway tests and Backlog/plan records for the three admin/config slices.

## Change summary
TODO: Human requester must replace this with a human-written summary before merge. The repo policy requires the human requester to explain what changed and why these implementation choices were made.

## Test Plan
- `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_gateway_admin_auth.py tldw_Server_API/app/core/MCP_unified/tests/test_gateway_credential_grants.py tldw_Server_API/app/core/MCP_unified/tests/test_gateway_config_snapshots.py tldw_Server_API/app/core/MCP_unified/tests/test_gateway_remote_runtime_cli.py tldw_Server_API/app/core/MCP_unified/tests/test_gateway_cli_package.py tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py -v` - 296 passed
- `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m bandit -r mcp_unified/gateway mcp_unified/interfaces/storage.py mcp_unified/storage/sqlite.py -f json -o /tmp/bandit_mcp_gateway_admin_config_rebased.json` - 0 findings
- `git diff --check` - passed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a standalone MCP gateway admin surface: admin auth, credential-grant management, config snapshot import/export, and a remote runtime CLI for controlling a running gateway—now with stricter default-assignment validation during snapshot import. Also fixes the setup recovery screen to render a semantic h1 and keeps the chat cockpit restore control clickable above the collapsed chat rail edge, with tests.

- New Features
  - Admin auth: optional header-based key for management routes; configurable via `GatewayAdminAuthBootstrapConfig`; key is provided via env and not persisted; consistent error payloads, normalized header handling, pluggable verifier, and `FastAPI` deps helper for easy injection.
  - Credential grants: `GatewayCredentialGrantManager` and FastAPI/CLI endpoints to list/create/update/delete with secret-safety checks; atomic `create_grant` added to storage.
  - Config snapshots: `GatewayConfigSnapshotManager` for export/import with dry-run, versioned, secret-safe output; stricter secret-metadata detection and default-assignment validation.
  - Remote runtime control: `RemoteGatewayAdminClient` and new CLI commands to list/start/stop/restart/refresh/reconcile/install/update servers via `--gateway-url` or `MCP_UNIFIED_GATEWAY_URL`; preserves mounted base path, trims trailing slashes, and improves error messages.
  - Docs: standalone admin guide and end-to-end workflow added.

- Migration
  - Storage implementors must add `create_grant` to `CredentialGrantStore` and raise `CredentialGrantAlreadyExistsError` on id conflicts; `SQLiteMCPStore` is updated.
  - To enable admin routes, set admin auth config in the gateway config and pass the key via an environment variable (e.g., `MCP_UNIFIED_GATEWAY_ADMIN_KEY`); do not store the key in config files.
  - Use remote CLI commands only against a running gateway and provide `--gateway-url` including the mounted base path; local store edit commands remain unchanged.
  - Snapshot export omits secrets by design; import validates references up front and rejects non-gateway default assignment ids; use import dry-run to validate before applying changes.

<sup>Written for commit 19a4f29972d0c1e699a5017c3f71636b5d6241ef. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2222?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

