### PR TITLE
Fix MCP broad regression expectations

### DIFF
--- a/backlog/tasks/task-514.8 - Investigate-broad-MCP-Hub-policy-resolver-regression-failures.md
+++ b/backlog/tasks/task-514.8 - Investigate-broad-MCP-Hub-policy-resolver-regression-failures.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-514.8
 title: Investigate broad MCP Hub policy resolver regression failures
-status: To Do
+status: Done
 parent_task_id: TASK-514
 documentation:
 - tldw_Server_API/tests/MCP_unified/test_mcp_hub_policy_overrides.py
@@ -18,29 +18,45 @@ Follow up on optional broad MCP Unified regression failures found during TASK-51
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Resolve or intentionally update the policy resolver authored/resolved document equality expectations.
-- [ ] #2 Determine whether the tool catalog shutdown_in_progress failure is test order/shared lifecycle leakage.
-- [ ] #3 Restore the broad Notes_NEW plus MCP_unified pytest sweep or document any accepted skips with focused verification.
+- [x] #1 Resolve or intentionally update the policy resolver authored/resolved document equality expectations.
+- [x] #2 Determine whether the tool catalog shutdown_in_progress failure is test order/shared lifecycle leakage.
+- [x] #3 Restore the broad Notes_NEW plus MCP_unified pytest sweep or document any accepted skips with focused verification.
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Reproduce the documented broad MCP Hub policy resolver failures from latest dev, inspect the resolver/authored-vs-resolved policy document data flow, add failing focused regression coverage for still-valid mismatches, implement the smallest policy-shape or test-expectation correction, investigate the broad-suite-only tool catalog shutdown_in_progress failure for order/lifecycle leakage, then run focused and broad verification plus Bandit/diff checks.
+<!-- SECTION:PLAN:END -->
 
 ## Implementation Notes
 
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
-
+- Reproduced the original three policy resolver failures and verified the resolver intentionally normalizes `resolved_policy_document` with empty `tool_tier_overrides` and `conditions`; updated stale tests to compare authored keys as a subset and assert the normalized defaults explicitly.
+- Verified additional current failures in the broad sweep: stale AuthNZ and telemetry monkeypatch seams after runtime dependency extraction, a static external federation test double missing the current scalar write-flag accessor, and a broad-suite `shutdown_in_progress` readiness leak caused by shared FastAPI app lifecycle state.
+- Fixed only still-valid test issues: patched the endpoint-level AuthNZ token classifier seam, injected telemetry through `protocol.dependencies.telemetry_provider`, added `get_virtual_tool_write_flag()` to the static external federation manager double, and reset lifecycle state before the first tool-catalog integration flow.
+- PR review follow-up: added explicit resolved-policy key-existence assertions before value comparisons and documented the static external federation write-flag test-double method.
+- Validation:
+  - `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/MCP_unified/test_mcp_http_auth_paths.py::test_get_current_user_authnz_revoked_does_not_fallback tldw_Server_API/tests/MCP_unified/test_mcp_protocol_external_federation.py::test_external_federation_virtual_write_tools_respect_protocol_write_disable tldw_Server_API/tests/MCP_unified/test_phase3_3_small_core_sanitizers.py::test_protocol_tool_execution_failure_log_omits_raw_exception_and_traceback tldw_Server_API/tests/MCP_unified/test_tool_catalogs_api.py::test_tool_catalogs_flow -q` -> 4 passed.
+  - `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/MCP_unified/test_mcp_hub_policy_overrides.py tldw_Server_API/tests/MCP_unified/test_mcp_hub_shared_workspace_registry.py tldw_Server_API/tests/MCP_unified/test_mcp_hub_workspace_set_objects.py tldw_Server_API/tests/MCP_unified/test_mcp_http_auth_paths.py tldw_Server_API/tests/MCP_unified/test_mcp_protocol_external_federation.py tldw_Server_API/tests/MCP_unified/test_phase3_3_small_core_sanitizers.py tldw_Server_API/tests/MCP_unified/test_tool_catalogs_api.py -q` -> 49 passed.
+  - `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Notes_NEW tldw_Server_API/tests/MCP_unified -q` -> 635 passed, 2 skipped.
+  - After rebasing onto latest `origin/dev`, reran the touched MCP regression set -> 49 passed, and reran the broad Notes_NEW plus MCP_unified sweep -> 635 passed, 2 skipped.
+  - `git diff --check` -> clean.
+  - `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r <touched test files> -s B101,B105,B106,B108 -f json -o /tmp/bandit_task_514_8_mcp_policy_regressions_filtered.json` -> 0 actionable findings; skipped test-only assert/synthetic credential/sanitizer sentinel warnings.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-
+Closed the broad MCP Hub regression follow-up. The policy resolver failures were stale assertions against normalized resolved policy documents, not production resolver defects. Additional current failures were also test-bound and were updated to current seams/contracts. The broad Notes_NEW plus MCP_unified sweep now passes.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->

