### PR TITLE
docs: address ADR workflow review comments

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -567,7 +567,8 @@ When multiple valid approaches exist, choose based on:
 - Use the project virtual environment when running Bandit.
 - Fix new findings in changed code before finishing; do not defer silently.
 - Recommended command pattern:
-  `source .venv/bin/activate && python -m bandit -r <touched_paths> -f json -o /tmp/bandit_<task>.json`
+  `source .venv/bin/activate && python -m bandit -r <touched_paths> -f json -o bandit_<task>.json`
+- Canonical policy: `Docs/ADR/006-bandit-report-path-portability.md`
 
 ### Test Guidelines
 

--- a/Docs/ADR/005-bandit-touched-scope-security-gate.md
+++ b/Docs/ADR/005-bandit-touched-scope-security-gate.md
@@ -1,6 +1,6 @@
 # ADR-005: Bandit Touched-Scope Security Gate
 
-**Status:** Accepted
+**Status:** Superseded by ADR-006
 **Date:** 2026-06-02
 **Backfilled from:** `AGENTS.md`
 **Decision owner:** User + prior project guidance

--- a/Docs/ADR/006-bandit-report-path-portability.md
+++ b/Docs/ADR/006-bandit-report-path-portability.md
@@ -1,0 +1,33 @@
+# ADR-006: Bandit Report Path Portability
+
+**Status:** Accepted
+**Date:** 2026-06-03
+**Backfilled from:** not backfilled
+**Decision owner:** User + Codex collaboration session
+**Related task:** TASK-512
+**Related spec/plan:** PR #2230 review follow-up
+**Supersedes:** ADR-005
+
+## Decision
+
+Bandit remains required for touched Python/code scope, but report output paths must be portable and must not hard-code `/tmp`.
+
+## Context
+
+ADR-005 established the touched-scope Bandit gate but used `/tmp/bandit_<task>.json` as the example report path. The project supports Windows, macOS, and Linux, so hard-coding a Unix temporary directory makes the guidance less portable and creates unnecessary friction for agents working outside Unix-like environments.
+
+## Alternatives considered
+
+| Option | Why rejected |
+| --- | --- |
+| Keep `/tmp/bandit_<task>.json` | Not portable to all supported platforms. |
+| Use platform-specific temporary environment variables | Adds shell-specific complexity to a simple project guidance command. |
+| Omit the report output path | Loses the durable JSON artifact useful for recording verification evidence. |
+
+## Consequences
+
+Agents should activate the project virtual environment and run `python -m bandit -r <touched_paths> -f json -o bandit_<task>.json` or another explicitly chosen portable output path for touched Python/code paths. New findings in changed code should be fixed before finishing. Docs-only work records Bandit as not applicable. Bandit report artifacts should not be committed unless explicitly requested.
+
+## Follow-up
+
+None for this follow-up.

--- a/Docs/ADR/README.md
+++ b/Docs/ADR/README.md
@@ -36,4 +36,5 @@ Small bug fixes, local implementation details, product copy, temporary experimen
 | [ADR-002](002-backlog-md-task-tracking.md) | Accepted | Require Backlog.md tasks for repo-changing work. |
 | [ADR-003](003-jobs-vs-scheduler-default.md) | Accepted | Use Jobs by default for new user-visible work and Scheduler for internal dependency orchestration. |
 | [ADR-004](004-ai-generated-pr-change-summary-gate.md) | Accepted | Require human-written change summaries for materially AI-authored PRs. |
-| [ADR-005](005-bandit-touched-scope-security-gate.md) | Accepted | Run Bandit on touched Python/code scope before completion. |
+| [ADR-005](005-bandit-touched-scope-security-gate.md) | Superseded by ADR-006 | Run Bandit on touched Python/code scope before completion. |
+| [ADR-006](006-bandit-report-path-portability.md) | Accepted | Keep the Bandit touched-scope gate but require portable report output paths. |

--- a/backlog/tasks/task-508 - Implement-ADR-workflow-adoption-Stage-1.md
+++ b/backlog/tasks/task-508 - Implement-ADR-workflow-adoption-Stage-1.md
@@ -7,6 +7,14 @@ labels:
 - process
 - adr
 modified_files:
