### PR TITLE
docs: tighten workspace assistant defaults PRD

### DIFF
--- a/Docs/Product/Workspace_Persona_Defaults_PRD.md
+++ b/Docs/Product/Workspace_Persona_Defaults_PRD.md
@@ -1,4 +1,4 @@
-# Workspace Persona Defaults PRD
+# Workspace Assistant Defaults PRD
 
 Status: Draft
 
@@ -6,17 +6,17 @@ Owner: Persona module / Workspaces integration
 
 Tracking: #1911, split from #1902
 
-Backlog: TASK-468
+Backlog: TASK-468, TASK-2275
 
 ## Summary
 
-Define Workspace-scoped Persona defaults as a thin composition layer over existing Workspaces, Persona profiles, and Workspace-scoped chat sessions. This PRD replaces the original Persona PRD's old `project_id` language with current Workspace terminology and keeps the work separate from Persona-backed ordinary chat startup, scheduled work, Buddy animation, and broad personalization memory.
+Define Workspace-scoped assistant defaults as a broad composition contract over existing Workspaces, Persona profiles, and Workspace-scoped assistant surfaces. This PRD replaces the original Persona PRD's old `project_id` language with current Workspace terminology and keeps the work separate from Persona-backed ordinary global chat startup, scheduled work, Buddy animation, tool administration, and broad personalization memory.
 
-The goal is not to make Workspaces own Persona profiles. The goal is to let a Workspace recommend a default assistant identity and related defaults for Workspace-bound surfaces, while preserving explicit user choices and session-level metadata.
+The goal is not to make Workspaces own Persona profiles. The goal is to let a Workspace recommend a default assistant configuration for Workspace-bound surfaces, while preserving explicit user choices and persisting resolved assistant metadata on concrete sessions, runs, or artifacts. Chat Workspace is the first implementation target; Research Workspace, Prompt Studio, writing, audio overview, and agent/tool workflows can adopt the same contract only through later focused stages.
 
 ## Problem
 
-Persona Garden now owns Persona profile creation, configuration, and live-session testing. Persona-backed Chat Startup now owns ordinary chat startup as a Persona. Workspaces still need a separate contract for cases where a research workspace should carry a preferred assistant shape: for example a "literature review" Workspace might default to a careful research Persona, a specific voice for audio overview workflows, and a limited tool policy appropriate for that workspace.
+Persona Garden now owns Persona profile creation, configuration, and live-session testing. Persona-backed Chat Startup now owns ordinary global chat startup as a Persona. Workspaces still need a separate contract for cases where a research workspace should carry a preferred assistant shape: for example a "literature review" Workspace might default to a careful research Persona, later pair that Persona with a workspace-appropriate voice, and eventually reference a constrained tool policy for that Workspace.
 
 The current code has the pieces but not the product contract:
 
@@ -24,16 +24,19 @@ The current code has the pieces but not the product contract:
 - Workspace chat uses `scope: { type: "workspace", workspaceId }`.
 - Chat session schemas already support `scope_type: "workspace"`, `workspace_id`, `assistant_kind`, `assistant_id`, and `persona_memory_mode`.
 - Chat Workspace UI already reports a runtime `selectedPersonaLabel`, but there is no documented Workspace default source of truth or precedence model.
+- Other Workspace-bound surfaces have no shared assistant-default contract and would otherwise invent incompatible default semantics.
 
-Without a PRD, Workspace defaults risk becoming implicit global state that silently overrides chat choices or Persona profile settings.
+Without a PRD, Workspace defaults risk becoming implicit global state that silently overrides user choices, leaks Persona references across shared Workspaces, or mutates historical chat/run behavior when a Workspace setting changes.
 
 ## Goals
 
-- Define a Workspace-level defaults object for Persona-related behavior.
-- Preserve explicit chat/session Persona selection over Workspace defaults.
+- Define a Workspace-level `assistant_defaults` object with Persona-only V1 validation and room for later assistant kinds.
+- Preserve explicit session/run/artifact assistant selection over Workspace defaults.
 - Keep Persona profiles user-owned and configured in Persona Garden.
 - Let Workspace-bound chat and later Workspace surfaces read a Workspace default without duplicating Persona profile data.
