### PR TITLE
Cover Mermaid artifact panel rendering

### DIFF
--- a/apps/packages/ui/src/components/Sidepanel/Chat/__tests__/ArtifactsPanel.mermaid.test.tsx
+++ b/apps/packages/ui/src/components/Sidepanel/Chat/__tests__/ArtifactsPanel.mermaid.test.tsx
@@ -120,28 +120,30 @@ describe("ArtifactsPanel Mermaid artifacts", () => {
     const scrollLatest = vi.fn()
     window.addEventListener("tldw:focus-artifacts-trigger", focusArtifactsTrigger)
     window.addEventListener("tldw:scroll-to-latest", scrollLatest)
-    useArtifactsStore.getState().openArtifact(diagramArtifact)
+    try {
+      useArtifactsStore.getState().openArtifact(diagramArtifact)
 
-    render(<ArtifactsPanel />)
+      render(<ArtifactsPanel />)
 
-    fireEvent.click(screen.getByTestId("artifacts-jump-source"))
+      fireEvent.click(screen.getByTestId("artifacts-jump-source"))
 
-    expect(origin.scrollIntoView).toHaveBeenCalledWith({
-      behavior: "smooth",
-      block: "center"
-    })
-    expect(useArtifactsStore.getState().isOpen).toBe(false)
-    expect(scrollLatest).not.toHaveBeenCalled()
+      expect(origin.scrollIntoView).toHaveBeenCalledWith({
+        behavior: "smooth",
+        block: "center"
+      })
+      expect(useArtifactsStore.getState().isOpen).toBe(false)
+      expect(scrollLatest).not.toHaveBeenCalled()
 
-    act(() => {
-      vi.runOnlyPendingTimers()
-    })
-    expect(focusArtifactsTrigger).toHaveBeenCalledTimes(1)
-
-    window.removeEventListener(
-      "tldw:focus-artifacts-trigger",
-      focusArtifactsTrigger
-    )
-    window.removeEventListener("tldw:scroll-to-latest", scrollLatest)
+      act(() => {
+        vi.runOnlyPendingTimers()
+      })
+      expect(focusArtifactsTrigger).toHaveBeenCalledTimes(1)
+    } finally {
+      window.removeEventListener(
+        "tldw:focus-artifacts-trigger",
+        focusArtifactsTrigger
+      )
+      window.removeEventListener("tldw:scroll-to-latest", scrollLatest)
+    }
   })
 })