+- AGENTS.md
+- Docs/ADR/000-template.md
+- Docs/ADR/001-adr-workflow-and-governance.md
+- Docs/ADR/002-backlog-md-task-tracking.md
+- Docs/ADR/003-jobs-vs-scheduler-default.md
+- Docs/ADR/004-ai-generated-pr-change-summary-gate.md
+- Docs/ADR/005-bandit-touched-scope-security-gate.md
+- Docs/ADR/README.md
 - backlog/tasks/task-508 - Implement-ADR-workflow-adoption-Stage-1.md
 - backlog/tasks/task-509 - Audit-docs-for-ADR-decision-inventory.md
 - backlog/tasks/task-510 - Backfill-authoritative-ADRs-from-decision-inventory.md

--- a/backlog/tasks/task-512 - Address-ADR-workflow-PR-2230-review-comments.md
+++ b/backlog/tasks/task-512 - Address-ADR-workflow-PR-2230-review-comments.md
@@ -1,0 +1,60 @@
+---
+id: TASK-512
+title: Address ADR workflow PR 2230 review comments
+status: In Progress
+labels:
+- docs
+- process
+- adr
+- review-followup
+modified_files:
+- AGENTS.md
+- Docs/ADR/005-bandit-touched-scope-security-gate.md
+- Docs/ADR/006-bandit-report-path-portability.md
+- Docs/ADR/README.md
+- backlog/tasks/task-508 - Implement-ADR-workflow-adoption-Stage-1.md
+- backlog/tasks/task-512 - Address-ADR-workflow-PR-2230-review-comments.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Create a follow-up PR for unresolved review comments on PR #2230. Update TASK-508 traceability metadata, supersede ADR-005 with portable Bandit report path guidance, and document/preserve canonical Backlog task filenames rather than renaming them to non-Backlog paths.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 TASK-508 modified_files frontmatter includes the primary Stage 1 deliverables and Backlog task files changed by PR #2230.
+- [ ] #2 ADR-005 is superseded by accepted portable Bandit report path guidance, and current AGENTS.md guidance avoids a hardcoded /tmp report path.
+- [ ] #3 Backlog task filename review comments are addressed without breaking the repository's canonical Backlog task-file naming convention.
+- [ ] #4 Verification commands pass, including git diff --check and targeted text checks.
+- [ ] #5 A new draft or ready PR is opened and linked from this Backlog task.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Scope: follow-up PR for unresolved PR #2230 review comments only. Valid fixes: add Stage 1 deliverables to TASK-508 modified_files, supersede ADR-005 with portable Bandit report path guidance, and update current AGENTS.md guidance. Filename-renaming comments will be addressed by preserving actual Backlog task paths and documenting why nonstandard paths are not used.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+PR #2230 filename review comments suggested lowercase kebab-case Backlog task paths, but this repository's Backlog.md task files use the canonical `task-<id> - <Title>.md` format. This follow-up preserves actual task file paths and avoids listing non-existent renamed paths in `modified_files`.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-512 - Address-ADR-workflow-PR-2230-review-comments.md
+++ b/backlog/tasks/task-512 - Address-ADR-workflow-PR-2230-review-comments.md
@@ -24,11 +24,11 @@ Create a follow-up PR for unresolved review comments on PR #2230. Update TASK-50
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 TASK-508 modified_files frontmatter includes the primary Stage 1 deliverables and Backlog task files changed by PR #2230.
-- [ ] #2 ADR-005 is superseded by accepted portable Bandit report path guidance, and current AGENTS.md guidance avoids a hardcoded /tmp report path.
-- [ ] #3 Backlog task filename review comments are addressed without breaking the repository's canonical Backlog task-file naming convention.
-- [ ] #4 Verification commands pass, including git diff --check and targeted text checks.
-- [ ] #5 A new draft or ready PR is opened and linked from this Backlog task.
+- [x] #1 TASK-508 modified_files frontmatter includes the primary Stage 1 deliverables and Backlog task files changed by PR #2230.
+- [x] #2 ADR-005 is superseded by accepted portable Bandit report path guidance, and current AGENTS.md guidance avoids a hardcoded /tmp report path.
+- [x] #3 Backlog task filename review comments are addressed without breaking the repository's canonical Backlog task-file naming convention.
+- [x] #4 Verification commands pass, including git diff --check and targeted text checks.
+- [x] #5 A new draft or ready PR is opened and linked from this Backlog task.
 <!-- AC:END -->
 
 ## Implementation Plan

