### PR TITLE
Fix chat media context full-content actions

### DIFF
--- a/Docs/superpowers/plans/2026-06-06-chat-media-context-full-content-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-06-06-chat-media-context-full-content-implementation-plan.md
@@ -451,7 +451,7 @@ git commit -m "fix: resolve chat media context actions"
 
 **Tests:** Targeted Vitest tests plus static checks.
 
-**Status:** Not Started
+**Status:** Complete
 
 ### Task 5: Verify submit-path assumptions and update tests only if needed
 
@@ -516,7 +516,7 @@ git commit -m "chore: record chat media context verification"
 
 **Tests:** Git status and targeted test evidence.
 
-**Status:** Not Started
+**Status:** Complete
 
 ### Task 6: Update task tracking and final status
 

--- a/Docs/superpowers/plans/2026-06-06-chat-media-context-full-content-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-06-06-chat-media-context-full-content-implementation-plan.md
@@ -1,0 +1,560 @@
+# Chat Media Context Full-Content Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix `/chat` Knowledge panel media-library context actions so they insert, ask, pin, and copy full media content instead of title-only fallback snippets.
+
+**Architecture:** Keep `/api/v1/media/search` lightweight and fix the frontend conversion boundary. Media-library results receive a narrow origin marker during normalization, `toPinnedResult` preserves that marker on `RagPinnedResult`, and the shared full-media resolver fetches full content only for pinned results with both `mediaId` and `contextOrigin === "media-library"`.
+
+**Tech Stack:** React, TypeScript, Zustand, Vitest, Testing Library, tldw frontend API client.
+
+---
+
+## Source Documents
+
+- Spec: `Docs/superpowers/specs/2026-06-06-chat-media-context-full-content-design.md`
+- Backlog: `TASK-527`
+
+## File Structure
+
+- Modify `apps/packages/ui/src/utils/rag-format.ts`
+  - Add a narrow optional `contextOrigin?: "media-library"` field to `RagPinnedResult`.
+  - Keep formatting output unchanged; do not print or serialize the origin marker into prompts.
+- Modify `apps/packages/ui/src/components/Knowledge/hooks/useKnowledgeSearch.ts`
+  - Add `metadata.origin = "media-library"` in `normalizeMediaSearchResults`.
+  - Preserve that marker as `contextOrigin` in `toPinnedResult`.
+  - Gate `withFullMediaTextIfAvailable` on `contextOrigin === "media-library"`.
+  - Resolve full media text before Knowledge Search Insert, Ask, Pin/Save, and copy actions.
+- Modify `apps/packages/ui/src/components/Knowledge/hooks/useFileSearch.ts`
+  - Resolve full media text before file-search copy actions. Attach already routes through the shared resolver and should continue to work after the origin guard.
+- Modify `apps/packages/ui/src/components/Knowledge/KnowledgePanel.tsx`
+  - Resolve full media text before component-level Ask confirmation paths and Preview modal Ask.
+  - Preserve existing Preview modal Insert behavior.
+- Modify `apps/packages/ui/src/components/Knowledge/hooks/__tests__/useKnowledgeSearch.test.ts`
+  - Add helper and hook regression tests for origin propagation, guarded fetching, ask, pin, copy, and RAG chunk non-expansion.
+- Modify `apps/packages/ui/src/components/Knowledge/hooks/__tests__/useFileSearch.test.ts`
+  - Add/adjust media-library origin expectations and file-search copy coverage.
+- Modify `apps/packages/ui/src/components/Knowledge/__tests__/KnowledgePanelQAPreview.test.tsx`
+  - Add Preview modal Ask coverage that verifies the formatted prompt uses the resolver result.
+
+## Stage 1: Marker and Resolver Contract
+
+**Goal:** Make media-library origin explicit and preserve it through conversion without broad metadata propagation.
+
+**Success Criteria:** Media search rows normalize with `metadata.origin = "media-library"`, `toPinnedResult` emits `contextOrigin: "media-library"`, and `withFullMediaTextIfAvailable` fetches only for pinned media-library results.
+
+**Tests:** `useKnowledgeSearch.test.ts`
+
+**Status:** Not Started
+
+### Task 1: Add failing helper tests for origin propagation and guarded fetching
+
+**Files:**
+- Modify: `apps/packages/ui/src/components/Knowledge/hooks/__tests__/useKnowledgeSearch.test.ts`
+
+- [ ] **Step 1: Add test setup mocks**
+
+Add mocked `tldwClient` before importing `../useKnowledgeSearch`:
+
+```ts
+vi.mock("@/services/tldw/TldwApiClient", () => ({
+  tldwClient: {
+    initialize: vi.fn(),
+    getMediaDetails: vi.fn(),
+    searchMedia: vi.fn()
+  }
+}))
+```
+
+Import `beforeEach`, `vi`, `waitFor`, and the resolver:
+
+```ts
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { tldwClient } from "@/services/tldw/TldwApiClient"
+import {
+  extractContentFromMediaDetail,
+  extractMediaId,
+  normalizeMediaSearchResults,
+  toPinnedResult,
+  withFullMediaTextIfAvailable,
+  type RagResult
+} from "../useKnowledgeSearch"
+```
+
+- [ ] **Step 2: Add failing tests**
+
+Add these tests:
+
+```ts
+it("marks normalized media-library rows and carries the marker into pinned results", () => {
+  const [result] = normalizeMediaSearchResults({
+    items: [{ id: 42, title: "Quarterly Report", type: "pdf", url: "/api/v1/media/42" }]
+  })
+
+  expect(result.metadata?.media_id).toBe(42)
+  expect(result.metadata?.origin).toBe("media-library")
+  expect(toPinnedResult(result).contextOrigin).toBe("media-library")
+})
+
+it("fetches full text only for pinned media-library results", async () => {
+  vi.mocked(tldwClient.getMediaDetails).mockResolvedValue({
+    content: { text: "Full media body content" }
+  })
+
+  const resolved = await withFullMediaTextIfAvailable({
+    id: "media-42",
+    title: "Quarterly Report",
+    snippet: "Library item: Quarterly Report",
+    mediaId: 42,
+    contextOrigin: "media-library"
+  })
+
+  expect(resolved.snippet).toBe("Full media body content")
+  expect(tldwClient.getMediaDetails).toHaveBeenCalledWith(
+    42,
+    expect.objectContaining({
+      include_content: true,
+      include_versions: false,
+      include_version_content: false
+    })
+  )
+})
+
+it("does not fetch full media details for chunk-scoped pinned results", async () => {
+  const resolved = await withFullMediaTextIfAvailable({
+    id: "chunk-42",
+    title: "Chunk",
+    snippet: "Retrieved chunk only",
+    mediaId: 42
+  })
+
+  expect(resolved.snippet).toBe("Retrieved chunk only")
+  expect(tldwClient.getMediaDetails).not.toHaveBeenCalled()
+})
+
+it("keeps fallback snippet when full media detail fetch fails or returns empty content", async () => {
+  vi.mocked(tldwClient.getMediaDetails).mockRejectedValueOnce(new Error("offline"))
+
+  const failedFetch = await withFullMediaTextIfAvailable({
+    id: "media-42",
+    title: "Quarterly Report",
+    snippet: "Library item: Quarterly Report",
+    mediaId: 42,
+    contextOrigin: "media-library"
+  })
+
+  vi.mocked(tldwClient.getMediaDetails).mockResolvedValueOnce({
+    content: { text: "" }
+  })
+
+  const emptyContent = await withFullMediaTextIfAvailable({
+    id: "media-42",
+    title: "Quarterly Report",
+    snippet: "Library item: Quarterly Report",
+    mediaId: 42,
+    contextOrigin: "media-library"
+  })
+
+  expect(failedFetch.snippet).toBe("Library item: Quarterly Report")
+  expect(emptyContent.snippet).toBe("Library item: Quarterly Report")
+})
+```
+
+- [ ] **Step 3: Run tests and verify they fail**
+
+Run from `apps/packages/ui`:
+
+```bash
+bunx vitest run src/components/Knowledge/hooks/__tests__/useKnowledgeSearch.test.ts
+```
+
+Expected: FAIL because `metadata.origin`, `contextOrigin`, and the guarded resolver behavior are not implemented yet.
+
+### Task 2: Implement origin marker and guarded resolver
+
+**Files:**
+- Modify: `apps/packages/ui/src/utils/rag-format.ts`
+- Modify: `apps/packages/ui/src/components/Knowledge/hooks/useKnowledgeSearch.ts`
+
+- [ ] **Step 1: Extend the pinned result type narrowly**
+
+In `rag-format.ts`:
+
+```ts
+export type RagPinnedResult = {
+  id: string
+  title?: string
+  source?: string
+  url?: string
+  snippet: string
+  type?: string
+  mediaId?: number
+  contextOrigin?: "media-library"
+}
+```
+
+- [ ] **Step 2: Mark normalized media-library results**
+
+In `normalizeMediaSearchResults`, add the origin marker to the metadata object:
+
+```ts
+const metadata: Record<string, unknown> = {
+  title,
+  type,
+  source: title,
+  url: itemUrl,
+  origin: "media-library",
+  created_at: getFirstString(rawItem, ["created_at", "date", "added_at"]) || undefined
+}
+```
+
+- [ ] **Step 3: Preserve only the narrow origin marker in pinned results**
+
+In `toPinnedResult`:
+
+```ts
+const contextOrigin =
+  getMetadataValue(item.metadata, "origin") === "media-library"
+    ? "media-library"
+    : undefined
+
+return {
+  id: buildPinnedResultId(item, text),
+  title: title || undefined,
+  source: getResultSource(item) || undefined,
+  url: url || undefined,
+  snippet,
+  type: getResultType(item) || undefined,
+  mediaId: extractMediaId(item) ?? undefined,
+  contextOrigin
+}
+```
+
+- [ ] **Step 4: Gate full-media fetching on the pinned origin marker**
+
+In `withFullMediaTextIfAvailable`:
+
+```ts
+if (!pinned.mediaId || pinned.contextOrigin !== "media-library") return pinned
+```
+
+Keep the existing fetch and fallback behavior unchanged after this guard.
+
+- [ ] **Step 5: Run helper tests and verify they pass**
+
+Run from `apps/packages/ui`:
+
+```bash
+bunx vitest run src/components/Knowledge/hooks/__tests__/useKnowledgeSearch.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit marker and resolver contract**
+
+```bash
+git add apps/packages/ui/src/utils/rag-format.ts apps/packages/ui/src/components/Knowledge/hooks/useKnowledgeSearch.ts apps/packages/ui/src/components/Knowledge/hooks/__tests__/useKnowledgeSearch.test.ts
+git commit -m "fix: gate chat media context expansion by origin"
+```
+
+## Stage 2: Media Context Action Paths
+
+**Goal:** Ensure every `/chat` media-library action path that creates context resolves full content before formatting.
+
+**Success Criteria:** Knowledge Search Insert, Ask, Pin/Save, copy, Preview Insert, Preview Ask, File Search Attach, and File Search copy all format full media content when detail content is available. RAG/QA chunks remain chunk-scoped.
+
+**Tests:** `useKnowledgeSearch.test.ts`, `useFileSearch.test.ts`, `KnowledgePanelQAPreview.test.tsx`
+
+**Status:** Not Started
+
+### Task 3: Add failing action-path tests
+
+**Files:**
+- Modify: `apps/packages/ui/src/components/Knowledge/hooks/__tests__/useKnowledgeSearch.test.ts`
+- Modify: `apps/packages/ui/src/components/Knowledge/hooks/__tests__/useFileSearch.test.ts`
+- Modify: `apps/packages/ui/src/components/Knowledge/__tests__/KnowledgePanelQAPreview.test.tsx`
+
+- [ ] **Step 1: Add hook-level tests for Ask, Pin/Save, and copy**
+
+In `useKnowledgeSearch.test.ts`, add mocks for `react-i18next`, `@plasmohq/storage/hook`, and reset the Zustand store:
+
+```ts
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (_key: string, fallback?: string) => fallback ?? _key })
+}))
+
+vi.mock("@plasmohq/storage/hook", () => ({
+  useStorage: () => [false, vi.fn()] as const
+}))
+```
+
+Import and reset `useStoreMessageOption` between hook tests so pinned state does not leak:
+
+```ts
+import { useStoreMessageOption } from "@/store/option"
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  useStoreMessageOption.setState({
+    ragPinnedResults: [],
+    ragMediaIds: null
+  })
+})
+```
+
+Use `renderHook`, `act`, and `waitFor` to test:
+
+```ts
+const mediaResult = normalizeMediaSearchResults({
+  items: [{ id: 42, title: "Quarterly Report", type: "pdf", url: "/api/v1/media/42" }]
+})[0]
+
+vi.mocked(tldwClient.getMediaDetails).mockResolvedValue({
+  content: { text: "Full media body content" }
+})
+```
+
+Required cases:
+
+- `handleAsk(mediaResult)` eventually calls `onAsk` with `"Full media body content"` and `{ ignorePinnedResults: true }`.
+- `handlePin(mediaResult)` eventually stores a pinned result whose `snippet` is `"Full media body content"` and keeps `ragMediaIds` as `[42]`.
+- `copyResult(mediaResult, "markdown")` writes full media content to the clipboard.
+- A chunk-style `RagResult` with `metadata.media_id = 42` and no `metadata.origin` does not call `getMediaDetails`.
+
+- [ ] **Step 2: Add file-search copy coverage**
+
+In `useFileSearch.test.ts`, add or adjust tests so:
+
+- Search results include `metadata.origin = "media-library"`.
+- `copyResult(result, "markdown")` writes full media content when `getMediaDetails` returns `content.text`.
+- Attach continues to insert full media content with the new origin guard.
+
+- [ ] **Step 3: Add Preview modal Ask coverage**
+
+In `KnowledgePanelQAPreview.test.tsx`, keep existing QA preview expectations and add a test that verifies the Preview modal Ask path uses the resolved pinned result:
+
+```ts
+mockWithFullMediaTextIfAvailable.mockResolvedValueOnce({
+  id: "pin-doc-1",
+  title: "QA Doc Title",
+  snippet: "Resolved preview context"
+})
+```
+
+Click Preview, then Ask, and assert `onAsk` receives `"Resolved preview context"`.
+
+- [ ] **Step 4: Run tests and verify they fail**
+
+Run from `apps/packages/ui`:
+
+```bash
+bunx vitest run src/components/Knowledge/hooks/__tests__/useKnowledgeSearch.test.ts src/components/Knowledge/hooks/__tests__/useFileSearch.test.ts src/components/Knowledge/__tests__/KnowledgePanelQAPreview.test.tsx
+```
+
+Expected: FAIL because Ask, Pin/Save, copy, and Preview Ask do not all resolve through `withFullMediaTextIfAvailable` yet.
+
+### Task 4: Resolve full media text in all action paths
+
+**Files:**
+- Modify: `apps/packages/ui/src/components/Knowledge/hooks/useKnowledgeSearch.ts`
+- Modify: `apps/packages/ui/src/components/Knowledge/hooks/useFileSearch.ts`
+- Modify: `apps/packages/ui/src/components/Knowledge/KnowledgePanel.tsx`
+
+- [ ] **Step 1: Resolve Knowledge Search copy**
+
+In `copyResult`:
+
+```ts
+const pinned = toPinnedResult(item)
+const resolvedPinned = await withFullMediaTextIfAvailable(pinned)
+await navigator.clipboard.writeText(formatRagResult(resolvedPinned, format))
+```
+
+- [ ] **Step 2: Resolve Knowledge Search Ask**
+
+Wrap the Ask path in an async IIFE while keeping the public handler type as `(item) => void`:
+
+```ts
+void (async () => {
+  const pinned = toPinnedResult(item)
+  const resolvedPinned = await withFullMediaTextIfAvailable(pinned)
+  onAsk(formatRagResult(resolvedPinned, "markdown"), { ignorePinnedResults: true })
+})()
+```
+
+- [ ] **Step 3: Resolve Pin/Save before storing**
+
+In `handlePin`, preserve the duplicate check using the original pinned ID, then resolve before storing:
+
+```ts
+const pinned = toPinnedResult(item)
+if (pinnedResults.some((result) => result.id === pinned.id)) return
+void (async () => {
+  const resolvedPinned = await withFullMediaTextIfAvailable(pinned)
+  const nextPinned = [...pinnedResults, resolvedPinned]
+  setRagPinnedResults(nextPinned)
+  const mediaIds = collectPinnedMediaIds(nextPinned)
+  setRagMediaIds(mediaIds.length > 0 ? mediaIds : null)
+})()
+```
+
+- [ ] **Step 4: Resolve File Search copy**
+
+In `useFileSearch.copyResult`, use the same `resolvedPinned` pattern as Knowledge Search copy.
+
+- [ ] **Step 5: Resolve component-level Ask and Preview Ask**
+
+In `KnowledgePanel.tsx`, add a local helper:
+
+```ts
+const askWithResolvedContext = React.useCallback(
+  (pinned: RagPinnedResult) => {
+    void (async () => {
+      const resolved = await withFullMediaTextIfAvailable(pinned)
+      onAsk(formatRagResult(resolved, "markdown"), {
+        ignorePinnedResults: true
+      })
+    })()
+  },
+  [onAsk]
+)
+```
+
+Use it in:
+
+- The immediate `handleAsk` path.
+- The `Modal.confirm` `onOk` path.
+- The Preview modal Ask button before `setPreviewItem(null)`.
+
+- [ ] **Step 6: Run action-path tests**
+
+Run from `apps/packages/ui`:
+
+```bash
+bunx vitest run src/components/Knowledge/hooks/__tests__/useKnowledgeSearch.test.ts src/components/Knowledge/hooks/__tests__/useFileSearch.test.ts src/components/Knowledge/__tests__/KnowledgePanelQAPreview.test.tsx
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit action-path fixes**
+
+```bash
+git add apps/packages/ui/src/components/Knowledge/hooks/useKnowledgeSearch.ts apps/packages/ui/src/components/Knowledge/hooks/useFileSearch.ts apps/packages/ui/src/components/Knowledge/KnowledgePanel.tsx apps/packages/ui/src/components/Knowledge/hooks/__tests__/useKnowledgeSearch.test.ts apps/packages/ui/src/components/Knowledge/hooks/__tests__/useFileSearch.test.ts apps/packages/ui/src/components/Knowledge/__tests__/KnowledgePanelQAPreview.test.tsx
+git commit -m "fix: resolve chat media context actions"
+```
+
+## Stage 3: Submit-Path and Regression Verification
+
+**Goal:** Verify the submit path receives full pinned media content without changing file-retrieval behavior.
+
+**Success Criteria:** `ragPinnedResults` still flow through `formatPinnedResults` on submit/raw preview, now with full snippets from Pin/Save; file retrieval continues to skip pinned inline expansion.
+
+**Tests:** Targeted Vitest tests plus static checks.
+
+**Status:** Not Started
+
+### Task 5: Verify submit-path assumptions and update tests only if needed
+
+**Files:**
+- Inspect: `apps/packages/ui/src/components/Option/Playground/hooks/usePlaygroundSubmit.ts`
+- Inspect: `apps/packages/ui/src/components/Option/Playground/hooks/usePlaygroundRawPreview.ts`
+- Modify only if existing tests need expectation updates.
+
+- [ ] **Step 1: Confirm no submit-path code change is needed**
+
+Check that both submit and raw preview still call:
+
+```ts
+formatPinnedResults(ragPinnedResults, "markdown")
+```
+
+when `fileRetrievalEnabled` is false.
+
+- [ ] **Step 2: Run targeted tests**
+
+Run from `apps/packages/ui`:
+
+```bash
+bunx vitest run src/components/Knowledge/hooks/__tests__/useKnowledgeSearch.test.ts src/components/Knowledge/hooks/__tests__/useFileSearch.test.ts src/components/Knowledge/__tests__/KnowledgePanelQAPreview.test.tsx src/components/Option/Playground/__tests__/PlaygroundForm.pinned-fallback.test.tsx src/components/Option/Playground/__tests__/usePlaygroundRawPreview.mcp-tools.test.tsx
+```
+
+Expected: PASS. If the Playground tests are unrelatedly flaky, document the exact failure and rerun only once before deciding whether it is unrelated baseline noise.
+
+- [ ] **Step 3: Run diff and formatting checks**
+
+Run from repo root:
+
+```bash
+git diff --check
+```
+
+Expected: no whitespace errors.
+
+- [ ] **Step 4: Record Bandit applicability**
+
+No Python files should be touched in this implementation. Record in `TASK-527` that Bandit is not applicable for this TypeScript-only frontend change. If any Python file is touched, run:
+
+```bash
+source .venv/bin/activate
+python -m bandit -r <touched_python_paths> -f json -o /tmp/bandit_chat_media_context.json
+```
+
+- [ ] **Step 5: Commit final verification metadata if needed**
+
+If only Backlog task metadata changes after verification:
+
+```bash
+git add "backlog/tasks/task-527 - Design-chat-media-context-full-content-insertion-fix.md"
+git commit -m "chore: record chat media context verification"
+```
+
+## Stage 4: Finalization
+
+**Goal:** Leave the branch with documented verification, focused commits, and no staged unrelated changes.
+
+**Success Criteria:** Backlog task has final notes, verification commands are recorded, unrelated dirty files are not staged, and the user receives the exact changed-file summary.
+
+**Tests:** Git status and targeted test evidence.
+
+**Status:** Not Started
+
+### Task 6: Update task tracking and final status
+
+**Files:**
+- Modify: `backlog/tasks/task-527 - Design-chat-media-context-full-content-insertion-fix.md`
+
+- [ ] **Step 1: Update Backlog task with implementation notes**
+
+Record:
+
+- The origin-marker guard.
+- The action paths covered.
+- The targeted Vitest commands and results.
+- Bandit applicability.
+- Any skipped or failed checks with reasons.
+
+- [ ] **Step 2: Inspect final status**
+
+Run from repo root:
+
+```bash
+git status --short
+```
+
+Expected: only intended files for this task are staged or modified by this work; unrelated pre-existing dirty files remain unstaged.
+
+- [ ] **Step 3: Commit Backlog update with implementation if not already committed**
+
+```bash
+git add "backlog/tasks/task-527 - Design-chat-media-context-full-content-insertion-fix.md"
+git commit -m "chore: finalize chat media context task"
+```
+
+- [ ] **Step 4: Final response**
+
+Report:
+
+- Files changed.
+- Tests run and results.
+- Bandit status or skip reason.
+- Any residual risk, especially if a verification command could not run.

