### PR TITLE
Add MCP filesystem helper tools

### DIFF
--- a/Docs/superpowers/plans/2026-06-04-mcp-filesystem-helper-tools-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-06-04-mcp-filesystem-helper-tools-implementation-plan.md
@@ -4,7 +4,7 @@
 
 **Goal:** Add workspace-bounded, cross-platform `fs.stat`, `fs.glob`, and `fs.grep` MCP tools as the first native filesystem helper slice after profile tooling discovery.
 
-**Architecture:** Extend the existing `FilesystemModule` so all helpers reuse the current workspace-root resolver, path containment checks, argument validation, and `asyncio.to_thread` offloading. Implement portable glob/search logic in Python rather than delegating to OS shell commands, and update profile metadata so read-capable default profiles can discover the new helpers.
+**Architecture:** Extend the existing `FilesystemModule` so all helpers reuse the current workspace-root resolver, path containment checks, argument validation, and `asyncio.to_thread` offloading. Implement portable glob/search logic in Python rather than delegating to OS shell commands, and update profile metadata so read-capable default profiles can discover the new helpers. The existing governed `run(command=...)` command runtime remains the shell-shaped surface; `bash`/`shell` compatibility aliases and CLI aliases for these helpers are a follow-up task, not part of this native-tool slice.
 
 **Tech Stack:** Python 3.11, FastAPI-side MCP module framework, `pathlib`, `os.walk`, `fnmatch`, `re`, pytest, Bandit.
 
@@ -24,6 +24,10 @@
   - Add a short filesystem helper note under profile/tool discovery docs.
 - Modify `backlog/tasks/<task>.md`
   - Track implementation notes, verification, final summary, and Definition of Done for the implementation task created before coding.
+- Follow-up, not this slice: `tldw_Server_API/app/core/MCP_unified/modules/implementations/run_command_module.py`,
+  `tldw_Server_API/app/core/MCP_unified/command_runtime/registry.py`,
+  `tldw_Server_API/app/core/MCP_unified/command_runtime/adapters.py`, and
+  command-runtime tests for governed CLI aliases.
 
 ## Task 0: Backlog And Baseline
 
@@ -134,6 +138,8 @@ Add tests that call `validate_tool_arguments()` directly for:
 - booleans must be booleans,
 - limits must be positive integers,
 - include/exclude must be lists of strings for `fs.grep`.
+- regex patterns above the configured maximum length are rejected before
+  compilation.
 
 - [ ] **Step 5: Run validation tests and verify RED**
 
@@ -156,6 +162,9 @@ Update `validate_tool_arguments()` with explicit allowed-key sets:
 - `fs.grep`: `pattern`, `base_path`, `include`, `exclude`, `regex`,
   `case_sensitive`, `include_hidden`, `follow_symlinks`, `limit`,
   `max_file_bytes`
+
+Do not expose walk-limit settings as caller arguments. Read them from module
+settings so users cannot raise traversal limits through a tool call.
 
 - [ ] **Step 7: Run Task 1 tests and verify GREEN**
 
@@ -265,8 +274,13 @@ Add tests for:
 - `case_sensitive=False` matches mixed-case file names,
 - hidden files are excluded by default and included when requested,
 - result limit sets `truncated=True` and `remaining_count`,
+- traversal cap stops broad walks even when the result limit is not reached,
 - absolute, drive-qualified, UNC, and parent-traversal patterns are rejected,
-- symlinked directories are not followed by default.
+- symlinked directories are not followed by default,
+- symlinked directories that resolve outside the workspace are rejected when
+  `follow_symlinks=true`,
+- hidden means a dot-prefixed workspace-relative segment, not platform hidden
+  attributes.
 
 - [ ] **Step 2: Run glob tests and verify RED**
 
@@ -288,6 +302,7 @@ Add helper methods:
 - `_portable_pattern_matches(path: str, pattern: str, *, case_sensitive: bool) -> bool`
 - `_is_hidden_relative_path(path: str) -> bool`
 - `_bounded_positive_int(value: Any, default: int) -> int`
+- `_setting_positive_int(name: str, default: int) -> int`
 
 Reject:
 
@@ -296,6 +311,10 @@ Reject:
 - Windows drive prefixes like `C:/...`,
 - UNC roots like `//server/share`,
 - `..` path segments.
+
+Use `_setting_positive_int()` for `glob_result_limit`,
+`glob_walk_entry_limit`, `grep_result_limit`, `grep_walk_entry_limit`,
+`grep_max_file_bytes`, and `grep_max_pattern_length`.
 
 - [ ] **Step 4: Implement `fs.glob` dispatch and worker**
 
@@ -310,6 +329,8 @@ For each candidate:
 - match with `_portable_pattern_matches()` so `**/*.py` matches both `app.py`
   and `pkg/app.py`,
 - lower pattern and candidate only when `case_sensitive=false`,
+- increment a visited-entry counter and stop with `truncated=True` once
+  `glob_walk_entry_limit` is reached,
 - sort by path,
 - return records capped by `limit`.
 
@@ -350,6 +371,12 @@ Add tests for:
 - oversized files are skipped without full read,
 - include/exclude glob filters apply,
 - limit truncates matches deterministically.
+- traversal cap stops broad walks deterministically,
+- overly long regex patterns raise a validation error,
+- invalid regex patterns return an actionable error without reading files,
+- symlinked files outside the workspace are rejected or skipped without leaking
+  targets,
+- symlink loops cannot cause unbounded traversal.
 
 - [ ] **Step 2: Run grep tests and verify RED**
 
@@ -379,6 +406,8 @@ Only files are searched.
 
 Implementation requirements:
 
+- reject overly long regex patterns before compiling,
+- report `re.error` messages as actionable tool errors,
 - read bytes only after checking file size,
 - skip NUL-containing files as binary,
 - decode UTF-8 only,
@@ -386,6 +415,8 @@ Implementation requirements:
 - default literal search via `str.find`,
 - regex search via compiled `re.Pattern`,
 - sort by normalized path and line number,
+- increment a visited-entry counter and stop with `truncated=True` once
+  `grep_walk_entry_limit` is reached,
 - cap returned matches by `limit`.
 
 - [ ] **Step 5: Run grep tests and verify GREEN**
@@ -405,6 +436,41 @@ Expected: PASS.
 git add tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_module.py tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_module.py
 git commit -m "feat: add portable workspace grep"
 ```
+
+## Follow-Up Task: Governed Shell Facade Aliases
+
+**Status:** Not part of this implementation branch. Create a separate Backlog
+task and branch after the native filesystem helpers are merged.
+
+**Goal:** Let models use familiar shell-shaped commands while the backend still
+routes every action through profile-granted MCP tools.
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/MCP_unified/modules/implementations/run_command_module.py`
+- Modify: `tldw_Server_API/app/core/MCP_unified/command_runtime/registry.py`
+- Modify: `tldw_Server_API/app/core/MCP_unified/command_runtime/adapters.py`
+- Modify: `tldw_Server_API/app/core/MCP_unified/tests/test_run_command_module.py`
+- Modify: `tldw_Server_API/app/core/MCP_unified/tests/test_command_runtime_registry.py`
+- Modify: `tldw_Server_API/app/core/MCP_unified/README.md`
+
+- [ ] Add a Backlog task such as `Add governed shell facade aliases`.
+- [ ] Keep `run` as the canonical MCP tool.
+- [ ] Optionally expose `bash` and/or `shell` as aliases that call the same
+  `RunCommandModule` implementation. Their descriptions must say they are
+  governed, shell-like facades and not host shell execution.
+- [ ] Add registry aliases after backing tools exist:
+  - `stat <path>` -> `fs.stat`
+  - `glob <pattern> [base]` or `find <pattern> [base]` -> `fs.glob`
+  - `rg <pattern> [base]` or `grep-files <pattern> [base]` -> `fs.grep`
+- [ ] Leave existing pure `grep` behavior unchanged for pipelines like
+  `cat app.log | grep ERROR`. Do not make hybrid stdin/file-backed `grep`
+  until command preflight can safely distinguish transform usage from backend
+  search usage.
+- [ ] Make aliases visible only when their backing MCP tools are executable for
+  the active profile.
+- [ ] Add tests for policy-filtered visibility, `run --help`, alias help/error
+  text, no raw shell delegation, and preservation of the existing presentation
+  footer/spill behavior.
 
 ## Task 5: Profile Metadata And Docs
 

--- a/Docs/superpowers/plans/2026-06-04-mcp-filesystem-helper-tools-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-06-04-mcp-filesystem-helper-tools-implementation-plan.md
@@ -314,7 +314,8 @@ Reject:
 
 Use `_setting_positive_int()` for `glob_result_limit`,
 `glob_walk_entry_limit`, `grep_result_limit`, `grep_walk_entry_limit`,
-`grep_max_file_bytes`, and `grep_max_pattern_length`.
+`grep_max_file_bytes`, `grep_max_total_bytes`, `grep_max_files`, and
+`grep_max_pattern_length`. Gate regex matching behind `grep_allow_regex`.
 
 - [ ] **Step 4: Implement `fs.glob` dispatch and worker**
 

