### PR TITLE
Add MCP Unified standalone artifact gate

### DIFF
--- a/.github/workflows/pypi-package.yml
+++ b/.github/workflows/pypi-package.yml
@@ -8,6 +8,7 @@ on:
     paths:
       - pyproject.toml
       - README.md
+      - mcp_unified/**
       - tldw_Server_API/**
       - .github/workflows/pypi-package.yml
   push:
@@ -16,6 +17,7 @@ on:
     paths:
       - pyproject.toml
       - README.md
+      - mcp_unified/**
       - tldw_Server_API/**
       - .github/workflows/pypi-package.yml
   workflow_dispatch:
@@ -46,6 +48,14 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install build twine setuptools wheel
+          pip install -e "mcp_unified[dev]"
+
+      - name: Validate MCP Unified standalone artifacts
+        run: |
+          python -m pytest \
+            tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py::test_mcp_unified_standalone_distribution_metadata_matches_extras \
+            tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py::test_mcp_unified_standalone_sdist_contains_only_package_boundary \
+            -q
 
       - name: Build and check package
         run: make pypi-check

--- a/Docs/MCP_UNIFIED_STANDALONE_GATEWAY_ADMIN.md
+++ b/Docs/MCP_UNIFIED_STANDALONE_GATEWAY_ADMIN.md
@@ -13,7 +13,7 @@ being hardened.
 
 The current package metadata uses the canonical repository license expression
 `GPL-3.0-only`. Downstream projects should treat the boundary as an in-repo
-integration surface until release CI publishes a separate artifact. The
+integration surface until a publishing workflow is explicitly enabled. The
 package-local descriptor lives at `mcp_unified/pyproject.toml` and is checked
 by the package-boundary tests before publishing is considered.
 
@@ -27,8 +27,25 @@ The dependency groups in that payload intentionally use a `names-only` policy.
 They identify the minimal standalone-package surface without duplicating the
 version floors carried by `mcp_unified/pyproject.toml`.
 
-Run the local standalone install smoke before changing release metadata or
+Run the local standalone artifact gate before changing release metadata or
 package dependencies:
+
+```bash
+python -m pytest \
+  tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py::test_mcp_unified_standalone_distribution_metadata_matches_extras \
+  tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py::test_mcp_unified_standalone_sdist_contains_only_package_boundary \
+  -q
+```
+
+That gate builds the package-local wheel and sdist with `python -m build
+--no-isolation`, then checks the wheel metadata, console script entry point,
+optional extras, dependency boundary, and sdist contents. The `PyPI Package
+Check` GitHub Actions workflow runs the same focused gate for
+`mcp_unified/**` changes before it builds the root `tldw-server` distribution.
+It validates artifacts but does not publish `mcp-unified`.
+
+Run the local standalone install smoke when changing import behavior or the
+minimal package boundary:
 
 ```bash
 python -m pytest \

--- a/Docs/superpowers/plans/2026-06-03-mcp-unified-standalone-extras-ci-gate-plan.md
+++ b/Docs/superpowers/plans/2026-06-03-mcp-unified-standalone-extras-ci-gate-plan.md
@@ -1,0 +1,133 @@
+# MCP Unified Standalone Extras CI Gate Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a focused release gate that proves the in-repo `mcp_unified` standalone distribution artifacts preserve the package-local metadata, extras, and dependency boundary.
+
+**Architecture:** Keep the standalone proof in the existing MCP Unified package-boundary tests, because those tests already own the runtime/package separation contract. Extend the existing PyPI package workflow with a package-local gate so `mcp_unified/**` changes trigger CI without changing the root package publishing flow.
+
+**Tech Stack:** Python 3.12 CI, `pytest`, `python -m build --no-isolation`, stdlib wheel/sdist metadata inspection, GitHub Actions.
+
+---
+
+### Task 1: Artifact Metadata Regression Tests
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py`
+
+- [x] **Step 1: Write the failing tests**
+
+Add tests that build `mcp_unified` wheel and sdist into a temp directory, parse the wheel `METADATA` and `entry_points.txt`, and assert:
+- `Name`, `Version`, and console script match `mcp_unified/package_metadata.py` and `mcp_unified/pyproject.toml`.
+- `Provides-Extra` contains `core`, `fastapi`, `sqlite`, `federation`, `gateway`, and `dev`.
+- `Requires-Dist` entries for each extra match the standalone metadata dependency names.
+- Heavy root-only dependencies are absent from artifact metadata.
+- The sdist includes `pyproject.toml`, package code, and no host `tldw_Server_API` tree.
+
+- [x] **Step 2: Run the new focused tests and verify RED**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest \
+  tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py::test_mcp_unified_standalone_distribution_metadata_matches_extras \
+  tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py::test_mcp_unified_standalone_sdist_contains_only_package_boundary \
+  -q
+```
+
+Expected: fail because the new artifact gate helpers/assertions are not implemented yet.
+
+- [x] **Step 3: Implement the minimal artifact helpers**
+
+Add small helpers that:
+- Copy only `mcp_unified/` into a temp source directory.
+- Run `python -m build --wheel --sdist --no-isolation --outdir <dist> <source>`.
+- Parse wheel metadata with `zipfile` and `email.parser.Parser`.
+- Parse sdist members with `tarfile`.
+
+- [x] **Step 4: Run focused tests and verify GREEN**
+
+Run the same focused pytest command. Expected: pass.
+
+### Task 2: CI Release Gate Wiring
+
+**Files:**
+- Modify: `.github/workflows/pypi-package.yml`
+- Modify: `tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py`
+
+- [x] **Step 1: Write the failing CI-contract test**
+
+Add a test that reads `.github/workflows/pypi-package.yml` and asserts:
+- `mcp_unified/**` changes trigger the workflow.
+- The workflow runs the standalone artifact metadata tests.
+- The root package build/upload artifact behavior remains present.
+
+- [x] **Step 2: Run the CI-contract test and verify RED**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest \
+  tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py::test_pypi_workflow_runs_mcp_unified_standalone_artifact_gate \
+  -q
+```
+
+Expected: fail because the workflow does not yet include `mcp_unified/**` paths or the standalone test step.
+
+- [x] **Step 3: Update the workflow**
+
+Add `mcp_unified/**` to pull request and push path filters. Add a step after packaging tool installation that runs the focused standalone artifact gate test.
+
+- [x] **Step 4: Run the CI-contract test and verify GREEN**
+
+Run the same focused pytest command. Expected: pass.
+
+### Task 3: Documentation And Backlog
+
+**Files:**
+- Modify: `Docs/MCP_UNIFIED_STANDALONE_GATEWAY_ADMIN.md`
+- Modify: `backlog/tasks/task-602 - Harden-MCP-Unified-standalone-extras-and-CI-artifact-gate.md`
+
+- [x] **Step 1: Update docs**
+
+Clarify that release CI now builds and inspects package-local artifacts as a pre-publish gate, while PyPI publishing is still not enabled.
+
+- [x] **Step 2: Update Backlog task**
+
+Record touched files, verification commands, known skips, and final summary.
+
+### Task 4: Final Verification
+
+**Files:**
+- No additional file edits expected.
+
+- [x] **Step 1: Run focused MCP Unified package-boundary tests**
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest \
+  tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py \
+  tldw_Server_API/app/core/MCP_unified/tests/test_gateway_cli_package.py \
+  -q
+```
+
+- [x] **Step 2: Run Bandit on touched Python test scope**
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit \
+  -r tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py \
+  -f json -o /tmp/bandit_mcp_standalone_extras_ci_gate.json
+```
+
+- [x] **Step 3: Inspect git diff**
+
+```bash
+git diff --stat
+git diff -- .github/workflows/pypi-package.yml Docs/MCP_UNIFIED_STANDALONE_GATEWAY_ADMIN.md tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .github/workflows/pypi-package.yml Docs/MCP_UNIFIED_STANDALONE_GATEWAY_ADMIN.md Docs/superpowers/plans/2026-06-03-mcp-unified-standalone-extras-ci-gate-plan.md tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py "backlog/tasks/task-602 - Harden-MCP-Unified-standalone-extras-and-CI-artifact-gate.md"
+git commit -m "test: add mcp unified standalone artifact gate"
+```

--- a/backlog/tasks/task-602 - Harden-MCP-Unified-standalone-extras-and-CI-artifact-gate.md
+++ b/backlog/tasks/task-602 - Harden-MCP-Unified-standalone-extras-and-CI-artifact-gate.md
@@ -1,0 +1,63 @@
+---
+id: TASK-602
+title: Harden MCP Unified standalone extras and CI artifact gate
+status: Done
+assignee: []
+created_date: ''
+updated_date: 2026-06-03 03:14
+labels:
+- mcp-unified
+- packaging
+- ci
+dependencies: []
+priority: medium
+modified_files:
+- .github/workflows/pypi-package.yml
+- Docs/MCP_UNIFIED_STANDALONE_GATEWAY_ADMIN.md
+- Docs/superpowers/plans/2026-06-03-mcp-unified-standalone-extras-ci-gate-plan.md
+- tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Add a focused release gate that builds the package-local mcp_unified distribution artifact and proves the standalone dependency extras are independently represented/tested without pulling in the root tldw-server dependency surface.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Built standalone mcp_unified wheel metadata is checked for package name, version, console script, extras, and dependency boundary.
+- [x] #2 Built standalone mcp_unified sdist is checked for package boundary contents and absence of host application trees.
+- [x] #3 PyPI Package Check workflow runs the standalone artifact gate for mcp_unified/** changes while preserving the root package build/check/upload flow.
+- [x] #4 Standalone admin documentation describes the artifact gate and publishing status.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Docs/superpowers/plans/2026-06-03-mcp-unified-standalone-extras-ci-gate-plan.md
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Implemented a package-local MCP Unified artifact gate that builds wheel and sdist artifacts, validates wheel metadata/extras/entry point/dependency boundary, validates sdist contents, wires the PyPI Package Check workflow to run the focused gate for mcp_unified/** changes, and documents the pre-publish gate. Verification: focused MCP package-boundary pytest passed; Bandit medium+ threshold passed on the touched Python test file; default Bandit output contains only existing low-severity test-scope findings.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-602 - Harden-MCP-Unified-standalone-extras-and-CI-artifact-gate.md
+++ b/backlog/tasks/task-602 - Harden-MCP-Unified-standalone-extras-and-CI-artifact-gate.md
@@ -4,7 +4,7 @@ title: Harden MCP Unified standalone extras and CI artifact gate
 status: Done
 assignee: []
 created_date: ''
-updated_date: 2026-06-03 03:14
+updated_date: 2026-06-03 03:33
 labels:
 - mcp-unified
 - packaging
@@ -41,15 +41,13 @@ Docs/superpowers/plans/2026-06-03-mcp-unified-standalone-extras-ci-gate-plan.md
 ## Implementation Notes
 
 <!-- SECTION:NOTES:BEGIN -->
-<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
-
-<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+Review follow-up complete: verified Qodo, CodeRabbit, and Gemini comments against current PR code. Implemented still-valid fixes for mandatory artifact gate build-tool assertions, shared artifact build fixture, structured workflow YAML assertions, null-safe Provides-Extra handling, explicit importlib.util import, and workflow-file existence guard.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Implemented a package-local MCP Unified artifact gate that builds wheel and sdist artifacts, validates wheel metadata/extras/entry point/dependency boundary, validates sdist contents, wires the PyPI Package Check workflow to run the focused gate for mcp_unified/** changes, and documents the pre-publish gate. Verification: focused MCP package-boundary pytest passed; Bandit medium+ threshold passed on the touched Python test file; default Bandit output contains only existing low-severity test-scope findings.
+Implemented a package-local MCP Unified artifact gate that builds wheel and sdist artifacts, validates wheel metadata/extras/entry point/dependency boundary, validates sdist contents, wires the PyPI Package Check workflow to run the focused gate for mcp_unified/** changes, and documents the pre-publish gate. Review follow-up addressed still-valid Qodo, CodeRabbit, and Gemini comments: artifact-gate build tool checks now fail instead of skipping, distribution artifacts are built once via a shared fixture, workflow assertions parse YAML structure, Provides-Extra handling is null-safe, importlib.util is explicitly imported, and workflow-file existence is checked before reading. Verification: focused MCP package-boundary pytest passed; Bandit medium+ threshold passed on the touched Python test file; default Bandit output contains only existing low-severity test-scope findings.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import ast
 import configparser
 import importlib
+import importlib.util
 import json
 import os
 import re
@@ -19,6 +20,7 @@ from pathlib import Path
 
 import mcp_unified
 import pytest
+import yaml
 from pydantic import ValidationError
 
 try:
@@ -97,9 +99,8 @@ def _version_satisfies_minimum(
     )
 
 
-def _require_offline_build_tools() -> None:
-    """Skip the offline build smoke when local build tools are unavailable."""
-
+def _offline_build_tool_issues() -> list[str]:
+    """Return missing or incompatible offline build tool requirements."""
     pyproject = _load_standalone_pyproject()
     build_requires = pyproject["build-system"]["requires"]
     missing: list[str] = []
@@ -115,16 +116,36 @@ def _require_offline_build_tools() -> None:
         if not _version_satisfies_minimum(installed_version, minimum):
             incompatible.append(f"{requirement} (found {installed_version})")
 
-    if missing or incompatible:
-        details = []
-        if missing:
-            details.append(f"missing: {', '.join(missing)}")
-        if incompatible:
-            details.append(f"incompatible: {', '.join(incompatible)}")
+    details = []
+    if missing:
+        details.append(f"missing: {', '.join(missing)}")
+    if incompatible:
+        details.append(f"incompatible: {', '.join(incompatible)}")
+    return details
+
+
+def _require_offline_build_tools() -> None:
+    """Skip the offline build smoke when local build tools are unavailable."""
+
+    details = _offline_build_tool_issues()
+    if details:
         pytest.skip(
             "Offline standalone package smoke requires preinstalled build-system "
             "requirements because it uses PIP_NO_INDEX=1 and "
             f"--no-build-isolation; {'; '.join(details)}."
+        )
+
+
+def _assert_artifact_gate_build_tools_available() -> None:
+    """Assert the mandatory artifact gate build tools are available."""
+
+    details = _offline_build_tool_issues()
+    if importlib.util.find_spec("build") is None:
+        details.append("missing: build")
+    if details:
+        raise AssertionError(
+            "Standalone artifact gate requires preinstalled build tools; "
+            f"{'; '.join(details)}."
         )
 
 
@@ -145,9 +166,7 @@ def _assert_subprocess_succeeded(
 def _build_standalone_distributions(tmp_path: Path) -> tuple[Path, Path]:
     """Build standalone MCP Unified wheel and sdist into a temporary directory."""
 
-    _require_offline_build_tools()
-    if importlib.util.find_spec("build") is None:
-        pytest.skip("Standalone distribution gate requires the 'build' package.")
+    _assert_artifact_gate_build_tools_available()
 
     package_source = tmp_path / "mcp_unified_source"
     shutil.copytree(
@@ -259,6 +278,17 @@ def _read_sdist_members(sdist: Path) -> set[str]:
 
     with tarfile.open(sdist, "r:gz") as archive:
         return {member.name for member in archive.getmembers()}
+
+
+@pytest.fixture(scope="module")
+def standalone_distributions(
+    tmp_path_factory: pytest.TempPathFactory,
+) -> tuple[Path, Path]:
+    """Build standalone artifacts once for distribution metadata tests."""
+
+    return _build_standalone_distributions(
+        tmp_path_factory.mktemp("mcp_unified_distribution")
+    )
 
 
 def test_subprocess_failure_assertion_includes_captured_output() -> None:
@@ -408,20 +438,19 @@ def test_mcp_unified_standalone_pyproject_matches_release_metadata() -> None:
 
 
 def test_mcp_unified_standalone_distribution_metadata_matches_extras(
-    tmp_path: Path,
+    standalone_distributions: tuple[Path, Path],
 ) -> None:
     """Built standalone artifacts must preserve the package-local extras contract."""
 
     metadata = importlib.import_module("mcp_unified.package_metadata")
-    wheel, _sdist = _build_standalone_distributions(tmp_path)
+    wheel, _sdist = standalone_distributions
     distribution_metadata = _read_wheel_metadata(wheel)
     entry_points = _read_wheel_entry_points(wheel)
 
     assert distribution_metadata["Name"] == metadata.PACKAGE_NAME  # nosec B101
     assert distribution_metadata["Version"] == mcp_unified.__version__  # nosec B101
-    assert set(distribution_metadata.get_all("Provides-Extra")) == set(
-        metadata.OPTIONAL_EXTRAS
-    )  # nosec B101
+    provides_extra = distribution_metadata.get_all("Provides-Extra") or []
+    assert set(provides_extra) == set(metadata.OPTIONAL_EXTRAS)  # nosec B101
     assert _wheel_extra_dependency_names(distribution_metadata) == {
         extra: set(dependencies)
         for extra, dependencies in metadata.OPTIONAL_EXTRAS.items()
@@ -450,11 +479,11 @@ def test_mcp_unified_standalone_distribution_metadata_matches_extras(
 
 
 def test_mcp_unified_standalone_sdist_contains_only_package_boundary(
-    tmp_path: Path,
+    standalone_distributions: tuple[Path, Path],
 ) -> None:
     """Built standalone sdist must not include the host server package tree."""
 
-    _wheel, sdist = _build_standalone_distributions(tmp_path)
+    _wheel, sdist = standalone_distributions
     members = _read_sdist_members(sdist)
 
     assert any(member.endswith("/pyproject.toml") for member in members)  # nosec B101
@@ -467,19 +496,35 @@ def test_mcp_unified_standalone_sdist_contains_only_package_boundary(
 def test_pypi_workflow_runs_mcp_unified_standalone_artifact_gate() -> None:
     """PyPI validation workflow must also gate package-local mcp_unified changes."""
 
-    workflow = (
+    workflow_path = (
         PACKAGE_ROOT.parent / ".github" / "workflows" / "pypi-package.yml"
-    ).read_text(encoding="utf-8")
+    )
+    assert workflow_path.is_file()  # nosec B101
+    workflow = yaml.safe_load(workflow_path.read_text(encoding="utf-8"))
+    triggers = workflow.get("on") or workflow.get(True)
 
-    expected_fragments = (
-        "mcp_unified/**",
-        "make pypi-check",
-        "Upload dist artifacts",
+    assert "mcp_unified/**" in triggers["pull_request"]["paths"]  # nosec B101
+    assert "mcp_unified/**" in triggers["push"]["paths"]  # nosec B101
+
+    steps = workflow["jobs"]["build-and-check"]["steps"]
+    run_blocks = [step.get("run", "") for step in steps]
+    artifact_gate_nodeids = (
         "test_mcp_unified_standalone_distribution_metadata_matches_extras",
         "test_mcp_unified_standalone_sdist_contains_only_package_boundary",
     )
-    for fragment in expected_fragments:
-        assert fragment in workflow  # nosec B101
+    assert any(
+        all(nodeid in run_block for nodeid in artifact_gate_nodeids)
+        for run_block in run_blocks
+    )  # nosec B101
+    assert any(
+        run_block.strip() == "make pypi-check"
+        for run_block in run_blocks
+    )  # nosec B101
+    assert any(
+        str(step.get("uses", "")).startswith("actions/upload-artifact@")
+        and step.get("with", {}).get("path") == "dist/*"
+        for step in steps
+    )  # nosec B101
 
 
 @pytest.mark.smoke

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py
@@ -1,13 +1,19 @@
 from __future__ import annotations
 
 import ast
+import configparser
 import importlib
 import json
 import os
+import re
 import shutil
 import subprocess
 import sys
+import tarfile
+import zipfile
 from datetime import datetime
+from email.message import Message
+from email.parser import Parser
 from importlib import metadata as importlib_metadata
 from pathlib import Path
 
@@ -22,6 +28,8 @@ except ModuleNotFoundError:  # pragma: no cover - Python 3.10 compatibility.
 
 PACKAGE_ROOT = Path(mcp_unified.__file__).resolve().parent
 STANDALONE_PYPROJECT = PACKAGE_ROOT / "pyproject.toml"
+REQUIRES_DIST_NAME_PATTERN = re.compile(r"^\s*([A-Za-z0-9_.-]+)")
+REQUIRES_DIST_EXTRA_PATTERN = re.compile(r"extra\s*==\s*['\"]([^'\"]+)['\"]")
 
 
 def _dependency_package_name(dependency: str) -> str:
@@ -132,6 +140,125 @@ def _assert_subprocess_succeeded(
             f"STDOUT:\n{result.stdout}\n"
             f"STDERR:\n{result.stderr}"
         )
+
+
+def _build_standalone_distributions(tmp_path: Path) -> tuple[Path, Path]:
+    """Build standalone MCP Unified wheel and sdist into a temporary directory."""
+
+    _require_offline_build_tools()
+    if importlib.util.find_spec("build") is None:
+        pytest.skip("Standalone distribution gate requires the 'build' package.")
+
+    package_source = tmp_path / "mcp_unified_source"
+    shutil.copytree(
+        PACKAGE_ROOT,
+        package_source,
+        ignore=shutil.ignore_patterns(
+            "__pycache__",
+            "build",
+            "dist",
+            "*.egg-info",
+        ),
+    )
+    dist_dir = tmp_path / "dist"
+    dist_dir.mkdir()
+
+    result = subprocess.run(  # nosec B603
+        [
+            sys.executable,
+            "-m",
+            "build",
+            "--wheel",
+            "--sdist",
+            "--no-isolation",
+            "--outdir",
+            str(dist_dir),
+            str(package_source),
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+        env={
+            **os.environ,
+            "PIP_DISABLE_PIP_VERSION_CHECK": "1",
+            "PIP_NO_INDEX": "1",
+        },
+    )
+    _assert_subprocess_succeeded(result, "python -m build")
+
+    wheels = sorted(dist_dir.glob("mcp_unified-*.whl"))
+    sdists = sorted(dist_dir.glob("mcp_unified-*.tar.gz"))
+    assert len(wheels) == 1  # nosec B101
+    assert len(sdists) == 1  # nosec B101
+    return wheels[0], sdists[0]
+
+
+def _read_wheel_metadata(wheel: Path) -> Message:
+    """Read the wheel distribution metadata."""
+
+    with zipfile.ZipFile(wheel) as archive:
+        metadata_members = [
+            name
+            for name in archive.namelist()
+            if name.endswith(".dist-info/METADATA")
+        ]
+        assert len(metadata_members) == 1  # nosec B101
+        raw_metadata = archive.read(metadata_members[0]).decode("utf-8")
+
+    return Parser().parsestr(raw_metadata)
+
+
+def _read_wheel_entry_points(wheel: Path) -> configparser.ConfigParser:
+    """Read wheel entry points as a ConfigParser document."""
+
+    parser = configparser.ConfigParser()
+    with zipfile.ZipFile(wheel) as archive:
+        entry_point_members = [
+            name
+            for name in archive.namelist()
+            if name.endswith(".dist-info/entry_points.txt")
+        ]
+        assert len(entry_point_members) == 1  # nosec B101
+        parser.read_string(archive.read(entry_point_members[0]).decode("utf-8"))
+    return parser
+
+
+def _wheel_declared_dependency_names(distribution_metadata: Message) -> set[str]:
+    """Return normalized dependency names declared by wheel metadata."""
+
+    dependencies = distribution_metadata.get_all("Requires-Dist") or []
+    names: set[str] = set()
+    for dependency in dependencies:
+        match = REQUIRES_DIST_NAME_PATTERN.match(dependency)
+        assert match is not None  # nosec B101
+        names.add(match.group(1).lower().replace("_", "-"))
+    return names
+
+
+def _wheel_extra_dependency_names(
+    distribution_metadata: Message,
+) -> dict[str, set[str]]:
+    """Return normalized dependency names grouped by wheel extra marker."""
+
+    dependencies = distribution_metadata.get_all("Requires-Dist") or []
+    grouped: dict[str, set[str]] = {}
+    for dependency in dependencies:
+        extra_match = REQUIRES_DIST_EXTRA_PATTERN.search(dependency)
+        if extra_match is None:
+            continue
+        name_match = REQUIRES_DIST_NAME_PATTERN.match(dependency)
+        assert name_match is not None  # nosec B101
+        grouped.setdefault(extra_match.group(1), set()).add(
+            name_match.group(1).lower().replace("_", "-")
+        )
+    return grouped
+
+
+def _read_sdist_members(sdist: Path) -> set[str]:
+    """Return normalized member names from a standalone source distribution."""
+
+    with tarfile.open(sdist, "r:gz") as archive:
+        return {member.name for member in archive.getmembers()}
 
 
 def test_subprocess_failure_assertion_includes_captured_output() -> None:
@@ -278,6 +405,81 @@ def test_mcp_unified_standalone_pyproject_matches_release_metadata() -> None:
         standalone_dependency_names.update(_dependency_names(dependencies))
 
     assert forbidden_dependency_names.isdisjoint(standalone_dependency_names)
+
+
+def test_mcp_unified_standalone_distribution_metadata_matches_extras(
+    tmp_path: Path,
+) -> None:
+    """Built standalone artifacts must preserve the package-local extras contract."""
+
+    metadata = importlib.import_module("mcp_unified.package_metadata")
+    wheel, _sdist = _build_standalone_distributions(tmp_path)
+    distribution_metadata = _read_wheel_metadata(wheel)
+    entry_points = _read_wheel_entry_points(wheel)
+
+    assert distribution_metadata["Name"] == metadata.PACKAGE_NAME  # nosec B101
+    assert distribution_metadata["Version"] == mcp_unified.__version__  # nosec B101
+    assert set(distribution_metadata.get_all("Provides-Extra")) == set(
+        metadata.OPTIONAL_EXTRAS
+    )  # nosec B101
+    assert _wheel_extra_dependency_names(distribution_metadata) == {
+        extra: set(dependencies)
+        for extra, dependencies in metadata.OPTIONAL_EXTRAS.items()
+    }  # nosec B101
+    assert (
+        entry_points["console_scripts"]["mcp-unified-gateway"]
+        == "mcp_unified.gateway.cli:main"
+    )  # nosec B101
+
+    forbidden_dependency_names = {
+        "chromadb",
+        "docling",
+        "faster-whisper",
+        "gradio",
+        "llama-cpp-python",
+        "nemo-toolkit",
+        "next",
+        "qwen",
+        "torch",
+        "tts",
+        "yt-dlp",
+    }
+    assert forbidden_dependency_names.isdisjoint(
+        _wheel_declared_dependency_names(distribution_metadata)
+    )  # nosec B101
+
+
+def test_mcp_unified_standalone_sdist_contains_only_package_boundary(
+    tmp_path: Path,
+) -> None:
+    """Built standalone sdist must not include the host server package tree."""
+
+    _wheel, sdist = _build_standalone_distributions(tmp_path)
+    members = _read_sdist_members(sdist)
+
+    assert any(member.endswith("/pyproject.toml") for member in members)  # nosec B101
+    assert any(member.endswith("/__init__.py") for member in members)  # nosec B101
+    assert any(member.endswith("/gateway/cli.py") for member in members)  # nosec B101
+    assert not any("/tldw_Server_API/" in member for member in members)  # nosec B101
+    assert not any("/apps/tldw-frontend/" in member for member in members)  # nosec B101
+
+
+def test_pypi_workflow_runs_mcp_unified_standalone_artifact_gate() -> None:
+    """PyPI validation workflow must also gate package-local mcp_unified changes."""
+
+    workflow = (
+        PACKAGE_ROOT.parent / ".github" / "workflows" / "pypi-package.yml"
+    ).read_text(encoding="utf-8")
+
+    expected_fragments = (
+        "mcp_unified/**",
+        "make pypi-check",
+        "Upload dist artifacts",
+        "test_mcp_unified_standalone_distribution_metadata_matches_extras",
+        "test_mcp_unified_standalone_sdist_contains_only_package_boundary",
+    )
+    for fragment in expected_fragments:
+        assert fragment in workflow  # nosec B101
 
 
 @pytest.mark.smoke


### PR DESCRIPTION
## Implementation summary

Adds a package-local MCP Unified artifact gate for the experimental standalone package boundary.

- Builds the `mcp_unified` wheel and sdist from `mcp_unified/pyproject.toml` with `python -m build --no-isolation`.
- Validates wheel metadata for package name, version, console script, optional extras, and forbidden root-only dependency leakage.
- Validates the sdist includes only the package boundary and not host application trees.
- Updates the PyPI Package Check workflow so `mcp_unified/**` changes trigger the focused artifact gate before the existing root `tldw-server` package build/check/upload path.
- Documents the new gate while keeping the package release status as internal/experimental and unpublished.

## Verification

- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py tldw_Server_API/app/core/MCP_unified/tests/test_gateway_cli_package.py -q`
  - `99 passed, 5 warnings`
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py -ll -f json -o /tmp/bandit_mcp_standalone_extras_ci_gate_medium.json`
  - `0` medium/high findings
- `git diff --check`
  - clean

## Merge note

Repo policy requires the human requester to provide the merge-ready `Change summary` explaining what changed and why those implementation choices were made.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a package-local artifact gate for the experimental `mcp_unified` standalone package and wires it into the PyPI Package Check workflow to block boundary regressions without publishing. Builds and validates wheel/sdist metadata, extras, and sdist contents.

- **New Features**
  - Build `mcp_unified` wheel/sdist via `python -m build --no-isolation` from `mcp_unified/pyproject.toml`; validate name/version, `mcp-unified-gateway` entry point, extras mapping, forbid root-only deps, and ensure sdist only contains the `mcp_unified` boundary.
  - Update `.github/workflows/pypi-package.yml` to watch `mcp_unified/**`, install `-e "mcp_unified[dev]"`, run the focused artifact-gate tests, then run root `make pypi-check`; keep artifact upload.
  - Add a CI-contract test enforcing the path triggers and gate steps; docs now include the local gate command and note publishing remains disabled.

- **Bug Fixes**
  - Hardened tests: fail if build tools are missing, build artifacts once via a shared fixture, parse workflow YAML structurally, handle `Provides-Extra` null-safely, and guard workflow-file reads.

<sup>Written for commit dfdd8f9d34a2b56a8b8e817653a6582c58b42cf6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2235?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