-- Document precedence between global user settings, Workspace defaults, Persona profile defaults, and per-session choices.
+- Document precedence between explicit surface choices, Workspace defaults, user/global assistant defaults, and server fallback.
+- Define permission-aware stored and effective API response shapes.
+- Make Chat Workspace the first implementation target without making later Workspace surfaces V1 blockers.
 - Replace `project_id` phrasing with `workspace_id` and current Workspace terminology.
 
 ## Non-goals
@@ -42,10 +45,11 @@ Without a PRD, Workspace defaults risk becoming implicit global state that silen
 - No Buddy animation or expressive avatar runtime.
 - No design-system backlog work.
 - No scheduled Persona work or recurring jobs.
-- No ordinary `/chat` Persona startup changes; that is covered by #1908.
+- No ordinary global `/chat` Persona startup changes; that is covered by #1908.
 - No cross-app semantic personalization memory layer.
 - No marketplace-style tool administration.
 - No multi-agent or multi-Persona collaboration.
+- No voice, style, or tool-policy implementation until their separate contracts are stable.
 
 ## Current Contract Evidence
 
@@ -61,105 +65,194 @@ Without a PRD, Workspace defaults risk becoming implicit global state that silen
 
 ## Product Shape
 
-Workspace Persona Defaults V1 should add an explicit optional defaults object to a Workspace:
+Workspace Assistant Defaults should add an explicit optional defaults object to a Workspace. The broad field name is `assistant_defaults`, but V1 accepts only Persona-backed defaults:
 
 ```json
 {
-  "persona_defaults": {
-    "default_persona_id": "persona-id",
+  "assistant_defaults": {
+    "assistant_kind": "persona",
+    "assistant_id": "persona-id",
     "persona_memory_mode": "read_only",
-    "style_preset_id": null,
-    "voice": {
-      "provider": "kokoro",
-      "model": "default",
-      "voice": "af_heart",
-      "speed": 1.0
-    },
+    "voice": null,
+    "style": null,
     "tool_policy_profile_id": null
   }
 }
 ```
 
-The object should be reference-backed where possible:
+The object must be reference-backed:
 
-- `default_persona_id` references a Persona profile owned by the user.
+- `assistant_kind` is `"persona"` in V1. Other assistant kinds require a future contract.
+- `assistant_id` references a Persona profile available to the Workspace owner/editor at save time.
 - `persona_memory_mode` defaults to `read_only`.
-- voice defaults can reuse existing Workspace audio fields in V1 or be mirrored into a structured response shape if the existing fields remain the storage source.
-- tool policy defaults should be a future reference to Persona policy/scopes, not an embedded copy of tool permissions.
+- `voice` remains `null` in V1. A later voice-default stage must reconcile assistant speaking voice with existing Workspace audio-overview settings before defining fields.
+- `style` remains `null` in V1 until a stable style preset/default-prompt contract exists.
+- `tool_policy_profile_id` remains `null` in V1 until Persona Tool Administration defines policy profile lifecycle.
+- Persona name, prompt, avatar, policy, tool permissions, and other Persona content must not be snapshotted into Workspace defaults.
+
+### Stored And Effective Defaults
+
+Workspace APIs should distinguish the saved reference from the runtime-safe resolved default:
+
+- `assistant_defaults`: stored Workspace setting. Returned only to users allowed to manage or read Workspace settings according to existing Workspace permissions.
+- `effective_assistant_default`: permission-filtered runtime view for the current user and surface. It can include the resolved assistant id, display label if visible, memory mode, source `"workspace"`, and degraded status/reason. It must not expose hidden Persona details when the current user lacks access.
+
+Example effective response:
+
+```json
+{
+  "effective_assistant_default": {
+    "status": "available",
+    "source": "workspace",
+    "assistant_kind": "persona",
+    "assistant_id": "persona-id",
+    "label": "Literature Review Assistant",
+    "persona_memory_mode": "read_only",
+    "degraded_reason": null
+  }
+}
+```
+
+Unavailable defaults should keep a stable shape:
+
+```json
+{
+  "effective_assistant_default": {
+    "status": "unavailable",
+    "source": "workspace",
+    "assistant_kind": null,
+    "assistant_id": null,
+    "label": null,
+    "persona_memory_mode": null,
+    "degraded_reason": "permission_denied"
+  }
+}
+```
 
 ## Precedence Rules
 
-V1 should use deterministic precedence:
+Workspace-bound surfaces should use deterministic precedence:
 