--- a/Docs/superpowers/plans/2026-06-04-mcp-filesystem-helper-tools-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-06-04-mcp-filesystem-helper-tools-implementation-plan.md
@@ -1,0 +1,556 @@
+# MCP Filesystem Helper Tools Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add workspace-bounded, cross-platform `fs.stat`, `fs.glob`, and `fs.grep` MCP tools as the first native filesystem helper slice after profile tooling discovery.
+
+**Architecture:** Extend the existing `FilesystemModule` so all helpers reuse the current workspace-root resolver, path containment checks, argument validation, and `asyncio.to_thread` offloading. Implement portable glob/search logic in Python rather than delegating to OS shell commands, and update profile metadata so read-capable default profiles can discover the new helpers.
+
+**Tech Stack:** Python 3.11, FastAPI-side MCP module framework, `pathlib`, `os.walk`, `fnmatch`, `re`, pytest, Bandit.
+
+---
+
+## File Map
+
+- Modify `tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_module.py`
+  - Add tool definitions, argument validation, path/pattern helpers, and worker-thread implementations for `fs.stat`, `fs.glob`, and `fs.grep`.
+- Modify `tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_module.py`
+  - Add TDD coverage for descriptors, validation, cross-platform path behavior, limits, binary/encoding skips, symlink policy, and protocol unknown-argument rejection.
+- Modify `mcp_unified/profiles/presets.py`
+  - Add the new read-only filesystem helpers to `_FILES_READ_TOOLS`.
+- Modify `tldw_Server_API/app/core/MCP_unified/tests/test_profile_presets.py`
+  - Assert read-capable presets include/discover the new filesystem helpers in tooling metadata.
+- Modify `mcp_unified/USER_GUIDE.md`
+  - Add a short filesystem helper note under profile/tool discovery docs.
+- Modify `backlog/tasks/<task>.md`
+  - Track implementation notes, verification, final summary, and Definition of Done for the implementation task created before coding.
+
+## Task 0: Backlog And Baseline
+
+**Files:**
+- Modify: implementation Backlog task only.
+
+- [ ] **Step 1: Create or locate the implementation Backlog task**
+
+Use Backlog MCP search first with a query like
+`MCP filesystem helper tools fs.stat fs.glob fs.grep`. If MCP is unavailable,
+use the CLI fallback:
+
+```bash
+backlog search "MCP filesystem helper tools fs.stat fs.glob fs.grep" --plain
+```
+
+Expected: no duplicate active implementation task. If none exists, create a task titled `Implement MCP filesystem helper tools`.
+
+- [ ] **Step 2: Record baseline status**
+
+Run:
+
+```bash
+git status --short --branch
+```
+
+Expected: clean branch before implementation edits.
+
+- [ ] **Step 3: Read existing module and tests**
+
+Read:
+
+```bash
+sed -n '1,360p' tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_module.py
+sed -n '1,520p' tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_module.py
+```
+
+Expected: confirm existing `fs.list`, `fs.read_text`, and `fs.write_text` patterns.
+
+## Task 1: Tool Schemas And Validation
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_module.py`
+- Modify: `tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_module.py`
+
+- [ ] **Step 1: Write failing descriptor test**
+
+Add a test similar to:
+
+```python
+@pytest.mark.asyncio
+async def test_filesystem_tools_include_stat_glob_and_grep_metadata() -> None:
+    resolver = _FakeWorkspaceRootResolver({"workspace_root": "/workspace/root"})
+    mod = FilesystemModule(ModuleConfig(name="filesystem"), workspace_root_resolver=resolver)
+
+    tools = await mod.get_tools()
+    by_name = {tool["name"]: tool for tool in tools}
+
+    assert {"fs.stat", "fs.glob", "fs.grep"} <= set(by_name)
+    for tool_name in ("fs.stat", "fs.glob", "fs.grep"):
+        schema = by_name[tool_name]["inputSchema"]
+        metadata = by_name[tool_name]["metadata"]
+        assert schema["additionalProperties"] is False
+        assert metadata["uses_filesystem"] is True
+        assert metadata["path_boundable"] is True
+        assert "filesystem.read" in metadata["capabilities"]
+        assert metadata["readOnlyHint"] is True
+```
+
+- [ ] **Step 2: Run descriptor test and verify RED**
+
+Run:
+
+```bash
+source .venv/bin/activate
+python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_module.py::test_filesystem_tools_include_stat_glob_and_grep_metadata -q
+```
+
+Expected: FAIL because tools are not defined.
+
+- [ ] **Step 3: Add minimal tool definitions**
+
+In `get_tools()`, add descriptors for:
+
+- `fs.stat`
+- `fs.glob`
+- `fs.grep`
+
+Use metadata:
+
+```python
+{
+    "category": "retrieval",
+    "readOnlyHint": True,
+    "capabilities": ["filesystem.read"],
+    **shared_fs_metadata,
+}
+```
+
+Set `additionalProperties` to `False` for all three schemas.
+
+- [ ] **Step 4: Add validation tests for unknown and malformed arguments**
+
+Add tests that call `validate_tool_arguments()` directly for:
+
+- unknown keys rejected,
+- required `path`/`pattern` rejected when missing or blank,
+- booleans must be booleans,
+- limits must be positive integers,
+- include/exclude must be lists of strings for `fs.grep`.
+
+- [ ] **Step 5: Run validation tests and verify RED**
+
+Run:
+
+```bash
+source .venv/bin/activate
+python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_module.py -q -k "stat_glob_grep_metadata or validates_new_filesystem_helper_arguments"
+```
+
+Expected: FAIL until validation branches exist.
+
+- [ ] **Step 6: Implement validation branches**
+
+Update `validate_tool_arguments()` with explicit allowed-key sets:
+
+- `fs.stat`: `path`, `follow_symlinks`
+- `fs.glob`: `pattern`, `base_path`, `include_hidden`, `include_files`,
+  `include_directories`, `follow_symlinks`, `case_sensitive`, `limit`
+- `fs.grep`: `pattern`, `base_path`, `include`, `exclude`, `regex`,
+  `case_sensitive`, `include_hidden`, `follow_symlinks`, `limit`,
+  `max_file_bytes`
+
+- [ ] **Step 7: Run Task 1 tests and verify GREEN**
+
+Run:
+
+```bash
+source .venv/bin/activate
+python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_module.py -q -k "stat_glob_grep_metadata or validates_new_filesystem_helper_arguments"
+```
+
+Expected: PASS.
+
+- [ ] **Step 8: Commit Task 1**
+
+```bash
+git add tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_module.py tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_module.py
+git commit -m "feat: add mcp filesystem helper schemas"
+```
+
+## Task 2: `fs.stat`
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_module.py`
+- Modify: `tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_module.py`
+
+- [ ] **Step 1: Write failing stat behavior tests**
+
+Add tests for:
+
+- file stat returns `path`, `name`, `type == "file"`, `size`, and `is_symlink is False`,
+- directory stat returns `type == "directory"`,
+- missing path raises `FileNotFoundError`,
+- `../escape.txt` raises `PermissionError`,
+- symlink stat does not leak target path.
+
+Use exact permission masks only as optional presence checks. Do not assert
+platform-specific mode values.
+
+- [ ] **Step 2: Run stat tests and verify RED**
+
+Run:
+
+```bash
+source .venv/bin/activate
+python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_module.py -q -k "filesystem_stat"
+```
+
+Expected: FAIL because `fs.stat` is not implemented.
+
+- [ ] **Step 3: Implement `fs.stat` dispatch**
+
+In `execute_tool()`, add:
+
+```python
+if tool_name == "fs.stat":
+    target = self._resolve_workspace_path(workspace_root, str(args.get("path")))
+    return await asyncio.to_thread(
+        self._stat_path,
+        workspace_root,
+        target,
+        bool(args.get("follow_symlinks", False)),
+    )
+```
+
+- [ ] **Step 4: Implement `_stat_path()`**
+
+Implementation requirements:
+
+- use `target.lstat()` when not following symlinks,
+- use `target.stat()` only after verifying the resolved target stays inside
+  the workspace,
+- return workspace-relative `/` path,
+- never return symlink target text,
+- include `modified_at` as UTC ISO text when stat succeeds.
+
+- [ ] **Step 5: Run stat tests and verify GREEN**
+
+Run:
+
+```bash
+source .venv/bin/activate
+python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_module.py -q -k "filesystem_stat"
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit Task 2**
+
+```bash
+git add tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_module.py tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_module.py
+git commit -m "feat: add workspace bounded fs stat"
+```
+
+## Task 3: `fs.glob`
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_module.py`
+- Modify: `tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_module.py`
+
+- [ ] **Step 1: Write failing glob tests**
+
+Add tests for:
+
+- `pattern="**/*.py"` returns sorted `/`-separated paths,
+- backslash input patterns normalize to `/`,
+- `case_sensitive=True` is deterministic across OS,
+- `case_sensitive=False` matches mixed-case file names,
+- hidden files are excluded by default and included when requested,
+- result limit sets `truncated=True` and `remaining_count`,
+- absolute, drive-qualified, UNC, and parent-traversal patterns are rejected,
+- symlinked directories are not followed by default.
+
+- [ ] **Step 2: Run glob tests and verify RED**
+
+Run:
+
+```bash
+source .venv/bin/activate
+python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_module.py -q -k "filesystem_glob"
+```
+
+Expected: FAIL because `fs.glob` is not implemented.
+
+- [ ] **Step 3: Add portable pattern helpers**
+
+Add helper methods:
+
+- `_normalize_portable_pattern(pattern: str) -> str`
+- `_reject_unsafe_pattern(pattern: str) -> None`
+- `_portable_pattern_matches(path: str, pattern: str, *, case_sensitive: bool) -> bool`
+- `_is_hidden_relative_path(path: str) -> bool`
+- `_bounded_positive_int(value: Any, default: int) -> int`
+
+Reject:
+
+- blank patterns,
+- absolute POSIX paths,
+- Windows drive prefixes like `C:/...`,
+- UNC roots like `//server/share`,
+- `..` path segments.
+
+- [ ] **Step 4: Implement `fs.glob` dispatch and worker**
+
+Use `os.walk()` from the resolved `base_path`.
+
+For each candidate:
+
+- compute workspace-relative POSIX path,
+- skip hidden paths unless requested,
+- skip symlink traversal unless `follow_symlinks=true` and target remains in
+  scope,
+- match with `_portable_pattern_matches()` so `**/*.py` matches both `app.py`
+  and `pkg/app.py`,
+- lower pattern and candidate only when `case_sensitive=false`,
+- sort by path,
+- return records capped by `limit`.
+
+- [ ] **Step 5: Run glob tests and verify GREEN**
+
+Run:
+
+```bash
+source .venv/bin/activate
+python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_module.py -q -k "filesystem_glob"
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit Task 3**
+
+```bash
+git add tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_module.py tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_module.py
+git commit -m "feat: add portable workspace glob"
+```
+
+## Task 4: `fs.grep`
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_module.py`
+- Modify: `tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_module.py`
+
+- [ ] **Step 1: Write failing grep tests**
+
+Add tests for:
+
+- literal search returns path, 1-based line number, line text, and match text,
+- regex search works when `regex=true`,
+- `case_sensitive=false` matches mixed-case text,
+- CRLF/LF mixed newline files report stable line numbers,
+- binary files are skipped with `skipped["binary"]`,
+- invalid UTF-8 files are skipped with `skipped["decode_error"]`,
+- oversized files are skipped without full read,
+- include/exclude glob filters apply,
+- limit truncates matches deterministically.
+
+- [ ] **Step 2: Run grep tests and verify RED**
+
+Run:
+
+```bash
+source .venv/bin/activate
+python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_module.py -q -k "filesystem_grep"
+```
+
+Expected: FAIL because `fs.grep` is not implemented.
+
+- [ ] **Step 3: Implement grep file selection**
+
+Reuse the same portable pattern and directory walk helpers from `fs.glob`.
+
+Default:
+
+```python
+include = ["*", "**/*"]
+exclude = []
+```
+
+Only files are searched.
+
+- [ ] **Step 4: Implement grep matching**
+
+Implementation requirements:
+
+- read bytes only after checking file size,
+- skip NUL-containing files as binary,
+- decode UTF-8 only,
+- use `splitlines()` for cross-platform line handling,
+- default literal search via `str.find`,
+- regex search via compiled `re.Pattern`,
+- sort by normalized path and line number,
+- cap returned matches by `limit`.
+
+- [ ] **Step 5: Run grep tests and verify GREEN**
+
+Run:
+
+```bash
+source .venv/bin/activate
+python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_module.py -q -k "filesystem_grep"
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit Task 4**
+
+```bash
+git add tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_module.py tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_module.py
+git commit -m "feat: add portable workspace grep"
+```
+
+## Task 5: Profile Metadata And Docs
+
+**Files:**
+- Modify: `mcp_unified/profiles/presets.py`
+- Modify: `tldw_Server_API/app/core/MCP_unified/tests/test_profile_presets.py`
+- Modify: `mcp_unified/USER_GUIDE.md`
+
+- [ ] **Step 1: Write failing preset metadata test**
+
+Add a test:
+
+```python
+def test_filesystem_read_presets_include_helper_tools() -> None:
+    expected = {"fs.stat", "fs.glob", "fs.grep"}
+    for preset in list_builtin_presets():
+        tooling = preset.profile.metadata.get("tooling")
+        if not isinstance(tooling, dict):
+            continue
+        enabled_tools = set(tooling.get("enabled_tools") or [])
+        if {"fs.list", "fs.read_text"} <= enabled_tools:
+            assert expected <= enabled_tools
+```
+
+- [ ] **Step 2: Run metadata test and verify RED**
+
+Run:
+
+```bash
+source .venv/bin/activate
+python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_profile_presets.py::test_filesystem_read_presets_include_helper_tools -q
+```
+
+Expected: FAIL because helper tools are not in `_FILES_READ_TOOLS`.
+
+- [ ] **Step 3: Update `_FILES_READ_TOOLS`**
+
+In `mcp_unified/profiles/presets.py`, change:
+
+```python
+_FILES_READ_TOOLS = ["fs.list", "fs.read_text"]
+```
+
+to include:
+
+```python
+_FILES_READ_TOOLS = ["fs.list", "fs.read_text", "fs.stat", "fs.glob", "fs.grep"]
+```
+
+- [ ] **Step 4: Update package user guide**
+
+In `mcp_unified/USER_GUIDE.md`, add a short note that filesystem-capable
+profiles can inspect metadata, glob paths, and search UTF-8 text with
+workspace-bounded, cross-platform helpers.
+
+- [ ] **Step 5: Run preset/docs-adjacent tests**
+
+Run:
+
+```bash
+source .venv/bin/activate
+python -m pytest \
+  tldw_Server_API/app/core/MCP_unified/tests/test_profile_presets.py \
+  tldw_Server_API/app/core/MCP_unified/tests/test_gateway_tool_discovery.py \
+  -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit Task 5**
+
+```bash
+git add mcp_unified/profiles/presets.py mcp_unified/USER_GUIDE.md tldw_Server_API/app/core/MCP_unified/tests/test_profile_presets.py
+git commit -m "docs: expose filesystem helper tools to profiles"
+```
+
+## Task 6: Protocol, Security, And Final Verification
+
+**Files:**
+- Modify: implementation Backlog task only unless verification finds issues.
+
+- [ ] **Step 1: Run focused filesystem tests**
+
+```bash
+source .venv/bin/activate
+python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_module.py -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run profile/discovery regression tests**
+
+```bash
+source .venv/bin/activate
+python -m pytest \
+  tldw_Server_API/app/core/MCP_unified/tests/test_profile_presets.py \
+  tldw_Server_API/app/core/MCP_unified/tests/test_gateway_tool_discovery.py \
+  tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py \
+  -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Run package boundary test**
+
+```bash
+source .venv/bin/activate
+python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Run Bandit on touched code**
+
+```bash
+source .venv/bin/activate
+python -m bandit -r \
+  tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_module.py \
+  mcp_unified/profiles/presets.py \
+  -f json \
+  -o /tmp/bandit_mcp_filesystem_helpers.json
+```
+
+Expected: exit 0 or only known non-touched baseline findings. Fix new findings.
+
+- [ ] **Step 5: Run whitespace check**
+
+```bash
+git diff --check
+```
+
+Expected: no output, exit 0.
+
+- [ ] **Step 6: Update Backlog task**
+
+Record:
+
+- RED/GREEN test notes,
+- final verification command results,
+- Bandit result path,
+- platform-specific skips, if any,
+- final summary and DOD.
+
+- [ ] **Step 7: Final commit for task tracking if needed**
+
+```bash
+git add backlog/tasks/<task-file>.md
+git commit -m "docs: finalize mcp filesystem helper task"
+```

--- a/Docs/superpowers/specs/2026-06-04-mcp-filesystem-helper-tools-design.md
+++ b/Docs/superpowers/specs/2026-06-04-mcp-filesystem-helper-tools-design.md
@@ -11,6 +11,12 @@ process execution, shell globbing, or OS-specific command behavior. `fs.edit`
 and `fs.patch` remain separate follow-up work because write conflict handling,
 encoding preservation, and approval semantics need their own review.
 
+The existing governed `run(command=...)` virtual CLI is the right place for
+shell-shaped ergonomics. This filesystem slice should expose typed MCP tools
+first; command aliases such as `stat`, `find`/`glob`, `rg`, and optional
+`bash`/`shell` facade names should be handled as a follow-up over the governed
+command runtime, not by invoking a host shell.
+
 ## Goals
 
 - Provide portable filesystem inspection and text-search helpers for MCP/ACP
@@ -27,6 +33,8 @@ encoding preservation, and approval semantics need their own review.
 
 - No free-form shell, subprocess grep, `find`, PowerShell, or platform command
   delegation.
+- No new `bash`/`shell` tool alias in this implementation slice. A follow-up
+  may expose those names only as aliases for the governed `run` runtime.
 - No writes, patches, file deletion, renames, chmod/chown, or symlink creation.
 - No binary search, archive traversal, or repository indexing service.
 - No attempt to normalize filesystem case rules globally. The tools provide a
@@ -49,6 +57,14 @@ tool metadata used by policy/path-scope layers.
 
 This design extends that module rather than creating a second filesystem
 module.
+
+The codebase also already includes
+`tldw_Server_API/app/core/MCP_unified/modules/implementations/run_command_module.py`
+and `tldw_Server_API/app/core/MCP_unified/command_runtime/`. That runtime
+accepts CLI-shaped strings, parses pipes and chain operators, and routes
+commands through policy-checked MCP tool calls. It is intentionally not a raw
+host shell. New filesystem helpers should be designed so that a later command
+runtime task can safely map familiar command names to these typed tools.
 
 ## Tool Contracts
 
@@ -120,6 +136,9 @@ Matching behavior:
   cannot rely on raw `fnmatch.fnmatchcase` alone.
 - Absolute patterns, drive-qualified patterns, UNC-style roots, and parent
   traversal segments are rejected.
+- Directory traversal stops at a configurable `glob_walk_entry_limit` even
+  when the result limit has not been reached. This prevents a broad pattern
+  such as `**/*` from walking an unexpectedly large workspace forever.
 
 ### `fs.grep`
 
@@ -160,12 +179,15 @@ Search behavior:
 - Reads files as bytes, skips files containing NUL bytes, and decodes UTF-8.
 - Non-UTF-8 files are skipped with `decode_error`.
 - Literal search is the default. Regex search uses Python `re` with normal
-  module limits and bounded file size.
+  module limits, bounded pattern length, bounded file size, and explicit regex
+  compile-error responses.
 - Line numbers use universal newline handling via `splitlines()`, so CRLF,
   LF, and CR are reported consistently.
 - Results are sorted by normalized path and line number.
 - Include/exclude matching uses the same portable pattern helper as `fs.glob`,
   including `**/` matching zero or more directories.
+- Directory traversal stops at a configurable `grep_walk_entry_limit` even
+  when the match limit has not been reached.
 
 ## Cross-Platform Policy
 
@@ -180,10 +202,46 @@ All external MCP clients should see stable behavior independent of the host OS:
   escapes after normalization.
 - Case sensitivity is explicit. Defaults do not depend on NTFS, APFS, ext4, or
   network share behavior.
+- Hidden path handling is application-defined: a path is hidden when any
+  workspace-relative segment starts with `.`. The tools do not attempt to read
+  Windows hidden attributes or platform-specific metadata.
 - Symlink tests must handle platforms where symlink creation requires elevated
   privileges by using existing pytest skip patterns when necessary.
+- Symlink handling must cover symlinked files, symlinked directories, targets
+  outside the workspace, and loop avoidance. `follow_symlinks=true` is allowed
+  only after resolved targets are proven to stay within the workspace root.
 - File mode metadata is best-effort. Tests should assert stable fields such as
   path, type, and size, not exact platform-specific permission masks.
+
+## Governed Shell Facade Follow-Up
+
+The backend-lead note argues for a single CLI-shaped surface because models are
+good at composing terminal-like commands. This project already has that shape
+through `run(command=...)`: a parser/executor/presentation runtime that keeps
+pipe execution raw, applies truncation and binary guards only at presentation
+time, and routes backend actions through approved MCP tools.
+
+The safe follow-up is to improve that governed runtime rather than add real
+shell execution:
+
+- Keep `run` as the canonical tool name.
+- Optionally expose `bash` and/or `shell` as compatibility aliases that call
+  the same `RunCommandModule` implementation and clearly describe themselves
+  as governed, shell-like facades rather than host shells.
+- Add command aliases only after the typed tools exist, for example
+  `stat <path>` -> `fs.stat`, `glob <pattern> [base]` or
+  `find <pattern> [base]` -> `fs.glob`, and `rg <pattern> [base]` or
+  `grep-files <pattern> [base]` -> `fs.grep`.
+- Do not overload the existing pure `grep` command in this slice. It currently
+  filters stdin in pipelines. File-backed grep needs either a distinct command
+  name such as `rg`/`grep-files` or a later hybrid-command refactor that can
+  distinguish stdin transforms from backend filesystem searches during
+  preflight.
+- Keep command visibility policy-driven: aliases appear only when their backing
+  MCP tools are executable for the active profile.
+- Keep `--help`, usage errors, stderr, exit-code footer, spill handling, and
+  binary/truncation presentation behavior consistent with the existing command
+  runtime.
 
 ## Profile Metadata Changes
 
@@ -203,6 +261,7 @@ as read-only filesystem tools:
   filesystem.
 - Every candidate path must remain under the resolved workspace root.
 - Directory walks must have configurable caps to avoid unbounded traversal.
+- Regex mode must cap pattern length and return actionable compile errors.
 - Grep must not read files larger than its configured limit.
 - Binary and undecodable files are skipped, not returned partially.
 - Unknown arguments are rejected by both module validation and protocol
@@ -214,12 +273,18 @@ as read-only filesystem tools:
   `additionalProperties: false`.
 - Unit tests for `fs.stat` on files, directories, missing paths, and symlinks.
 - Unit tests for `fs.glob` deterministic sorting, limits, hidden handling,
-  case sensitivity, pattern validation, and workspace escape rejection.
+  case sensitivity, pattern validation, traversal caps, and workspace escape
+  rejection.
 - Unit tests for `fs.grep` literal search, regex search, UTF-8 handling,
-  binary/decode skips, file-size skips, result limits, and line numbering with
-  mixed newline styles.
+  binary/decode skips, file-size skips, regex pattern guards, result limits,
+  traversal caps, and line numbering with mixed newline styles.
+- Symlink regression tests for outside-workspace targets and symlinked
+  directory traversal behavior.
 - Protocol validation tests for unknown arguments.
 - Preset metadata test proving `_FILES_READ_TOOLS` exposes the new helpers.
+- Follow-up command-runtime tests should cover policy-filtered visibility and
+  help text for `stat`, `glob`/`find`, `rg`/`grep-files`, and any `bash`/`shell`
+  alias once that follow-up is implemented.
 - Cross-platform tests should avoid exact permission masks and skip symlink
   creation only when the OS denies it.
 

--- a/Docs/superpowers/specs/2026-06-04-mcp-filesystem-helper-tools-design.md
+++ b/Docs/superpowers/specs/2026-06-04-mcp-filesystem-helper-tools-design.md
@@ -150,7 +150,8 @@ Arguments:
 - `base_path: string` optional, default `"."`.
 - `include: list[string]` optional, default `["*", "**/*"]`.
 - `exclude: list[string]` optional, default `[]`.
-- `regex: boolean` optional, default `false`.
+- `regex: boolean` optional, default `false`; accepted only when the module
+  setting `grep_allow_regex` is enabled.
 - `case_sensitive: boolean` optional, default `true`.
 - `include_hidden: boolean` optional, default `false`.
 - `follow_symlinks: boolean` optional, default `false`.
@@ -158,6 +159,8 @@ Arguments:
   or `200`.
 - `max_file_bytes: integer` optional, capped by module setting
   `grep_max_file_bytes` or the current `max_read_bytes`.
+- Global scan limits come from module settings `grep_max_total_bytes`,
+  `grep_max_files`, and `grep_walk_entry_limit`.
 
 Response:
 
@@ -169,6 +172,10 @@ Response:
   - `match_text`
 - `truncated`: boolean.
 - `remaining_count`: count of additional matches skipped after the limit.
+- `remaining_count_known`: false when the scan stops early because a walk-entry,
+  file, or byte budget was exhausted.
+- `truncation_reasons`: zero or more of `walk_entry_limit`, `io_budget`,
+  `file_budget`, and `match_limit`.
 - `skipped`: counts for `binary`, `decode_error`, `too_large`,
   `permission_error`, and `unsupported_type`.
 

--- a/Docs/superpowers/specs/2026-06-04-mcp-filesystem-helper-tools-design.md
+++ b/Docs/superpowers/specs/2026-06-04-mcp-filesystem-helper-tools-design.md
@@ -1,0 +1,235 @@
+# MCP Filesystem Helper Tools Design
+
+## Summary
+
+Add the next native/default-included MCP filesystem helper slice to the existing
+workspace-bounded `FilesystemModule`: `fs.stat`, `fs.glob`, and `fs.grep`.
+
+This slice intentionally stays read-only. It expands discovery/search workflows
+for default role profiles without introducing edit/patch semantics, arbitrary
+process execution, shell globbing, or OS-specific command behavior. `fs.edit`
+and `fs.patch` remain separate follow-up work because write conflict handling,
+encoding preservation, and approval semantics need their own review.
+
+## Goals
+
+- Provide portable filesystem inspection and text-search helpers for MCP/ACP
+  workspaces.
+- Reuse the current workspace root resolver and path-scope enforcement.
+- Make behavior deterministic across macOS, Linux, Windows, containers, and
+  network-mounted workspaces.
+- Keep all new tools read-only and governed by the existing
+  `filesystem.read` capability metadata.
+- Update bundled profile metadata so read-capable profiles can discover the new
+  helpers.
+
+## Non-Goals
+
+- No free-form shell, subprocess grep, `find`, PowerShell, or platform command
+  delegation.
+- No writes, patches, file deletion, renames, chmod/chown, or symlink creation.
+- No binary search, archive traversal, or repository indexing service.
+- No attempt to normalize filesystem case rules globally. The tools provide a
+  deterministic application-level `case_sensitive` option instead.
+- No external MCP server installation or browser/CDP integration in this slice.
+
+## Existing Context
+
+`tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_module.py`
+already provides:
+
+- `fs.list`
+- `fs.read_text`
+- `fs.write_text`
+
+The module resolves a trusted workspace root through
+`McpHubWorkspaceRootResolver`, rejects path escapes, offloads blocking file I/O
+with `asyncio.to_thread`, rejects binary text reads, caps large reads, and emits
+tool metadata used by policy/path-scope layers.
+
+This design extends that module rather than creating a second filesystem
+module.
+
+## Tool Contracts
+
+### `fs.stat`
+
+Purpose: return metadata for one workspace-scoped path.
+
+Arguments:
+
+- `path: string` required.
+- `follow_symlinks: boolean` optional, default `false`.
+
+Response:
+
+- `path`: workspace-relative path using `/` separators.
+- `name`: final path segment.
+- `type`: `file`, `directory`, `symlink`, or `other`.
+- `size`: byte size when available.
+- `modified_at`: UTC ISO timestamp when available.
+- `mode`: permission bits as an integer when available.
+- `is_symlink`: boolean.
+- `target_within_workspace`: boolean only when `follow_symlinks=true` or when
+  the platform exposes enough symlink metadata without leaking the target.
+
+Security behavior:
+
+- Does not return a symlink target path.
+- If `follow_symlinks=true`, the resolved target must remain inside the
+  workspace root or the call fails with `PermissionError`.
+- If `follow_symlinks=false`, metadata is gathered with non-following stat
+  behavior where the platform supports it.
+
+### `fs.glob`
+
+Purpose: enumerate workspace-relative paths matching a portable pattern.
+
+Arguments:
+
+- `pattern: string` required. Portable patterns use `/` separators. Backslashes
+  are accepted as separators and normalized before matching.
+- `base_path: string` optional, default `"."`.
+- `include_hidden: boolean` optional, default `false`.
+- `include_files: boolean` optional, default `true`.
+- `include_directories: boolean` optional, default `true`.
+- `follow_symlinks: boolean` optional, default `false`.
+- `case_sensitive: boolean` optional, default `true`.
+- `limit: integer` optional, default from module setting `glob_result_limit`
+  or `500`.
+
+Response:
+
+- `base_path`: normalized workspace-relative base path.
+- `pattern`: normalized portable pattern.
+- `matches`: sorted list of `{path, type, size?}` records.
+- `truncated`: boolean.
+- `remaining_count`: count of additional matches skipped after the limit.
+
+Matching behavior:
+
+- Implemented in Python using `os.walk`, `fnmatch.fnmatchcase`, and normalized
+  POSIX-style relative paths. It must not invoke a shell or rely on
+  platform-native glob behavior.
+- Matching is deterministic by default: `case_sensitive=true` means exact
+  string matching on every OS, including Windows and default macOS filesystems.
+- `case_sensitive=false` lowercases both the candidate path and pattern before
+  matching.
+- `**` is supported through a small wrapper around `fnmatch`. Patterns such as
+  `**/*.py` must match both `app.py` and `pkg/app.py`, so the implementation
+  cannot rely on raw `fnmatch.fnmatchcase` alone.
+- Absolute patterns, drive-qualified patterns, UNC-style roots, and parent
+  traversal segments are rejected.
+
+### `fs.grep`
+
+Purpose: search UTF-8 text files under a workspace-scoped base path.
+
+Arguments:
+
+- `pattern: string` required.
+- `base_path: string` optional, default `"."`.
+- `include: list[string]` optional, default `["*", "**/*"]`.
+- `exclude: list[string]` optional, default `[]`.
+- `regex: boolean` optional, default `false`.
+- `case_sensitive: boolean` optional, default `true`.
+- `include_hidden: boolean` optional, default `false`.
+- `follow_symlinks: boolean` optional, default `false`.
+- `limit: integer` optional, default from module setting `grep_result_limit`
+  or `200`.
+- `max_file_bytes: integer` optional, capped by module setting
+  `grep_max_file_bytes` or the current `max_read_bytes`.
+
+Response:
+
+- `base_path`: normalized workspace-relative base path.
+- `matches`: sorted list of match records:
+  - `path`
+  - `line_number` (1-based)
+  - `line`
+  - `match_text`
+- `truncated`: boolean.
+- `remaining_count`: count of additional matches skipped after the limit.
+- `skipped`: counts for `binary`, `decode_error`, `too_large`,
+  `permission_error`, and `unsupported_type`.
+
+Search behavior:
+
+- Implemented in Python. No shell, subprocess, ripgrep, GNU grep, BSD grep, or
+  PowerShell dependency.
+- Reads files as bytes, skips files containing NUL bytes, and decodes UTF-8.
+- Non-UTF-8 files are skipped with `decode_error`.
+- Literal search is the default. Regex search uses Python `re` with normal
+  module limits and bounded file size.
+- Line numbers use universal newline handling via `splitlines()`, so CRLF,
+  LF, and CR are reported consistently.
+- Results are sorted by normalized path and line number.
+- Include/exclude matching uses the same portable pattern helper as `fs.glob`,
+  including `**/` matching zero or more directories.
+
+## Cross-Platform Policy
+
+All external MCP clients should see stable behavior independent of the host OS:
+
+- Public paths use `/` separators in responses.
+- Inputs accept `/` on every OS; backslashes are normalized as separators for
+  compatibility.
+- Windows drive prefixes, UNC roots, and POSIX absolute patterns are rejected
+  for pattern arguments.
+- Path resolution continues to use the trusted workspace root and rejects
+  escapes after normalization.
+- Case sensitivity is explicit. Defaults do not depend on NTFS, APFS, ext4, or
+  network share behavior.
+- Symlink tests must handle platforms where symlink creation requires elevated
+  privileges by using existing pytest skip patterns when necessary.
+- File mode metadata is best-effort. Tests should assert stable fields such as
+  path, type, and size, not exact platform-specific permission masks.
+
+## Profile Metadata Changes
+
+The default profile metadata should treat `fs.stat`, `fs.glob`, and `fs.grep`
+as read-only filesystem tools:
+
+- Add them to `_FILES_READ_TOOLS`.
+- Existing profiles that already include `_FILES_READ_TOOLS` inherit them.
+- Tool descriptors use `filesystem.read`, `uses_filesystem`,
+  `path_boundable`, and path argument hints.
+- `fs.grep` and `fs.glob` belong to the `files` or `retrieval` category
+  consistently with existing filesystem tools.
+
+## Safety And Limits
+
+- Every new operation resolves the workspace root before touching the
+  filesystem.
+- Every candidate path must remain under the resolved workspace root.
+- Directory walks must have configurable caps to avoid unbounded traversal.
+- Grep must not read files larger than its configured limit.
+- Binary and undecodable files are skipped, not returned partially.
+- Unknown arguments are rejected by both module validation and protocol
+  schema validation.
+
+## Testing Requirements
+
+- Tool descriptor tests for all new tools, metadata, required arguments, and
+  `additionalProperties: false`.
+- Unit tests for `fs.stat` on files, directories, missing paths, and symlinks.
+- Unit tests for `fs.glob` deterministic sorting, limits, hidden handling,
+  case sensitivity, pattern validation, and workspace escape rejection.
+- Unit tests for `fs.grep` literal search, regex search, UTF-8 handling,
+  binary/decode skips, file-size skips, result limits, and line numbering with
+  mixed newline styles.
+- Protocol validation tests for unknown arguments.
+- Preset metadata test proving `_FILES_READ_TOOLS` exposes the new helpers.
+- Cross-platform tests should avoid exact permission masks and skip symlink
+  creation only when the OS denies it.
+
+## Rollout
+
+The implementation should land as one reviewable branch with small commits:
+
+1. Tool schema and validation tests.
+2. `fs.stat`.
+3. `fs.glob`.
+4. `fs.grep`.
+5. Preset metadata and docs.
+6. Final verification and security scan.

