### PR TITLE
Harden MCP Unified package release gate

### DIFF
--- a/Docs/MCP_UNIFIED_STANDALONE_GATEWAY_ADMIN.md
+++ b/Docs/MCP_UNIFIED_STANDALONE_GATEWAY_ADMIN.md
@@ -22,6 +22,10 @@ Inspect the current release-readiness metadata with:
 mcp-unified-gateway package-info
 ```
 
+The dependency groups in that payload intentionally use a `names-only` policy.
+They identify the minimal standalone-package surface without duplicating version
+floors from `pyproject.toml` or future package build metadata.
+
 ## Local Store Commands vs Remote Runtime Commands
 
 The `mcp-unified-gateway` CLI has two different operating modes:

--- a/Docs/MCP_UNIFIED_STANDALONE_GATEWAY_ADMIN.md
+++ b/Docs/MCP_UNIFIED_STANDALONE_GATEWAY_ADMIN.md
@@ -4,6 +4,24 @@ This guide covers the standalone gateway admin/config surface for profiles,
 external server definitions, credential grants, config snapshots, and remote
 runtime lifecycle commands.
 
+## Package Release Status
+
+The `mcp_unified` package boundary is currently internal/experimental and is
+not a separately published standalone package. It is still distributed as part
+of the broader `tldw-server` source tree while the package release gate is
+being hardened.
+
+The current package metadata uses the canonical repository license expression
+`GPL-3.0-only`. Downstream projects should treat the boundary as an in-repo
+integration surface until a later packaging pass adds a clean minimal install,
+independent extras verification, and release CI for the standalone package.
+
+Inspect the current release-readiness metadata with:
+
+```bash
+mcp-unified-gateway package-info
+```
+
 ## Local Store Commands vs Remote Runtime Commands
 
 The `mcp-unified-gateway` CLI has two different operating modes:

--- a/Docs/superpowers/plans/2026-06-03-mcp-unified-package-release-readiness-plan.md
+++ b/Docs/superpowers/plans/2026-06-03-mcp-unified-package-release-readiness-plan.md
@@ -1,0 +1,182 @@
+# MCP Unified Package Release Readiness Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a tested release-readiness metadata surface for `mcp_unified` so the package boundary advertises its current internal/experimental status, verified license, dependency extras, and import smoke expectations without implying unsupported standalone publication.
+
+**Architecture:** Keep the slice intentionally small: add a pure-stdlib metadata module under `mcp_unified`, expose it through a read-only CLI command, and document the current packaging gate. Do not split a separate PyPI distribution in this task; the metadata becomes the testable contract that later packaging work can consume.
+
+**Tech Stack:** Python 3.10+, argparse CLI, pytest, Bandit.
+
+---
+
+## File Structure
+
+- Create `mcp_unified/package_metadata.py` for import-light package status, license, dependency extras, and JSON-safe summary helpers.
+- Modify `mcp_unified/gateway/cli.py` to add a `package-info` command that prints the metadata summary without requiring gateway config or remote runtime state.
+- Modify `Docs/MCP_UNIFIED_STANDALONE_GATEWAY_ADMIN.md` to describe the current internal/experimental release status, GPL-3.0-only license decision, and dependency-extra intent.
+- Modify `tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py` for metadata shape and minimal import-boundary smoke coverage.
+- Modify `tldw_Server_API/app/core/MCP_unified/tests/test_gateway_cli_package.py` for CLI visibility.
+- Update `backlog/tasks/task-599 - Harden-MCP-Unified-package-release-readiness-metadata-and-install-smoke.md` with progress and verification results.
+
+### Task 1: Metadata Contract Tests
+
+**Files:**
+- Test: `tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py`
+
+- [x] **Step 1: Write failing metadata tests**
+
+Add tests that import `mcp_unified.package_metadata` and assert:
+- `PACKAGE_STATUS` is internal/experimental.
+- `PUBLISHING_STATUS` is not published.
+- `LICENSE_EXPRESSION` is `GPL-3.0-only`.
+- extras include exactly the required public groups: `core`, `fastapi`, `sqlite`, `federation`, `gateway`, `dev`.
+- no extra dependency string mentions heavy host stacks such as ChromaDB, faster-whisper, torch, yt-dlp, or Next.js.
+
+- [x] **Step 2: Verify RED**
+
+Run:
+
+```bash
+source .venv/bin/activate
+python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py::test_mcp_unified_package_metadata_declares_release_gate -v
+```
+
+Expected: fail because `mcp_unified.package_metadata` does not exist yet.
+
+- [x] **Step 3: Implement minimal metadata module**
+
+Create `mcp_unified/package_metadata.py` with immutable constants and a `package_metadata_summary()` helper that returns JSON-safe dictionaries/lists.
+
+- [x] **Step 4: Verify GREEN**
+
+Run the focused metadata test and confirm it passes.
+
+### Task 2: Import Smoke Test
+
+**Files:**
+- Test: `tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py`
+
+- [x] **Step 1: Write failing import smoke test**
+
+Add a subprocess test that imports only `mcp_unified` and `mcp_unified.package_metadata`, then asserts these modules are not imported:
+- `tldw_Server_API`
+- `chromadb`
+- `torch`
+- `faster_whisper`
+- `yt_dlp`
+- `next`
+
+- [x] **Step 2: Verify RED**
+
+Run the new subprocess test before production changes if Task 1 has not yet added the module. If Task 1 is complete, this may already pass; in that case record that the red condition was satisfied by Task 1's missing-module failure.
+
+- [x] **Step 3: Keep implementation import-light**
+
+Ensure `package_metadata.py` imports only standard-library modules and does not import gateway, storage, federation, or host code.
+
+- [x] **Step 4: Verify GREEN**
+
+Run:
+
+```bash
+source .venv/bin/activate
+python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py::test_mcp_unified_core_import_smoke_stays_minimal -v
+```
+
+Expected: pass.
+
+### Task 3: CLI Visibility
+
+**Files:**
+- Modify: `mcp_unified/gateway/cli.py`
+- Test: `tldw_Server_API/app/core/MCP_unified/tests/test_gateway_cli_package.py`
+
+- [x] **Step 1: Write failing CLI test**
+
+Add a test that runs `gateway_cli.main(["package-info"])`, reads stdout JSON, and asserts:
+- `ok` is true.
+- package name and license match metadata.
+- status is internal/experimental.
+- extras include `gateway`.
+- no stderr is emitted.
+
+- [x] **Step 2: Verify RED**
+
+Run:
+
+```bash
+source .venv/bin/activate
+python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_gateway_cli_package.py::test_gateway_cli_package_info_reports_release_gate -v
+```
+
+Expected: fail because the parser does not know `package-info`.
+
+- [x] **Step 3: Implement CLI command**
+
+Import `package_metadata_summary` from `mcp_unified.package_metadata`, add a `package-info` subparser, and implement `_handle_package_info()` using existing `_emit_json()`.
+
+- [x] **Step 4: Verify GREEN**
+
+Run the focused CLI test and confirm it passes.
+
+### Task 4: Documentation
+
+**Files:**
+- Modify: `Docs/MCP_UNIFIED_STANDALONE_GATEWAY_ADMIN.md`
+- Test: `tldw_Server_API/app/core/MCP_unified/tests/test_gateway_cli_package.py`
+
+- [x] **Step 1: Add release-readiness section**
+
+Document that `mcp_unified` is currently an in-repo/internal experimental package boundary, not a separately published standalone package. Note the current canonical license metadata is GPL-3.0-only and that downstream users should not treat the package as independently release-ready until minimal install/extras CI is added.
+
+- [x] **Step 2: Add CLI discoverability**
+
+Show `mcp-unified-gateway package-info` as the way to inspect the current metadata contract.
+
+- [x] **Step 3: Add docs visibility test**
+
+Add a lightweight test that reads `Docs/MCP_UNIFIED_STANDALONE_GATEWAY_ADMIN.md` and asserts it mentions `package-info`, `GPL-3.0-only`, and the internal/experimental release gate.
+
+- [x] **Step 4: Keep wording conservative**
+
+Avoid claims that the package is already available on PyPI or ready for third-party embedding.
+
+### Task 5: Validation And Task Finalization
+
+**Files:**
+- Modify: `backlog/tasks/task-599 - Harden-MCP-Unified-package-release-readiness-metadata-and-install-smoke.md`
+
+- [x] **Step 1: Run focused tests**
+
+```bash
+source .venv/bin/activate
+python -m pytest \
+  tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py \
+  tldw_Server_API/app/core/MCP_unified/tests/test_gateway_cli_package.py \
+  -v
+```
+
+- [x] **Step 2: Run Bandit on touched Python**
+
+```bash
+source .venv/bin/activate
+python -m bandit -r mcp_unified/package_metadata.py mcp_unified/gateway/cli.py -f json -o /tmp/bandit_mcp_package_release_readiness.json
+```
+
+- [x] **Step 3: Run diff whitespace check**
+
+```bash
+git diff --check
+```
+
+- [x] **Step 4: Update Backlog**
+
+Record changed files, verification results, and any known skips in TASK-599. Mark acceptance criteria and Definition of Done complete only after verification passes.
+
+- [x] **Step 5: Commit**
+
+```bash
+git add Docs/MCP_UNIFIED_STANDALONE_GATEWAY_ADMIN.md Docs/superpowers/plans/2026-06-03-mcp-unified-package-release-readiness-plan.md mcp_unified/package_metadata.py mcp_unified/gateway/cli.py tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py tldw_Server_API/app/core/MCP_unified/tests/test_gateway_cli_package.py "backlog/tasks/task-599 - Harden-MCP-Unified-package-release-readiness-metadata-and-install-smoke.md"
+git commit -m "chore: document mcp unified package release gate"
+```

--- a/backlog/tasks/task-599 - Harden-MCP-Unified-package-release-readiness-metadata-and-install-smoke.md
+++ b/backlog/tasks/task-599 - Harden-MCP-Unified-package-release-readiness-metadata-and-install-smoke.md
@@ -1,0 +1,64 @@
+---
+id: TASK-599
+title: Harden MCP Unified package release readiness metadata and install smoke
+status: Done
+assignee: []
+created_date: ''
+updated_date: '2026-06-03 01:15'
+labels:
+  - mcp-unified
+  - packaging
+  - standalone-gateway
+dependencies: []
+documentation:
+  - >-
+    Docs/superpowers/specs/2026-05-26-mcp-unified-standalone-library-gateway-design.md
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement the next MCP Unified standalone-library release-readiness slice after the gateway admin/config surface: define explicit package metadata/extras and add minimal install/import smoke coverage so mcp_unified is not presented as third-party-ready without a tested dependency/license boundary.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 MCP Unified package/release metadata documents the current license decision and experimental/internal status without marketing unsupported standalone publishing.
+- [x] #2 Dependency extras for MCP Unified core, fastapi, sqlite, federation, and gateway are declared or otherwise represented in a testable metadata surface separate from the full tldw-server dependency graph.
+- [x] #3 A clean minimal-install/import smoke test proves mcp_unified core imports without importing tldw_Server_API or requiring media/RAG/STT/TTS dependencies.
+- [x] #4 Focused tests cover metadata shape, extras membership, import-boundary behavior, and docs/CLI visibility for the release-readiness status.
+- [x] #5 Bandit on touched Python source, focused tests, and git diff --check pass before PR.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Docs/superpowers/plans/2026-06-03-mcp-unified-package-release-readiness-plan.md
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+Verification completed: focused red checks failed before implementation for missing package metadata, CLI package-info, and docs release gate; full focused pytest files passed 91 tests; Bandit on touched Python reported zero findings; git diff --check passed. No skips or blockers.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Added a pure-stdlib mcp_unified.package_metadata release-readiness contract declaring the current internal-experimental/not-published status, GPL-3.0-only license expression, and dependency-extra groups for core, fastapi, sqlite, federation, gateway, and dev. Exposed the contract through mcp-unified-gateway package-info and documented that mcp_unified is an in-repo/internal experimental package boundary, not a separately published standalone package. Added regression coverage for metadata shape, heavy-stack-free extras, minimal import smoke, CLI visibility, and docs visibility. Verification: targeted red checks failed before implementation for the expected missing surfaces; full focused pytest files passed 91 tests; Bandit reported zero findings; git diff --check passed.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-600 - Address-PR-2228-MCP-package-release-gate-review-comments.md
+++ b/backlog/tasks/task-600 - Address-PR-2228-MCP-package-release-gate-review-comments.md
@@ -1,0 +1,56 @@
+---
+id: TASK-600
+title: Address PR 2228 MCP package release gate review comments
+status: Done
+assignee: []
+created_date: ''
+updated_date: '2026-06-03 01:32'
+labels:
+  - mcp-unified
+  - packaging
+  - pr-review
+dependencies: []
+documentation:
+  - 'https://github.com/rmusser01/tldw_server/pull/2228'
+  - >-
+    Docs/superpowers/plans/2026-06-03-mcp-unified-package-release-readiness-plan.md
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Verify and address still-valid PR #2228 review feedback after rebasing onto latest dev. Scope: dependency metadata version drift, package-name dependency checks, long-line style cleanup, and brittle test repo-root lookup.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 PR #2228 is rebased onto latest origin/dev without losing TASK-599 work.
+- [x] #2 Still-valid Qodo/Gemini review comments are fixed with minimal changes; invalid items are documented with a reason.
+- [x] #3 Focused tests cover metadata dependency names, CLI/docs visibility, and import-boundary behavior after the fixes.
+- [x] #4 Bandit on touched Python, focused pytest, and git diff --check pass before updating the PR.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Rebased PR #2228 onto latest origin/dev and addressed all still-valid Qodo/Gemini comments. Dependency metadata now uses a names-only policy instead of duplicating pyproject version floors, and package-info/docs expose that policy. Tests now validate package names rather than substring matches, new assertions are PEP8-formatted, and docs/pyproject path lookup uses a repo-root helper instead of fixed parent depth. Verification passed: 91 focused tests, Bandit zero findings, and git diff --check.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/mcp_unified/gateway/cli.py
+++ b/mcp_unified/gateway/cli.py
@@ -11,6 +11,7 @@ from collections.abc import Callable, Coroutine, Mapping, Sequence
 from pathlib import Path
 from typing import Any, NoReturn, TextIO
 
+from mcp_unified.package_metadata import package_metadata_summary
 from mcp_unified.profiles.presets import (
     duplicate_builtin_preset,
     get_builtin_preset,
@@ -134,6 +135,12 @@ def _build_parser() -> _JsonArgumentParser:
         parser_class=_JsonArgumentParser,
         required=True,
     )
+
+    package_info = subparsers.add_parser(
+        "package-info",
+        help="Show MCP Unified package release-readiness metadata.",
+    )
+    package_info.set_defaults(handler=_handle_package_info)
 
     validate_config = subparsers.add_parser(
         "validate-config",
@@ -573,6 +580,13 @@ def _handle_validate_config(args: argparse.Namespace) -> int:
         return 1
 
     _emit_json(_validated_config_payload(config, config_path), sys.stdout)
+    return 0
+
+
+def _handle_package_info(_args: argparse.Namespace) -> int:
+    """Emit MCP Unified package release-readiness metadata."""
+
+    _emit_json(package_metadata_summary(), sys.stdout)
     return 0
 
 

--- a/mcp_unified/package_metadata.py
+++ b/mcp_unified/package_metadata.py
@@ -11,28 +11,29 @@ PACKAGE_STATUS: Final = "internal-experimental"
 PUBLISHING_STATUS: Final = "not-published"
 LICENSE_EXPRESSION: Final = "GPL-3.0-only"
 SOURCE_DISTRIBUTION: Final = "tldw-server"
+DEPENDENCY_VERSION_POLICY: Final = "names-only"
 
 CORE_DEPENDENCIES: Final = (
-    "pydantic>=2.0.0",
-    "loguru>=0.7.0",
-    "PyYAML>=6.0.0",
+    "pydantic",
+    "loguru",
+    "pyyaml",
 )
 FASTAPI_DEPENDENCIES: Final = (
-    "fastapi>=0.104.0",
-    "starlette>=0.27.0",
+    "fastapi",
+    "starlette",
 )
-SQLITE_DEPENDENCIES: Final = ("SQLAlchemy>=2.0.29",)
+SQLITE_DEPENDENCIES: Final = ("sqlalchemy",)
 FEDERATION_DEPENDENCIES: Final = CORE_DEPENDENCIES
 GATEWAY_DEPENDENCIES: Final = (
     *CORE_DEPENDENCIES,
     *FASTAPI_DEPENDENCIES,
     *SQLITE_DEPENDENCIES,
-    "uvicorn>=0.24.0",
+    "uvicorn",
 )
 DEV_DEPENDENCIES: Final = (
-    "pytest>=8.0.0",
-    "pytest-asyncio>=1.0.0",
-    "bandit>=1.7.0",
+    "pytest",
+    "pytest-asyncio",
+    "bandit",
 )
 
 OPTIONAL_EXTRAS: Final = MappingProxyType(
@@ -58,6 +59,7 @@ def package_metadata_summary() -> dict[str, object]:
         "publishing_status": PUBLISHING_STATUS,
         "license_expression": LICENSE_EXPRESSION,
         "source_distribution": SOURCE_DISTRIBUTION,
+        "dependency_version_policy": DEPENDENCY_VERSION_POLICY,
         "optional_extras": {
             extra: list(dependencies)
             for extra, dependencies in OPTIONAL_EXTRAS.items()

--- a/mcp_unified/package_metadata.py
+++ b/mcp_unified/package_metadata.py
@@ -1,0 +1,65 @@
+"""Release-readiness metadata for the in-repo MCP Unified package boundary."""
+
+from __future__ import annotations
+
+from types import MappingProxyType
+from typing import Final
+
+PACKAGE_NAME: Final = "mcp-unified"
+PACKAGE_IMPORT_NAME: Final = "mcp_unified"
+PACKAGE_STATUS: Final = "internal-experimental"
+PUBLISHING_STATUS: Final = "not-published"
+LICENSE_EXPRESSION: Final = "GPL-3.0-only"
+SOURCE_DISTRIBUTION: Final = "tldw-server"
+
+CORE_DEPENDENCIES: Final = (
+    "pydantic>=2.0.0",
+    "loguru>=0.7.0",
+    "PyYAML>=6.0.0",
+)
+FASTAPI_DEPENDENCIES: Final = (
+    "fastapi>=0.104.0",
+    "starlette>=0.27.0",
+)
+SQLITE_DEPENDENCIES: Final = ("SQLAlchemy>=2.0.29",)
+FEDERATION_DEPENDENCIES: Final = CORE_DEPENDENCIES
+GATEWAY_DEPENDENCIES: Final = (
+    *CORE_DEPENDENCIES,
+    *FASTAPI_DEPENDENCIES,
+    *SQLITE_DEPENDENCIES,
+    "uvicorn>=0.24.0",
+)
+DEV_DEPENDENCIES: Final = (
+    "pytest>=8.0.0",
+    "pytest-asyncio>=1.0.0",
+    "bandit>=1.7.0",
+)
+
+OPTIONAL_EXTRAS: Final = MappingProxyType(
+    {
+        "core": CORE_DEPENDENCIES,
+        "fastapi": FASTAPI_DEPENDENCIES,
+        "sqlite": SQLITE_DEPENDENCIES,
+        "federation": FEDERATION_DEPENDENCIES,
+        "gateway": GATEWAY_DEPENDENCIES,
+        "dev": DEV_DEPENDENCIES,
+    }
+)
+
+
+def package_metadata_summary() -> dict[str, object]:
+    """Return JSON-safe MCP Unified package release metadata."""
+
+    return {
+        "ok": True,
+        "package_name": PACKAGE_NAME,
+        "package_import_name": PACKAGE_IMPORT_NAME,
+        "package_status": PACKAGE_STATUS,
+        "publishing_status": PUBLISHING_STATUS,
+        "license_expression": LICENSE_EXPRESSION,
+        "source_distribution": SOURCE_DISTRIBUTION,
+        "optional_extras": {
+            extra: list(dependencies)
+            for extra, dependencies in OPTIONAL_EXTRAS.items()
+        },
+    }

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_cli_package.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_cli_package.py
@@ -2011,6 +2011,41 @@ def test_gateway_cli_project_script_is_registered() -> None:
     )
 
 
+def test_gateway_cli_package_info_reports_release_gate(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Expose conservative package-release metadata through the CLI."""
+
+    exit_code = gateway_cli.main(["package-info"])
+
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+    assert exit_code == 0
+    assert captured.err == ""
+    assert payload["ok"] is True
+    assert payload["package_name"] == "mcp-unified"
+    assert payload["package_status"] == "internal-experimental"
+    assert payload["publishing_status"] == "not-published"
+    assert payload["license_expression"] == "GPL-3.0-only"
+    assert "gateway" in payload["optional_extras"]
+
+
+def test_standalone_gateway_docs_describe_package_release_gate() -> None:
+    """Document the current package boundary without implying PyPI readiness."""
+
+    docs_path = (
+        Path(__file__).resolve().parents[5]
+        / "Docs"
+        / "MCP_UNIFIED_STANDALONE_GATEWAY_ADMIN.md"
+    )
+    docs = docs_path.read_text(encoding="utf-8")
+
+    assert "package-info" in docs
+    assert "GPL-3.0-only" in docs
+    assert "internal/experimental" in docs
+    assert "not a separately published standalone package" in docs
+
+
 def _parse_cli_timestamp(value: str) -> datetime:
     """Parse a JSON timestamp without depending on a specific UTC suffix."""
 

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_cli_package.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_cli_package.py
@@ -31,6 +31,15 @@ except ModuleNotFoundError:  # pragma: no cover - Python 3.10 compatibility.
     import tomli as tomllib
 
 
+def _repo_root() -> Path:
+    """Locate the repository root from this test file."""
+
+    for parent in Path(__file__).resolve().parents:
+        if (parent / "pyproject.toml").is_file():
+            return parent
+    raise AssertionError("Unable to locate repository root from test path")
+
+
 def test_gateway_cli_validate_config_reports_success_json(
     tmp_path: Path,
     capsys: pytest.CaptureFixture[str],
@@ -2002,7 +2011,7 @@ def test_gateway_cli_memory_store_rejects_mutations_before_reading_payload_files
 def test_gateway_cli_project_script_is_registered() -> None:
     """Expose the package CLI through the installed project scripts."""
 
-    pyproject_path = Path(__file__).resolve().parents[5] / "pyproject.toml"
+    pyproject_path = _repo_root() / "pyproject.toml"
     pyproject = tomllib.loads(pyproject_path.read_text(encoding="utf-8"))
 
     assert (
@@ -2027,22 +2036,20 @@ def test_gateway_cli_package_info_reports_release_gate(
     assert payload["package_status"] == "internal-experimental"
     assert payload["publishing_status"] == "not-published"
     assert payload["license_expression"] == "GPL-3.0-only"
+    assert payload["dependency_version_policy"] == "names-only"
     assert "gateway" in payload["optional_extras"]
 
 
 def test_standalone_gateway_docs_describe_package_release_gate() -> None:
     """Document the current package boundary without implying PyPI readiness."""
 
-    docs_path = (
-        Path(__file__).resolve().parents[5]
-        / "Docs"
-        / "MCP_UNIFIED_STANDALONE_GATEWAY_ADMIN.md"
-    )
+    docs_path = _repo_root() / "Docs" / "MCP_UNIFIED_STANDALONE_GATEWAY_ADMIN.md"
     docs = docs_path.read_text(encoding="utf-8")
 
     assert "package-info" in docs
     assert "GPL-3.0-only" in docs
     assert "internal/experimental" in docs
+    assert "names-only" in docs
     assert "not a separately published standalone package" in docs
 
 

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py
@@ -15,6 +15,15 @@ from pydantic import ValidationError
 PACKAGE_ROOT = Path(mcp_unified.__file__).resolve().parent
 
 
+def _dependency_package_name(dependency: str) -> str:
+    """Return a normalized package name from a dependency declaration."""
+
+    name = dependency.strip()
+    for separator in ("[", "<", ">", "=", "!", "~", ";"):
+        name = name.split(separator, 1)[0]
+    return name.strip().lower().replace("_", "-")
+
+
 def _tldw_imports_for(path: Path) -> list[str]:
     tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
     imports: list[str] = []
@@ -51,10 +60,26 @@ def test_mcp_unified_package_metadata_declares_release_gate() -> None:
     assert metadata.LICENSE_EXPRESSION == "GPL-3.0-only"
 
     extras = metadata.OPTIONAL_EXTRAS
-    assert set(extras) == {"core", "fastapi", "sqlite", "federation", "gateway", "dev"}
-    assert all(isinstance(dependency, str) for values in extras.values() for dependency in values)
+    assert set(extras) == {
+        "core",
+        "fastapi",
+        "sqlite",
+        "federation",
+        "gateway",
+        "dev",
+    }
+    assert all(
+        isinstance(dependency, str)
+        for values in extras.values()
+        for dependency in values
+    )
+    assert all(
+        dependency == _dependency_package_name(dependency)
+        for values in extras.values()
+        for dependency in values
+    )
 
-    forbidden_dependency_terms = {
+    forbidden_dependency_names = {
         "chromadb",
         "faster-whisper",
         "torch",
@@ -64,13 +89,21 @@ def test_mcp_unified_package_metadata_declares_release_gate() -> None:
         "tts",
         "stt",
     }
-    flattened = "\n".join(dependency.lower() for values in extras.values() for dependency in values)
-    assert not any(term in flattened for term in forbidden_dependency_terms)
+    dependency_names = {
+        _dependency_package_name(dependency)
+        for values in extras.values()
+        for dependency in values
+    }
+    assert forbidden_dependency_names.isdisjoint(dependency_names)
 
     summary = metadata.package_metadata_summary()
     assert summary["ok"] is True
     assert summary["package_name"] == metadata.PACKAGE_NAME
-    assert summary["optional_extras"] == {key: list(value) for key, value in extras.items()}
+    assert summary["dependency_version_policy"] == metadata.DEPENDENCY_VERSION_POLICY
+    assert summary["optional_extras"] == {
+        key: list(value)
+        for key, value in extras.items()
+    }
 
 
 def test_mcp_unified_core_import_smoke_stays_minimal() -> None:

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import ast
 import importlib
+import json
 import subprocess
 import sys
 from datetime import datetime
@@ -39,6 +40,65 @@ def test_runtime_package_boundary_has_no_tldw_server_imports() -> None:
         if imports:
             offenders[str(path)] = imports
     assert offenders == {}
+
+
+def test_mcp_unified_package_metadata_declares_release_gate() -> None:
+    metadata = importlib.import_module("mcp_unified.package_metadata")
+
+    assert metadata.PACKAGE_NAME == "mcp-unified"
+    assert metadata.PACKAGE_STATUS == "internal-experimental"
+    assert metadata.PUBLISHING_STATUS == "not-published"
+    assert metadata.LICENSE_EXPRESSION == "GPL-3.0-only"
+
+    extras = metadata.OPTIONAL_EXTRAS
+    assert set(extras) == {"core", "fastapi", "sqlite", "federation", "gateway", "dev"}
+    assert all(isinstance(dependency, str) for values in extras.values() for dependency in values)
+
+    forbidden_dependency_terms = {
+        "chromadb",
+        "faster-whisper",
+        "torch",
+        "yt-dlp",
+        "next",
+        "rag",
+        "tts",
+        "stt",
+    }
+    flattened = "\n".join(dependency.lower() for values in extras.values() for dependency in values)
+    assert not any(term in flattened for term in forbidden_dependency_terms)
+
+    summary = metadata.package_metadata_summary()
+    assert summary["ok"] is True
+    assert summary["package_name"] == metadata.PACKAGE_NAME
+    assert summary["optional_extras"] == {key: list(value) for key, value in extras.items()}
+
+
+def test_mcp_unified_core_import_smoke_stays_minimal() -> None:
+    """Importing the package metadata must not pull in host or heavy stacks."""
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            (
+                "import json, sys; "
+                "import mcp_unified; "
+                "import mcp_unified.package_metadata; "
+                "blocked = ["
+                "name for name in ("
+                "'tldw_Server_API', 'chromadb', 'torch', 'faster_whisper', "
+                "'yt_dlp', 'next'"
+                ") if name in sys.modules"
+                "]; "
+                "print(json.dumps(blocked))"
+            ),
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    assert json.loads(result.stdout) == []
 
 
 def test_host_interface_shims_reexport_package_contracts() -> None:


### PR DESCRIPTION
## Summary

- Added `mcp_unified.package_metadata` as a pure-stdlib release-readiness contract for the current `mcp_unified` package boundary.
- Exposed the contract through `mcp-unified-gateway package-info` and documented that the package is internal/experimental, not separately published, and currently GPL-3.0-only.
- Added regression coverage for metadata shape, dependency-extra membership, minimal import smoke, CLI visibility, and docs visibility.

## Test Plan

- [x] `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py tldw_Server_API/app/core/MCP_unified/tests/test_gateway_cli_package.py -v` (91 passed)
- [x] `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r mcp_unified/package_metadata.py mcp_unified/gateway/cli.py -f json -o /tmp/bandit_mcp_package_release_readiness.json` (0 findings)
- [x] `git diff --check`

## Change Summary

AI-authored PR. A human maintainer must add or own the final change summary before merge per `Docs/superpowers/AI_GENERATED_PR_CHANGE_SUMMARY_POLICY_2026_04_17.md`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened the `mcp_unified` package release gate with a pure-stdlib metadata contract and a CLI to surface it. Adds a strict names-only dependency policy, clarifies internal/experimental and GPL-3.0-only status, and enforces a minimal, heavy-deps-free import boundary.

- **New Features**
  - Added `mcp_unified.package_metadata` with release-readiness constants, `package_metadata_summary()`, and `dependency_version_policy: "names-only"`. Declares status internal-experimental, not-published, license `GPL-3.0-only`, and extras: `core`, `fastapi`, `sqlite`, `federation`, `gateway`, `dev`.
  - Added `mcp-unified-gateway package-info` to print JSON metadata without requiring gateway config.
  - Updated docs with release status, “not a separately published standalone package,” the names-only policy, and the `package-info` command.
  - Strengthened tests: metadata shape and normalized package names, extras exclude heavy stacks (`chromadb`, `torch`, `yt-dlp`, etc.), subprocess import-smoke stays minimal, CLI JSON output, docs visibility, and stable repo-root discovery.

<sup>Written for commit db4782461b1f0e080eab8488d5a77ecc02a407d1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2228?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