-1. Per-chat/session explicit assistant selection.
-2. Workspace Persona default.
-3. User/global chat default.
+1. Explicit per-session, per-run, or per-artifact assistant choice.
+2. Workspace assistant default.
+3. User/global assistant default.
+4. Server fallback.
+
+Chat Workspace V1 applies this as:
+
+1. Existing chat session metadata.
+2. Explicit assistant selected before first send.
+3. Workspace `effective_assistant_default`.
 4. System fallback assistant.
 
-For other Persona-adjacent defaults:
+Other surfaces must not adopt Workspace defaults until they can persist the resolved assistant metadata on their own concrete record. That means:
 
-1. Per-session explicit value.
-2. Workspace default.
-3. Persona profile default.
-4. Global user setting.
-5. Server fallback.
+- Prompt Studio runs record the resolved assistant metadata on the run.
+- Writing workflows record the resolved assistant metadata on the draft/session.
+- Research Workspace chat/RAG records the resolved assistant metadata on the chat or run.
+- Audio overview and agent/tool workflows wait until voice/tool policy contracts are stable enough to persist meaningful resolved metadata.
 
-Workspace defaults should apply only when the active surface has Workspace scope. They must not silently affect ordinary global `/chat` unless that chat is explicitly started from or bound to a Workspace.
+Workspace defaults apply only when the active surface has Workspace scope. They must not silently affect ordinary global `/chat` unless that chat is explicitly started from or bound to a Workspace.
 
 ## UX Requirements
 
-- Workspace settings should show the default Persona as a reference to an existing Persona profile, not as copied Persona content.
+- Workspace settings should show the default assistant as a reference to an existing Persona profile, not as copied Persona content.
 - Chat Workspace should surface whether a Persona is inherited from Workspace defaults or explicitly selected for the chat.
 - Users must be able to clear a Workspace Persona default.
-- If the referenced Persona is deleted or unavailable, the Workspace should show a degraded state and continue to open.
+- If the referenced Persona is deleted, inaccessible, or unavailable, the Workspace should show a degraded state and continue to open.
 - Applying a Workspace default should not overwrite an active chat session's existing Persona metadata.
-- Any `read_write` memory mode default must be explicit and visible before use.
+- Any `read_write` memory mode default must be explicit, visible before use, and confirmed when saved as a Workspace default.
+- Shared Workspace collaborators who cannot access the referenced Persona should see a redacted unavailable state and should not auto-apply the default.
+- Users can always choose an explicit assistant for their own session/run where the surface supports explicit selection.
+
+## Surface Behavior
+
+### Chat Workspace: V1 Implementation Target
+
+Chat Workspace is the first applying surface. When a user starts a new Workspace-scoped chat and no assistant is explicitly selected, Chat Workspace resolves `effective_assistant_default` and writes concrete session metadata:
+
+- `assistant_kind: "persona"`
+- `assistant_id`
+- `persona_memory_mode`
+- Workspace scope metadata
+
+After the chat is created, the conversation is independent of later Workspace default edits. Changing the Workspace default does not mutate existing conversations, open conversations with persisted metadata, or historical chat records.
+
+### Later Workspace Surfaces
+
+The PRD defines a shared contract for later adoption, but these are not V1 blockers:
+
+- Research Workspace chat/RAG may inherit the default only for new Workspace-scoped assistant interactions, never for global search or non-Workspace chat.
+- Prompt Studio may preselect the default only for Workspace-bound prompt tests/runs and must record the resolved assistant metadata on the run.
+- Writing workflows may treat the default as a suggested assistant/style for new Workspace-bound drafts, not as a hidden rewrite of existing drafts.
+- Audio overview or media generation may use voice defaults only after this PRD or a follow-up explicitly distinguishes assistant speaking voice from existing Workspace audio overview settings.
+- Agent/tool workflows may reference tool-policy defaults only after Persona Tool Administration defines policy profile lifecycle and permission layering.
 
 ## Backend Requirements
 
-- Workspace read/update APIs should expose an optional Persona defaults contract.
+- Workspace read/update APIs should expose an optional assistant defaults contract.
 - The persisted contract should avoid snapshots of Persona name, prompt, avatar, policy, or tool permissions.
 - Workspace update should validate references where practical:
-  - Persona exists and belongs to the current user.
+  - `assistant_kind` is `"persona"` in V1.
+  - Persona exists and is usable by the current owner/editor where practical.
   - memory mode is one of `read_only` or `read_write`.
