### PR TITLE
Apply MCP tool observability contract

### DIFF
--- a/Docs/superpowers/plans/2026-06-04-mcp-tool-observability-contract-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-06-04-mcp-tool-observability-contract-implementation-plan.md
@@ -1,0 +1,35 @@
+# MCP Tool Observability Contract Implementation Plan
+
+> **For:** TASK-2256
+> **Spec Reference:** Docs/superpowers/specs/2026-06-04-mcp-git-read-tools-design.md
+> **Required Sub-Skills:** test-driven-development, verification-before-completion
+
+## Stage 1: Central Tool Definition Metadata
+**Goal:** Ensure every tool definition produced by the shared MCP helper carries safe, stable evaluation metadata while preserving explicit module metadata.
+**Success Criteria:** `create_tool_definition()` adds `metadata.eval` by default, does not overwrite explicit `metadata.eval`, and derives deterministic defaults from tool name/category/read/write hints.
+**Tests:** Extend `test_tool_observability.py` with failing tests for default inference, preservation of explicit eval metadata, and helper-created definitions.
+**Status:** Complete
+
+## Stage 2: Protocol Execution Event Enrichment
+**Goal:** Attach safe execution eval metadata to protocol-level structured tool-call responses without changing direct module return contracts.
+**Success Criteria:** `tools/call` responses include scalar eval metadata for dict/structured results, preserve module-provided eval metadata, and leave text/list content compatible.
+**Tests:** Add protocol tests with a stub module returning a dict result and a result with existing eval metadata.
+**Status:** Complete
+
+## Stage 3: Manual And Federated Tool Surfaces
+**Goal:** Cover tool surfaces that bypass `create_tool_definition()`, especially external/federated virtual tools and manually built descriptors.
+**Success Criteria:** External virtual tool definitions expose `metadata.eval` with an external/federated prompt variant, and manually constructed module tools use the same helper where needed.
+**Tests:** Extend external federation/runtime tests or add focused helper tests to verify virtual tool eval metadata without mutating external adapter DTOs.
+**Status:** Complete
+
+## Stage 4: Documentation And Operator Contract
+**Goal:** Document the cross-tool observability/evaluation contract for standalone gateway operators and future tool authors.
+**Success Criteria:** User-facing MCP module docs describe definition metadata, execution metadata, safe field constraints, and how profile/tool evaluations can consume the contract.
+**Tests:** Documentation-only review plus targeted grep/inspection.
+**Status:** Complete
+
+## Stage 5: Validation And Cleanup
+**Goal:** Run targeted tests, Bandit over touched Python scope, and record results in Backlog.md.
+**Success Criteria:** Targeted pytest suite passes, Bandit has no new findings in touched code, task notes/final summary record verification and any intentional skips.
+**Tests:** `python -m pytest` for touched MCP tests; `python -m bandit -r` on touched Python files.
+**Status:** Complete

--- a/backlog/tasks/task-2256 - Apply-MCP-tool-observability-and-evaluation-contract-across-all-tools.md
+++ b/backlog/tasks/task-2256 - Apply-MCP-tool-observability-and-evaluation-contract-across-all-tools.md
@@ -1,12 +1,16 @@
 ---
 id: TASK-2256
 title: Apply MCP tool observability and evaluation contract across all tools
-status: To Do
+status: Done
+assignee: []
+created_date: ''
+updated_date: 2026-06-05 00:55
 labels:
 - mcp
 - observability
 - evals
 - tools
+dependencies: []
 references:
 - Docs/superpowers/specs/2026-06-04-mcp-git-read-tools-design.md
 ---
@@ -23,22 +27,30 @@ Define and apply the shared MCP tool observability/evaluation metadata and execu
 
 ## Implementation Notes
 
-<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+<!-- SECTION:NOTES:BEGIN -->
+Implemented shared MCP tool observability/eval metadata helpers; create_tool_definition now fills sanitized metadata.eval defaults while preserving safe explicit eval blocks.
 
-<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+Protocol tools/list enriches copied descriptors, prepare_tool_call normalizes resolved definitions, and tools/call responses now include safe execution eval metadata with structured results receiving embedded eval when absent.
+
+External federated virtual tools now attach local external_federated eval metadata and strip upstream eval blocks to prevent untrusted prompt-id/metadata override.
+
+Docs updated in tldw_Server_API/app/core/MCP_unified/README.md; plan recorded in Docs/superpowers/plans/2026-06-04-mcp-tool-observability-contract-implementation-plan.md.
+
+Verification: 126 targeted MCP tests passed; Bandit on touched production files exited 0 with zero findings.
+<!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-
+Implemented the cross-tool MCP observability/evaluation contract with sanitized definition metadata, protocol execution eval enrichment, direct external federation coverage, documentation, and targeted verification.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->

--- a/backlog/tasks/task-2256 - Apply-MCP-tool-observability-and-evaluation-contract-across-all-tools.md
+++ b/backlog/tasks/task-2256 - Apply-MCP-tool-observability-and-evaluation-contract-across-all-tools.md
@@ -4,15 +4,15 @@ title: Apply MCP tool observability and evaluation contract across all tools
 status: Done
 assignee: []
 created_date: ''
-updated_date: 2026-06-05 00:55
+updated_date: '2026-06-05 01:37'
 labels:
-- mcp
-- observability
-- evals
-- tools
+  - mcp
+  - observability
+  - evals
+  - tools
 dependencies: []
 references:
-- Docs/superpowers/specs/2026-06-04-mcp-git-read-tools-design.md
+  - Docs/superpowers/specs/2026-06-04-mcp-git-read-tools-design.md
 ---
 
 ## Description
@@ -37,6 +37,8 @@ External federated virtual tools now attach local external_federated eval metada
 Docs updated in tldw_Server_API/app/core/MCP_unified/README.md; plan recorded in Docs/superpowers/plans/2026-06-04-mcp-tool-observability-contract-implementation-plan.md.
 
 Verification: 126 targeted MCP tests passed; Bandit on touched production files exited 0 with zero findings.
+
+PR review fixes: addressed valid Gemini/CodeRabbit/Qodo feedback by allowlisting eval profile IDs, merging safe partial explicit eval metadata over inferred defaults, rejecting non-string explicit eval scalar fields, guarding list cleanup for null/scalar strings, logging non-critical eval enrichment failures, keeping top-level execution eval canonical, and documenting the profile-id constraint. Review-fix verification: 131 targeted MCP tests passed; Bandit on touched production MCP files exited 0 with zero findings.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary

--- a/tldw_Server_API/app/core/MCP_unified/README.md
+++ b/tldw_Server_API/app/core/MCP_unified/README.md
@@ -371,10 +371,12 @@ embedded copy. These fields are intentionally limited to scalar values such as
 tool name, prompt id/version, action family, result kind, optional profile id,
 truncation/path-filter flags, reason code, and duration. They must not contain
 raw arguments, raw file contents, diffs, secrets, absolute local paths, or user
-email addresses.
+email addresses. Profile IDs are accepted only as short safe labels using
+letters, numbers, `_`, `.`, or `-`; unsafe values are omitted.
 
-Module authors should use `create_tool_definition()` for new tools. It preserves
-explicit `metadata.eval` and fills safe defaults when metadata is omitted.
+Module authors should use `create_tool_definition()` for new tools. It merges
+safe explicit `metadata.eval` fields over inferred defaults and drops unknown or
+non-string scalar fields.
 Manual descriptors and federated external tools are normalized at catalog and
 protocol boundaries so standalone gateway and hosted MCP callers see the same
 contract.

