### PR TITLE
docs: adopt ADR workflow stage 1

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -428,6 +428,18 @@ If MCP is unavailable but the CLI works, use CLI fallback commands such as `back
 
 If neither MCP nor CLI is available, pause before making repo file changes unless the user explicitly approves a temporary exception. Commit Backlog.md task changes with the related work unless the user asks for different staging.
 
+### 0.1 Architecture Decision Records (ADRs)
+
+This repository uses Architecture Decision Records in `Docs/ADR/` for significant, durable architecture decisions. ADRs explain why an architecture rule exists; design docs, module docs, and plans describe how work is shaped or implemented.
+
+Every substantial Superpowers spec, implementation plan, or PR must make an explicit `ADR needed?` call. Use the trigger list in `Docs/ADR/README.md`: module boundaries, public API shape, persistence, security, worker ownership, provider integration, WebUI/extension conventions, major dependencies, and repository workflow gates usually require ADR consideration.
+
+If an ADR is required, create or supersede it in the same reviewable unit of work and link it from the Backlog task, spec, plan, or PR. If no ADR is required, record a brief rationale in the task, spec, plan, or PR notes.
+
+Accepted ADRs are immutable except for metadata needed to mark supersession. If a decision changes, create a new ADR and mark the old one `Superseded by ADR-{N}`. Backfilled still-governing ADRs use `Status: Accepted` plus `Backfilled from: <source>`; do not pretend they were written at original decision time.
+
+For workflow details, numbering, template, and the current ADR index, start with `Docs/ADR/README.md`.
+
 ### 1. Planning & Staging
 
 Break complex work into 3-5 stages. Document in a uniquely named plan file for the specific task (avoid generic names like `IMPLEMENTATION.md` or `IMPLEMENTATION_PLAN.md`), for example `IMPLEMENTATION_PLAN_<short_task_slug>.md` (e.g., `IMPLEMENTATION_PLAN_feedback_system.md`, `IMPLEMENTATION_PLAN_auth_refactor.md`):

--- a/Docs/ADR/000-template.md
+++ b/Docs/ADR/000-template.md
@@ -1,0 +1,30 @@
+# ADR-{N}: {Short title}
+
+**Status:** Proposed | Accepted | Superseded by ADR-{N}
+**Date:** YYYY-MM-DD
+**Backfilled from:** {source path, or "not backfilled"}
+**Decision owner:** {human/session/reviewer}
+**Related task:** {Backlog task ID/link}
+**Related spec/plan:** {paths}
+
+## Decision
+
+One sentence stating what was decided.
+
+## Context
+
+Why this decision was needed.
+
+## Alternatives considered
+
+| Option | Why rejected |
+| --- | --- |
+| {Alternative A} | {Reason} |
+
+## Consequences
+
+What this means going forward, including accepted tradeoffs.
+
+## Follow-up
+
+Optional implementation, audit, or documentation follow-up links.

--- a/Docs/ADR/001-adr-workflow-and-governance.md
+++ b/Docs/ADR/001-adr-workflow-and-governance.md
@@ -1,0 +1,32 @@
+# ADR-001: ADR Workflow And Governance
+
+**Status:** Accepted
+**Date:** 2026-06-02
+**Backfilled from:** not backfilled
+**Decision owner:** User + Codex collaboration session
+**Related task:** TASK-506, TASK-507, TASK-508
+**Related spec/plan:** `Docs/superpowers/specs/2026-06-02-adr-workflow-adoption-design.md`, `Docs/superpowers/plans/2026-06-02-adr-workflow-adoption-stage-1-implementation-plan.md`
+
+## Decision
+
+Use `Docs/ADR/` as the canonical home for Architecture Decision Records and require ADR assessment for substantial specs, implementation plans, and PRs.
+
+## Context
+
+Architecture decisions existed in scattered design docs, plans, review packets, and embedded ADR-like sections. The project needs a lightweight durable record that explains why architectural rules exist without replacing Backlog.md, Superpowers specs, implementation plans, or module documentation.
+
+## Alternatives considered
+
+| Option | Why rejected |
+| --- | --- |
+| Big-bang migration | Too much churn and too high a risk of converting stale decisions into accepted policy. |
+| Decision index before ADRs | Safer for audit, but delays the actual ADR workflow. |
+| Module-by-module only | Too passive; it would not establish a repo-wide standard. |
+
+## Consequences
+
+Significant durable architecture decisions need ADRs. Substantial specs, plans, and PRs need an explicit ADR assessment. Accepted ADRs are immutable except for supersession metadata. Backfilled decisions use source metadata rather than pretending they were written at decision time.
+
+## Follow-up
+
+Create follow-up Backlog tasks for the decision inventory, module-by-module backfill, and possible global Superpowers updates.

--- a/Docs/ADR/002-backlog-md-task-tracking.md
+++ b/Docs/ADR/002-backlog-md-task-tracking.md
@@ -1,0 +1,32 @@
+# ADR-002: Backlog.md Task Tracking
+
+**Status:** Accepted
+**Date:** 2026-06-02
+**Backfilled from:** `AGENTS.md`, `Docs/superpowers/specs/2026-05-03-backlog-md-task-tracking-design.md`
+**Decision owner:** User + prior Codex collaboration session
+**Related task:** TASK-506, TASK-507, TASK-508
+**Related spec/plan:** `Docs/superpowers/specs/2026-05-03-backlog-md-task-tracking-design.md`
+
+## Decision
+
+Require an associated Backlog.md task before work changes repository files.
+
+## Context
+
+The repository needs a durable task and history layer that records why work exists, how it was planned, what files changed, what verification ran, and what was skipped or blocked.
+
+## Alternatives considered
+
+| Option | Why rejected |
+| --- | --- |
+| Git commits only | Commits do not capture task state, verification history, blockers, or reviewable unit boundaries. |
+| GitHub issues only | Not every local agent task maps cleanly to a remote issue, and local work needs MCP/CLI-first task tracking. |
+| Manual markdown notes | Too easy to duplicate or bypass; Backlog.md provides a consistent task workflow. |
+
+## Consequences
+
+Repo-changing work must search for or create a Backlog task before edits begin. Read-only investigation can proceed without a task. Backlog tasks link to specs, plans, PRs, verification, and final summaries; they do not replace those artifacts.
+
+## Follow-up
+
+None for Stage 1.

--- a/Docs/ADR/003-jobs-vs-scheduler-default.md
+++ b/Docs/ADR/003-jobs-vs-scheduler-default.md
@@ -1,0 +1,32 @@
+# ADR-003: Jobs Vs Scheduler Default
+
+**Status:** Accepted
+**Date:** 2026-06-02
+**Backfilled from:** `AGENTS.md`
+**Decision owner:** User + prior project guidance
+**Related task:** TASK-506, TASK-507, TASK-508
+**Related spec/plan:** `Docs/superpowers/specs/2026-06-02-adr-workflow-adoption-design.md`
+
+## Decision
+
+Use Jobs by default for new user-visible work that needs admin or ops visibility, and use Scheduler for internal orchestration where dependency handling is central.
+
+## Context
+
+The project has both Jobs and Scheduler systems. Future contributors need a durable default to avoid ad hoc queue/orchestration choices.
+
+## Alternatives considered
+
+| Option | Why rejected |
+| --- | --- |
+| Jobs for all async work | Internal dependency orchestration fits Scheduler better and does not always need user/admin controls. |
+| Scheduler for all async work | User-facing work often needs pause, resume, drain, retries, quotas, RLS, status endpoints, and worker processes. |
+| Decide per feature with no default | Repeated debates and inconsistent ownership would slow implementation and increase maintenance cost. |
+
+## Consequences
+
+New user-visible features or work needing admin controls should use Jobs. Internal orchestration with task dependencies, idempotency keys, and registered handlers should use Scheduler. Recurring schedules use APScheduler to enqueue into whichever backend the feature chooses.
+
+## Follow-up
+
+Later ADR inventory work should identify any module-specific exceptions.

--- a/Docs/ADR/004-ai-generated-pr-change-summary-gate.md
+++ b/Docs/ADR/004-ai-generated-pr-change-summary-gate.md
@@ -1,0 +1,32 @@
+# ADR-004: AI-Generated PR Change Summary Gate
+
+**Status:** Accepted
+**Date:** 2026-06-02
+**Backfilled from:** `AGENTS.md`, `Docs/superpowers/AI_GENERATED_PR_CHANGE_SUMMARY_POLICY_2026_04_17.md`
+**Decision owner:** User + prior project guidance
+**Related task:** TASK-506, TASK-507, TASK-508
+**Related spec/plan:** `Docs/superpowers/AI_GENERATED_PR_CHANGE_SUMMARY_POLICY_2026_04_17.md`
+
+## Decision
+
+Materially AI-authored PRs are not merge-ready until the human requester writes a `Change summary` explaining what changed and why those implementation choices were made.
+
+## Context
+
+The project allows AI-assisted development but needs human ownership of architectural and implementation rationale before merge.
+
+## Alternatives considered
+
+| Option | Why rejected |
+| --- | --- |
+| Allow AI-generated summaries | A diff recap or AI-authored rationale does not prove human understanding or ownership. |
+| Require no summary | Reviewers lose a concise human explanation of why the implementation is the right one. |
+| Ban AI-authored PRs | Too restrictive for the project workflow. |
+
+## Consequences
+
+AI-generated PRs need a human-written summary. If the requester cannot explain the rationale in their own words, the PR is not merge-ready. Agents may prepare context, but the merge gate requires human ownership.
+
+## Follow-up
+
+None for Stage 1.

--- a/Docs/ADR/005-bandit-touched-scope-security-gate.md
+++ b/Docs/ADR/005-bandit-touched-scope-security-gate.md
@@ -1,0 +1,32 @@
+# ADR-005: Bandit Touched-Scope Security Gate
+
+**Status:** Accepted
+**Date:** 2026-06-02
+**Backfilled from:** `AGENTS.md`
+**Decision owner:** User + prior project guidance
+**Related task:** TASK-506, TASK-507, TASK-508
+**Related spec/plan:** `Docs/superpowers/specs/2026-06-02-adr-workflow-adoption-design.md`
+
+## Decision
+
+Run Bandit on touched Python/code scope before considering work complete; for docs-only changes, document why Bandit is not applicable.
+
+## Context
+
+The project handles authentication, media ingestion, sandboxing, providers, and local/self-hosted data. Security-sensitive Python changes need an explicit security scan gate that scales to the touched scope.
+
+## Alternatives considered
+
+| Option | Why rejected |
+| --- | --- |
+| Full-repo Bandit every time | Can be expensive and noisy for narrow changes. |
+| No routine Bandit gate | Security regressions in touched code could be missed. |
+| Run only in CI | Local completion should catch new findings before review. |
+
+## Consequences
+
+Agents should activate the project virtual environment and run `python -m bandit -r <touched_paths> -f json -o /tmp/bandit_<task>.json` for touched Python/code paths. New findings in changed code should be fixed before finishing. Docs-only work records Bandit as not applicable.
+
+## Follow-up
+
+None for Stage 1.

--- a/Docs/ADR/README.md
+++ b/Docs/ADR/README.md
@@ -1,0 +1,39 @@
+# Architecture Decision Records
+
+Architecture Decision Records (ADRs) capture durable architecture decisions for `tldw_server`: what was decided, why, what alternatives were considered, and what tradeoffs were accepted.
+
+Module docs, design specs, and plans describe how things work. ADRs explain why important architecture rules exist.
+
+## Workflow
+
+1. Search existing ADRs before creating a new one.
+2. Create a Backlog.md task or use the task already associated with the work.
+3. Use `000-template.md`.
+4. Use the next sequential number.
+5. Record one decision per ADR.
+6. Write ADRs at decision time whenever possible.
+7. If backfilling, keep `Status: Accepted` for still-governing decisions and set `Backfilled from:` to the source path.
+8. Do not rewrite accepted ADR rationale. To change a decision, create a new ADR and mark the old one `Superseded by ADR-{N}`.
+
+## Status Rules
+
+- `Proposed`: drafted for review but not yet accepted.
+- `Accepted`: current governing decision.
+- `Superseded by ADR-{N}`: no longer governing because a newer ADR replaced it.
+- Backfill is metadata, not status. Backfilled still-governing decisions use `Status: Accepted` plus `Backfilled from: <source>`.
+
+## ADR Required When
+
+An ADR is required when a decision creates or changes a durable rule for module boundaries, public API shape, persistence, security, worker ownership, provider integration, WebUI/extension conventions, major dependencies, or repository workflow gates.
+
+Small bug fixes, local implementation details, product copy, temporary experiments, and test-only changes usually do not need ADRs unless they create durable policy.
+
+## Index
+
+| ADR | Status | Decision |
+| --- | --- | --- |
+| [ADR-001](001-adr-workflow-and-governance.md) | Accepted | Adopt `Docs/ADR/` as the canonical ADR workflow. |
+| [ADR-002](002-backlog-md-task-tracking.md) | Accepted | Require Backlog.md tasks for repo-changing work. |
+| [ADR-003](003-jobs-vs-scheduler-default.md) | Accepted | Use Jobs by default for new user-visible work and Scheduler for internal dependency orchestration. |
+| [ADR-004](004-ai-generated-pr-change-summary-gate.md) | Accepted | Require human-written change summaries for materially AI-authored PRs. |
+| [ADR-005](005-bandit-touched-scope-security-gate.md) | Accepted | Run Bandit on touched Python/code scope before completion. |

--- a/backlog/tasks/task-508 - Implement-ADR-workflow-adoption-Stage-1.md
+++ b/backlog/tasks/task-508 - Implement-ADR-workflow-adoption-Stage-1.md
@@ -6,6 +6,11 @@ labels:
 - docs
 - process
 - adr
+modified_files:
+- backlog/tasks/task-508 - Implement-ADR-workflow-adoption-Stage-1.md
+- backlog/tasks/task-509 - Audit-docs-for-ADR-decision-inventory.md
+- backlog/tasks/task-510 - Backfill-authoritative-ADRs-from-decision-inventory.md
+- backlog/tasks/task-511 - Evaluate-global-Superpowers-ADR-workflow-updates.md
 ---
 
 ## Description
@@ -38,7 +43,7 @@ Executing Docs/superpowers/plans/2026-06-02-adr-workflow-adoption-stage-1-implem
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-
+Task 4 follow-up Backlog tasks created via Backlog MCP and linked from TASK-508. Plan path: Docs/superpowers/plans/2026-06-02-adr-workflow-adoption-stage-1-implementation-plan.md. Follow-up IDs: TASK-509 Audit docs for ADR decision inventory; TASK-510 Backfill authoritative ADRs from decision inventory; TASK-511 Evaluate global Superpowers ADR workflow updates. Verification: `rg -n "ADR decision inventory|Backfill authoritative ADRs|global Superpowers ADR workflow" backlog/tasks` found the new follow-up task files plus existing TASK-507/TASK-508 planning references; `git diff --check -- 'backlog/tasks/task-508 - Implement-ADR-workflow-adoption-Stage-1.md' 'backlog/tasks/task-509 - Audit-docs-for-ADR-decision-inventory.md' 'backlog/tasks/task-510 - Backfill-authoritative-ADRs-from-decision-inventory.md' 'backlog/tasks/task-511 - Evaluate-global-Superpowers-ADR-workflow-updates.md'` exited 0. Bandit not run because this Task 4 slice touched only Backlog Markdown task files.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-508 - Implement-ADR-workflow-adoption-Stage-1.md
+++ b/backlog/tasks/task-508 - Implement-ADR-workflow-adoption-Stage-1.md
@@ -43,7 +43,7 @@ Executing Docs/superpowers/plans/2026-06-02-adr-workflow-adoption-stage-1-implem
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Final summary: Created Docs/ADR framework, seed ADRs, root AGENTS.md policy, and follow-up Backlog tasks for inventory/backfill and global Superpowers review. Follow-up tasks: TASK-509, TASK-510, TASK-511. Verification: final documentation checks passed; git diff --check passed; Bandit not applicable for docs-only changes.
+Final summary: Created Docs/ADR framework, seed ADRs, root AGENTS.md policy, and follow-up Backlog tasks for inventory/backfill and global Superpowers review. Follow-up tasks: TASK-509, TASK-510, TASK-511. Verification: final documentation checks passed; git diff --check passed; Bandit not applicable for docs-only changes. Draft PR: https://github.com/rmusser01/tldw_server/pull/2230
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-508 - Implement-ADR-workflow-adoption-Stage-1.md
+++ b/backlog/tasks/task-508 - Implement-ADR-workflow-adoption-Stage-1.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-508
 title: Implement ADR workflow adoption Stage 1
-status: In Progress
+status: Done
 labels:
 - docs
 - process
@@ -43,7 +43,7 @@ Executing Docs/superpowers/plans/2026-06-02-adr-workflow-adoption-stage-1-implem
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Task 4 follow-up Backlog tasks created via Backlog MCP and linked from TASK-508. Plan path: Docs/superpowers/plans/2026-06-02-adr-workflow-adoption-stage-1-implementation-plan.md. Follow-up IDs: TASK-509 Audit docs for ADR decision inventory; TASK-510 Backfill authoritative ADRs from decision inventory; TASK-511 Evaluate global Superpowers ADR workflow updates. Verification: `rg -n "ADR decision inventory|Backfill authoritative ADRs|global Superpowers ADR workflow" backlog/tasks` found the new follow-up task files plus existing TASK-507/TASK-508 planning references; `git diff --check -- 'backlog/tasks/task-508 - Implement-ADR-workflow-adoption-Stage-1.md' 'backlog/tasks/task-509 - Audit-docs-for-ADR-decision-inventory.md' 'backlog/tasks/task-510 - Backfill-authoritative-ADRs-from-decision-inventory.md' 'backlog/tasks/task-511 - Evaluate-global-Superpowers-ADR-workflow-updates.md'` exited 0. Bandit not run because this Task 4 slice touched only Backlog Markdown task files.
+Final summary: Created Docs/ADR framework, seed ADRs, root AGENTS.md policy, and follow-up Backlog tasks for inventory/backfill and global Superpowers review. Follow-up tasks: TASK-509, TASK-510, TASK-511. Verification: final documentation checks passed; git diff --check passed; Bandit not applicable for docs-only changes.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-508 - Implement-ADR-workflow-adoption-Stage-1.md
+++ b/backlog/tasks/task-508 - Implement-ADR-workflow-adoption-Stage-1.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-508
 title: Implement ADR workflow adoption Stage 1
-status: To Do
+status: In Progress
 labels:
 - docs
 - process
@@ -22,6 +22,12 @@ Implement Stage 1 of the ADR workflow adoption: create Docs/ADR framework, add r
 - [ ] #4 Follow-up Backlog tasks exist for decision inventory/backfill and global Superpowers ADR workflow review.
 - [ ] #5 Verification commands pass, including git diff --check; Bandit is recorded as not applicable for docs-only changes unless code is touched.
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Executing Docs/superpowers/plans/2026-06-02-adr-workflow-adoption-stage-1-implementation-plan.md in isolated worktree .worktrees/adr-workflow-stage-1 on branch codex/adr-workflow-stage-1. Baseline: git status --short clean; git diff --check clean; .venv absent, so no Python baseline tests run for this docs-only stage.
+<!-- SECTION:PLAN:END -->
 
 ## Implementation Notes
 

--- a/backlog/tasks/task-509 - Audit-docs-for-ADR-decision-inventory.md
+++ b/backlog/tasks/task-509 - Audit-docs-for-ADR-decision-inventory.md
@@ -1,0 +1,44 @@
+---
+id: TASK-509
+title: Audit docs for ADR decision inventory
+status: To Do
+labels:
+- docs
+- process
+- adr
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Audit existing decision sources and produce Docs/ADR/inventory/YYYY-MM-DD-decision-inventory.md with current, superseded, stale, duplicate, and needs-owner-review classifications.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Inventory covers Docs/Design/**, Docs/Plans/**, Docs/superpowers/specs/**, Docs/superpowers/plans/**, embedded ADRs, and module docs with decision language.
+- [ ] #2 Inventory records source path, decision summary, candidate status, recommended action, and owner-review need.
+- [ ] #3 No accepted ADR is created for ambiguous or contradicted decisions without owner review.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-510 - Backfill-authoritative-ADRs-from-decision-inventory.md
+++ b/backlog/tasks/task-510 - Backfill-authoritative-ADRs-from-decision-inventory.md
@@ -6,20 +6,24 @@ labels:
 - docs
 - process
 - adr
+modified_files:
+- backlog/tasks/task-510 - Backfill-authoritative-ADRs-from-decision-inventory.md
 ---
 
 ## Description
 
 <!-- SECTION:DESCRIPTION:BEGIN -->
-Convert owner-reviewed current governing decisions from the ADR decision inventory into numbered ADRs and add short source-doc references where practical.
+Plan and coordinate bounded module/domain ADR backfill child tasks from the owner-reviewed ADR decision inventory, rather than converting every current governing decision in one sweep.
 <!-- SECTION:DESCRIPTION:END -->
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Current governing decisions from the reviewed inventory have ADRs or explicit owner-reviewed exclusions.
-- [ ] #2 Backfilled ADRs use Status: Accepted plus Backfilled from metadata.
-- [ ] #3 Stale, superseded, duplicate, and ambiguous decisions remain classified in the inventory.
-- [ ] #4 High-value source docs link to covering or superseding ADRs where practical.
+- [ ] #1 Reviewed current governing decisions from the ADR decision inventory are grouped into bounded module/domain slices before conversion work begins when the inventory contains multiple independent domains.
+- [ ] #2 Child Backlog tasks are created for each non-trivial module/domain backfill slice, with clear scope, source inventory entries, expected ADR outputs, and owner-review prerequisites.
+- [ ] #3 Small single-domain inventories may be converted directly only when the task remains reviewable and the owner-reviewed scope is explicit.
+- [ ] #4 Backfilled ADR child-task outputs use Status: Accepted plus Backfilled from metadata.
+- [ ] #5 Stale, superseded, duplicate, and ambiguous decisions remain classified in the inventory.
+- [ ] #6 High-value source docs link to covering or superseding ADRs where practical within each bounded slice.
 <!-- AC:END -->
 
 ## Implementation Notes

--- a/backlog/tasks/task-510 - Backfill-authoritative-ADRs-from-decision-inventory.md
+++ b/backlog/tasks/task-510 - Backfill-authoritative-ADRs-from-decision-inventory.md
@@ -1,0 +1,45 @@
+---
+id: TASK-510
+title: Backfill authoritative ADRs from decision inventory
+status: To Do
+labels:
+- docs
+- process
+- adr
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Convert owner-reviewed current governing decisions from the ADR decision inventory into numbered ADRs and add short source-doc references where practical.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Current governing decisions from the reviewed inventory have ADRs or explicit owner-reviewed exclusions.
+- [ ] #2 Backfilled ADRs use Status: Accepted plus Backfilled from metadata.
+- [ ] #3 Stale, superseded, duplicate, and ambiguous decisions remain classified in the inventory.
+- [ ] #4 High-value source docs link to covering or superseding ADRs where practical.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-511 - Evaluate-global-Superpowers-ADR-workflow-updates.md
+++ b/backlog/tasks/task-511 - Evaluate-global-Superpowers-ADR-workflow-updates.md
@@ -1,0 +1,44 @@
+---
+id: TASK-511
+title: Evaluate global Superpowers ADR workflow updates
+status: To Do
+labels:
+- docs
+- process
+- adr
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+After repo-local ADR workflow validation, decide whether to update global Superpowers skills so brainstorming, writing-plans, and verification workflows consider ADR assessment across repositories.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Review repo-local ADR workflow outcomes before proposing global skill edits.
+- [ ] #2 Identify which skill files would change and what trigger wording they need.
+- [ ] #3 Produce a separate design/spec before modifying global Superpowers files.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## Summary
- Adds `Docs/ADR/` with an ADR template, README index, and seed ADRs for workflow governance, Backlog task tracking, Jobs vs Scheduler, AI PR change summary policy, and Bandit touched-scope validation.
- Updates root `AGENTS.md` to require explicit ADR assessment for substantial specs, plans, PRs, and architecture-affecting work.
- Adds follow-up Backlog tasks for ADR decision inventory, bounded ADR backfill, and future global Superpowers ADR workflow evaluation.

## Verification
- `test -f Docs/ADR/000-template.md Docs/ADR/README.md Docs/ADR/001-adr-workflow-and-governance.md Docs/ADR/002-backlog-md-task-tracking.md Docs/ADR/003-jobs-vs-scheduler-default.md Docs/ADR/004-ai-generated-pr-change-summary-gate.md Docs/ADR/005-bandit-touched-scope-security-gate.md`
- `rg -n 'ADR needed\?|Docs/ADR/README.md' AGENTS.md`
- `rg -n 'ADR-00[1-5]' Docs/ADR/README.md`
- `git diff --check`
- Bandit not applicable: documentation/process-only changes; no Python or executable code touched.

## Change summary
Pending human-authored summary required by `Docs/superpowers/AI_GENERATED_PR_CHANGE_SUMMARY_POLICY_2026_04_17.md`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adopts Stage 1 of the ADR workflow by adding a canonical Docs/ADR framework, seeding core decisions, and updating AGENTS.md to require ADR assessment for substantial work. Adds follow-up backlog tasks for decision inventory, bounded backfill, and global workflow evaluation.

- **New Features**
  - Added Docs/ADR with a template and README index.
  - Seeded ADRs: workflow/governance, Backlog.md task tracking, Jobs vs Scheduler default, human-written change summaries required for auto-generated PRs, and Bandit gate on touched code.
  - Updated AGENTS.md with ADR triggers, immutability, and supersession rules.
  - Marked TASK-508 Done with verification notes and a link to this PR for traceability.

- **Migration**
  - For substantial specs, plans, and PRs, add an “ADR needed?” decision and create/supersede ADRs in the same review.
  - Run Bandit on touched Python/code; for docs-only changes, note not applicable.

<sup>Written for commit 986796375e343a2efa7fa51a778dc8f5213ce0cb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2230?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

