### PR TITLE
test: document MCP docs assertion nosec rationale

### DIFF
--- a/backlog/tasks/task-2229 - Address-MCP-package-docs-PR-review-comments.md
+++ b/backlog/tasks/task-2229 - Address-MCP-package-docs-PR-review-comments.md
@@ -2,10 +2,14 @@
 id: TASK-2229
 title: Address MCP package docs PR review comments
 status: Done
+assignee: []
+created_date: ''
+updated_date: 2026-06-03 04:54
 labels:
 - mcp-unified
 - review
 - docs
+dependencies: []
 priority: medium
 modified_files:
 - tldw_Server_API/app/core/MCP_unified/tests/test_gateway_cli_package.py
@@ -24,9 +28,11 @@ Verify PR review comments after rebasing the MCP package docs PR on latest dev. 
 
 ## Implementation Notes
 
+<!-- SECTION:NOTES:BEGIN -->
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
 
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
+<!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
@@ -36,10 +42,10 @@ Rebased PR branch on latest dev; branch was already up to date. Fixed the still-
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->

--- a/backlog/tasks/task-2229 - Address-MCP-package-docs-PR-review-comments.md
+++ b/backlog/tasks/task-2229 - Address-MCP-package-docs-PR-review-comments.md
@@ -1,0 +1,45 @@
+---
+id: TASK-2229
+title: Address MCP package docs PR review comments
+status: Done
+labels:
+- mcp-unified
+- review
+- docs
+priority: medium
+modified_files:
+- tldw_Server_API/app/core/MCP_unified/tests/test_gateway_cli_package.py
+- backlog/tasks/task-2229 - Address-MCP-package-docs-PR-review-comments.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Verify PR review comments after rebasing the MCP package docs PR on latest dev. Fix still-valid review feedback with minimal changes and document skipped comments with the verification reason.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Rebased PR branch on latest dev; branch was already up to date. Fixed the still-valid Qodo review item by documenting why pytest assertions retain nosec B101. Skipped the Gemini workflow-nodeid item as already addressed in current code. Verified targeted docs test, package boundary/CLI tests, isolated artifact-gate tests, git diff --check, and Bandit medium+ on the touched test file.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_cli_package.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_cli_package.py
@@ -2050,6 +2050,7 @@ def test_standalone_gateway_docs_describe_package_release_gate() -> None:
     assert "GPL-3.0-only" in docs
     assert "internal/experimental" in docs
     assert "names-only" in docs
+    # These are pytest assertions; nosec keeps Bandit B101 from flagging test checks.
     assert "py.typed" in docs  # nosec B101
     assert "PEP 561" in docs  # nosec B101
     assert "not a separately published standalone package" in docs


### PR DESCRIPTION
Change summary:
- Adds an explicit rationale before the package-release docs assertions that retain # nosec B101.
- Keeps the existing pytest assertion style while documenting why Bandit B101 is suppressed in this test.
- Records the review follow-up in Backlog.md TASK-2229.

Review handling:
- Fixed Qodo thread about unjustified # nosec B101 in test_standalone_gateway_docs_describe_package_release_gate().
- Skipped the Gemini workflow-nodeid thread as no longer valid: the current PyPI workflow includes test_mcp_unified_standalone_artifacts_include_typed_marker and test_mcp_unified_standalone_artifacts_include_package_docs.

Verification:
- python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_gateway_cli_package.py::test_standalone_gateway_docs_describe_package_release_gate -q: 1 passed
- python -m pytest -c mcp_unified/pytest-artifact-gate.ini .github/tests/test_mcp_unified_artifact_gate.py::test_mcp_unified_standalone_artifacts_include_typed_marker .github/tests/test_mcp_unified_artifact_gate.py::test_mcp_unified_standalone_artifacts_include_package_docs -q: 2 passed
- git diff --check: passed
- python -m bandit -r tldw_Server_API/app/core/MCP_unified/tests/test_gateway_cli_package.py --severity-level medium -f json -o /tmp/bandit_mcp_package_docs_review_rebase_medium.json: no medium+ findings

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add an inline comment in the MCP package docs gate test explaining why pytest assertions keep `# nosec B101`, clarifying the Bandit suppression; no functional changes. Closes review feedback in `TASK-2229` and adds a backlog note recording the decision.

<sup>Written for commit 9857a47a7141627629f8f6672da424076287e339. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2246?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