--- a/tldw_Server_API/app/core/MCP_unified/README.md
+++ b/tldw_Server_API/app/core/MCP_unified/README.md
@@ -350,6 +350,35 @@ Tool results include the serving module:
 
 See `Docs/MCP/Unified/Modules.md` for a complete guide.
 
+## Tool Observability And Evaluation Metadata
+
+MCP Unified attaches a shared, non-sensitive evaluation contract across the tool
+surface so operators can compare tool prompt variants, profile grants, model
+tool-use quality, and external-server behavior without scraping raw tool output.
+
+Tool definitions include `metadata.eval` with:
+
+- `tool_prompt_id`: stable identifier, defaulting to `mcp.<tool-name>.v1`
+- `tool_prompt_version`: version of the built-in or operator-supplied tool prompt
+- `task_families`: coarse evaluation category derived from explicit metadata or tool name
+- `expected_result_kind`: expected structured result family
+- `success_signals`: safe rubric hints such as `avoided_mutation`
+- `prompt_variant`: `builtin`, `alias`, `external_federated`, or an operator variant
+
+Execution responses include top-level `eval` metadata. Structured JSON tool
+results that do not already provide their own `eval` block also receive an
+embedded copy. These fields are intentionally limited to scalar values such as
+tool name, prompt id/version, action family, result kind, optional profile id,
+truncation/path-filter flags, reason code, and duration. They must not contain
+raw arguments, raw file contents, diffs, secrets, absolute local paths, or user
+email addresses.
+
+Module authors should use `create_tool_definition()` for new tools. It preserves
+explicit `metadata.eval` and fills safe defaults when metadata is omitted.
+Manual descriptors and federated external tools are normalized at catalog and
+protocol boundaries so standalone gateway and hosted MCP callers see the same
+contract.
+
 ## Git Read-Only Inspection Module
 
 The optional native Git inspection module is enabled only when explicitly
@@ -378,8 +407,7 @@ Git responses are intentionally privacy- and safety-bounded. Ignored files are
 excluded from status output; author emails are omitted from log and blame
 output; and external diff/textconv processing is disabled for diff reads.
 Responses are bounded by tool limits and include non-sensitive evaluation
-metadata for observability. Follow-up `TASK-2256` covers MCP-wide adoption of
-that eval metadata contract for all tools, not only Git.
+metadata through the shared MCP tool observability contract.
 
 ## 🧭 Phase-1 Virtual CLI Runtime
 

--- a/tldw_Server_API/app/core/MCP_unified/modules/base.py
+++ b/tldw_Server_API/app/core/MCP_unified/modules/base.py
@@ -16,6 +16,8 @@ from typing import Any, Optional, TypeVar
 
 from loguru import logger
 
+from ..tool_observability import ensure_tool_definition_eval_metadata
+
 T = TypeVar("T")
 
 