--- a/backlog/tasks/task-2242 - Plan-MCP-filesystem-helper-tools.md
+++ b/backlog/tasks/task-2242 - Plan-MCP-filesystem-helper-tools.md
@@ -1,0 +1,48 @@
+---
+id: TASK-2242
+title: Plan MCP filesystem helper tools
+status: Done
+labels:
+- mcp-unified
+- filesystem
+- planning
+- cross-platform
+references:
+- Docs/superpowers/specs/2026-06-03-mcp-default-profile-tooling-presets-design.md
+- Docs/superpowers/plans/2026-06-03-mcp-default-profile-tooling-presets-implementation-plan.md
+modified_files:
+- Docs/superpowers/specs/2026-06-04-mcp-filesystem-helper-tools-design.md
+- Docs/superpowers/plans/2026-06-04-mcp-filesystem-helper-tools-implementation-plan.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Design and implementation planning for the next MCP native/default-included filesystem helper slice: workspace-bounded fs.stat, fs.glob, and fs.grep with cross-platform path, symlink, encoding, and case-sensitivity behavior. Planning only; implementation follows after review/approval.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Planning complete for MCP filesystem helper tools. Added Docs/superpowers/specs/2026-06-04-mcp-filesystem-helper-tools-design.md and Docs/superpowers/plans/2026-06-04-mcp-filesystem-helper-tools-implementation-plan.md. Verification: git diff --check passed. Bandit not run because this task only adds planning markdown and a Backlog record; the implementation plan requires Bandit on touched Python code in the implementation slice.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-2243 - Update-MCP-filesystem-helper-design-with-governed-shell-follow-up.md
+++ b/backlog/tasks/task-2243 - Update-MCP-filesystem-helper-design-with-governed-shell-follow-up.md
@@ -1,0 +1,45 @@
+---
+id: TASK-2243
+title: Update MCP filesystem helper design with governed shell follow-up
+status: Done
+assignee: []
+created_date: ''
+updated_date: '2026-06-04 00:43'
+labels: []
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Revise the MCP filesystem helper spec and implementation plan to incorporate design-review findings, including bounded traversal, regex hardening, cross-platform hidden semantics, symlink coverage, and a follow-up task for a governed bash/shell alias facade over the existing run command runtime.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Spec documents the governed shell facade boundary and leaves bash/shell aliases as follow-up work.
+- [x] #2 Implementation plan includes traversal-cap, regex-hardening, hidden-path, and symlink test requirements.
+- [x] #3 Implementation plan names the separate governed shell facade alias follow-up task with command-runtime files and tests.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Reviewed the existing RunCommandModule and command_runtime parser/adapter/registry against the pasted backend-lead note. The repo already has the safe shell-shaped execution model, so the plan now keeps typed filesystem helpers in the current slice and scopes bash/shell compatibility aliases to a separate governed runtime follow-up. Added requirements for traversal caps, regex pattern guards, explicit dot-segment hidden semantics, and symlink outside-workspace/loop coverage.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Updated the MCP filesystem helper spec and implementation plan with the approved governed shell facade direction. Bash/shell aliases are documented as a separate follow-up over the existing run command runtime, not as raw shell execution. Validation: git diff --check passed. Bandit skipped because no Python/source files changed.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-2244 - Implement-MCP-filesystem-helper-tools.md
+++ b/backlog/tasks/task-2244 - Implement-MCP-filesystem-helper-tools.md
@@ -1,0 +1,52 @@
+---
+id: TASK-2244
+title: Implement MCP filesystem helper tools
+status: Done
+assignee: []
+created_date: ''
+updated_date: '2026-06-04 01:04'
+labels: []
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement workspace-bounded read-only MCP filesystem helper tools fs.stat, fs.glob, and fs.grep according to Docs/superpowers/plans/2026-06-04-mcp-filesystem-helper-tools-implementation-plan.md, including profile metadata, tests, docs, verification, and security scan.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 fs.stat, fs.glob, and fs.grep are implemented as workspace-bounded read-only MCP tools.
+- [x] #2 New filesystem helpers include schemas, validation, protocol unknown-argument coverage, and focused behavior tests.
+- [x] #3 Read-capable presets expose the new helper tools and the package user guide documents them.
+- [x] #4 Focused tests, package boundary tests, Bandit, and whitespace checks pass.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Docs/superpowers/plans/2026-06-04-mcp-filesystem-helper-tools-implementation-plan.md
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented the filesystem helper plan with TDD slices: schemas/validation, fs.stat, fs.glob, fs.grep, profile metadata, docs, and final verification. Added deterministic grep ordering before result limiting, traversal caps, regex pattern guards, dot-segment hidden handling, symlink outside-workspace checks, symlink loop avoidance, skipped counters, and protocol unknown-argument coverage for the new tools.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Implemented workspace-bounded fs.stat, fs.glob, and fs.grep in FilesystemModule. Updated builtin profile metadata and mcp_unified/USER_GUIDE.md so filesystem-capable presets discover the helpers. Verification passed: filesystem module tests (26 passed), profile/discovery/gateway package tests (197 passed), runtime package boundary tests (27 passed), Bandit report /tmp/bandit_mcp_filesystem_helpers.json, and git diff --check.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-2245 - Address-PR-2254-filesystem-helper-review-feedback.md
+++ b/backlog/tasks/task-2245 - Address-PR-2254-filesystem-helper-review-feedback.md
@@ -1,0 +1,46 @@
+---
+id: TASK-2245
+title: Address PR 2254 filesystem helper review feedback
+status: Done
+assignee: []
+created_date: ''
+updated_date: '2026-06-04 01:40'
+labels: []
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Rebase PR 2254 onto latest dev and address still-valid review findings: secure no-follow path resolution through parent symlinks, cap double-star wildcard expansion, return symlink directory entries from fs.glob without traversing, count directories in grep walk caps, and bump builtin preset version for the tool-surface change.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 PR branch rebased cleanly onto latest origin/dev.
+- [x] #2 Still-valid PR review comments fixed with regression coverage.
+- [x] #3 Preset bundle version bumped for the helper-tool surface change.
+- [x] #4 Focused filesystem/profile/gateway/package tests, Bandit, and git diff --check pass.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Verified all PR 2254 review findings against the rebased code and found them still valid. Rebased codex/mcp-filesystem-helper-plan onto origin/dev without conflicts. Added regression coverage for no-follow parent symlink escapes, excessive **/ patterns, symlink directory entries in fs.glob without traversal, grep directory-only walk caps, and the preset version bump.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Addressed PR 2254 review feedback after rebasing onto origin/dev. Filesystem fixes secure parent symlink handling for no-follow stats, cap double-star expansion, preserve symlink directory entries in fs.glob, and count directories toward grep walk caps. Bumped built-in preset release version to 2026.06.04. Validation passed: test_filesystem_module.py (30 passed), profile/discovery/gateway package tests (197 passed), runtime package boundary tests (27 passed), Bandit report /tmp/bandit_mcp_filesystem_helpers_pr2254_review.json, and git diff --check.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-2245 - Address-PR-2254-filesystem-helper-review-feedback.md
+++ b/backlog/tasks/task-2245 - Address-PR-2254-filesystem-helper-review-feedback.md
@@ -4,7 +4,7 @@ title: Address PR 2254 filesystem helper review feedback
 status: Done
 assignee: []
 created_date: ''
-updated_date: '2026-06-04 01:40'
+updated_date: 2026-06-04 01:40
 labels: []
 dependencies: []
 ---
@@ -32,7 +32,7 @@ Verified all PR 2254 review findings against the rebased code and found them sti
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Addressed PR 2254 review feedback after rebasing onto origin/dev. Filesystem fixes secure parent symlink handling for no-follow stats, cap double-star expansion, preserve symlink directory entries in fs.glob, and count directories toward grep walk caps. Bumped built-in preset release version to 2026.06.04. Validation passed: test_filesystem_module.py (30 passed), profile/discovery/gateway package tests (197 passed), runtime package boundary tests (27 passed), Bandit report /tmp/bandit_mcp_filesystem_helpers_pr2254_review.json, and git diff --check.
+Rebased PR 2254 onto origin/dev after PR 2251 merged, addressed all still-valid unresolved Qodo comments, and validated the filesystem helper changes. Validation: focused red tests failed before implementation, then passed; test_filesystem_module.py passed 33 tests; adjacent MCP profile/discovery/package suite passed 90 tests; Ruff passed for touched Python files; Bandit report /tmp/bandit_pr2254_filesystem_qodo.json had zero findings; git diff --check passed.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
@@ -44,3 +44,9 @@ Addressed PR 2254 review feedback after rebasing onto origin/dev. Filesystem fix
 - [x] #5 Final summary added
 - [x] #6 Known skips or blockers documented
 <!-- DOD:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Second PR review pass: verified Qodo's three new findings against current code and found all still valid. Fixed fs.glob to return size=null and size_unavailable=true when best-effort file size metadata cannot be read. Added grep_allow_regex gating so regex mode is disabled by default, and added grep_max_total_bytes / grep_max_files aggregate scan budgets with truncation_reasons and remaining_count_known metadata. Updated packaged docs and design/plan artifacts for the new settings.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->

--- a/mcp_unified/USER_GUIDE.md
+++ b/mcp_unified/USER_GUIDE.md
@@ -115,7 +115,9 @@ Filesystem-capable presets expose portable workspace-bounded helpers for common
 read workflows: `fs.stat` for metadata, `fs.glob` for cross-platform path
 matching, and `fs.grep` for UTF-8 text search. These helpers do not invoke a
 host shell and remain subject to the active profile policy and workspace path
-scope.
+scope. `fs.grep` uses literal matching by default; regex matching requires the
+filesystem module `grep_allow_regex` setting. Grep scans are also bounded by
+per-file, total-byte, total-file, and walk-entry limits.
 
 Recommendation catalog patches only change discovery metadata. They do not grant
 execution authority, start external servers, create credential grants, or bypass

--- a/mcp_unified/USER_GUIDE.md
+++ b/mcp_unified/USER_GUIDE.md
@@ -111,6 +111,12 @@ Profiles can expose progressive disclosure bridge tools such as
 then discover recommended next-step tools without expanding the executable tool
 surface by default.
 
+Filesystem-capable presets expose portable workspace-bounded helpers for common
+read workflows: `fs.stat` for metadata, `fs.glob` for cross-platform path
+matching, and `fs.grep` for UTF-8 text search. These helpers do not invoke a
+host shell and remain subject to the active profile policy and workspace path
+scope.
+
 Recommendation catalog patches only change discovery metadata. They do not grant
 execution authority, start external servers, create credential grants, or bypass
 profile policy and approval requirements.

--- a/mcp_unified/profiles/presets.py
+++ b/mcp_unified/profiles/presets.py
@@ -186,7 +186,7 @@ _TOOL_DISCOVERY_TOOLS = [
     "tool_describe",
     "profile.tools.list",
 ]
-_FILES_READ_TOOLS = ["fs.list", "fs.read_text"]
+_FILES_READ_TOOLS = ["fs.list", "fs.read_text", "fs.stat", "fs.glob", "fs.grep"]
 _FILES_WRITE_TOOLS = [*_FILES_READ_TOOLS, "fs.write_text"]
 _CODE_READ_TOOLS = ["code.search", "code.symbols", "code.references"]
 _DOCS_READ_TOOLS = ["docs.search", "docs.read"]
