### PR TITLE
Add Mermaid chat card artifacts

### DIFF
--- a/Docs/superpowers/specs/2026-06-06-chat-mermaid-card-artifact-rail-design.md
+++ b/Docs/superpowers/specs/2026-06-06-chat-mermaid-card-artifact-rail-design.md
@@ -1,0 +1,239 @@
+# Chat Mermaid Card Artifact Rail Design
+
+## Metadata
+
+- Task: TASK-2264
+- Status: Draft for review
+- Target area: `apps/packages/ui/src/components/Common`, `apps/packages/ui/src/components/Option/Playground`, `apps/packages/ui/src/components/Sidepanel/Chat`
+- Related work:
+  - PR #2268: assistant-only Mermaid rendering in chat markdown
+  - TASK-495: OpenUI dynamic chat rendering
+  - `Docs/superpowers/specs/2026-06-01-openui-dynamic-chat-rendering-design.md`
+
+## Problem
+
+Assistant chat messages can now render fenced `mermaid` diagrams inline, but diagrams remain trapped inside the transcript. The user can preview, download SVG, or copy source from the inline block, but cannot open a diagram into the existing chat artifact/card rail or pin it while reading the surrounding conversation.
+
+The repository already has a lightweight chat artifact panel used by code blocks and tables. It supports `kind: "diagram"` and renders diagram artifacts with the shared Mermaid renderer. Mermaid chat blocks should use this existing rail instead of introducing a separate Mermaid-specific card surface.
+
+## Goals
+
+- Add an explicit "open as card" affordance to assistant Mermaid diagram blocks in `/chat`.
+- Reuse the existing chat artifact rail and `ArtifactItem.kind === "diagram"` path.
+- Keep Mermaid source as the canonical artifact payload.
+- Keep inline assistant rendering unchanged.
+- Keep user messages unchanged.
+- Keep assistant-only gating from PR #2268 intact across the markdown surfaces that already opt in.
+- Preserve the current Mermaid preview, copy, download, and error fallback behavior.
+- Make the implementation compatible with later shared card support for Dynamic UI/OpenUI without expanding the artifact model prematurely.
+
+## Non-Goals
+
+- No backend persistence for Mermaid chat cards in the first version.
+- No server-side Mermaid rendering.
+- No generated SVG persistence as canonical data.
+- No Mermaid source editor in the artifact panel.
+- No card affordance for user-authored messages.
+- No automatic conversion of every diagram into a persistent workspace artifact.
+- No broad redesign of the chat artifact rail.
+
+## Existing Constraints
+
+- `Markdown` only renders `MermaidDiagramBlock` when `enableMermaidDiagrams` is true and the code fence is a closed `mermaid` fence.
+- `Message` and `MessageContent` only enable Mermaid rendering for assistant-facing paths.
+- `Markdown` is shared by multiple assistant-facing surfaces, including main chat, QuickChat, and reasoning blocks. Not every caller mounts `ArtifactsPanel`.
+- `MermaidDiagramBlock` currently owns preview, copy-source, download-SVG, and render-error UI.
+- `CodeBlock` and `TableBlock` directly use `useArtifactsStore` to open chat artifacts.
+- `useArtifactsStore` is a transient client-side rail store with `active`, `history`, `isOpen`, `isPinned`, and `openArtifact`.
+- `ArtifactsPanel` already renders `active.kind === "diagram"` with `Mermaid` and already supports pin, close, copy, download, and jump-to-source.
+
+## Product Requirements
+
+### Inline Block Actions
+
+Assistant Mermaid blocks should expose a card action beside the existing preview, download, and copy actions.
+
+- Label: `View`
+- Tooltip: `View diagram`
+- Icon: use a lucide icon already consistent with artifact opening, preferably `ExpandIcon` or `PanelRightOpenIcon`.
+- The action opens the existing artifacts panel with a diagram artifact.
+- The action is available only when the caller explicitly opts the markdown surface into Mermaid artifact actions.
+- The default for shared markdown surfaces is no artifact action.
+- Main `/chat` assistant response content should opt in because it mounts the artifact rail.
+- QuickChat and other assistant-facing surfaces should keep Mermaid rendering without a card action unless they also mount the artifact rail.
+- The action should not appear in user messages because user messages continue to render as plain text.
+
+### Artifact Shape
+
+The card should use the existing `ArtifactItem` shape:
+
+```ts
+{
+  id: string
+  title: string
+  content: string
+  language: "mermaid"
+  kind: "diagram"
+  lineCount: number
+}
+```
+
+Recommended fields:
+
+- `id`: stable deterministic id based on `mermaid`, source surface or message context, block index, and source hash.
+- `title`: `Mermaid diagram` for a single diagram; `Mermaid diagram N` when a block index is available.
+- `content`: raw Mermaid source.
+- `language`: `mermaid`.
+- `kind`: `diagram`.
+- `lineCount`: source line count.
+
+The implementation should not extend `ArtifactItem` until a concrete need appears. Source message lineage is desirable later, but the current rail only needs source jump anchoring by `artifact.id`.
+
+The id must not be based on source hash and block index alone. Two messages can contain the same diagram in the same code-block position, and duplicate DOM ids would cause `Jump to source` to scroll to the wrong message.
+
+### Source Anchoring
+
+The inline Mermaid block should set:
+
+- `id="artifact-origin-${artifactId}"`
+- `data-artifact-origin={artifactId}`
+
+This keeps `ArtifactsPanel.handleJumpToSource` working the same way it does for code and table artifacts.
+
+The `artifactId` must be shared by:
+
+- the inline origin element
+- the artifact item opened by the `View` action
+- any auto-open behavior, if added later
+
+When the caller has a saved message id, the artifact id should include it. When no saved message id exists, use a per-render context id from the markdown/component tree so that jump-to-source remains correct for the current session.
+
+### Artifact Panel Rendering
+
+The first implementation should reuse the existing `ArtifactsPanel` diagram branch:
+
+```tsx
+active.kind === "diagram" ? <Mermaid code={active.content} ... /> : ...
+```
+
+No panel renderer registry is needed for Mermaid v1. The existing branch is already the minimal shared renderer boundary because both inline and artifact views use `Mermaid`.
+
+### Dynamic UI Compatibility
+
+Dynamic UI/OpenUI should not be bundled into this Mermaid implementation. The only design alignment needed now is to avoid coupling `MermaidDiagramBlock` too tightly to chat if that would block later cards.
+
+Preferred implementation:
+
+- Add `enableMermaidArtifactActions?: boolean` to `Markdown`, defaulting to `false`.
+- Add `artifactContextId?: string` to `Markdown` so main chat can pass the saved message id when available.
+- Pass the artifact-action gate and context id to `MermaidDiagramBlock`.
+- Add a small artifact-opening helper local to `MermaidDiagramBlock`, mirroring `CodeBlock`, but render the action only when the gate is true.
+- Keep the action disabled by default for shared markdown callers.
+- Do not add Dynamic UI concepts to Mermaid types.
+
+Later, if OpenUI artifacts are added, they can use the same rail and a separate `kind` or renderer-specific payload after the artifact model has a real persistence requirement.
+
+## UX Requirements
+
+- The inline block header remains visually similar to the merged Mermaid implementation.
+- Card action should not crowd mobile layouts; icon-only with tooltip is acceptable in narrow headers.
+- The artifact panel title should be readable and short.
+- Clicking `View` should open the panel immediately.
+- Pinning remains the panel's responsibility.
+- Jump-to-source should scroll back to the diagram block.
+- Invalid Mermaid source should behave consistently:
+  - inline block shows the existing raw-source fallback
+  - artifact panel attempts the same shared `Mermaid` render path
+  - errors should not break the transcript or panel shell
+
+## Accessibility Requirements
+
+- The card action must have an aria-label, for example `View Mermaid diagram`.
+- The artifact origin wrapper should keep the existing `aria-labelledby` relationship in `MermaidDiagramBlock`.
+- The action should be keyboard reachable.
+- Existing preview, copy, and download labels should remain unchanged.
+
+## Security Requirements
+
+- Raw Mermaid source remains the canonical payload.
+- Do not store or execute arbitrary HTML.
+- Do not add backend calls for this feature.
+- Continue to rely on the shared `Mermaid` renderer's current safe rendering behavior.
+- Do not render Mermaid for user messages.
+
+## Implementation Plan
+
+### Stage 1: Artifact Helper And Inline Action
+
+Add deterministic artifact metadata construction to `MermaidDiagramBlock`.
+
+Acceptance criteria:
+
+- `MermaidDiagramBlock` renders a `View diagram` action only when artifact actions are explicitly enabled.
+- Clicking it opens `useArtifactsStore.openArtifact` with `kind: "diagram"` and `language: "mermaid"`.
+- The artifact source equals the original Mermaid source.
+- The artifact id includes context plus source hash, and the block has an artifact origin id matching the opened artifact id.
+
+### Stage 2: Artifact Panel Fit And Error Path
+
+Verify the existing diagram branch in `ArtifactsPanel` handles chat Mermaid cards well.
+
+Acceptance criteria:
+
+- A Mermaid artifact renders in the panel.
+- Copy/download use raw Mermaid source.
+- Jump-to-source returns to the inline Mermaid block.
+- Invalid Mermaid source does not crash the panel.
+
+### Stage 3: Assistant-Only Surface Guardrails
+
+Preserve the user-message boundary from PR #2268.
+
+Acceptance criteria:
+
+- Main `/chat` assistant messages with both Mermaid rendering and artifact actions enabled show the card action.
+- User messages do not render Mermaid blocks and do not show card actions.
+- QuickChat, reasoning blocks, sidepanel fallback, and workspace fallback surfaces remain unchanged unless they explicitly opt into artifact actions and mount the artifact rail.
+
+### Stage 4: Tests And Verification
+
+Add focused frontend tests.
+
+Acceptance criteria:
+
+- `MermaidDiagramBlock` test covers artifact action payload and origin id.
+- `Markdown.mermaid` test covers continued source/block index propagation and default-disabled artifact actions.
+- `Message.mermaid-rendering` test covers assistant-only behavior and main-chat artifact-action opt-in.
+- `QuickChatMessage.mermaid` test covers Mermaid rendering without artifact-action opt-in.
+- `ArtifactsPanel` test covers `kind: "diagram"` rendering and jump-to-source if not already covered.
+- Run the targeted Vitest files touched by the implementation.
+
+## Recommended Test Targets
+
+- `apps/packages/ui/src/components/Common/__tests__/MermaidDiagramBlock.test.tsx`
+- `apps/packages/ui/src/components/Common/__tests__/Markdown.mermaid.test.tsx`
+- `apps/packages/ui/src/components/Common/Playground/__tests__/Message.mermaid-rendering.test.tsx`
+- `apps/packages/ui/src/components/Common/QuickChatHelper/__tests__/QuickChatMessage.mermaid.test.tsx`
+- `apps/packages/ui/src/components/Sidepanel/Chat/__tests__/ArtifactsPanel.*.test.tsx` or a new focused panel test if none exists
+
+## Risks
+
+- `blockIndex` and source hash alone are not stable enough for source jump ids if two messages contain identical diagram positions. Include a caller-provided message or context id in the artifact id.
+- The current artifact store is global and transient. This is acceptable for `/chat` cards, but should not be described as durable persistence.
+- Because `Markdown` is shared, adding the store action directly to every Mermaid block would expose dead artifact actions in surfaces without `ArtifactsPanel`. Keep the action opt-in.
+- Auto-open behavior could be surprising for diagrams generated in normal assistant responses. Do not add Mermaid auto-open in v1.
+- The artifact panel currently renders diagrams with the base `Mermaid` component, not `MermaidDiagramBlock`, so preview/download behavior differs between inline and panel. This is acceptable because the panel already has copy/download controls for source; SVG preview/download can remain an inline-only enhancement for v1.
+
+## Open Questions
+
+- Should the button text be icon-only or icon plus `View` on desktop? Recommendation: match `TableBlock` and use icon plus `View` where space allows.
+- Should the panel title include the source message position? Recommendation: use `Mermaid diagram N` for now and avoid message metadata until the artifact model is expanded.
+
+## Definition Of Done
+
+- Mermaid cards open in the existing artifact rail from assistant chat blocks.
+- Inline Mermaid rendering behavior is otherwise unchanged.
+- User messages remain unchanged.
+- Tests cover artifact payload, source anchoring, and assistant-only gating.
+- Targeted frontend tests pass.
+- Bandit is documented as not applicable if only frontend files are touched.