--- a/Docs/superpowers/plans/2026-06-06-chat-media-context-full-content-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-06-06-chat-media-context-full-content-implementation-plan.md
@@ -45,7 +45,7 @@
 
 **Tests:** `useKnowledgeSearch.test.ts`
 
-**Status:** Not Started
+**Status:** Complete
 
 ### Task 1: Add failing helper tests for origin propagation and guarded fetching
 
@@ -265,7 +265,7 @@ git commit -m "fix: gate chat media context expansion by origin"
 
 **Tests:** `useKnowledgeSearch.test.ts`, `useFileSearch.test.ts`, `KnowledgePanelQAPreview.test.tsx`
 
-**Status:** Not Started
+**Status:** Complete
 
 ### Task 3: Add failing action-path tests
 

--- a/Docs/superpowers/specs/2026-06-06-chat-media-context-full-content-design.md
+++ b/Docs/superpowers/specs/2026-06-06-chat-media-context-full-content-design.md
@@ -1,0 +1,73 @@
+# Chat Media Context Full-Content Design
+
+## Problem
+
+Users report that adding a media item as context from `/chat` can insert or send only the media title and metadata, not the media content. The exact clicked control is unknown, so the fix should cover every `/chat` media-result action that turns a media search result into chat context.
+
+## Root Cause
+
+`/api/v1/media/search` returns list-shaped media items with `id`, `title`, `type`, and `url`. The backend search repository selects `m.content`, but the media search endpoint formats results as `MediaListItem`, which does not include content or `content_preview`.
+
+The `/chat` Knowledge panel normalizes those search rows into RAG-style results. When no content is present, it creates a fallback snippet like `Library item: <title>`. Some action paths already fetch full media details before inserting context, but pinning/saving and ask-style paths can format and store the fallback snippet directly. When pinned results are later appended to a prompt, the chat receives only that fallback text.
+
+## Goals
+
+- Ensure media search results used as chat context resolve to full media text whenever the result has a media ID.
+- Keep `/api/v1/media/search` lightweight for listing/search use.
+- Make Insert, Attach, Ask, Preview Insert, and Pin/Save behavior consistent for media results.
+- Preserve existing RAG chunk behavior: chunks returned by the RAG endpoint should still insert the retrieved chunk, not force whole-document expansion unless they are explicitly media library items.
+
+## Non-Goals
+
+- Do not change the media search API response contract in this slice.
+- Do not redesign the Knowledge panel UI.
+- Do not force full media content into prompts when file retrieval is enabled and the user is relying on media-scoped RAG instead.
+
+## Design
+
+Use the existing full-media resolver as the central boundary for actions that convert a media search result into context:
+
+- Convert a result to `RagPinnedResult`.
+- If it has `mediaId`, fetch `/api/v1/media/{id}` with `include_content=true`, `include_versions=false`, and `include_version_content=false`.
+- Extract content from the returned detail using the existing media-detail extraction helper.
+- Replace the snippet with full text only when non-empty full text is available.
+- Fall back to the existing snippet on fetch failure or missing content.
+
+Apply this resolver before:
+
+- Direct Knowledge Search Insert.
+- File Search Attach.
+- Preview modal Insert.
+- Knowledge Search Ask for a media result.
+- Pin/Save of a media result.
+- Clipboard copy of a media search result if it is exposed as a context-copy action.
+
+For Pin/Save, store the resolved full-text snippet in `ragPinnedResults`. The existing submit path can keep using `formatPinnedResults(ragPinnedResults, "markdown")`; it will then append real content rather than `Library item: <title>`.
+
+## Data Flow
+
+1. User searches media from `/chat` Knowledge panel.
+2. `/api/v1/media/search` returns lightweight media rows.
+3. UI normalizes rows into `RagResult` with `metadata.media_id`.
+4. User chooses an action that creates context.
+5. The action resolves full media content through the shared resolver.
+6. The action inserts, sends, pins, or copies the formatted resolved context.
+
+## Error Handling
+
+If fetching full media details fails, keep the current fallback behavior and do not block the user action. The UI should not throw from context insertion. This preserves offline/degraded behavior while making successful connected flows include content.
+
+## Testing
+
+Add focused frontend tests around the Knowledge helpers/actions:
+
+- A lightweight media search row normalizes with `metadata.media_id`.
+- A media result with only `id/title/type/url` resolves full content from `getMediaDetails`.
+- Pin/Save stores full content when detail content is available.
+- Ask formats full content for media results.
+- Existing fallback snippet remains when detail fetch fails or content is empty.
+- RAG chunk insertion remains chunk-scoped and is not expanded to full media content by default.
+
+## Backlog
+
+Tracked by `TASK-527`.

