### PR TITLE
chore(onboarding): close sprint backlog tasks

### DIFF
--- a/backlog/tasks/task-583 - Design-onboarding-confidence-flow-follow-up.md
+++ b/backlog/tasks/task-583 - Design-onboarding-confidence-flow-follow-up.md
@@ -1,18 +1,24 @@
 ---
 id: TASK-583
 title: Design onboarding confidence flow follow-up
-status: In Progress
+status: Done
+assignee: []
+created_date: ''
+updated_date: '2026-06-03 04:21'
 labels:
-- onboarding
-- webui
-- setup
-priority: High
+  - onboarding
+  - webui
+  - setup
+dependencies: []
 documentation:
-- Docs/superpowers/specs/2026-06-01-onboarding-confidence-flow-design.md
-- Docs/superpowers/plans/2026-06-01-onboarding-confidence-flow-implementation-plan.md
+  - Docs/superpowers/specs/2026-06-01-onboarding-confidence-flow-design.md
+  - >-
+    Docs/superpowers/plans/2026-06-01-onboarding-confidence-flow-implementation-plan.md
 modified_files:
-- Docs/superpowers/specs/2026-06-01-onboarding-confidence-flow-design.md
-- Docs/superpowers/plans/2026-06-01-onboarding-confidence-flow-implementation-plan.md
+  - Docs/superpowers/specs/2026-06-01-onboarding-confidence-flow-design.md
+  - >-
+    Docs/superpowers/plans/2026-06-01-onboarding-confidence-flow-implementation-plan.md
+priority: high
 ---
 
 ## Description
@@ -23,30 +29,32 @@ Design the next unified solo onboarding follow-up PR: manual provider validation
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Design spec captures the approved four-stage order: provider validation, readiness panel, first-chat recovery, first-source milestone.
-- [ ] #2 Spec explicitly preserves current dev readiness architecture and avoids resurrecting stale branch deletions.
-- [ ] #3 Spec defines staged commits/tasks and test expectations for the eventual one-PR implementation.
-- [ ] #4 Backlog task references the written spec and records review/verification status.
+- [x] #1 Design spec captures the approved four-stage order: provider validation, readiness panel, first-chat recovery, first-source milestone.
+- [x] #2 Spec explicitly preserves current dev readiness architecture and avoids resurrecting stale branch deletions.
+- [x] #3 Spec defines staged commits/tasks and test expectations for the eventual one-PR implementation.
+- [x] #4 Backlog task references the written spec and records review/verification status.
 <!-- AC:END -->
 
 ## Implementation Notes
 
+<!-- SECTION:NOTES:BEGIN -->
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
 ['Design spec written and marked ready for user review.', 'Local review completed against approved sequence: provider validation, readiness panel, first-chat recovery, first-source milestone.', 'Subagent spec review not run because available subagent tooling is restricted to explicit user-requested delegation in this session.', 'Verification: git diff --cached --check passed for staged documentation/task changes.', 'Bandit: skipped because this commit changes only documentation and Backlog task metadata.', 'Follow-up review found and addressed validation-gate deadlock for syntax-only hosted providers by distinguishing ready vs accepted validation results.', 'Follow-up review found and addressed first-source readiness risk by requiring queryable/source readiness before offering a grounded question.', 'Follow-up review narrowed provider save semantics so persistence status is not overloaded with validation status.', 'Implementation plan written with four staged commits, exact touched files, TDD steps, focused verification commands, UAT checklist, and cleanup requirements.', 'Plan review subagent not run because available subagent tooling requires explicit user-requested delegation in this session.', 'Local plan review adjusted execution details: validate-first happy path preserves validation across safe key clearing, first-source ask action must not overclaim readiness, and exact verification commands now keep venv/workdir requirements explicit.']
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
+<!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-
+Closed the onboarding confidence-flow design task after the implementation sprint completed. The design and implementation plan captured the approved provider validation, readiness panel, first-chat recovery, and first-source milestone sequence; preserved the current dev readiness architecture; defined staged commits and verification expectations; and fed the completed implementation in TASK-584.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->

--- a/backlog/tasks/task-605 - Implement-solo-onboarding-local-model-guided-alternative-V2.md
+++ b/backlog/tasks/task-605 - Implement-solo-onboarding-local-model-guided-alternative-V2.md
@@ -1,28 +1,37 @@
 ---
 id: TASK-605
 title: Implement solo onboarding local model guided alternative V2
-status: In Progress
+status: Done
+assignee: []
+created_date: ''
+updated_date: '2026-06-03 04:21'
+labels: []
+dependencies: []
 references:
-- https://github.com/rmusser01/tldw_server/pull/2227
-- https://github.com/rmusser01/tldw_server/pull/2236
+  - 'https://github.com/rmusser01/tldw_server/pull/2227'
+  - 'https://github.com/rmusser01/tldw_server/pull/2236'
 documentation:
-- Docs/superpowers/specs/2026-06-02-solo-onboarding-v2-roadmap-design.md
+  - Docs/superpowers/specs/2026-06-02-solo-onboarding-v2-roadmap-design.md
 modified_files:
-- Docs/superpowers/plans/2026-06-03-solo-onboarding-local-model-v2-plan.md
-- apps/packages/ui/src/components/Option/Onboarding/__tests__/ProviderSetupStep.test.tsx
-- apps/packages/ui/src/components/Option/Onboarding/steps/ProviderSetupStep.tsx
-- apps/tldw-frontend/e2e/onboarding-uat/helpers.ts
-- apps/tldw-frontend/e2e/onboarding-uat/mock-openai/configs/local-model-unavailable.json
-- apps/tldw-frontend/e2e/onboarding-uat/mock-openai/configs/local-models-unavailable.json
-- apps/tldw-frontend/e2e/onboarding-uat/playwright.config.ts
-- apps/tldw-frontend/e2e/onboarding-uat/recovery.spec.ts
-- apps/tldw-frontend/e2e/onboarding-uat/scenarios.ts
-- apps/tldw-frontend/e2e/onboarding-uat/setup-happy-path.spec.ts
-- apps/tldw-frontend/scripts/__tests__/onboarding-uat-runner.test.ts
-- apps/tldw-frontend/scripts/onboarding-uat/run.mjs
-- tldw_Server_API/app/core/Setup/provider_validation.py
-- tldw_Server_API/tests/Setup/test_setup_provider_validation.py
-- backlog/tasks/task-605 - Implement-solo-onboarding-local-model-guided-alternative-V2.md
+  - Docs/superpowers/plans/2026-06-03-solo-onboarding-local-model-v2-plan.md
+  - >-
+    apps/packages/ui/src/components/Option/Onboarding/__tests__/ProviderSetupStep.test.tsx
+  - apps/packages/ui/src/components/Option/Onboarding/steps/ProviderSetupStep.tsx
+  - apps/tldw-frontend/e2e/onboarding-uat/helpers.ts
+  - >-
+    apps/tldw-frontend/e2e/onboarding-uat/mock-openai/configs/local-model-unavailable.json
+  - >-
+    apps/tldw-frontend/e2e/onboarding-uat/mock-openai/configs/local-models-unavailable.json
+  - apps/tldw-frontend/e2e/onboarding-uat/playwright.config.ts
+  - apps/tldw-frontend/e2e/onboarding-uat/recovery.spec.ts
+  - apps/tldw-frontend/e2e/onboarding-uat/scenarios.ts
+  - apps/tldw-frontend/e2e/onboarding-uat/setup-happy-path.spec.ts
+  - apps/tldw-frontend/scripts/__tests__/onboarding-uat-runner.test.ts
+  - apps/tldw-frontend/scripts/onboarding-uat/run.mjs
+  - tldw_Server_API/app/core/Setup/provider_validation.py
+  - tldw_Server_API/tests/Setup/test_setup_provider_validation.py
+  - >-
+    backlog/tasks/task-605 - Implement-solo-onboarding-local-model-guided-alternative-V2.md
 ---
 
 ## Description
@@ -43,6 +52,7 @@ Docs/superpowers/plans/2026-06-03-solo-onboarding-local-model-v2-plan.md
 
 ## Implementation Notes
 
+<!-- SECTION:NOTES:BEGIN -->
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
 Stage 2 complete. Added backend manual-model fallback for reachable local OpenAI-compatible endpoints when model discovery is unavailable. Red run before implementation: 2 new provider validation tests failed as expected. Green verification: source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tldw_Server_API/tests/Setup/test_setup_provider_validation.py -q -> 28 passed, 6 warnings.
 
@@ -52,6 +62,9 @@ Stage 4 complete. Added explicit local-provider UAT scenarios for discovered mod
 
 Stage 5 verification complete. Focused verification: bunx vitest run scripts/__tests__/onboarding-uat-runner.test.ts --reporter=dot -> 27 passed; bunx vitest run ../packages/ui/src/components/Option/Onboarding/__tests__/ProviderSetupStep.test.tsx --reporter=dot -> 22 passed; source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tldw_Server_API/tests/Setup/test_setup_provider_validation.py -q -> 28 passed, 6 warnings; Bandit touched setup scope -> 0 findings in /tmp/bandit_onboarding_local_model_v2.json; git diff --check -> clean. Draft PR opened at https://github.com/rmusser01/tldw_server/pull/2236. Worktree status has two unrelated untracked watchlist template files left untouched.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+Closeout: PR #2236 merged into dev at c26155476aed188c4fbd7870287a740451c27e59. The review follow-up rebased the PR onto latest dev, addressed local OpenAI-compatible /v1/models validation parity and non-default manual-model recovery, preserved the four-commit structure, and verified focused backend/frontend/UAT checks before merge.
+<!-- SECTION:NOTES:END -->
 
 ## Final Summary
 


### PR DESCRIPTION
## Summary
- Mark TASK-583 onboarding confidence-flow design as Done after its implementation sprint completed.
- Mark TASK-605 local-model onboarding implementation as Done and record PR #2236 merge closeout.

## Test Plan
- `git diff --check`
- Bandit/app tests not applicable: backlog metadata only.

## Change summary
This closes stale onboarding sprint bookkeeping after the implementation PRs merged. The only files changed are Backlog task records; no product code or tests are modified.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Close out onboarding sprint bookkeeping by marking TASK-583 and TASK-605 as Done and updating acceptance/DoD checklists, final summaries, and verification notes. Backlog task markdown only; no product code or tests changed.

<sup>Written for commit f2c3be9dae8877c9b99a9fbe2cc1c85a1b84d54d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2240?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