@@ -718,7 +720,7 @@ def create_tool_definition(
     if metadata:
         tool_def["metadata"] = metadata
 
-    return tool_def
+    return ensure_tool_definition_eval_metadata(tool_def)
 
 
 def create_resource_definition(

--- a/tldw_Server_API/app/core/MCP_unified/modules/implementations/external_federation_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/modules/implementations/external_federation_module.py
@@ -23,6 +23,7 @@ from tldw_Server_API.app.services.mcp_hub_external_registry_service import (
     get_mcp_hub_external_registry_service,
 )
 
+from ...tool_observability import ensure_tool_definition_eval_metadata
 from ..base import BaseModule, create_tool_definition
 
 
@@ -119,20 +120,25 @@ class ExternalFederationModule(BaseModule):
             return tools
 
         for virtual_tool in self._manager.list_virtual_tools():
+            virtual_metadata = dict(virtual_tool.metadata or {})
+            virtual_metadata.pop("eval", None)
             tools.append(
-                {
-                    "name": virtual_tool.virtual_name,
-                    "description": virtual_tool.description,
-                    "inputSchema": virtual_tool.input_schema,
-                    "metadata": {
-                        "category": "external",
-                        "federated": True,
-                        "server_id": virtual_tool.server_id,
-                        "upstream_tool": virtual_tool.upstream_tool_name,
-                        **(virtual_tool.metadata or {}),
-                        "write_capable": bool(virtual_tool.is_write),
+                ensure_tool_definition_eval_metadata(
+                    {
+                        "name": virtual_tool.virtual_name,
+                        "description": virtual_tool.description,
+                        "inputSchema": virtual_tool.input_schema,
+                        "metadata": {
+                            "category": "external",
+                            "federated": True,
+                            "server_id": virtual_tool.server_id,
+                            "upstream_tool": virtual_tool.upstream_tool_name,
+                            **virtual_metadata,
+                            "write_capable": bool(virtual_tool.is_write),
+                        },
                     },
-                }
+                    prompt_variant="external_federated",
+                )
             )
 
         return tools

--- a/tldw_Server_API/app/core/MCP_unified/protocol.py
+++ b/tldw_Server_API/app/core/MCP_unified/protocol.py
@@ -43,6 +43,7 @@ from .tool_observability import (
     attach_execution_eval_metadata,
     ensure_tool_definition_eval_metadata,
     execution_eval_metadata_from_tool_definition,
+    sanitize_eval_profile_id,
 )
 
 try:  # pragma: no cover - optional dependency
@@ -1828,8 +1829,15 @@ class MCPProtocol:
                     tool_copy = tool.copy()
                     name = tool_copy.get("name")
                     if isinstance(name, str) and name.strip():
-                        with contextlib.suppress(_MCP_PROTOCOL_NONCRITICAL_EXCEPTIONS):
+                        try:
                             tool_copy = ensure_tool_definition_eval_metadata(tool_copy)
+                        except _MCP_PROTOCOL_NONCRITICAL_EXCEPTIONS as exc:
+                            context.logger.opt(exception=exc).debug(
+                                "Failed to attach eval metadata to listed tool",
+                                module_id=module_id,
+                                tool_name=name,
+                                error_type=exc.__class__.__name__,
+                            )
                     tool_copy["module"] = module_id
                     # Scoped tool permissions: when scopes are present, list only matching tools
                     if self._mcp_scopes(context) and isinstance(name, str):
@@ -1887,8 +1895,9 @@ class MCPProtocol:
             return None
         for key in ("profile_id", "mcp_profile_id", "gateway_profile_id"):
             value = metadata.get(key)
-            if isinstance(value, str) and value.strip():
-                return value.strip()
+            clean_value = sanitize_eval_profile_id(value)
+            if clean_value is not None:
+                return clean_value
         return None
 
     def _extract_tool_command(self, tool_args: Any) -> str | None:
@@ -2333,8 +2342,15 @@ class MCPProtocol:
         # Look up tool definition early for scope gating and validation
         tool_def = await self._resolve_tool_definition(module, tool_name)
         if isinstance(tool_def, dict):
-            with contextlib.suppress(_MCP_PROTOCOL_NONCRITICAL_EXCEPTIONS):
+            try:
                 tool_def = ensure_tool_definition_eval_metadata(tool_def)
+            except _MCP_PROTOCOL_NONCRITICAL_EXCEPTIONS as exc:
+                context.logger.opt(exception=exc).debug(
+                    "Failed to attach eval metadata to resolved tool definition",
+                    module_id=module_id,
+                    tool_name=tool_name,
+                    error_type=exc.__class__.__name__,
+                )
         tool_args = self._harden_and_sanitize_tool_arguments(module, tool_args)
 
         # Determine write-capable status from sanitized arguments.
@@ -2618,15 +2634,11 @@ class MCPProtocol:
                     profile_id=profile_id,
                     duration_ms=duration_ms,
                 )
-                execution_eval = (
-                    result.get("eval")
-                    if isinstance(result, dict) and isinstance(result.get("eval"), dict)
-                    else execution_eval_metadata_from_tool_definition(
-                        tool_name=tool_name,
-                        tool_def=tool_def,
-                        profile_id=profile_id,
-                        duration_ms=duration_ms,
-                    )
+                execution_eval = execution_eval_metadata_from_tool_definition(
+                    tool_name=tool_name,
+                    tool_def=tool_def,
+                    profile_id=profile_id,
+                    duration_ms=duration_ms,
                 )
                 if isinstance(result, str):
                     content = [{"type": "text", "text": result}]

--- a/tldw_Server_API/app/core/MCP_unified/protocol.py
+++ b/tldw_Server_API/app/core/MCP_unified/protocol.py
@@ -39,6 +39,11 @@ from .auth.rate_limiter import RateLimitExceeded
 from .config import get_config
 from .interfaces.runtime import MCPRuntimeDependencies, TelemetryProvider
 from .modules.base import BaseModule
+from .tool_observability import (
+    attach_execution_eval_metadata,
+    ensure_tool_definition_eval_metadata,
+    execution_eval_metadata_from_tool_definition,
+)
 
 try:  # pragma: no cover - optional dependency
     from redis.exceptions import RedisError
@@ -1821,8 +1826,11 @@ class MCPProtocol:
 
                 for tool in module_tools:
                     tool_copy = tool.copy()
-                    tool_copy["module"] = module_id
                     name = tool_copy.get("name")
+                    if isinstance(name, str) and name.strip():
+                        with contextlib.suppress(_MCP_PROTOCOL_NONCRITICAL_EXCEPTIONS):
+                            tool_copy = ensure_tool_definition_eval_metadata(tool_copy)
+                    tool_copy["module"] = module_id
                     # Scoped tool permissions: when scopes are present, list only matching tools
                     if self._mcp_scopes(context) and isinstance(name, str):
                         if not self._scope_allows_tool_name(context, name):
@@ -1870,6 +1878,17 @@ class MCPProtocol:
                 pass
             cleaned = [part.strip() for part in allowed.split(",") if part.strip()]
             return cleaned or None
+        return None
+
+    def _extract_eval_profile_id(self, context: RequestContext) -> str | None:
+        """Extract a non-sensitive profile identifier for execution eval metadata."""
+        metadata = getattr(context, "metadata", {})
+        if not isinstance(metadata, dict):
+            return None
+        for key in ("profile_id", "mcp_profile_id", "gateway_profile_id"):
+            value = metadata.get(key)
+            if isinstance(value, str) and value.strip():
+                return value.strip()
         return None
 
     def _extract_tool_command(self, tool_args: Any) -> str | None:
@@ -2313,6 +2332,9 @@ class MCPProtocol:
 
         # Look up tool definition early for scope gating and validation
         tool_def = await self._resolve_tool_definition(module, tool_name)
+        if isinstance(tool_def, dict):
+            with contextlib.suppress(_MCP_PROTOCOL_NONCRITICAL_EXCEPTIONS):
+                tool_def = ensure_tool_definition_eval_metadata(tool_def)
         tool_args = self._harden_and_sanitize_tool_arguments(module, tool_args)
 
         # Determine write-capable status from sanitized arguments.
@@ -2587,6 +2609,25 @@ class MCPProtocol:
                         span.set_attribute("mcp.duration_ms", max(0.0, (time.time() - t0) * 1000.0))
 
                 # Format result
+                duration_ms = max(0.0, (time.time() - t0) * 1000.0)
+                profile_id = self._extract_eval_profile_id(context)
+                result = attach_execution_eval_metadata(
+                    result,
+                    tool_name=tool_name,
+                    tool_def=tool_def,
+                    profile_id=profile_id,
+                    duration_ms=duration_ms,
+                )
+                execution_eval = (
+                    result.get("eval")
+                    if isinstance(result, dict) and isinstance(result.get("eval"), dict)
+                    else execution_eval_metadata_from_tool_definition(
+                        tool_name=tool_name,
+                        tool_def=tool_def,
+                        profile_id=profile_id,
+                        duration_ms=duration_ms,
+                    )
+                )
                 if isinstance(result, str):
                     content = [{"type": "text", "text": result}]
                 elif isinstance(result, list):
@@ -2612,7 +2653,12 @@ class MCPProtocol:
                     duration_ms=max(0.0, (time.time() - t0) * 1000.0),
                     arguments_hash=args_hash,
                 )
-                response_payload = {"content": content, "module": module_name, "tool": tool_name}
+                response_payload = {
+                    "content": content,
+                    "module": module_name,
+                    "tool": tool_name,
+                    "eval": execution_eval,
+                }
                 return response_payload
 
             except _MCP_PROTOCOL_NONCRITICAL_EXCEPTIONS as e:

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_external_federation_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_external_federation_module.py
@@ -2,6 +2,9 @@ from __future__ import annotations
 
 from typing import Any
 
+import pytest
+from mcp_unified.federation.models import VirtualExternalTool
+
 from tldw_Server_API.app.core.MCP_unified.modules.base import ModuleConfig
 from tldw_Server_API.app.core.MCP_unified.modules.implementations.external_federation_module import (
     ExternalFederationModule,
@@ -32,3 +35,75 @@ def test_external_federation_write_classification_uses_scalar_manager_lookup() -
     assert module.is_write_tool_call("ext.docs.docs.update", {}) is True  # nosec B101
     assert module.is_write_tool_call("ext.docs.docs.search", {}) is False  # nosec B101
     assert manager.lookups == ["ext.docs.docs.update", "ext.docs.docs.search"]  # nosec B101
+
+
+class _VirtualToolListManager:
+    def list_virtual_tools(self) -> list[VirtualExternalTool]:
+        return [
+            VirtualExternalTool(
+                virtual_name="ext.docs.docs.search",
+                server_id="docs",
+                upstream_tool_name="docs.search",
+                description="Search external docs.",
+                input_schema={"type": "object", "properties": {"query": {"type": "string"}}},
+                metadata={"source": "unit-test"},
+                is_write=False,
+            )
+        ]
+
+
+class _VirtualToolWithUpstreamEvalManager:
+    def list_virtual_tools(self) -> list[VirtualExternalTool]:
+        return [
+            VirtualExternalTool(
+                virtual_name="ext.docs.docs.search",
+                server_id="docs",
+                upstream_tool_name="docs.search",
+                description="Search external docs.",
+                input_schema={"type": "object"},
+                metadata={
+                    "eval": {
+                        "tool_prompt_id": "mcp.upstream.untrusted.v1",
+                        "tool_prompt_version": "upstream",
+                        "task_families": ["raw"],
+                        "expected_result_kind": "raw_payload",
+                        "success_signals": ["raw_output"],
+                    }
+                },
+                is_write=False,
+            )
+        ]
+
+
+@pytest.mark.asyncio
+async def test_external_federation_virtual_tools_include_eval_metadata() -> None:
+    module = ExternalFederationModule(ModuleConfig(name="external_federation"))
+    module._manager = _VirtualToolListManager()  # noqa: SLF001 - focused module wiring test.
+
+    tools = await module.get_tools()
+    by_name = {tool["name"]: tool for tool in tools}
+    metadata = by_name["ext.docs.docs.search"]["metadata"]
+    eval_metadata = metadata["eval"]
+
+    assert metadata["federated"] is True  # nosec B101
+    assert metadata["server_id"] == "docs"  # nosec B101
+    assert metadata["upstream_tool"] == "docs.search"  # nosec B101
+    assert eval_metadata["tool_prompt_id"] == "mcp.ext.docs.docs.search.v1"  # nosec B101
+    assert eval_metadata["task_families"] == ["external"]  # nosec B101
+    assert eval_metadata["expected_result_kind"] == "external_result"  # nosec B101
+    assert eval_metadata["prompt_variant"] == "external_federated"  # nosec B101
+
+
+@pytest.mark.asyncio
+async def test_external_federation_ignores_upstream_eval_metadata() -> None:
+    module = ExternalFederationModule(ModuleConfig(name="external_federation"))
+    module._manager = _VirtualToolWithUpstreamEvalManager()  # noqa: SLF001 - focused module wiring test.
+
+    tools = await module.get_tools()
+    by_name = {tool["name"]: tool for tool in tools}
+    eval_metadata = by_name["ext.docs.docs.search"]["metadata"]["eval"]
+
+    assert eval_metadata["tool_prompt_id"] == "mcp.ext.docs.docs.search.v1"  # nosec B101
+    assert eval_metadata["tool_prompt_version"] != "upstream"  # nosec B101
+    assert eval_metadata["task_families"] == ["external"]  # nosec B101
+    assert eval_metadata["prompt_variant"] == "external_federated"  # nosec B101

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_tool_observability.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_tool_observability.py
@@ -3,9 +3,16 @@
 from __future__ import annotations
 
 import inspect
+from typing import Any
 
 import pytest
 
+from tldw_Server_API.app.core.MCP_unified.modules.base import (
+    BaseModule,
+    ModuleConfig,
+    create_tool_definition,
+)
+from tldw_Server_API.app.core.MCP_unified.protocol import MCPProtocol, RequestContext
 from tldw_Server_API.app.core.MCP_unified.tool_observability import (
     build_execution_eval_metadata,
     build_tool_eval_metadata,
@@ -63,9 +70,7 @@ def test_build_tool_eval_metadata_strips_values_and_removes_blank_list_items() -
         ("expected_result_kind", {"expected_result_kind": "\t"}),
     ],
 )
-def test_build_tool_eval_metadata_rejects_blank_required_strings(
-    field: str, kwargs: dict[str, str]
-) -> None:
+def test_build_tool_eval_metadata_rejects_blank_required_strings(field: str, kwargs: dict[str, str]) -> None:
     values = {
         "tool_prompt_id": "mcp.git.status.v1",
         "tool_prompt_version": "2026.06.04",
@@ -105,9 +110,7 @@ def test_build_execution_eval_metadata_returns_only_safe_scalar_fields() -> None
         "reason_code": "ok",
         "duration_ms": 12.75,
     }
-    assert all(
-        isinstance(value, str | bool | int | float) for value in metadata.values()
-    )
+    assert all(isinstance(value, str | bool | int | float) for value in metadata.values())
 
 
 def test_build_execution_eval_metadata_omits_blank_optional_fields() -> None:
@@ -157,3 +160,185 @@ def test_build_execution_eval_metadata_does_not_accept_arbitrary_label_dicts() -
                 "author_email": "author@example.com",
             },
         )