--- a/Docs/superpowers/specs/2026-06-06-chat-media-context-full-content-design.md
+++ b/Docs/superpowers/specs/2026-06-06-chat-media-context-full-content-design.md
@@ -15,7 +15,7 @@ The `/chat` Knowledge panel normalizes those search rows into RAG-style results.
 - Ensure media search results used as chat context resolve to full media text whenever the result has a media ID.
 - Keep `/api/v1/media/search` lightweight for listing/search use.
 - Make Insert, Attach, Ask, Preview Insert, and Pin/Save behavior consistent for media results.
-- Preserve existing RAG chunk behavior: chunks returned by the RAG endpoint should still insert the retrieved chunk, not force whole-document expansion unless they are explicitly media library items.
+- Preserve existing RAG chunk behavior: chunks returned by the RAG endpoint should still insert the retrieved chunk, not force whole-document expansion.
 
 ## Non-Goals
 
@@ -25,10 +25,12 @@ The `/chat` Knowledge panel normalizes those search rows into RAG-style results.
 
 ## Design
 
-Use the existing full-media resolver as the central boundary for actions that convert a media search result into context:
+Use the existing full-media resolver as the central boundary for actions that convert a media library search result into context.
+
+To avoid expanding RAG chunks that happen to include `media_id`, normalized media-library search results should carry an explicit origin marker: `metadata.origin = "media-library"`. Only results with that marker are eligible for whole-media expansion. RAG/QA source chunks should remain chunk-scoped even when their metadata includes `media_id`.
 
 - Convert a result to `RagPinnedResult`.
-- If it has `mediaId`, fetch `/api/v1/media/{id}` with `include_content=true`, `include_versions=false`, and `include_version_content=false`.
+- If it has `mediaId` and the media-library origin marker, fetch `/api/v1/media/{id}` with `include_content=true`, `include_versions=false`, and `include_version_content=false`.
 - Extract content from the returned detail using the existing media-detail extraction helper.
 - Replace the snippet with full text only when non-empty full text is available.
 - Fall back to the existing snippet on fetch failure or missing content.
@@ -38,6 +40,7 @@ Apply this resolver before:
 - Direct Knowledge Search Insert.
 - File Search Attach.
 - Preview modal Insert.
+- Preview modal Ask.
 - Knowledge Search Ask for a media result.
 - Pin/Save of a media result.
 - Clipboard copy of a media search result if it is exposed as a context-copy action.
@@ -48,7 +51,7 @@ For Pin/Save, store the resolved full-text snippet in `ragPinnedResults`. The ex
 
 1. User searches media from `/chat` Knowledge panel.
 2. `/api/v1/media/search` returns lightweight media rows.
-3. UI normalizes rows into `RagResult` with `metadata.media_id`.
+3. UI normalizes rows into `RagResult` with `metadata.media_id` and a media-library origin marker.
 4. User chooses an action that creates context.
 5. The action resolves full media content through the shared resolver.
 6. The action inserts, sends, pins, or copies the formatted resolved context.
@@ -61,12 +64,13 @@ If fetching full media details fails, keep the current fallback behavior and do 
 
 Add focused frontend tests around the Knowledge helpers/actions:
 
-- A lightweight media search row normalizes with `metadata.media_id`.
+- A lightweight media search row normalizes with `metadata.media_id` and `metadata.origin = "media-library"`.
 - A media result with only `id/title/type/url` resolves full content from `getMediaDetails`.
 - Pin/Save stores full content when detail content is available.
 - Ask formats full content for media results.
+- Preview Ask formats full content for media results.
 - Existing fallback snippet remains when detail fetch fails or content is empty.
-- RAG chunk insertion remains chunk-scoped and is not expanded to full media content by default.
+- RAG chunk insertion remains chunk-scoped and is not expanded to full media content even if the chunk metadata contains `media_id`.
 
 ## Backlog
 

--- a/Docs/superpowers/specs/2026-06-06-chat-media-context-full-content-design.md
+++ b/Docs/superpowers/specs/2026-06-06-chat-media-context-full-content-design.md
@@ -12,7 +12,7 @@ The `/chat` Knowledge panel normalizes those search rows into RAG-style results.
 
 ## Goals
 
-- Ensure media search results used as chat context resolve to full media text whenever the result has a media ID.
+- Ensure media-library search results used as chat context resolve to full media text whenever the result has a media ID.
 - Keep `/api/v1/media/search` lightweight for listing/search use.
 - Make Insert, Attach, Ask, Preview Insert, and Pin/Save behavior consistent for media results.
 - Preserve existing RAG chunk behavior: chunks returned by the RAG endpoint should still insert the retrieved chunk, not force whole-document expansion.
@@ -29,8 +29,10 @@ Use the existing full-media resolver as the central boundary for actions that co
 
 To avoid expanding RAG chunks that happen to include `media_id`, normalized media-library search results should carry an explicit origin marker: `metadata.origin = "media-library"`. Only results with that marker are eligible for whole-media expansion. RAG/QA source chunks should remain chunk-scoped even when their metadata includes `media_id`.
 
+Because the current resolver operates on `RagPinnedResult`, the marker must survive conversion from `RagResult` to `RagPinnedResult`. Add a narrow pinned-result field for this, for example `contextOrigin?: "media-library"`, and populate it from `metadata.origin` in `toPinnedResult`. Do not preserve arbitrary search metadata on pinned results.
+
 - Convert a result to `RagPinnedResult`.
-- If it has `mediaId` and the media-library origin marker, fetch `/api/v1/media/{id}` with `include_content=true`, `include_versions=false`, and `include_version_content=false`.
+- If it has `mediaId` and `contextOrigin === "media-library"`, fetch `/api/v1/media/{id}` with `include_content=true`, `include_versions=false`, and `include_version_content=false`.
 - Extract content from the returned detail using the existing media-detail extraction helper.
 - Replace the snippet with full text only when non-empty full text is available.
 - Fall back to the existing snippet on fetch failure or missing content.
@@ -65,11 +67,13 @@ If fetching full media details fails, keep the current fallback behavior and do 
 Add focused frontend tests around the Knowledge helpers/actions:
 
 - A lightweight media search row normalizes with `metadata.media_id` and `metadata.origin = "media-library"`.
+- `toPinnedResult` preserves the media-library marker as a narrow pinned-result origin field.
 - A media result with only `id/title/type/url` resolves full content from `getMediaDetails`.
 - Pin/Save stores full content when detail content is available.
 - Ask formats full content for media results.
 - Preview Ask formats full content for media results.
 - Existing fallback snippet remains when detail fetch fails or content is empty.
+- A pinned result with `mediaId` but no media-library origin does not fetch full media details.
 - RAG chunk insertion remains chunk-scoped and is not expanded to full media content even if the chunk metadata contains `media_id`.
 
 ## Backlog