--- a/tldw_Server_API/tests/MCP_unified/test_mcp_http_auth_paths.py
+++ b/tldw_Server_API/tests/MCP_unified/test_mcp_http_auth_paths.py
@@ -13,7 +13,6 @@ from tldw_Server_API.app.api.v1.endpoints import mcp_unified_endpoint as mcp_ep
 from tldw_Server_API.app.core.AuthNZ.principal_model import AuthContext, AuthPrincipal
 from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import User
 from tldw_Server_API.app.core.MCP_unified.auth import UserRole
-from tldw_Server_API.app.core.MCP_unified import server as mcp_server
 
 
 # Disable HTTP security guard for these tests (IP allowlist/mTLS) to focus on auth behavior.
@@ -689,17 +688,12 @@ async def test_get_current_user_authnz_revoked_does_not_fallback(monkeypatch):
             detail="Could not validate credentials",
         )
 
-    class _JwtService:
-        def decode_access_token(self, token: str):
-            assert token == "revoked.jwt.token"
-            return {"sub": "42"}
-
     class _FailingJwtManager:
         def verify_token(self, _token: str):
             raise AssertionError("MCP JWT fallback should not be attempted")
 
     monkeypatch.setattr(mcp_ep, "verify_jwt_and_fetch_user", _revoked_verify)
-    monkeypatch.setattr(mcp_server, "get_jwt_service", lambda: _JwtService())
+    monkeypatch.setattr(mcp_ep, "_is_authnz_access_token", lambda token: token == "revoked.jwt.token")
     monkeypatch.setattr(mcp_ep, "get_jwt_manager", lambda: _FailingJwtManager())
 
     creds = HTTPAuthorizationCredentials(scheme="Bearer", credentials="revoked.jwt.token")