+
+
+def test_create_tool_definition_adds_default_eval_metadata() -> None:
+    tool = create_tool_definition(
+        name="docs.search",
+        description="Search indexed docs.",
+        parameters={"properties": {"query": {"type": "string"}}, "required": ["query"]},
+        metadata={"category": "search", "readOnlyHint": True},
+    )
+
+    metadata = tool["metadata"]
+    eval_metadata = metadata["eval"]
+
+    assert metadata["category"] == "search"
+    assert metadata["readOnlyHint"] is True
+    assert eval_metadata["tool_prompt_id"] == "mcp.docs.search.v1"
+    assert eval_metadata["tool_prompt_version"]
+    assert eval_metadata["task_families"] == ["search"]
+    assert eval_metadata["expected_result_kind"] == "search_result"
+    assert "avoided_mutation" in eval_metadata["success_signals"]
+    assert eval_metadata["prompt_variant"] == "builtin"
+
+
+def test_create_tool_definition_preserves_explicit_eval_metadata() -> None:
+    explicit_eval = build_tool_eval_metadata(
+        tool_prompt_id="mcp.custom.docs_search.v2",
+        tool_prompt_version="2026.06.04-custom",
+        task_families=["custom_docs"],
+        expected_result_kind="custom_doc_matches",
+        success_signals=["matched_custom_prompt"],
+        prompt_variant="operator_patch",
+    )
+
+    tool = create_tool_definition(
+        name="docs.search",
+        description="Search indexed docs.",
+        parameters={"properties": {"query": {"type": "string"}}, "required": ["query"]},
+        metadata={"category": "search", **explicit_eval},
+    )
+
+    assert tool["metadata"]["eval"] == explicit_eval["eval"]
+
+
+def test_create_tool_definition_sanitizes_explicit_eval_metadata() -> None:
+    tool = create_tool_definition(
+        name="docs.search",
+        description="Search indexed docs.",
+        parameters={"properties": {"query": {"type": "string"}}, "required": ["query"]},
+        metadata={
+            "category": "search",
+            "eval": {
+                "tool_prompt_id": "mcp.docs.search.custom.v1",
+                "tool_prompt_version": "2026.06.04-custom",
+                "task_families": ["search", {"raw": "do-not-leak"}],
+                "expected_result_kind": "search_result",
+                "success_signals": ["completed_without_error", {"raw": "secret"}],
+                "prompt_variant": "operator_patch",
+                "raw_payload": "diff --git a/secret.txt b/secret.txt",
+            },
+        },
+    )
+
+    assert tool["metadata"]["eval"] == {
+        "tool_prompt_id": "mcp.docs.search.custom.v1",
+        "tool_prompt_version": "2026.06.04-custom",
+        "task_families": ["search"],
+        "expected_result_kind": "search_result",
+        "success_signals": ["completed_without_error"],
+        "prompt_variant": "operator_patch",
+    }
+
+
+class _ManualObservableModule(BaseModule):
+    """Test module that intentionally bypasses the shared definition helper."""
+
+    async def on_initialize(self) -> None:
+        return None
+
+    async def on_shutdown(self) -> None:
+        return None
+
+    async def check_health(self) -> dict[str, bool]:
+        return {"ok": True}
+
+    async def get_tools(self) -> list[dict[str, Any]]:
+        return [
+            {
+                "name": "manual.inspect",
+                "description": "Inspect a manual result.",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {"target": {"type": "string"}},
+                    "required": ["target"],
+                },
+                "metadata": {"category": "inspection", "readOnlyHint": True},
+            }
+        ]
+
+    async def execute_tool(
+        self,
+        tool_name: str,
+        arguments: dict[str, Any],
+        context: Any | None = None,
+    ) -> Any:
+        return {"target": arguments["target"], "ok": True}
+
+
+class _ManualRegistryStub:
+    def __init__(self, module: _ManualObservableModule) -> None:
+        self.module = module
+
+    async def find_module_for_tool(self, tool_name: str) -> _ManualObservableModule | None:
+        return self.module if tool_name == "manual.inspect" else None
+
+    def get_module_id_for_tool(self, tool_name: str) -> str | None:
+        return "manual" if tool_name == "manual.inspect" else None
+
+    async def get_all_modules(self) -> dict[str, _ManualObservableModule]:
+        return {"manual": self.module}
+
+
+def _manual_observable_protocol() -> MCPProtocol:
+    protocol = MCPProtocol()
+    module = _ManualObservableModule(ModuleConfig(name="manual"))
+    protocol.module_registry = _ManualRegistryStub(module)  # type: ignore[assignment]
+
+    async def _allow_module(_context: RequestContext, _module_id: str | None) -> bool:
+        return True
+
+    async def _allow_tool(
+        _context: RequestContext,
+        _tool_name: str,
+        **_kwargs: Any,
+    ) -> bool:
+        return True
+
+    protocol._has_module_permission = _allow_module  # type: ignore[method-assign]
+    protocol._has_tool_permission = _allow_tool  # type: ignore[method-assign]
+    return protocol
+
+
+@pytest.mark.asyncio
+async def test_tools_list_adds_eval_metadata_to_manual_tool_definitions() -> None:
+    protocol = _manual_observable_protocol()
+    context = RequestContext(request_id="manual-list", metadata={})
+
+    payload = await protocol._handle_tools_list({}, context)
+    tool = payload["tools"][0]
+    eval_metadata = tool["metadata"]["eval"]
+
+    assert eval_metadata["tool_prompt_id"] == "mcp.manual.inspect.v1"
+    assert eval_metadata["task_families"] == ["inspection"]
+    assert eval_metadata["expected_result_kind"] == "inspection_result"
+    assert "avoided_mutation" in eval_metadata["success_signals"]
+
+
+@pytest.mark.asyncio
+async def test_tools_call_adds_execution_eval_metadata_to_structured_results() -> None:
+    protocol = _manual_observable_protocol()
+    context = RequestContext(
+        request_id="manual-call",
+        user_id="user-1",
+        client_id="client-1",
+        metadata={"profile_id": "researcher"},
+    )
+
+    payload = await protocol._handle_tools_call(
+        {"name": "manual.inspect", "arguments": {"target": "readme"}},
+        context,
+    )
+
+    result_json = payload["content"][0]["json"]
+    eval_metadata = result_json["eval"]
+
+    assert result_json["target"] == "readme"
+    assert eval_metadata["tool_name"] == "manual.inspect"
+    assert eval_metadata["tool_prompt_id"] == "mcp.manual.inspect.v1"
+    assert eval_metadata["tool_prompt_version"]
+    assert eval_metadata["action_family"] == "inspection"
+    assert eval_metadata["result_kind"] == "inspection_result"
+    assert eval_metadata["profile_id"] == "researcher"
+    assert isinstance(eval_metadata["duration_ms"], float)

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_tool_observability.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_tool_observability.py
@@ -62,6 +62,19 @@ def test_build_tool_eval_metadata_strips_values_and_removes_blank_list_items() -
     }
 
 