--- a/apps/packages/ui/src/components/Knowledge/KnowledgePanel.tsx
+++ b/apps/packages/ui/src/components/Knowledge/KnowledgePanel.tsx
@@ -197,6 +197,18 @@ const KnowledgePanelBase: React.FC<KnowledgePanelProps> = ({
     [handlePreview]
   )
 
+  const askWithResolvedContext = React.useCallback(
+    (pinned: RagPinnedResult) => {
+      void (async () => {
+        const resolved = await withFullMediaTextIfAvailable(pinned)
+        onAsk(formatRagResult(resolved, "markdown"), {
+          ignorePinnedResults: true
+        })
+      })()
+    },
+    [onAsk]
+  )
+
   // Discard staged settings on close
   const previousOpen = React.useRef(isOpen)
   React.useEffect(() => {
@@ -219,16 +231,13 @@ const KnowledgePanelBase: React.FC<KnowledgePanelProps> = ({
           ),
           okText: t("common:continue", "Continue"),
           cancelText: t("common:cancel", "Cancel"),
-          onOk: () =>
-            onAsk(formatRagResult(pinned, "markdown"), {
-              ignorePinnedResults: true
-            })
+          onOk: () => askWithResolvedContext(pinned)
         })
         return
       }
-      onAsk(formatRagResult(pinned, "markdown"), { ignorePinnedResults: true })
+      askWithResolvedContext(pinned)
     },
-    [onAsk, search.pinnedResults.length, t]
+    [askWithResolvedContext, search.pinnedResults.length, t]
   )
 
   // Context item count for badge (image + tabs + files + pinned results)
@@ -502,9 +511,7 @@ const KnowledgePanelBase: React.FC<KnowledgePanelProps> = ({
                 </button>
                 <button
                   onClick={() => {
-                    onAsk(formatRagResult(previewItem, "markdown"), {
-                      ignorePinnedResults: true
-                    })
+                    askWithResolvedContext(previewItem)
                     setPreviewItem(null)
                   }}
                   className="px-3 py-1.5 text-sm bg-surface2 text-text rounded hover:bg-surface3"

--- a/apps/packages/ui/src/components/Knowledge/__tests__/KnowledgePanelQAPreview.test.tsx
+++ b/apps/packages/ui/src/components/Knowledge/__tests__/KnowledgePanelQAPreview.test.tsx
@@ -1,19 +1,53 @@
 import React from "react"
-import { fireEvent, render, screen, waitFor, within } from "@testing-library/react"
-import { beforeEach, describe, expect, it, vi } from "vitest"
-import { KnowledgePanel } from "../KnowledgePanel"
+import {
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within
+} from "@testing-library/react"
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest"
 
 const mockUseKnowledgeSettings = vi.fn()
 const mockUseKnowledgeSearch = vi.fn()
 const mockUseFileSearch = vi.fn()
 const mockUseQASearch = vi.fn()
 const mockWithFullMediaTextIfAvailable = vi.fn()
+let KnowledgePanel: typeof import("../KnowledgePanel").KnowledgePanel
 
 vi.mock("react-i18next", () => ({
   useTranslation: () => ({
     t: (_key: string, fallback?: string) => fallback ?? _key
   })
 }))
+
+vi.mock(
+  "antd",
+  () => ({
+    Modal: Object.assign(
+      ({
+        children,
+        open,
+        title
+      }: {
+        children?: React.ReactNode
+        open?: boolean
+        title?: React.ReactNode
+      }) =>
+        open ? (
+          <div
+            role="dialog"
+            aria-label={typeof title === "string" ? title : undefined}
+          >
+            {title ? <h2>{title}</h2> : null}
+            {children}
+          </div>
+        ) : null,
+      { confirm: vi.fn() }
+    )
+  }),
+  { virtual: true }
+)
 
 vi.mock("../hooks", () => {
   const toPinnedResult = (item: any) => ({
@@ -76,6 +110,10 @@ describe("KnowledgePanel QA chunk preview", () => {
     metadata: { title: "QA Doc Title", source: "qa-source" },
     score: 0.8
   }
+
+  beforeAll(async () => {
+    ;({ KnowledgePanel } = await import("../KnowledgePanel"))
+  })
 
   beforeEach(() => {
     vi.clearAllMocks()
@@ -213,5 +251,40 @@ describe("KnowledgePanel QA chunk preview", () => {
         { ignorePinnedResults: true }
       )
     })
+  })
+
+  it("resolves shared preview modal context before Ask", async () => {
+    const onAsk = vi.fn()
+    mockWithFullMediaTextIfAvailable.mockResolvedValueOnce({
+      id: "pin-doc-1",
+      title: "QA Doc Title",
+      snippet: "Resolved preview context"
+    })
+
+    render(
+      <KnowledgePanel
+        open
+        showToggle={false}
+        onInsert={vi.fn()}
+        onAsk={onAsk}
+      />
+    )
+
+    fireEvent.click(screen.getByRole("button", { name: "Preview" }))
+    const dialog = await screen.findByRole("dialog")
+    fireEvent.click(within(dialog).getByRole("button", { name: "Ask" }))
+
+    await waitFor(() => {
+      expect(onAsk).toHaveBeenCalledWith(
+        expect.stringContaining("Resolved preview context"),
+        { ignorePinnedResults: true }
+      )
+    })
+    expect(mockWithFullMediaTextIfAvailable).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: "QA Doc Title",
+        snippet: "Chunk preview text"
+      })
+    )
   })
 })

--- a/apps/packages/ui/src/components/Knowledge/__tests__/KnowledgePanelQAPreview.test.tsx
+++ b/apps/packages/ui/src/components/Knowledge/__tests__/KnowledgePanelQAPreview.test.tsx
@@ -23,8 +23,64 @@ vi.mock("react-i18next", () => ({
 
 vi.mock(
   "antd",
-  () => ({
-    Modal: Object.assign(
+  () => {
+    const ButtonComponent = ({
+      children,
+      disabled,
+      htmlType,
+      onClick,
+      title,
+      "aria-label": ariaLabel
+    }: any) => (
+      <button
+        type={htmlType === "submit" ? "submit" : "button"}
+        disabled={disabled}
+        onClick={onClick}
+        title={title}
+        aria-label={ariaLabel}
+      >
+        {children}
+      </button>
+    )
+
+    const InputComponent = React.forwardRef<HTMLInputElement, any>(
+      ({ value, onChange, onPressEnter, placeholder, disabled }, ref) => (
+        <input
+          ref={ref}
+          value={value ?? ""}
+          onChange={(event) => onChange?.(event)}
+          onKeyDown={(event) => {
+            if (event.key === "Enter") onPressEnter?.(event)
+          }}
+          placeholder={placeholder}
+          disabled={disabled}
+        />
+      )
+    )
+    InputComponent.displayName = "MockAntdInput"
+
+    const SelectComponent = ({ value, options = [], onChange, disabled }: any) => (
+      <select
+        value={Array.isArray(value) ? value[0] ?? "" : value ?? ""}
+        onChange={(event) => onChange?.(event.target.value)}
+        disabled={disabled}
+      >
+        {Array.isArray(options)
+          ? options.map((option: any) => (
+              <option
+                key={String(option?.value)}
+                value={String(option?.value ?? "")}
+              >
+                {typeof option?.label === "string"
+                  ? option.label
+                  : String(option?.value ?? "")}
+              </option>
+            ))
+          : null}
+      </select>
+    )
+
+    const Modal = Object.assign(
       ({
         children,
         open,
@@ -45,7 +101,37 @@ vi.mock(
         ) : null,
       { confirm: vi.fn() }
     )
-  }),
+
+    return {
+      AutoComplete: InputComponent,
+      Button: ButtonComponent,
+      Checkbox: ({ children }: { children?: React.ReactNode }) => (
+        <label>{children}</label>
+      ),
+      Input: InputComponent,
+      InputNumber: InputComponent,
+      Modal,
+      Radio: {
+        Group: ({ children }: { children?: React.ReactNode }) => (
+          <div>{children}</div>
+        ),
+        Button: ButtonComponent
+      },
+      Select: SelectComponent,
+      Spin: ({ children }: { children?: React.ReactNode }) => (
+        <div>{children}</div>
+      ),
+      Switch: ({ checked, onChange, disabled }: any) => (
+        <input
+          type="checkbox"
+          checked={Boolean(checked)}
+          onChange={(event) => onChange?.(event.target.checked)}
+          disabled={disabled}
+        />
+      ),
+      Tooltip: ({ children }: { children?: React.ReactNode }) => <>{children}</>
+    }
+  },
   { virtual: true }
 )
 

--- a/apps/packages/ui/src/components/Knowledge/hooks/__tests__/useFileSearch.test.ts
+++ b/apps/packages/ui/src/components/Knowledge/hooks/__tests__/useFileSearch.test.ts
@@ -26,6 +26,12 @@ describe("useFileSearch", () => {
   beforeEach(() => {
     vi.clearAllMocks()
     vi.mocked(tldwClient.initialize).mockResolvedValue(undefined)
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: {
+        writeText: vi.fn()
+      }
+    })
   })
 
   const createHook = (resolvedQuery = "knowledge query") => {
@@ -83,6 +89,7 @@ describe("useFileSearch", () => {
     expect(result.current.results).toHaveLength(1)
     expect(result.current.results[0].metadata?.title).toBe("Quarterly Report")
     expect(result.current.results[0].metadata?.media_id).toBe(42)
+    expect(result.current.results[0].metadata?.origin).toBe("media-library")
   })
 
   it("sets query error and skips search when resolved query is empty", async () => {
@@ -136,6 +143,35 @@ describe("useFileSearch", () => {
     expect(tldwClient.getMediaDetails).toHaveBeenCalledWith(
       42,
       expect.objectContaining({ include_content: true })
+    )
+  })
+
+  it("copies full media-library content as markdown", async () => {
+    vi.mocked(tldwClient.getMediaDetails).mockResolvedValue({
+      content: {
+        text: "Full media body content"
+      }
+    })
+
+    const { result } = createHook("quarterly report")
+    const mediaResult = {
+      content: "Short snippet",
+      metadata: {
+        id: 42,
+        media_id: 42,
+        title: "Quarterly Report",
+        type: "pdf",
+        url: "/api/v1/media/42",
+        origin: "media-library"
+      }
+    }
+
+    await act(async () => {
+      await result.current.copyResult(mediaResult, "markdown")
+    })
+
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
+      expect.stringContaining("Full media body content")
     )
   })
 

--- a/apps/packages/ui/src/components/Knowledge/hooks/__tests__/useKnowledgeSearch.test.ts
+++ b/apps/packages/ui/src/components/Knowledge/hooks/__tests__/useKnowledgeSearch.test.ts
@@ -1,4 +1,6 @@
+import { act, renderHook, waitFor } from "@testing-library/react"
 import { beforeEach, describe, expect, it, vi } from "vitest"
+import { DEFAULT_RAG_SETTINGS } from "@/services/rag/unified-rag"
 
 vi.mock("@/services/tldw/TldwApiClient", () => ({
   tldwClient: {
@@ -8,13 +10,25 @@ vi.mock("@/services/tldw/TldwApiClient", () => ({
   }
 }))
 
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (_key: string, fallback?: string) => fallback ?? _key
+  })
+}))
+
+vi.mock("@plasmohq/storage/hook", () => ({
+  useStorage: () => [false, vi.fn()] as const
+}))
+
 import { tldwClient } from "@/services/tldw/TldwApiClient"
+import { useStoreMessageOption } from "@/store/option"
 
 import {
   extractContentFromMediaDetail,
   extractMediaId,
   normalizeMediaSearchResults,
   toPinnedResult,
+  useKnowledgeSearch,
   withFullMediaTextIfAvailable,
   type RagResult
 } from "../useKnowledgeSearch"
@@ -169,5 +183,215 @@ describe("useKnowledgeSearch helpers", () => {
     })
 
     expect(emptyContent.snippet).toBe("Library item: Quarterly Report")
+  })
+})
+
+describe("useKnowledgeSearch action paths", () => {
+  const baseSettings = {
+    ...DEFAULT_RAG_SETTINGS
+  }
+
+  const mediaResult = (overrides?: { id?: number; title?: string }) =>
+    normalizeMediaSearchResults({
+      items: [
+        {
+          id: overrides?.id ?? 42,
+          title: overrides?.title ?? "Quarterly Report",
+          type: "pdf",
+          url: `/api/v1/media/${overrides?.id ?? 42}`
+        }
+      ]
+    })[0]
+
+  const chunkResult = (): RagResult => ({
+    content: "Retrieved chunk only",
+    metadata: {
+      media_id: 42,
+      title: "Chunk Title",
+      type: "pdf"
+    }
+  })
+
+  const createHook = () => {
+    const applySettings = vi.fn()
+    const onInsert = vi.fn()
+    const onAsk = vi.fn()
+
+    const hook = renderHook(() =>
+      useKnowledgeSearch({
+        resolvedQuery: "quarterly report",
+        draftSettings: baseSettings,
+        applySettings,
+        onInsert,
+        onAsk
+      })
+    )
+
+    return { ...hook, applySettings, onInsert, onAsk }
+  }
+
+  const deferredMediaDetails = (text: string) => {
+    let resolveDetail: () => void = () => {}
+    const pending = new Promise((resolve) => {
+      resolveDetail = () => resolve({ content: { text } })
+    })
+    vi.mocked(tldwClient.getMediaDetails).mockReturnValue(
+      pending as ReturnType<typeof tldwClient.getMediaDetails>
+    )
+    return resolveDetail
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(tldwClient.initialize).mockResolvedValue(undefined)
+    useStoreMessageOption.setState({
+      ragPinnedResults: [],
+      ragMediaIds: null
+    })
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: {
+        writeText: vi.fn()
+      }
+    })
+  })
+
+  it("asks with full media-library content and ignores pinned results", async () => {
+    vi.mocked(tldwClient.getMediaDetails).mockResolvedValue({
+      content: { text: "Full media body content" }
+    })
+    const { result, onAsk } = createHook()
+
+    act(() => {
+      result.current.handleAsk(mediaResult())
+    })
+
+    await waitFor(() => {
+      expect(onAsk).toHaveBeenCalledWith(
+        expect.stringContaining("Full media body content"),
+        { ignorePinnedResults: true }
+      )
+    })
+  })
+
+  it("pins full media-library content and preserves media id scoping", async () => {
+    vi.mocked(tldwClient.getMediaDetails).mockResolvedValue({
+      content: { text: "Full media body content" }
+    })
+    const { result } = createHook()
+
+    act(() => {
+      result.current.handlePin(mediaResult())
+    })
+
+    await waitFor(() => {
+      expect(useStoreMessageOption.getState().ragPinnedResults[0]?.snippet).toBe(
+        "Full media body content"
+      )
+    })
+    expect(useStoreMessageOption.getState().ragMediaIds).toEqual([42])
+  })
+
+  it("preserves separate media pins resolved from overlapping requests", async () => {
+    vi.mocked(tldwClient.getMediaDetails)
+      .mockResolvedValueOnce({ content: { text: "Full first content" } })
+      .mockResolvedValueOnce({ content: { text: "Full second content" } })
+    const { result } = createHook()
+
+    act(() => {
+      result.current.handlePin(mediaResult({ id: 42, title: "First Report" }))
+      result.current.handlePin(mediaResult({ id: 43, title: "Second Report" }))
+    })
+
+    await waitFor(() => {
+      expect(useStoreMessageOption.getState().ragPinnedResults).toHaveLength(2)
+    })
+    expect(useStoreMessageOption.getState().ragPinnedResults).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          mediaId: 42,
+          snippet: "Full first content"
+        }),
+        expect.objectContaining({
+          mediaId: 43,
+          snippet: "Full second content"
+        })
+      ])
+    )
+    expect(useStoreMessageOption.getState().ragMediaIds).toEqual([42, 43])
+  })
+
+  it("does not re-add a pending media pin after clear all", async () => {
+    const resolveDetail = deferredMediaDetails("Full media body content")
+    const { result } = createHook()
+
+    act(() => {
+      result.current.handlePin(mediaResult())
+    })
+
+    await waitFor(() => {
+      expect(tldwClient.getMediaDetails).toHaveBeenCalledTimes(1)
+    })
+    expect(useStoreMessageOption.getState().ragPinnedResults).toEqual([])
+
+    await act(async () => {
+      result.current.handleClearPins()
+      resolveDetail()
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+    expect(useStoreMessageOption.getState().ragPinnedResults).toEqual([])
+    expect(useStoreMessageOption.getState().ragMediaIds).toBeNull()
+  })
+
+  it("copies full media-library content as markdown", async () => {
+    vi.mocked(tldwClient.getMediaDetails).mockResolvedValue({
+      content: { text: "Full media body content" }
+    })
+    const { result } = createHook()
+
+    await act(async () => {
+      await result.current.copyResult(mediaResult(), "markdown")
+    })
+
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
+      expect.stringContaining("Full media body content")
+    )
+  })
+
+  it("keeps chunk-scoped media results unexpanded for ask, pin, and copy", async () => {
+    const { result, onAsk } = createHook()
+
+    act(() => {
+      result.current.handleAsk(chunkResult())
+    })
+
+    await waitFor(() => {
+      expect(onAsk).toHaveBeenCalledWith(
+        expect.stringContaining("Retrieved chunk only"),
+        { ignorePinnedResults: true }
+      )
+    })
+    expect(tldwClient.getMediaDetails).not.toHaveBeenCalled()
+
+    act(() => {
+      result.current.handlePin(chunkResult())
+    })
+
+    await waitFor(() => {
+      expect(useStoreMessageOption.getState().ragPinnedResults[0]?.snippet).toBe(
+        "Retrieved chunk only"
+      )
+    })
+    expect(tldwClient.getMediaDetails).not.toHaveBeenCalled()
+
+    await act(async () => {
+      await result.current.copyResult(chunkResult(), "markdown")
+    })
+
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
+      expect.stringContaining("Retrieved chunk only")
+    )
+    expect(tldwClient.getMediaDetails).not.toHaveBeenCalled()
   })
 })

