### PR TITLE
docs: ignore generated Bandit reports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,6 +59,7 @@ htmlcov/
 .nox/
 .coverage
 .coverage.*
+bandit_*.json
 .cache
 nosetests.xml
 coverage.xml

--- a/Docs/ADR/006-bandit-report-path-portability.md
+++ b/Docs/ADR/006-bandit-report-path-portability.md
@@ -26,7 +26,7 @@ ADR-005 established the touched-scope Bandit gate but used `/tmp/bandit_<task>.j
 
 ## Consequences
 
-Agents should activate the project virtual environment and run `python -m bandit -r <touched_paths> -f json -o bandit_<task>.json` or another explicitly chosen portable output path for touched Python/code paths. New findings in changed code should be fixed before finishing. Docs-only work records Bandit as not applicable. Bandit report artifacts should not be committed unless explicitly requested.
+Agents should activate the project virtual environment and run `python -m bandit -r <touched_paths> -f json -o bandit_<task>.json` or another explicitly chosen portable output path for touched Python/code paths. New findings in changed code should be fixed before finishing. Docs-only work records Bandit as not applicable. Generated `bandit_*.json` report artifacts are ignored by `.gitignore` and should not be committed unless explicitly requested.
 
 ## Follow-up
 

--- a/backlog/tasks/task-513 - Ignore-generated-Bandit-report-artifacts.md
+++ b/backlog/tasks/task-513 - Ignore-generated-Bandit-report-artifacts.md
@@ -10,7 +10,7 @@ labels:
 modified_files:
 - .gitignore
 - Docs/ADR/006-bandit-report-path-portability.md
-- backlog/tasks/task-513 - Ignore-generated-Bandit-report-artifacts.md
+- backlog/tasks/task-513-ignore-generated-bandit-report-artifacts.md
 ---
 
 ## Description

--- a/backlog/tasks/task-513 - Ignore-generated-Bandit-report-artifacts.md
+++ b/backlog/tasks/task-513 - Ignore-generated-Bandit-report-artifacts.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-513
 title: Ignore generated Bandit report artifacts
-status: In Progress
+status: Done
 labels:
 - docs
 - process
@@ -43,7 +43,7 @@ Add an explicit bandit_*.json ignore rule near generated report artifacts, updat
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-
+Final summary: Added an explicit .gitignore rule for generated bandit_*.json reports and updated ADR-006 to document that generated Bandit JSON report artifacts are ignored and should not be committed unless explicitly requested. Verification passed: git check-ignore confirms bandit_TASK-513.json is ignored; targeted rg checks found the ignore rule, ADR guidance, and AGENTS.md command; git diff --check passed. Bandit not applicable for docs/process-only changes. Draft PR: https://github.com/rmusser01/tldw_server/pull/2234
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-513 - Ignore-generated-Bandit-report-artifacts.md
+++ b/backlog/tasks/task-513 - Ignore-generated-Bandit-report-artifacts.md
@@ -1,0 +1,57 @@
+---
+id: TASK-513
+title: Ignore generated Bandit report artifacts
+status: In Progress
+labels:
+- docs
+- process
+- security
+- review-followup
+modified_files:
+- .gitignore
+- Docs/ADR/006-bandit-report-path-portability.md
+- backlog/tasks/task-513 - Ignore-generated-Bandit-report-artifacts.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Address the post-merge PR #2233 review feedback by explicitly ignoring generated bandit_*.json reports now that AGENTS.md recommends a repository-relative Bandit report output path.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 .gitignore explicitly ignores bandit_*.json report artifacts.
+- [ ] #2 ADR-006 documents that generated bandit_*.json reports are ignored and should not be committed unless explicitly requested.
+- [ ] #3 git check-ignore confirms a sample bandit_<task>.json filename is ignored.
+- [ ] #4 Verification commands pass, including git diff --check.
+- [ ] #5 A follow-up PR is opened and linked from this task.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Add an explicit bandit_*.json ignore rule near generated report artifacts, update ADR-006 to state generated Bandit reports are ignored, verify with git check-ignore and git diff --check, then open a follow-up PR.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## Summary
- Adds an explicit `.gitignore` rule for generated `bandit_*.json` reports.
- Updates ADR-006 to state generated Bandit JSON reports are ignored and should not be committed unless explicitly requested.
- Tracks the post-merge review follow-up in TASK-513.

## Verification
- `git check-ignore bandit_TASK-513.json`
- `rg -n 'bandit_\*\.json|Generated .*report artifacts|bandit_<task>\.json' .gitignore Docs/ADR/006-bandit-report-path-portability.md AGENTS.md`
- `git diff --check`
- Bandit not applicable: docs/process-only changes; no Python or executable code touched.

## Change summary
Pending human-authored summary required by `Docs/superpowers/AI_GENERATED_PR_CHANGE_SUMMARY_POLICY_2026_04_17.md`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added an explicit `.gitignore` rule to ignore generated Bandit JSON reports (`bandit_*.json`) and updated ADR-006 to document this. Updated the TASK-513 backlog record with verification steps and follow-up details.

<sup>Written for commit 2fa188a84b8ee8449d1923ded063d2977a2f045b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2234?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