+def test_build_tool_eval_metadata_ignores_non_list_iterable_values() -> None:
+    metadata = build_tool_eval_metadata(
+        tool_prompt_id="mcp.git.diff.v1",
+        tool_prompt_version="2026.06.04",
+        task_families="search",
+        expected_result_kind="bounded_diff",
+        success_signals=None,  # type: ignore[arg-type]
+    )
+
+    assert metadata["eval"]["task_families"] == []
+    assert metadata["eval"]["success_signals"] == []
+
+
 @pytest.mark.parametrize(
     ("field", "kwargs"),
     [
@@ -232,8 +245,64 @@ def test_create_tool_definition_sanitizes_explicit_eval_metadata() -> None:
     }
 
 
+def test_create_tool_definition_merges_partial_explicit_eval_metadata() -> None:
+    tool = create_tool_definition(
+        name="docs.search",
+        description="Search indexed docs.",
+        parameters={"properties": {"query": {"type": "string"}}, "required": ["query"]},
+        metadata={
+            "category": "search",
+            "eval": {
+                "tool_prompt_id": "mcp.docs.search.operator.v1",
+                "task_families": ["operator_docs"],
+                "success_signals": ["matched_operator_prompt"],
+            },
+        },
+    )
+
+    assert tool["metadata"]["eval"] == {
+        "tool_prompt_id": "mcp.docs.search.operator.v1",
+        "tool_prompt_version": "2026.06.04",
+        "task_families": ["operator_docs"],
+        "expected_result_kind": "search_result",
+        "success_signals": ["matched_operator_prompt"],
+        "prompt_variant": "builtin",
+    }
+
+
+def test_create_tool_definition_rejects_non_string_required_eval_fields() -> None:
+    tool = create_tool_definition(
+        name="docs.search",
+        description="Search indexed docs.",
+        parameters={"properties": {"query": {"type": "string"}}, "required": ["query"]},
+        metadata={
+            "category": "search",
+            "eval": {
+                "tool_prompt_id": {"raw": "do-not-leak"},
+                "tool_prompt_version": "2026.06.04-custom",
+                "expected_result_kind": "custom_search_result",
+            },
+        },
+    )
+
+    eval_metadata = tool["metadata"]["eval"]
+    assert eval_metadata["tool_prompt_id"] == "mcp.docs.search.v1"
+    assert "do-not-leak" not in str(eval_metadata)
+    assert eval_metadata["tool_prompt_version"] == "2026.06.04-custom"
+    assert eval_metadata["expected_result_kind"] == "custom_search_result"
+
+
 class _ManualObservableModule(BaseModule):
     """Test module that intentionally bypasses the shared definition helper."""
+
+    def __init__(
+        self,
+        config: ModuleConfig,
+        *,
+        result_override: dict[str, Any] | None = None,
+    ) -> None:
+        super().__init__(config)
+        self._result_override = result_override
 
     async def on_initialize(self) -> None:
         return None
@@ -264,6 +333,8 @@ class _ManualObservableModule(BaseModule):
         arguments: dict[str, Any],
         context: Any | None = None,
     ) -> Any:
+        if self._result_override is not None:
+            return dict(self._result_override)
         return {"target": arguments["target"], "ok": True}
 
 
@@ -281,9 +352,12 @@ class _ManualRegistryStub:
         return {"manual": self.module}
 
 
-def _manual_observable_protocol() -> MCPProtocol:
+def _manual_observable_protocol(
+    *,
+    result_override: dict[str, Any] | None = None,
+) -> MCPProtocol:
     protocol = MCPProtocol()
-    module = _ManualObservableModule(ModuleConfig(name="manual"))
+    module = _ManualObservableModule(ModuleConfig(name="manual"), result_override=result_override)
     protocol.module_registry = _ManualRegistryStub(module)  # type: ignore[assignment]
 
     async def _allow_module(_context: RequestContext, _module_id: str | None) -> bool:
@@ -342,3 +416,55 @@ async def test_tools_call_adds_execution_eval_metadata_to_structured_results() -
     assert eval_metadata["result_kind"] == "inspection_result"
     assert eval_metadata["profile_id"] == "researcher"
     assert isinstance(eval_metadata["duration_ms"], float)
