### PR TITLE
Stabilize Notes first-time UX Vitest flow

### DIFF
--- a/apps/packages/ui/src/components/Notes/__tests__/NotesManagerPage.stage48.first-time-ux.test.tsx
+++ b/apps/packages/ui/src/components/Notes/__tests__/NotesManagerPage.stage48.first-time-ux.test.tsx
@@ -181,9 +181,10 @@ describe("NotesManagerPage stage 48 first-time notes UX", () => {
     expect(screen.getByTestId("notes-editor-empty-state")).toBeInTheDocument()
 
     const listRegion = screen.getByTestId("notes-list-region")
+    await within(listRegion).findByText("No notes yet", {}, { timeout: 3000 })
     const createButton = await within(listRegion).findByRole("button", {
       name: "Create note"
-    })
+    }, { timeout: 3000 })
     fireEvent.click(createButton)
 
     await waitFor(() => {

--- a/backlog/tasks/task-514.7 - Investigate-broad-Notes-Vitest-ai-title-and-backlink-label-failures.md
+++ b/backlog/tasks/task-514.7 - Investigate-broad-Notes-Vitest-ai-title-and-backlink-label-failures.md
@@ -1,11 +1,18 @@
 ---
 id: TASK-514.7
 title: Investigate broad Notes Vitest ai-title and backlink-label failures
-status: To Do
-parent_task_id: TASK-514
+status: Done
+assignee: []
+created_date: ''
+updated_date: '2026-06-07 05:28'
+labels: []
+dependencies: []
 documentation:
-- apps/packages/ui/src/components/Notes/__tests__/NotesManagerPage.stage10.ai-title.test.tsx
-- apps/packages/ui/src/components/Notes/__tests__/NotesManagerPage.stage26.backlink-labels.test.tsx
+  - >-
+    apps/packages/ui/src/components/Notes/__tests__/NotesManagerPage.stage10.ai-title.test.tsx
+  - >-
+    apps/packages/ui/src/components/Notes/__tests__/NotesManagerPage.stage26.backlink-labels.test.tsx
+parent_task_id: TASK-514
 ---
 
 ## Description
@@ -16,29 +23,32 @@ Follow up on optional broad Notes/NotesDock Vitest failures found during TASK-51
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Determine whether the ai-title strategy dropdown failure is product code, test harness, or AntD interaction drift.
-- [ ] #2 Determine whether the backlink label failures are product code, test harness, or fixture drift.
-- [ ] #3 Restore the broad Notes/NotesDock Vitest sweep or document any intentional test updates with focused verification.
+- [x] #1 Determine whether the ai-title strategy dropdown failure is product code, test harness, or AntD interaction drift.
+- [x] #2 Determine whether the backlink label failures are product code, test harness, or fixture drift.
+- [x] #3 Restore the broad Notes/NotesDock Vitest sweep or document any intentional test updates with focused verification.
 <!-- AC:END -->
 
 ## Implementation Notes
 
-<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
-
-<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+<!-- SECTION:NOTES:BEGIN -->
+Root cause investigation:
+- The originally recorded ai-title strategy dropdown and backlink-label failures no longer reproduce on current dev; both files pass in isolation and in the broad Notes/NotesDock sweep.
+- The current broad sweep exposed one remaining failure in NotesManagerPage.stage48.first-time-ux.test.tsx. The test queried the list empty-state Create note CTA before the async first-time empty-state render had settled; the list region still only contained toolbar actions such as New note.
+- Fixed the Stage 48 test harness to wait for the No notes yet empty-state title before querying and clicking the Create note CTA.
+<!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-
+Verified the original TASK-514.7 ai-title and backlink-label failures no longer reproduce on current dev. Fixed the remaining broad Notes/NotesDock sweep failure by stabilizing the Stage 48 first-time UX test around the async list empty-state render. Focused and broad Vitest verification now pass.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->


### PR DESCRIPTION
## Summary
- Stabilizes the Stage 48 first-time Notes UX Vitest by waiting for the async empty-state render before querying the Create note CTA.
- Records TASK-514.7 investigation results: the originally reported ai-title and backlink-label failures no longer reproduce on latest dev; the remaining broad Notes/NotesDock blocker was the Stage 48 test harness race.

## Test Plan
- bunx vitest run src/components/Notes/__tests__/NotesManagerPage.stage10.ai-title.test.tsx src/components/Notes/__tests__/NotesManagerPage.stage26.backlink-labels.test.tsx src/components/Notes/__tests__/NotesManagerPage.stage48.first-time-ux.test.tsx --reporter=verbose
- bunx vitest run src/components/Notes src/components/Common/NotesDock --reporter=verbose

## Merge Gate
- Draft PR: human requester must add the required human-written Change summary before this is merge-ready.

Task: TASK-514.7

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes the Stage 48 first-time Notes UX Vitest by waiting for the async empty-state before clicking Create note. Unblocks the Notes/NotesDock test sweep and confirms TASK-514.7 ai-title/backlink-label issues no longer reproduce on `dev`.

- **Bug Fixes**
  - Wait for "No notes yet" inside the list region, then query the "Create note" button with a 3s timeout in `NotesManagerPage.stage48.first-time-ux.test.tsx`.

<sup>Written for commit df98ff20d70dd079786b74f39c9ee2950e99d42d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2283?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