-  - voice fields follow existing Workspace audio validation once that validation exists.
+  - `read_write` saves require explicit confirmation or an equivalent review step.
+  - voice/style/tool fields are absent or `null` in V1 unless their contracts have landed.
 - Chat session creation should continue to store concrete assistant metadata on the conversation; Workspace defaults are startup hints, not hidden mutable session state.
-- If a Workspace default changes, existing conversations should not silently change assistant identity.
+- If a Workspace default changes, existing conversations, runs, drafts, and artifacts should not silently change assistant identity.
+- Runtime clients should prefer `effective_assistant_default` over raw stored defaults.
 
 ## Data Model Direction
 
-Preferred V1 storage is an explicit JSON/object field or companion table on Workspace records rather than overloading existing banner/audio fields.
+Preferred storage is an explicit JSON/object field or companion table on Workspace records rather than overloading existing banner/audio fields.
 
-Required fields:
+Required V1 fields:
 
-- `default_persona_id: string | null`
+- `assistant_kind: "persona" | null`
+- `assistant_id: string | null`
 - `persona_memory_mode: "read_only" | "read_write" | null`
-
-Allowed V1-adjacent fields:
-
-- `voice_provider`
-- `voice_model`
-- `voice_id`
-- `voice_speed`
 
 Deferred fields:
 
+- voice defaults until assistant voice and Workspace audio-overview semantics are reconciled.
 - style preset references until a stable style preset catalog exists.
-- tool policy profile references until Persona Tool Administration PRD defines install/config lifecycle.
+- tool policy profile references until Persona Tool Administration defines install/config lifecycle.
 - personalization memory tuning until the Personalization Memory Layer PRD.
+
+Suggested degraded reason codes:
+
+- `persona_deleted`
+- `persona_unavailable`
+- `persona_feature_disabled`
+- `permission_denied`
+- `invalid_default`
+- `unsupported_assistant_kind`
+
+## V1 Acceptance Boundary
+
+V1 is complete when:
+
+- Workspace schema/API can store and return `assistant_defaults` with Persona-only validation.
+- Workspace API exposes permission-filtered `effective_assistant_default`.
+- Workspace settings can select, confirm `read_write`, clear, and show degraded Persona defaults.
+- Chat Workspace applies the default only to new Workspace-scoped chats with no explicit assistant.
+- Existing sessions remain unchanged after Workspace default edits.
+
+Research Workspace, Prompt Studio, writing, audio overview, and agent/tool adoption are contract-defined but not V1 blockers.
 
 ## Staged Delivery
 
-### Stage 1: Contract Audit And Schema Design
+### Stage 1: Contract Audit And Schema/API Design
 
-Goal: define the smallest Workspace defaults contract without writing runtime behavior first.
+Goal: define the shared Workspace assistant defaults contract without writing runtime behavior first.
 
 Deliverables:
 
-- Backend schema proposal for Workspace Persona defaults.
-- DB migration design for storing references and memory mode.
+- Backend schema proposal for Workspace `assistant_defaults`.
+- DB migration design for storing Persona references and memory mode.
+- Stored-versus-effective API response examples.
 - Validation rules for missing/deleted Persona references.
-- API response examples for no default, valid default, and degraded default.
+- Degraded reason-code contract.
 
 ### Stage 2: Workspace Settings And Read Path
 
@@ -168,7 +261,8 @@ Goal: make defaults visible and editable without changing chat behavior yet.
 Deliverables:
 
 - Workspace settings UI for selecting/clearing a default Persona.
-- Read-only degraded state for deleted/unavailable Persona.
+- `read_write` confirmation/review step.
+- Read-only degraded state for deleted/unavailable/inaccessible Persona.
 - Tests for optimistic locking and reference validation.
 
 ### Stage 3: Chat Workspace Startup Application
@@ -182,14 +276,26 @@ Deliverables:
 - Existing conversations are unaffected by later Workspace default edits.
 - Inspector labels distinguish inherited vs explicit Persona where feasible.
 
-### Stage 4: Voice And Tool Defaults
+### Stage 4: Surface Adoption Gates
 
-Goal: integrate adjacent defaults only after Persona identity behavior is stable.
+Goal: allow other Workspace surfaces to adopt the shared contract only after they can persist resolved assistant metadata.
 
 Deliverables:
 