+    assert payload["eval"]["tool_name"] == "manual.inspect"
+    assert payload["eval"]["profile_id"] == "researcher"
+
+
+@pytest.mark.asyncio
+async def test_tools_call_omits_unsafe_profile_id_from_eval_metadata() -> None:
+    protocol = _manual_observable_protocol()
+    context = RequestContext(
+        request_id="manual-call",
+        user_id="user-1",
+        client_id="client-1",
+        metadata={"profile_id": "researcher@example.com"},
+    )
+
+    payload = await protocol._handle_tools_call(
+        {"name": "manual.inspect", "arguments": {"target": "readme"}},
+        context,
+    )
+
+    result_eval = payload["content"][0]["json"]["eval"]
+    assert "profile_id" not in result_eval
+    assert "profile_id" not in payload["eval"]
+
+
+@pytest.mark.asyncio
+async def test_tools_call_does_not_promote_tool_returned_eval_to_top_level() -> None:
+    protocol = _manual_observable_protocol(
+        result_override={
+            "target": "readme",
+            "eval": {
+                "tool_name": "malicious.override",
+                "raw_payload": "diff --git a/secret.txt b/secret.txt",
+                "profile_id": "operator@example.com",
+            },
+        }
+    )
+    context = RequestContext(
+        request_id="manual-call",
+        user_id="user-1",
+        client_id="client-1",
+        metadata={"profile_id": "researcher"},
+    )
+
+    payload = await protocol._handle_tools_call(
+        {"name": "manual.inspect", "arguments": {"target": "readme"}},
+        context,
+    )
+
+    assert payload["content"][0]["json"]["eval"]["tool_name"] == "malicious.override"
+    assert payload["eval"]["tool_name"] == "manual.inspect"
+    assert payload["eval"]["profile_id"] == "researcher"
+    assert "raw_payload" not in payload["eval"]

--- a/tldw_Server_API/app/core/MCP_unified/tool_observability.py
+++ b/tldw_Server_API/app/core/MCP_unified/tool_observability.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 from collections.abc import Iterable
-from typing import TypeAlias
+import re
+from typing import Any, TypeAlias
 
 
 ToolEvalValue: TypeAlias = str | list[str]
@@ -11,10 +12,14 @@ ToolEvalMetadata: TypeAlias = dict[str, dict[str, ToolEvalValue]]
 ExecutionEvalValue: TypeAlias = str | bool | int | float
 ExecutionEvalMetadata: TypeAlias = dict[str, ExecutionEvalValue]
 
+DEFAULT_TOOL_PROMPT_VERSION = "2026.06.04"
+_TOOL_PROMPT_ID_INVALID_CHARS = re.compile(r"[^a-z0-9_.-]+")
+_WRITE_CATEGORIES = frozenset({"ingestion", "management", "write", "mutation"})
+
 
 def _clean_list(values: Iterable[str]) -> list[str]:
     """Return stripped, non-blank values while preserving input order."""
-    return [cleaned for value in values if (cleaned := str(value).strip())]
+    return [cleaned for value in values if isinstance(value, str) and (cleaned := value.strip())]
 
 
 def _required_string(value: str, field_name: str) -> str:
@@ -31,6 +36,75 @@ def _optional_string(value: str | None) -> str | None:
     return cleaned or None
 
 