--- a/apps/packages/ui/src/components/Common/Markdown.tsx
+++ b/apps/packages/ui/src/components/Common/Markdown.tsx
@@ -133,6 +133,8 @@ export function Markdown({
   richTextModeOverride,
   headingAnchorIds,
   enableMermaidDiagrams = false,
+  enableMermaidArtifactActions = false,
+  artifactContextId,
 }: {
   message: string
   className?: string
@@ -142,6 +144,8 @@ export function Markdown({
   richTextModeOverride?: ChatRichTextMode
   headingAnchorIds?: string[]
   enableMermaidDiagrams?: boolean
+  enableMermaidArtifactActions?: boolean
+  artifactContextId?: string
 }) {
   const [checkWideMode] = useStorage("checkWideMode", false)
   const [codeTheme] = useStorage("codeTheme", "auto")
@@ -379,7 +383,12 @@ export function Markdown({
             ) {
               closedMermaidFenceCursorRef.current = closedMermaidFenceIndex + 1
               return (
-                <MermaidDiagramBlock source={value} blockIndex={blockIndex} />
+                <MermaidDiagramBlock
+                  artifactContextId={artifactContextId}
+                  blockIndex={blockIndex}
+                  enableArtifactAction={enableMermaidArtifactActions}
+                  source={value}
+                />
               )
             }
 

--- a/apps/packages/ui/src/components/Common/MermaidDiagramBlock.tsx
+++ b/apps/packages/ui/src/components/Common/MermaidDiagramBlock.tsx
@@ -18,20 +18,13 @@ import React, {
 import Mermaid, { type MermaidRenderState } from "./Mermaid"
 import { MermaidPreviewDialog } from "./MermaidPreviewDialog"
 import { useArtifactsStore } from "@/store/artifacts"
+import { stableHashString } from "@/utils/stable-hash"
 
 export type MermaidDiagramBlockProps = {
   source: string
   blockIndex?: number
   artifactContextId?: string
   enableArtifactAction?: boolean
-}
-
-const hashString = (input: string) => {
-  let hash = 0
-  for (let i = 0; i < input.length; i += 1) {
-    hash = (hash * 31 + input.charCodeAt(i)) >>> 0
-  }
-  return hash.toString(36)
 }
 
 const sanitizeArtifactIdPart = (value: string) =>
@@ -130,7 +123,7 @@ export const MermaidDiagramBlock: React.FC<MermaidDiagramBlockProps> = ({
     )
     const blockPart =
       typeof blockIndex === "number" ? `block-${blockIndex}` : "block"
-    return `mermaid-${contextId}-${blockPart}-${hashString(source)}`
+    return `mermaid-${contextId}-${blockPart}-${stableHashString(source)}`
   }, [artifactContextId, blockIndex, componentId, source])
 
   const artifactLineCount = useMemo(

--- a/apps/packages/ui/src/components/Common/MermaidDiagramBlock.tsx
+++ b/apps/packages/ui/src/components/Common/MermaidDiagramBlock.tsx
@@ -3,6 +3,7 @@ import {
   CopyCheckIcon,
   CopyIcon,
   DownloadIcon,
+  ExpandIcon,
   EyeIcon,
   WorkflowIcon
 } from "lucide-react"
@@ -16,11 +17,28 @@ import React, {
 } from "react"
 import Mermaid, { type MermaidRenderState } from "./Mermaid"
 import { MermaidPreviewDialog } from "./MermaidPreviewDialog"
+import { useArtifactsStore } from "@/store/artifacts"
 
 export type MermaidDiagramBlockProps = {
   source: string
   blockIndex?: number
+  artifactContextId?: string
+  enableArtifactAction?: boolean
 }
+
+const hashString = (input: string) => {
+  let hash = 0
+  for (let i = 0; i < input.length; i += 1) {
+    hash = (hash * 31 + input.charCodeAt(i)) >>> 0
+  }
+  return hash.toString(36)
+}
+
+const sanitizeArtifactIdPart = (value: string) =>
+  value
+    .trim()
+    .replace(/[^a-zA-Z0-9_-]+/g, "-")
+    .replace(/^-+|-+$/g, "") || "local"
 
 const downloadSvg = (svg: string, blockIndex?: number) => {
   const blob = new Blob([svg], { type: "image/svg+xml;charset=utf-8" })
@@ -37,7 +55,9 @@ const downloadSvg = (svg: string, blockIndex?: number) => {
 
 export const MermaidDiagramBlock: React.FC<MermaidDiagramBlockProps> = ({
   source,
-  blockIndex
+  blockIndex,
+  artifactContextId,
+  enableArtifactAction = false
 }) => {
   const [renderStatus, setRenderStatus] =
     useState<MermaidRenderState["status"]>("idle")
@@ -47,6 +67,7 @@ export const MermaidDiagramBlock: React.FC<MermaidDiagramBlockProps> = ({
   const [previousSource, setPreviousSource] = useState(source)
   const copyTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const componentId = useId()
+  const { openArtifact } = useArtifactsStore()
   const hasGeneratedSvg = Boolean(generatedSvg)
   const isRenderError = renderStatus === "error"
 
@@ -102,6 +123,37 @@ export const MermaidDiagramBlock: React.FC<MermaidDiagramBlockProps> = ({
     downloadSvg(generatedSvg, blockIndex)
   }, [blockIndex, generatedSvg])
 
+  const artifactId = useMemo(() => {
+    const fallbackContextId = `local-${componentId.replace(/:/g, "")}`
+    const contextId = sanitizeArtifactIdPart(
+      artifactContextId || fallbackContextId
+    )
+    const blockPart =
+      typeof blockIndex === "number" ? `block-${blockIndex}` : "block"
+    return `mermaid-${contextId}-${blockPart}-${hashString(source)}`
+  }, [artifactContextId, blockIndex, componentId, source])
+
+  const artifactLineCount = useMemo(
+    () => (source ? source.split(/\r\n?|\n/).length : 0),
+    [source]
+  )
+
+  const artifactTitle =
+    typeof blockIndex === "number"
+      ? `Mermaid diagram ${blockIndex + 1}`
+      : "Mermaid diagram"
+
+  const handleOpenArtifact = useCallback(() => {
+    openArtifact({
+      id: artifactId,
+      title: artifactTitle,
+      content: source,
+      language: "mermaid",
+      kind: "diagram",
+      lineCount: artifactLineCount
+    })
+  }, [artifactId, artifactLineCount, artifactTitle, openArtifact, source])
+
   const headerId = useMemo(() => {
     const safeComponentId = componentId.replace(/:/g, "")
     if (typeof blockIndex === "number") {
@@ -112,7 +164,11 @@ export const MermaidDiagramBlock: React.FC<MermaidDiagramBlockProps> = ({
 
   return (
     <>
-      <div className="not-prose">
+      <div
+        id={enableArtifactAction ? `artifact-origin-${artifactId}` : undefined}
+        data-artifact-origin={enableArtifactAction ? artifactId : undefined}
+        className="not-prose"
+      >
         <div
           aria-labelledby={headerId}
           className="my-4 overflow-hidden rounded-xl border border-border bg-surface"
@@ -128,6 +184,18 @@ export const MermaidDiagramBlock: React.FC<MermaidDiagramBlockProps> = ({
               </span>
             </div>
             <div className="flex items-center gap-1">
+              {enableArtifactAction && (
+                <Tooltip title="View diagram">
+                  <button
+                    type="button"
+                    aria-label="View Mermaid diagram"
+                    onClick={handleOpenArtifact}
+                    className="inline-flex size-8 items-center justify-center rounded text-text-muted hover:bg-surface hover:text-text"
+                  >
+                    <ExpandIcon className="size-4" />
+                  </button>
+                </Tooltip>
+              )}
               <Tooltip title="Open Mermaid preview">
                 <button
                   type="button"

--- a/apps/packages/ui/src/components/Common/Playground/CompactMessage.tsx
+++ b/apps/packages/ui/src/components/Common/Playground/CompactMessage.tsx
@@ -40,6 +40,14 @@ const Markdown = React.lazy(() => import("../../Common/Markdown"))
 
 const MAX_PREVIEW_SOURCES = 5
 
+const hashString = (input: string) => {
+  let hash = 0
+  for (let i = 0; i < input.length; i += 1) {
+    hash = (hash * 31 + input.charCodeAt(i)) >>> 0
+  }
+  return hash.toString(36)
+}
+
 interface CompactMessageProps {
   message: string
   isBot: boolean
@@ -146,6 +154,12 @@ export function CompactMessage({
   const isProMode = uiMode === "pro"
   const isActiveStreamingMessage =
     Boolean(isStreaming) && currentMessageIndex === totalMessages - 1
+  const enableAssistantMermaidDiagrams =
+    isBot && renderMermaidDiagrams !== false && !isActiveStreamingMessage
+  const mermaidArtifactContextId = useMemo(
+    () => `compact-message-${currentMessageIndex}-${hashString(message)}`,
+    [currentMessageIndex, message]
+  )
   const actionBarVisibility = isProMode
     ? "opacity-100"
     : "opacity-0 pointer-events-none group-hover:opacity-100 group-hover:pointer-events-auto group-focus-within:opacity-100 group-focus-within:pointer-events-auto"
@@ -523,11 +537,9 @@ export function CompactMessage({
                         message={block.content}
                         searchQuery={searchQuery}
                         codeBlockVariant="github"
-                        enableMermaidDiagrams={
-                          isBot &&
-                          renderMermaidDiagrams !== false &&
-                          !isActiveStreamingMessage
-                        }
+                        artifactContextId={mermaidArtifactContextId}
+                        enableMermaidArtifactActions={enableAssistantMermaidDiagrams}
+                        enableMermaidDiagrams={enableAssistantMermaidDiagrams}
                       />
                     )
                   })}

--- a/apps/packages/ui/src/components/Common/Playground/CompactMessage.tsx
+++ b/apps/packages/ui/src/components/Common/Playground/CompactMessage.tsx
@@ -35,18 +35,11 @@ import type { FeedbackThumb } from "@/store/feedback"
 import type { Source, GenerationInfo } from "./types"
 import { FeedbackButtons } from "@/components/Sidepanel/Chat/FeedbackButtons"
 import { DEFAULT_CHAT_SETTINGS } from "@/types/chat-settings"
+import { stableHashString } from "@/utils/stable-hash"
 
 const Markdown = React.lazy(() => import("../../Common/Markdown"))
 
 const MAX_PREVIEW_SOURCES = 5
-
-const hashString = (input: string) => {
-  let hash = 0
-  for (let i = 0; i < input.length; i += 1) {
-    hash = (hash * 31 + input.charCodeAt(i)) >>> 0
-  }
-  return hash.toString(36)
-}
 
 interface CompactMessageProps {
   message: string
@@ -157,8 +150,11 @@ export function CompactMessage({
   const enableAssistantMermaidDiagrams =
     isBot && renderMermaidDiagrams !== false && !isActiveStreamingMessage
   const mermaidArtifactContextId = useMemo(
-    () => `compact-message-${currentMessageIndex}-${hashString(message)}`,
-    [currentMessageIndex, message]
+    () =>
+      enableAssistantMermaidDiagrams
+        ? `compact-message-${currentMessageIndex}-${stableHashString(message)}`
+        : undefined,
+    [currentMessageIndex, enableAssistantMermaidDiagrams, message]
   )
   const actionBarVisibility = isProMode
     ? "opacity-100"

--- a/apps/packages/ui/src/components/Common/Playground/Message.tsx
+++ b/apps/packages/ui/src/components/Common/Playground/Message.tsx
@@ -1211,10 +1211,10 @@ export const PlaygroundMessage = (props: Props) => {
     !isSystemMessage &&
     renderMermaidDiagrams !== false &&
     !isActiveStreamingMessage
-  const mermaidArtifactContextId =
+  const mermaidArtifactBaseContextId =
     props.messageId ||
     props.serverMessageId ||
-    `${props.conversationInstanceId}-message-${props.currentMessageIndex}`
+    `${props.conversationInstanceId || "local"}-message-${props.currentMessageIndex}`
   const dynamicUIEnvelope = normalizeDynamicUIEnvelope(
     props.metadataExtra?.dynamic_ui
   )
@@ -2567,7 +2567,7 @@ export const PlaygroundMessage = (props: Props) => {
                       className={`${MARKDOWN_BASE_CLASSES} ${assistantTextClass}`}
                       searchQuery={props.searchQuery}
                       codeBlockVariant="compact"
-                      artifactContextId={mermaidArtifactContextId}
+                      artifactContextId={`${mermaidArtifactBaseContextId}-greeting`}
                       enableMermaidArtifactActions={enableAssistantMermaidDiagrams}
                       enableMermaidDiagrams={enableAssistantMermaidDiagrams}
                     />
@@ -2607,7 +2607,7 @@ export const PlaygroundMessage = (props: Props) => {
                             className={`${MARKDOWN_BASE_CLASSES} ${assistantTextClass}`}
                             searchQuery={props.searchQuery}
                             codeBlockVariant="github"
-                            artifactContextId={mermaidArtifactContextId}
+                            artifactContextId={`${mermaidArtifactBaseContextId}-segment-${i}`}
                             enableMermaidArtifactActions={enableAssistantMermaidDiagrams}
                             enableMermaidDiagrams={enableAssistantMermaidDiagrams}
                           />

--- a/apps/packages/ui/src/components/Common/Playground/Message.tsx
+++ b/apps/packages/ui/src/components/Common/Playground/Message.tsx
@@ -1211,6 +1211,10 @@ export const PlaygroundMessage = (props: Props) => {
     !isSystemMessage &&
     renderMermaidDiagrams !== false &&
     !isActiveStreamingMessage
+  const mermaidArtifactContextId =
+    props.messageId ||
+    props.serverMessageId ||
+    `${props.conversationInstanceId}-message-${props.currentMessageIndex}`
   const dynamicUIEnvelope = normalizeDynamicUIEnvelope(
     props.metadataExtra?.dynamic_ui
   )
@@ -2563,6 +2567,8 @@ export const PlaygroundMessage = (props: Props) => {
                       className={`${MARKDOWN_BASE_CLASSES} ${assistantTextClass}`}
                       searchQuery={props.searchQuery}
                       codeBlockVariant="compact"
+                      artifactContextId={mermaidArtifactContextId}
+                      enableMermaidArtifactActions={enableAssistantMermaidDiagrams}
                       enableMermaidDiagrams={enableAssistantMermaidDiagrams}
                     />
                   </React.Suspense>
@@ -2601,6 +2607,8 @@ export const PlaygroundMessage = (props: Props) => {
                             className={`${MARKDOWN_BASE_CLASSES} ${assistantTextClass}`}
                             searchQuery={props.searchQuery}
                             codeBlockVariant="github"
+                            artifactContextId={mermaidArtifactContextId}
+                            enableMermaidArtifactActions={enableAssistantMermaidDiagrams}
                             enableMermaidDiagrams={enableAssistantMermaidDiagrams}
                           />
                         </React.Suspense>

--- a/apps/packages/ui/src/components/Common/Playground/__tests__/Message.mermaid-rendering.test.tsx
+++ b/apps/packages/ui/src/components/Common/Playground/__tests__/Message.mermaid-rendering.test.tsx
@@ -325,11 +325,45 @@ describe("PlaygroundMessage Mermaid rendering gates", () => {
 
     expect(markdownCalls[0]).toEqual(
       expect.objectContaining({
-        artifactContextId: "assistant-message-123",
+        artifactContextId: "assistant-message-123-segment-0",
         enableMermaidArtifactActions: true,
         enableMermaidDiagrams: true
       })
     )
+  })
+
+  it("uses a safe local Mermaid artifact context when no message or conversation id is available", async () => {
+    render(
+      <PlaygroundMessage
+        {...baseProps}
+        conversationInstanceId={undefined as any}
+      />
+    )
+
+    await screen.findByTestId("mock-markdown")
+
+    const contextId = String(markdownCalls[0]?.artifactContextId ?? "")
+    expect(contextId).toBe("local-message-0-segment-0")
+    expect(contextId).not.toContain("undefined")
+    expect(contextId).not.toContain("null")
+  })
+
+  it("namespaces Mermaid artifact contexts per assistant Markdown segment", async () => {
+    parseReasoningMock.mockImplementation(() => [
+      { type: "message", content: "```mermaid\ngraph TD\n  A-->B\n```" },
+      { type: "message", content: "```mermaid\ngraph TD\n  A-->B\n```" }
+    ])
+
+    render(<PlaygroundMessage {...baseProps} messageId="assistant-message-123" />)
+
+    await waitFor(() => {
+      expect(markdownCalls).toHaveLength(2)
+    })
+
+    expect(markdownCalls.map((call) => call.artifactContextId)).toEqual([
+      "assistant-message-123-segment-0",
+      "assistant-message-123-segment-1"
+    ])
   })
 
   it("uses plain text instead of Markdown while assistant output is streaming", () => {
@@ -447,5 +481,28 @@ describe("PlaygroundMessage Mermaid rendering gates", () => {
         enableMermaidDiagrams: true
       })
     )
+  })
+
+  it("does not compute a compact Mermaid artifact context when Mermaid actions are disabled", async () => {
+    render(
+      <CompactMessage
+        message="```mermaid\ngraph TD\n  A-->B\n```"
+        isBot
+        name="Assistant"
+        currentMessageIndex={0}
+        totalMessages={1}
+        isStreaming
+      />
+    )
+
+    await screen.findByTestId("mock-markdown")
+
+    expect(markdownCalls[0]).toEqual(
+      expect.objectContaining({
+        enableMermaidArtifactActions: false,
+        enableMermaidDiagrams: false
+      })
+    )
+    expect(markdownCalls[0]?.artifactContextId).toBeUndefined()
   })
 })

--- a/apps/packages/ui/src/components/Common/Playground/__tests__/Message.mermaid-rendering.test.tsx
+++ b/apps/packages/ui/src/components/Common/Playground/__tests__/Message.mermaid-rendering.test.tsx
@@ -307,6 +307,26 @@ describe("PlaygroundMessage Mermaid rendering gates", () => {
 
     expect(markdownCalls[0]).toEqual(
       expect.objectContaining({
+        enableMermaidArtifactActions: true,
+        enableMermaidDiagrams: true
+      })
+    )
+  })
+
+  it("uses the saved assistant message id as the Mermaid artifact context", async () => {
+    render(
+      <PlaygroundMessage
+        {...baseProps}
+        messageId="assistant-message-123"
+      />
+    )
+
+    await screen.findByTestId("mock-markdown")
+
+    expect(markdownCalls[0]).toEqual(
+      expect.objectContaining({
+        artifactContextId: "assistant-message-123",
+        enableMermaidArtifactActions: true,
         enableMermaidDiagrams: true
       })
     )
@@ -335,6 +355,7 @@ describe("PlaygroundMessage Mermaid rendering gates", () => {
 
     expect(markdownCalls[0]).toEqual(
       expect.objectContaining({
+        enableMermaidArtifactActions: true,
         enableMermaidDiagrams: true
       })
     )
@@ -385,6 +406,7 @@ describe("PlaygroundMessage Mermaid rendering gates", () => {
         enableMermaidDiagrams: true
       })
     )
+    expect(markdownCalls[0]?.enableMermaidArtifactActions).not.toBe(true)
   })
 
   it("keeps Mermaid disabled while reasoning is actively streaming", async () => {
@@ -421,6 +443,7 @@ describe("PlaygroundMessage Mermaid rendering gates", () => {
 
     expect(markdownCalls[0]).toEqual(
       expect.objectContaining({
+        enableMermaidArtifactActions: true,
         enableMermaidDiagrams: true
       })
     )

--- a/apps/packages/ui/src/components/Common/QuickChatHelper/__tests__/QuickChatMessage.mermaid.test.tsx
+++ b/apps/packages/ui/src/components/Common/QuickChatHelper/__tests__/QuickChatMessage.mermaid.test.tsx
@@ -53,6 +53,7 @@ describe("QuickChatMessage Mermaid rendering gates", () => {
         enableMermaidDiagrams: true
       })
     )
+    expect(markdownCalls[0]?.enableMermaidArtifactActions).not.toBe(true)
   })
 
   it("does not enable Mermaid while an assistant message is streaming", async () => {

--- a/apps/packages/ui/src/components/Common/__tests__/Markdown.mermaid.test.tsx
+++ b/apps/packages/ui/src/components/Common/__tests__/Markdown.mermaid.test.tsx
@@ -8,6 +8,8 @@ const mermaidDiagramBlockMock = vi.hoisted(() => vi.fn())
 type MermaidDiagramBlockMockProps = {
   source: string
   blockIndex?: number
+  artifactContextId?: string
+  enableArtifactAction?: boolean
 }
 
 vi.mock("@plasmohq/storage/hook", () => ({
@@ -44,10 +46,49 @@ describe("Markdown Mermaid fences", () => {
     expect(screen.getByTestId("mermaid-diagram-block").textContent).toBe(
       "graph TD\nA --> B"
     )
-    expect(mermaidDiagramBlockMock).toHaveBeenCalledWith({
-      source: "graph TD\nA --> B",
-      blockIndex: 0
-    })
+    expect(mermaidDiagramBlockMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        source: "graph TD\nA --> B",
+        blockIndex: 0
+      })
+    )
+  })
+
+  it("keeps Mermaid artifact actions disabled by default", () => {
+    render(
+      <Markdown
+        message={"```mermaid\ngraph TD\nA --> B\n```"}
+        enableMermaidDiagrams
+      />
+    )
+
+    expect(mermaidDiagramBlockMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        source: "graph TD\nA --> B",
+        blockIndex: 0,
+        enableArtifactAction: false
+      })
+    )
+  })
+
+  it("forwards artifact action opt-in and context to Mermaid blocks", () => {
+    render(
+      <Markdown
+        artifactContextId="assistant-message-42"
+        enableMermaidArtifactActions
+        enableMermaidDiagrams
+        message={"```mermaid\ngraph TD\nA --> B\n```"}
+      />
+    )
+
+    expect(mermaidDiagramBlockMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        artifactContextId: "assistant-message-42",
+        blockIndex: 0,
+        enableArtifactAction: true,
+        source: "graph TD\nA --> B"
+      })
+    )
   })
 
   it("renders enabled Mermaid tilde fences through the Mermaid diagram block", () => {
@@ -61,10 +102,12 @@ describe("Markdown Mermaid fences", () => {
     expect(screen.getByTestId("mermaid-diagram-block").textContent).toBe(
       "graph TD\nA --> B"
     )
-    expect(mermaidDiagramBlockMock).toHaveBeenCalledWith({
-      source: "graph TD\nA --> B",
-      blockIndex: 0
-    })
+    expect(mermaidDiagramBlockMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        source: "graph TD\nA --> B",
+        blockIndex: 0
+      })
+    )
   })
 
   it("renders Mermaid fences case-insensitively", () => {
@@ -78,10 +121,12 @@ describe("Markdown Mermaid fences", () => {
     expect(screen.getByTestId("mermaid-diagram-block").textContent).toBe(
       "graph TD\nA --> B"
     )
-    expect(mermaidDiagramBlockMock).toHaveBeenCalledWith({
-      source: "graph TD\nA --> B",
-      blockIndex: 0
-    })
+    expect(mermaidDiagramBlockMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        source: "graph TD\nA --> B",
+        blockIndex: 0
+      })
+    )
   })
 
   it("renders Mermaid fences with CRLF line endings", () => {
@@ -95,10 +140,12 @@ describe("Markdown Mermaid fences", () => {
     expect(screen.getByTestId("mermaid-diagram-block").textContent).toBe(
       "graph TD\nA --> B"
     )
-    expect(mermaidDiagramBlockMock).toHaveBeenCalledWith({
-      source: "graph TD\nA --> B",
-      blockIndex: 0
-    })
+    expect(mermaidDiagramBlockMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        source: "graph TD\nA --> B",
+        blockIndex: 0
+      })
+    )
   })
 
   it("ignores literal Mermaid fences inside non-Mermaid code blocks", () => {
@@ -125,10 +172,12 @@ describe("Markdown Mermaid fences", () => {
       "graph LR\nC --> D"
     )
     expect(mermaidDiagramBlockMock).toHaveBeenCalledTimes(1)
-    expect(mermaidDiagramBlockMock).toHaveBeenCalledWith({
-      source: "graph LR\nC --> D",
-      blockIndex: 1
-    })
+    expect(mermaidDiagramBlockMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        source: "graph LR\nC --> D",
+        blockIndex: 1
+      })
+    )
   })
 
   it("renders Mermaid fences after indented code blocks", () => {
@@ -149,10 +198,12 @@ describe("Markdown Mermaid fences", () => {
     expect(screen.getByTestId("mermaid-diagram-block").textContent).toBe(
       "graph TD\nA --> B"
     )
-    expect(mermaidDiagramBlockMock).toHaveBeenCalledWith({
-      source: "graph TD\nA --> B",
-      blockIndex: 1
-    })
+    expect(mermaidDiagramBlockMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        source: "graph TD\nA --> B",
+        blockIndex: 1
+      })
+    )
   })
 
   it("does not render unclosed Mermaid fences as diagrams", () => {
@@ -187,10 +238,12 @@ describe("Markdown Mermaid fences", () => {
       />
     )
 
-    expect(mermaidDiagramBlockMock).toHaveBeenCalledWith({
-      source: "graph TD\nA --> B",
-      blockIndex: 1
-    })
+    expect(mermaidDiagramBlockMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        source: "graph TD\nA --> B",
+        blockIndex: 1
+      })
+    )
   })
 
   it("keeps Mermaid fences as normal code blocks when Mermaid rendering is disabled", () => {

--- a/apps/packages/ui/src/components/Common/__tests__/MermaidDiagramBlock.test.tsx
+++ b/apps/packages/ui/src/components/Common/__tests__/MermaidDiagramBlock.test.tsx
@@ -10,6 +10,10 @@ const mermaidMock = vi.hoisted(() => ({
     svg: '<svg xmlns="http://www.w3.org/2000/svg"><text>Generated</text></svg>'
   } as MermaidRenderState
 }))
+const artifactsStoreMock = vi.hoisted(() => ({
+  openArtifact: vi.fn(),
+  isPinned: false
+}))
 
 vi.mock("../Mermaid", async () => {
   const ReactModule = await import("react")
@@ -52,6 +56,10 @@ vi.mock("antd", () => ({
   Tooltip: ({ children }: any) => <>{children}</>
 }))
 
+vi.mock("@/store/artifacts", () => ({
+  useArtifactsStore: () => artifactsStoreMock
+}))
+
 describe("MermaidDiagramBlock", () => {
   const source = "graph TD\n  A-->B"
   let writeText: ReturnType<typeof vi.fn>
@@ -61,6 +69,8 @@ describe("MermaidDiagramBlock", () => {
   let blobParts: BlobPart[] | undefined
 
   beforeEach(() => {
+    artifactsStoreMock.openArtifact.mockClear()
+    artifactsStoreMock.isPinned = false
     mermaidMock.renderState = {
       status: "success",
       svg: '<svg xmlns="http://www.w3.org/2000/svg"><text>Generated</text></svg>'
@@ -211,6 +221,74 @@ describe("MermaidDiagramBlock", () => {
       expect(headerId).toBeTruthy()
       expect(document.getElementById(headerId || "")).toBeInTheDocument()
     })
+  })
+
+  it("does not show the artifact action by default", () => {
+    render(<MermaidDiagramBlock blockIndex={0} source={source} />)
+
+    expect(
+      screen.queryByRole("button", { name: "View Mermaid diagram" })
+    ).not.toBeInTheDocument()
+  })
+
+  it("opens a diagram artifact when the artifact action is enabled", () => {
+    render(
+      <MermaidDiagramBlock
+        artifactContextId="assistant-message-123"
+        blockIndex={2}
+        enableArtifactAction
+        source={source}
+      />
+    )
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "View Mermaid diagram" })
+    )
+
+    expect(artifactsStoreMock.openArtifact).toHaveBeenCalledTimes(1)
+    const artifact = artifactsStoreMock.openArtifact.mock.calls[0]?.[0]
+    expect(artifact).toEqual(
+      expect.objectContaining({
+        content: source,
+        kind: "diagram",
+        language: "mermaid",
+        lineCount: 2,
+        title: "Mermaid diagram 3"
+      })
+    )
+    expect(artifact.id).toContain("assistant-message-123")
+    expect(
+      document.getElementById(`artifact-origin-${artifact.id}`)
+    ).toBeInTheDocument()
+  })
+
+  it("includes artifact context in repeated diagram origin ids", () => {
+    render(
+      <>
+        <MermaidDiagramBlock
+          artifactContextId="assistant-a"
+          blockIndex={0}
+          enableArtifactAction
+          source={source}
+        />
+        <MermaidDiagramBlock
+          artifactContextId="assistant-b"
+          blockIndex={0}
+          enableArtifactAction
+          source={source}
+        />
+      </>
+    )
+
+    const origins = Array.from(document.querySelectorAll("[data-artifact-origin]"))
+    const originIds = origins.map((origin) =>
+      origin.getAttribute("data-artifact-origin")
+    )
+
+    expect(originIds).toHaveLength(2)
+    expect(new Set(originIds).size).toBe(2)
+    expect(originIds[0]).toContain("assistant-a")
+    expect(originIds[1]).toContain("assistant-b")
   })
 
   it("opens the Mermaid preview dialog with the generated SVG", async () => {

--- a/apps/packages/ui/src/components/Knowledge/__tests__/KnowledgePanelQAPreview.test.tsx
+++ b/apps/packages/ui/src/components/Knowledge/__tests__/KnowledgePanelQAPreview.test.tsx
@@ -131,8 +131,7 @@ vi.mock(
       ),
       Tooltip: ({ children }: { children?: React.ReactNode }) => <>{children}</>
     }
-  },
-  { virtual: true }
+  }
 )
 
 vi.mock("../hooks", () => {

--- a/apps/packages/ui/src/components/Notes/TaskActivityNotice.tsx
+++ b/apps/packages/ui/src/components/Notes/TaskActivityNotice.tsx
@@ -52,7 +52,8 @@ const TaskActivityNotice: React.FC<TaskActivityNoticeProps> = ({
     defaultValue: summaryDefault,
     actor: actorLabel,
     tool: toolLabel,
-    count: countLabel,
+    count: events.length,
+    countLabel,
     note: affectedLabel
   })
 

--- a/apps/packages/ui/src/components/Notes/__tests__/NotesManagerPage.task-activity.test.tsx
+++ b/apps/packages/ui/src/components/Notes/__tests__/NotesManagerPage.task-activity.test.tsx
@@ -1,7 +1,9 @@
 import React from "react"
 import { fireEvent, render, screen } from "@testing-library/react"
-import { describe, expect, it, vi } from "vitest"
+import { beforeEach, describe, expect, it, vi } from "vitest"
 import TaskActivityNotice from "@/components/Notes/TaskActivityNotice"
+
+const tMock = vi.hoisted(() => vi.fn())
 
 vi.mock("react-i18next", () => ({
   useTranslation: () => ({
@@ -11,11 +13,18 @@ vi.mock("react-i18next", () => ({
         defaultValue?: string
         [key: string]: unknown
       }
-    ) => options?.defaultValue || _key
+    ) => {
+      tMock(_key, options)
+      return options?.defaultValue || _key
+    }
   })
 }))
 
 describe("NotesManagerPage task activity notice", () => {
+  beforeEach(() => {
+    tMock.mockClear()
+  })
+
   it("shows actor, tool, affected note context, inspect, and dismiss actions", () => {
     const onInspect = vi.fn()
     const onDismiss = vi.fn()
@@ -50,5 +59,43 @@ describe("NotesManagerPage task activity notice", () => {
 
     expect(onInspect).toHaveBeenCalledTimes(1)
     expect(onDismiss).toHaveBeenCalledWith("event-1")
+  })
+
+  it("keeps i18next count numeric while interpolating the task count label", () => {
+    render(
+      <TaskActivityNotice
+        events={[
+          {
+            id: "event-1",
+            task_id: "task-1",
+            note_id: "note-1",
+            event_type: "status_changed",
+            actor_type: "agent",
+            actor_id: "agent-1",
+            tool_name: "notes.tasks.set_status",
+            created_at: "2026-06-05T07:05:00Z"
+          },
+          {
+            id: "event-2",
+            task_id: "task-2",
+            note_id: "note-1",
+            event_type: "status_changed",
+            actor_type: "agent",
+            actor_id: "agent-1",
+            tool_name: "notes.tasks.set_status",
+            created_at: "2026-06-05T07:06:00Z"
+          }
+        ]}
+        noteTitle="Task note"
+      />
+    )
+
+    expect(tMock).toHaveBeenCalledWith(
+      "option:notesSearch_taskActivitySummary",
+      expect.objectContaining({
+        count: 2,
+        countLabel: "2 tasks"
+      })
+    )
   })
 })

--- a/apps/packages/ui/src/public/_locales/en/option.json
+++ b/apps/packages/ui/src/public/_locales/en/option.json
@@ -1272,7 +1272,7 @@
     "message": "this note"
   },
   "notesSearch_taskActivitySummary": {
-    "message": "{{actor}} via {{tool}} changed {{count}} in {{note}}."
+    "message": "{{actor}} via {{tool}} changed {{countLabel}} in {{note}}."
   },
   "notesSearch_taskActivityInspect": {
     "message": "Inspect"

--- a/apps/packages/ui/src/utils/stable-hash.ts
+++ b/apps/packages/ui/src/utils/stable-hash.ts
@@ -1,0 +1,7 @@
+export const stableHashString = (input: string): string => {
+  let hash = 0
+  for (let i = 0; i < input.length; i += 1) {
+    hash = (hash * 31 + input.charCodeAt(i)) >>> 0
+  }
+  return hash.toString(36)
+}

--- a/backlog/tasks/task-2264 - Design-chat-Mermaid-card-artifact-rail-support.md
+++ b/backlog/tasks/task-2264 - Design-chat-Mermaid-card-artifact-rail-support.md
@@ -1,0 +1,67 @@
+---
+id: TASK-2264
+title: Design chat Mermaid card artifact rail support
+status: In Progress
+assignee: []
+created_date: ''
+updated_date: '2026-06-06 23:51'
+labels:
+  - chat
+  - mermaid
+  - webui
+  - artifacts
+  - spec
+dependencies: []
+references:
+  - ggml-org/llama.cpp#24032 review context
+  - 'tldw_server PR #2268 merged Mermaid assistant chat rendering'
+  - TASK-495 OpenUI dynamic chat rendering
+documentation:
+  - Docs/superpowers/specs/2026-06-06-chat-mermaid-card-artifact-rail-design.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Create a design spec for opening or pinning assistant Mermaid diagram blocks as chat cards/artifacts using the existing shared renderer and artifact rail boundaries, preserving Mermaid source, assistant-only behavior, and current inline markdown rendering.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Design spec covers product goals, non-goals, UX, data shape, security, test plan, risks, and implementation stages for Mermaid chat cards.
+- [ ] #2 Spec reuses the existing chat artifact rail and diagram artifact kind instead of creating a Mermaid-specific card system.
+- [ ] #3 Spec preserves assistant-only Mermaid rendering and leaves user messages unchanged.
+- [ ] #4 Backlog task references the design spec and records markdown-only verification.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Docs/superpowers/specs/2026-06-06-chat-mermaid-card-artifact-rail-design.md
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Drafted a PRD/design spec for opening assistant Mermaid diagram blocks into the existing chat artifact rail as diagram artifacts. The design intentionally avoids backend persistence, keeps Mermaid source canonical, preserves assistant-only markdown gating, and documents markdown-only verification with Bandit not applicable for this design-only change.
+
+Verification: git diff --check passed. Bandit skipped because this change only adds Markdown design/task documentation and touches no executable Python code.
+
+Design review update: tightened the PRD to make Mermaid artifact actions explicitly opt-in per markdown surface, keep QuickChat/reasoning/fallback surfaces unchanged by default, and require message/context-aware artifact ids so jump-to-source cannot collide across repeated diagrams.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Draft PRD reviewed and amended. It is ready for implementation approval.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-2265 - Implement-chat-Mermaid-card-artifact-rail-support.md
+++ b/backlog/tasks/task-2265 - Implement-chat-Mermaid-card-artifact-rail-support.md
@@ -1,0 +1,60 @@
+---
+id: TASK-2265
+title: Implement chat Mermaid card artifact rail support
+status: Done
+assignee: []
+created_date: ''
+updated_date: '2026-06-07 00:06'
+labels:
+  - chat
+  - mermaid
+  - webui
+  - artifacts
+  - implementation
+dependencies: []
+references:
+  - TASK-2264
+  - Docs/superpowers/specs/2026-06-06-chat-mermaid-card-artifact-rail-design.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Add opt-in chat artifact rail actions for assistant Mermaid diagram blocks, preserving shared Markdown defaults and QuickChat behavior while opening main chat diagrams as existing diagram artifacts.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Assistant Mermaid diagram blocks can open the existing chat artifact rail as diagram artifacts when artifact actions are enabled.
+- [x] #2 Markdown defaults Mermaid artifact actions off so QuickChat and shared fallback surfaces keep render-only behavior.
+- [x] #3 Main chat and compact chat assistant Mermaid messages opt into artifact actions and pass context-aware ids for jump-to-source.
+- [x] #4 Tests cover artifact payload, source anchoring, opt-in forwarding, main-chat opt-in, and QuickChat non-opt-in behavior.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Docs/superpowers/specs/2026-06-06-chat-mermaid-card-artifact-rail-design.md
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented TDD red/green flow for Mermaid chat cards. Red run failed on missing artifact action, prop forwarding, and context-aware ids. Green run passed the focused Vitest suite. TypeScript full UI check was attempted with an 8GB heap and failed on an unrelated existing TaskActivityNotice i18next count type error outside the touched files. Bandit is not applicable because no Python code changed.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Implemented opt-in Mermaid artifact rail actions for main chat while preserving shared Markdown defaults and QuickChat render-only behavior.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-2266 - Fix-TaskActivityNotice-i18next-count-typing.md
+++ b/backlog/tasks/task-2266 - Fix-TaskActivityNotice-i18next-count-typing.md
@@ -1,0 +1,58 @@
+---
+id: TASK-2266
+title: Fix TaskActivityNotice i18next count typing
+status: Done
+assignee: []
+created_date: ''
+updated_date: 2026-06-07 00:16
+labels:
+- webui
+- notes
+- typescript
+- verification
+dependencies: []
+references:
+- TASK-2265 verification blocker
+modified_files:
+- apps/packages/ui/src/components/Notes/TaskActivityNotice.tsx
+- apps/packages/ui/src/components/Notes/__tests__/NotesManagerPage.task-activity.test.tsx
+- apps/packages/ui/src/public/_locales/en/option.json
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Fix the UI TypeScript verification blocker where TaskActivityNotice passes a string label through the reserved i18next count option, which must remain numeric for typed translation options.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 TaskActivityNotice passes a numeric value through the i18next reserved count option.
+- [x] #2 TaskActivityNotice still renders the human-readable task count label in the summary text.
+- [x] #3 A regression test covers the translation option shape so future TypeScript checks catch regressions.
+- [x] #4 Full UI TypeScript verification passes after the fix.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Root cause: TaskActivityNotice used count for display text, but i18next reserves count for numeric pluralization. Fixed by passing count: events.length and interpolating countLabel separately. Updated the English locale template from {{count}} to {{countLabel}}.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Fixed the UI TypeScript blocker by keeping i18next count numeric in TaskActivityNotice and introducing countLabel for the rendered task-count phrase. Added regression coverage for the translation option shape and verified the notes regression, Mermaid chat artifact suites, full UI TypeScript check, diff whitespace, and locale JSON parsing. Bandit is not applicable because only TypeScript, test, JSON locale, and Backlog task files were touched.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-2266 - Fix-TaskActivityNotice-i18next-count-typing.md
+++ b/backlog/tasks/task-2266 - Fix-TaskActivityNotice-i18next-count-typing.md
@@ -4,7 +4,7 @@ title: Fix TaskActivityNotice i18next count typing
 status: Done
 assignee: []
 created_date: ''
-updated_date: 2026-06-07 00:16
+updated_date: '2026-06-07 00:16'
 labels:
 - webui
 - notes

--- a/backlog/tasks/task-2274 - Address-Mermaid-chat-card-PR-review-comments.md
+++ b/backlog/tasks/task-2274 - Address-Mermaid-chat-card-PR-review-comments.md
@@ -1,0 +1,61 @@
+---
+id: TASK-2274
+title: Address Mermaid chat card PR review comments
+status: Done
+assignee: []
+created_date: ''
+updated_date: '2026-06-07 05:25'
+labels:
+- webui
+- chat
+- mermaid
+- review
+dependencies: []
+references:
+- https://github.com/rmusser01/tldw_server/pull/2276
+- 'PR #2276 review pass'
+modified_files:
+- apps/packages/ui/src/components/Common/Playground/Message.tsx
+- apps/packages/ui/src/components/Common/Playground/CompactMessage.tsx
+- apps/packages/ui/src/components/Common/MermaidDiagramBlock.tsx
+- apps/packages/ui/src/components/Common/Playground/__tests__/Message.mermaid-rendering.test.tsx
+- apps/packages/ui/src/components/Knowledge/__tests__/KnowledgePanelQAPreview.test.tsx
+- apps/packages/ui/src/utils/stable-hash.ts
+- backlog/tasks/task-2266 - Fix-TaskActivityNotice-i18next-count-typing.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Rebase PR #2276 onto latest dev and address validated review feedback for Mermaid chat card artifacts, compact message hashing, context-id fallbacks, task timestamp serialization, and rebased UI TypeScript verification blockers.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 PR #2276 is rebased onto latest origin/dev.
+- [x] #2 Validated review comments are addressed with scoped code or task metadata changes.
+- [x] #3 Regression tests cover safe fallback contexts, per-segment Mermaid namespaces, and disabled compact artifact contexts.
+- [x] #4 Local focused tests and UI TypeScript verification pass.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Rebased branch onto origin/dev at 6c2b2b7c8f with no conflicts. Verified review feedback before fixing: duplicate Mermaid artifact contexts across message Markdown segments, unsafe undefined/null fallback context, CompactMessage hashing while Mermaid actions are disabled, duplicated branch-local hash helper, and unquoted TASK-2266 updated_date. Added failing Message Mermaid tests for the three behavioral review issues, then fixed them. The PR's Wizard coverage check failure was inspected and failed before tests due Docker Hub postgres image pull timeouts; sampled full-suite failed job had no failed test output. A rebased TypeScript baseline issue in KnowledgePanelQAPreview.test.tsx was fixed by removing an unnecessary third vi.mock option for installed antd.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Rebased PR #2276 onto latest origin/dev and addressed validated review comments. Mermaid artifact contexts now use safe local fallbacks plus per-render greeting/segment namespaces, CompactMessage only computes/passes artifact contexts when Mermaid actions are enabled, the branch-local hash helper is shared through stableHashString, and TASK-2266 updated_date is quoted. Also fixed the rebased UI TypeScript blocker in KnowledgePanelQAPreview.test.tsx. Verification: Message Mermaid red tests failed on the intended review regressions, then passed; focused Vitest suite passed (5 files, 49 tests); Knowledge QA preview test passed (3 tests); UI TypeScript check passed; git diff --check and locale JSON parse passed. Bandit is not applicable because only TypeScript, tests, JSON/task metadata, and docs/task files were touched.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## Change summary

Human-authored summary required before merge. This PR is draft until the requester adds the merge-gate summary explaining what changed and why.

## Summary

- Adds a chat-scoped Mermaid artifact action for assistant-facing Markdown surfaces while keeping user messages and render-only surfaces unchanged.
- Opens Mermaid diagrams in the existing artifact rail with stable context-aware artifact IDs and jump-to-source origin metadata.
- Adds focused coverage for Markdown defaults, assistant chat opt-in behavior, QuickChat exclusion, artifact opening, and artifact ID isolation.
- Fixes the pre-existing notes task activity i18next typing blocker so the UI TypeScript check passes.

## Test plan

- bunx vitest run src/components/Notes/__tests__/NotesManagerPage.task-activity.test.tsx src/components/Common/__tests__/MermaidDiagramBlock.test.tsx src/components/Common/__tests__/Markdown.mermaid.test.tsx src/components/Common/Playground/__tests__/Message.mermaid-rendering.test.tsx src/components/Common/QuickChatHelper/__tests__/QuickChatMessage.mermaid.test.tsx
- env NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit --project tsconfig.json
- git diff --check
- bun -e "const fs=require('fs'); JSON.parse(fs.readFileSync('apps/packages/ui/src/public/_locales/en/option.json','utf8'))"

Bandit was not run because this branch touches only docs, TypeScript, tests, JSON locale data, and Backlog task records.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables opening assistant Mermaid diagrams from chat as cards in the existing artifact rail using stable, context-aware IDs with jump‑to‑source. Keeps user and QuickChat messages render‑only and fixes an i18n typing issue so the UI typecheck passes.

- **New Features**
  - `Markdown` adds `enableMermaidArtifactActions` (default off) and `artifactContextId`; main chat and compact chat opt in.
  - `MermaidDiagramBlock` shows a “View diagram” action when enabled; opens a `kind: "diagram"` artifact with `language: "mermaid"` and sets `id="artifact-origin-..."`/`data-artifact-origin`.
  - Deterministic IDs use context + block index + `stableHashString(source)` with safe local fallbacks; main chat namespaces per segment (`...-greeting`, `...-segment-N`); compact chat derives `compact-message-…` contexts and only computes/passes them when actions are enabled.
  - Focused tests added for opt‑in forwarding, assistant‑only gates, payloads/lineCount, origin anchoring, per‑segment namespaces, and disabled compact contexts. Design spec documented. Implements TASK‑2265 per TASK‑2264; addresses review in TASK‑2274.

- **Bug Fixes**
  - `TaskActivityNotice`: keep i18next `count` numeric and interpolate `countLabel`; updated `option.json` and added a regression test. (TASK‑2266)

<sup>Written for commit c3a54095e80b80f38416d2fc830e143044125e11. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2276?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