--- a/apps/packages/ui/src/components/Sidepanel/Chat/__tests__/ArtifactsPanel.mermaid.test.tsx
+++ b/apps/packages/ui/src/components/Sidepanel/Chat/__tests__/ArtifactsPanel.mermaid.test.tsx
@@ -1,0 +1,147 @@
+// @vitest-environment jsdom
+import React from "react"
+import { act, fireEvent, render, screen } from "@testing-library/react"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { ArtifactsPanel } from "../ArtifactsPanel"
+import { useArtifactsStore, type ArtifactItem } from "@/store/artifacts"
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (_key: string, fallback?: string) => fallback || _key
+  })
+}))
+
+vi.mock("@plasmohq/storage/hook", () => ({
+  useStorage: (_key: string, defaultValue: unknown) => [defaultValue, vi.fn()]
+}))
+
+vi.mock("antd", () => ({
+  Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  message: {
+    error: vi.fn()
+  }
+}))
+
+vi.mock("wxt/browser", () => ({
+  browser: {
+    runtime: {
+      getURL: vi.fn((path: string) => path)
+    },
+    tabs: {
+      create: vi.fn()
+    }
+  }
+}))
+
+vi.mock("@/store/option", () => ({
+  useStoreMessageOption: (selector: (state: any) => unknown) =>
+    selector({
+      serverChatId: "chat-1",
+      serverChatTitle: "Chat title"
+    })
+}))
+
+vi.mock("@/components/Common/Mermaid", () => ({
+  Mermaid: ({
+    code,
+    className
+  }: {
+    code: string
+    className?: string
+  }) => (
+    <div
+      aria-label="Mock artifact Mermaid diagram"
+      className={className}
+      role="img"
+    >
+      {code}
+    </div>
+  ),
+  default: ({ code }: { code: string }) => (
+    <div aria-label="Mock artifact Mermaid diagram" role="img">
+      {code}
+    </div>
+  )
+}))
+
+const diagramArtifact: ArtifactItem = {
+  id: "mermaid-assistant-message-1-segment-0-block-0-abc123",
+  title: "Mermaid diagram 1",
+  content: "graph TD\n  A-->B",
+  kind: "diagram",
+  language: "mermaid",
+  lineCount: 2
+}
+
+const resetArtifactsStore = () => {
+  useArtifactsStore.setState((state) => ({
+    ...state,
+    active: null,
+    isOpen: false,
+    isPinned: false,
+    history: [],
+    unreadCount: 0
+  }))
+}
+
+describe("ArtifactsPanel Mermaid artifacts", () => {
+  beforeEach(() => {
+    resetArtifactsStore()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+    document.body.innerHTML = ""
+    resetArtifactsStore()
+  })
+
+  it("renders diagram artifacts with the shared Mermaid renderer", () => {
+    useArtifactsStore.getState().openArtifact(diagramArtifact)
+
+    render(<ArtifactsPanel />)
+
+    expect(screen.getByTestId("artifacts-panel")).toBeInTheDocument()
+    expect(screen.getByText("Mermaid diagram 1")).toBeInTheDocument()
+    expect(
+      screen.getByRole("img", { name: "Mock artifact Mermaid diagram" })
+    ).toHaveTextContent("graph TD A-->B")
+    expect(screen.getByRole("button", { name: /copy/i })).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: /download/i })).toBeInTheDocument()
+  })
+
+  it("jumps to the matching Mermaid artifact origin", () => {
+    vi.useFakeTimers()
+    const origin = document.createElement("div")
+    origin.id = `artifact-origin-${diagramArtifact.id}`
+    origin.scrollIntoView = vi.fn()
+    document.body.appendChild(origin)
+    const focusArtifactsTrigger = vi.fn()
+    const scrollLatest = vi.fn()
+    window.addEventListener("tldw:focus-artifacts-trigger", focusArtifactsTrigger)
+    window.addEventListener("tldw:scroll-to-latest", scrollLatest)
+    useArtifactsStore.getState().openArtifact(diagramArtifact)
+
+    render(<ArtifactsPanel />)
+
+    fireEvent.click(screen.getByTestId("artifacts-jump-source"))
+
+    expect(origin.scrollIntoView).toHaveBeenCalledWith({
+      behavior: "smooth",
+      block: "center"
+    })
+    expect(useArtifactsStore.getState().isOpen).toBe(false)
+    expect(scrollLatest).not.toHaveBeenCalled()
+
+    act(() => {
+      vi.runOnlyPendingTimers()
+    })
+    expect(focusArtifactsTrigger).toHaveBeenCalledTimes(1)
+
+    window.removeEventListener(
+      "tldw:focus-artifacts-trigger",
+      focusArtifactsTrigger
+    )
+    window.removeEventListener("tldw:scroll-to-latest", scrollLatest)
+  })
+})

