### PR TITLE
Add governed shell command aliases

### DIFF
--- a/backlog/tasks/task-2246 - Add-governed-shell-facade-aliases.md
+++ b/backlog/tasks/task-2246 - Add-governed-shell-facade-aliases.md
@@ -4,10 +4,12 @@ title: Add governed shell facade aliases
 status: Done
 modified_files:
 - tldw_Server_API/app/core/MCP_unified/modules/implementations/run_command_module.py
+- tldw_Server_API/app/core/MCP_unified/protocol.py
 - tldw_Server_API/app/core/MCP_unified/command_runtime/registry.py
 - tldw_Server_API/app/core/MCP_unified/command_runtime/adapters.py
 - tldw_Server_API/app/core/MCP_unified/tests/test_run_command_module.py
 - tldw_Server_API/app/core/MCP_unified/tests/test_command_runtime_registry.py
+- tldw_Server_API/app/core/MCP_unified/tests/test_protocol_allowed_tools.py
 - tldw_Server_API/app/core/MCP_unified/README.md
 ---
 
@@ -36,7 +38,7 @@ Docs/superpowers/plans/2026-06-04-mcp-filesystem-helper-tools-implementation-pla
 ## Implementation Notes
 
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
-Implemented governed shell facade aliases and filesystem command aliases. `run` remains canonical; `bash` and `shell` share the same RunCommandModule schema and execution path with descriptions that explicitly state they are not raw host shell surfaces. The command registry now exposes `stat`, `glob`/`find`, and `rg`/`grep-files` only when their backing filesystem MCP tools are executable, and adapters route them through prepared MCP calls. Plain `grep` remains a pure stdin transform.
+Implemented the Qodo follow-up items. Added protocol-level authorization alias mapping for lowercase `bash` and `shell` so context allowed-tools patterns, effective policy allowed/denied patterns, RBAC/scope tool permission checks, and tools/list `canExecute` can authorize those aliases through canonical `run` while preserving the invoked tool name for module routing. Added regression tests for context/RBAC and effective-policy/listing behavior. Added the missing test return type and `_create_run_tool_definition` docstring.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary
@@ -44,12 +46,17 @@ Implemented governed shell facade aliases and filesystem command aliases. `run` 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
 Added governed `bash` and `shell` compatibility tool aliases for `run`, policy-filtered filesystem command aliases for `fs.stat`, `fs.glob`, and `fs.grep`, regression coverage for visibility/routing/no-shell-delegation/pure-grep behavior, and README guidance for packaged users.
 
+Qodo follow-up:
+- Fixed alias authorization by mapping `bash`/`shell` to canonical `run` for context allowed-tools, effective policy allowed/denied checks, RBAC/scope permission checks, and tools/list `canExecute`, while preserving the invoked alias for routing.
+- Added regression coverage for canonical `run` grants authorizing `shell`/`bash` without raw shell delegation.
+- Added missing `-> None` on the new registry test and a docstring for `_create_run_tool_definition`.
+
 Verification:
-- RED before implementation: 7 expected failures in `test_command_runtime_registry.py` and `test_run_command_module.py`.
-- GREEN: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_protocol_nested_tool_preparation.py tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_module.py tldw_Server_API/app/core/MCP_unified/tests/test_command_runtime_parser.py tldw_Server_API/app/core/MCP_unified/tests/test_command_runtime_registry.py tldw_Server_API/app/core/MCP_unified/tests/test_command_runtime_execution.py tldw_Server_API/app/core/MCP_unified/tests/test_command_runtime_presentation.py tldw_Server_API/app/core/MCP_unified/tests/test_run_command_module.py tldw_Server_API/app/core/MCP_unified/tests/test_idempotency_and_category.py tldw_Server_API/app/core/MCP_unified/tests/test_protocol_allowed_tools.py -q` -> 133 passed, 4 warnings.
-- GREEN: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m ruff check ...` -> all checks passed.
+- RED before implementation: 2 expected failures for alias authorization regression tests.
+- GREEN: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_protocol_allowed_tools.py tldw_Server_API/app/core/MCP_unified/tests/test_protocol_nested_tool_preparation.py tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_module.py tldw_Server_API/app/core/MCP_unified/tests/test_command_runtime_parser.py tldw_Server_API/app/core/MCP_unified/tests/test_command_runtime_registry.py tldw_Server_API/app/core/MCP_unified/tests/test_command_runtime_execution.py tldw_Server_API/app/core/MCP_unified/tests/test_command_runtime_presentation.py tldw_Server_API/app/core/MCP_unified/tests/test_run_command_module.py tldw_Server_API/app/core/MCP_unified/tests/test_idempotency_and_category.py tldw_Server_API/app/core/MCP_unified/tests/test_scope_and_fallbacks.py -q` -> 140 passed, 4 warnings.
+- GREEN: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m ruff check tldw_Server_API/app/core/MCP_unified/protocol.py tldw_Server_API/app/core/MCP_unified/modules/implementations/run_command_module.py tldw_Server_API/app/core/MCP_unified/tests/test_command_runtime_registry.py tldw_Server_API/app/core/MCP_unified/tests/test_protocol_allowed_tools.py` -> all checks passed.
 - GREEN: `git diff --check`.