--- a/apps/packages/ui/src/components/Knowledge/hooks/__tests__/useKnowledgeSearch.test.ts
+++ b/apps/packages/ui/src/components/Knowledge/hooks/__tests__/useKnowledgeSearch.test.ts
@@ -26,6 +26,8 @@ import { useStoreMessageOption } from "@/store/option"
 import {
   extractContentFromMediaDetail,
   extractMediaId,
+  PINNED_MEDIA_CONTEXT_CHAR_CAP,
+  PINNED_MEDIA_CONTEXT_TRUNCATION_NOTICE,
   normalizeMediaSearchResults,
   toPinnedResult,
   useKnowledgeSearch,
@@ -33,7 +35,8 @@ import {
   type RagResult
 } from "../useKnowledgeSearch"
 
-const maxPinnedSnippetChars = 20_000
+const maxPinnedSnippetChars = PINNED_MEDIA_CONTEXT_CHAR_CAP
+const pinnedTruncationNotice = PINNED_MEDIA_CONTEXT_TRUNCATION_NOTICE
 
 describe("useKnowledgeSearch helpers", () => {
   beforeEach(() => {
@@ -387,9 +390,52 @@ describe("useKnowledgeSearch action paths", () => {
         useStoreMessageOption.getState().ragPinnedResults[0]?.snippet
       expect(snippet).toBeDefined()
       expect(snippet?.length).toBeLessThanOrEqual(maxPinnedSnippetChars)
-      expect(snippet).toContain("Content truncated")
+      expect(snippet?.startsWith(pinnedTruncationNotice)).toBe(true)
       expect(snippet).not.toBe(fullText)
     })
+  })
+
+  it("stores under-cap media-library pinned content without a truncation notice", async () => {
+    const fullText = "Under cap full media body content"
+    vi.mocked(tldwClient.getMediaDetails).mockResolvedValue({
+      content: { text: fullText }
+    })
+    const { result } = createHook()
+
+    act(() => {
+      result.current.handlePin(mediaResult())
+    })
+
+    await waitFor(() => {
+      const snippet =
+        useStoreMessageOption.getState().ragPinnedResults[0]?.snippet
+      expect(snippet).toBe(fullText)
+      expect(snippet).not.toContain(pinnedTruncationNotice)
+    })
+  })
+
+  it("keeps long full media text for insert and copy even when pinned storage is capped", async () => {
+    const fullText = "B".repeat(maxPinnedSnippetChars + 200)
+    vi.mocked(tldwClient.getMediaDetails).mockResolvedValue({
+      content: { text: fullText }
+    })
+    const { result, onInsert } = createHook()
+
+    act(() => {
+      result.current.handleInsert(mediaResult())
+    })
+
+    await waitFor(() => {
+      expect(onInsert).toHaveBeenCalledWith(expect.stringContaining(fullText))
+    })
+
+    await act(async () => {
+      await result.current.copyResult(mediaResult(), "markdown")
+    })
+
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
+      expect.stringContaining(fullText)
+    )
   })
 
   it("copies full media-library content as markdown", async () => {

--- a/apps/packages/ui/src/components/Knowledge/hooks/__tests__/useKnowledgeSearch.test.ts
+++ b/apps/packages/ui/src/components/Knowledge/hooks/__tests__/useKnowledgeSearch.test.ts
@@ -1,14 +1,29 @@
-import { describe, expect, it } from "vitest"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+vi.mock("@/services/tldw/TldwApiClient", () => ({
+  tldwClient: {
+    initialize: vi.fn(),
+    getMediaDetails: vi.fn(),
+    searchMedia: vi.fn()
+  }
+}))
+
+import { tldwClient } from "@/services/tldw/TldwApiClient"
 
 import {
   extractContentFromMediaDetail,
   extractMediaId,
   normalizeMediaSearchResults,
   toPinnedResult,
+  withFullMediaTextIfAvailable,
   type RagResult
 } from "../useKnowledgeSearch"
 
 describe("useKnowledgeSearch helpers", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
   it("normalizes media search responses into knowledge result cards", () => {
     const payload = {
       items: [
@@ -74,5 +89,85 @@ describe("useKnowledgeSearch helpers", () => {
       "Latest version text"
     )
     expect(extractContentFromMediaDetail(dataDetail)).toBe("Data-level text")
+  })
+
+  it("marks normalized media-library rows and carries the marker into pinned results", () => {
+    const [result] = normalizeMediaSearchResults({
+      items: [
+        {
+          id: 42,
+          title: "Quarterly Report",
+          type: "pdf",
+          url: "/api/v1/media/42"
+        }
+      ]
+    })
+
+    expect(result.metadata?.media_id).toBe(42)
+    expect(result.metadata?.origin).toBe("media-library")
+    expect(toPinnedResult(result).contextOrigin).toBe("media-library")
+  })
+
+  it("fetches full text only for pinned media-library results", async () => {
+    vi.mocked(tldwClient.getMediaDetails).mockResolvedValue({
+      content: { text: "Full media body content" }
+    })
+
+    const pinned = await withFullMediaTextIfAvailable({
+      id: "media-42",
+      title: "Quarterly Report",
+      snippet: "Library item: Quarterly Report",
+      mediaId: 42,
+      contextOrigin: "media-library"
+    })
+
+    expect(pinned.snippet).toBe("Full media body content")
+    expect(tldwClient.getMediaDetails).toHaveBeenCalledWith(42, {
+      include_content: true,
+      include_versions: false,
+      include_version_content: false
+    })
+  })
+
+  it("does not fetch full media details for chunk-scoped pinned results", async () => {
+    const pinned = await withFullMediaTextIfAvailable({
+      id: "chunk-42",
+      title: "Chunk",
+      snippet: "Retrieved chunk only",
+      mediaId: 42
+    })
+
+    expect(pinned.snippet).toBe("Retrieved chunk only")
+    expect(tldwClient.getMediaDetails).not.toHaveBeenCalled()
+  })
+
+  it("keeps fallback snippet when full media detail fetch fails or returns empty content", async () => {
+    vi.mocked(tldwClient.getMediaDetails).mockRejectedValueOnce(
+      new Error("media detail unavailable")
+    )
+
+    const failedFetch = await withFullMediaTextIfAvailable({
+      id: "media-42",
+      title: "Quarterly Report",
+      snippet: "Library item: Quarterly Report",
+      mediaId: 42,
+      contextOrigin: "media-library"
+    })
+
+    expect(failedFetch.snippet).toBe("Library item: Quarterly Report")
+
+    vi.mocked(tldwClient.getMediaDetails).mockResolvedValue({
+      content: { text: "" }
+    })
+
+    const emptyContent = await withFullMediaTextIfAvailable({
+      id: "media-42",
+      title: "Quarterly Report",
+      snippet: "Library item: Quarterly Report",
+      mediaId: 42,
+      contextOrigin: "media-library"
+    })
+
+    expect(emptyContent.snippet).toBe("Library item: Quarterly Report")
   })
 })

--- a/apps/packages/ui/src/components/Knowledge/hooks/__tests__/useKnowledgeSearch.test.ts
+++ b/apps/packages/ui/src/components/Knowledge/hooks/__tests__/useKnowledgeSearch.test.ts
@@ -33,6 +33,8 @@ import {
   type RagResult
 } from "../useKnowledgeSearch"
 
+const maxPinnedSnippetChars = 20_000
+
 describe("useKnowledgeSearch helpers", () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -342,6 +344,52 @@ describe("useKnowledgeSearch action paths", () => {
     })
     expect(useStoreMessageOption.getState().ragPinnedResults).toEqual([])
     expect(useStoreMessageOption.getState().ragMediaIds).toBeNull()
+  })
+
+  it("does not re-add a pending media pin after unpinning that item", async () => {
+    const item = mediaResult()
+    const pinnedId = toPinnedResult(item).id
+    const resolveDetail = deferredMediaDetails("Full media body content")
+    const { result } = createHook()
+
+    act(() => {
+      result.current.handlePin(item)
+    })
+
+    await waitFor(() => {
+      expect(tldwClient.getMediaDetails).toHaveBeenCalledTimes(1)
+    })
+
+    await act(async () => {
+      result.current.handleUnpin(pinnedId)
+      resolveDetail()
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    expect(useStoreMessageOption.getState().ragPinnedResults).toEqual([])
+    expect(useStoreMessageOption.getState().ragMediaIds).toBeNull()
+  })
+
+  it("caps full media-library content stored for pinned context", async () => {
+    const fullText = "A".repeat(maxPinnedSnippetChars + 200)
+    vi.mocked(tldwClient.getMediaDetails).mockResolvedValue({
+      content: { text: fullText }
+    })
+    const { result } = createHook()
+
+    act(() => {
+      result.current.handlePin(mediaResult())
+    })
+
+    await waitFor(() => {
+      const snippet =
+        useStoreMessageOption.getState().ragPinnedResults[0]?.snippet
+      expect(snippet).toBeDefined()
+      expect(snippet?.length).toBeLessThanOrEqual(maxPinnedSnippetChars)
+      expect(snippet).toContain("Content truncated")
+      expect(snippet).not.toBe(fullText)
+    })
   })
 
   it("copies full media-library content as markdown", async () => {

--- a/apps/packages/ui/src/components/Knowledge/hooks/useFileSearch.ts
+++ b/apps/packages/ui/src/components/Knowledge/hooks/useFileSearch.ts
@@ -236,7 +236,10 @@ export function useFileSearch({
         return
       }
       try {
-        await navigator.clipboard.writeText(formatRagResult(pinned, format))
+        const resolvedPinned = await withFullMediaTextIfAvailable(pinned)
+        await navigator.clipboard.writeText(
+          formatRagResult(resolvedPinned, format)
+        )
       } catch (error) {
         console.error("Failed to copy result to clipboard:", error)
       }

--- a/apps/packages/ui/src/components/Knowledge/hooks/useKnowledgeSearch.ts
+++ b/apps/packages/ui/src/components/Knowledge/hooks/useKnowledgeSearch.ts
@@ -441,6 +441,7 @@ export function useKnowledgeSearch({
   )
 
   const pinnedResults = ragPinnedResults || []
+  const clearPinsGenerationRef = React.useRef(0)
   const collectPinnedMediaIds = React.useCallback((items: RagPinnedResult[]) => {
     const ids = items
       .map((item) => item.mediaId)
@@ -556,7 +557,10 @@ export function useKnowledgeSearch({
         return
       }
       try {
-        await navigator.clipboard.writeText(formatRagResult(pinned, format))
+        const resolvedPinned = await withFullMediaTextIfAvailable(pinned)
+        await navigator.clipboard.writeText(
+          formatRagResult(resolvedPinned, format)
+        )
       } catch (error) {
         console.error("Failed to copy knowledge result to clipboard:", error)
       }
@@ -577,10 +581,15 @@ export function useKnowledgeSearch({
 
   const handleAsk = React.useCallback(
     (item: RagResult) => {
-      const pinned = toPinnedResult(item)
-      // Note: Modal.confirm would need to be handled at the component level
-      // For now, we directly call onAsk
-      onAsk(formatRagResult(pinned, "markdown"), { ignorePinnedResults: true })
+      void (async () => {
+        const pinned = toPinnedResult(item)
+        const resolvedPinned = await withFullMediaTextIfAvailable(pinned)
+        // Note: Modal.confirm would need to be handled at the component level
+        // For now, we directly call onAsk
+        onAsk(formatRagResult(resolvedPinned, "markdown"), {
+          ignorePinnedResults: true
+        })
+      })()
     },
     [onAsk]
   )
@@ -593,12 +602,22 @@ export function useKnowledgeSearch({
 
   const handlePin = React.useCallback(
     (item: RagResult) => {
-      const pinned = toPinnedResult(item)
-      if (pinnedResults.some((result) => result.id === pinned.id)) return
-      const nextPinned = [...pinnedResults, pinned]
-      setRagPinnedResults(nextPinned)
-      const mediaIds = collectPinnedMediaIds(nextPinned)
-      setRagMediaIds(mediaIds.length > 0 ? mediaIds : null)
+      void (async () => {
+        const pinned = toPinnedResult(item)
+        if (pinnedResults.some((result) => result.id === pinned.id)) return
+        const clearPinsGeneration = clearPinsGenerationRef.current
+        const resolvedPinned = await withFullMediaTextIfAvailable(pinned)
+        if (clearPinsGeneration !== clearPinsGenerationRef.current) return
+        const currentPinned =
+          useStoreMessageOption.getState().ragPinnedResults || []
+        if (currentPinned.some((result) => result.id === resolvedPinned.id)) {
+          return
+        }
+        const nextPinned = [...currentPinned, resolvedPinned]
+        setRagPinnedResults(nextPinned)
+        const mediaIds = collectPinnedMediaIds(nextPinned)
+        setRagMediaIds(mediaIds.length > 0 ? mediaIds : null)
+      })()
     },
     [collectPinnedMediaIds, pinnedResults, setRagMediaIds, setRagPinnedResults]
   )
@@ -614,6 +633,7 @@ export function useKnowledgeSearch({
   )
 
   const handleClearPins = React.useCallback(() => {
+    clearPinsGenerationRef.current += 1
     setRagPinnedResults([])
     setRagMediaIds(null)
   }, [setRagMediaIds, setRagPinnedResults])

--- a/apps/packages/ui/src/components/Knowledge/hooks/useKnowledgeSearch.ts
+++ b/apps/packages/ui/src/components/Knowledge/hooks/useKnowledgeSearch.ts
@@ -180,6 +180,7 @@ export const normalizeMediaSearchResults = (payload: unknown): RagResult[] => {
       type,
       source: title,
       url: itemUrl,
+      origin: "media-library",
       created_at: getFirstString(rawItem, ["created_at", "date", "added_at"]) || undefined
     }
     if (mediaId !== null) {
@@ -253,6 +254,10 @@ export const toPinnedResult = (item: RagResult): RagPinnedResult => {
   const snippet = text.slice(0, 800)
   const title = getResultTitle(item)
   const url = getResultUrl(item)
+  const contextOrigin =
+    getMetadataValue(item.metadata, "origin") === "media-library"
+      ? "media-library"
+      : undefined
   return {
     id: buildPinnedResultId(item, text),
     title: title || undefined,
@@ -260,7 +265,8 @@ export const toPinnedResult = (item: RagResult): RagPinnedResult => {
     url: url || undefined,
     snippet,
     type: getResultType(item) || undefined,
-    mediaId: extractMediaId(item) ?? undefined
+    mediaId: extractMediaId(item) ?? undefined,
+    contextOrigin
   }
 }
 
@@ -345,7 +351,7 @@ const fetchFullMediaTextById = async (mediaId: number): Promise<string | null> =
 export const withFullMediaTextIfAvailable = async (
   pinned: RagPinnedResult
 ): Promise<RagPinnedResult> => {
-  if (!pinned.mediaId) return pinned
+  if (!pinned.mediaId || pinned.contextOrigin !== "media-library") return pinned
   const fullText = await fetchFullMediaTextById(pinned.mediaId)
   if (!fullText) return pinned
   return {

--- a/apps/packages/ui/src/components/Knowledge/hooks/useKnowledgeSearch.ts
+++ b/apps/packages/ui/src/components/Knowledge/hooks/useKnowledgeSearch.ts
@@ -348,6 +348,26 @@ const fetchFullMediaTextById = async (mediaId: number): Promise<string | null> =
   }
 }
 
+const MAX_PINNED_SNIPPET_CHARS = 20_000
+const PINNED_SNIPPET_TRUNCATION_NOTICE =
+  "\n\n[Content truncated for pinned context.]"
+
+const limitPinnedSnippetForContext = (
+  pinned: RagPinnedResult
+): RagPinnedResult => {
+  if (pinned.snippet.length <= MAX_PINNED_SNIPPET_CHARS) return pinned
+  const sliceLength = Math.max(
+    0,
+    MAX_PINNED_SNIPPET_CHARS - PINNED_SNIPPET_TRUNCATION_NOTICE.length
+  )
+  return {
+    ...pinned,
+    snippet:
+      pinned.snippet.slice(0, sliceLength) +
+      PINNED_SNIPPET_TRUNCATION_NOTICE
+  }
+}
+
 export const withFullMediaTextIfAvailable = async (
   pinned: RagPinnedResult
 ): Promise<RagPinnedResult> => {
@@ -441,7 +461,8 @@ export function useKnowledgeSearch({
   )
 
   const pinnedResults = ragPinnedResults || []
-  const clearPinsGenerationRef = React.useRef(0)
+  const nextPinTokenRef = React.useRef(0)
+  const pendingPinTokensRef = React.useRef(new Map<string, number>())
   const collectPinnedMediaIds = React.useCallback((items: RagPinnedResult[]) => {
     const ids = items
       .map((item) => item.mediaId)
@@ -604,36 +625,49 @@ export function useKnowledgeSearch({
     (item: RagResult) => {
       void (async () => {
         const pinned = toPinnedResult(item)
-        if (pinnedResults.some((result) => result.id === pinned.id)) return
-        const clearPinsGeneration = clearPinsGenerationRef.current
-        const resolvedPinned = await withFullMediaTextIfAvailable(pinned)
-        if (clearPinsGeneration !== clearPinsGenerationRef.current) return
+        const currentPinnedBefore =
+          useStoreMessageOption.getState().ragPinnedResults || []
+        if (currentPinnedBefore.some((result) => result.id === pinned.id)) {
+          return
+        }
+        const pinToken = nextPinTokenRef.current + 1
+        nextPinTokenRef.current = pinToken
+        pendingPinTokensRef.current.set(pinned.id, pinToken)
+        const resolvedPinned = limitPinnedSnippetForContext(
+          await withFullMediaTextIfAvailable(pinned)
+        )
+        if (pendingPinTokensRef.current.get(pinned.id) !== pinToken) return
         const currentPinned =
           useStoreMessageOption.getState().ragPinnedResults || []
         if (currentPinned.some((result) => result.id === resolvedPinned.id)) {
+          pendingPinTokensRef.current.delete(pinned.id)
           return
         }
         const nextPinned = [...currentPinned, resolvedPinned]
+        pendingPinTokensRef.current.delete(pinned.id)
         setRagPinnedResults(nextPinned)
         const mediaIds = collectPinnedMediaIds(nextPinned)
         setRagMediaIds(mediaIds.length > 0 ? mediaIds : null)
       })()
     },
-    [collectPinnedMediaIds, pinnedResults, setRagMediaIds, setRagPinnedResults]
+    [collectPinnedMediaIds, setRagMediaIds, setRagPinnedResults]
   )
 
   const handleUnpin = React.useCallback(
     (id: string) => {
-      const nextPinned = pinnedResults.filter((item) => item.id !== id)
+      pendingPinTokensRef.current.delete(id)
+      const currentPinned =
+        useStoreMessageOption.getState().ragPinnedResults || []
+      const nextPinned = currentPinned.filter((item) => item.id !== id)
       setRagPinnedResults(nextPinned)
       const mediaIds = collectPinnedMediaIds(nextPinned)
       setRagMediaIds(mediaIds.length > 0 ? mediaIds : null)
     },
-    [collectPinnedMediaIds, pinnedResults, setRagMediaIds, setRagPinnedResults]
+    [collectPinnedMediaIds, setRagMediaIds, setRagPinnedResults]
   )
 
   const handleClearPins = React.useCallback(() => {
-    clearPinsGenerationRef.current += 1
+    pendingPinTokensRef.current.clear()
     setRagPinnedResults([])
     setRagMediaIds(null)
   }, [setRagMediaIds, setRagPinnedResults])

--- a/apps/packages/ui/src/components/Knowledge/hooks/useKnowledgeSearch.ts
+++ b/apps/packages/ui/src/components/Knowledge/hooks/useKnowledgeSearch.ts
@@ -348,23 +348,22 @@ const fetchFullMediaTextById = async (mediaId: number): Promise<string | null> =
   }
 }
 
-const MAX_PINNED_SNIPPET_CHARS = 20_000
-const PINNED_SNIPPET_TRUNCATION_NOTICE =
-  "\n\n[Content truncated for pinned context.]"
+export const PINNED_MEDIA_CONTEXT_CHAR_CAP = 20_000
+export const PINNED_MEDIA_CONTEXT_TRUNCATION_NOTICE =
+  "[Truncated to 20,000 characters]"
 
 const limitPinnedSnippetForContext = (
   pinned: RagPinnedResult
 ): RagPinnedResult => {
-  if (pinned.snippet.length <= MAX_PINNED_SNIPPET_CHARS) return pinned
+  if (pinned.snippet.length <= PINNED_MEDIA_CONTEXT_CHAR_CAP) return pinned
+  const notice = `${PINNED_MEDIA_CONTEXT_TRUNCATION_NOTICE}\n\n`
   const sliceLength = Math.max(
     0,
-    MAX_PINNED_SNIPPET_CHARS - PINNED_SNIPPET_TRUNCATION_NOTICE.length
+    PINNED_MEDIA_CONTEXT_CHAR_CAP - notice.length
   )
   return {
     ...pinned,
-    snippet:
-      pinned.snippet.slice(0, sliceLength) +
-      PINNED_SNIPPET_TRUNCATION_NOTICE
+    snippet: notice + pinned.snippet.slice(0, sliceLength)
   }
 }
 

--- a/apps/packages/ui/src/components/Option/Playground/__tests__/PlaygroundForm.pinned-fallback.test.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/__tests__/PlaygroundForm.pinned-fallback.test.tsx
@@ -414,7 +414,13 @@ vi.mock("@/hooks/useMcpTools", () => ({
     healthState: "ready",
     discoveredTools: [],
     chatTools: [],
-    toolCounts: { enabled: 0, available: 0 },
+    toolCounts: {
+      discovered: 0,
+      executable: 0,
+      disabled: 0,
+      colliding: 0,
+      chatEnabled: 0
+    },
     tools: [],
     toolsLoading: false,
     catalogs: [],

--- a/apps/packages/ui/src/utils/rag-format.ts
+++ b/apps/packages/ui/src/utils/rag-format.ts
@@ -6,6 +6,7 @@ export type RagPinnedResult = {
   snippet: string
   type?: string
   mediaId?: number
+  contextOrigin?: "media-library"
 }
 
 export type RagCopyFormat = "markdown" | "text"

--- a/backlog/tasks/task-527 - Design-chat-media-context-full-content-insertion-fix.md
+++ b/backlog/tasks/task-527 - Design-chat-media-context-full-content-insertion-fix.md
@@ -1,0 +1,51 @@
+---
+id: TASK-527
+title: Design chat media context full-content insertion fix
+status: In Progress
+labels:
+- chat
+- media
+- webui
+- spec
+priority: medium
+documentation:
+- Docs/superpowers/specs/2026-06-06-chat-media-context-full-content-design.md
+modified_files:
+- Docs/superpowers/specs/2026-06-06-chat-media-context-full-content-design.md
+- apps/packages/ui/src/components/Knowledge/hooks/useKnowledgeSearch.ts
+- apps/packages/ui/src/components/Knowledge/hooks/useFileSearch.ts
+- apps/packages/ui/src/components/Knowledge/KnowledgePanel.tsx
+- apps/packages/ui/src/components/Option/Playground/hooks/usePlaygroundSubmit.ts
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Investigate and specify a fix for /chat media context actions that can insert or pin title-only media search results instead of full media content.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-527 - Design-chat-media-context-full-content-insertion-fix.md
+++ b/backlog/tasks/task-527 - Design-chat-media-context-full-content-insertion-fix.md
@@ -10,8 +10,11 @@ labels:
 priority: medium
 documentation:
 - Docs/superpowers/specs/2026-06-06-chat-media-context-full-content-design.md
+- Docs/superpowers/plans/2026-06-06-chat-media-context-full-content-implementation-plan.md
 modified_files:
 - Docs/superpowers/specs/2026-06-06-chat-media-context-full-content-design.md
+- Docs/superpowers/plans/2026-06-06-chat-media-context-full-content-implementation-plan.md
+- apps/packages/ui/src/utils/rag-format.ts
 - apps/packages/ui/src/components/Knowledge/hooks/useKnowledgeSearch.ts
 - apps/packages/ui/src/components/Knowledge/hooks/useFileSearch.ts
 - apps/packages/ui/src/components/Knowledge/KnowledgePanel.tsx

--- a/backlog/tasks/task-527 - Design-chat-media-context-full-content-insertion-fix.md
+++ b/backlog/tasks/task-527 - Design-chat-media-context-full-content-insertion-fix.md
@@ -34,13 +34,13 @@ Investigate and specify a fix for /chat media context actions that can insert or
 ## Implementation Notes
 
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
-Implemented the frontend media-context fix. Media-library search results are origin-marked, pinned conversion preserves only contextOrigin, and full media content is fetched only for pinned results with mediaId plus contextOrigin === "media-library". Knowledge Search Insert/Ask/Pin/copy, File Search Attach/copy, and KnowledgePanel direct/confirmed/preview Ask now resolve full media text before formatting. Pin handling re-reads current pinned state after async resolution and guards pending media pins against Clear All races.
+Implemented the frontend media-context fix. Media-library search results are origin-marked, pinned conversion preserves only contextOrigin, and full media content is fetched only for pinned results with mediaId plus contextOrigin === "media-library". Knowledge Search Insert/Ask/Pin/copy, File Search Attach/copy, and KnowledgePanel direct/confirmed/preview Ask now resolve full media text before formatting. Pin handling re-reads current pinned state after async resolution and guards pending media pins against Clear All races. Test scaffolding was also updated so the targeted component suites can run in a hydrated dependency environment.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Fixed /chat media-library context actions so media items use full content instead of title-only fallback snippets when full media detail content is available. Verified submit/raw-preview paths already consume ragPinnedResults through formatPinnedResults when file retrieval is off, so no submit-path code change was needed. Verification: Vitest Knowledge/File hook tests passed (19 tests); non-blocked Stage 3 subset passed (21 tests including raw preview). Known blocker: component suites importing antd fail in this clean worktree before assertions because the tracked apps/packages/ui/node_modules/antd symlink points to a missing .bun package path. Bandit is not applicable because the implementation touched TypeScript/TSX/docs only.
+Fixed /chat media-library context actions so media items use full content instead of title-only fallback snippets when full media detail content is available. Verified submit/raw-preview paths already consume ragPinnedResults through formatPinnedResults when file retrieval is off, so no submit-path code change was needed. Verification: targeted Vitest suite passed after temporarily relinking the tracked antd symlink to the installed local package path, then restoring it before commit: Knowledge hooks, File hooks, KnowledgePanel QA preview, Playground pinned fallback, and raw preview MCP tools; 5 test files, 26 tests. The branch leaves the tracked antd symlink unchanged. Bandit is not applicable because the implementation touched TypeScript/TSX/docs only.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-527 - Design-chat-media-context-full-content-insertion-fix.md
+++ b/backlog/tasks/task-527 - Design-chat-media-context-full-content-insertion-fix.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-527
 title: Design chat media context full-content insertion fix
-status: In Progress
+status: Done
 labels:
 - chat
 - media
@@ -34,21 +34,21 @@ Investigate and specify a fix for /chat media context actions that can insert or
 ## Implementation Notes
 
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
-
+Implemented the frontend media-context fix. Media-library search results are origin-marked, pinned conversion preserves only contextOrigin, and full media content is fetched only for pinned results with mediaId plus contextOrigin === "media-library". Knowledge Search Insert/Ask/Pin/copy, File Search Attach/copy, and KnowledgePanel direct/confirmed/preview Ask now resolve full media text before formatting. Pin handling re-reads current pinned state after async resolution and guards pending media pins against Clear All races.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-
+Fixed /chat media-library context actions so media items use full content instead of title-only fallback snippets when full media detail content is available. Verified submit/raw-preview paths already consume ragPinnedResults through formatPinnedResults when file retrieval is off, so no submit-path code change was needed. Verification: Vitest Knowledge/File hook tests passed (19 tests); non-blocked Stage 3 subset passed (21 tests including raw preview). Known blocker: component suites importing antd fail in this clean worktree before assertions because the tracked apps/packages/ui/node_modules/antd symlink points to a missing .bun package path. Bandit is not applicable because the implementation touched TypeScript/TSX/docs only.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->

--- a/backlog/tasks/task-528 - Address-PR-2279-review-comments-after-dev-rebase.md
+++ b/backlog/tasks/task-528 - Address-PR-2279-review-comments-after-dev-rebase.md
@@ -29,9 +29,9 @@ Rebase PR #2279 onto latest origin/dev and address actionable GitHub review comm
 - Verified the Gemini import comments do not reproduce after rebase: `useFileSearch.ts` imports `withFullMediaTextIfAvailable` directly from `./useKnowledgeSearch`, and `KnowledgePanel.tsx` imports it through the `./hooks` barrel.
 - Verified the calendar review comments refer to files from the previous stacked PR diff. Those paths are not present in the rebased `origin/dev..HEAD` diff and should be treated as obsolete after force-pushing and changing the PR base to `dev`.
 - Addressed active Qodo chat-media comments by adding per-pin in-flight cancellation so `handleUnpin` cancels pending full-media resolution for that item.
-- Added a 20,000-character cap for snippets stored in pinned context while leaving direct insert/ask/copy resolution paths able to use full media text.
-- Added regression coverage for pending unpin cancellation and pinned-context truncation.
-- Verification: `bunx vitest run src/components/Knowledge/hooks/__tests__/useKnowledgeSearch.test.ts src/components/Knowledge/hooks/__tests__/useFileSearch.test.ts src/components/Knowledge/__tests__/KnowledgePanelQAPreview.test.tsx src/components/Option/Playground/__tests__/PlaygroundForm.pinned-fallback.test.tsx` from `apps/packages/ui` passed with 27 tests.
+- Added exported 20,000-character cap/notice constants for snippets stored in pinned context while leaving direct insert/ask/copy resolution paths able to use full media text.
+- Added regression coverage for pending unpin cancellation, pinned-context truncation, under-cap pinned content without notice, and full insert/copy bypassing the pinned cap.
+- Verification: `bunx vitest run src/components/Knowledge/hooks/__tests__/useKnowledgeSearch.test.ts src/components/Knowledge/hooks/__tests__/useFileSearch.test.ts src/components/Knowledge/__tests__/KnowledgePanelQAPreview.test.tsx src/components/Option/Playground/__tests__/PlaygroundForm.pinned-fallback.test.tsx` from `apps/packages/ui` passed with 29 tests.
 - Temporarily repointed the broken local `apps/packages/ui/node_modules/antd` symlink to an installed package hash for frontend test execution, then restored the tracked symlink target before finishing.
 - Bandit was not run for this follow-up because the final `origin/dev..HEAD` diff touches frontend/docs/task files only and no Python code.
 
@@ -40,7 +40,7 @@ Rebase PR #2279 onto latest origin/dev and address actionable GitHub review comm
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-PR #2279 was rebased onto latest `origin/dev` as a focused chat-media context branch. The review follow-up resolved the test mock shape conflict introduced by newer MCP tool count fields on `dev`, added per-pin cancellation for in-flight full-media pin resolution, and capped stored pinned-context snippets at 20,000 characters. Review comments about missing imports were verified as stale/incorrect on the rebased source, and calendar/notes comments are obsolete because changing the PR base/head removed the unrelated stacked diff.
+PR #2279 was rebased onto latest `origin/dev` as a focused chat-media context branch. The review follow-up resolved the test mock shape conflict introduced by newer MCP tool count fields on `dev`, added per-pin cancellation for in-flight full-media pin resolution, and capped stored pinned-context snippets at 20,000 characters with a leading truncation notice. Review comments about missing imports were verified as stale/incorrect on the rebased source, and calendar/notes comments are obsolete because changing the PR base/head removed the unrelated stacked diff.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-528 - Address-PR-2279-review-comments-after-dev-rebase.md
+++ b/backlog/tasks/task-528 - Address-PR-2279-review-comments-after-dev-rebase.md
@@ -1,12 +1,11 @@
 ---
 id: TASK-528
 title: Address PR 2279 review comments after dev rebase
-status: In Progress
+status: Done
 labels:
 - pr-review
 - rebase
 - webui
-- calendar
 priority: medium
 documentation:
 - https://github.com/rmusser01/tldw_server/pull/2279
@@ -25,21 +24,27 @@ Rebase PR #2279 onto latest origin/dev and address actionable GitHub review comm
 ## Implementation Notes
 
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+- Rebased `codex/chat-media-context-full-content` onto latest `origin/dev` using a focused `--onto` rebase so PR #2279 is scoped to the chat media context fix rather than the older stacked calendar/notes branch.
+- Resolved the only rebase conflict in `PlaygroundForm.pinned-fallback.test.tsx` by updating the mock `toolCounts` shape to the current `ChatToolFilterCounts` contract on `dev`.
+- Verified the Gemini import comments do not reproduce after rebase: `useFileSearch.ts` imports `withFullMediaTextIfAvailable` directly from `./useKnowledgeSearch`, and `KnowledgePanel.tsx` imports it through the `./hooks` barrel.
+- Verified the calendar review comments refer to files from the previous stacked PR diff. Those paths are not present in the rebased `origin/dev..HEAD` diff and should be treated as obsolete after force-pushing and changing the PR base to `dev`.
+- Temporarily repointed the broken local `apps/packages/ui/node_modules/antd` symlink to an installed package hash for frontend test execution, then restored the tracked symlink target before finishing.
+- Bandit was not run for this follow-up because the final `origin/dev..HEAD` diff touches frontend/docs/task files only and no Python code.
 
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-
+PR #2279 was rebased onto latest `origin/dev` as a focused chat-media context branch. The remaining actionable local fix was the test mock shape conflict introduced by newer MCP tool count fields on `dev`. Review comments about missing imports were verified as stale/incorrect on the rebased source, and calendar comments are obsolete once the PR base/head update removes the unrelated stacked calendar diff.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->

--- a/backlog/tasks/task-528 - Address-PR-2279-review-comments-after-dev-rebase.md
+++ b/backlog/tasks/task-528 - Address-PR-2279-review-comments-after-dev-rebase.md
@@ -28,6 +28,10 @@ Rebase PR #2279 onto latest origin/dev and address actionable GitHub review comm
 - Resolved the only rebase conflict in `PlaygroundForm.pinned-fallback.test.tsx` by updating the mock `toolCounts` shape to the current `ChatToolFilterCounts` contract on `dev`.
 - Verified the Gemini import comments do not reproduce after rebase: `useFileSearch.ts` imports `withFullMediaTextIfAvailable` directly from `./useKnowledgeSearch`, and `KnowledgePanel.tsx` imports it through the `./hooks` barrel.
 - Verified the calendar review comments refer to files from the previous stacked PR diff. Those paths are not present in the rebased `origin/dev..HEAD` diff and should be treated as obsolete after force-pushing and changing the PR base to `dev`.
+- Addressed active Qodo chat-media comments by adding per-pin in-flight cancellation so `handleUnpin` cancels pending full-media resolution for that item.
+- Added a 20,000-character cap for snippets stored in pinned context while leaving direct insert/ask/copy resolution paths able to use full media text.
+- Added regression coverage for pending unpin cancellation and pinned-context truncation.
+- Verification: `bunx vitest run src/components/Knowledge/hooks/__tests__/useKnowledgeSearch.test.ts src/components/Knowledge/hooks/__tests__/useFileSearch.test.ts src/components/Knowledge/__tests__/KnowledgePanelQAPreview.test.tsx src/components/Option/Playground/__tests__/PlaygroundForm.pinned-fallback.test.tsx` from `apps/packages/ui` passed with 27 tests.
 - Temporarily repointed the broken local `apps/packages/ui/node_modules/antd` symlink to an installed package hash for frontend test execution, then restored the tracked symlink target before finishing.
 - Bandit was not run for this follow-up because the final `origin/dev..HEAD` diff touches frontend/docs/task files only and no Python code.
 
@@ -36,7 +40,7 @@ Rebase PR #2279 onto latest origin/dev and address actionable GitHub review comm
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-PR #2279 was rebased onto latest `origin/dev` as a focused chat-media context branch. The remaining actionable local fix was the test mock shape conflict introduced by newer MCP tool count fields on `dev`. Review comments about missing imports were verified as stale/incorrect on the rebased source, and calendar comments are obsolete once the PR base/head update removes the unrelated stacked calendar diff.
+PR #2279 was rebased onto latest `origin/dev` as a focused chat-media context branch. The review follow-up resolved the test mock shape conflict introduced by newer MCP tool count fields on `dev`, added per-pin cancellation for in-flight full-media pin resolution, and capped stored pinned-context snippets at 20,000 characters. Review comments about missing imports were verified as stale/incorrect on the rebased source, and calendar/notes comments are obsolete because changing the PR base/head removed the unrelated stacked diff.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-528 - Address-PR-2279-review-comments-after-dev-rebase.md
+++ b/backlog/tasks/task-528 - Address-PR-2279-review-comments-after-dev-rebase.md
@@ -1,0 +1,45 @@
+---
+id: TASK-528
+title: Address PR 2279 review comments after dev rebase
+status: In Progress
+labels:
+- pr-review
+- rebase
+- webui
+- calendar
+priority: medium
+documentation:
+- https://github.com/rmusser01/tldw_server/pull/2279
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Rebase PR #2279 onto latest origin/dev and address actionable GitHub review comments across the stacked PR branch.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## Summary

- Fixes `/chat` media-library context actions so media items resolve full detail content before Insert, Ask, Pin, copy, and preview Ask paths.
- Adds a narrow `contextOrigin: "media-library"` marker so full-content expansion applies only to media-library rows, preserving chunk-scoped RAG/QA results.
- Hardens async pin behavior against overlapping pins and Clear All races, and updates targeted regression coverage.

## Change summary

AI-assisted PR. Before this is merge-ready, a human maintainer must replace this section with a human-written Change summary explaining what changed and why these implementation choices were made.

## Test Plan

- [x] `./node_modules/.bin/vitest run src/components/Knowledge/hooks/__tests__/useKnowledgeSearch.test.ts src/components/Knowledge/hooks/__tests__/useFileSearch.test.ts src/components/Option/Playground/__tests__/usePlaygroundRawPreview.mcp-tools.test.tsx`
- [x] Temporarily relinked local `apps/packages/ui/node_modules/antd` to the installed package path, ran `./node_modules/.bin/vitest run src/components/Knowledge/hooks/__tests__/useKnowledgeSearch.test.ts src/components/Knowledge/hooks/__tests__/useFileSearch.test.ts src/components/Knowledge/__tests__/KnowledgePanelQAPreview.test.tsx src/components/Option/Playground/__tests__/PlaygroundForm.pinned-fallback.test.tsx src/components/Option/Playground/__tests__/usePlaygroundRawPreview.mcp-tools.test.tsx`, then restored the tracked symlink.
- [x] `git diff --check`

## Notes

- `TASK-527` is marked Done with verification notes.
- Bandit is not applicable: touched implementation files are TypeScript/TSX/docs only.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes /chat media-library actions so they insert and ask with full media content instead of title-only snippets. Adds a narrow `contextOrigin: "media-library"` guard so RAG chunks aren’t expanded.

- **Bug Fixes**
  - Resolve full media text before Insert, Ask (including confirmation and Preview Ask), Pin/Save, and Copy in Knowledge and File Search.
  - Gate expansion with `contextOrigin: "media-library"` on normalized and pinned results; only media-library items with `mediaId` expand.
  - Harden pinning: de-duplicate pins, cancel in-flight resolution on Unpin/Clear All, and cap stored pinned snippets at 20k with a truncation notice; direct Insert/Ask/Copy still use full text.
  - Expand tests for origin propagation, guarded fetching, all action paths, and truncation/cancellation; update Playground mocks after rebase.

<sup>Written for commit b7783e292b50b6799014718fa51d7f318d9e6c40. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2279?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