--- a/backlog/tasks/task-2275 - Add-Mermaid-artifact-panel-rendering-coverage.md
+++ b/backlog/tasks/task-2275 - Add-Mermaid-artifact-panel-rendering-coverage.md
@@ -1,0 +1,54 @@
+---
+id: TASK-2275
+title: Add Mermaid artifact panel rendering coverage
+status: Done
+assignee: []
+created_date: ''
+updated_date: '2026-06-07 05:37'
+labels:
+  - webui
+  - chat
+  - mermaid
+  - tests
+dependencies: []
+references:
+  - Docs/superpowers/specs/2026-06-06-chat-mermaid-card-artifact-rail-design.md
+  - 'https://github.com/rmusser01/tldw_server/pull/2276'
+modified_files:
+  - apps/packages/ui/src/components/Sidepanel/Chat/__tests__/ArtifactsPanel.mermaid.test.tsx
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Cover the remaining Mermaid chat card follow-up from the design spec: verify ArtifactsPanel renders diagram artifacts and jump-to-source targets Mermaid origins correctly without changing runtime behavior unless tests expose a defect.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 ArtifactsPanel has rendered coverage for diagram artifacts using the shared Mermaid renderer.
+- [x] #2 ArtifactsPanel jump-to-source coverage verifies Mermaid artifact origins are targeted before fallback scrolling.
+- [x] #3 Related Mermaid artifact tests and UI TypeScript verification pass.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Added a focused jsdom component test for ArtifactsPanel diagram artifacts. The test opens a kind: diagram artifact through the real artifact store, verifies the shared Mermaid renderer receives the Mermaid source, and verifies Jump to source scrolls the matching artifact-origin element, closes the panel, and does not dispatch the fallback latest-message event.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Added ArtifactsPanel Mermaid coverage for the remaining chat-card design-spec gap. Verification: new ArtifactsPanel Mermaid test passed (2 tests); focused Mermaid/artifact panel regression set passed (4 files, 27 tests); UI TypeScript check passed; git diff --check passed. Bandit is not applicable because only frontend test and Backlog task files were touched.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-2276 - Address-PR-2284-Mermaid-artifact-panel-review-comments.md
+++ b/backlog/tasks/task-2276 - Address-PR-2284-Mermaid-artifact-panel-review-comments.md
@@ -1,0 +1,61 @@
+---
+id: TASK-2276
+title: Address PR 2284 Mermaid artifact panel review comments
+status: Done
+assignee:
+- '@codex'
+labels:
+- frontend
+- tests
+- review
+priority: medium
+references:
+- https://github.com/rmusser01/tldw_server/pull/2284
+- https://github.com/rmusser01/tldw_server/pull/2284#discussion_r3368815174
+modified_files:
+- apps/packages/ui/src/components/Sidepanel/Chat/__tests__/ArtifactsPanel.mermaid.test.tsx
+- backlog/tasks/task-2276 - Address-PR-2284-Mermaid-artifact-panel-review-comments.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Address review feedback on PR #2284 for Mermaid artifact panel rendering coverage, specifically ensuring global window event listeners in the jump-to-source test are always cleaned up.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Rebase PR branch onto latest origin/dev.
+- [x] #2 Wrap event listener cleanup in the Mermaid artifact jump-to-source test with try/finally.
+- [x] #3 Resolve or respond to the GitHub review thread.
+- [x] #4 Run focused frontend verification for the touched Mermaid artifact test scope.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+- Rebased `codex/chat-mermaid-artifact-panel-tests` onto `origin/dev` at `9b36cbf232`.
+- Wrapped the Mermaid artifact jump-to-source test body in `try...finally` so `tldw:focus-artifacts-trigger` and `tldw:scroll-to-latest` listeners are always removed.
+- Verification:
+  - `bunx vitest run src/components/Sidepanel/Chat/__tests__/ArtifactsPanel.mermaid.test.tsx` passed: 1 file, 2 tests.
+  - `bunx vitest run src/components/Sidepanel/Chat/__tests__/ArtifactsPanel.mermaid.test.tsx src/components/Sidepanel/Chat/__tests__/ArtifactsPanel.jump-source.guard.test.ts src/components/Common/__tests__/MermaidDiagramBlock.test.tsx src/components/Common/Playground/__tests__/Message.mermaid-rendering.test.tsx` passed: 4 files, 27 tests.
+  - `git diff --check` passed.
+  - `env NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit --project tsconfig.json` failed in latest `origin/dev` KnowledgeQA test fixtures outside this PR diff: `KnowledgeQALayout.behavior.test.tsx` and `knowledgeQaStateFixtures.ts`.
+- Bandit not run: touched scope is frontend test code plus Backlog task metadata only.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Rebased PR #2284 onto latest origin/dev, wrapped Mermaid artifact panel jump-to-source listener cleanup in try/finally, pushed the rebased review-fix branch, and resolved the inline Gemini review thread. Focused Mermaid/chat tests and git diff --check passed. Full UI type-check currently fails in unrelated latest-dev KnowledgeQA test fixtures outside this PR diff; Bandit was skipped because the touched scope is frontend test code plus Backlog metadata.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## Change summary

Human-authored summary required before merge. This PR is draft until the requester adds the merge-gate summary explaining what changed and why.

## Summary

- Adds rendered ArtifactsPanel coverage for Mermaid diagram artifacts using the shared Mermaid renderer path.
- Verifies Jump to source targets the matching Mermaid artifact origin and does not fall back to latest-message scrolling.
- Records the follow-up in Backlog task TASK-2275.

## Test plan

- bunx vitest run src/components/Sidepanel/Chat/__tests__/ArtifactsPanel.mermaid.test.tsx
- bunx vitest run src/components/Sidepanel/Chat/__tests__/ArtifactsPanel.mermaid.test.tsx src/components/Sidepanel/Chat/__tests__/ArtifactsPanel.jump-source.guard.test.ts src/components/Common/__tests__/MermaidDiagramBlock.test.tsx src/components/Common/Playground/__tests__/Message.mermaid-rendering.test.tsx
- env NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit --project tsconfig.json
- git diff --check

Bandit was not run because this PR touches only frontend test and Backlog task files.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds rendered test coverage for Mermaid diagram artifacts in `ArtifactsPanel`, using the shared Mermaid renderer. Verifies Jump to source scrolls to the matching origin, closes the panel, and does not fall back to latest-message scrolling; also hardens the test by cleaning up window listeners with try/finally (Backlog TASK-2275, TASK-2276).

<sup>Written for commit 766bf269b731d1b3ac8f1692a364f071c9e4ab25. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2284?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