-- GREEN: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/core/MCP_unified/command_runtime tldw_Server_API/app/core/MCP_unified/modules/implementations/run_command_module.py -f json -o /tmp/bandit_mcp_governed_shell_aliases.json` -> 0 findings.
+- GREEN: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/core/MCP_unified/protocol.py tldw_Server_API/app/core/MCP_unified/command_runtime tldw_Server_API/app/core/MCP_unified/modules/implementations/run_command_module.py -f json -o /tmp/bandit_mcp_governed_shell_aliases_qodo.json` -> 0 findings.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-2246 - Add-governed-shell-facade-aliases.md
+++ b/backlog/tasks/task-2246 - Add-governed-shell-facade-aliases.md
@@ -1,0 +1,63 @@
+---
+id: TASK-2246
+title: Add governed shell facade aliases
+status: Done
+modified_files:
+- tldw_Server_API/app/core/MCP_unified/modules/implementations/run_command_module.py
+- tldw_Server_API/app/core/MCP_unified/command_runtime/registry.py
+- tldw_Server_API/app/core/MCP_unified/command_runtime/adapters.py
+- tldw_Server_API/app/core/MCP_unified/tests/test_run_command_module.py
+- tldw_Server_API/app/core/MCP_unified/tests/test_command_runtime_registry.py
+- tldw_Server_API/app/core/MCP_unified/README.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Add shell-shaped governed command aliases after native filesystem helper tools have landed. Keep `run` as the canonical MCP tool, expose optional `bash`/`shell` facades through the same RunCommandModule implementation without raw host shell execution, and add command-runtime aliases that route `stat`, `glob`/`find`, and `rg`/`grep-files` to profile-granted MCP tools.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 `run` remains the canonical MCP command tool.
+- [ ] #2 `bash` and `shell` aliases, if exposed, call the same governed RunCommandModule implementation and clearly describe that they are not host shell execution.
+- [ ] #3 Command runtime aliases route `stat <path>` to `fs.stat`, `glob <pattern> [base]` and `find <pattern> [base]` to `fs.glob`, and `rg <pattern> [base]` plus `grep-files <pattern> [base]` to `fs.grep`.
+- [ ] #4 Existing pure stdin `grep` behavior remains unchanged for pipelines such as `cat app.log | grep ERROR`.
+- [ ] #5 Aliases are visible/executable only when their backing MCP tools are granted to the active profile.
+- [ ] #6 Tests cover policy-filtered visibility, `run --help`, alias help/error text, no raw shell delegation, and preservation of presentation footer/spill behavior.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Docs/superpowers/plans/2026-06-04-mcp-filesystem-helper-tools-implementation-plan.md#follow-up-task-governed-shell-facade-aliases
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Implemented governed shell facade aliases and filesystem command aliases. `run` remains canonical; `bash` and `shell` share the same RunCommandModule schema and execution path with descriptions that explicitly state they are not raw host shell surfaces. The command registry now exposes `stat`, `glob`/`find`, and `rg`/`grep-files` only when their backing filesystem MCP tools are executable, and adapters route them through prepared MCP calls. Plain `grep` remains a pure stdin transform.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Added governed `bash` and `shell` compatibility tool aliases for `run`, policy-filtered filesystem command aliases for `fs.stat`, `fs.glob`, and `fs.grep`, regression coverage for visibility/routing/no-shell-delegation/pure-grep behavior, and README guidance for packaged users.
+
+Verification:
+- RED before implementation: 7 expected failures in `test_command_runtime_registry.py` and `test_run_command_module.py`.
+- GREEN: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_protocol_nested_tool_preparation.py tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_module.py tldw_Server_API/app/core/MCP_unified/tests/test_command_runtime_parser.py tldw_Server_API/app/core/MCP_unified/tests/test_command_runtime_registry.py tldw_Server_API/app/core/MCP_unified/tests/test_command_runtime_execution.py tldw_Server_API/app/core/MCP_unified/tests/test_command_runtime_presentation.py tldw_Server_API/app/core/MCP_unified/tests/test_run_command_module.py tldw_Server_API/app/core/MCP_unified/tests/test_idempotency_and_category.py tldw_Server_API/app/core/MCP_unified/tests/test_protocol_allowed_tools.py -q` -> 133 passed, 4 warnings.
+- GREEN: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m ruff check ...` -> all checks passed.
+- GREEN: `git diff --check`.
+- GREEN: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/core/MCP_unified/command_runtime tldw_Server_API/app/core/MCP_unified/modules/implementations/run_command_module.py -f json -o /tmp/bandit_mcp_governed_shell_aliases.json` -> 0 findings.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/tldw_Server_API/app/core/MCP_unified/README.md
+++ b/tldw_Server_API/app/core/MCP_unified/README.md
@@ -360,6 +360,8 @@ Phase-1 adds a governed virtual CLI foundation to MCP Unified.
 
 `run` is not a raw host shell. It compiles command steps into policy-checked MCP tool calls (`prepare_tool_call` / `execute_prepared_tool_call`) so approvals, RBAC, path scope, validation, and idempotency all still apply.
 
+`bash` and `shell` may also appear as compatibility aliases for `run`. They use the same `command` argument and the same governed runtime; they are not host shell execution surfaces.
+
 Phase-1 command families:
 
 - Pure transforms (no MCP backend call): `grep`, `head`, `tail`, `json`
@@ -367,10 +369,15 @@ Phase-1 command families:
   - `ls` -> `fs.list`
   - `cat` -> `fs.read_text`
   - `write` -> `fs.write_text`
+  - `stat` -> `fs.stat`
+  - `glob`, `find` -> `fs.glob`
+  - `rg`, `grep-files` -> `fs.grep`
   - `knowledge` -> `knowledge.search`, `knowledge.get`
   - `media` -> `media.search`, `media.get`
   - `mcp` -> `mcp.modules.list`, `mcp.tools.list`
   - `sandbox` -> `sandbox.run`
+
+Command aliases are policy-filtered by their backing MCP tools. For example, `rg` and `grep-files` are visible only when `fs.grep` is executable in the active profile. Plain `grep` remains a pure stdin filter for pipelines such as `cat app.log | grep ERROR`.
 
 Default `run_command` runtime settings in module inventory:
 

--- a/tldw_Server_API/app/core/MCP_unified/command_runtime/adapters.py
+++ b/tldw_Server_API/app/core/MCP_unified/command_runtime/adapters.py
@@ -5,10 +5,10 @@ from __future__ import annotations
 import difflib
 import hashlib
 import json
-from collections.abc import Iterator
+from collections.abc import Callable, Iterator, Mapping
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Callable, Mapping
+from typing import Any
 
 from .executor import HandlerInvocationContext
 from .models import CommandChain, CommandSpillReference, CommandStepResult
@@ -260,6 +260,36 @@ class PhaseOneCommandAdapters:
                 tool_name="fs.write_text",
                 arguments={"path": argv[1], "content": " ".join(argv[2:])},
                 renderer=self._render_write,
+            )
+        if command == "stat":
+            if len(argv) != 2:
+                return _UsageError("usage: stat <path>")
+            return _GovernedCallPlan(
+                tool_name="fs.stat",
+                arguments={"path": argv[1]},
+                renderer=self._render_json_payload,
+            )
+        if command in {"glob", "find"}:
+            if len(argv) not in {2, 3}:
+                return _UsageError(f"usage: {command} <pattern> [base_path]")
+            arguments = {"pattern": argv[1]}
+            if len(argv) == 3:
+                arguments["base_path"] = argv[2]
+            return _GovernedCallPlan(
+                tool_name="fs.glob",
+                arguments=arguments,
+                renderer=self._render_json_payload,
+            )
+        if command in {"rg", "grep-files"}:
+            if len(argv) not in {2, 3}:
+                return _UsageError(f"usage: {command} <pattern> [base_path]")
+            arguments = {"pattern": argv[1]}
+            if len(argv) == 3:
+                arguments["base_path"] = argv[2]
+            return _GovernedCallPlan(
+                tool_name="fs.grep",
+                arguments=arguments,
+                renderer=self._render_json_payload,
             )
         if command == "knowledge":
             return self._knowledge_plan(argv)

--- a/tldw_Server_API/app/core/MCP_unified/command_runtime/registry.py
+++ b/tldw_Server_API/app/core/MCP_unified/command_runtime/registry.py
@@ -71,6 +71,31 @@ _DEFAULT_COMMANDS: Final[tuple[CommandDescriptor, ...]] = (
         pure_transform=True,
     ),
     CommandDescriptor(
+        name="stat",
+        summary="Inspect workspace file metadata.",
+        backend_tools=("fs.stat",),
+    ),
+    CommandDescriptor(
+        name="glob",
+        summary="Find workspace paths matching a portable pattern.",
+        backend_tools=("fs.glob",),
+    ),
+    CommandDescriptor(
+        name="find",
+        summary="Alias for glob over workspace paths.",
+        backend_tools=("fs.glob",),
+    ),
+    CommandDescriptor(
+        name="rg",
+        summary="Search workspace UTF-8 text files.",
+        backend_tools=("fs.grep",),
+    ),
+    CommandDescriptor(
+        name="grep-files",
+        summary="Alias for governed workspace file search.",
+        backend_tools=("fs.grep",),
+    ),
+    CommandDescriptor(
         name="head",
         summary="Keep the first lines of input.",
         backend_tools=(),

--- a/tldw_Server_API/app/core/MCP_unified/modules/implementations/run_command_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/modules/implementations/run_command_module.py
@@ -3,10 +3,10 @@
 from __future__ import annotations
 
 import asyncio
-import os
 import time
+from collections.abc import Mapping
 from pathlib import Path
-from typing import Any, Mapping
+from typing import Any
 
 from loguru import logger
 
@@ -27,6 +27,9 @@ from ..base import BaseModule, ModuleConfig, create_tool_definition
 RUN_PARENT_IDEMPOTENCY_KEY_METADATA_KEY = "run_parent_idempotency_key"
 
 _RUN_WRITE_BACKEND_TOOLS = {"fs.write_text", "sandbox.run"}
+_RUN_TOOL_NAME = "run"
+_RUN_TOOL_ALIASES = ("bash", "shell")
+_RUN_TOOL_NAMES = frozenset((_RUN_TOOL_NAME, *_RUN_TOOL_ALIASES))
 
 
 class _AdapterBackend(CommandBackend):
@@ -59,36 +62,33 @@ class RunCommandModule(BaseModule):
         return {"initialized": True}
 
     async def get_tools(self) -> list[dict[str, Any]]:
-        run_tool = create_tool_definition(
-            name="run",
+        run_tool = self._create_run_tool_definition(
+            name=_RUN_TOOL_NAME,
             description="Execute a governed command in the MCP virtual CLI runtime.",
-            parameters={
-                "properties": {
-                    "command": {
-                        "type": "string",
-                        "description": "Command chain to execute (example: ls | grep py).",
-                    },
-                    "idempotency_key": {
-                        "type": "string",
-                        "description": "Legacy alias for idempotencyKey.",
-                    },
-                    "idempotencyKey": {
-                        "type": "string",
-                        "description": "Optional parent idempotency key for nested governed steps.",
-                    },
-                },
-                "required": ["command"],
-            },
             metadata={
                 "category": "utility",
                 "notes": "Wrapper tool; nested prepared MCP calls carry path/process metadata",
             },
         )
-        run_tool["inputSchema"]["additionalProperties"] = False
-        return [run_tool]
+        alias_tools = [
+            self._create_run_tool_definition(
+                name=alias_name,
+                description=(
+                    f"Governed shell-like facade for `run`; {alias_name} is not a raw host shell "
+                    "and only executes profile-granted virtual CLI commands."
+                ),
+                metadata={
+                    "category": "utility",
+                    "canonical_tool": _RUN_TOOL_NAME,
+                    "notes": "Compatibility alias; no raw host shell execution is performed.",
+                },
+            )
+            for alias_name in _RUN_TOOL_ALIASES
+        ]
+        return [run_tool, *alias_tools]
 
     async def execute_tool(self, tool_name: str, arguments: dict[str, Any], context: Any | None = None) -> Any:
-        if tool_name != "run":
+        if tool_name not in _RUN_TOOL_NAMES:
             raise ValueError(f"Unknown tool: {tool_name}")
         args = self.sanitize_input(arguments or {})
         self.validate_tool_arguments(tool_name, args)
@@ -167,9 +167,9 @@ class RunCommandModule(BaseModule):
             await self._cleanup_spill_artifacts(result)
 
     def validate_tool_arguments(self, tool_name: str, arguments: dict[str, Any]) -> None:
-        if tool_name != "run":
+        if tool_name not in _RUN_TOOL_NAMES:
             raise ValueError(f"Unknown tool: {tool_name}")
-        unknown = sorted({key for key in arguments.keys()} - {"command", "idempotencyKey", "idempotency_key"})
+        unknown = sorted(set(arguments) - {"command", "idempotencyKey", "idempotency_key"})
         if unknown:
             raise ValueError(f"unknown arguments: {', '.join(unknown)}")
         command = arguments.get("command")
@@ -217,7 +217,7 @@ class RunCommandModule(BaseModule):
         arguments: dict[str, Any],
         tool_def: dict[str, Any] | None = None,
     ) -> bool:
-        if tool_name != "run":
+        if tool_name not in _RUN_TOOL_NAMES:
             return super().is_write_tool_call(tool_name, arguments, tool_def=tool_def)
 
         command = str(arguments.get("command") or "").strip()
@@ -239,6 +239,38 @@ class RunCommandModule(BaseModule):
                 if any(tool in _RUN_WRITE_BACKEND_TOOLS for tool in descriptor.backend_tools):
                     return True
         return False
+
+    @staticmethod
+    def _create_run_tool_definition(
+        *,
+        name: str,
+        description: str,
+        metadata: dict[str, Any],
+    ) -> dict[str, Any]:
+        tool = create_tool_definition(
+            name=name,
+            description=description,
+            parameters={
+                "properties": {
+                    "command": {
+                        "type": "string",
+                        "description": "Command chain to execute (example: ls | grep py).",
+                    },
+                    "idempotency_key": {
+                        "type": "string",
+                        "description": "Legacy alias for idempotencyKey.",
+                    },
+                    "idempotencyKey": {
+                        "type": "string",
+                        "description": "Optional parent idempotency key for nested governed steps.",
+                    },
+                },
+                "required": ["command"],
+            },
+            metadata=metadata,
+        )
+        tool["inputSchema"]["additionalProperties"] = False
+        return tool
 
     async def _resolve_protocol(self) -> Any:
         configured = self.config.settings.get("protocol")

--- a/tldw_Server_API/app/core/MCP_unified/modules/implementations/run_command_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/modules/implementations/run_command_module.py
@@ -247,6 +247,8 @@ class RunCommandModule(BaseModule):
         description: str,
         metadata: dict[str, Any],
     ) -> dict[str, Any]:
+        """Build a run-compatible tool definition with the shared command schema."""
+
         tool = create_tool_definition(
             name=name,
             description=description,

--- a/tldw_Server_API/app/core/MCP_unified/protocol.py
+++ b/tldw_Server_API/app/core/MCP_unified/protocol.py
@@ -116,6 +116,10 @@ _MCP_PROTOCOL_NONCRITICAL_EXCEPTIONS = (
 )
 
 _MCP_TOOL_EXECUTION_ERROR = "tool_execution_error"
+_TOOL_AUTHORIZATION_ALIASES = {
+    "bash": "run",
+    "shell": "run",
+}
 _TRUTHY_VALUES = {"1", "true", "yes", "y", "on"}
 
 
@@ -735,9 +739,15 @@ class MCPProtocol:
         return self._scope_allows(context, Resource.MODULE.value, module_id_norm or None)
 
     async def _has_tool_permission(self, context: RequestContext, tool_name: str, *, is_write: Optional[bool] = None) -> bool:
-        if not await self._rbac_check(context.user_id, Resource.TOOL, Action.EXECUTE, tool_name):
-            return False
-        if not self._scope_allows(context, Resource.TOOL.value, tool_name):
+        has_named_permission = False
+        for auth_name in self._tool_authorization_names(tool_name):
+            if not await self._rbac_check(context.user_id, Resource.TOOL, Action.EXECUTE, auth_name):
+                continue
+            if not self._scope_allows(context, Resource.TOOL.value, auth_name):
+                continue
+            has_named_permission = True
+            break
+        if not has_named_permission:
             return False
         return self._api_key_allows(context, is_write=is_write)
 
@@ -1815,7 +1825,7 @@ class MCPProtocol:
                     name = tool_copy.get("name")
                     # Scoped tool permissions: when scopes are present, list only matching tools
                     if self._mcp_scopes(context) and isinstance(name, str):
-                        if not self._scope_allows(context, Resource.TOOL.value, name):
+                        if not self._scope_allows_tool_name(context, name):
                             continue
                     # Catalog filter: include only when in selected catalog
                     if catalog_filter is not None and isinstance(name, str):
@@ -1903,12 +1913,37 @@ class MCPProtocol:
         except re.error:
             return False
 
+    @staticmethod
+    def _tool_authorization_names(tool_name: str) -> tuple[str, ...]:
+        """Return invoked and canonical names that may authorize a tool call."""
+
+        canonical_name = _TOOL_AUTHORIZATION_ALIASES.get(tool_name)
+        if canonical_name and canonical_name != tool_name:
+            return (tool_name, canonical_name)
+        return (tool_name,)
+
+    def _matches_tool_authorization_pattern(self, tool_name: str, tool_args: Any, pattern: str) -> bool:
+        """Match a policy pattern against the invoked name and any canonical alias."""
+
+        return any(
+            self._matches_allowed_tool_pattern(auth_name, tool_args, pattern)
+            for auth_name in self._tool_authorization_names(tool_name)
+        )
+
+    def _scope_allows_tool_name(self, context: RequestContext, tool_name: str) -> bool:
+        """Return True when scopes allow the invoked tool name or canonical alias."""
+
+        return any(
+            self._scope_allows(context, Resource.TOOL.value, auth_name)
+            for auth_name in self._tool_authorization_names(tool_name)
+        )
+
     def _is_tool_allowed_by_context(self, tool_name: str, tool_args: Any, context: RequestContext) -> bool:
         """Return True when tool usage is allowed by context metadata."""
         allowed_tools = self._extract_allowed_tools(context)
         if not allowed_tools:
             return True
-        return any(self._matches_allowed_tool_pattern(tool_name, tool_args, pattern) for pattern in allowed_tools)
+        return any(self._matches_tool_authorization_pattern(tool_name, tool_args, pattern) for pattern in allowed_tools)
 
     async def _resolve_effective_tool_policy(self, context: RequestContext) -> dict[str, Any] | None:
         metadata = getattr(context, "metadata", None)
@@ -1953,7 +1988,7 @@ class MCPProtocol:
             for pattern in (policy.get("denied_tools") or [])
             if str(pattern).strip()
         ]
-        if any(self._matches_allowed_tool_pattern(tool_name, tool_args, pattern) for pattern in denied_tools):
+        if any(self._matches_tool_authorization_pattern(tool_name, tool_args, pattern) for pattern in denied_tools):
             return False
         allowed_tools = [
             str(pattern).strip()
@@ -1962,7 +1997,7 @@ class MCPProtocol:
         ]
         if not allowed_tools:
             return True
-        return any(self._matches_allowed_tool_pattern(tool_name, tool_args, pattern) for pattern in allowed_tools)
+        return any(self._matches_tool_authorization_pattern(tool_name, tool_args, pattern) for pattern in allowed_tools)
 
     async def _evaluate_runtime_approval(
         self,

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_command_runtime_registry.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_command_runtime_registry.py
@@ -18,6 +18,23 @@ def test_registry_hides_commands_without_visible_backing_tools():
     assert "knowledge" not in visible
     assert "media" not in visible
     assert "sandbox" not in visible
+    assert "stat" not in visible
+    assert "glob" not in visible
+    assert "find" not in visible
+    assert "rg" not in visible
+    assert "grep-files" not in visible
+
+
+def test_registry_exposes_filesystem_aliases_only_when_backing_tools_are_visible():
+    registry = build_default_registry()
+    visible = registry.visible_commands(allowed_tools={"fs.stat", "fs.grep"})
+
+    assert "stat" in visible
+    assert "rg" in visible
+    assert "grep-files" in visible
+    assert "grep" in visible
+    assert "glob" not in visible
+    assert "find" not in visible
 
 
 def test_registry_exposes_phase_one_mappings():
@@ -31,3 +48,8 @@ def test_registry_exposes_phase_one_mappings():
     assert registry.get_command("mcp").backend_tools == ("mcp.modules.list", "mcp.tools.list")
     assert registry.get_command("sandbox").backend_tools == ("sandbox.run",)
     assert registry.get_command("grep").pure_transform is True
+    assert registry.get_command("stat").backend_tools == ("fs.stat",)
+    assert registry.get_command("glob").backend_tools == ("fs.glob",)
+    assert registry.get_command("find").backend_tools == ("fs.glob",)
+    assert registry.get_command("rg").backend_tools == ("fs.grep",)
+    assert registry.get_command("grep-files").backend_tools == ("fs.grep",)

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_command_runtime_registry.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_command_runtime_registry.py
@@ -25,7 +25,7 @@ def test_registry_hides_commands_without_visible_backing_tools():
     assert "grep-files" not in visible
 
 
-def test_registry_exposes_filesystem_aliases_only_when_backing_tools_are_visible():
+def test_registry_exposes_filesystem_aliases_only_when_backing_tools_are_visible() -> None:
     registry = build_default_registry()
     visible = registry.visible_commands(allowed_tools={"fs.stat", "fs.grep"})
 

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_protocol_allowed_tools.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_protocol_allowed_tools.py
@@ -6,7 +6,97 @@ from tldw_Server_API.app.core.MCP_unified.modules.base import ModuleConfig
 from tldw_Server_API.app.core.MCP_unified.modules.implementations.run_command_module import (
     RunCommandModule,
 )
-from tldw_Server_API.app.core.MCP_unified.protocol import RequestContext
+from tldw_Server_API.app.core.MCP_unified.protocol import MCPProtocol, RequestContext
+
+
+class _RunAliasRegistryStub:
+    def __init__(self, module: RunCommandModule) -> None:
+        self.module = module
+
+    async def find_module_for_tool(self, tool_name: str) -> RunCommandModule | None:
+        return self.module if tool_name in {"run", "bash", "shell"} else None
+
+    def get_module_id_for_tool(self, tool_name: str) -> str | None:
+        return "run_command" if tool_name in {"run", "bash", "shell"} else None
+
+    async def get_all_modules(self) -> dict[str, RunCommandModule]:
+        return {"run_command": self.module}
+
+
+def _build_run_alias_protocol(*, rbac_tool_names: set[str] | None = None) -> MCPProtocol:
+    proto = MCPProtocol()
+    module = RunCommandModule(ModuleConfig(name="run", settings={"protocol": proto}))
+    proto.module_registry = _RunAliasRegistryStub(module)
+    allowed_tool_names = rbac_tool_names or {"run"}
+
+    async def _rbac_check(user_id, resource, action, identifier):  # noqa: ANN001
+        del user_id, action
+        if resource.value == "module":
+            return True
+        if resource.value == "tool":
+            return str(identifier) in allowed_tool_names
+        return True
+
+    proto._rbac_check = _rbac_check  # type: ignore[method-assign]
+    return proto
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_protocol_allows_run_alias_when_context_allows_canonical_run() -> None:
+    proto = _build_run_alias_protocol(rbac_tool_names={"run"})
+    context = RequestContext(
+        request_id="run-alias-context-allow",
+        user_id="1",
+        client_id="unit",
+        session_id=None,
+        metadata={"allowed_tools": ["run"]},
+    )
+
+    result = await proto._handle_tools_call(
+        {"name": "shell", "arguments": {"command": "echo unsafe"}},
+        context,
+    )
+
+    assert result["tool"] == "shell"
+    assert "Unknown command: echo" in str(result["content"])
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_protocol_maps_run_aliases_for_effective_policy_and_listing() -> None:
+    proto = _build_run_alias_protocol(rbac_tool_names={"run"})
+
+    async def _resolve_policy(_context):  # noqa: ANN001
+        return {
+            "enabled": True,
+            "allowed_tools": ["run(help)"],
+            "denied_tools": [],
+            "capabilities": [],
+            "sources": [],
+        }
+
+    proto._resolve_effective_tool_policy = _resolve_policy  # type: ignore[method-assign]
+    context = RequestContext(
+        request_id="run-alias-policy-allow",
+        user_id="1",
+        client_id="unit",
+        session_id=None,
+        metadata={"mcp_policy_context_enabled": True},
+    )
+
+    result = await proto._handle_tools_call(
+        {"name": "bash", "arguments": {"command": "help"}},
+        context,
+    )
+    tools = await proto._handle_tools_list({}, context)
+    by_name = {tool["name"]: tool for tool in tools["tools"]}
+
+    assert result["tool"] == "bash"
+    assert "Virtual CLI commands available" in str(result["content"])
+    assert by_name["run"]["canExecute"] is True
+    assert by_name["bash"]["canExecute"] is True
+    assert by_name["shell"]["canExecute"] is True
 
 
 @pytest.mark.unit

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_run_command_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_run_command_module.py
@@ -44,6 +44,9 @@ class _ProtocolStub:
                 {"name": "fs.list", "module": "filesystem", "canExecute": True},
                 {"name": "fs.read_text", "module": "filesystem", "canExecute": True},
                 {"name": "fs.write_text", "module": "filesystem", "canExecute": True},
+                {"name": "fs.stat", "module": "filesystem", "canExecute": True},
+                {"name": "fs.glob", "module": "filesystem", "canExecute": True},
+                {"name": "fs.grep", "module": "filesystem", "canExecute": True},
             ]
         }
 
@@ -95,6 +98,53 @@ class _ProtocolStub:
                 "content": [{"type": "json", "json": {"path": "notes.txt", "text": self.read_text_content}}],
                 "tool": tool_name,
             }
+        if tool_name == "fs.stat":
+            return {
+                "content": [
+                    {
+                        "type": "json",
+                        "json": {
+                            "path": "docs/readme.md",
+                            "type": "file",
+                            "size_bytes": 42,
+                        },
+                    }
+                ],
+                "tool": tool_name,
+            }
+        if tool_name == "fs.glob":
+            return {
+                "content": [
+                    {
+                        "type": "json",
+                        "json": {
+                            "matches": [
+                                {"path": "src/app.py", "type": "file"},
+                                {"path": "src/pkg", "type": "directory"},
+                            ]
+                        },
+                    }
+                ],
+                "tool": tool_name,
+            }
+        if tool_name == "fs.grep":
+            return {
+                "content": [
+                    {
+                        "type": "json",
+                        "json": {
+                            "matches": [
+                                {
+                                    "path": "src/app.py",
+                                    "line_number": 7,
+                                    "line": "TODO: wire facade",
+                                }
+                            ]
+                        },
+                    }
+                ],
+                "tool": tool_name,
+            }
         raise AssertionError(f"Unexpected tool execution: {tool_name}")
 
 
@@ -123,6 +173,23 @@ def _build_module(protocol: _ProtocolStub) -> RunCommandModule:
 
 
 @pytest.mark.asyncio
+async def test_run_module_exposes_governed_bash_and_shell_alias_tools() -> None:
+    protocol = _ProtocolStub()
+    module = _build_module(protocol)
+
+    tools = await module.get_tools()
+
+    by_name = {tool["name"]: tool for tool in tools}
+    assert list(by_name) == ["run", "bash", "shell"]
+    assert by_name["run"]["metadata"].get("canonical_tool") is None
+    for alias_name in ("bash", "shell"):
+        alias = by_name[alias_name]
+        assert alias["metadata"]["canonical_tool"] == "run"
+        assert "not a raw host shell" in alias["description"]
+        assert alias["inputSchema"]["properties"] == by_name["run"]["inputSchema"]["properties"]
+
+
+@pytest.mark.asyncio
 async def test_run_ls_uses_fs_list_and_returns_footer() -> None:
     protocol = _ProtocolStub()
     module = _build_module(protocol)
@@ -136,6 +203,103 @@ async def test_run_ls_uses_fs_list_and_returns_footer() -> None:
     assert len(protocol.prepare_calls) == 1
     assert protocol.prepare_calls[0].params["name"] == "fs.list"
     assert protocol.prepare_calls[0].params["arguments"] == {"path": "."}
+
+
+@pytest.mark.asyncio
+async def test_shell_alias_uses_governed_run_implementation_without_raw_shell_delegation() -> None:
+    protocol = _ProtocolStub()
+    module = _build_module(protocol)
+    context = RequestContext(request_id="run-shell-alias", user_id="1", client_id="unit")
+
+    rendered = await module.execute_tool("shell", {"command": "echo unsafe"}, context=context)
+
+    assert "Unknown command: echo" in rendered
+    assert "[exit:127 |" in rendered
+    assert protocol.prepare_calls == []
+    assert protocol.execute_calls == []
+
+
+@pytest.mark.asyncio
+async def test_run_filesystem_aliases_route_to_backing_tools() -> None:
+    protocol = _ProtocolStub()
+    module = _build_module(protocol)
+    context = RequestContext(request_id="run-filesystem-aliases", user_id="1", client_id="unit")
+
+    rendered = await module.execute_tool(
+        "run",
+        {"command": 'stat docs/readme.md ; glob "**/*.py" src ; find "*.md" docs ; rg TODO src ; grep-files FIXME docs'},
+        context=context,
+    )
+
+    assert "[exit:0 |" in rendered
+    assert [call.params["name"] for call in protocol.prepare_calls] == [
+        "fs.stat",
+        "fs.glob",
+        "fs.glob",
+        "fs.grep",
+        "fs.grep",
+    ]
+    assert [call.params["arguments"] for call in protocol.prepare_calls] == [
+        {"path": "docs/readme.md"},
+        {"pattern": "**/*.py", "base_path": "src"},
+        {"pattern": "*.md", "base_path": "docs"},
+        {"pattern": "TODO", "base_path": "src"},
+        {"pattern": "FIXME", "base_path": "docs"},
+    ]
+
+
+@pytest.mark.asyncio
+async def test_run_plain_grep_still_filters_stdin_instead_of_calling_fs_grep() -> None:
+    protocol = _ProtocolStub()
+    protocol.read_text_content = "ERROR one\nINFO two\nerror three\n"
+    module = _build_module(protocol)
+    context = RequestContext(request_id="run-pure-grep", user_id="1", client_id="unit")
+
+    rendered = await module.execute_tool("run", {"command": "cat app.log | grep ERROR"}, context=context)
+
+    assert "ERROR one" in rendered
+    assert "INFO two" not in rendered
+    assert [call.params["name"] for call in protocol.prepare_calls] == ["fs.read_text"]
+    assert [call.params["name"] for call in protocol.execute_calls] == ["fs.read_text"]
+
+
+@pytest.mark.asyncio
+async def test_run_help_policy_filters_filesystem_aliases() -> None:
+    class _RestrictedProtocolStub(_ProtocolStub):
+        async def _handle_tools_list(self, params: dict[str, Any], context: RequestContext) -> dict[str, Any]:
+            del params, context
+            return {
+                "tools": [
+                    {"name": "fs.stat", "module": "filesystem", "canExecute": True},
+                    {"name": "fs.grep", "module": "filesystem", "canExecute": True},
+                ]
+            }
+
+    module = _build_module(_RestrictedProtocolStub())
+    context = RequestContext(request_id="run-help-filesystem-aliases", user_id="1", client_id="unit")
+
+    rendered = await module.execute_tool("run", {"command": "--help"}, context=context)
+
+    assert "stat" in rendered
+    assert "rg" in rendered
+    assert "grep-files" in rendered
+    assert "grep" in rendered
+    assert "glob" not in rendered
+    assert "find" not in rendered
+
+
+@pytest.mark.asyncio
+async def test_bash_alias_returns_governed_alias_usage_errors() -> None:
+    protocol = _ProtocolStub()
+    module = _build_module(protocol)
+    context = RequestContext(request_id="run-bash-alias-usage", user_id="1", client_id="unit")
+
+    rendered = await module.execute_tool("bash", {"command": "rg"}, context=context)
+
+    assert "usage: rg <pattern> [base_path]" in rendered
+    assert "[exit:2 |" in rendered
+    assert protocol.prepare_calls == []
+    assert protocol.execute_calls == []
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Draft Notes

- Adds governed `bash` and `shell` MCP tool aliases that share the canonical `run` command schema and execution path.
- Adds policy-filtered virtual CLI aliases: `stat` to `fs.stat`, `glob` and `find` to `fs.glob`, and `rg` plus `grep-files` to `fs.grep`.
- Keeps plain `grep` as a pure stdin transform and documents that the shell facades are not raw host shell execution.
- Adds Backlog task `TASK-2246` with verification notes.

## Verification

- RED before implementation: 7 expected failures in focused run-command and registry tests.
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_protocol_nested_tool_preparation.py tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_module.py tldw_Server_API/app/core/MCP_unified/tests/test_command_runtime_parser.py tldw_Server_API/app/core/MCP_unified/tests/test_command_runtime_registry.py tldw_Server_API/app/core/MCP_unified/tests/test_command_runtime_execution.py tldw_Server_API/app/core/MCP_unified/tests/test_command_runtime_presentation.py tldw_Server_API/app/core/MCP_unified/tests/test_run_command_module.py tldw_Server_API/app/core/MCP_unified/tests/test_idempotency_and_category.py tldw_Server_API/app/core/MCP_unified/tests/test_protocol_allowed_tools.py -q` -> 133 passed, 4 warnings.
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m ruff check ...` -> all checks passed.
- `git diff --check` -> passed.
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/core/MCP_unified/command_runtime tldw_Server_API/app/core/MCP_unified/modules/implementations/run_command_module.py -f json -o /tmp/bandit_mcp_governed_shell_aliases.json` -> 0 findings.

## Merge Gate

Human-authored Change summary is still required before marking this AI-authored PR ready or merging.