@@ -221,9 +221,7 @@ _BUILTIN_PRESETS: tuple[ProfilePreset, ...] = (
         tooling_metadata_document=tooling_metadata(
             enabled_tools=[
                 *_TOOL_DISCOVERY_TOOLS,
-                "fs.list",
-                "fs.read_text",
-                "fs.write_text",
+                *_FILES_WRITE_TOOLS,
                 "kanban.cards.create",
                 "memory.recall",
             ],

--- a/mcp_unified/profiles/presets.py
+++ b/mcp_unified/profiles/presets.py
@@ -17,7 +17,7 @@ from .tooling import (
     web_search_server_recommendation,
 )
 
-PRESET_RELEASE_DATE = date(2026, 5, 27)
+PRESET_RELEASE_DATE = date(2026, 6, 4)
 PRESET_VERSION = PRESET_RELEASE_DATE.strftime("%Y.%m.%d")
 PRESET_CREATED_AT = datetime(
     PRESET_RELEASE_DATE.year,

--- a/tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_module.py
@@ -14,7 +14,9 @@ from __future__ import annotations
 
 import asyncio
 import os
+import stat as stat_module
 from contextlib import suppress
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
@@ -230,6 +232,15 @@ class FilesystemModule(BaseModule):
                 "bytes_written": write_result["bytes_written"],
             }
 
+        if tool_name == "fs.stat":
+            target = self._resolve_workspace_path_no_follow(workspace_root, str(args.get("path")))
+            return await asyncio.to_thread(
+                self._stat_path,
+                workspace_root,
+                target,
+                bool(args.get("follow_symlinks", False)),
+            )
+
         raise ValueError(f"Unknown tool: {tool_name}")
 
     def _list_entry_limit(self) -> int:
@@ -434,6 +445,61 @@ class FilesystemModule(BaseModule):
         if resolved != workspace_root and workspace_root not in resolved.parents:
             raise PermissionError("path is outside workspace scope")
         return resolved
+
+    @staticmethod
+    def _resolve_workspace_path_no_follow(workspace_root: Path, raw_path: str) -> Path:
+        candidate = Path(raw_path).expanduser()
+        if not candidate.is_absolute():
+            candidate = workspace_root / candidate
+        normalized = Path(os.path.abspath(os.fspath(candidate)))
+        if normalized != workspace_root and workspace_root not in normalized.parents:
+            raise PermissionError("path is outside workspace scope")
+        return normalized
+
+    @staticmethod
+    def _resolved_path_within_workspace(workspace_root: Path, target: Path) -> Path:
+        resolved = target.resolve(strict=False)
+        if resolved != workspace_root and workspace_root not in resolved.parents:
+            raise PermissionError("path is outside workspace scope")
+        return resolved
+
+    @staticmethod
+    def _stat_path(workspace_root: Path, target: Path, follow_symlinks: bool) -> dict[str, Any]:
+        if not target.exists() and not target.is_symlink():
+            raise FileNotFoundError(f"path not found: {target}")
+
+        if follow_symlinks:
+            stat_target = FilesystemModule._resolved_path_within_workspace(workspace_root, target)
+            stat_result = stat_target.stat()
+            is_symlink = target.is_symlink()
+            target_within_workspace = True
+        else:
+            stat_result = target.lstat()
+            is_symlink = stat_module.S_ISLNK(stat_result.st_mode)
+            target_within_workspace = None
+
+        mode = stat_result.st_mode
+        if is_symlink and not follow_symlinks:
+            entry_type = "symlink"
+        elif stat_module.S_ISDIR(mode):
+            entry_type = "directory"
+        elif stat_module.S_ISREG(mode):
+            entry_type = "file"
+        else:
+            entry_type = "other"
+
+        record: dict[str, Any] = {
+            "path": FilesystemModule._to_workspace_relative_path(workspace_root, target),
+            "name": target.name or ".",
+            "type": entry_type,
+            "size": stat_result.st_size,
+            "modified_at": datetime.fromtimestamp(stat_result.st_mtime, timezone.utc).isoformat(),
+            "mode": stat_module.S_IMODE(mode),
+            "is_symlink": is_symlink,
+        }
+        if target_within_workspace is not None:
+            record["target_within_workspace"] = target_within_workspace
+        return record
 
     @staticmethod
     def _list_directory(workspace_root: Path, target: Path, entry_limit: int) -> dict[str, Any]:

--- a/tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_module.py
@@ -535,9 +535,12 @@ class FilesystemModule(BaseModule):
         if not candidate.is_absolute():
             candidate = workspace_root / candidate
         normalized = Path(os.path.abspath(os.fspath(candidate)))
-        if normalized != workspace_root and workspace_root not in normalized.parents:
+        if normalized == workspace_root:
+            return workspace_root
+        parent_resolved = normalized.parent.resolve(strict=False)
+        if parent_resolved != workspace_root and workspace_root not in parent_resolved.parents:
             raise PermissionError("path is outside workspace scope")
-        return normalized
+        return parent_resolved / normalized.name
 
     @staticmethod
     def _resolved_path_within_workspace(workspace_root: Path, target: Path) -> Path:
@@ -571,6 +574,8 @@ class FilesystemModule(BaseModule):
             raise ValueError("unsafe pattern: drive-qualified patterns are not allowed")
         if any(part == ".." for part in pattern.split("/")):
             raise ValueError("unsafe pattern: parent traversal is not allowed")
+        if pattern.count("**/") > 5:
+            raise ValueError("unsafe pattern: too many double-star wildcards")
 
     @staticmethod
     def _portable_pattern_matches(path: str, pattern: str, *, case_sensitive: bool) -> bool:
@@ -665,6 +670,7 @@ class FilesystemModule(BaseModule):
             dirnames.sort()
             filenames.sort()
 
+            symlink_dirs: list[str] = []
             for dirname in list(dirnames):
                 dir_path = current_root / dirname
                 rel_path = FilesystemModule._to_workspace_relative_path(workspace_root, dir_path)
@@ -682,8 +688,10 @@ class FilesystemModule(BaseModule):
                         seen_dirs.add(resolved_dir)
                     else:
                         dirnames.remove(dirname)
+                        symlink_dirs.append(dirname)
 
             candidates: list[tuple[Path, str]] = [(current_root / dirname, "directory") for dirname in dirnames]
+            candidates.extend((current_root / dirname, "directory") for dirname in symlink_dirs)
             candidates.extend((current_root / filename, "file") for filename in filenames)
 
             for candidate, candidate_kind in candidates:
@@ -791,6 +799,15 @@ class FilesystemModule(BaseModule):
                         seen_dirs.add(resolved_dir)
                     else:
                         dirnames.remove(dirname)
+                        continue
+                visited_entries += 1
+                if visited_entries > walk_entry_limit:
+                    walk_truncated = True
+                    dirnames.clear()
+                    break
+
+            if walk_truncated:
+                break
 
             for filename in filenames:
                 visited_entries += 1

--- a/tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_module.py
@@ -181,7 +181,11 @@ class FilesystemModule(BaseModule):
                     "base_path": {"type": "string", "description": "Workspace-relative base path"},
                     "include": {"type": "array", "items": {"type": "string"}},
                     "exclude": {"type": "array", "items": {"type": "string"}},
-                    "regex": {"type": "boolean", "default": False},
+                    "regex": {
+                        "type": "boolean",
+                        "default": False,
+                        "description": "Requires the filesystem module grep_allow_regex setting.",
+                    },
                     "case_sensitive": {"type": "boolean", "default": True},
                     "include_hidden": {"type": "boolean", "default": False},
                     "follow_symlinks": {"type": "boolean", "default": False},
@@ -293,6 +297,10 @@ class FilesystemModule(BaseModule):
                 args.get("max_file_bytes"),
                 self._setting_positive_int("grep_max_file_bytes", self._max_read_bytes()),
             )
+            max_total_bytes = self._setting_positive_int(
+                "grep_max_total_bytes",
+                self._DEFAULT_MAX_READ_BYTES * 10,
+            )
             return await asyncio.to_thread(
                 self._grep_files,
                 workspace_root,
@@ -307,6 +315,8 @@ class FilesystemModule(BaseModule):
                 bool(args.get("follow_symlinks", False)),
                 limit,
                 max_file_bytes,
+                max_total_bytes,
+                self._setting_positive_int("grep_max_files", 1_000),
                 self._setting_positive_int("grep_walk_entry_limit", 50_000),
             )
 
@@ -336,9 +346,17 @@ class FilesystemModule(BaseModule):
             limit = default
         return max(1, limit)
 
+    def _setting_bool(self, name: str, default: bool = False) -> bool:
+        raw_value = self.config.settings.get(name, default)
+        if isinstance(raw_value, bool):
+            return raw_value
+        if isinstance(raw_value, str):
+            return raw_value.strip().lower() in {"1", "true", "yes", "on", "y"}
+        return bool(raw_value)
+
     def validate_tool_arguments(self, tool_name: str, arguments: dict[str, Any]) -> None:
         if tool_name == "fs.list":
-            unknown = sorted({key for key in arguments.keys()} - {"path"})
+            unknown = sorted(set(arguments) - {"path"})
             if unknown:
                 raise ValueError(f"unknown arguments: {', '.join(unknown)}")
             path = arguments.get("path")
@@ -347,7 +365,7 @@ class FilesystemModule(BaseModule):
             return
 
         if tool_name == "fs.read_text":
-            unknown = sorted({key for key in arguments.keys()} - {"path"})
+            unknown = sorted(set(arguments) - {"path"})
             if unknown:
                 raise ValueError(f"unknown arguments: {', '.join(unknown)}")
             path = arguments.get("path")
@@ -356,7 +374,7 @@ class FilesystemModule(BaseModule):
             return
 
         if tool_name == "fs.write_text":
-            unknown = sorted({key for key in arguments.keys()} - {"path", "content"})
+            unknown = sorted(set(arguments) - {"path", "content"})
             if unknown:
                 raise ValueError(f"unknown arguments: {', '.join(unknown)}")
             path = arguments.get("path")
@@ -368,7 +386,7 @@ class FilesystemModule(BaseModule):
             return
 
         if tool_name == "fs.stat":
-            unknown = sorted({key for key in arguments.keys()} - {"path", "follow_symlinks"})
+            unknown = sorted(set(arguments) - {"path", "follow_symlinks"})
             if unknown:
                 raise ValueError(f"unknown arguments: {', '.join(unknown)}")
             path = arguments.get("path")
@@ -379,7 +397,7 @@ class FilesystemModule(BaseModule):
 
         if tool_name == "fs.glob":
             unknown = sorted(
-                {key for key in arguments.keys()}
+                set(arguments)
                 - {
                     "pattern",
                     "base_path",
@@ -412,7 +430,7 @@ class FilesystemModule(BaseModule):
 
         if tool_name == "fs.grep":
             unknown = sorted(
-                {key for key in arguments.keys()}
+                set(arguments)
                 - {
                     "pattern",
                     "base_path",
@@ -449,6 +467,8 @@ class FilesystemModule(BaseModule):
             self._validate_positive_int_argument(arguments, "limit")
             self._validate_positive_int_argument(arguments, "max_file_bytes")
             if arguments.get("regex") is True:
+                if not self._setting_bool("grep_allow_regex", False):
+                    raise ValueError("regex grep is disabled by module configuration")
                 max_pattern_length = self._setting_positive_int("grep_max_pattern_length", 512)
                 if len(pattern) > max_pattern_length:
                     raise ValueError(
@@ -724,8 +744,11 @@ class FilesystemModule(BaseModule):
                     "type": candidate_type,
                 }
                 if candidate_kind == "file":
-                    with suppress(OSError):
+                    try:
                         record["size"] = candidate.stat(follow_symlinks=False).st_size
+                    except OSError:
+                        record["size"] = None
+                        record["size_unavailable"] = True
                 matches.append(record)
 
             if walk_truncated:
@@ -756,6 +779,8 @@ class FilesystemModule(BaseModule):
         follow_symlinks: bool,
         limit: int,
         max_file_bytes: int,
+        max_total_bytes: int,
+        max_files: int,
         walk_entry_limit: int,
     ) -> dict[str, Any]:
         if not base.exists():
@@ -774,6 +799,10 @@ class FilesystemModule(BaseModule):
         }
         visited_entries = 0
         walk_truncated = False
+        io_truncated = False
+        file_budget_truncated = False
+        total_bytes_read = 0
+        files_read = 0
         seen_dirs: set[Path] = {base.resolve(strict=False)}
         file_candidates: list[tuple[str, Path]] = []
 
@@ -860,6 +889,12 @@ class FilesystemModule(BaseModule):
             if file_size > max_file_bytes:
                 skipped["too_large"] += 1
                 continue
+            if files_read >= max_files:
+                file_budget_truncated = True
+                break
+            if total_bytes_read + file_size > max_total_bytes:
+                io_truncated = True
+                break
             try:
                 payload = read_target.read_bytes()
             except PermissionError:
@@ -868,6 +903,8 @@ class FilesystemModule(BaseModule):
             except OSError:
                 skipped["unsupported_type"] += 1
                 continue
+            files_read += 1
+            total_bytes_read += len(payload)
             if b"\x00" in payload:
                 skipped["binary"] += 1
                 continue
@@ -899,11 +936,22 @@ class FilesystemModule(BaseModule):
                     remaining_count += 1
 
         matches.sort(key=lambda item: (str(item.get("path") or ""), int(item.get("line_number") or 0)))
+        truncation_reasons = []
+        if walk_truncated:
+            truncation_reasons.append("walk_entry_limit")
+        if io_truncated:
+            truncation_reasons.append("io_budget")
+        if file_budget_truncated:
+            truncation_reasons.append("file_budget")
+        if remaining_count > 0:
+            truncation_reasons.append("match_limit")
         return {
             "base_path": FilesystemModule._to_workspace_relative_path(workspace_root, base),
             "matches": matches,
-            "truncated": walk_truncated or remaining_count > 0,
+            "truncated": bool(truncation_reasons),
             "remaining_count": remaining_count,
+            "remaining_count_known": not (walk_truncated or io_truncated or file_budget_truncated),
+            "truncation_reasons": truncation_reasons,
             "skipped": skipped,
         }
 

--- a/tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_module.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import asyncio
 import fnmatch
 import os
+import re
 import stat as stat_module
 from contextlib import suppress
 from datetime import datetime, timezone
@@ -260,6 +261,53 @@ class FilesystemModule(BaseModule):
                 bool(args.get("case_sensitive", True)),
                 limit,
                 self._setting_positive_int("glob_walk_entry_limit", 50_000),
+            )
+
+        if tool_name == "fs.grep":
+            base_path = str(args.get("base_path") or ".")
+            base = self._resolve_workspace_path(workspace_root, base_path)
+            pattern = str(args.get("pattern") or "")
+            regex = bool(args.get("regex", False))
+            case_sensitive = bool(args.get("case_sensitive", True))
+            regex_pattern = None
+            if regex:
+                flags = 0 if case_sensitive else re.IGNORECASE
+                try:
+                    regex_pattern = re.compile(pattern, flags)
+                except re.error as exc:
+                    raise ValueError(f"invalid regex pattern: {exc}") from exc
+            include = [
+                self._normalize_portable_pattern(str(item))
+                for item in (args.get("include") if args.get("include") is not None else ["*", "**/*"])
+            ]
+            exclude = [
+                self._normalize_portable_pattern(str(item))
+                for item in (args.get("exclude") if args.get("exclude") is not None else [])
+            ]
+            for include_pattern in include:
+                self._reject_unsafe_pattern(include_pattern)
+            for exclude_pattern in exclude:
+                self._reject_unsafe_pattern(exclude_pattern)
+            limit = self._bounded_positive_int(args.get("limit"), self._setting_positive_int("grep_result_limit", 200))
+            max_file_bytes = self._bounded_positive_int(
+                args.get("max_file_bytes"),
+                self._setting_positive_int("grep_max_file_bytes", self._max_read_bytes()),
+            )
+            return await asyncio.to_thread(
+                self._grep_files,
+                workspace_root,
+                base,
+                pattern,
+                regex_pattern,
+                regex,
+                case_sensitive,
+                include,
+                exclude,
+                bool(args.get("include_hidden", False)),
+                bool(args.get("follow_symlinks", False)),
+                limit,
+                max_file_bytes,
+                self._setting_positive_int("grep_walk_entry_limit", 50_000),
             )
 
         raise ValueError(f"Unknown tool: {tool_name}")
@@ -685,6 +733,180 @@ class FilesystemModule(BaseModule):
             "truncated": walk_truncated or remaining_count > 0,
             "remaining_count": remaining_count,
         }
+
+    @staticmethod
+    def _grep_files(
+        workspace_root: Path,
+        base: Path,
+        pattern: str,
+        regex_pattern: re.Pattern[str] | None,
+        regex: bool,
+        case_sensitive: bool,
+        include: list[str],
+        exclude: list[str],
+        include_hidden: bool,
+        follow_symlinks: bool,
+        limit: int,
+        max_file_bytes: int,
+        walk_entry_limit: int,
+    ) -> dict[str, Any]:
+        if not base.exists():
+            raise FileNotFoundError(f"path not found: {base}")
+        if not base.is_dir():
+            raise NotADirectoryError(f"path is not a directory: {base}")
+
+        matches: list[dict[str, Any]] = []
+        remaining_count = 0
+        skipped = {
+            "binary": 0,
+            "decode_error": 0,
+            "too_large": 0,
+            "permission_error": 0,
+            "unsupported_type": 0,
+        }
+        visited_entries = 0
+        walk_truncated = False
+        seen_dirs: set[Path] = {base.resolve(strict=False)}
+
+        for root, dirnames, filenames in os.walk(base, topdown=True, followlinks=follow_symlinks):
+            current_root = Path(root)
+            dirnames.sort()
+            filenames.sort()
+
+            for dirname in list(dirnames):
+                dir_path = current_root / dirname
+                rel_path = FilesystemModule._to_workspace_relative_path(workspace_root, dir_path)
+                if not include_hidden and FilesystemModule._is_hidden_relative_path(rel_path):
+                    dirnames.remove(dirname)
+                    continue
+                if dir_path.is_symlink():
+                    resolved_dir = dir_path.resolve(strict=False)
+                    if follow_symlinks:
+                        if resolved_dir != workspace_root and workspace_root not in resolved_dir.parents:
+                            raise PermissionError("path is outside workspace scope")
+                        if resolved_dir in seen_dirs:
+                            dirnames.remove(dirname)
+                            continue
+                        seen_dirs.add(resolved_dir)
+                    else:
+                        dirnames.remove(dirname)
+
+            for filename in filenames:
+                visited_entries += 1
+                if visited_entries > walk_entry_limit:
+                    walk_truncated = True
+                    dirnames.clear()
+                    break
+
+                candidate = current_root / filename
+                rel_path = FilesystemModule._to_workspace_relative_path(workspace_root, candidate)
+                if not include_hidden and FilesystemModule._is_hidden_relative_path(rel_path):
+                    continue
+                if candidate.is_symlink():
+                    if not follow_symlinks:
+                        skipped["unsupported_type"] += 1
+                        continue
+                    resolved_file = candidate.resolve(strict=False)
+                    if resolved_file != workspace_root and workspace_root not in resolved_file.parents:
+                        raise PermissionError("path is outside workspace scope")
+                    read_target = resolved_file
+                else:
+                    read_target = candidate
+                if not any(
+                    FilesystemModule._portable_pattern_matches(rel_path, include_pattern, case_sensitive=True)
+                    for include_pattern in include
+                ):
+                    continue
+                if any(
+                    FilesystemModule._portable_pattern_matches(rel_path, exclude_pattern, case_sensitive=True)
+                    for exclude_pattern in exclude
+                ):
+                    continue
+                if not read_target.is_file():
+                    skipped["unsupported_type"] += 1
+                    continue
+                try:
+                    file_size = read_target.stat().st_size
+                except PermissionError:
+                    skipped["permission_error"] += 1
+                    continue
+                except OSError:
+                    skipped["unsupported_type"] += 1
+                    continue
+                if file_size > max_file_bytes:
+                    skipped["too_large"] += 1
+                    continue
+                try:
+                    payload = read_target.read_bytes()
+                except PermissionError:
+                    skipped["permission_error"] += 1
+                    continue
+                except OSError:
+                    skipped["unsupported_type"] += 1
+                    continue
+                if b"\x00" in payload:
+                    skipped["binary"] += 1
+                    continue
+                try:
+                    text = payload.decode("utf-8")
+                except UnicodeDecodeError:
+                    skipped["decode_error"] += 1
+                    continue
+
+                for line_number, line in enumerate(text.splitlines(), start=1):
+                    match_text = FilesystemModule._line_match_text(
+                        line,
+                        pattern,
+                        regex_pattern,
+                        regex=regex,
+                        case_sensitive=case_sensitive,
+                    )
+                    if match_text is None:
+                        continue
+                    match_record = {
+                        "path": rel_path,
+                        "line_number": line_number,
+                        "line": line,
+                        "match_text": match_text,
+                    }
+                    if len(matches) < limit:
+                        matches.append(match_record)
+                    else:
+                        remaining_count += 1
+
+            if walk_truncated:
+                break
+
+        matches.sort(key=lambda item: (str(item.get("path") or ""), int(item.get("line_number") or 0)))
+        return {
+            "base_path": FilesystemModule._to_workspace_relative_path(workspace_root, base),
+            "matches": matches,
+            "truncated": walk_truncated or remaining_count > 0,
+            "remaining_count": remaining_count,
+            "skipped": skipped,
+        }
+
+    @staticmethod
+    def _line_match_text(
+        line: str,
+        pattern: str,
+        regex_pattern: re.Pattern[str] | None,
+        *,
+        regex: bool,
+        case_sensitive: bool,
+    ) -> str | None:
+        if regex:
+            if regex_pattern is None:
+                return None
+            match = regex_pattern.search(line)
+            return match.group(0) if match else None
+
+        haystack = line if case_sensitive else line.lower()
+        needle = pattern if case_sensitive else pattern.lower()
+        index = haystack.find(needle)
+        if index < 0:
+            return None
+        return line[index : index + len(pattern)]
 
     @staticmethod
     def _list_directory(workspace_root: Path, target: Path, entry_limit: int) -> dict[str, Any]:

--- a/tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_module.py
@@ -767,6 +767,7 @@ class FilesystemModule(BaseModule):
         visited_entries = 0
         walk_truncated = False
         seen_dirs: set[Path] = {base.resolve(strict=False)}
+        file_candidates: list[tuple[str, Path]] = []
 
         for root, dirnames, filenames in os.walk(base, topdown=True, followlinks=follow_symlinks):
             current_root = Path(root)
@@ -825,57 +826,60 @@ class FilesystemModule(BaseModule):
                 if not read_target.is_file():
                     skipped["unsupported_type"] += 1
                     continue
-                try:
-                    file_size = read_target.stat().st_size
-                except PermissionError:
-                    skipped["permission_error"] += 1
-                    continue
-                except OSError:
-                    skipped["unsupported_type"] += 1
-                    continue
-                if file_size > max_file_bytes:
-                    skipped["too_large"] += 1
-                    continue
-                try:
-                    payload = read_target.read_bytes()
-                except PermissionError:
-                    skipped["permission_error"] += 1
-                    continue
-                except OSError:
-                    skipped["unsupported_type"] += 1
-                    continue
-                if b"\x00" in payload:
-                    skipped["binary"] += 1
-                    continue
-                try:
-                    text = payload.decode("utf-8")
-                except UnicodeDecodeError:
-                    skipped["decode_error"] += 1
-                    continue
-
-                for line_number, line in enumerate(text.splitlines(), start=1):
-                    match_text = FilesystemModule._line_match_text(
-                        line,
-                        pattern,
-                        regex_pattern,
-                        regex=regex,
-                        case_sensitive=case_sensitive,
-                    )
-                    if match_text is None:
-                        continue
-                    match_record = {
-                        "path": rel_path,
-                        "line_number": line_number,
-                        "line": line,
-                        "match_text": match_text,
-                    }
-                    if len(matches) < limit:
-                        matches.append(match_record)
-                    else:
-                        remaining_count += 1
+                file_candidates.append((rel_path, read_target))
 
             if walk_truncated:
                 break
+
+        for rel_path, read_target in sorted(file_candidates, key=lambda item: item[0]):
+            try:
+                file_size = read_target.stat().st_size
+            except PermissionError:
+                skipped["permission_error"] += 1
+                continue
+            except OSError:
+                skipped["unsupported_type"] += 1
+                continue
+            if file_size > max_file_bytes:
+                skipped["too_large"] += 1
+                continue
+            try:
+                payload = read_target.read_bytes()
+            except PermissionError:
+                skipped["permission_error"] += 1
+                continue
+            except OSError:
+                skipped["unsupported_type"] += 1
+                continue
+            if b"\x00" in payload:
+                skipped["binary"] += 1
+                continue
+            try:
+                text = payload.decode("utf-8")
+            except UnicodeDecodeError:
+                skipped["decode_error"] += 1
+                continue
+
+            for line_number, line in enumerate(text.splitlines(), start=1):
+                match_text = FilesystemModule._line_match_text(
+                    line,
+                    pattern,
+                    regex_pattern,
+                    regex=regex,
+                    case_sensitive=case_sensitive,
+                )
+                if match_text is None:
+                    continue
+                match_record = {
+                    "path": rel_path,
+                    "line_number": line_number,
+                    "line": line,
+                    "match_text": match_text,
+                }
+                if len(matches) < limit:
+                    matches.append(match_record)
+                else:
+                    remaining_count += 1
 
         matches.sort(key=lambda item: (str(item.get("path") or ""), int(item.get("line_number") or 0)))
         return {

--- a/tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_module.py
@@ -5,6 +5,9 @@ Exposes:
 - fs.list
 - fs.read_text
 - fs.write_text
+- fs.stat
+- fs.glob
+- fs.grep
 """
 
 from __future__ import annotations
@@ -58,6 +61,9 @@ class FilesystemModule(BaseModule):
         shared_fs_metadata = {
             "uses_filesystem": True,
             "path_boundable": True,
+        }
+        shared_path_metadata = {
+            **shared_fs_metadata,
             "path_argument_hints": ["path"],
         }
         list_tool = create_tool_definition(
@@ -72,7 +78,7 @@ class FilesystemModule(BaseModule):
                 "category": "retrieval",
                 "readOnlyHint": True,
                 "capabilities": ["filesystem.read"],
-                **shared_fs_metadata,
+                **shared_path_metadata,
             },
         )
         list_tool["inputSchema"]["additionalProperties"] = False
@@ -90,7 +96,7 @@ class FilesystemModule(BaseModule):
                 "category": "retrieval",
                 "readOnlyHint": True,
                 "capabilities": ["filesystem.read"],
-                **shared_fs_metadata,
+                **shared_path_metadata,
             },
         )
         read_text_tool["inputSchema"]["additionalProperties"] = False
@@ -108,12 +114,89 @@ class FilesystemModule(BaseModule):
             metadata={
                 "category": "management",
                 "capabilities": ["filesystem.write"],
-                **shared_fs_metadata,
+                **shared_path_metadata,
             },
         )
         write_text_tool["inputSchema"]["additionalProperties"] = False
 
-        return [list_tool, read_text_tool, write_text_tool]
+        stat_tool = create_tool_definition(
+            name="fs.stat",
+            description="Return metadata for one path under the active trusted workspace root.",
+            parameters={
+                "properties": {
+                    "path": {"type": "string", "description": "Workspace-relative or absolute path"},
+                    "follow_symlinks": {
+                        "type": "boolean",
+                        "default": False,
+                        "description": "Follow a symlink after verifying the target remains in workspace scope.",
+                    },
+                },
+                "required": ["path"],
+            },
+            metadata={
+                "category": "retrieval",
+                "readOnlyHint": True,
+                "capabilities": ["filesystem.read"],
+                **shared_path_metadata,
+            },
+        )
+        stat_tool["inputSchema"]["additionalProperties"] = False
+
+        glob_tool = create_tool_definition(
+            name="fs.glob",
+            description="Find workspace paths matching a portable pattern without invoking a shell.",
+            parameters={
+                "properties": {
+                    "pattern": {"type": "string", "description": "Portable pattern using / separators"},
+                    "base_path": {"type": "string", "description": "Workspace-relative base path"},
+                    "include_hidden": {"type": "boolean", "default": False},
+                    "include_files": {"type": "boolean", "default": True},
+                    "include_directories": {"type": "boolean", "default": True},
+                    "follow_symlinks": {"type": "boolean", "default": False},
+                    "case_sensitive": {"type": "boolean", "default": True},
+                    "limit": {"type": "integer", "minimum": 1},
+                },
+                "required": ["pattern"],
+            },
+            metadata={
+                "category": "retrieval",
+                "readOnlyHint": True,
+                "capabilities": ["filesystem.read"],
+                **shared_fs_metadata,
+                "path_argument_hints": ["base_path"],
+            },
+        )
+        glob_tool["inputSchema"]["additionalProperties"] = False
+
+        grep_tool = create_tool_definition(
+            name="fs.grep",
+            description="Search UTF-8 text files under a workspace path without invoking a shell.",
+            parameters={
+                "properties": {
+                    "pattern": {"type": "string"},
+                    "base_path": {"type": "string", "description": "Workspace-relative base path"},
+                    "include": {"type": "array", "items": {"type": "string"}},
+                    "exclude": {"type": "array", "items": {"type": "string"}},
+                    "regex": {"type": "boolean", "default": False},
+                    "case_sensitive": {"type": "boolean", "default": True},
+                    "include_hidden": {"type": "boolean", "default": False},
+                    "follow_symlinks": {"type": "boolean", "default": False},
+                    "limit": {"type": "integer", "minimum": 1},
+                    "max_file_bytes": {"type": "integer", "minimum": 1},
+                },
+                "required": ["pattern"],
+            },
+            metadata={
+                "category": "retrieval",
+                "readOnlyHint": True,
+                "capabilities": ["filesystem.read"],
+                **shared_fs_metadata,
+                "path_argument_hints": ["base_path"],
+            },
+        )
+        grep_tool["inputSchema"]["additionalProperties"] = False
+
+        return [list_tool, read_text_tool, write_text_tool, stat_tool, glob_tool, grep_tool]
 
     async def execute_tool(self, tool_name: str, arguments: dict[str, Any], context: Any | None = None) -> Any:
         args = self.sanitize_input(arguments or {})
@@ -165,6 +248,14 @@ class FilesystemModule(BaseModule):
             limit = self._DEFAULT_MAX_READ_BYTES
         return max(1, limit)
 
+    def _setting_positive_int(self, name: str, default: int) -> int:
+        raw_limit = self.config.settings.get(name, default)
+        try:
+            limit = int(raw_limit)
+        except (TypeError, ValueError):
+            limit = default
+        return max(1, limit)
+
     def validate_tool_arguments(self, tool_name: str, arguments: dict[str, Any]) -> None:
         if tool_name == "fs.list":
             unknown = sorted({key for key in arguments.keys()} - {"path"})
@@ -196,7 +287,108 @@ class FilesystemModule(BaseModule):
                 raise ValueError("content must be a string")
             return
 
+        if tool_name == "fs.stat":
+            unknown = sorted({key for key in arguments.keys()} - {"path", "follow_symlinks"})
+            if unknown:
+                raise ValueError(f"unknown arguments: {', '.join(unknown)}")
+            path = arguments.get("path")
+            if not isinstance(path, str) or not path.strip():
+                raise ValueError("path is required")
+            self._validate_bool_argument(arguments, "follow_symlinks")
+            return
+
+        if tool_name == "fs.glob":
+            unknown = sorted(
+                {key for key in arguments.keys()}
+                - {
+                    "pattern",
+                    "base_path",
+                    "include_hidden",
+                    "include_files",
+                    "include_directories",
+                    "follow_symlinks",
+                    "case_sensitive",
+                    "limit",
+                }
+            )
+            if unknown:
+                raise ValueError(f"unknown arguments: {', '.join(unknown)}")
+            pattern = arguments.get("pattern")
+            if not isinstance(pattern, str) or not pattern.strip():
+                raise ValueError("pattern is required")
+            base_path = arguments.get("base_path")
+            if base_path is not None and not isinstance(base_path, str):
+                raise ValueError("base_path must be a string")
+            for key in (
+                "include_hidden",
+                "include_files",
+                "include_directories",
+                "follow_symlinks",
+                "case_sensitive",
+            ):
+                self._validate_bool_argument(arguments, key)
+            self._validate_positive_int_argument(arguments, "limit")
+            return
+
+        if tool_name == "fs.grep":
+            unknown = sorted(
+                {key for key in arguments.keys()}
+                - {
+                    "pattern",
+                    "base_path",
+                    "include",
+                    "exclude",
+                    "regex",
+                    "case_sensitive",
+                    "include_hidden",
+                    "follow_symlinks",
+                    "limit",
+                    "max_file_bytes",
+                }
+            )
+            if unknown:
+                raise ValueError(f"unknown arguments: {', '.join(unknown)}")
+            pattern = arguments.get("pattern")
+            if not isinstance(pattern, str) or not pattern.strip():
+                raise ValueError("pattern is required")
+            base_path = arguments.get("base_path")
+            if base_path is not None and not isinstance(base_path, str):
+                raise ValueError("base_path must be a string")
+            include = arguments.get("include")
+            if include is not None and (
+                not isinstance(include, list) or not all(isinstance(item, str) for item in include)
+            ):
+                raise ValueError("include must be a list of strings")
+            exclude = arguments.get("exclude")
+            if exclude is not None and (
+                not isinstance(exclude, list) or not all(isinstance(item, str) for item in exclude)
+            ):
+                raise ValueError("exclude must be a list of strings")
+            for key in ("regex", "case_sensitive", "include_hidden", "follow_symlinks"):
+                self._validate_bool_argument(arguments, key)
+            self._validate_positive_int_argument(arguments, "limit")
+            self._validate_positive_int_argument(arguments, "max_file_bytes")
+            if arguments.get("regex") is True:
+                max_pattern_length = self._setting_positive_int("grep_max_pattern_length", 512)
+                if len(pattern) > max_pattern_length:
+                    raise ValueError(
+                        f"pattern exceeds grep regex length limit ({len(pattern)} > {max_pattern_length})"
+                    )
+            return
+
         raise ValueError(f"Unknown tool: {tool_name}")
+
+    @staticmethod
+    def _validate_bool_argument(arguments: dict[str, Any], key: str) -> None:
+        value = arguments.get(key)
+        if value is not None and not isinstance(value, bool):
+            raise ValueError(f"{key} must be a boolean")
+
+    @staticmethod
+    def _validate_positive_int_argument(arguments: dict[str, Any], key: str) -> None:
+        value = arguments.get(key)
+        if value is not None and (not isinstance(value, int) or isinstance(value, bool) or value <= 0):
+            raise ValueError(f"{key} must be a positive integer")
 
     async def _resolve_workspace_root(self, context: Any | None) -> Path:
         metadata = getattr(context, "metadata", None)

--- a/tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_module.py
@@ -13,6 +13,7 @@ Exposes:
 from __future__ import annotations
 
 import asyncio
+import fnmatch
 import os
 import stat as stat_module
 from contextlib import suppress
@@ -241,6 +242,26 @@ class FilesystemModule(BaseModule):
                 bool(args.get("follow_symlinks", False)),
             )
 
+        if tool_name == "fs.glob":
+            base_path = str(args.get("base_path") or ".")
+            base = self._resolve_workspace_path(workspace_root, base_path)
+            pattern = self._normalize_portable_pattern(str(args.get("pattern")))
+            self._reject_unsafe_pattern(pattern)
+            limit = self._bounded_positive_int(args.get("limit"), self._setting_positive_int("glob_result_limit", 500))
+            return await asyncio.to_thread(
+                self._glob_paths,
+                workspace_root,
+                base,
+                pattern,
+                bool(args.get("include_hidden", False)),
+                bool(args.get("include_files", True)),
+                bool(args.get("include_directories", True)),
+                bool(args.get("follow_symlinks", False)),
+                bool(args.get("case_sensitive", True)),
+                limit,
+                self._setting_positive_int("glob_walk_entry_limit", 50_000),
+            )
+
         raise ValueError(f"Unknown tool: {tool_name}")
 
     def _list_entry_limit(self) -> int:
@@ -401,6 +422,20 @@ class FilesystemModule(BaseModule):
         if value is not None and (not isinstance(value, int) or isinstance(value, bool) or value <= 0):
             raise ValueError(f"{key} must be a positive integer")
 
+    def sanitize_input(self, input_data: Any, _depth: int = 0) -> Any:
+        """Sanitize filesystem inputs while allowing portable glob syntax."""
+
+        if _depth > 20:
+            raise ValueError("Input too deeply nested")
+
+        if isinstance(input_data, str):
+            return "".join(ch for ch in input_data if ch >= " " or ch == "\n")
+        if isinstance(input_data, dict):
+            return {k: self.sanitize_input(v, _depth + 1) for k, v in input_data.items()}
+        if isinstance(input_data, list):
+            return [self.sanitize_input(v, _depth + 1) for v in input_data]
+        return input_data
+
     async def _resolve_workspace_root(self, context: Any | None) -> Path:
         metadata = getattr(context, "metadata", None)
         metadata_map = dict(metadata) if isinstance(metadata, dict) else {}
@@ -464,6 +499,59 @@ class FilesystemModule(BaseModule):
         return resolved
 
     @staticmethod
+    def _bounded_positive_int(value: Any, default: int) -> int:
+        if value is None:
+            return max(1, int(default))
+        if not isinstance(value, int) or isinstance(value, bool) or value <= 0:
+            raise ValueError("limit must be a positive integer")
+        return value
+
+    @staticmethod
+    def _normalize_portable_pattern(pattern: str) -> str:
+        normalized = pattern.strip().replace("\\", "/")
+        while "//" in normalized and not normalized.startswith("//"):
+            normalized = normalized.replace("//", "/")
+        return normalized
+
+    @staticmethod
+    def _reject_unsafe_pattern(pattern: str) -> None:
+        if not pattern:
+            raise ValueError("unsafe pattern: pattern is required")
+        if pattern.startswith("/") or pattern.startswith("//"):
+            raise ValueError("unsafe pattern: absolute patterns are not allowed")
+        if len(pattern) >= 2 and pattern[1] == ":" and pattern[0].isalpha():
+            raise ValueError("unsafe pattern: drive-qualified patterns are not allowed")
+        if any(part == ".." for part in pattern.split("/")):
+            raise ValueError("unsafe pattern: parent traversal is not allowed")
+
+    @staticmethod
+    def _portable_pattern_matches(path: str, pattern: str, *, case_sensitive: bool) -> bool:
+        candidate = path if case_sensitive else path.lower()
+        patterns = FilesystemModule._expand_double_star_zero_dir_patterns(
+            pattern if case_sensitive else pattern.lower()
+        )
+        return any(fnmatch.fnmatchcase(candidate, candidate_pattern) for candidate_pattern in patterns)
+
+    @staticmethod
+    def _expand_double_star_zero_dir_patterns(pattern: str) -> set[str]:
+        patterns = {pattern}
+        queue = [pattern]
+        while queue:
+            current = queue.pop()
+            start = current.find("**/")
+            while start != -1:
+                collapsed = f"{current[:start]}{current[start + 3:]}"
+                if collapsed not in patterns:
+                    patterns.add(collapsed)
+                    queue.append(collapsed)
+                start = current.find("**/", start + 1)
+        return patterns
+
+    @staticmethod
+    def _is_hidden_relative_path(path: str) -> bool:
+        return any(part.startswith(".") and part not in {"."} for part in path.split("/"))
+
+    @staticmethod
     def _stat_path(workspace_root: Path, target: Path, follow_symlinks: bool) -> dict[str, Any]:
         if not target.exists() and not target.is_symlink():
             raise FileNotFoundError(f"path not found: {target}")
@@ -500,6 +588,103 @@ class FilesystemModule(BaseModule):
         if target_within_workspace is not None:
             record["target_within_workspace"] = target_within_workspace
         return record
+
+    @staticmethod
+    def _glob_paths(
+        workspace_root: Path,
+        base: Path,
+        pattern: str,
+        include_hidden: bool,
+        include_files: bool,
+        include_directories: bool,
+        follow_symlinks: bool,
+        case_sensitive: bool,
+        limit: int,
+        walk_entry_limit: int,
+    ) -> dict[str, Any]:
+        if not base.exists():
+            raise FileNotFoundError(f"path not found: {base}")
+        if not base.is_dir():
+            raise NotADirectoryError(f"path is not a directory: {base}")
+
+        matches: list[dict[str, Any]] = []
+        visited_entries = 0
+        walk_truncated = False
+        seen_dirs: set[Path] = {base.resolve(strict=False)}
+
+        for root, dirnames, filenames in os.walk(base, topdown=True, followlinks=follow_symlinks):
+            current_root = Path(root)
+            dirnames.sort()
+            filenames.sort()
+
+            for dirname in list(dirnames):
+                dir_path = current_root / dirname
+                rel_path = FilesystemModule._to_workspace_relative_path(workspace_root, dir_path)
+                if not include_hidden and FilesystemModule._is_hidden_relative_path(rel_path):
+                    dirnames.remove(dirname)
+                    continue
+                if dir_path.is_symlink():
+                    resolved_dir = dir_path.resolve(strict=False)
+                    if follow_symlinks:
+                        if resolved_dir != workspace_root and workspace_root not in resolved_dir.parents:
+                            raise PermissionError("path is outside workspace scope")
+                        if resolved_dir in seen_dirs:
+                            dirnames.remove(dirname)
+                            continue
+                        seen_dirs.add(resolved_dir)
+                    else:
+                        dirnames.remove(dirname)
+
+            candidates: list[tuple[Path, str]] = [(current_root / dirname, "directory") for dirname in dirnames]
+            candidates.extend((current_root / filename, "file") for filename in filenames)
+
+            for candidate, candidate_kind in candidates:
+                visited_entries += 1
+                if visited_entries > walk_entry_limit:
+                    walk_truncated = True
+                    dirnames.clear()
+                    break
+
+                rel_path = FilesystemModule._to_workspace_relative_path(workspace_root, candidate)
+                if not include_hidden and FilesystemModule._is_hidden_relative_path(rel_path):
+                    continue
+                is_symlink = candidate.is_symlink()
+                if is_symlink:
+                    candidate_type = "symlink"
+                else:
+                    candidate_type = candidate_kind
+
+                include_candidate = (
+                    (candidate_kind == "file" and include_files)
+                    or (candidate_kind == "directory" and include_directories)
+                )
+                if not include_candidate:
+                    continue
+                if not FilesystemModule._portable_pattern_matches(rel_path, pattern, case_sensitive=case_sensitive):
+                    continue
+
+                record: dict[str, Any] = {
+                    "path": rel_path,
+                    "type": candidate_type,
+                }
+                if candidate_kind == "file":
+                    with suppress(OSError):
+                        record["size"] = candidate.stat(follow_symlinks=False).st_size
+                matches.append(record)
+
+            if walk_truncated:
+                break
+
+        matches.sort(key=lambda item: str(item.get("path") or ""))
+        limited_matches = matches[:limit]
+        remaining_count = max(0, len(matches) - len(limited_matches))
+        return {
+            "base_path": FilesystemModule._to_workspace_relative_path(workspace_root, base),
+            "pattern": pattern,
+            "matches": limited_matches,
+            "truncated": walk_truncated or remaining_count > 0,
+            "remaining_count": remaining_count,
+        }
 
     @staticmethod
     def _list_directory(workspace_root: Path, target: Path, entry_limit: int) -> dict[str, Any]:

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_module.py
@@ -187,6 +187,96 @@ async def test_filesystem_tools_include_path_scope_metadata() -> None:
 
 
 @pytest.mark.asyncio
+async def test_filesystem_tools_include_stat_glob_and_grep_metadata() -> None:
+    resolver = _FakeWorkspaceRootResolver(
+        {
+            "workspace_root": "/workspace/mcp-filesystem-workspace",
+            "workspace_id": "workspace-1",
+            "source": "sandbox_workspace_lookup",
+            "reason": None,
+        }
+    )
+    mod = FilesystemModule(ModuleConfig(name="filesystem"), workspace_root_resolver=resolver)
+
+    tools = await mod.get_tools()
+    by_name = {tool["name"]: tool for tool in tools}
+
+    assert {"fs.stat", "fs.glob", "fs.grep"} <= set(by_name)  # nosec B101
+    for tool_name in ("fs.stat", "fs.glob", "fs.grep"):
+        schema = by_name[tool_name]["inputSchema"]
+        metadata = by_name[tool_name]["metadata"]
+        assert schema["additionalProperties"] is False  # nosec B101
+        assert metadata["uses_filesystem"] is True  # nosec B101
+        assert metadata["path_boundable"] is True  # nosec B101
+        assert "filesystem.read" in metadata["capabilities"]  # nosec B101
+        assert metadata["readOnlyHint"] is True  # nosec B101
+
+
+def test_filesystem_validates_new_filesystem_helper_arguments() -> None:
+    mod = FilesystemModule(
+        ModuleConfig(
+            name="filesystem",
+            settings={
+                "grep_max_pattern_length": 4,
+            },
+        ),
+        workspace_root_resolver=_FakeWorkspaceRootResolver({"workspace_root": "/workspace/root"}),
+    )
+
+    mod.validate_tool_arguments("fs.stat", {"path": "docs/readme.md"})
+    mod.validate_tool_arguments("fs.glob", {"pattern": "**/*.py", "limit": 10})
+    mod.validate_tool_arguments(
+        "fs.grep",
+        {
+            "pattern": "TODO",
+            "include": ["*.py", "**/*.md"],
+            "exclude": ["**/.venv/**"],
+            "limit": 10,
+            "max_file_bytes": 1024,
+        },
+    )
+
+    invalid_cases = [
+        ("fs.stat", {"path": "docs/readme.md", "extra": True}, "unknown arguments"),
+        ("fs.stat", {}, "path is required"),
+        ("fs.stat", {"path": ""}, "path is required"),
+        ("fs.stat", {"path": "docs/readme.md", "follow_symlinks": "yes"}, "follow_symlinks must be a boolean"),
+        ("fs.glob", {"pattern": "**/*.py", "unknown": True}, "unknown arguments"),
+        ("fs.glob", {}, "pattern is required"),
+        ("fs.glob", {"pattern": ""}, "pattern is required"),
+        ("fs.glob", {"pattern": "**/*.py", "base_path": 7}, "base_path must be a string"),
+        ("fs.glob", {"pattern": "**/*.py", "include_hidden": "yes"}, "include_hidden must be a boolean"),
+        ("fs.glob", {"pattern": "**/*.py", "include_files": "yes"}, "include_files must be a boolean"),
+        ("fs.glob", {"pattern": "**/*.py", "include_directories": "yes"}, "include_directories must be a boolean"),
+        ("fs.glob", {"pattern": "**/*.py", "follow_symlinks": "yes"}, "follow_symlinks must be a boolean"),
+        ("fs.glob", {"pattern": "**/*.py", "case_sensitive": "yes"}, "case_sensitive must be a boolean"),
+        ("fs.glob", {"pattern": "**/*.py", "limit": 0}, "limit must be a positive integer"),
+        ("fs.grep", {"pattern": "TODO", "unknown": True}, "unknown arguments"),
+        ("fs.grep", {}, "pattern is required"),
+        ("fs.grep", {"pattern": ""}, "pattern is required"),
+        ("fs.grep", {"pattern": "TODO", "base_path": 7}, "base_path must be a string"),
+        ("fs.grep", {"pattern": "TODO", "include": "*.py"}, "include must be a list of strings"),
+        ("fs.grep", {"pattern": "TODO", "include": [1]}, "include must be a list of strings"),
+        ("fs.grep", {"pattern": "TODO", "exclude": "*.py"}, "exclude must be a list of strings"),
+        ("fs.grep", {"pattern": "TODO", "regex": "yes"}, "regex must be a boolean"),
+        ("fs.grep", {"pattern": "TODO", "case_sensitive": "yes"}, "case_sensitive must be a boolean"),
+        ("fs.grep", {"pattern": "TODO", "include_hidden": "yes"}, "include_hidden must be a boolean"),
+        ("fs.grep", {"pattern": "TODO", "follow_symlinks": "yes"}, "follow_symlinks must be a boolean"),
+        ("fs.grep", {"pattern": "TODO", "limit": 0}, "limit must be a positive integer"),
+        ("fs.grep", {"pattern": "TODO", "max_file_bytes": 0}, "max_file_bytes must be a positive integer"),
+        (
+            "fs.grep",
+            {"pattern": "abcde", "regex": True},
+            "pattern exceeds grep regex length limit",
+        ),
+    ]
+
+    for tool_name, arguments, expected_message in invalid_cases:
+        with pytest.raises(ValueError, match=expected_message):
+            mod.validate_tool_arguments(tool_name, arguments)
+
+
+@pytest.mark.asyncio
 async def test_filesystem_list_read_and_write_text_within_workspace(tmp_path: Path) -> None:
     workspace_root = tmp_path / "workspace"
     docs_dir = workspace_root / "docs"

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_module.py
@@ -320,6 +320,113 @@ async def test_filesystem_list_read_and_write_text_within_workspace(tmp_path: Pa
 
 
 @pytest.mark.asyncio
+async def test_filesystem_stat_file_and_directory_metadata(tmp_path: Path) -> None:
+    workspace_root = tmp_path / "workspace"
+    docs_dir = workspace_root / "docs"
+    docs_dir.mkdir(parents=True, exist_ok=True)
+    source_file = docs_dir / "hello.txt"
+    source_file.write_text("hello world", encoding="utf-8")
+
+    resolver = _FakeWorkspaceRootResolver(
+        {
+            "workspace_root": str(workspace_root),
+            "workspace_id": "workspace-1",
+            "source": "sandbox_workspace_lookup",
+            "reason": None,
+        }
+    )
+    mod = FilesystemModule(ModuleConfig(name="filesystem"), workspace_root_resolver=resolver)
+    context = RequestContext(
+        request_id="req-filesystem-stat",
+        user_id="7",
+        session_id="sess-1",
+        metadata={"workspace_id": "workspace-1"},
+    )
+
+    file_stat = await mod.execute_tool("fs.stat", {"path": "docs/hello.txt"}, context=context)
+    dir_stat = await mod.execute_tool("fs.stat", {"path": "docs"}, context=context)
+
+    assert file_stat["path"] == "docs/hello.txt"  # nosec B101
+    assert file_stat["name"] == "hello.txt"  # nosec B101
+    assert file_stat["type"] == "file"  # nosec B101
+    assert file_stat["size"] == len("hello world".encode("utf-8"))  # nosec B101
+    assert file_stat["is_symlink"] is False  # nosec B101
+    assert isinstance(file_stat["modified_at"], str) and file_stat["modified_at"]  # nosec B101
+    assert isinstance(file_stat.get("mode"), int)  # nosec B101
+    assert dir_stat["path"] == "docs"  # nosec B101
+    assert dir_stat["name"] == "docs"  # nosec B101
+    assert dir_stat["type"] == "directory"  # nosec B101
+    assert dir_stat["is_symlink"] is False  # nosec B101
+
+
+@pytest.mark.asyncio
+async def test_filesystem_stat_rejects_missing_and_escaped_paths(tmp_path: Path) -> None:
+    workspace_root = tmp_path / "workspace"
+    workspace_root.mkdir(parents=True, exist_ok=True)
+
+    resolver = _FakeWorkspaceRootResolver(
+        {
+            "workspace_root": str(workspace_root),
+            "workspace_id": "workspace-1",
+            "source": "sandbox_workspace_lookup",
+            "reason": None,
+        }
+    )
+    mod = FilesystemModule(ModuleConfig(name="filesystem"), workspace_root_resolver=resolver)
+    context = RequestContext(
+        request_id="req-filesystem-stat-missing",
+        user_id="7",
+        metadata={"workspace_id": "workspace-1"},
+    )
+
+    with pytest.raises(FileNotFoundError, match="path not found"):
+        await mod.execute_tool("fs.stat", {"path": "missing.txt"}, context=context)
+    with pytest.raises(PermissionError, match="outside"):
+        await mod.execute_tool("fs.stat", {"path": "../escape.txt"}, context=context)
+
+
+@pytest.mark.asyncio
+async def test_filesystem_stat_symlink_policy_does_not_leak_targets(tmp_path: Path) -> None:
+    workspace_root = tmp_path / "workspace"
+    docs_dir = workspace_root / "docs"
+    docs_dir.mkdir(parents=True, exist_ok=True)
+    outside_dir = tmp_path / "outside"
+    outside_dir.mkdir(parents=True, exist_ok=True)
+    outside_file = outside_dir / "secret.txt"
+    outside_file.write_text("outside", encoding="utf-8")
+    link_path = docs_dir / "secret-link"
+    try:
+        link_path.symlink_to(outside_file)
+    except OSError as exc:
+        pytest.skip(f"symlink creation unavailable on this platform: {exc}")
+
+    resolver = _FakeWorkspaceRootResolver(
+        {
+            "workspace_root": str(workspace_root),
+            "workspace_id": "workspace-1",
+            "source": "sandbox_workspace_lookup",
+            "reason": None,
+        }
+    )
+    mod = FilesystemModule(ModuleConfig(name="filesystem"), workspace_root_resolver=resolver)
+    context = RequestContext(
+        request_id="req-filesystem-stat-symlink",
+        user_id="7",
+        metadata={"workspace_id": "workspace-1"},
+    )
+
+    link_stat = await mod.execute_tool("fs.stat", {"path": "docs/secret-link"}, context=context)
+
+    assert link_stat["path"] == "docs/secret-link"  # nosec B101
+    assert link_stat["name"] == "secret-link"  # nosec B101
+    assert link_stat["type"] == "symlink"  # nosec B101
+    assert link_stat["is_symlink"] is True  # nosec B101
+    assert str(outside_file.resolve()) not in str(link_stat)  # nosec B101
+    with pytest.raises(PermissionError, match="outside"):
+        await mod.execute_tool("fs.stat", {"path": "docs/secret-link", "follow_symlinks": True}, context=context)
+
+
+@pytest.mark.asyncio
 async def test_protocol_rejects_unknown_fs_read_text_arguments(tmp_path: Path) -> None:
     workspace_root = tmp_path / "workspace"
     docs_dir = workspace_root / "docs"

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_module.py
@@ -427,6 +427,39 @@ async def test_filesystem_stat_symlink_policy_does_not_leak_targets(tmp_path: Pa
 
 
 @pytest.mark.asyncio
+async def test_filesystem_stat_rejects_parent_symlink_escape_without_following(tmp_path: Path) -> None:
+    workspace_root = tmp_path / "workspace"
+    workspace_root.mkdir(parents=True, exist_ok=True)
+    outside_dir = tmp_path / "outside"
+    outside_dir.mkdir(parents=True, exist_ok=True)
+    outside_file = outside_dir / "secret.txt"
+    outside_file.write_text("outside", encoding="utf-8")
+    link_dir = workspace_root / "outside-dir"
+    try:
+        link_dir.symlink_to(outside_dir, target_is_directory=True)
+    except OSError as exc:
+        pytest.skip(f"symlink creation unavailable on this platform: {exc}")
+
+    resolver = _FakeWorkspaceRootResolver(
+        {
+            "workspace_root": str(workspace_root),
+            "workspace_id": "workspace-1",
+            "source": "sandbox_workspace_lookup",
+            "reason": None,
+        }
+    )
+    mod = FilesystemModule(ModuleConfig(name="filesystem"), workspace_root_resolver=resolver)
+    context = RequestContext(
+        request_id="req-filesystem-stat-parent-symlink",
+        user_id="7",
+        metadata={"workspace_id": "workspace-1"},
+    )
+
+    with pytest.raises(PermissionError, match="outside"):
+        await mod.execute_tool("fs.stat", {"path": "outside-dir/secret.txt"}, context=context)
+
+
+@pytest.mark.asyncio
 async def test_filesystem_glob_matches_sorted_paths_and_normalizes_patterns(tmp_path: Path) -> None:
     workspace_root = tmp_path / "workspace"
     package_dir = workspace_root / "pkg"
@@ -458,6 +491,30 @@ async def test_filesystem_glob_matches_sorted_paths_and_normalizes_patterns(tmp_
     assert result["base_path"] == "."  # nosec B101
     assert result["pattern"] == "**/*.py"  # nosec B101
     assert result["truncated"] is False  # nosec B101
+
+
+@pytest.mark.asyncio
+async def test_filesystem_glob_rejects_excessive_double_star_patterns(tmp_path: Path) -> None:
+    workspace_root = tmp_path / "workspace"
+    workspace_root.mkdir(parents=True, exist_ok=True)
+
+    resolver = _FakeWorkspaceRootResolver(
+        {
+            "workspace_root": str(workspace_root),
+            "workspace_id": "workspace-1",
+            "source": "sandbox_workspace_lookup",
+            "reason": None,
+        }
+    )
+    mod = FilesystemModule(ModuleConfig(name="filesystem"), workspace_root_resolver=resolver)
+    context = RequestContext(
+        request_id="req-filesystem-glob-double-star-cap",
+        user_id="7",
+        metadata={"workspace_id": "workspace-1"},
+    )
+
+    with pytest.raises(ValueError, match="too many double-star"):
+        await mod.execute_tool("fs.glob", {"pattern": "**/**/**/**/**/**/*.py"}, context=context)
 
 
 @pytest.mark.asyncio
@@ -582,6 +639,41 @@ async def test_filesystem_glob_caps_walk_and_rejects_outside_symlink_dirs(tmp_pa
     assert "outside-link/secret.py" not in [match["path"] for match in no_follow["matches"]]  # nosec B101
     with pytest.raises(PermissionError, match="outside"):
         await mod.execute_tool("fs.glob", {"pattern": "**/*.py", "follow_symlinks": True}, context=context)
+
+
+@pytest.mark.asyncio
+async def test_filesystem_glob_returns_symlink_directories_without_traversing(tmp_path: Path) -> None:
+    workspace_root = tmp_path / "workspace"
+    workspace_root.mkdir(parents=True, exist_ok=True)
+    outside_dir = tmp_path / "outside"
+    outside_dir.mkdir(parents=True, exist_ok=True)
+    (outside_dir / "secret.py").write_text("secret", encoding="utf-8")
+    link_path = workspace_root / "outside-link"
+    try:
+        link_path.symlink_to(outside_dir, target_is_directory=True)
+    except OSError as exc:
+        pytest.skip(f"symlink creation unavailable on this platform: {exc}")
+
+    resolver = _FakeWorkspaceRootResolver(
+        {
+            "workspace_root": str(workspace_root),
+            "workspace_id": "workspace-1",
+            "source": "sandbox_workspace_lookup",
+            "reason": None,
+        }
+    )
+    mod = FilesystemModule(ModuleConfig(name="filesystem"), workspace_root_resolver=resolver)
+    context = RequestContext(
+        request_id="req-filesystem-glob-symlink-dir-entry",
+        user_id="7",
+        metadata={"workspace_id": "workspace-1"},
+    )
+
+    result = await mod.execute_tool("fs.glob", {"pattern": "*"}, context=context)
+
+    assert result["matches"] == [  # nosec B101
+        {"path": "outside-link", "type": "symlink"}
+    ]
 
 
 @pytest.mark.asyncio
@@ -732,6 +824,37 @@ async def test_filesystem_grep_limits_and_regex_errors(tmp_path: Path, monkeypat
     monkeypatch.setattr(Path, "read_bytes", _fail_read_bytes)
     with pytest.raises(ValueError, match="invalid regex pattern"):
         await limit_mod.execute_tool("fs.grep", {"pattern": "[", "regex": True}, context=context)
+
+
+@pytest.mark.asyncio
+async def test_filesystem_grep_caps_directory_only_walks(tmp_path: Path) -> None:
+    workspace_root = tmp_path / "workspace"
+    workspace_root.mkdir(parents=True, exist_ok=True)
+    for index in range(5):
+        (workspace_root / f"empty-{index}").mkdir()
+
+    resolver = _FakeWorkspaceRootResolver(
+        {
+            "workspace_root": str(workspace_root),
+            "workspace_id": "workspace-1",
+            "source": "sandbox_workspace_lookup",
+            "reason": None,
+        }
+    )
+    mod = FilesystemModule(
+        ModuleConfig(name="filesystem", settings={"grep_walk_entry_limit": 2}),
+        workspace_root_resolver=resolver,
+    )
+    context = RequestContext(
+        request_id="req-filesystem-grep-dir-cap",
+        user_id="7",
+        metadata={"workspace_id": "workspace-1"},
+    )
+
+    result = await mod.execute_tool("fs.grep", {"pattern": "missing"}, context=context)
+
+    assert result["matches"] == []  # nosec B101
+    assert result["truncated"] is True  # nosec B101
 
 
 @pytest.mark.asyncio

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_module.py
@@ -427,6 +427,164 @@ async def test_filesystem_stat_symlink_policy_does_not_leak_targets(tmp_path: Pa
 
 
 @pytest.mark.asyncio
+async def test_filesystem_glob_matches_sorted_paths_and_normalizes_patterns(tmp_path: Path) -> None:
+    workspace_root = tmp_path / "workspace"
+    package_dir = workspace_root / "pkg"
+    package_dir.mkdir(parents=True, exist_ok=True)
+    (workspace_root / "app.py").write_text("print('root')", encoding="utf-8")
+    (package_dir / "app.py").write_text("print('pkg')", encoding="utf-8")
+    (package_dir / "README.md").write_text("# docs", encoding="utf-8")
+
+    resolver = _FakeWorkspaceRootResolver(
+        {
+            "workspace_root": str(workspace_root),
+            "workspace_id": "workspace-1",
+            "source": "sandbox_workspace_lookup",
+            "reason": None,
+        }
+    )
+    mod = FilesystemModule(ModuleConfig(name="filesystem"), workspace_root_resolver=resolver)
+    context = RequestContext(
+        request_id="req-filesystem-glob",
+        user_id="7",
+        metadata={"workspace_id": "workspace-1"},
+    )
+
+    result = await mod.execute_tool("fs.glob", {"pattern": "**/*.py"}, context=context)
+    backslash_result = await mod.execute_tool("fs.glob", {"pattern": r"**\*.py"}, context=context)
+
+    assert [match["path"] for match in result["matches"]] == ["app.py", "pkg/app.py"]  # nosec B101
+    assert [match["path"] for match in backslash_result["matches"]] == ["app.py", "pkg/app.py"]  # nosec B101
+    assert result["base_path"] == "."  # nosec B101
+    assert result["pattern"] == "**/*.py"  # nosec B101
+    assert result["truncated"] is False  # nosec B101
+
+
+@pytest.mark.asyncio
+async def test_filesystem_glob_case_hidden_and_limit_behavior(tmp_path: Path) -> None:
+    workspace_root = tmp_path / "workspace"
+    hidden_dir = workspace_root / ".secret"
+    hidden_dir.mkdir(parents=True, exist_ok=True)
+    (workspace_root / "App.PY").write_text("print('mixed')", encoding="utf-8")
+    (workspace_root / "visible.py").write_text("print('visible')", encoding="utf-8")
+    (workspace_root / ".hidden.py").write_text("print('hidden')", encoding="utf-8")
+    (hidden_dir / "nested.py").write_text("print('nested')", encoding="utf-8")
+
+    resolver = _FakeWorkspaceRootResolver(
+        {
+            "workspace_root": str(workspace_root),
+            "workspace_id": "workspace-1",
+            "source": "sandbox_workspace_lookup",
+            "reason": None,
+        }
+    )
+    mod = FilesystemModule(ModuleConfig(name="filesystem"), workspace_root_resolver=resolver)
+    context = RequestContext(
+        request_id="req-filesystem-glob-hidden",
+        user_id="7",
+        metadata={"workspace_id": "workspace-1"},
+    )
+
+    sensitive = await mod.execute_tool("fs.glob", {"pattern": "**/*.py"}, context=context)
+    insensitive = await mod.execute_tool(
+        "fs.glob",
+        {"pattern": "**/*.py", "case_sensitive": False},
+        context=context,
+    )
+    hidden = await mod.execute_tool(
+        "fs.glob",
+        {"pattern": "**/*.py", "case_sensitive": False, "include_hidden": True},
+        context=context,
+    )
+    limited = await mod.execute_tool(
+        "fs.glob",
+        {"pattern": "**/*.py", "case_sensitive": False, "include_hidden": True, "limit": 2},
+        context=context,
+    )
+
+    assert [match["path"] for match in sensitive["matches"]] == ["visible.py"]  # nosec B101
+    assert [match["path"] for match in insensitive["matches"]] == ["App.PY", "visible.py"]  # nosec B101
+    assert [match["path"] for match in hidden["matches"]] == [  # nosec B101
+        ".hidden.py",
+        ".secret/nested.py",
+        "App.PY",
+        "visible.py",
+    ]
+    assert limited["truncated"] is True  # nosec B101
+    assert limited["remaining_count"] == 2  # nosec B101
+    assert len(limited["matches"]) == 2  # nosec B101
+
+
+@pytest.mark.asyncio
+async def test_filesystem_glob_rejects_unsafe_patterns(tmp_path: Path) -> None:
+    workspace_root = tmp_path / "workspace"
+    workspace_root.mkdir(parents=True, exist_ok=True)
+
+    resolver = _FakeWorkspaceRootResolver(
+        {
+            "workspace_root": str(workspace_root),
+            "workspace_id": "workspace-1",
+            "source": "sandbox_workspace_lookup",
+            "reason": None,
+        }
+    )
+    mod = FilesystemModule(ModuleConfig(name="filesystem"), workspace_root_resolver=resolver)
+    context = RequestContext(
+        request_id="req-filesystem-glob-unsafe",
+        user_id="7",
+        metadata={"workspace_id": "workspace-1"},
+    )
+
+    for pattern in ("/tmp/*", "C:/tmp/*", "//server/share/*", "../*"):
+        with pytest.raises(ValueError, match="unsafe pattern"):
+            await mod.execute_tool("fs.glob", {"pattern": pattern}, context=context)
+
+
+@pytest.mark.asyncio
+async def test_filesystem_glob_caps_walk_and_rejects_outside_symlink_dirs(tmp_path: Path) -> None:
+    workspace_root = tmp_path / "workspace"
+    docs_dir = workspace_root / "docs"
+    docs_dir.mkdir(parents=True, exist_ok=True)
+    for index in range(5):
+        (docs_dir / f"file-{index}.py").write_text("x", encoding="utf-8")
+    outside_dir = tmp_path / "outside"
+    outside_dir.mkdir(parents=True, exist_ok=True)
+    (outside_dir / "secret.py").write_text("secret", encoding="utf-8")
+    link_path = workspace_root / "outside-link"
+    try:
+        link_path.symlink_to(outside_dir, target_is_directory=True)
+    except OSError as exc:
+        pytest.skip(f"symlink creation unavailable on this platform: {exc}")
+
+    resolver = _FakeWorkspaceRootResolver(
+        {
+            "workspace_root": str(workspace_root),
+            "workspace_id": "workspace-1",
+            "source": "sandbox_workspace_lookup",
+            "reason": None,
+        }
+    )
+    mod = FilesystemModule(
+        ModuleConfig(name="filesystem", settings={"glob_walk_entry_limit": 2}),
+        workspace_root_resolver=resolver,
+    )
+    context = RequestContext(
+        request_id="req-filesystem-glob-cap",
+        user_id="7",
+        metadata={"workspace_id": "workspace-1"},
+    )
+
+    capped = await mod.execute_tool("fs.glob", {"pattern": "**/*.py", "base_path": "docs"}, context=context)
+    no_follow = await mod.execute_tool("fs.glob", {"pattern": "**/*.py"}, context=context)
+
+    assert capped["truncated"] is True  # nosec B101
+    assert len(capped["matches"]) <= 2  # nosec B101
+    assert "outside-link/secret.py" not in [match["path"] for match in no_follow["matches"]]  # nosec B101
+    with pytest.raises(PermissionError, match="outside"):
+        await mod.execute_tool("fs.glob", {"pattern": "**/*.py", "follow_symlinks": True}, context=context)
+
+
+@pytest.mark.asyncio
 async def test_protocol_rejects_unknown_fs_read_text_arguments(tmp_path: Path) -> None:
     workspace_root = tmp_path / "workspace"
     docs_dir = workspace_root / "docs"

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_module.py
@@ -9,9 +9,7 @@ from tldw_Server_API.app.core.MCP_unified.modules.base import ModuleConfig
 from tldw_Server_API.app.core.MCP_unified.modules.implementations.filesystem_module import (
     FilesystemModule,
 )
-from tldw_Server_API.app.core.MCP_unified.protocol import InvalidParamsException
-from tldw_Server_API.app.core.MCP_unified.protocol import MCPProtocol
-from tldw_Server_API.app.core.MCP_unified.protocol import RequestContext
+from tldw_Server_API.app.core.MCP_unified.protocol import InvalidParamsException, MCPProtocol, RequestContext
 from tldw_Server_API.app.services.mcp_hub_workspace_root_resolver import (
     McpHubWorkspaceRootResolver,
 )
@@ -217,6 +215,7 @@ def test_filesystem_validates_new_filesystem_helper_arguments() -> None:
         ModuleConfig(
             name="filesystem",
             settings={
+                "grep_allow_regex": True,
                 "grep_max_pattern_length": 4,
             },
         ),
@@ -314,7 +313,7 @@ async def test_filesystem_list_read_and_write_text_within_workspace(tmp_path: Pa
         context=context,
     )
     assert write_result["path"] == "docs/new.txt"  # nosec B101
-    assert write_result["bytes_written"] == len("created by fs.write_text".encode("utf-8"))  # nosec B101
+    assert write_result["bytes_written"] == len(b"created by fs.write_text")  # nosec B101
     assert (docs_dir / "new.txt").read_text(encoding="utf-8") == "created by fs.write_text"  # nosec B101
     assert len(resolver.calls) == 3  # nosec B101
 
@@ -349,7 +348,7 @@ async def test_filesystem_stat_file_and_directory_metadata(tmp_path: Path) -> No
     assert file_stat["path"] == "docs/hello.txt"  # nosec B101
     assert file_stat["name"] == "hello.txt"  # nosec B101
     assert file_stat["type"] == "file"  # nosec B101
-    assert file_stat["size"] == len("hello world".encode("utf-8"))  # nosec B101
+    assert file_stat["size"] == len(b"hello world")  # nosec B101
     assert file_stat["is_symlink"] is False  # nosec B101
     assert isinstance(file_stat["modified_at"], str) and file_stat["modified_at"]  # nosec B101
     assert isinstance(file_stat.get("mode"), int)  # nosec B101
@@ -491,6 +490,53 @@ async def test_filesystem_glob_matches_sorted_paths_and_normalizes_patterns(tmp_
     assert result["base_path"] == "."  # nosec B101
     assert result["pattern"] == "**/*.py"  # nosec B101
     assert result["truncated"] is False  # nosec B101
+
+
+@pytest.mark.asyncio
+async def test_filesystem_glob_marks_file_size_unavailable(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace_root = tmp_path / "workspace"
+    workspace_root.mkdir(parents=True, exist_ok=True)
+    source_file = workspace_root / "unreadable-size.txt"
+    source_file.write_text("content", encoding="utf-8")
+
+    resolver = _FakeWorkspaceRootResolver(
+        {
+            "workspace_root": str(workspace_root),
+            "workspace_id": "workspace-1",
+            "source": "sandbox_workspace_lookup",
+            "reason": None,
+        }
+    )
+    mod = FilesystemModule(ModuleConfig(name="filesystem"), workspace_root_resolver=resolver)
+    context = RequestContext(
+        request_id="req-filesystem-glob-size-unavailable",
+        user_id="7",
+        metadata={"workspace_id": "workspace-1"},
+    )
+    original_stat = Path.stat
+    stat_calls_by_path: dict[Path, int] = {}
+
+    def _raise_for_source_file(self: Path, *args: Any, **kwargs: Any):
+        stat_calls_by_path[self] = stat_calls_by_path.get(self, 0) + 1
+        if self == source_file and stat_calls_by_path[self] > 1:
+            raise OSError("metadata unavailable")
+        return original_stat(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "stat", _raise_for_source_file)
+
+    result = await mod.execute_tool("fs.glob", {"pattern": "*.txt"}, context=context)
+
+    assert result["matches"] == [  # nosec B101
+        {
+            "path": "unreadable-size.txt",
+            "type": "file",
+            "size": None,
+            "size_unavailable": True,
+        }
+    ]
 
 
 @pytest.mark.asyncio
@@ -692,7 +738,10 @@ async def test_filesystem_grep_literal_regex_case_and_newlines(tmp_path: Path) -
             "reason": None,
         }
     )
-    mod = FilesystemModule(ModuleConfig(name="filesystem"), workspace_root_resolver=resolver)
+    mod = FilesystemModule(
+        ModuleConfig(name="filesystem", settings={"grep_allow_regex": True}),
+        workspace_root_resolver=resolver,
+    )
     context = RequestContext(
         request_id="req-filesystem-grep",
         user_id="7",
@@ -732,6 +781,30 @@ async def test_filesystem_grep_literal_regex_case_and_newlines(tmp_path: Path) -
     assert insensitive["matches"][0]["match_text"] == "Error"  # nosec B101
     assert newline["matches"][0]["line_number"] == 3  # nosec B101
     assert newline["matches"][0]["line"] == "third"  # nosec B101
+
+
+@pytest.mark.asyncio
+async def test_filesystem_grep_rejects_regex_when_disabled_by_default(tmp_path: Path) -> None:
+    workspace_root = tmp_path / "workspace"
+    workspace_root.mkdir(parents=True, exist_ok=True)
+
+    resolver = _FakeWorkspaceRootResolver(
+        {
+            "workspace_root": str(workspace_root),
+            "workspace_id": "workspace-1",
+            "source": "sandbox_workspace_lookup",
+            "reason": None,
+        }
+    )
+    mod = FilesystemModule(ModuleConfig(name="filesystem"), workspace_root_resolver=resolver)
+    context = RequestContext(
+        request_id="req-filesystem-grep-regex-disabled",
+        user_id="7",
+        metadata={"workspace_id": "workspace-1"},
+    )
+
+    with pytest.raises(ValueError, match="regex grep is disabled"):
+        await mod.execute_tool("fs.grep", {"pattern": "TODO", "regex": True}, context=context)
 
 
 @pytest.mark.asyncio
@@ -797,7 +870,10 @@ async def test_filesystem_grep_limits_and_regex_errors(tmp_path: Path, monkeypat
             "reason": None,
         }
     )
-    limit_mod = FilesystemModule(ModuleConfig(name="filesystem"), workspace_root_resolver=resolver)
+    limit_mod = FilesystemModule(
+        ModuleConfig(name="filesystem", settings={"grep_allow_regex": True}),
+        workspace_root_resolver=resolver,
+    )
     cap_mod = FilesystemModule(
         ModuleConfig(name="filesystem", settings={"grep_walk_entry_limit": 2}),
         workspace_root_resolver=resolver,
@@ -824,6 +900,48 @@ async def test_filesystem_grep_limits_and_regex_errors(tmp_path: Path, monkeypat
     monkeypatch.setattr(Path, "read_bytes", _fail_read_bytes)
     with pytest.raises(ValueError, match="invalid regex pattern"):
         await limit_mod.execute_tool("fs.grep", {"pattern": "[", "regex": True}, context=context)
+
+
+@pytest.mark.asyncio
+async def test_filesystem_grep_caps_global_io_budgets(tmp_path: Path) -> None:
+    workspace_root = tmp_path / "workspace"
+    workspace_root.mkdir(parents=True, exist_ok=True)
+    for name in ("a.txt", "b.txt", "c.txt"):
+        (workspace_root / name).write_text("TODO " + ("x" * 16), encoding="utf-8")
+
+    resolver = _FakeWorkspaceRootResolver(
+        {
+            "workspace_root": str(workspace_root),
+            "workspace_id": "workspace-1",
+            "source": "sandbox_workspace_lookup",
+            "reason": None,
+        }
+    )
+    byte_budget_mod = FilesystemModule(
+        ModuleConfig(name="filesystem", settings={"grep_max_total_bytes": 24}),
+        workspace_root_resolver=resolver,
+    )
+    file_budget_mod = FilesystemModule(
+        ModuleConfig(name="filesystem", settings={"grep_max_files": 1}),
+        workspace_root_resolver=resolver,
+    )
+    context = RequestContext(
+        request_id="req-filesystem-grep-io-budget",
+        user_id="7",
+        metadata={"workspace_id": "workspace-1"},
+    )
+
+    byte_limited = await byte_budget_mod.execute_tool("fs.grep", {"pattern": "TODO"}, context=context)
+    file_limited = await file_budget_mod.execute_tool("fs.grep", {"pattern": "TODO"}, context=context)
+
+    assert [match["path"] for match in byte_limited["matches"]] == ["a.txt"]  # nosec B101
+    assert byte_limited["truncated"] is True  # nosec B101
+    assert byte_limited["remaining_count_known"] is False  # nosec B101
+    assert "io_budget" in byte_limited["truncation_reasons"]  # nosec B101
+    assert [match["path"] for match in file_limited["matches"]] == ["a.txt"]  # nosec B101
+    assert file_limited["truncated"] is True  # nosec B101
+    assert file_limited["remaining_count_known"] is False  # nosec B101
+    assert "file_budget" in file_limited["truncation_reasons"]  # nosec B101
 
 
 @pytest.mark.asyncio

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_module.py
@@ -585,6 +585,192 @@ async def test_filesystem_glob_caps_walk_and_rejects_outside_symlink_dirs(tmp_pa
 
 
 @pytest.mark.asyncio
+async def test_filesystem_grep_literal_regex_case_and_newlines(tmp_path: Path) -> None:
+    workspace_root = tmp_path / "workspace"
+    docs_dir = workspace_root / "docs"
+    docs_dir.mkdir(parents=True, exist_ok=True)
+    (docs_dir / "app.py").write_text("alpha\nTODO: fix root\nError mixed\n", encoding="utf-8")
+    (docs_dir / "notes.txt").write_text("first\r\nTODO: docs\rthird\r", encoding="utf-8", newline="")
+
+    resolver = _FakeWorkspaceRootResolver(
+        {
+            "workspace_root": str(workspace_root),
+            "workspace_id": "workspace-1",
+            "source": "sandbox_workspace_lookup",
+            "reason": None,
+        }
+    )
+    mod = FilesystemModule(ModuleConfig(name="filesystem"), workspace_root_resolver=resolver)
+    context = RequestContext(
+        request_id="req-filesystem-grep",
+        user_id="7",
+        metadata={"workspace_id": "workspace-1"},
+    )
+
+    literal = await mod.execute_tool(
+        "fs.grep",
+        {"pattern": "TODO", "base_path": "docs", "include": ["**/*.py"]},
+        context=context,
+    )
+    regex = await mod.execute_tool(
+        "fs.grep",
+        {"pattern": r"TODO:\s+\w+", "base_path": "docs", "regex": True},
+        context=context,
+    )
+    insensitive = await mod.execute_tool(
+        "fs.grep",
+        {"pattern": "error", "base_path": "docs", "case_sensitive": False},
+        context=context,
+    )
+    newline = await mod.execute_tool(
+        "fs.grep",
+        {"pattern": "third", "base_path": "docs"},
+        context=context,
+    )
+
+    assert literal["matches"] == [  # nosec B101
+        {
+            "path": "docs/app.py",
+            "line_number": 2,
+            "line": "TODO: fix root",
+            "match_text": "TODO",
+        }
+    ]
+    assert regex["matches"][0]["match_text"] == "TODO: fix"  # nosec B101
+    assert insensitive["matches"][0]["match_text"] == "Error"  # nosec B101
+    assert newline["matches"][0]["line_number"] == 3  # nosec B101
+    assert newline["matches"][0]["line"] == "third"  # nosec B101
+
+
+@pytest.mark.asyncio
+async def test_filesystem_grep_skips_binary_decode_and_large_files(tmp_path: Path) -> None:
+    workspace_root = tmp_path / "workspace"
+    src_dir = workspace_root / "src"
+    src_dir.mkdir(parents=True, exist_ok=True)
+    (src_dir / "a.py").write_text("TODO small\n", encoding="utf-8")
+    (src_dir / "b.md").write_text("TODO excluded\n", encoding="utf-8")
+    (src_dir / "large.txt").write_text("TODO " + ("x" * 64), encoding="utf-8")
+    (src_dir / "blob.bin").write_bytes(b"\x00TODO")
+    (src_dir / "bad.txt").write_bytes(b"\xffTODO")
+
+    resolver = _FakeWorkspaceRootResolver(
+        {
+            "workspace_root": str(workspace_root),
+            "workspace_id": "workspace-1",
+            "source": "sandbox_workspace_lookup",
+            "reason": None,
+        }
+    )
+    mod = FilesystemModule(ModuleConfig(name="filesystem"), workspace_root_resolver=resolver)
+    context = RequestContext(
+        request_id="req-filesystem-grep-skips",
+        user_id="7",
+        metadata={"workspace_id": "workspace-1"},
+    )
+
+    result = await mod.execute_tool(
+        "fs.grep",
+        {
+            "pattern": "TODO",
+            "base_path": "src",
+            "include": ["**/*"],
+            "exclude": ["**/*.md"],
+            "max_file_bytes": 32,
+        },
+        context=context,
+    )
+
+    assert [match["path"] for match in result["matches"]] == ["src/a.py"]  # nosec B101
+    assert result["skipped"]["binary"] == 1  # nosec B101
+    assert result["skipped"]["decode_error"] == 1  # nosec B101
+    assert result["skipped"]["too_large"] == 1  # nosec B101
+
+
+@pytest.mark.asyncio
+async def test_filesystem_grep_limits_and_regex_errors(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    workspace_root = tmp_path / "workspace"
+    workspace_root.mkdir(parents=True, exist_ok=True)
+    for index in range(5):
+        (workspace_root / f"file-{index}.txt").write_text("TODO\n", encoding="utf-8")
+
+    resolver = _FakeWorkspaceRootResolver(
+        {
+            "workspace_root": str(workspace_root),
+            "workspace_id": "workspace-1",
+            "source": "sandbox_workspace_lookup",
+            "reason": None,
+        }
+    )
+    limit_mod = FilesystemModule(ModuleConfig(name="filesystem"), workspace_root_resolver=resolver)
+    cap_mod = FilesystemModule(
+        ModuleConfig(name="filesystem", settings={"grep_walk_entry_limit": 2}),
+        workspace_root_resolver=resolver,
+    )
+    context = RequestContext(
+        request_id="req-filesystem-grep-limits",
+        user_id="7",
+        metadata={"workspace_id": "workspace-1"},
+    )
+
+    limited = await limit_mod.execute_tool("fs.grep", {"pattern": "TODO", "limit": 2}, context=context)
+    capped = await cap_mod.execute_tool("fs.grep", {"pattern": "TODO"}, context=context)
+
+    assert limited["truncated"] is True  # nosec B101
+    assert len(limited["matches"]) == 2  # nosec B101
+    assert capped["truncated"] is True  # nosec B101
+    assert len(capped["matches"]) <= 2  # nosec B101
+
+    def _fail_read_bytes(self):  # noqa: ANN001
+        raise AssertionError("invalid regex should be rejected before file reads")
+
+    monkeypatch.setattr(Path, "read_bytes", _fail_read_bytes)
+    with pytest.raises(ValueError, match="invalid regex pattern"):
+        await limit_mod.execute_tool("fs.grep", {"pattern": "[", "regex": True}, context=context)
+
+
+@pytest.mark.asyncio
+async def test_filesystem_grep_symlink_policy_and_loop_avoidance(tmp_path: Path) -> None:
+    workspace_root = tmp_path / "workspace"
+    workspace_root.mkdir(parents=True, exist_ok=True)
+    (workspace_root / "root.txt").write_text("TODO root\n", encoding="utf-8")
+    outside_dir = tmp_path / "outside"
+    outside_dir.mkdir(parents=True, exist_ok=True)
+    (outside_dir / "secret.txt").write_text("TODO secret\n", encoding="utf-8")
+    outside_link = workspace_root / "outside-link"
+    loop_link = workspace_root / "loop"
+    try:
+        outside_link.symlink_to(outside_dir, target_is_directory=True)
+        loop_link.symlink_to(workspace_root, target_is_directory=True)
+    except OSError as exc:
+        pytest.skip(f"symlink creation unavailable on this platform: {exc}")
+
+    resolver = _FakeWorkspaceRootResolver(
+        {
+            "workspace_root": str(workspace_root),
+            "workspace_id": "workspace-1",
+            "source": "sandbox_workspace_lookup",
+            "reason": None,
+        }
+    )
+    mod = FilesystemModule(ModuleConfig(name="filesystem"), workspace_root_resolver=resolver)
+    context = RequestContext(
+        request_id="req-filesystem-grep-symlink",
+        user_id="7",
+        metadata={"workspace_id": "workspace-1"},
+    )
+
+    no_follow = await mod.execute_tool("fs.grep", {"pattern": "TODO"}, context=context)
+    outside_link.unlink()
+    loop_safe = await mod.execute_tool("fs.grep", {"pattern": "TODO", "follow_symlinks": True}, context=context)
+
+    assert [match["path"] for match in no_follow["matches"]] == ["root.txt"]  # nosec B101
+    assert [match["path"] for match in loop_safe["matches"]] == ["root.txt"]  # nosec B101
+    outside_link.symlink_to(outside_dir, target_is_directory=True)
+    with pytest.raises(PermissionError, match="outside"):
+        await mod.execute_tool("fs.grep", {"pattern": "TODO", "follow_symlinks": True}, context=context)
+
+
+@pytest.mark.asyncio
 async def test_protocol_rejects_unknown_fs_read_text_arguments(tmp_path: Path) -> None:
     workspace_root = tmp_path / "workspace"
     docs_dir = workspace_root / "docs"

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_module.py
@@ -30,7 +30,7 @@ class _FakeWorkspaceRootResolver:
 class _FilesystemRegistry:
     def __init__(self, module: FilesystemModule) -> None:
         self.module = module
-        self._tool_names = {"fs.list", "fs.read_text", "fs.write_text"}
+        self._tool_names = {"fs.list", "fs.read_text", "fs.write_text", "fs.stat", "fs.glob", "fs.grep"}
 
     async def find_module_for_tool(self, tool_name: str):  # noqa: ANN001
         if tool_name in self._tool_names:
@@ -689,7 +689,11 @@ async def test_filesystem_grep_skips_binary_decode_and_large_files(tmp_path: Pat
 @pytest.mark.asyncio
 async def test_filesystem_grep_limits_and_regex_errors(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     workspace_root = tmp_path / "workspace"
+    nested_dir = workspace_root / "a"
     workspace_root.mkdir(parents=True, exist_ok=True)
+    nested_dir.mkdir(parents=True, exist_ok=True)
+    (workspace_root / "z-root.txt").write_text("TODO root\n", encoding="utf-8")
+    (nested_dir / "a-nested.txt").write_text("TODO nested\n", encoding="utf-8")
     for index in range(5):
         (workspace_root / f"file-{index}.txt").write_text("TODO\n", encoding="utf-8")
 
@@ -713,10 +717,12 @@ async def test_filesystem_grep_limits_and_regex_errors(tmp_path: Path, monkeypat
     )
 
     limited = await limit_mod.execute_tool("fs.grep", {"pattern": "TODO", "limit": 2}, context=context)
+    sorted_limited = await limit_mod.execute_tool("fs.grep", {"pattern": "TODO", "limit": 1}, context=context)
     capped = await cap_mod.execute_tool("fs.grep", {"pattern": "TODO"}, context=context)
 
     assert limited["truncated"] is True  # nosec B101
     assert len(limited["matches"]) == 2  # nosec B101
+    assert sorted_limited["matches"][0]["path"] == "a/a-nested.txt"  # nosec B101
     assert capped["truncated"] is True  # nosec B101
     assert len(capped["matches"]) <= 2  # nosec B101
 
@@ -813,6 +819,58 @@ async def test_protocol_rejects_unknown_fs_read_text_arguments(tmp_path: Path) -
             {"name": "fs.read_text", "arguments": {"path": "docs/hello.txt", "unknown": "boom"}},
             context,
         )
+
+
+@pytest.mark.asyncio
+async def test_protocol_rejects_unknown_new_filesystem_helper_arguments(tmp_path: Path) -> None:
+    workspace_root = tmp_path / "workspace"
+    docs_dir = workspace_root / "docs"
+    docs_dir.mkdir(parents=True, exist_ok=True)
+    (docs_dir / "hello.txt").write_text("hello world", encoding="utf-8")
+
+    resolver = _FakeWorkspaceRootResolver(
+        {
+            "workspace_root": str(workspace_root),
+            "workspace_id": "workspace-1",
+            "source": "sandbox_workspace_lookup",
+            "reason": None,
+        }
+    )
+    mod = FilesystemModule(ModuleConfig(name="filesystem"), workspace_root_resolver=resolver)
+
+    protocol = MCPProtocol()
+    protocol.module_registry = _FilesystemRegistry(mod)
+
+    async def _resolve_effective_policy(_context):
+        return {
+            "enabled": True,
+            "allowed_tools": ["fs.stat", "fs.glob", "fs.grep"],
+            "policy_document": {"path_scope_mode": "none"},
+        }
+
+    async def _allow(*_args, **_kwargs) -> bool:
+        return True
+
+    protocol._resolve_effective_tool_policy = _resolve_effective_policy  # type: ignore[method-assign]
+    protocol._has_module_permission = _allow  # type: ignore[method-assign]
+    protocol._has_tool_permission = _allow  # type: ignore[method-assign]
+    protocol._is_tool_allowed_by_context = lambda *_args, **_kwargs: True  # type: ignore[method-assign]
+
+    context = RequestContext(
+        request_id="req-fs-new-helper-unknown-arg",
+        user_id="7",
+        session_id="sess-1",
+        metadata={"workspace_id": "workspace-1"},
+    )
+
+    cases = [
+        ("fs.stat", {"path": "docs/hello.txt", "unknown": "boom"}),
+        ("fs.glob", {"pattern": "**/*.txt", "unknown": "boom"}),
+        ("fs.grep", {"pattern": "hello", "unknown": "boom"}),
+    ]
+    for tool_name, arguments in cases:
+        with pytest.raises(InvalidParamsException, match="Unknown parameters"):
+            await protocol._handle_tools_call({"name": tool_name, "arguments": arguments}, context)
 
 
 @pytest.mark.asyncio

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_profile_presets.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_profile_presets.py
@@ -85,7 +85,7 @@ def test_profile_presets_module_has_no_tldw_server_imports() -> None:
 def test_builtin_presets_cover_initial_mode_ids_and_pass_safety_baseline() -> None:
     bundled = presets.list_builtin_presets()
     assert {preset.id for preset in bundled} == EXPECTED_PRESET_IDS
-    assert all(preset.version == "2026.05.27" for preset in bundled)
+    assert all(preset.version == "2026.06.04" for preset in bundled)
 
     safety_violations = {
         preset.id: presets.validate_preset_safety(preset)
@@ -257,7 +257,7 @@ def test_duplicate_builtin_preset_returns_editable_profile_with_provenance() -> 
     assert profile.id == "workspace-architect"
     assert profile.name == "Workspace Architect"
     assert profile.preset_id == "architect"
-    assert profile.preset_version == "2026.05.27"
+    assert profile.preset_version == "2026.06.04"
     assert profile.provenance["source"] == "builtin_preset"
     assert profile.provenance["preset_id"] == "architect"
 

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_profile_presets.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_profile_presets.py
@@ -135,6 +135,17 @@ def test_role_presets_include_tooling_metadata() -> None:
         assert tooling["progressive_disclosure"]["max_direct_tools"] <= 24
 
 
+def test_filesystem_read_presets_include_helper_tools() -> None:
+    expected = {"fs.stat", "fs.glob", "fs.grep"}
+    for preset in presets.list_builtin_presets():
+        tooling = preset.profile.metadata.get("tooling")
+        if not isinstance(tooling, dict):
+            continue
+        enabled_tools = set(tooling.get("enabled_tools") or [])
+        if {"fs.list", "fs.read_text"} <= enabled_tools:
+            assert expected <= enabled_tools
+
+
 def test_web_search_is_recommended_unavailable_not_enabled() -> None:
     product_owner = presets.get_builtin_preset("product-owner")
     assert product_owner is not None


### PR DESCRIPTION
## Summary
- Add workspace-bounded read-only MCP filesystem helpers: fs.stat, fs.glob, and fs.grep.
- Add validation, protocol coverage, symlink/path-scope handling, traversal caps, deterministic grep ordering, and skipped-file accounting.
- Expose the helpers through read-capable profile presets and document them in the packaged MCP user guide.

## Test Plan
- [x] source .venv/bin/activate && python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_module.py -q
- [x] source .venv/bin/activate && python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_profile_presets.py tldw_Server_API/app/core/MCP_unified/tests/test_gateway_tool_discovery.py tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py -q
- [x] source .venv/bin/activate && python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py -q
- [x] source .venv/bin/activate && python -m bandit -r tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_module.py mcp_unified/profiles/presets.py -f json -o /tmp/bandit_mcp_filesystem_helpers.json
- [x] git diff --check

## Change summary
Human-authored change summary required before marking this PR ready or merging.

## Notes
- Draft stacked on codex/mcp-default-profile-tooling-design to keep this review focused on the filesystem-helper slice.
- The governed bash/shell alias remains a documented follow-up over the existing run command runtime, not raw host shell execution.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds workspace-bounded, read-only filesystem helpers (`fs.stat`, `fs.glob`, `fs.grep`) and exposes them in read-capable presets with compact metadata and updated docs. Focuses on secure traversal, predictable search, and simple discovery through preset tooling metadata.

- New Features
  - Implemented `fs.stat`, `fs.glob`, `fs.grep` (cross‑platform, workspace‑scoped, no host shell) with path containment, no‑follow symlinks, capped `**` and walk limits, UTF‑8 text handling with binary skips.
  - Added explicit schemas and `path_argument_hints`; updated presets to include helpers; bumped preset version to `2026.06.04`; documented helpers in `mcp_unified/USER_GUIDE.md` (regex opt‑in via `grep_allow_regex`, budgets for per‑file, total bytes/files, and walk entries). Tests cover helpers and presets.

- Bug Fixes
  - Prevent parent‑symlink traversal, cap `**` expansion, return symlink directories without traversing, count directories in grep walk caps, harden grep budgets, and order grep results before limiting.

<sup>Written for commit 5009fc8b95ce0d892abcd2598245713b520f6851. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2254?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