-- Reconcile existing Workspace audio fields with Persona voice defaults.
-- Add tool policy reference display only if the referenced policy contract already exists.
+- Research Workspace adoption plan and tests.
+- Prompt Studio adoption plan and tests.
+- Writing workflow adoption plan and tests.
+- Explicit non-adoption behavior for surfaces that cannot persist resolved metadata yet.
+
+### Stage 5: Voice, Style, And Tool Defaults
+
+Goal: integrate adjacent defaults only after Persona identity behavior and the relevant contracts are stable.
+
+Deliverables:
+
+- Reconcile existing Workspace audio fields with assistant speaking voice defaults.
+- Add style references only after style presets are stable.
+- Add tool policy reference display only after Persona Tool Administration defines policy lifecycle.
 - Keep broad tool installation/admin flows out of this PRD.
 
 ## Risks
@@ -199,32 +305,37 @@ Deliverables:
 - Reusing existing Workspace audio fields without a structured contract may confuse voice defaults with audio overview generation settings.
 - `read_write` memory mode could create unexpected durable memory if it is inherited invisibly.
 - Workspace sharing may expose default Persona references in ways that require permission-aware redaction.
+- Later surfaces could accidentally treat Workspace defaults as live pointers unless they persist resolved assistant metadata on their own records.
 
 ## Open Questions For Implementation Planning
 
-- Should V1 store voice defaults in existing Workspace audio fields or introduce a nested Persona defaults object immediately?
-- Should shared Workspace viewers see the owner's default Persona label, a redacted label, or only "Persona default unavailable"?
-- Should Workspace defaults apply to Prompt Studio and writing surfaces in V1, or only Chat Workspace?
-- Should changing the Workspace default offer to apply to new chats only, or also prompt the user to update open unsent chat state?
+- Which exact Workspace permission level may save or clear `assistant_defaults`?
+- Should owners/admins see raw inaccessible Persona references for repair, or should the API return only redacted unavailable state to all clients?
+- Should `read_write` confirmation be a frontend-only review step, a backend-required acknowledgement field, or both?
+- Should later surfaces share one `effective_assistant_default` response, or request surface-specific resolution with explicit capability filters?
 
 ## Acceptance Criteria
 
-- Workspace Persona defaults are documented as Workspace-scoped startup hints, not hidden global assistant state.
-- Explicit per-session Persona choices override Workspace defaults.
-- Existing conversations do not silently change when Workspace defaults change.
+- Workspace assistant defaults are documented as Workspace-scoped startup hints, not hidden global assistant state.
+- V1 accepts only Persona-backed `assistant_defaults` while preserving the broader field name for future assistant kinds.
+- Explicit per-session, per-run, and per-artifact assistant choices override Workspace defaults.
+- Existing conversations, runs, drafts, and artifacts do not silently change when Workspace defaults change.
 - Persona references remain reference-backed with no Persona content snapshots.
-- Missing/deleted Persona references degrade visibly and do not block opening the Workspace.
-- `read_write` memory mode is never inherited invisibly.
+- Missing, deleted, inaccessible, disabled, or invalid Persona references degrade visibly and do not block opening the Workspace.
+- Stored defaults and effective runtime defaults are separate API concepts.
+- `read_write` memory mode is never inherited invisibly and requires explicit save confirmation.
+- Later Workspace surfaces do not adopt defaults until they can persist resolved assistant metadata.
 - Old `project_id` terminology is replaced by current Workspace terminology in this feature's contract.
 
 ## Verification Plan
 
-- Schema tests for valid, empty, invalid, and deleted Persona default references.
+- Schema tests for valid, empty, invalid, unsupported assistant kind, and deleted Persona default references.
 - Migration tests for adding Workspace Persona defaults without altering existing Workspace records.
-- API tests for Workspace read/update optimistic locking and reference validation.
-- Component tests for selecting, clearing, and degraded display of Workspace Persona defaults.
+- API tests for Workspace read/update optimistic locking, reference validation, stored/effective response shape, and permission redaction.
+- Component tests for selecting, confirming `read_write`, clearing, and degraded display of Workspace Persona defaults.
 - Integration tests proving Workspace chat startup applies defaults only for new Workspace-scoped chats with no explicit assistant.
-- Regression tests proving global chat and existing conversations are unaffected.
+- Regression tests proving global chat, existing conversations, and unsupported surfaces are unaffected.
+- Later surface adoption tests proving resolved assistant metadata is persisted on runs/drafts/artifacts before defaults are applied.
 
 ## References
 

