### PR TITLE
Add MCP Unified standalone package install smoke

### DIFF
--- a/Docs/MCP_UNIFIED_STANDALONE_GATEWAY_ADMIN.md
+++ b/Docs/MCP_UNIFIED_STANDALONE_GATEWAY_ADMIN.md
@@ -13,8 +13,9 @@ being hardened.
 
 The current package metadata uses the canonical repository license expression
 `GPL-3.0-only`. Downstream projects should treat the boundary as an in-repo
-integration surface until a later packaging pass adds a clean minimal install,
-independent extras verification, and release CI for the standalone package.
+integration surface until release CI publishes a separate artifact. The
+package-local descriptor lives at `mcp_unified/pyproject.toml` and is checked
+by the package-boundary tests before publishing is considered.
 
 Inspect the current release-readiness metadata with:
 
@@ -23,8 +24,21 @@ mcp-unified-gateway package-info
 ```
 
 The dependency groups in that payload intentionally use a `names-only` policy.
-They identify the minimal standalone-package surface without duplicating version
-floors from `pyproject.toml` or future package build metadata.
+They identify the minimal standalone-package surface without duplicating the
+version floors carried by `mcp_unified/pyproject.toml`.
+
+Run the local standalone install smoke before changing release metadata or
+package dependencies:
+
+```bash
+python -m pytest \
+  tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py::test_mcp_unified_standalone_package_installs_without_root_dependencies \
+  -q
+```
+
+That smoke builds the package-local wheel with `--no-deps`, installs it into an
+isolated target directory with `--no-index`, and imports `mcp_unified` from a
+`python -S` subprocess outside the repository checkout.
 
 ## Local Store Commands vs Remote Runtime Commands
 

--- a/Docs/superpowers/plans/2026-06-03-mcp-unified-standalone-package-install-smoke-plan.md
+++ b/Docs/superpowers/plans/2026-06-03-mcp-unified-standalone-package-install-smoke-plan.md
@@ -1,0 +1,83 @@
+# MCP Unified Standalone Package Install Smoke Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a dedicated standalone package descriptor and an offline clean-environment install smoke test for `mcp_unified`.
+
+**Architecture:** Keep the standalone package metadata beside the package source at `mcp_unified/pyproject.toml`. Validate it from the existing package-boundary test suite, then build/install it without dependency resolution into an isolated target directory and import from a `python -S` process outside the repo to prove `import mcp_unified` does not rely on the root `tldw-server` package surface.
+
+**Tech Stack:** Python packaging with setuptools, pytest, pip `--target`, existing `mcp_unified.package_metadata` release metadata.
+
+---
+
+### Task 1: Package Descriptor Contract
+
+**Files:**
+- Create: `mcp_unified/pyproject.toml`
+- Modify: `tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py`
+- Modify: `Docs/MCP_UNIFIED_STANDALONE_GATEWAY_ADMIN.md`
+
+- [x] **Step 1: Write failing metadata tests**
+
+Add tests that require `mcp_unified/pyproject.toml` to exist, match `mcp_unified.package_metadata`, expose `mcp-unified-gateway`, and keep heavyweight root dependencies out of standalone core dependencies.
+
+- [x] **Step 2: Run tests to verify RED**
+
+Run: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py -q`
+
+Expected: FAIL because `mcp_unified/pyproject.toml` is not present.
+
+- [x] **Step 3: Add minimal standalone descriptor**
+
+Create `mcp_unified/pyproject.toml` using setuptools, package name `mcp-unified`, package-dir `mcp_unified = "."`, the existing CLI entry point, core dependency floors, and extras for `fastapi`, `sqlite`, `federation`, `gateway`, and `dev`.
+
+- [x] **Step 4: Run tests to verify GREEN**
+
+Run: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py -q`
+
+Expected: PASS.
+
+### Task 2: Offline Clean Install Smoke
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py`
+- Modify: `Docs/MCP_UNIFIED_STANDALONE_GATEWAY_ADMIN.md`
+
+- [x] **Step 1: Write failing install smoke test**
+
+Add a pytest smoke test that builds the standalone package wheel with `--no-deps --no-build-isolation`, installs that wheel into an isolated target directory with `--no-deps --no-index`, and imports only `mcp_unified` plus `mcp_unified.package_metadata` from a `python -S` subprocess.
+
+- [x] **Step 2: Run smoke test to verify RED/GREEN state**
+
+Run: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py::test_mcp_unified_standalone_package_installs_without_root_dependencies -q`
+
+Expected before descriptor: FAIL due missing package descriptor. Expected after descriptor: PASS.
+
+- [x] **Step 3: Document the release smoke command**
+
+Document the standalone package descriptor and focused install-smoke command in `Docs/MCP_UNIFIED_STANDALONE_GATEWAY_ADMIN.md`.
+
+- [x] **Step 4: Run focused verification**
+
+Run:
+- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py tldw_Server_API/app/core/MCP_unified/tests/test_gateway_cli_package.py -q`
+- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r mcp_unified -f json -o /tmp/bandit_mcp_package_build_smoke.json`
+
+Expected: tests pass; Bandit reports no findings in package runtime source.
+
+### Task 3: Backlog And Commit
+
+**Files:**
+- Modify: `backlog/tasks/task-601 - Add-MCP-Unified-standalone-package-install-smoke.md`
+
+- [x] **Step 1: Update Backlog task**
+
+Record implementation notes, touched files, verification results, and final summary in `TASK-601`.
+
+- [x] **Step 2: Self-review diff**
+
+Run: `git diff --check` and inspect `git diff --stat`.
+
+- [x] **Step 3: Commit**
+
+Stage the plan, descriptor, tests, docs, and Backlog task. Commit with message: `test: add mcp unified standalone install smoke`.

--- a/backlog/tasks/task-601 - Add-MCP-Unified-standalone-package-install-smoke.md
+++ b/backlog/tasks/task-601 - Add-MCP-Unified-standalone-package-install-smoke.md
@@ -1,0 +1,54 @@
+---
+id: TASK-601
+title: Add MCP Unified standalone package install smoke
+status: Done
+labels:
+- mcp-unified
+- packaging
+priority: medium
+references:
+- Docs/superpowers/specs/2026-05-26-mcp-unified-standalone-library-gateway-design.md
+modified_files:
+- Docs/MCP_UNIFIED_STANDALONE_GATEWAY_ADMIN.md
+- Docs/superpowers/plans/2026-06-03-mcp-unified-standalone-package-install-smoke-plan.md
+- mcp_unified/pyproject.toml
+- tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Add a dedicated standalone MCP Unified package descriptor plus an offline clean-environment install smoke test so the package release gate proves mcp_unified can be installed independently from the root tldw-server dependency surface.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Docs/superpowers/plans/2026-06-03-mcp-unified-standalone-package-install-smoke-plan.md
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Implemented in isolated worktree codex/mcp-package-build-smoke. Added package-local mcp_unified/pyproject.toml, red/green package descriptor tests, and an offline wheel install smoke that builds from a temporary source copy, installs with --no-deps/--no-index into an isolated target directory, and imports via python -S outside the repository checkout. Nested venv interpreters abort under this local UV-managed Python, so the final smoke avoids that environment-specific path while preserving the clean import/install invariant. Verification: baseline 91 passed before edits; red run failed on missing mcp_unified/pyproject.toml; focused final tests passed with 93 passed and 5 warnings; git diff --check passed; Bandit on mcp_unified wrote /tmp/bandit_mcp_package_build_smoke.json with 0 findings.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Added a standalone MCP Unified package descriptor and release-gate smoke coverage. The descriptor carries core dependency floors, expected extras, package-dir mappings, GPL-3.0-only license metadata, and the mcp-unified-gateway entry point. The package-boundary suite now validates descriptor alignment with mcp_unified.package_metadata and proves the built wheel can be installed/imported without root tldw-server dependencies.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-601 - Add-MCP-Unified-standalone-package-install-smoke.md
+++ b/backlog/tasks/task-601 - Add-MCP-Unified-standalone-package-install-smoke.md
@@ -11,7 +11,9 @@ references:
 modified_files:
 - Docs/MCP_UNIFIED_STANDALONE_GATEWAY_ADMIN.md
 - Docs/superpowers/plans/2026-06-03-mcp-unified-standalone-package-install-smoke-plan.md
+- mcp_unified/federation/manager.py
 - mcp_unified/pyproject.toml
+- mcp_unified/storage/__init__.py
 - tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py
 ---
 
@@ -34,13 +36,13 @@ Docs/superpowers/plans/2026-06-03-mcp-unified-standalone-package-install-smoke-p
 ## Implementation Notes
 
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
-Implemented in isolated worktree codex/mcp-package-build-smoke. Added package-local mcp_unified/pyproject.toml, red/green package descriptor tests, and an offline wheel install smoke that builds from a temporary source copy, installs with --no-deps/--no-index into an isolated target directory, and imports via python -S outside the repository checkout. Nested venv interpreters abort under this local UV-managed Python, so the final smoke avoids that environment-specific path while preserving the clean import/install invariant. Verification: baseline 91 passed before edits; red run failed on missing mcp_unified/pyproject.toml; focused final tests passed with 93 passed and 5 warnings; git diff --check passed; Bandit on mcp_unified wrote /tmp/bandit_mcp_package_build_smoke.json with 0 findings.
+PR #2232 rebased cleanly onto origin/dev and review remediation completed. Verified Qodo's federation/SQLAlchemy finding with red import-leak tests, then made SQLiteMCPStore a lazy storage export and changed federation manager imports to storage.models. Verified Qodo's offline build concern by adding descriptor-driven build-system preflight, explicit wheel_dir creation, and lowering the standalone build-system floor to setuptools>=61.0 to match the root project and avoid an unnecessary wheel runtime requirement. Addressed Gemini's subprocess diagnostics by replacing check=True in the smoke path with explicit return-code assertions that include captured stdout/stderr. Verification after fixes: package-boundary file passed with 20 passed; focused package suite passed with 96 passed and 5 warnings; git diff --check passed; no generated mcp_unified build/egg-info artifacts remain; Bandit runtime scan found 0 issues; Bandit test scan found 0 issues with expected test-only B101/B603/B404/B105 excluded.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Added a standalone MCP Unified package descriptor and release-gate smoke coverage. The descriptor carries core dependency floors, expected extras, package-dir mappings, GPL-3.0-only license metadata, and the mcp-unified-gateway entry point. The package-boundary suite now validates descriptor alignment with mcp_unified.package_metadata and proves the built wheel can be installed/imported without root tldw-server dependencies.
+Added standalone package install-smoke coverage and addressed PR #2232 review feedback. The final package boundary keeps storage/federation imports free of eager SQLAlchemy loading, preflights offline build-system requirements from the package descriptor, and reports captured subprocess output directly when the smoke build/install/import steps fail.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/mcp_unified/federation/manager.py
+++ b/mcp_unified/federation/manager.py
@@ -9,7 +9,7 @@ from datetime import datetime, timezone
 from typing import Any
 from uuid import uuid4
 
-from mcp_unified.storage import AuditEvent, ExternalServerDefinition
+from mcp_unified.storage.models import AuditEvent, ExternalServerDefinition
 
 from .models import (
     ExternalToolCallResult,

--- a/mcp_unified/pyproject.toml
+++ b/mcp_unified/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=68", "wheel"]
+requires = ["setuptools>=61.0"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/mcp_unified/pyproject.toml
+++ b/mcp_unified/pyproject.toml
@@ -1,0 +1,70 @@
+[build-system]
+requires = ["setuptools>=68", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "mcp-unified"
+version = "0.1.0"
+description = "Standalone MCP Unified runtime and gateway package boundary."
+requires-python = ">=3.10"
+license = {text = "GPL-3.0-only"}
+dependencies = [
+  "pydantic>=2.0.0",
+  "loguru>=0.7.0",
+  "PyYAML>=6.0.0",
+]
+
+[project.optional-dependencies]
+core = [
+  "pydantic>=2.0.0",
+  "loguru>=0.7.0",
+  "PyYAML>=6.0.0",
+]
+fastapi = [
+  "fastapi>=0.136.3",
+  "starlette>=1.0.1",
+]
+sqlite = [
+  "SQLAlchemy>=2.0.29",
+]
+federation = [
+  "pydantic>=2.0.0",
+  "loguru>=0.7.0",
+  "PyYAML>=6.0.0",
+]
+gateway = [
+  "pydantic>=2.0.0",
+  "loguru>=0.7.0",
+  "PyYAML>=6.0.0",
+  "fastapi>=0.136.3",
+  "starlette>=1.0.1",
+  "SQLAlchemy>=2.0.29",
+  "uvicorn[standard]>=0.23.0",
+]
+dev = [
+  "pytest>=9.0.3",
+  "pytest-asyncio>=1.3.0",
+  "bandit>=1.7.0",
+]
+
+[project.scripts]
+mcp-unified-gateway = "mcp_unified.gateway.cli:main"
+
+[tool.setuptools]
+include-package-data = false
+packages = [
+  "mcp_unified",
+  "mcp_unified.federation",
+  "mcp_unified.gateway",
+  "mcp_unified.interfaces",
+  "mcp_unified.profiles",
+  "mcp_unified.storage",
+]
+
+[tool.setuptools.package-dir]
+mcp_unified = "."
+"mcp_unified.federation" = "federation"
+"mcp_unified.gateway" = "gateway"
+"mcp_unified.interfaces" = "interfaces"
+"mcp_unified.profiles" = "profiles"
+"mcp_unified.storage" = "storage"

--- a/mcp_unified/storage/__init__.py
+++ b/mcp_unified/storage/__init__.py
@@ -1,5 +1,7 @@
 """Storage payload models for MCP Unified standalone stores."""
 
+from typing import TYPE_CHECKING, Any
+
 from .models import (
     ApprovalPolicyDocument,
     AuditEvent,
@@ -7,7 +9,9 @@ from .models import (
     ExternalServerDefinition,
     ProfileAssignment,
 )
-from .sqlite import SQLiteMCPStore
+
+if TYPE_CHECKING:
+    from .sqlite import SQLiteMCPStore
 
 __all__ = [
     "ApprovalPolicyDocument",
@@ -17,3 +21,20 @@ __all__ = [
     "ProfileAssignment",
     "SQLiteMCPStore",
 ]
+
+
+def __getattr__(name: str) -> Any:
+    """Lazily expose SQLite storage so core imports do not require SQLAlchemy."""
+
+    if name == "SQLiteMCPStore":
+        try:
+            from .sqlite import SQLiteMCPStore
+        except ModuleNotFoundError as exc:
+            if exc.name == "sqlalchemy":
+                raise ImportError(
+                    "SQLiteMCPStore requires the mcp-unified sqlite extra. "
+                    "Install mcp-unified[sqlite] or mcp-unified[gateway]."
+                ) from exc
+            raise
+        return SQLiteMCPStore
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py
@@ -8,6 +8,7 @@ import shutil
 import subprocess
 import sys
 from datetime import datetime
+from importlib import metadata as importlib_metadata
 from pathlib import Path
 
 import mcp_unified
@@ -47,6 +48,109 @@ def _dependency_names(dependencies: list[str] | tuple[str, ...]) -> set[str]:
         _dependency_package_name(dependency)
         for dependency in dependencies
     }
+
+
+def _version_release_parts(version: str) -> tuple[int, ...] | None:
+    """Return leading numeric release parts from a version string."""
+
+    parts: list[int] = []
+    for part in version.split("+", 1)[0].split("-", 1)[0].split("."):
+        if not part.isdigit():
+            break
+        parts.append(int(part))
+    if not parts:
+        return None
+    return tuple(parts)
+
+
+def _minimum_version(requirement: str) -> tuple[int, ...] | None:
+    """Return a simple >= minimum version tuple from a requirement string."""
+
+    if ">=" not in requirement:
+        return None
+    minimum = requirement.split(">=", 1)[1].split(",", 1)[0].strip()
+    return _version_release_parts(minimum)
+
+
+def _version_satisfies_minimum(
+    installed_version: str,
+    minimum_version: tuple[int, ...] | None,
+) -> bool:
+    """Return whether an installed version satisfies a simple minimum tuple."""
+
+    if minimum_version is None:
+        return True
+    installed_parts = _version_release_parts(installed_version)
+    if installed_parts is None:
+        return False
+    width = max(len(installed_parts), len(minimum_version))
+    return installed_parts + (0,) * (width - len(installed_parts)) >= (
+        minimum_version + (0,) * (width - len(minimum_version))
+    )
+
+
+def _require_offline_build_tools() -> None:
+    """Skip the offline build smoke when local build tools are unavailable."""
+
+    pyproject = _load_standalone_pyproject()
+    build_requires = pyproject["build-system"]["requires"]
+    missing: list[str] = []
+    incompatible: list[str] = []
+    for requirement in build_requires:
+        package_name = _dependency_package_name(requirement)
+        try:
+            installed_version = importlib_metadata.version(package_name)
+        except importlib_metadata.PackageNotFoundError:
+            missing.append(requirement)
+            continue
+        minimum = _minimum_version(requirement)
+        if not _version_satisfies_minimum(installed_version, minimum):
+            incompatible.append(f"{requirement} (found {installed_version})")
+
+    if missing or incompatible:
+        details = []
+        if missing:
+            details.append(f"missing: {', '.join(missing)}")
+        if incompatible:
+            details.append(f"incompatible: {', '.join(incompatible)}")
+        pytest.skip(
+            "Offline standalone package smoke requires preinstalled build-system "
+            "requirements because it uses PIP_NO_INDEX=1 and "
+            f"--no-build-isolation; {'; '.join(details)}."
+        )
+
+
+def _assert_subprocess_succeeded(
+    result: subprocess.CompletedProcess[str],
+    command_label: str,
+) -> None:
+    """Assert a captured subprocess succeeded while preserving diagnostics."""
+
+    if result.returncode != 0:
+        raise AssertionError(
+            f"{command_label} failed with exit code {result.returncode}:\n"
+            f"STDOUT:\n{result.stdout}\n"
+            f"STDERR:\n{result.stderr}"
+        )
+
+
+def test_subprocess_failure_assertion_includes_captured_output() -> None:
+    """Subprocess smoke failures should expose captured stdout and stderr."""
+
+    result = subprocess.CompletedProcess(
+        args=["python", "-m", "pip", "wheel"],
+        returncode=2,
+        stdout="build stdout",
+        stderr="build stderr",
+    )
+
+    with pytest.raises(AssertionError) as exc_info:
+        _assert_subprocess_succeeded(result, "pip wheel")
+
+    message = str(exc_info.value)
+    assert "pip wheel failed with exit code 2" in message
+    assert "STDOUT:\nbuild stdout" in message
+    assert "STDERR:\nbuild stderr" in message
 
 
 def _tldw_imports_for(path: Path) -> list[str]:
@@ -138,6 +242,7 @@ def test_mcp_unified_standalone_pyproject_matches_release_metadata() -> None:
     pyproject = _load_standalone_pyproject()
     project = pyproject["project"]
 
+    assert pyproject["build-system"]["requires"] == ["setuptools>=61.0"]
     assert project["name"] == metadata.PACKAGE_NAME
     assert project["version"] == mcp_unified.__version__
     assert project["license"]["text"] == metadata.LICENSE_EXPRESSION
@@ -182,6 +287,7 @@ def test_mcp_unified_standalone_package_installs_without_root_dependencies(
     """Install the standalone package into an isolated target without root deps."""
 
     _load_standalone_pyproject()
+    _require_offline_build_tools()
     package_source = tmp_path / "mcp_unified_source"
     shutil.copytree(
         PACKAGE_ROOT,
@@ -193,6 +299,7 @@ def test_mcp_unified_standalone_package_installs_without_root_dependencies(
         ),
     )
     wheel_dir = tmp_path / "dist"
+    wheel_dir.mkdir()
     build_env = {
         **os.environ,
         "PIP_DISABLE_PIP_VERSION_CHECK": "1",
@@ -210,18 +317,19 @@ def test_mcp_unified_standalone_package_installs_without_root_dependencies(
             str(wheel_dir),
             str(package_source),
         ],
-        check=True,
+        check=False,
         capture_output=True,
         text=True,
         env=build_env,
     )
+    _assert_subprocess_succeeded(build_result, "pip wheel")
 
     wheels = sorted(wheel_dir.glob("mcp_unified-*.whl"))
-    assert wheels, build_result.stdout + build_result.stderr
+    assert wheels, "No mcp_unified wheel found after pip wheel completed."
 
     install_dir = tmp_path / "install"
 
-    subprocess.run(
+    install_result = subprocess.run(
         [
             sys.executable,
             "-m",
@@ -233,11 +341,12 @@ def test_mcp_unified_standalone_package_installs_without_root_dependencies(
             str(install_dir),
             str(wheels[-1]),
         ],
-        check=True,
+        check=False,
         capture_output=True,
         text=True,
         env=build_env,
     )
+    _assert_subprocess_succeeded(install_result, "pip install")
     import_result = subprocess.run(
         [
             sys.executable,
@@ -261,7 +370,7 @@ def test_mcp_unified_standalone_package_installs_without_root_dependencies(
                 "}))"
             ),
         ],
-        check=True,
+        check=False,
         capture_output=True,
         text=True,
         cwd=tmp_path,
@@ -271,6 +380,7 @@ def test_mcp_unified_standalone_package_installs_without_root_dependencies(
             "PYTHONPATH": "",
         },
     )
+    _assert_subprocess_succeeded(import_result, "standalone package import")
 
     assert json.loads(import_result.stdout) == {
         "version": mcp_unified.__version__,
@@ -296,6 +406,38 @@ def test_mcp_unified_core_import_smoke_stays_minimal() -> None:
                 "'yt_dlp', 'next'"
                 ") if name in sys.modules"
                 "]; "
+                "print(json.dumps(blocked))"
+            ),
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    assert json.loads(result.stdout) == []
+
+
+@pytest.mark.parametrize(
+    ("module_name", "blocked_modules"),
+    [
+        ("mcp_unified.storage", ("mcp_unified.storage.sqlite", "sqlalchemy")),
+        ("mcp_unified.federation", ("mcp_unified.storage.sqlite", "sqlalchemy")),
+    ],
+)
+def test_package_imports_do_not_eagerly_load_sqlite_backend(
+    module_name: str,
+    blocked_modules: tuple[str, ...],
+) -> None:
+    """Core and federation imports must not require SQLite storage dependencies."""
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            (
+                "import importlib, json, sys; "
+                f"importlib.import_module({module_name!r}); "
+                f"blocked = [name for name in {blocked_modules!r} if name in sys.modules]; "
                 "print(json.dumps(blocked))"
             ),
         ],

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import ast
 import importlib
 import json
+import os
+import shutil
 import subprocess
 import sys
 from datetime import datetime
@@ -12,7 +14,13 @@ import mcp_unified
 import pytest
 from pydantic import ValidationError
 
+try:
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover - Python 3.10 compatibility.
+    import tomli as tomllib
+
 PACKAGE_ROOT = Path(mcp_unified.__file__).resolve().parent
+STANDALONE_PYPROJECT = PACKAGE_ROOT / "pyproject.toml"
 
 
 def _dependency_package_name(dependency: str) -> str:
@@ -22,6 +30,23 @@ def _dependency_package_name(dependency: str) -> str:
     for separator in ("[", "<", ">", "=", "!", "~", ";"):
         name = name.split(separator, 1)[0]
     return name.strip().lower().replace("_", "-")
+
+
+def _load_standalone_pyproject() -> dict[str, object]:
+    """Load the package-local MCP Unified pyproject document."""
+
+    assert STANDALONE_PYPROJECT.is_file()
+    with STANDALONE_PYPROJECT.open("rb") as pyproject_file:
+        return tomllib.load(pyproject_file)
+
+
+def _dependency_names(dependencies: list[str] | tuple[str, ...]) -> set[str]:
+    """Return normalized package names from dependency declarations."""
+
+    return {
+        _dependency_package_name(dependency)
+        for dependency in dependencies
+    }
 
 
 def _tldw_imports_for(path: Path) -> list[str]:
@@ -103,6 +128,154 @@ def test_mcp_unified_package_metadata_declares_release_gate() -> None:
     assert summary["optional_extras"] == {
         key: list(value)
         for key, value in extras.items()
+    }
+
+
+def test_mcp_unified_standalone_pyproject_matches_release_metadata() -> None:
+    """Standalone package metadata must stay aligned with release gate metadata."""
+
+    metadata = importlib.import_module("mcp_unified.package_metadata")
+    pyproject = _load_standalone_pyproject()
+    project = pyproject["project"]
+
+    assert project["name"] == metadata.PACKAGE_NAME
+    assert project["version"] == mcp_unified.__version__
+    assert project["license"]["text"] == metadata.LICENSE_EXPRESSION
+    assert project["scripts"]["mcp-unified-gateway"] == "mcp_unified.gateway.cli:main"
+
+    assert _dependency_names(project["dependencies"]) == set(metadata.CORE_DEPENDENCIES)
+
+    optional_dependencies = project["optional-dependencies"]
+    assert set(optional_dependencies) == set(metadata.OPTIONAL_EXTRAS)
+    assert {
+        extra: _dependency_names(dependencies)
+        for extra, dependencies in optional_dependencies.items()
+    } == {
+        extra: set(dependencies)
+        for extra, dependencies in metadata.OPTIONAL_EXTRAS.items()
+    }
+
+    forbidden_dependency_names = {
+        "chromadb",
+        "docling",
+        "faster-whisper",
+        "gradio",
+        "llama-cpp-python",
+        "nemo-toolkit",
+        "next",
+        "qwen",
+        "torch",
+        "tts",
+        "yt-dlp",
+    }
+    standalone_dependency_names = _dependency_names(project["dependencies"])
+    for dependencies in optional_dependencies.values():
+        standalone_dependency_names.update(_dependency_names(dependencies))
+
+    assert forbidden_dependency_names.isdisjoint(standalone_dependency_names)
+
+
+@pytest.mark.smoke
+def test_mcp_unified_standalone_package_installs_without_root_dependencies(
+    tmp_path: Path,
+) -> None:
+    """Install the standalone package into an isolated target without root deps."""
+
+    _load_standalone_pyproject()
+    package_source = tmp_path / "mcp_unified_source"
+    shutil.copytree(
+        PACKAGE_ROOT,
+        package_source,
+        ignore=shutil.ignore_patterns(
+            "__pycache__",
+            "build",
+            "*.egg-info",
+        ),
+    )
+    wheel_dir = tmp_path / "dist"
+    build_env = {
+        **os.environ,
+        "PIP_DISABLE_PIP_VERSION_CHECK": "1",
+        "PIP_NO_INDEX": "1",
+    }
+    build_result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "pip",
+            "wheel",
+            "--no-build-isolation",
+            "--no-deps",
+            "--wheel-dir",
+            str(wheel_dir),
+            str(package_source),
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+        env=build_env,
+    )
+
+    wheels = sorted(wheel_dir.glob("mcp_unified-*.whl"))
+    assert wheels, build_result.stdout + build_result.stderr
+
+    install_dir = tmp_path / "install"
+
+    subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "pip",
+            "install",
+            "--no-deps",
+            "--no-index",
+            "--target",
+            str(install_dir),
+            str(wheels[-1]),
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+        env=build_env,
+    )
+    import_result = subprocess.run(
+        [
+            sys.executable,
+            "-S",
+            "-c",
+            (
+                "import json, sys; "
+                f"sys.path.insert(0, {str(install_dir)!r}); "
+                "import mcp_unified; "
+                "import mcp_unified.package_metadata as metadata; "
+                "blocked = ["
+                "name for name in ("
+                "'tldw_Server_API', 'chromadb', 'torch', 'faster_whisper', "
+                "'yt_dlp', 'fastapi', 'sqlalchemy'"
+                ") if name in sys.modules"
+                "]; "
+                "print(json.dumps({"
+                "'version': mcp_unified.__version__, "
+                "'package': metadata.PACKAGE_NAME, "
+                "'blocked': blocked"
+                "}))"
+            ),
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+        cwd=tmp_path,
+        env={
+            **os.environ,
+            "PYTHONNOUSERSITE": "1",
+            "PYTHONPATH": "",
+        },
+    )
+
+    assert json.loads(import_result.stdout) == {
+        "version": mcp_unified.__version__,
+        "package": "mcp-unified",
+        "blocked": [],
     }
 
 


### PR DESCRIPTION
## Summary
- Added `mcp_unified/pyproject.toml` as the package-local standalone descriptor for the MCP Unified runtime boundary.
- Extended package-boundary tests to validate descriptor metadata/extras against `mcp_unified.package_metadata` and reject heavyweight root dependency leakage.
- Added an offline wheel install smoke that builds from a temporary package source copy, installs with `--no-deps --no-index`, and imports from a `python -S` process outside the repo checkout.

## Test Plan
- [x] `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py tldw_Server_API/app/core/MCP_unified/tests/test_gateway_cli_package.py -q`
- [x] `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r mcp_unified -f json -o /tmp/bandit_mcp_package_build_smoke.json`
- [x] `git diff --check`

## AI-Generated PR Merge Gate
This PR was materially authored by AI. A human-authored `Change summary` explaining what changed and why these choices were made is required before merge.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a standalone package descriptor for `mcp_unified` and an offline install smoke test to ensure the package builds, installs, and imports without root repo dependencies. Tightens the release gate by aligning descriptor metadata and blocking heavyweight dependency leakage, with better diagnostics and import hygiene.

- **New Features**
  - Added `mcp_unified/pyproject.toml` with `setuptools>=61.0`, core deps/extras, package layouts, and the `mcp-unified-gateway` script.
  - Extended package-boundary tests to match `mcp_unified.package_metadata`, preflight build tools from `build-system.requires`, include subprocess output on failure, and reject heavy/root deps.
  - Made `SQLiteMCPStore` a lazy export and updated federation manager imports to `mcp_unified.storage.models` so core/federation imports don’t load `SQLAlchemy`; added an offline wheel install smoke that builds with `--no-deps --no-build-isolation`, installs with `--no-index`, and imports via `python -S` outside the repo (docs updated with the command).

<sup>Written for commit 132e2c74e891e4f2704d91e11fb90900ee40556f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2232?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