--- a/backlog/tasks/task-512 - Address-ADR-workflow-PR-2230-review-comments.md
+++ b/backlog/tasks/task-512 - Address-ADR-workflow-PR-2230-review-comments.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-512
 title: Address ADR workflow PR 2230 review comments
-status: In Progress
+status: Done
 labels:
 - docs
 - process
@@ -46,7 +46,7 @@ PR #2230 filename review comments suggested lowercase kebab-case Backlog task pa
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-
+Final summary: Addressed PR #2230 review follow-up by expanding TASK-508 modified_files to include the Stage 1 deliverables, superseding ADR-005 with ADR-006 for portable Bandit report path guidance, aligning AGENTS.md to the portable command, and documenting why canonical Backlog task filenames were preserved instead of renamed. Verification passed: ADR-006 exists, ADR index/status checks passed, TASK-508 metadata checks passed, filename rationale check passed, and git diff --check passed. Bandit not applicable for docs/process-only changes. Draft PR: https://github.com/rmusser01/tldw_server/pull/2233
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-512 - Address-ADR-workflow-PR-2230-review-comments.md
+++ b/backlog/tasks/task-512 - Address-ADR-workflow-PR-2230-review-comments.md
@@ -51,10 +51,10 @@ Final summary: Addressed PR #2230 review follow-up by expanding TASK-508 modifie
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
 - [ ] #5 Final summary added
 - [ ] #6 Known skips or blockers documented
 <!-- DOD:END -->


### PR DESCRIPTION
## Summary
- Adds missing Stage 1 deliverables to `TASK-508` `modified_files` for PR #2230 traceability.
- Supersedes ADR-005 with ADR-006 so Bandit report-path guidance is portable without rewriting accepted ADR rationale.
- Keeps canonical Backlog task filenames and records why the lowercase/no-space filename suggestions were not applied.

## Review Comments Addressed
- PR #2230 unresolved Qodo thread: incomplete `TASK-508.modified_files`.
- PR #2230 unresolved Gemini thread: portable Bandit report output path.
- PR #2230 unresolved Gemini filename threads: addressed by preserving actual Backlog task paths instead of listing non-existent renamed paths.

## Verification
- `test -f Docs/ADR/006-bandit-report-path-portability.md`
- `rg -n "ADR-006|Superseded by ADR-006|bandit_<task>\\.json" Docs/ADR/README.md Docs/ADR/005-bandit-touched-scope-security-gate.md Docs/ADR/006-bandit-report-path-portability.md AGENTS.md`
- `rg -n "AGENTS.md|Docs/ADR/000-template.md|Docs/ADR/001-adr-workflow-and-governance.md|Docs/ADR/002-backlog-md-task-tracking.md|Docs/ADR/003-jobs-vs-scheduler-default.md|Docs/ADR/004-ai-generated-pr-change-summary-gate.md|Docs/ADR/005-bandit-touched-scope-security-gate.md|Docs/ADR/README.md|task-511" "backlog/tasks/task-508 - Implement-ADR-workflow-adoption-Stage-1.md"`
- `rg -n 'canonical .*format|non-existent renamed paths' "backlog/tasks/task-512 - Address-ADR-workflow-PR-2230-review-comments.md"`
- `git diff --check`
- Bandit not applicable: docs/process-only changes; no Python or executable code touched.

## Change summary
Pending human-authored summary required by `Docs/superpowers/AI_GENERATED_PR_CHANGE_SUMMARY_POLICY_2026_04_17.md`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds ADR-006 to require portable Bandit report paths and supersede ADR-005, while keeping the touched-scope gate. Completes Stage 1 traceability and records the follow-up PR link in `TASK-512`.

- **New Features**
  - Added ADR-006; supersedes ADR-005. Keeps Bandit on touched code and uses a portable report path like `bandit_<task>.json`. Updated ADR index.

- **Bug Fixes**
  - Filled `TASK-508.modified_files` with missing Stage 1 deliverables; kept canonical Backlog task filenames and documented why renames weren’t applied.
  - Updated `AGENTS.md` with the portable Bandit command and ADR-006 link.
  - Added/updated `TASK-512` with acceptance criteria and a final summary; recorded the follow-up PR link for traceability.

<sup>Written for commit a8d6ed3b8a4ef639bdc61264c92844a9413375e9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2233?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