--- a/backlog/tasks/task-2275 - Tighten-Workspace-Persona-Defaults-PRD-broad-contract.md
+++ b/backlog/tasks/task-2275 - Tighten-Workspace-Persona-Defaults-PRD-broad-contract.md
@@ -1,0 +1,57 @@
+---
+id: TASK-2275
+title: Tighten Workspace Persona Defaults PRD broad contract
+status: Done
+labels:
+- persona
+- workspaces
+- prd
+- docs
+priority: Medium
+references:
+- https://github.com/rmusser01/tldw_server/issues/1911
+- https://github.com/rmusser01/tldw_server/issues/1902
+- Docs/Product/Workspace_Persona_Defaults_PRD.md
+- TASK-468
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Patch the existing Workspace Persona Defaults PRD after brainstorming so it defines the broader Workspace assistant defaults contract: assistant_defaults naming, V1 Persona-only validation, separated stored/effective response shapes, permission-aware degraded states, read_write confirmation, Chat Workspace as first implementation target, and later adoption criteria for other Workspace surfaces.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 PRD defines Workspace Assistant Defaults as the broad contract while keeping Chat Workspace as the first implementation target.
+- [x] #2 PRD uses a structured assistant_defaults model with Persona-only V1 validation and no Persona snapshots.
+- [x] #3 PRD distinguishes stored defaults from permission-filtered effective defaults and covers shared Workspace degraded states.
+- [x] #4 PRD records read_write confirmation, existing-session immutability, and adoption criteria for later Workspace surfaces.
+- [x] #5 Docs-only verification and Bandit applicability are recorded.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+- Patched `Docs/Product/Workspace_Persona_Defaults_PRD.md` to define Workspace Assistant Defaults as a broad Workspace-scoped contract with Chat Workspace as the first implementation target.
+- Added structured `assistant_defaults` semantics with Persona-only V1 validation, no Persona snapshots, stored-versus-effective response shapes, permission-aware degraded states, `read_write` confirmation, and later-surface adoption gates.
+- Self-review tightened ambiguous precedence language so the contract now falls back from explicit surface choice to Workspace default, then user/global assistant default, then server fallback.
+- Verification: stale-field `rg` check returned no `persona_defaults` or old voice field hits; positive-contract `rg` check found expected `assistant_defaults`, `effective_assistant_default`, `read_write`, and surface references; `git diff --check` passed.
+- Bandit: skipped because this change touches only Markdown PRD/task documentation and no Python code.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Revised the Workspace Persona Defaults PRD into a broader Workspace Assistant Defaults PRD for #1911. The contract now keeps V1 Persona-backed and reference-only, separates stored defaults from permission-filtered effective defaults, captures `read_write` confirmation and degraded shared-Workspace states, and defines adoption gates for later Workspace surfaces without making them V1 blockers.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## Change summary

This updates the #1911 PRD from a narrow Workspace Persona Defaults draft into a broader Workspace Assistant Defaults contract. The PRD keeps V1 Persona-backed and reference-only, while leaving room for later assistant kinds and Workspace surfaces.

It also documents stored versus effective defaults, permission-aware degraded states, read_write confirmation, existing-record immutability, and adoption gates for Chat Workspace first and later Workspace surfaces after they can persist resolved assistant metadata.

## Verification

- rg stale-field check for persona_defaults and old voice field names returned no matches
- rg positive-contract check found expected assistant_defaults, effective_assistant_default, read_write, and surface references
- git diff --check
- Bandit skipped: docs/backlog-only change, no Python touched

## Review note

This is a PRD/spec review PR only. Implementation planning should wait until the PRD wording is accepted.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expands the Workspace Persona Defaults PRD into a broader Workspace Assistant Defaults contract for #1911, with V1 limited to Persona-backed references. Adds stored vs effective defaults, clear precedence, degraded states, and `read_write` confirmation; Chat Workspace is the first adopting surface.

- **Refactors**
  - Rename to `assistant_defaults` with V1 validation for `assistant_kind: "persona"` and `assistant_id`.
  - Define stored `assistant_defaults` vs permission-filtered `effective_assistant_default`.
  - Set precedence: explicit choice > workspace default > user/global > server fallback; persist resolved metadata so existing records don’t change.
  - Add permission-aware degraded states with reason codes; no Persona content snapshots.
  - Gate adoption: apply only to new Chat Workspace chats; other Workspace surfaces adopt later when they can persist resolved assistant metadata.

<sup>Written for commit f414182c94ce6f3267ed8d904d316c24dd4ae88d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2286?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