--- a/tldw_Server_API/tests/MCP_unified/test_mcp_hub_policy_overrides.py
+++ b/tldw_Server_API/tests/MCP_unified/test_mcp_hub_policy_overrides.py
@@ -203,7 +203,11 @@ async def test_policy_resolver_applies_assignment_override_and_emits_provenance(
     assert policy["allowed_tools"] == ["notes.search", "Bash(git *)", "remote.fetch"]
     assert policy["capabilities"] == ["filesystem.read"]
     assert policy["approval_mode"] == "ask_outside_profile"
-    assert policy["authored_policy_document"] == policy["resolved_policy_document"]
+    for key, value in policy["authored_policy_document"].items():
+        assert key in policy["resolved_policy_document"]
+        assert policy["resolved_policy_document"][key] == value
+    assert policy["resolved_policy_document"]["tool_tier_overrides"] == {}
+    assert policy["resolved_policy_document"]["conditions"] == {}
     assert policy["sources"] == [
         {
             "assignment_id": 12,

--- a/tldw_Server_API/tests/MCP_unified/test_mcp_hub_shared_workspace_registry.py
+++ b/tldw_Server_API/tests/MCP_unified/test_mcp_hub_shared_workspace_registry.py
@@ -128,4 +128,8 @@ async def test_policy_resolver_marks_shared_workspace_set_as_shared_registry_sou
     assert policy["selected_workspace_set_object_name"] == "Team Workspaces"
     assert policy["selected_workspace_trust_source"] == "shared_registry"
     assert policy["selected_assignment_workspace_ids"] == ["shared-docs"]
-    assert policy["authored_policy_document"] == policy["resolved_policy_document"]
+    for key, value in policy["authored_policy_document"].items():
+        assert key in policy["resolved_policy_document"]
+        assert policy["resolved_policy_document"][key] == value
+    assert policy["resolved_policy_document"]["tool_tier_overrides"] == {}
+    assert policy["resolved_policy_document"]["conditions"] == {}

--- a/tldw_Server_API/tests/MCP_unified/test_mcp_hub_workspace_set_objects.py
+++ b/tldw_Server_API/tests/MCP_unified/test_mcp_hub_workspace_set_objects.py
@@ -105,4 +105,8 @@ async def test_policy_resolver_uses_named_workspace_set_members_over_preserved_i
     assert policy["selected_workspace_set_object_id"] == 501
     assert policy["selected_workspace_set_object_name"] == "Research Workspaces"
     assert policy["selected_assignment_workspace_ids"] == ["workspace-alpha", "workspace-beta"]
-    assert policy["authored_policy_document"] == policy["resolved_policy_document"]
+    for key, value in policy["authored_policy_document"].items():
+        assert key in policy["resolved_policy_document"]
+        assert policy["resolved_policy_document"][key] == value
+    assert policy["resolved_policy_document"]["tool_tier_overrides"] == {}
+    assert policy["resolved_policy_document"]["conditions"] == {}

--- a/tldw_Server_API/tests/MCP_unified/test_mcp_protocol_external_federation.py
+++ b/tldw_Server_API/tests/MCP_unified/test_mcp_protocol_external_federation.py
@@ -102,6 +102,12 @@ class _StaticExternalWriteManager:
             )
         ]
 
+    def get_virtual_tool_write_flag(self, virtual_tool_name: str) -> bool | None:
+        """Return the static write flag for the virtual write-policy regression tool."""
+        if virtual_tool_name == "ext.docs.repo.set":
+            return True
+        return None
+
     async def execute_virtual_tool(
         self,
         virtual_tool_name: str,

--- a/tldw_Server_API/tests/MCP_unified/test_phase3_3_small_core_sanitizers.py
+++ b/tldw_Server_API/tests/MCP_unified/test_phase3_3_small_core_sanitizers.py
@@ -274,12 +274,10 @@ async def test_protocol_metadata_probe_log_omits_raw_exception_message() -> None
 
 
 @pytest.mark.asyncio
-async def test_protocol_tool_execution_failure_log_omits_raw_exception_and_traceback(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
+async def test_protocol_tool_execution_failure_log_omits_raw_exception_and_traceback() -> None:
     fake_telemetry = _FakeTelemetry()
-    monkeypatch.setattr(protocol_mod, "get_telemetry_manager", lambda: fake_telemetry)
     protocol = MCPProtocol()
+    protocol.dependencies.telemetry_provider = fake_telemetry
     protocol.rate_limiter = _NoopRateLimiter()
     context = RequestContext(request_id="req-tool", client_id="client-tool")
     prepared = _prepared_tool_call(protocol, context)

--- a/tldw_Server_API/tests/MCP_unified/test_tool_catalogs_api.py
+++ b/tldw_Server_API/tests/MCP_unified/test_tool_catalogs_api.py
@@ -142,6 +142,7 @@ def test_tool_catalogs_flow():
     # Start app
     from fastapi.testclient import TestClient
     from tldw_Server_API.app.main import app
+    from tldw_Server_API.app.services.app_lifecycle import reset_lifecycle_state
 
     # Disable HTTP security guard for this test (IP allowlist/mTLS)
     try:
@@ -149,6 +150,7 @@ def test_tool_catalogs_flow():
         app.dependency_overrides[_ehs] = lambda: None
     except Exception:
         _ = None
+    reset_lifecycle_state(app)
     client = TestClient(app)
 
     # Prepare single-user row so role assignments don't fail silently


### PR DESCRIPTION
## Summary
- Updates stale MCP Hub policy resolver assertions to treat authored policy keys as a subset of normalized resolved policy documents.
- Updates MCP regression tests to current auth, telemetry, and external federation seams.
- Resets shared FastAPI lifecycle state before the first tool catalog integration flow to avoid order-dependent shutdown leakage.
- Closes TASK-514.8 with verification notes.

## Verification
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/MCP_unified/test_mcp_hub_policy_overrides.py tldw_Server_API/tests/MCP_unified/test_mcp_hub_shared_workspace_registry.py tldw_Server_API/tests/MCP_unified/test_mcp_hub_workspace_set_objects.py tldw_Server_API/tests/MCP_unified/test_mcp_http_auth_paths.py tldw_Server_API/tests/MCP_unified/test_mcp_protocol_external_federation.py tldw_Server_API/tests/MCP_unified/test_phase3_3_small_core_sanitizers.py tldw_Server_API/tests/MCP_unified/test_tool_catalogs_api.py -q` -> 49 passed after final rebase.
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Notes_NEW tldw_Server_API/tests/MCP_unified -q` -> 635 passed, 2 skipped before the final no-conflict rebase; touched set was rerun after final rebase.
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r <touched test files> -s B101,B105,B106,B108 -f json -o /tmp/bandit_task_514_8_mcp_policy_regressions_filtered.json` -> 0 actionable findings.
- `git diff --check HEAD~1..HEAD` -> clean.

## Merge gate
- Human requester still needs to add the required human-written Change summary before merge.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes MCP Hub policy resolver regressions by aligning tests with normalized resolved policy documents and patching auth, telemetry, and federation seams; also resets `FastAPI` lifecycle state to remove order-dependent tool catalog failures. Closes TASK-514.8 and restores the Notes_NEW + MCP_unified test sweep.

- **Bug Fixes**
  - Treat authored policy keys as a subset of the resolved document; assert empty `tool_tier_overrides` and `conditions`.
  - Patch endpoint `_is_authnz_access_token` to prevent JWT fallback in the revoked-token test.
  - Inject `protocol.dependencies.telemetry_provider` in sanitizer tests to avoid raw exception leakage.
  - Add `get_virtual_tool_write_flag()` to the external federation test double.
  - Reset lifecycle state before the first tool catalog flow to prevent `shutdown_in_progress` leakage.

<sup>Written for commit daf69e09120324fe7fc60e5fbfea5fcb0279811d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2287?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