+def _metadata_dict(tool_def: dict[str, Any] | None) -> dict[str, Any]:
+    metadata = (tool_def or {}).get("metadata") if isinstance(tool_def, dict) else None
+    return dict(metadata) if isinstance(metadata, dict) else {}
+
+
+def _clean_tool_prompt_name(tool_name: str) -> str:
+    cleaned = _TOOL_PROMPT_ID_INVALID_CHARS.sub("_", tool_name.strip().lower())
+    cleaned = cleaned.strip("._-")
+    return cleaned or "unknown"
+
+
+def _first_tool_family(tool_name: str) -> str:
+    cleaned = _clean_tool_prompt_name(tool_name)
+    family = cleaned.split(".", 1)[0].strip()
+    return family or "general"
+
+
+def _infer_category(tool_name: str, metadata: dict[str, Any]) -> str:
+    category = _optional_string(str(metadata.get("category"))) if metadata.get("category") is not None else None
+    return category or _first_tool_family(tool_name)
+
+
+def _infer_prompt_variant(metadata: dict[str, Any], prompt_variant: str | None) -> str:
+    explicit = _optional_string(prompt_variant)
+    if explicit is not None:
+        return explicit
+    if metadata.get("federated") is True or any(
+        key in metadata for key in ("external_server_id", "server_id", "upstream_tool")
+    ):
+        return "external_federated"
+    if metadata.get("canonical_tool"):
+        return "alias"
+    return "builtin"
+
+
+def _infer_success_signals(metadata: dict[str, Any], category: str) -> list[str]:
+    signals = ["completed_without_error"]
+    if bool(metadata.get("readOnlyHint")):
+        signals.insert(0, "avoided_mutation")
+    if bool(metadata.get("write_capable")) or bool(metadata.get("is_write")) or category.lower() in _WRITE_CATEGORIES:
+        signals.append("completed_requested_mutation")
+    return signals
+
+
+def _clean_existing_tool_eval(value: Any) -> dict[str, ToolEvalValue] | None:
+    if not isinstance(value, dict):
+        return None
+
+    tool_prompt_id = _optional_string(value.get("tool_prompt_id"))
+    tool_prompt_version = _optional_string(value.get("tool_prompt_version"))
+    expected_result_kind = _optional_string(value.get("expected_result_kind"))
+    if tool_prompt_id is None or tool_prompt_version is None or expected_result_kind is None:
+        return None
+
+    raw_task_families = value.get("task_families")
+    task_families = _clean_list(raw_task_families) if isinstance(raw_task_families, list) else []
+    raw_success_signals = value.get("success_signals")
+    success_signals = _clean_list(raw_success_signals) if isinstance(raw_success_signals, list) else []
+
+    return {
+        "tool_prompt_id": tool_prompt_id,
+        "tool_prompt_version": tool_prompt_version,
+        "task_families": task_families,
+        "expected_result_kind": expected_result_kind,
+        "success_signals": success_signals,
+        "prompt_variant": _optional_string(value.get("prompt_variant")) or "builtin",
+    }
+
+
 def build_tool_eval_metadata(
     *,
     tool_prompt_id: str,
@@ -44,17 +118,122 @@ def build_tool_eval_metadata(
     return {
         "eval": {
             "tool_prompt_id": _required_string(tool_prompt_id, "tool_prompt_id"),
-            "tool_prompt_version": _required_string(
-                tool_prompt_version, "tool_prompt_version"
-            ),
+            "tool_prompt_version": _required_string(tool_prompt_version, "tool_prompt_version"),
             "task_families": _clean_list(task_families),
-            "expected_result_kind": _required_string(
-                expected_result_kind, "expected_result_kind"
-            ),
+            "expected_result_kind": _required_string(expected_result_kind, "expected_result_kind"),
             "success_signals": _clean_list(success_signals),
             "prompt_variant": _optional_string(prompt_variant) or "builtin",
         }
     }
+
+
+def infer_tool_eval_metadata(
+    *,
+    tool_name: str,
+    metadata: dict[str, Any] | None = None,
+    prompt_variant: str | None = None,
+) -> ToolEvalMetadata:
+    """Infer stable evaluation metadata for a tool definition."""
+    cleaned_tool_name = _required_string(tool_name, "tool_name")
+    metadata = dict(metadata or {})
+    category = _infer_category(cleaned_tool_name, metadata)
+    return build_tool_eval_metadata(
+        tool_prompt_id=f"mcp.{_clean_tool_prompt_name(cleaned_tool_name)}.v1",
+        tool_prompt_version=DEFAULT_TOOL_PROMPT_VERSION,
+        task_families=[category],
+        expected_result_kind=f"{category}_result",
+        success_signals=_infer_success_signals(metadata, category),
+        prompt_variant=_infer_prompt_variant(metadata, prompt_variant),
+    )
+
+
+def ensure_tool_definition_eval_metadata(
+    tool_def: dict[str, Any],
+    *,
+    prompt_variant: str | None = None,
+) -> dict[str, Any]:
+    """Return a tool definition copy with safe evaluation metadata attached."""
+    if not isinstance(tool_def, dict):
+        return tool_def
+
+    normalized = dict(tool_def)
+    tool_name = _required_string(str(normalized.get("name") or ""), "tool_name")
+    metadata = _metadata_dict(normalized)
+    existing_eval = _clean_existing_tool_eval(metadata.get("eval"))
+    if existing_eval is None:
+        metadata.update(
+            infer_tool_eval_metadata(
+                tool_name=tool_name,
+                metadata=metadata,
+                prompt_variant=prompt_variant,
+            )
+        )
+    else:
+        metadata["eval"] = existing_eval
+    normalized["metadata"] = metadata
+    return normalized
+
+
+def execution_eval_metadata_from_tool_definition(
+    *,
+    tool_name: str,
+    tool_def: dict[str, Any] | None,
+    profile_id: str | None = None,
+    path_filter_used: bool | None = None,
+    truncated: bool | None = False,
+    reason_code: str | None = None,
+    duration_ms: float | None = None,
+) -> ExecutionEvalMetadata:
+    """Build execution eval metadata from the matching tool definition metadata."""
+    normalized_tool_def = ensure_tool_definition_eval_metadata(
+        tool_def if isinstance(tool_def, dict) else {"name": tool_name}
+    )
+    definition_eval = _metadata_dict(normalized_tool_def).get("eval")
+    if not isinstance(definition_eval, dict):
+        definition_eval = infer_tool_eval_metadata(tool_name=tool_name)["eval"]
+
+    task_families = definition_eval.get("task_families")
+    action_family = _clean_list(task_families) if isinstance(task_families, list) else []
+    return build_execution_eval_metadata(
+        tool_name=tool_name,
+        tool_prompt_id=str(definition_eval.get("tool_prompt_id") or f"mcp.{_clean_tool_prompt_name(tool_name)}.v1"),
+        tool_prompt_version=str(definition_eval.get("tool_prompt_version") or DEFAULT_TOOL_PROMPT_VERSION),
+        action_family=action_family[0] if action_family else _first_tool_family(tool_name),
+        result_kind=str(definition_eval.get("expected_result_kind") or f"{_first_tool_family(tool_name)}_result"),
+        profile_id=profile_id,
+        path_filter_used=path_filter_used,
+        truncated=truncated,
+        reason_code=reason_code,
+        duration_ms=duration_ms,
+    )
+
+
+def attach_execution_eval_metadata(
+    result: Any,
+    *,
+    tool_name: str,
+    tool_def: dict[str, Any] | None,
+    profile_id: str | None = None,
+    path_filter_used: bool | None = None,
+    truncated: bool | None = False,
+    reason_code: str | None = None,
+    duration_ms: float | None = None,
+) -> Any:
+    """Attach safe eval metadata to a structured tool result copy when absent."""
+    if not isinstance(result, dict) or isinstance(result.get("eval"), dict):
+        return result
+
+    enriched = dict(result)
+    enriched["eval"] = execution_eval_metadata_from_tool_definition(
+        tool_name=tool_name,
+        tool_def=tool_def,
+        profile_id=profile_id,
+        path_filter_used=path_filter_used,
+        truncated=truncated,
+        reason_code=reason_code,
+        duration_ms=duration_ms,
+    )
+    return enriched
 
 
 def build_execution_eval_metadata(
@@ -74,9 +253,7 @@ def build_execution_eval_metadata(
     metadata: ExecutionEvalMetadata = {
         "tool_name": _required_string(tool_name, "tool_name"),
         "tool_prompt_id": _required_string(tool_prompt_id, "tool_prompt_id"),
-        "tool_prompt_version": _required_string(
-            tool_prompt_version, "tool_prompt_version"
-        ),
+        "tool_prompt_version": _required_string(tool_prompt_version, "tool_prompt_version"),
         "action_family": _required_string(action_family, "action_family"),
         "result_kind": _required_string(result_kind, "result_kind"),
     }

--- a/tldw_Server_API/app/core/MCP_unified/tool_observability.py
+++ b/tldw_Server_API/app/core/MCP_unified/tool_observability.py
@@ -14,15 +14,19 @@ ExecutionEvalMetadata: TypeAlias = dict[str, ExecutionEvalValue]
 
 DEFAULT_TOOL_PROMPT_VERSION = "2026.06.04"
 _TOOL_PROMPT_ID_INVALID_CHARS = re.compile(r"[^a-z0-9_.-]+")
+_SAFE_PROFILE_ID = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.-]{0,127}$")
 _WRITE_CATEGORIES = frozenset({"ingestion", "management", "write", "mutation"})
 
 
-def _clean_list(values: Iterable[str]) -> list[str]:
-    """Return stripped, non-blank values while preserving input order."""
+def _clean_list(values: Iterable[Any] | None) -> list[str]:
+    """Return stripped string list values while rejecting scalar strings and nulls."""
+    if values is None or isinstance(values, str | bytes):
+        return []
     return [cleaned for value in values if isinstance(value, str) and (cleaned := value.strip())]
 
 
 def _required_string(value: str, field_name: str) -> str:
+    """Return a stripped required string or raise for blank values."""
     cleaned = str(value).strip()
     if not cleaned:
         raise ValueError(f"{field_name} must not be blank")
@@ -30,35 +34,49 @@ def _required_string(value: str, field_name: str) -> str:
 
 
 def _optional_string(value: str | None) -> str | None:
+    """Return a stripped optional string for trusted internal scalar values."""
     if value is None:
         return None
     cleaned = str(value).strip()
     return cleaned or None
 
 
+def _optional_raw_string(value: Any) -> str | None:
+    """Return a stripped string only when the raw value is already a string."""
+    if not isinstance(value, str):
+        return None
+    cleaned = value.strip()
+    return cleaned or None
+
+
 def _metadata_dict(tool_def: dict[str, Any] | None) -> dict[str, Any]:
+    """Return a shallow metadata copy from a tool definition-like mapping."""
     metadata = (tool_def or {}).get("metadata") if isinstance(tool_def, dict) else None
     return dict(metadata) if isinstance(metadata, dict) else {}
 
 
 def _clean_tool_prompt_name(tool_name: str) -> str:
+    """Normalize a tool name into a stable prompt-id-safe name segment."""
     cleaned = _TOOL_PROMPT_ID_INVALID_CHARS.sub("_", tool_name.strip().lower())
     cleaned = cleaned.strip("._-")
     return cleaned or "unknown"
 
 
 def _first_tool_family(tool_name: str) -> str:
+    """Infer the broad tool family from the first prompt-id-safe name segment."""
     cleaned = _clean_tool_prompt_name(tool_name)
     family = cleaned.split(".", 1)[0].strip()
     return family or "general"
 
 
 def _infer_category(tool_name: str, metadata: dict[str, Any]) -> str:
+    """Infer a non-empty task family from metadata.category or the tool name."""
     category = _optional_string(str(metadata.get("category"))) if metadata.get("category") is not None else None
     return category or _first_tool_family(tool_name)
 
 
 def _infer_prompt_variant(metadata: dict[str, Any], prompt_variant: str | None) -> str:
+    """Infer which prompt/catalog variant should be attributed to a tool."""
     explicit = _optional_string(prompt_variant)
     if explicit is not None:
         return explicit
@@ -72,6 +90,7 @@ def _infer_prompt_variant(metadata: dict[str, Any], prompt_variant: str | None) 
 
 
 def _infer_success_signals(metadata: dict[str, Any], category: str) -> list[str]:
+    """Infer coarse success signals from tool metadata without inspecting arguments."""
     signals = ["completed_without_error"]
     if bool(metadata.get("readOnlyHint")):
         signals.insert(0, "avoided_mutation")
@@ -81,28 +100,28 @@ def _infer_success_signals(metadata: dict[str, Any], category: str) -> list[str]
 
 
 def _clean_existing_tool_eval(value: Any) -> dict[str, ToolEvalValue] | None:
+    """Clean an explicit metadata.eval block into a safe partial override."""
     if not isinstance(value, dict):
         return None
 
-    tool_prompt_id = _optional_string(value.get("tool_prompt_id"))
-    tool_prompt_version = _optional_string(value.get("tool_prompt_version"))
-    expected_result_kind = _optional_string(value.get("expected_result_kind"))
-    if tool_prompt_id is None or tool_prompt_version is None or expected_result_kind is None:
-        return None
+    cleaned: dict[str, ToolEvalValue] = {}
+
+    for key in ("tool_prompt_id", "tool_prompt_version", "expected_result_kind"):
+        clean_value = _optional_raw_string(value.get(key))
+        if clean_value is not None:
+            cleaned[key] = clean_value
 
     raw_task_families = value.get("task_families")
-    task_families = _clean_list(raw_task_families) if isinstance(raw_task_families, list) else []
+    if isinstance(raw_task_families, list):
+        cleaned["task_families"] = _clean_list(raw_task_families)
     raw_success_signals = value.get("success_signals")
-    success_signals = _clean_list(raw_success_signals) if isinstance(raw_success_signals, list) else []
+    if isinstance(raw_success_signals, list):
+        cleaned["success_signals"] = _clean_list(raw_success_signals)
+    prompt_variant = _optional_raw_string(value.get("prompt_variant"))
+    if prompt_variant is not None:
+        cleaned["prompt_variant"] = prompt_variant
 
-    return {
-        "tool_prompt_id": tool_prompt_id,
-        "tool_prompt_version": tool_prompt_version,
-        "task_families": task_families,
-        "expected_result_kind": expected_result_kind,
-        "success_signals": success_signals,
-        "prompt_variant": _optional_string(value.get("prompt_variant")) or "builtin",
-    }
+    return cleaned
 
 
 def build_tool_eval_metadata(
@@ -159,19 +178,27 @@ def ensure_tool_definition_eval_metadata(
     normalized = dict(tool_def)
     tool_name = _required_string(str(normalized.get("name") or ""), "tool_name")
     metadata = _metadata_dict(normalized)
+    inferred_eval = dict(
+        infer_tool_eval_metadata(
+            tool_name=tool_name,
+            metadata=metadata,
+            prompt_variant=prompt_variant,
+        )["eval"]
+    )
     existing_eval = _clean_existing_tool_eval(metadata.get("eval"))
-    if existing_eval is None:
-        metadata.update(
-            infer_tool_eval_metadata(
-                tool_name=tool_name,
-                metadata=metadata,
-                prompt_variant=prompt_variant,
-            )
-        )
-    else:
-        metadata["eval"] = existing_eval
+    if existing_eval is not None:
+        inferred_eval.update(existing_eval)
+    metadata["eval"] = inferred_eval
     normalized["metadata"] = metadata
     return normalized
+
+
+def sanitize_eval_profile_id(value: Any) -> str | None:
+    """Return a non-sensitive profile id, or None when it fails the allowlist."""
+    cleaned = _optional_raw_string(value)
+    if cleaned is None or _SAFE_PROFILE_ID.fullmatch(cleaned) is None:
+        return None
+    return cleaned
 
 
 def execution_eval_metadata_from_tool_definition(
@@ -258,7 +285,7 @@ def build_execution_eval_metadata(
         "result_kind": _required_string(result_kind, "result_kind"),
     }
 
-    clean_profile_id = _optional_string(profile_id)
+    clean_profile_id = sanitize_eval_profile_id(profile_id)
     if clean_profile_id is not None:
         metadata["profile_id"] = clean_profile_id
     if path_filter_used is not None:


### PR DESCRIPTION
## Summary
- Add shared MCP tool observability helpers that infer and sanitize safe metadata.eval blocks on tool definitions.
- Enrich tools/list, prepared tool definitions, and tools/call responses with execution eval metadata for profile/tool evaluation.
- Cover external federated tools by applying local external_federated eval metadata and stripping untrusted upstream eval overrides; update MCP README, plan, and Backlog task.

## Change summary
Human-written change summary required before merge per repo policy. The requester should replace this paragraph with their own explanation of what changed and why these implementation choices were made.

## Test Plan
- [x] /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_tool_observability.py tldw_Server_API/app/core/MCP_unified/tests/test_external_federation_module.py tldw_Server_API/app/core/MCP_unified/tests/test_run_command_module.py tldw_Server_API/app/core/MCP_unified/tests/test_browser_cdp_module.py tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_module.py tldw_Server_API/app/core/MCP_unified/tests/test_idempotency_and_category.py tldw_Server_API/app/core/MCP_unified/tests/test_protocol_allowed_tools.py tldw_Server_API/app/core/MCP_unified/tests/test_git_module.py::test_git_schema_lists_exact_tools_with_strict_metadata tldw_Server_API/app/core/MCP_unified/tests/test_basic_functionality.py tldw_Server_API/app/core/MCP_unified/tests/test_mcp_discovery_module.py tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py::test_profile_runtime_exposes_discovery_bridge_tools_for_deferred_categories tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py::test_profile_runtime_backend_tool_with_bridge_name_wins_collision -q
- [x] /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/core/MCP_unified/tool_observability.py tldw_Server_API/app/core/MCP_unified/modules/base.py tldw_Server_API/app/core/MCP_unified/protocol.py tldw_Server_API/app/core/MCP_unified/modules/implementations/external_federation_module.py -f json -o /tmp/bandit_mcp_tool_observability_post_rebase.json

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Applies the shared MCP tool observability/evaluation contract across all tools and hardens eval handling. Addresses TASK-2256 to enable safe profile/tool evaluation without exposing sensitive data.

- New Features
  - `create_tool_definition()` now infers and sanitizes `metadata.eval`, merges safe explicit blocks, and sets default `tool_prompt_version` and `prompt_variant`.
  - `tools/list` and resolved tool definitions are normalized with eval metadata.
  - `tools/call` adds top-level `eval` and injects `eval` into JSON results when missing; includes allowlisted `profile_id` and `duration_ms`.
  - External federated tools get local `external_federated` eval; untrusted upstream eval is stripped.
  - Updated MCP README and added an implementation plan; expanded tests; Bandit reports no new findings.

- Bug Fixes
  - Hardened eval parsing: ignore non-list iterables, drop blanks, reject non-string required fields, and drop unknown scalars.
  - Added safe `profile_id` allowlist (letters, numbers, `_`, `.`, `-`); unsafe values are omitted.
  - Top-level execution `eval` is canonical; tool-returned `eval` is not promoted.
  - Non-critical eval enrichment failures are logged and do not break responses.

<sup>Written for commit 00f95eff58174377bf3ffdebf53da8b8474b81cc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2270?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

