### PR TITLE
Harden /knowledge QA recovery and guardrails

### DIFF
--- a/Docs/Plans/2026-06-07-knowledge-qa-uat-checklist.md
+++ b/Docs/Plans/2026-06-07-knowledge-qa-uat-checklist.md
@@ -1,0 +1,341 @@
+# Knowledge QA UAT And Regression Checklist
+
+Use this checklist when validating `/knowledge` for a release or focused Knowledge QA change. The page is a Knowledge QA workflow for searching a personal library and reviewing grounded answers with citations. Flashcards are handled by the separate flashcards route and are out of scope for `/knowledge`.
+
+## Setup
+
+Preconditions common to all scripts:
+
+- WebUI can open `/knowledge`.
+- Extension options page can open Knowledge QA.
+- Test user has a configured tldw server URL and credentials unless the script explicitly tests setup failure.
+- At least one fixture or real indexed document/note is available for successful-search scripts.
+- At least one known query has a cited answer, and at least one known query has no matching local result.
+
+Record for each run:
+
+- Surface: WebUI or extension.
+- Browser and viewport.
+- Server URL/auth mode.
+- Backend state: healthy, offline, empty, or mocked fixture.
+- Pass/fail result.
+- Screenshots, traces, or console/network notes for failures and skips.
+
+## Script 1: Backend Unavailable Recovery
+
+Preconditions:
+
+- Backend health check is unavailable, stalled, or mocked as failed.
+- No offline bypass should make the page look ready.
+
+Steps:
+
+1. Open `/knowledge` in WebUI.
+2. Open Knowledge QA in the extension options route.
+3. Wait for the readiness or setup gate to settle.
+4. Inspect the visible recovery state.
+5. Activate the visible retry or setup action when present.
+
+Expected result:
+
+- The page does not stay blank.
+- The user sees that Knowledge QA cannot reach the backend.
+- WebUI offers backend recovery or retry.
+- Extension distinguishes setup problems from backend reachability when possible.
+
+Pass/fail criteria:
+
+- Pass if the blocked state is visible, actionable, and does not present the ready search state as tested.
+- Fail if the page is blank, search is enabled without a usable backend, or the error gives no recovery path.
+
+WebUI versus extension notes:
+
+- WebUI failure is usually a server readiness or health issue.
+- Extension failure can also involve missing server URL, API key, host permission, or allowlist.
+
+Automated guardrails:
+
+```bash
+cd apps/tldw-frontend
+npx playwright test e2e/ux-audit/knowledge-readiness-recovery.spec.ts --project=chromium
+
+cd apps/extension
+npx playwright test tests/e2e/knowledge-qa-setup-diagnostics.spec.ts --project=chromium-extension
+```
+
+## Script 2: First-Run Or No-Source Recovery
+
+Preconditions:
+
+- Backend is reachable.
+- Knowledge QA reports no indexed sources, or indexed sources exist but no source categories are selected.
+
+Steps:
+
+1. Open Knowledge QA.
+2. Confirm the first visible state explains that the library has no indexed searchable sources, or that no source categories are selected.
+3. Try entering a question.
+4. Confirm `Ask` remains disabled when no local source and no web fallback can be used.
+5. Use the visible recovery action for adding/indexing sources or selecting categories.
+
+Expected result:
+
+- The page explains what is missing before the user asks a question.
+- The primary recovery action leads to source setup or source selection.
+- The search box does not imply a successful Knowledge QA search can run when no source can be searched.
+
+Pass/fail criteria:
+
+- Pass if recovery copy is specific and search is blocked until at least one valid source path exists.
+- Fail if the user can submit a dead-end search, or if the page suggests data was searched when no data was available.
+
+WebUI versus extension notes:
+
+- Extension options may show compact source controls sooner because of width.
+- The source-selection contract should remain the same across both surfaces.
+
+Automated guardrails:
+
+```bash
+cd apps/tldw-frontend
+npx playwright test e2e/ux-audit/knowledge-empty-recovery.spec.ts --project=chromium
+
+cd apps/extension
+npx playwright test tests/e2e/knowledge-empty-recovery.spec.ts --project=chromium-extension
+```
+
+## Script 3: First Successful Grounded Search
+
+Preconditions:
+
+- Backend is healthy.
+- At least one indexed source is selected.
+- A known question returns a generated answer and at least one source.
+
+Steps:
+
+1. Open Knowledge QA.
+2. Confirm `Ask Your Library` and the search input are visible.
+3. Ask the known question.
+4. Wait for the answer.
+5. Confirm the answer cites visible evidence.
+6. Open the cited source or evidence panel if available.
+
+Expected result:
+
+- The answer appears with citations.
+- The cited evidence is inspectable.
+- Export is available after an answer is produced.
+
+Pass/fail criteria:
+
+- Pass if the user can connect the answer claim to a visible cited source.
+- Fail if the answer is uncited, citations are not inspectable, or export appears before useful content exists.
+
+WebUI versus extension notes:
+
+- WebUI may show the evidence rail beside the answer in detailed layout.
+- Extension may require compact controls or a narrower evidence view.
+
+Automated guardrail:
+
+```bash
+cd apps/tldw-frontend
+npx playwright test e2e/ux-audit/knowledge-qa-states.spec.ts --project=chromium
+```
+
+## Script 4: No-Results Recovery
+
+Preconditions:
+
+- Backend is healthy.
+- Sources are selected.
+- A known query returns no local results.
+
+Steps:
+
+1. Ask the known no-results query.
+2. Read the recovery state.
+3. Check for suggested actions such as changing wording, broadening scope, selecting sources, waiting for indexing, or using web fallback when available.
+4. If nearest matches are available, open them and confirm they are labeled as weaker candidates.
+
+Expected result:
+
+- The UI clearly says no results were found.
+- Recovery actions are relevant to source scope and indexing.
+- The page does not fabricate an answer.
+
+Pass/fail criteria:
+
+- Pass if no-results recovery helps the user change scope or query without pretending success.
+- Fail if an answer is generated without supporting evidence, or if no recovery action is visible.
+
+Automated guardrails:
+
+```bash
+cd apps/packages/ui
+bunx vitest run src/components/Option/KnowledgeQA/__tests__/NoResultsRecovery.test.tsx src/components/Option/KnowledgeQA/__tests__/KnowledgeQA.golden-layout.test.tsx
+```
+
+## Script 5: Power-User Scoped Document/Note Search
+
+Preconditions:
+
+- Backend is healthy.
+- At least two documents or notes are indexed so a scoped search can exclude one of them.
+
+Steps:
+
+1. Open source scope controls.
+2. Select source categories.
+3. Select specific documents or notes.
+4. Save the scope as a profile.
+5. Run a question that should only match the selected items.
+6. Restore the saved profile and confirm the exact scope returns.
+
+Expected result:
+
+- Exact document/note counts are visible in compact mode when selected.
+- Saved profiles restore source categories and exact selections.
+- The search request is constrained to the chosen source scope.
+
+Pass/fail criteria:
+
+- Pass if the scoped answer and evidence only come from allowed sources.
+- Fail if excluded sources appear, profile restore loses exact selections, or compact mode hides scope controls.
+
+Automated guardrails:
+
+```bash
+cd apps/packages/ui
+bunx vitest run src/components/Option/KnowledgeQA/__tests__/KnowledgeContextBar.test.tsx src/components/Option/KnowledgeQA/__tests__/KnowledgeContextBar.profiles.test.tsx src/components/Option/KnowledgeQA/__tests__/CompactToolbar.test.tsx
+```
+
+## Script 6: Advanced Settings And Evidence Review
+
+Preconditions:
+
+- Backend is healthy.
+- A successful cited search result is available.
+
+Steps:
+
+1. Open Knowledge QA settings.
+2. Switch between Basic and Expert settings.
+3. Change a safe setting and reset defaults.
+4. Run a cited search.
+5. Open evidence review.
+6. Switch between `Sources` and `Details` views when available.
+7. Confirm keyboard Escape/close controls return focus to the launching control.
+
+Expected result:
+
+- Settings are reversible and keyboard accessible.
+- Expert settings are discoverable without overwhelming Basic mode.
+- Evidence views support source inspection and retrieval detail review.
+
+Pass/fail criteria:
+
+- Pass if settings open/close safely, reset works, and evidence remains tied to citations.
+- Fail if focus is trapped incorrectly, settings cannot be reset, or evidence views are missing for cited answers.
+
+Automated guardrails:
+
+```bash
+cd apps/packages/ui
+bunx vitest run src/components/Option/KnowledgeQA/__tests__/SettingsPanel.behavior.test.tsx src/components/Option/KnowledgeQA/__tests__/ExpertSettings.accessibility.test.tsx src/components/Option/KnowledgeQA/__tests__/KnowledgeQALayout.behavior.test.tsx
+```
+
+## Script 7: Export
+
+Preconditions:
+
+- A Knowledge QA answer with citations is visible.
+- The current thread supports the export action being tested.
+
+Steps:
+
+1. Choose `Export`.
+2. Select Markdown and export.
+3. Select PDF and confirm the browser print/export flow starts when supported.
+4. Select Chatbook and export when supported.
+5. Save to Notes when available.
+6. Create and revoke a share link when available.
+7. Confirm export errors show actionable recovery.
+
+Expected result:
+
+- Exported content includes the Knowledge QA question, answer, citations, and source/retrieval context when available.
+- Chatbook download uses the returned export job.
+- Save-to-Notes and share-link actions report success or a clear error.
+
+Pass/fail criteria:
+
+- Pass if export succeeds or fails with specific, recoverable feedback.
+- Fail if export silently fails, omits citations, leaks sensitive provider details, or leaves stale loading state.
+
+Automated guardrails:
+
+```bash
+cd apps/packages/ui
+bunx vitest run src/components/Option/KnowledgeQA/__tests__/ExportDialog.a11y.test.tsx src/components/Option/KnowledgeQA/__tests__/errorMessages.test.ts
+```
+
+## Consolidated Regression Commands
+
+Shared Knowledge QA UI:
+
+```bash
+cd apps/packages/ui
+bunx vitest run src/components/Option/KnowledgeQA
+```
+
+WebUI route states:
+
+```bash
+cd apps/tldw-frontend
+npx playwright test e2e/ux-audit/knowledge-readiness-recovery.spec.ts e2e/ux-audit/knowledge-qa-states.spec.ts e2e/ux-audit/knowledge-empty-recovery.spec.ts --project=chromium
+```
+
+Extension route states:
+
+```bash
+cd apps/extension
+npx playwright test tests/e2e/knowledge-qa-setup-diagnostics.spec.ts tests/e2e/knowledge-qa-states.spec.ts tests/e2e/knowledge-empty-recovery.spec.ts --project=chromium-extension
+```
+
+Backend checks:
+
+```bash
+source .venv/bin/activate
+python -m pytest <touched backend test paths> -v
+python -m bandit -r <touched backend paths> -f json -o /tmp/bandit_knowledge_qa.json
+```
+
+Only run backend checks when backend Knowledge QA/RAG files are touched. For documentation-only changes, record Bandit as not applicable.
+
+Scope guard:
+
+```bash
+rg -n "deck|spaced repetition|study-set|study set" \
+  apps/packages/ui/src/components/Option/KnowledgeQA \
+  apps/tldw-frontend/e2e/ux-audit/knowledge*.spec.ts \
+  apps/extension/tests/e2e/knowledge*.spec.ts
+```
+
+This guard intentionally excludes the word `flashcards` because documentation may mention the separate flashcards route when explaining what `/knowledge` does not do.
+
+## Current Known Blockers
+
+- Extension E2E can be blocked by the WXT production build stalling before browser tests start. When that happens, record the build stall as an environment/build blocker and do not claim extension runtime behavior was verified.
+- Package-wide TypeScript checks may be blocked by existing baseline errors outside the Knowledge QA slice. Prefer targeted Knowledge QA Vitest and Playwright checks for this release gate unless the baseline is fixed.
+
+## Release Sign-Off
+
+Before closing a Knowledge QA release gate:
+
+- [ ] UAT scripts 1-7 are passed or explicitly skipped with a reason.
+- [ ] WebUI and extension differences are documented.
+- [ ] Automated regression commands and results are recorded.
+- [ ] No `/knowledge` UI or test change introduced flashcard workflows.
+- [ ] Known blockers are recorded in the relevant Backlog task.

--- a/Docs/User_Guides/WebUI_Extension/Knowledge_QA_Guide.md
+++ b/Docs/User_Guides/WebUI_Extension/Knowledge_QA_Guide.md
@@ -1,0 +1,168 @@
+# Knowledge QA Guide
+
+Knowledge QA is the `/knowledge` workflow for asking questions against your personal library and reviewing grounded answers with citations. Use it when you want a cited answer from indexed documents, media, notes, conversations, task boards, or other selected Knowledge QA source categories.
+
+Knowledge QA is not the flashcards workflow. Flashcards are handled by the separate flashcards route and are not part of `/knowledge`.
+
+## Where To Open It
+
+- WebUI: open `/knowledge`.
+- Browser extension: open the extension options page and choose Knowledge QA.
+
+The WebUI and extension use the same shared Knowledge QA interface. The extension can also be blocked by extension-specific setup, such as missing server URL, API key, host permission, or an allowlist/backend reachability problem.
+
+## Setup Requirements
+
+Before Knowledge QA can answer:
+
+1. The tldw server must be reachable.
+2. Credentials must be configured for the selected auth mode.
+3. The server must expose the Knowledge QA/RAG endpoints.
+4. At least one selected personal-library source category must be searchable, or web fallback must be available and enabled.
+5. Documents, media, notes, or other library items must be indexed before local-only answers can cite them.
+
+If setup is incomplete, Knowledge QA should show a recovery state instead of a blank page. Follow the visible action, such as finishing setup, reconnecting, adding or indexing sources, selecting source categories, or retrying the backend check.
+
+## Ask A Question
+
+1. Open Knowledge QA.
+2. Confirm the page says `Ask Your Library`.
+3. Review the source scope.
+4. Enter a question in the search box.
+5. Choose `Ask`.
+6. Review the answer and citations.
+
+Good questions are specific and library-grounded, for example:
+
+- "What does my library say about the onboarding checklist?"
+- "Which notes mention API key setup?"
+- "Summarize the cited evidence about the release process."
+
+## Source Scope
+
+Source scope controls what Knowledge QA is allowed to search.
+
+Use the source scope controls to:
+
+- Select source categories such as documents/media or notes.
+- Select specific documents or notes when available.
+- Save and restore source/search profiles for repeated workflows.
+- Enable or disable web fallback when the server supports web search.
+
+If no source categories are selected and web fallback is off, Knowledge QA should block submission with recovery copy. If the server has no indexed library sources, add or index content first through source-owner surfaces such as Media, Notes, or Quick Ingest.
+
+## Presets And Settings
+
+Use presets when you want a quick tradeoff:
+
+- `Fast`: quicker retrieval with lighter search.
+- `Balanced`: normal default for most questions.
+- `Deep` or `Thorough`: broader retrieval for harder questions.
+- `Custom`: manual settings have diverged from a preset.
+
+Use settings when you need more control:
+
+- Basic settings cover common tuning.
+- Expert settings expose retrieval details for power users.
+- Reset defaults returns settings to the supported baseline.
+
+Keep settings changes tied to a concrete question. If answers become noisy, reduce scope or return to `Balanced`.
+
+## Answer Model
+
+The answer model/provider menu controls which configured model generates the final answer. You can use the server default, select a configured provider/model, or enter a manual model name when the UI supports it.
+
+Provider/model availability depends on server configuration. Knowledge QA should avoid exposing sensitive provider configuration details in UI errors.
+
+## Citations And Evidence
+
+Citations connect answer claims to retrieved evidence. Use them to decide whether the answer is grounded enough to trust.
+
+Expected review flow:
+
+1. Read the answer.
+2. Open or inspect cited sources.
+3. Compare citation snippets with the answer claims.
+4. Use the evidence rail when more detail is needed.
+5. Switch between `Sources` and `Details` evidence views when available.
+
+Treat uncited or weakly cited claims as lower confidence. Narrow source scope, try a more specific question, or use a deeper preset if the evidence does not support the answer.
+
+## No Results And Recovery
+
+When Knowledge QA returns no results:
+
+- Check whether the correct source categories are selected.
+- Select exact documents or notes if the search should be scoped.
+- Try a broader query or a different phrase.
+- Use web fallback only when you want external web evidence and the server supports it.
+- Wait for indexing to finish if recently added sources are not searchable yet.
+
+No-results recovery should be explicit and should not imply that the library was searched successfully when the backend was offline or no sources were selected.
+
+## Export
+
+Use export after reviewing the answer and evidence.
+
+Observed export behavior includes:
+
+- Markdown export for text reuse.
+- PDF export through the browser print flow.
+- Chatbook export for portable tldw conversation packaging.
+- Save to Notes when exportable content is available.
+- Share-link controls when the current thread supports read-only sharing.
+
+Exported content should preserve the question, answer, citations, source scope, and relevant retrieval details when available.
+
+## Relationship To Other Workflows
+
+- Research Workspace: use it for broader research projects, source organization, and multi-step investigation. Knowledge QA can support focused cited questions.
+- Chat: use it for general conversation or model interaction. Knowledge QA is for library-grounded answers with citations.
+- Notes: notes can be searched as Knowledge QA sources when indexed and selected. Export can also save reviewed output back to Notes.
+- Media: ingested and indexed media can be searched as Knowledge QA sources.
+- Flashcards: use the separate flashcards route. `/knowledge` does not create decks, review cards, or run spaced repetition.
+
+## WebUI Versus Extension Differences
+
+Shared behavior:
+
+- Search state, source scope, presets, model controls, settings, citations, evidence review, and export should follow the same product contract.
+- Backend unavailable, no-source, no-results, and blocked-search states should show actionable recovery.
+
+Extension-specific behavior:
+
+- Extension setup can fail because of missing server configuration, missing API key, host permission, allowlist, or backend reachability.
+- Extension options width can force compact layout sooner than the WebUI.
+- Extension shared-link routing may differ from WebUI routing.
+
+WebUI-specific behavior:
+
+- WebUI readiness can be blocked by route-level backend readiness or server health checks.
+- WebUI has more horizontal space for detailed layout and evidence review.
+
+## Regression Commands
+
+Run focused Knowledge QA checks from the relevant package directory.
+
+Shared UI:
+
+```bash
+cd apps/packages/ui
+bunx vitest run src/components/Option/KnowledgeQA
+```
+
+WebUI:
+
+```bash
+cd apps/tldw-frontend
+npx playwright test e2e/ux-audit/knowledge-readiness-recovery.spec.ts e2e/ux-audit/knowledge-qa-states.spec.ts e2e/ux-audit/knowledge-empty-recovery.spec.ts --project=chromium
+```
+
+Extension:
+
+```bash
+cd apps/extension
+npx playwright test tests/e2e/knowledge-qa-setup-diagnostics.spec.ts tests/e2e/knowledge-qa-states.spec.ts tests/e2e/knowledge-empty-recovery.spec.ts --project=chromium-extension
+```
+
+Python backend checks are not required for documentation-only changes. If backend Knowledge QA/RAG code is touched, run the focused pytest paths and Bandit on the touched Python scope.

--- a/Docs/superpowers/plans/2026-06-07-knowledge-extension-setup-diagnostics-plan.md
+++ b/Docs/superpowers/plans/2026-06-07-knowledge-extension-setup-diagnostics-plan.md
@@ -1,0 +1,90 @@
+# Knowledge Extension Setup Diagnostics Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the extension `/knowledge` setup-required state diagnostic enough for users to recover without opening DevTools.
+
+**Architecture:** Keep the shared Knowledge QA route, but add extension-aware setup diagnostics that can report missing server URL, missing API key, host permission or allowlist problems, and backend reachability failures. The extension setup state should not compete with a feature tour while setup is blocking.
+
+**Tech Stack:** React, WXT/browser extension options route, shared `@tldw/ui`, Vitest, Playwright.
+
+**Backlog Task:** TASK-528.3
+
+---
+
+## Boundaries
+
+- This phase is extension setup and diagnostics only.
+- WebUI readiness recovery is handled by TASK-528.2.
+- Do not add flashcard behavior to `/knowledge`.
+
+## Files
+
+- Modify: `apps/packages/ui/src/components/Option/KnowledgeQA/index.tsx`
+- Create: `apps/packages/ui/src/components/Option/KnowledgeQA/SetupDiagnostics.tsx`
+- Modify: `apps/packages/ui/src/components/Option/KnowledgeQA/__tests__/KnowledgeQA.connection.test.tsx`
+- Modify: `apps/packages/ui/src/components/Option/KnowledgeQA/__tests__/knowledgeQaStateFixtures.ts`
+- Create or modify: `apps/extension/tests/e2e/knowledge-qa-setup-diagnostics.spec.ts`
+
+## Task 1: Write Failing Setup Diagnostic Tests
+
+- [x] Add unit tests for missing server URL, missing API key, blocked absolute URL or allowlist issue, and unreachable backend.
+- [x] Assert the setup state shows specific checks and next actions, not only "Setup Required."
+- [x] Assert a setup-blocked state suppresses the ready search workspace while recovery is blocking.
+- [x] Run:
+
+```bash
+bunx vitest run src/components/Option/KnowledgeQA/__tests__/KnowledgeQA.connection.test.tsx
+```
+
+Result: failed before implementation on missing diagnostic content, then passed after implementation.
+
+## Task 2: Add Extension-Aware Diagnostics Model
+
+- [x] Identify the source of extension server URL and API key configuration.
+- [x] Add a typed diagnostic summary that can report:
+  - server URL missing
+  - API key missing
+  - backend unreachable
+  - request blocked by extension permission or allowlist
+  - server configured but auth failed
+- [x] Keep diagnostics generic enough to be reused by other extension setup states if local patterns support it.
+
+Notes: The shared connection store already exposes the needed route-level facts through `useConnectionState` and `useConnectionUxState`: `serverUrl`, `configStep`, `errorKind`, `lastError`, `lastStatusCode`, and `isChecking`. No new connection store or request-core state was needed.
+
+## Task 3: Update Setup Required UI
+
+- [x] Replace the single vague setup message with a compact checklist.
+- [x] Provide primary action to finish setup.
+- [x] Provide secondary action to retry or open diagnostics when useful.
+- [x] Show the configured server origin when available, redacting paths/query strings.
+- [x] Defer the page tour until setup passes by returning the blocking diagnostics surface before the ready workspace renders.
+
+Notes: WebUI and extension use the same diagnostics panel. The extension additionally shows `Request host access` when `chrome.permissions.request` is available; WebUI users receive origin/CORS guidance in the browser access row.
+
+## Task 4: Verify Extension Route
+
+- [x] Add Playwright tests for extension options `#/knowledge` in missing config, missing auth, unreachable/backend-blocked, and configured healthy states.
+- [x] Use the extension test config and static/mock runtime already used by the repository.
+- [ ] Run:
+
+```bash
+npx playwright test --config apps/extension/playwright.config.ts apps/extension/tests/e2e/knowledge-qa-setup-diagnostics.spec.ts
+```
+
+Result: blocked before Playwright launched because the extension WXT production build hung twice after the duplicated-import warnings. Both hung processes were terminated.
+
+## Task 5: Close Verification
+
+- [x] Run related unit tests and extension compile.
+- [x] Record WebUI versus extension setup differences in TASK-528.3 notes.
+- [x] Record Bandit as not applicable because no Python backend files were touched.
+
+Verification:
+
+```bash
+bunx vitest run src/components/Option/KnowledgeQA/__tests__/KnowledgeQA.connection.test.tsx src/components/Option/KnowledgeQA/__tests__/KnowledgeQALayout.behavior.test.tsx
+bun run compile
+```
+
+Results: Vitest passed 20 tests. Extension TypeScript compile passed. Extension runtime E2E is authored but not executed due WXT build hang; see TASK-306 for the existing build pre-render hang track.

--- a/Docs/superpowers/plans/2026-06-07-knowledge-first-run-empty-recovery-plan.md
+++ b/Docs/superpowers/plans/2026-06-07-knowledge-first-run-empty-recovery-plan.md
@@ -1,0 +1,104 @@
+# Knowledge First-Run Empty Recovery Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make beginner recovery paths on `/knowledge` clear for first-run, no indexed sources, no selected sources, offline backend, and failed search states.
+
+**Architecture:** Split state detection from copy and actions. The Knowledge QA empty-state layer should classify why the user cannot search, then render one primary recovery path plus relevant secondary actions. Source creation remains in existing source owner surfaces such as Quick Ingest, Media, Notes, or setup routes.
+
+**Tech Stack:** React, shared Knowledge QA UI, Vitest, Playwright.
+
+**Backlog Task:** TASK-528.4
+
+---
+
+## Boundaries
+
+- `/knowledge` may point users to add or index sources, but it must not become a full source-management CRUD hub.
+- Do not add flashcard behavior to `/knowledge`.
+- Do not enable web fallback automatically.
+
+## Files
+
+- Modify: `apps/packages/ui/src/components/Option/KnowledgeQA/empty/KnowledgeReadyState.tsx`
+- Modify: `apps/packages/ui/src/components/Option/KnowledgeQA/panels/NoResultsRecovery.tsx`
+- Modify: `apps/packages/ui/src/components/Option/KnowledgeQA/SearchBar.tsx`
+- Modify: `apps/packages/ui/src/components/Option/KnowledgeQA/context/KnowledgeContextBar.tsx`
+- Modify: `apps/packages/ui/src/components/Option/KnowledgeQA/__tests__/KnowledgeQALayout.behavior.test.tsx`
+- Modify: `apps/packages/ui/src/components/Option/KnowledgeQA/__tests__/SearchBar.behavior.test.tsx`
+- Create or modify: `apps/tldw-frontend/e2e/ux-audit/knowledge-empty-recovery.spec.ts`
+- Create or modify: `apps/extension/tests/e2e/knowledge-empty-recovery.spec.ts`
+
+## Task 1: Write Failing Empty-State Tests
+
+- [x] Add tests for first-run with no indexed documents or notes.
+- [x] Add tests for indexed sources present but none selected.
+- [x] Add tests for web fallback available versus unavailable.
+- [x] Add tests proving disabled Ask has visible inline explanation without hover.
+- [x] Run:
+
+```bash
+bunx vitest run apps/packages/ui/src/components/Option/KnowledgeQA/__tests__/KnowledgeQALayout.behavior.test.tsx apps/packages/ui/src/components/Option/KnowledgeQA/__tests__/SearchBar.behavior.test.tsx
+```
+
+Expected: tests fail before implementation.
+
+Observed: focused Vitest run failed for the expected missing behavior: no recovery classifier was passed to the ready state, no-source blocking was tooltip-only, and unavailable web fallback was ignored.
+
+## Task 2: Classify Beginner Recovery States
+
+- [x] Add a small state classifier for:
+  - backend unavailable
+  - setup or auth missing
+  - no indexed sources
+  - sources indexed but none selected
+  - no results after search
+  - failed search
+- [x] Keep classifier inputs based on existing source counts, selected sources, capabilities, and connection state.
+- [x] Avoid duplicating backend health logic already owned by connection hooks.
+
+Implemented: `empty/recoveryState.ts` classifies ready, backend unavailable, no indexed sources, no selected sources, and web-only states from `knowledgeStatus`, selected source count, web fallback setting, and server capability. Backend setup/auth/offline gates remain owned by the existing connection diagnostics chain. No-results and failed-search recovery remain in the results/error surfaces rather than the ready-state classifier.
+
+## Task 3: Update First-Run And No-Source Copy
+
+- [x] Update "Ask Your Library" copy to explain that the page searches selected personal-library sources and returns grounded answers with citations.
+- [x] For no indexed sources, primary CTA should route to add or index sources.
+- [x] For no selected sources, primary CTA should open source selection.
+- [x] If web fallback is enabled, state that the search will use web results only.
+- [x] If web fallback is available but off, offer it as a secondary action.
+
+Implemented: ready-state copy now explains selected personal-library search and inspectable citations. No indexed sources routes to `/media` and `/notes`; no selected sources opens source selection. Search is visibly disabled for no selected sources without web fallback and for no indexed library sources when web fallback is unavailable/off.
+
+## Task 4: Harden No-Results Recovery
+
+- [x] Make no-results recovery actions conditional on available capabilities and real candidate data.
+- [x] Offer broaden source scope, adjust query, tune settings, or enable web fallback.
+- [x] Do not show nearest matches unless the backend returned candidates or the UI can prove they exist.
+
+Implemented: no-results recovery only shows web search actions when web search is available, and only shows nearest matches when `searchDetails.alsoConsidered` is populated.
+
+## Task 5: Verify Beginner Flow
+
+- [x] Run unit tests.
+- [x] Add WebUI and extension route tests:
+
+```bash
+npx playwright test apps/tldw-frontend/e2e/ux-audit/knowledge-empty-recovery.spec.ts
+npx playwright test --config apps/extension/playwright.config.ts apps/extension/tests/e2e/knowledge-empty-recovery.spec.ts
+```
+
+- [x] Attempt WebUI and extension route tests.
+- [x] Record Bandit as not applicable unless Python backend files were touched.
+- [x] Update TASK-528.4 with verification and known skips.
+
+Verification:
+
+- Passing: `bunx vitest run src/components/Option/KnowledgeQA/__tests__/KnowledgeQALayout.behavior.test.tsx src/components/Option/KnowledgeQA/__tests__/SearchBar.behavior.test.tsx src/components/Option/KnowledgeQA/__tests__/KnowledgeQA.connection.test.tsx` from `apps/packages/ui` passed 48 tests.
+- Passing: `bun run compile` from `apps/extension` passed TypeScript compile.
+- Added route specs:
+  - `apps/tldw-frontend/e2e/ux-audit/knowledge-empty-recovery.spec.ts`
+  - `apps/extension/tests/e2e/knowledge-empty-recovery.spec.ts`
+- WebUI route runtime blocked: after manually starting `bun run dev -- -p 8080`, `TLDW_WEB_AUTOSTART=false npx playwright test e2e/ux-audit/knowledge-empty-recovery.spec.ts --reporter=line` failed before test execution because Chromium could not launch in this sandbox: `bootstrap_check_in org.chromium.Chromium.MachPortRendezvousServer... Permission denied (1100)`.
+- Extension route runtime blocked: `npx playwright test --config apps/extension/playwright.config.ts apps/extension/tests/e2e/knowledge-empty-recovery.spec.ts --reporter=line` hung in WXT production build after duplicated-import warnings; terminated the verification process chain. This matches existing TASK-306 WXT build-hang blocker.
+- Scope check: `rg "flashcard|deck|spaced repetition|study set" apps/packages/ui/src/components/Option/KnowledgeQA apps/tldw-frontend/e2e/ux-audit/knowledge-empty-recovery.spec.ts apps/extension/tests/e2e/knowledge-empty-recovery.spec.ts -n` returned no matches.
+- Bandit: not applicable; no Python backend files were touched.

--- a/Docs/superpowers/plans/2026-06-07-knowledge-power-user-settings-parity-plan.md
+++ b/Docs/superpowers/plans/2026-06-07-knowledge-power-user-settings-parity-plan.md
@@ -1,0 +1,82 @@
+# Knowledge Power User Settings Parity Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Harden `/knowledge` for experienced users who need compact source control, advanced RAG tuning, evidence review, provider selection, and WebUI/extension parity.
+
+**Architecture:** Keep simple and detailed modes as two presentations of the same Knowledge QA state. Advanced settings should remain progressive: Basic mode for common tuning, Expert mode for retrieval details, with focus-safe drawer behavior and reversible defaults.
+
+**Tech Stack:** React, shared Knowledge QA UI, local persistence, Vitest, Playwright, accessibility checks.
+
+**Backlog Task:** TASK-528.7
+
+---
+
+## Boundaries
+
+- This phase optimizes the existing Knowledge QA power-user workflow.
+- Do not convert `/knowledge` into a generic CRUD workspace.
+- Do not add flashcard behavior to `/knowledge`.
+
+## Files
+
+- Modify: `apps/packages/ui/src/components/Option/KnowledgeQA/SettingsPanel/index.tsx`
+- Modify: `apps/packages/ui/src/components/Option/KnowledgeQA/SettingsPanel/BasicSettings.tsx`
+- Modify: `apps/packages/ui/src/components/Option/KnowledgeQA/SettingsPanel/ExpertSettings.tsx`
+- Modify: `apps/packages/ui/src/components/Option/KnowledgeQA/SettingsPanel/PresetSelector.tsx`
+- Modify: `apps/packages/ui/src/components/Option/KnowledgeQA/context/CompactToolbar.tsx`
+- Modify: `apps/packages/ui/src/components/Option/KnowledgeQA/context/KnowledgeContextBar.tsx`
+- Modify: `apps/packages/ui/src/components/Option/KnowledgeQA/context/AnswerModelMenu.tsx`
+- Modify: `apps/packages/ui/src/components/Option/KnowledgeQA/hooks/useLayoutMode.ts`
+- Modify: `apps/packages/ui/src/components/Option/KnowledgeQA/__tests__/SettingsPanel.behavior.test.tsx`
+- Modify: `apps/packages/ui/src/components/Option/KnowledgeQA/__tests__/ExpertSettings.accessibility.test.tsx`
+- Modify: `apps/packages/ui/src/components/Option/KnowledgeQA/__tests__/HistorySidebar.responsive.test.tsx`
+- Modify: `apps/packages/ui/src/components/Option/KnowledgeQA/__tests__/CompactToolbar.test.tsx`
+
+## Task 1: Write Failing Settings Accessibility Tests
+
+- [x] Add tests for settings drawer open, close, Escape, focus return, focus trap, and reset defaults.
+- [x] Add tests for Basic versus Expert mode switch and first-use Expert hint.
+- [x] Add tests for All Options filtering in Expert mode.
+- [x] Run:
+
+```bash
+bunx vitest run apps/packages/ui/src/components/Option/KnowledgeQA/__tests__/SettingsPanel.behavior.test.tsx apps/packages/ui/src/components/Option/KnowledgeQA/__tests__/ExpertSettings.accessibility.test.tsx
+```
+
+Expected: tests fail where accessibility or filtering is incomplete.
+
+Result: Focused settings and expert coverage is included in the passing 102-test Knowledge QA Vitest run.
+
+## Task 2: Improve Compact And Detailed Mode Parity
+
+- [x] Audit all controls available in detailed mode: sources, exact scope, profiles, preset, web fallback, model, settings, history, evidence.
+- [x] Ensure compact mode exposes the same critical controls through toolbar buttons or a compact drawer.
+- [x] Add tests for compact-mode source/profile/model/settings access.
+- [x] Confirm text does not overflow in mobile and extension options widths.
+
+Result: Compact simple mode now opens a source scope and profiles dialog that reuses the shared context controls for source categories, exact documents/notes, saved profiles, preset, web fallback, answer model, and settings.
+
+## Task 3: Harden Provider And Model Controls
+
+- [x] Add tests for provider list loading, provider list failure, server default, manual model entry, and restored model selection.
+- [x] Redact or avoid sensitive provider configuration details in UI errors.
+- [x] Keep provider/model copy short and task-focused.
+
+## Task 4: Verify Cross-Surface Parity
+
+- [x] Run WebUI fixture e2e in desktop and mobile viewports.
+- [ ] Run extension options e2e at representative extension viewport.
+- [x] Document intentional differences, especially setup and permissions.
+- [x] Fail tests if shared Knowledge QA controls disappear from one surface without a documented reason.
+
+Result: WebUI Chromium fixture coverage passed for the Knowledge QA state and empty-recovery flows. Extension E2E was attempted, but the WXT production build stalled before any browser test started; the stuck process tree was terminated and the blocker is recorded on TASK-528.7.
+
+## Task 5: Close Verification
+
+- [x] Run targeted Vitest files for settings, compact toolbar, history sidebar, and provider controls.
+- [x] Run WebUI and extension e2e parity checks.
+- [x] Record Bandit as not applicable unless Python backend files were touched.
+- [x] Update TASK-528.7 with verification results and parity notes.
+
+Result: Targeted Vitest passed. WebUI E2E passed. Extension E2E is recorded as blocked by the extension production build stall. Bandit is not applicable because TASK-528.7 touched frontend and E2E files only.

--- a/Docs/superpowers/plans/2026-06-07-knowledge-qa-state-fixtures-and-baseline-plan.md
+++ b/Docs/superpowers/plans/2026-06-07-knowledge-qa-state-fixtures-and-baseline-plan.md
@@ -1,0 +1,91 @@
+# Knowledge QA State Fixtures And Baseline Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make every audited `/knowledge` state reproducible in WebUI and extension tests before UI remediation begins.
+
+**Architecture:** Add deterministic frontend fixtures and route-level tests around the shared Knowledge QA component, the WebUI readiness gate, and the extension options route. Prefer mocked API responses and explicit state builders over live backend dependencies so the QA states can be tested in CI and during local review.
+
+**Tech Stack:** React, Vitest, Testing Library, Playwright, Next.js WebUI, WXT/browser extension options route, shared `@tldw/ui` package.
+
+**Backlog Task:** TASK-528.1
+
+---
+
+## Boundaries
+
+- `/knowledge` remains a Knowledge QA workflow for searching a personal library and reviewing grounded answers with citations.
+- Do not add flashcard, deck, spaced repetition, study-set, or card review behavior to `/knowledge`.
+- This phase should capture current failures and build test access. It should not redesign the UI except for test-only seams.
+
+## Files
+
+- Modify: `apps/packages/ui/src/components/Option/KnowledgeQA/__tests__/KnowledgeQA.connection.test.tsx`
+- Modify: `apps/packages/ui/src/components/Option/KnowledgeQA/__tests__/KnowledgeQALayout.behavior.test.tsx`
+- Create or modify: `apps/packages/ui/src/components/Option/KnowledgeQA/__tests__/knowledgeQaStateFixtures.ts`
+- Create or modify: `apps/tldw-frontend/components/networking/__tests__/ServerReadinessGate.test.tsx`
+- Create or modify: `apps/tldw-frontend/e2e/ux-audit/knowledge-qa-states.spec.ts`
+- Create or modify: `apps/extension/tests/e2e/knowledge-qa-states.spec.ts`
+- Modify: `apps/extension/tests/e2e/setup/build-extension.ts`
+
+## Task 1: Inventory Existing Test Helpers
+
+- [x] Inspect existing Knowledge QA tests and identify reusable render helpers, mocked API clients, and connection-state builders.
+- [x] Inspect existing WebUI e2e fixtures under `apps/tldw-frontend/e2e` and extension fixtures under `apps/extension/tests/e2e`.
+- [x] Record missing helper seams through this plan and TASK-528.1 closeout.
+
+## Task 2: Add State Fixture Builder
+
+- [x] Write a failing unit test that renders each audited state from a named fixture:
+  - backend offline
+  - setup required
+  - no indexed sources
+  - no selected sources
+  - ready search
+  - results with citations
+  - no results
+  - settings drawer
+  - export dialog
+- [x] Add `knowledgeQaStateFixtures.ts` with small, typed builders for server state, capabilities, source lists, RAG result payloads, and provider lists.
+- [x] Keep fixture names Knowledge QA-specific. Do not use flashcard terminology.
+- [x] Run:
+
+```bash
+bunx vitest run src/components/Option/KnowledgeQA/__tests__/KnowledgeQA.connection.test.tsx src/components/Option/KnowledgeQA/__tests__/KnowledgeQALayout.behavior.test.tsx
+```
+
+Result: passed, 18 tests.
+
+## Task 3: Capture WebUI Readiness Baseline
+
+- [x] Write a WebUI readiness baseline test that simulates failed `/api/v1/health` readiness.
+- [x] Assert the current failure state is observable: route children render without recovery UI after timeout.
+- [x] Leave the recovery panel implementation to TASK-528.2 rather than changing behavior in this baseline task.
+- [x] Run:
+
+```bash
+bunx vitest run components/networking/__tests__/ServerReadinessGate.test.tsx
+```
+
+Result: passed, 5 tests.
+
+## Task 4: Add WebUI And Extension Route Fixtures
+
+- [x] Add Playwright route mocks for health, capabilities, source listing, providers, thread setup, and RAG search.
+- [x] Add WebUI e2e cases for ready search and cited results without a live backend.
+- [x] Add extension e2e cases for setup required and connected ready search without live backend data.
+- [x] Add `TLDW_E2E_SKIP_EXTENSION_BUILD` to extension global setup so existing valid builds can be used when WXT rebuilds are not part of the test.
+- [x] Run:
+
+```bash
+npx playwright test e2e/ux-audit/knowledge-qa-states.spec.ts --reporter=line
+TLDW_E2E_SKIP_EXTENSION_BUILD=1 TLDW_E2E_EXTENSION_HEADLESS=1 npx playwright test tests/e2e/knowledge-qa-states.spec.ts --reporter=line
+```
+
+Result: WebUI passed, 2 tests. Extension passed, 2 tests, when launched outside the sandbox because Chromium extension startup is blocked by sandboxed macOS Crashpad permissions.
+
+## Task 5: Close Verification
+
+- [x] Update TASK-528.1 with created fixture files, route coverage, and known extension launch requirement.
+- [x] No Python code was touched; Bandit is not applicable for this test-fixture-only phase.
+- [x] Confirm all fixture copy and test names preserve the Knowledge QA-only scope.

--- a/Docs/superpowers/plans/2026-06-07-knowledge-ready-search-source-scope-plan.md
+++ b/Docs/superpowers/plans/2026-06-07-knowledge-ready-search-source-scope-plan.md
@@ -1,0 +1,97 @@
+# Knowledge Ready Search Source Scope Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Harden the ready `/knowledge` search workflow for source scope, exact source selection, saved profiles, suggestions, shortcuts, presets, web fallback, and answer model selection.
+
+**Architecture:** Treat source scope as the user's search contract. Keep category selection, exact document/note selection, saved profiles, and compact-mode controls synchronized through the existing Knowledge QA provider and context toolbar rather than one-off local state.
+
+**Tech Stack:** React, shared Knowledge QA UI, local storage profile persistence, Vitest, Playwright.
+
+**Backlog Task:** TASK-528.5
+
+---
+
+## Boundaries
+
+- This phase assumes the route can reach ready state through TASK-528.1 and TASK-528.2 fixtures.
+- Do not change backend retrieval semantics unless a frontend contract bug requires a separate backend task.
+- Do not add flashcard behavior to `/knowledge`.
+
+## Files
+
+- Modify: `apps/packages/ui/src/components/Option/KnowledgeQA/SearchBar.tsx`
+- Modify: `apps/packages/ui/src/components/Option/KnowledgeQA/context/KnowledgeContextBar.tsx`
+- Modify: `apps/packages/ui/src/components/Option/KnowledgeQA/context/CompactToolbar.tsx`
+- Modify: `apps/packages/ui/src/components/Option/KnowledgeQA/context/AnswerModelMenu.tsx`
+- Modify: `apps/packages/ui/src/components/Option/KnowledgeQA/SettingsPanel/PresetSelector.tsx`
+- Modify: `apps/packages/ui/src/components/Option/KnowledgeQA/SettingsPanel/BasicSettings.tsx`
+- Modify: `apps/packages/ui/src/components/Option/KnowledgeQA/AnswerPanel.tsx`
+- Modify: `apps/packages/ui/src/components/Option/KnowledgeQA/layout/KnowledgeQALayout.tsx`
+- Modify: `apps/packages/ui/src/components/Option/KnowledgeQA/querySuggestions.ts`
+- Modify: `apps/packages/ui/src/components/Option/KnowledgeQA/__tests__/KnowledgeContextBar.test.tsx`
+- Modify: `apps/packages/ui/src/components/Option/KnowledgeQA/__tests__/KnowledgeContextBar.profiles.test.tsx`
+- Modify: `apps/packages/ui/src/components/Option/KnowledgeQA/__tests__/CompactToolbar.test.tsx`
+- Modify: `apps/packages/ui/src/components/Option/KnowledgeQA/__tests__/SearchBar.behavior.test.tsx`
+- Add: `apps/packages/ui/src/components/Option/KnowledgeQA/__tests__/AnswerModelMenu.test.tsx`
+- Modify: `apps/packages/ui/src/components/Option/KnowledgeQA/__tests__/SettingsPanel.behavior.test.tsx`
+- Modify: `apps/packages/ui/src/components/Option/KnowledgeQA/__tests__/AnswerPanel.states.test.tsx`
+
+## Task 1: Write Failing Scope And Profile Tests
+
+- [x] Add tests for selecting source categories, selecting exact documents, selecting exact notes, and clearing exact scope.
+- [x] Add tests for saved profile create, restore, delete, and compact-mode access.
+- [x] Add tests for provider/model loading success and failure.
+- [x] Run:
+
+```bash
+bunx vitest run apps/packages/ui/src/components/Option/KnowledgeQA/__tests__/KnowledgeContextBar.test.tsx apps/packages/ui/src/components/Option/KnowledgeQA/__tests__/KnowledgeContextBar.profiles.test.tsx apps/packages/ui/src/components/Option/KnowledgeQA/__tests__/CompactToolbar.test.tsx
+```
+
+Expected: tests fail where current behavior is incomplete.
+
+Result: initial focused run failed on exact profile scope round-trip, compact exact counts, Deep preset naming, and answer-provider loading/error states.
+
+## Task 2: Normalize Preset Labels
+
+- [x] Choose one user-facing label set: Fast, Balanced, Deep, Custom.
+- [x] Update toolbar, settings drawer, saved profile summaries, loading hints, and tests to use the same labels.
+- [x] Keep internal ids stable; `thorough` remains the internal preset id for API/provider compatibility.
+- [x] Add unit coverage that fails if settings drifts back to `Thorough`.
+
+## Task 3: Harden Exact Source Selection
+
+- [x] Ensure document/media and notes selectors have loading, empty, retry, and API error states.
+- [x] Show selected counts clearly in both detailed and compact modes.
+- [x] Ensure filtering exact sources does not clear already selected items unexpectedly.
+- [x] Ensure "Use all" clears exact filters without changing selected source categories.
+
+## Task 4: Improve Search Input And Shortcuts
+
+- [x] Validate `/` focus, Cmd/Ctrl+K new search, arrow navigation in suggestions, Enter selection, and Escape close.
+- [x] Ensure shortcuts do not steal focus from text inputs, dialogs, or menus.
+- [x] Keep suggestions grounded in history, source titles, or static examples.
+
+## Task 5: Harden Web Fallback And Model Controls
+
+- [x] Show capability-aware web fallback state and disabled reason.
+- [x] Preserve user-controlled fallback state when web fallback is unavailable.
+- [x] Handle provider list loading, error, server default, and manual model entry.
+- [ ] Add e2e coverage for a scoped ready search with selected documents and notes.
+
+## Task 6: Close Verification
+
+- [x] Run targeted Vitest files listed above.
+- [ ] Run route fixture e2e for ready search once TASK-528.1 fixtures exist.
+- [x] Record Bandit as not applicable; only TypeScript/React files were touched.
+- [ ] Update TASK-528.5 with verification results.
+
+Verification:
+
+```bash
+bunx vitest run src/components/Option/KnowledgeQA/__tests__/KnowledgeContextBar.profiles.test.tsx src/components/Option/KnowledgeQA/__tests__/CompactToolbar.test.tsx src/components/Option/KnowledgeQA/__tests__/SettingsPanel.behavior.test.tsx src/components/Option/KnowledgeQA/__tests__/AnswerModelMenu.test.tsx src/components/Option/KnowledgeQA/__tests__/KnowledgeContextBar.test.tsx src/components/Option/KnowledgeQA/__tests__/SearchBar.behavior.test.tsx src/components/Option/KnowledgeQA/__tests__/querySuggestions.test.ts src/components/Option/KnowledgeQA/__tests__/AnswerPanel.states.test.tsx
+```
+
+Result: 8 files, 93 tests passed.
+
+Route fixture e2e note: not rerun in this slice because the current environment still has the previously recorded browser launch/WXT production build blockers from TASK-528.4 and TASK-306.

--- a/Docs/superpowers/plans/2026-06-07-knowledge-results-evidence-export-plan.md
+++ b/Docs/superpowers/plans/2026-06-07-knowledge-results-evidence-export-plan.md
@@ -1,0 +1,95 @@
+# Knowledge Results Evidence Export Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Validate and harden `/knowledge` results, citations, evidence inspection, no-results recovery, follow-up search, and export.
+
+**Architecture:** Treat answer, citations, evidence, details, and export as one trust workflow. The answer panel should never claim grounded support without visible evidence, and export should preserve enough query, source, and settings context for later review.
+
+**Tech Stack:** React, shared Knowledge QA UI, Markdown export utilities, Vitest, Playwright.
+
+**Backlog Task:** TASK-528.6
+
+---
+
+## Boundaries
+
+- This phase validates and hardens existing Knowledge QA result workflows.
+- Do not introduce unrelated Research Workspace, Chat, Notes, or Media redesigns.
+- Do not add flashcard behavior to `/knowledge`.
+
+## Files
+
+- Modify: `apps/packages/ui/src/components/Option/KnowledgeQA/AnswerPanel.tsx`
+- Modify: `apps/packages/ui/src/components/Option/KnowledgeQA/panels/AnswerWorkspace.tsx`
+- Modify: `apps/packages/ui/src/components/Option/KnowledgeQA/evidence/EvidenceRail.tsx`
+- Modify: `apps/packages/ui/src/components/Option/KnowledgeQA/SearchDetailsPanel.tsx`
+- Modify: `apps/packages/ui/src/components/Option/KnowledgeQA/SourceList.tsx`
+- Modify: `apps/packages/ui/src/components/Option/KnowledgeQA/SourceCard.tsx`
+- Modify: `apps/packages/ui/src/components/Option/KnowledgeQA/panels/NoResultsRecovery.tsx`
+- Modify: `apps/packages/ui/src/components/Option/KnowledgeQA/ExportDialog.tsx`
+- Modify: `apps/packages/ui/src/components/Option/KnowledgeQA/__tests__/AnswerPanel.states.test.tsx`
+- Modify: `apps/packages/ui/src/components/Option/KnowledgeQA/__tests__/SearchDetailsPanel.test.tsx`
+- Modify: `apps/packages/ui/src/components/Option/KnowledgeQA/__tests__/SourceList.behavior.test.tsx`
+- Modify: `apps/packages/ui/src/components/Option/KnowledgeQA/__tests__/ExportDialog.a11y.test.tsx`
+
+## Task 1: Write Failing Cited Result Tests
+
+- [x] Add a fixture result with answer text, inline citations, source cards, and search details.
+- [x] Assert each visible citation maps to a source in the evidence rail.
+- [x] Assert Sources and Details tabs expose relevant metadata when available.
+- [x] Run:
+
+```bash
+bunx vitest run apps/packages/ui/src/components/Option/KnowledgeQA/__tests__/AnswerPanel.states.test.tsx apps/packages/ui/src/components/Option/KnowledgeQA/__tests__/SearchDetailsPanel.test.tsx
+```
+
+Result: focused tests first failed on missing export citation/settings details and missing telemetry explanation; after implementation the focused suite passed.
+
+## Task 2: Harden Answer And Evidence Coupling
+
+- [x] Make citation count and source support badges reflect actual available evidence.
+- [x] Ensure citation buttons jump or focus the matching source.
+- [x] Ensure low-confidence or no-citation answers show recovery copy instead of overstating support.
+- [x] Keep streaming and final answer states distinct.
+
+Existing `AnswerPanel.states.test.tsx` coverage was retained and rerun; no production AnswerPanel changes were needed in this slice.
+
+## Task 3: Validate Sources And Details Views
+
+- [x] Sources view should support cited-first sorting, filters, source feedback, copy, open original, and document workspace handoff where applicable.
+- [x] Details view should show query expansion, reranking, average relevance, web fallback, verification, candidates considered, and latency only when data exists.
+- [x] Missing detail data should be explained without looking broken.
+
+## Task 4: Harden No-Results And Failed Search
+
+- [x] Add tests for empty result set, timeout, unreachable backend, and generic failed search.
+- [x] Offer broaden scope, adjust query, tune settings, or enable web fallback based on available capabilities.
+- [x] Do not show "nearest matches" unless real candidates are present.
+
+## Task 5: Validate Export
+
+- [x] Add tests for Markdown export content structure.
+- [x] Verify PDF and Chatbook actions expose success and failure states or clearly document unsupported test coverage.
+- [x] Ensure export includes query, answer, sources, citations, conversation history when available, and optional settings snapshot.
+- [x] Verify Save to Notes and share-link actions surface errors.
+
+## Task 6: Close Verification
+
+- [x] Run targeted Vitest files for answer, evidence, source list, no-results, and export.
+- [x] Run WebUI route fixture e2e for ready, cited result, empty, and no-source recovery states.
+- [x] Record route fixture coverage limits: export and failed-search behavior are covered by focused Vitest; extension E2E was attempted but blocked by a WXT production build hang before tests executed.
+- [x] Record Bandit as not applicable unless Python backend files were touched.
+- [x] Update TASK-528.6 with verification results.
+
+## Verification Results
+
+- `bunx vitest run src/components/Option/KnowledgeQA/__tests__/ExportDialog.a11y.test.tsx src/components/Option/KnowledgeQA/__tests__/SearchDetailsPanel.test.tsx` - passed, 30 tests.
+- `bunx vitest run src/components/Option/KnowledgeQA/__tests__/NoResultsRecovery.test.tsx` - passed, 2 tests.
+- `bunx vitest run src/components/Option/KnowledgeQA/__tests__/AnswerPanel.states.test.tsx src/components/Option/KnowledgeQA/__tests__/SearchDetailsPanel.test.tsx src/components/Option/KnowledgeQA/__tests__/SourceList.behavior.test.tsx src/components/Option/KnowledgeQA/__tests__/NoResultsRecovery.test.tsx src/components/Option/KnowledgeQA/__tests__/ExportDialog.a11y.test.tsx src/components/Option/KnowledgeQA/__tests__/KnowledgeQALayout.behavior.test.tsx src/components/Option/KnowledgeQA/__tests__/errorMessages.test.ts` - passed, 97 tests.
+- `npx playwright test e2e/ux-audit/knowledge-qa-states.spec.ts e2e/ux-audit/knowledge-empty-recovery.spec.ts --project=chromium --reporter=line` - passed, 4 tests after strict locator hardening in the WebUI empty-recovery spec.
+- `CI=1 npx playwright test tests/e2e/knowledge-qa-states.spec.ts tests/e2e/knowledge-empty-recovery.spec.ts --project=chromium-extension --reporter=line` - attempted; blocked because the extension WXT production build hung after the initial build warnings and had to be terminated. No extension tests executed.
+- `bunx tsc --noEmit --pretty false` in `apps/packages/ui` - failed on existing repo-wide baseline TypeScript errors outside this slice; touched Knowledge QA paths compiled through Vitest.
+- `git diff --check -- <touched files>` - passed.
+- `rg -n "flashcard|deck|spaced repetition|study set" <touched Knowledge QA files>` - no matches.
+- Bandit - not applicable; no Python backend files touched.

--- a/Docs/superpowers/plans/2026-06-07-knowledge-uat-regression-guardrails-plan.md
+++ b/Docs/superpowers/plans/2026-06-07-knowledge-uat-regression-guardrails-plan.md
@@ -1,0 +1,90 @@
+# Knowledge UAT Regression Guardrails Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Turn the `/knowledge` audit UAT scripts into repeatable release checks, docs, and regression guardrails for WebUI and extension.
+
+**Architecture:** Consolidate the UAT scripts into page-specific QA documentation and automated smoke coverage. Keep human UAT steps concrete enough for release review while preserving automated route-state tests for CI.
+
+**Tech Stack:** Markdown documentation, Playwright, Vitest, optional pytest and Bandit if backend code is touched.
+
+**Backlog Task:** TASK-528.8
+
+---
+
+## Boundaries
+
+- This phase documents and verifies the completed remediation series.
+- Do not use this phase to add new product scope.
+- Do not add flashcard behavior to `/knowledge`.
+
+## Files
+
+- Create or modify: `Docs/User_Guides/WebUI_Extension/Knowledge_QA_Guide.md`
+- Create or modify: `Docs/Plans/2026-06-07-knowledge-qa-uat-checklist.md`
+- Modify: `apps/tldw-frontend/e2e/ux-audit/knowledge-qa-states.spec.ts`
+- Modify: `apps/extension/tests/e2e/knowledge-qa-states.spec.ts`
+- Modify: relevant Knowledge QA Vitest files touched by TASK-528.1 through TASK-528.7
+- Modify: Backlog tasks TASK-528 and TASK-528.1 through TASK-528.8
+
+## Task 1: Write UAT Checklist Document
+
+- [x] Create a UAT checklist covering:
+  - backend unavailable recovery
+  - first-run no-source setup
+  - first successful grounded search
+  - no-results recovery
+  - power-user scoped document/note search
+  - advanced settings and evidence review
+  - export
+- [x] Include WebUI and extension notes for each script.
+- [x] Include pass/fail criteria and known setup requirements.
+
+Result: Added `Docs/Plans/2026-06-07-knowledge-qa-uat-checklist.md`.
+
+## Task 2: Add Page-Specific User Help
+
+- [x] Add or update a Knowledge QA user guide.
+- [x] Explain what `/knowledge` searches, how source scope works, how citations map to evidence, what web fallback does, and how exports work.
+- [x] Explain relationship to Research Workspace, Chat, Notes, and Media.
+- [x] State that flashcards are handled by the separate flashcards route and are not part of `/knowledge`.
+
+Result: Added `Docs/User_Guides/WebUI_Extension/Knowledge_QA_Guide.md`.
+
+## Task 3: Consolidate Regression Commands
+
+- [x] Record the final command set for unit tests, WebUI e2e, extension e2e, and backend checks if backend code was touched.
+- [x] Recommended frontend commands:
+
+```bash
+bunx vitest run apps/packages/ui/src/components/Option/KnowledgeQA
+npx playwright test apps/tldw-frontend/e2e/ux-audit/knowledge-qa-states.spec.ts
+npx playwright test --config apps/extension/playwright.config.ts apps/extension/tests/e2e/knowledge-qa-states.spec.ts
+```
+
+- [x] If Python backend files were touched in earlier phases, run:
+
+```bash
+source .venv/bin/activate
+python -m pytest <touched backend test paths> -v
+python -m bandit -r <touched backend paths> -f json -o /tmp/bandit_knowledge_qa.json
+```
+
+Result: Regression commands are recorded in the UAT checklist and user guide. Bandit is recorded as not applicable for documentation-only TASK-528.8 work.
+
+## Task 4: Run Final UAT Pass
+
+- [x] Run automated WebUI route-state regression checks for UAT-critical states.
+- [x] Record extension options route UAT as blocked when the WXT build stalls before browser launch.
+- [x] Record screenshots or traces for any failed or skipped state.
+- [x] Update each child Backlog task with final verification status or blockers.
+
+Result: Automated WebUI route-state checks passed. Extension runtime UAT remains blocked by the previously recorded WXT production build stall before browser launch, so no extension screenshots or traces were produced in this closeout pass.
+
+## Task 5: Close Parent Program Task
+
+- [x] Update TASK-528 with links to all plans, final UAT checklist, user guide, and verification results.
+- [x] Confirm no `/knowledge` plan, test, or UI change introduced flashcard workflows.
+- [x] Mark completed child tasks Done only when their implementation acceptance criteria and verification are complete.
+
+Result: TASK-528 records the linked remediation plans, UAT checklist, user guide, verification commands, and known extension E2E blocker.

--- a/Docs/superpowers/plans/2026-06-07-knowledge-webui-readiness-recovery-plan.md
+++ b/Docs/superpowers/plans/2026-06-07-knowledge-webui-readiness-recovery-plan.md
@@ -1,0 +1,80 @@
+# Knowledge WebUI Readiness Recovery Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix the WebUI `/knowledge` readiness failure so users never see a blank route after backend health timeout.
+
+**Architecture:** Keep the global WebUI readiness gate, but make timeout and failure states visible, actionable, and compatible with route-level Knowledge QA recovery. Route-level recovery should explain Knowledge-specific setup and offline states after the global gate stops waiting.
+
+**Tech Stack:** Next.js, React, shared Knowledge QA UI, Vitest, Playwright.
+
+**Backlog Task:** TASK-528.2
+
+---
+
+## Boundaries
+
+- This plan fixes WebUI readiness and route recovery only.
+- Do not redesign the full Knowledge QA workspace in this phase.
+- Do not add flashcard behavior to `/knowledge`.
+
+## Files
+
+- Modify: `apps/tldw-frontend/components/networking/ServerReadinessGate.tsx`
+- Modify: `apps/tldw-frontend/components/networking/__tests__/ServerReadinessGate.test.tsx`
+- Create or modify: `apps/tldw-frontend/e2e/ux-audit/knowledge-readiness-recovery.spec.ts`
+- Verify: `apps/packages/ui/src/components/Option/KnowledgeQA/__tests__/KnowledgeQA.connection.test.tsx`
+
+## Task 1: Write Failing WebUI Timeout Test
+
+- [x] Add a test where `/api/v1/health` never resolves before the readiness timeout.
+- [x] Assert that the rendered page contains a visible recovery heading, backend URL or health target, Retry action, diagnostics/setup action, and no blank main area.
+- [x] Run:
+
+```bash
+bunx vitest run components/networking/__tests__/ServerReadinessGate.test.tsx
+```
+
+Result: failed before implementation because no readiness recovery heading/actions rendered and stalled health never reached recovery.
+
+## Task 2: Expose Actionable Readiness State
+
+- [x] Update `ServerReadinessGate` to distinguish checking, retrying, timeout, and explicit failed/stalled health outcomes.
+- [x] Preserve existing behavior for healthy backend.
+- [x] On timeout, render an explicit visible gate recovery panel while keeping route children mounted for route-level recovery.
+- [x] Include Retry, Health and diagnostics, and server settings actions.
+- [x] Ensure dark and light theme text uses existing design-system surface/text tokens.
+
+## Task 3: Allow KnowledgeQA Route Recovery
+
+- [x] Inspect `_app.tsx` ordering for `ServerReadinessGate` and `FirstRunGate`.
+- [x] Ensure `/knowledge` can reach `KnowledgeQA` recovery states after timeout by keeping route children mounted beneath the global recovery panel.
+- [x] Avoid new shared context/props because the existing route-level Knowledge QA recovery remains available.
+- [x] Add test coverage that route-level content remains mounted when backend health fails.
+
+## Task 4: Verify Browser Behavior
+
+- [x] Add Playwright coverage for WebUI `/knowledge` with stalled health and failed health.
+- [x] Assert the route exposes visible recovery within the configured timeout.
+- [x] Assert route content remains mounted and the recovery panel is non-empty.
+- [x] Run:
+
+```bash
+npx playwright test e2e/ux-audit/knowledge-readiness-recovery.spec.ts --reporter=line
+```
+
+Result: passed, 2 tests. A stale existing dev server had to be restarted so Playwright loaded the updated gate bundle.
+
+## Task 5: Close Verification
+
+- [x] Run relevant frontend unit tests:
+
+```bash
+bunx vitest run components/networking/__tests__/ServerReadinessGate.test.tsx
+bunx vitest run src/components/Option/KnowledgeQA/__tests__/KnowledgeQA.connection.test.tsx
+```
+
+- [x] Run the Playwright readiness recovery test.
+- [x] Run the prior WebUI Knowledge QA deterministic route-state spec as a regression check.
+- [x] Record Bandit as not applicable because no Python backend files were touched.
+- [x] Update TASK-528.2 with verification results and known skips.

--- a/apps/extension/tests/e2e/knowledge-empty-recovery.spec.ts
+++ b/apps/extension/tests/e2e/knowledge-empty-recovery.spec.ts
@@ -1,0 +1,104 @@
+import { expect, test } from "@playwright/test"
+
+import { launchWithBuiltExtension } from "./utils/extension-build"
+import { forceConnected, waitForConnectionStore } from "./utils/connection"
+
+test.describe("Knowledge QA extension empty recovery", () => {
+  test("shows add/index recovery when the connected backend reports no indexed sources", async () => {
+    const serverUrl = "http://dummy-tldw"
+    const { context, page, optionsUrl } = await launchWithBuiltExtension({
+      seedConfig: {
+        tldwConfig: {
+          serverUrl,
+          authMode: "single-user",
+          apiKey: "THIS-IS-A-SECURE-KEY-123-FAKE-KEY",
+        },
+      },
+      allowOffline: true,
+    })
+
+    try {
+      await page.goto(`${optionsUrl}#/knowledge`, { waitUntil: "domcontentloaded" })
+      await waitForConnectionStore(page, "knowledge-empty-recovery:no-indexed")
+      await forceConnected(
+        page,
+        { serverUrl, knowledgeStatus: "empty" },
+        "knowledge-empty-recovery:no-indexed"
+      )
+
+      await expect(page.getByText("No indexed library sources yet")).toBeVisible()
+      await expect(page.getByRole("link", { name: "Add or index sources" })).toBeVisible()
+
+      await page.getByLabel(/Search your knowledge base/i).fill("What does my library say?")
+      await expect(page.getByRole("button", { name: /^Ask$/i })).toBeDisabled()
+      await expect(
+        page.getByText("Add or index library sources before asking Knowledge QA.")
+      ).toBeVisible()
+    } finally {
+      await context.close()
+    }
+  })
+
+  test("shows source-selection recovery when indexed sources exist but none are selected", async () => {
+    const serverUrl = "http://dummy-tldw"
+    const { context, page, optionsUrl } = await launchWithBuiltExtension({
+      seedConfig: {
+        tldwConfig: {
+          serverUrl,
+          authMode: "single-user",
+          apiKey: "THIS-IS-A-SECURE-KEY-123-FAKE-KEY",
+        },
+      },
+      allowOffline: true,
+    })
+
+    try {
+      await page.goto(`${optionsUrl}#/knowledge`, { waitUntil: "domcontentloaded" })
+      await waitForConnectionStore(page, "knowledge-empty-recovery:no-selected")
+      await forceConnected(
+        page,
+        { serverUrl, knowledgeStatus: "ready" },
+        "knowledge-empty-recovery:no-selected"
+      )
+
+      const webToggle = page.getByRole("button", {
+        name: /Web fallback is currently/i,
+      })
+      await expect(webToggle).toBeVisible()
+      if ((await webToggle.getAttribute("aria-pressed")) === "true") {
+        await webToggle.click()
+      }
+      await page.getByRole("button", { name: /Open source scope and saved profiles/i }).click()
+      const scopeDialog = page.getByRole("dialog", { name: "Source scope and profiles" })
+      await expect(scopeDialog).toBeVisible()
+      await scopeDialog.getByRole("button", { name: /Sources:/i }).click()
+      for (const label of [
+        "Documents & Media",
+        "Notes",
+        "Story Characters",
+        "Conversations",
+        "Task Boards",
+      ]) {
+        const sourceOption = scopeDialog.getByRole("menuitemcheckbox", {
+          name: new RegExp(label),
+        })
+        if ((await sourceOption.count()) === 0) continue
+        if ((await sourceOption.first().getAttribute("aria-checked")) === "true") {
+          await sourceOption.first().click()
+        }
+      }
+      await scopeDialog.getByRole("button", { name: "Close source scope" }).click()
+
+      await expect(page.getByText("No source categories selected")).toBeVisible()
+      await expect(page.getByRole("button", { name: "Select source categories" })).toBeVisible()
+
+      await page.getByLabel(/Search your knowledge base/i).fill("What does my library say?")
+      await expect(page.getByRole("button", { name: /^Ask$/i })).toBeDisabled()
+      await expect(
+        page.getByText("Select source categories or enable web fallback before asking Knowledge QA.")
+      ).toBeVisible()
+    } finally {
+      await context.close()
+    }
+  })
+})

--- a/apps/extension/tests/e2e/knowledge-qa-setup-diagnostics.spec.ts
+++ b/apps/extension/tests/e2e/knowledge-qa-setup-diagnostics.spec.ts
@@ -1,0 +1,154 @@
+import { expect, test } from "@playwright/test"
+
+import { launchWithBuiltExtension } from "./utils/extension-build"
+import {
+  forceConnected,
+  forceConnectionState,
+  forceErrorUnreachable,
+  forceUnconfigured,
+  waitForConnectionStore,
+} from "./utils/connection"
+
+test.describe("Knowledge QA extension setup diagnostics", () => {
+  test("shows concrete recovery checks when no server is configured", async () => {
+    const { context, page, optionsUrl } = await launchWithBuiltExtension({
+      seedConfig: {},
+      allowOffline: false,
+    })
+
+    try {
+      await page.goto(`${optionsUrl}#/knowledge`, { waitUntil: "domcontentloaded" })
+      await waitForConnectionStore(page, "knowledge-setup-diagnostics:missing-url")
+      await forceUnconfigured(page, "knowledge-setup-diagnostics:missing-url")
+
+      await expect(page.getByTestId("knowledge-setup-diagnostics")).toBeVisible()
+      await expect(page.getByText("Server URL")).toBeVisible()
+      await expect(
+        page.getByText("Add a tldw server URL before Knowledge QA can search your library.")
+      ).toBeVisible()
+      await expect(
+        page.getByText("Waiting for a server URL before checking credentials.")
+      ).toBeVisible()
+      await expect(page.getByRole("button", { name: "Finish Setup" })).toBeVisible()
+    } finally {
+      await context.close()
+    }
+  })
+
+  test("shows credential recovery when a server URL is saved without auth", async () => {
+    const serverUrl = "http://127.0.0.1:8000"
+    const { context, page, optionsUrl } = await launchWithBuiltExtension({
+      seedConfig: {
+        tldwConfig: {
+          serverUrl,
+          authMode: "single-user",
+        },
+      },
+      allowOffline: false,
+    })
+
+    try {
+      await page.goto(`${optionsUrl}#/knowledge`, { waitUntil: "domcontentloaded" })
+      await waitForConnectionStore(page, "knowledge-setup-diagnostics:missing-auth")
+      await forceConnectionState(
+        page,
+        {
+          phase: "unconfigured",
+          serverUrl,
+          isConnected: false,
+          isChecking: false,
+          offlineBypass: false,
+          configStep: "auth",
+          errorKind: "none",
+          lastError: null,
+          lastStatusCode: null,
+          knowledgeStatus: "unknown",
+          knowledgeLastCheckedAt: null,
+          knowledgeError: null,
+          hasCompletedFirstRun: true,
+        },
+        "knowledge-setup-diagnostics:missing-auth"
+      )
+
+      await expect(
+        page.getByText("Add your credentials to use Knowledge QA")
+      ).toBeVisible()
+      await expect(page.getByText(`Configured server: ${serverUrl}`)).toBeVisible()
+      await expect(
+        page.getByText("Add the API key or login token for this tldw server.")
+      ).toBeVisible()
+      await expect(page.getByRole("button", { name: "Open Settings" })).toBeVisible()
+    } finally {
+      await context.close()
+    }
+  })
+
+  test("shows host access and allowlist recovery when backend requests are blocked", async () => {
+    const serverUrl = "http://127.0.0.1:8000"
+    const { context, page, optionsUrl } = await launchWithBuiltExtension({
+      seedConfig: {
+        tldwConfig: {
+          serverUrl,
+          authMode: "single-user",
+          apiKey: "THIS-IS-A-SECURE-KEY-123-FAKE-KEY",
+        },
+      },
+      allowOffline: false,
+    })
+
+    try {
+      await page.goto(`${optionsUrl}#/knowledge`, { waitUntil: "domcontentloaded" })
+      await waitForConnectionStore(page, "knowledge-setup-diagnostics:blocked")
+      await forceErrorUnreachable(
+        page,
+        {
+          serverUrl,
+          lastError:
+            "Absolute URL requests are blocked unless the request origin is explicitly allowlisted.",
+          lastStatusCode: 400,
+        },
+        "knowledge-setup-diagnostics:blocked"
+      )
+
+      await expect(
+        page.getByText("Can't reach your tldw server right now")
+      ).toBeVisible()
+      await expect(page.getByText("Browser access")).toBeVisible()
+      await expect(
+        page.getByText(/Allowlist this server origin or grant extension host access/i)
+      ).toBeVisible()
+      await expect(page.getByRole("button", { name: "Retry connection" })).toBeVisible()
+      await expect(
+        page.getByRole("button", { name: "Health & diagnostics" })
+      ).toBeVisible()
+    } finally {
+      await context.close()
+    }
+  })
+
+  test("keeps the ready search workspace available after setup is healthy", async () => {
+    const serverUrl = "http://dummy-tldw"
+    const { context, page, optionsUrl } = await launchWithBuiltExtension({
+      seedConfig: {
+        tldwConfig: {
+          serverUrl,
+          authMode: "single-user",
+          apiKey: "THIS-IS-A-SECURE-KEY-123-FAKE-KEY",
+        },
+      },
+      allowOffline: true,
+    })
+
+    try {
+      await page.goto(`${optionsUrl}#/knowledge`, { waitUntil: "domcontentloaded" })
+      await waitForConnectionStore(page, "knowledge-setup-diagnostics:ready")
+      await forceConnected(page, { serverUrl }, "knowledge-setup-diagnostics:ready")
+
+      await expect(page.getByTestId("knowledge-setup-diagnostics")).toBeHidden()
+      await expect(page.getByRole("heading", { name: /Ask Your Library/i })).toBeVisible()
+      await expect(page.getByLabel(/Search your knowledge base/i)).toBeVisible()
+    } finally {
+      await context.close()
+    }
+  })
+})

--- a/apps/extension/tests/e2e/knowledge-qa-states.spec.ts
+++ b/apps/extension/tests/e2e/knowledge-qa-states.spec.ts
@@ -1,0 +1,56 @@
+import { test, expect } from "@playwright/test"
+
+import { launchWithBuiltExtension } from "./utils/extension-build"
+import {
+  forceConnected,
+  forceUnconfigured,
+  waitForConnectionStore,
+} from "./utils/connection"
+
+test.describe("Knowledge QA deterministic extension states", () => {
+  test("extension renders setup-required state without live backend data", async () => {
+    const { context, page, optionsUrl } = await launchWithBuiltExtension({
+      seedConfig: {},
+      allowOffline: false,
+    })
+
+    try {
+      await page.goto(`${optionsUrl}#/knowledge`, { waitUntil: "domcontentloaded" })
+      await waitForConnectionStore(page, "knowledge-qa-setup-required")
+      await forceUnconfigured(page, "knowledge-qa-setup-required")
+
+      await expect(page.getByText(/Setup Required/i)).toBeVisible()
+      await expect(page.getByRole("button", { name: /Finish Setup/i })).toBeVisible()
+    } finally {
+      await context.close()
+    }
+  })
+
+  test("extension renders connected ready search state without live backend data", async () => {
+    const { context, page, optionsUrl } = await launchWithBuiltExtension({
+      seedConfig: {
+        tldwConfig: {
+          serverUrl: "http://dummy-tldw",
+          authMode: "single-user",
+          apiKey: "THIS-IS-A-SECURE-KEY-123-FAKE-KEY",
+        },
+      },
+      allowOffline: true,
+    })
+
+    try {
+      await page.goto(`${optionsUrl}#/knowledge`, { waitUntil: "domcontentloaded" })
+      await waitForConnectionStore(page, "knowledge-qa-ready")
+      await forceConnected(
+        page,
+        { serverUrl: "http://dummy-tldw" },
+        "knowledge-qa-ready"
+      )
+
+      await expect(page.getByRole("heading", { name: /Ask Your Library/i })).toBeVisible()
+      await expect(page.getByLabel(/Search your knowledge base/i)).toBeVisible()
+    } finally {
+      await context.close()
+    }
+  })
+})

--- a/apps/extension/tests/e2e/setup/build-extension.ts
+++ b/apps/extension/tests/e2e/setup/build-extension.ts
@@ -5,6 +5,14 @@ import path from 'path'
 export default async function globalSetup() {
   // If a built chrome extension already exists, skip rebuilding.
   const projectRoot = path.resolve(__dirname, '..', '..', '..')
+  const skipBuild =
+    process.env.TLDW_E2E_SKIP_EXTENSION_BUILD === '1' ||
+    process.env.TLDW_E2E_SKIP_EXTENSION_BUILD === 'true'
+  if (skipBuild) {
+    applyTestHostPermissions(projectRoot)
+    return
+  }
+
   const builtChromeCandidates = [
     path.resolve(projectRoot, 'build/chrome-mv3'),
     path.resolve(projectRoot, '.output/chrome-mv3')

--- a/apps/packages/ui/src/components/Option/KnowledgeQA/AnswerPanel.tsx
+++ b/apps/packages/ui/src/components/Option/KnowledgeQA/AnswerPanel.tsx
@@ -553,7 +553,7 @@ export function AnswerPanel({ className }: AnswerPanelProps) {
       return "Balanced preset typically completes within about 10 seconds."
     }
     if (preset === "thorough") {
-      return "Thorough preset may take up to 30 seconds."
+      return "Deep preset may take up to 30 seconds."
     }
     return "Custom preset timing varies with your settings."
   }, [preset])

--- a/apps/packages/ui/src/components/Option/KnowledgeQA/ExportDialog.tsx
+++ b/apps/packages/ui/src/components/Option/KnowledgeQA/ExportDialog.tsx
@@ -15,8 +15,18 @@ import {
 } from "lucide-react"
 import { useKnowledgeQA } from "./KnowledgeQAProvider"
 import { cn } from "@/libs/utils"
-import type { ExportFormat, ExportOptions } from "./types"
-import type { RagCitationStyle } from "@/services/rag/unified-rag"
+import type {
+  CitationRef,
+  ExportFormat,
+  ExportOptions,
+  RagResult,
+  SearchRuntimeDetails,
+} from "./types"
+import type {
+  RagCitationStyle,
+  RagPresetName,
+  RagSettings,
+} from "@/services/rag/unified-rag"
 import { useAntdMessage } from "@/hooks/useAntdMessage"
 import { mapKnowledgeQaExportErrorMessage } from "./errorMessages"
 import { tldwClient } from "@/services/tldw/TldwApiClient"
@@ -39,6 +49,15 @@ const CITATION_APPROXIMATION_NOTE =
 const SHARE_THREAD_LINKS_ENABLED = true
 const SHARE_THREAD_LINKS_HELP_TEXT =
   "Share links use a dedicated token with read-only access and an expiry window, independent from normal thread permissions. Extension shared-link routing is currently TBD."
+const SENSITIVE_EXPORT_KEY_PATTERN =
+  /(?:api[_-]?key|authorization|bearer|credential|password|secret|token)/i
+
+type ExportContext = {
+  citations?: CitationRef[]
+  settings?: Partial<RagSettings> | null
+  preset?: RagPresetName | string | null
+  searchDetails?: Partial<SearchRuntimeDetails> | null
+}
 
 function getFocusableElements(container: HTMLElement): HTMLElement[] {
   const focusableSelectors = [
@@ -54,7 +73,17 @@ function getFocusableElements(container: HTMLElement): HTMLElement[] {
 }
 
 export function ExportDialog({ open, onClose, className }: ExportDialogProps) {
-  const { messages, currentThreadId, results, answer, query } = useKnowledgeQA()
+  const {
+    messages,
+    currentThreadId,
+    results,
+    citations,
+    answer,
+    query,
+    settings,
+    preset,
+    searchDetails,
+  } = useKnowledgeQA()
   const message = useAntdMessage()
   const [options, setOptions] = useState<ExportOptions>(DEFAULT_OPTIONS)
   const [isExporting, setIsExporting] = useState(false)
@@ -138,7 +167,8 @@ export function ExportDialog({ open, onClose, className }: ExportDialogProps) {
           answer,
           results,
           messages,
-          options
+          options,
+          { citations, settings, preset, searchDetails }
         )
         if (activeDialogSessionKeyRef.current !== requestSessionKey) {
           return
@@ -151,7 +181,8 @@ export function ExportDialog({ open, onClose, className }: ExportDialogProps) {
           answer,
           results,
           messages,
-          options
+          options,
+          { citations, settings, preset, searchDetails }
         )
         if (activeDialogSessionKeyRef.current !== requestSessionKey) {
           return
@@ -238,6 +269,10 @@ export function ExportDialog({ open, onClose, className }: ExportDialogProps) {
     answer,
     results,
     messages,
+    citations,
+    settings,
+    preset,
+    searchDetails,
     currentThreadId,
     onClose,
     message,
@@ -287,7 +322,8 @@ export function ExportDialog({ open, onClose, className }: ExportDialogProps) {
         answer,
         results,
         messages,
-        { ...options, format: "markdown" }
+        { ...options, format: "markdown" },
+        { citations, settings, preset, searchDetails }
       )
       const trimmedQuery = query.trim()
       const title =
@@ -347,6 +383,10 @@ export function ExportDialog({ open, onClose, className }: ExportDialogProps) {
     results,
     messages,
     options,
+    citations,
+    settings,
+    preset,
+    searchDetails,
     currentThreadId,
     message,
   ])
@@ -890,22 +930,107 @@ function downloadBlob(blob: Blob, filename: string) {
   URL.revokeObjectURL(url)
 }
 
+function getSourceTitle(result: RagResult | undefined, index: number): string {
+  return (
+    result?.metadata?.title ||
+    result?.metadata?.source ||
+    `Source ${index + 1}`
+  )
+}
+
+function collectCitationIndexes(
+  citations: CitationRef[] | undefined,
+  answer: string | null
+): number[] {
+  const indexes: number[] = []
+  const seen = new Set<number>()
+  const pushIndex = (value: unknown) => {
+    if (typeof value !== "number" || !Number.isInteger(value) || value <= 0) {
+      return
+    }
+    if (seen.has(value)) return
+    seen.add(value)
+    indexes.push(value)
+  }
+
+  citations?.forEach((citation) => pushIndex(citation.index))
+
+  if (indexes.length === 0 && answer) {
+    for (const match of answer.matchAll(/\[(\d+)\]/g)) {
+      pushIndex(Number(match[1]))
+    }
+  }
+
+  return indexes
+}
+
+function sanitizeExportValue(value: unknown, depth = 0): unknown {
+  if (value == null) return value
+  if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") {
+    return value
+  }
+  if (Array.isArray(value)) {
+    return value
+      .map((item) => sanitizeExportValue(item, depth + 1))
+      .filter((item) => item !== undefined)
+  }
+  if (typeof value === "object" && depth < 5) {
+    const output: Record<string, unknown> = {}
+    Object.entries(value as Record<string, unknown>).forEach(([key, rawValue]) => {
+      if (SENSITIVE_EXPORT_KEY_PATTERN.test(key)) return
+      const sanitized = sanitizeExportValue(rawValue, depth + 1)
+      if (sanitized !== undefined) {
+        output[key] = sanitized
+      }
+    })
+    return output
+  }
+
+  return undefined
+}
+
+function hasSnapshotContent(value: unknown): value is Record<string, unknown> {
+  return (
+    value != null &&
+    typeof value === "object" &&
+    !Array.isArray(value) &&
+    Object.keys(value).length > 0
+  )
+}
+
+function buildExportSettingsSnapshot(
+  options: ExportOptions,
+  context?: ExportContext
+): Record<string, unknown> {
+  const snapshot: Record<string, unknown> = {
+    format: options.format,
+    citationStyle: options.citationStyle,
+    includeSourceExcerpts: options.includeSourceExcerpts,
+    exportDate: new Date().toISOString(),
+  }
+
+  if (context?.preset) {
+    snapshot.preset = context.preset
+  }
+
+  const settingsSnapshot = sanitizeExportValue(context?.settings)
+  if (hasSnapshotContent(settingsSnapshot)) {
+    snapshot.settings = settingsSnapshot
+  }
+
+  const searchDetailsSnapshot = sanitizeExportValue(context?.searchDetails)
+  if (hasSnapshotContent(searchDetailsSnapshot)) {
+    snapshot.searchDetails = searchDetailsSnapshot
+  }
+
+  return snapshot
+}
+
 // Generate markdown content
 function generateMarkdown(
   query: string,
   answer: string | null,
-  results: Array<{
-    id?: string
-    content?: string
-    text?: string
-    metadata?: {
-      title?: string
-      source?: string
-      url?: string
-      page_number?: number
-    }
-    score?: number
-  }>,
+  results: RagResult[],
   messages: Array<{
     role: string
     content: string
@@ -918,9 +1043,11 @@ function generateMarkdown(
       }>
     }
   }>,
-  options: ExportOptions
+  options: ExportOptions,
+  context?: ExportContext
 ): string {
   const lines: string[] = []
+  const citationIndexes = collectCitationIndexes(context?.citations, answer)
 
   // Header
   lines.push("# Knowledge QA Export")
@@ -942,13 +1069,37 @@ function generateMarkdown(
     lines.push("")
   }
 
+  // Citation mappings
+  if (citationIndexes.length > 0) {
+    lines.push("## Citations")
+    lines.push("")
+    citationIndexes.forEach((citationIndex) => {
+      const sourceIndex = citationIndex - 1
+      const result = results[sourceIndex]
+      const title = getSourceTitle(result, sourceIndex)
+
+      if (!result) {
+        lines.push(`- [${citationIndex}] Source unavailable in exported results.`)
+        return
+      }
+
+      lines.push(`- [${citationIndex}] ${title} maps to Source ${sourceIndex + 1}.`)
+      if (result.metadata?.page_number) {
+        lines.push(`  Page: ${result.metadata.page_number}`)
+      }
+      if (result.metadata?.url) {
+        lines.push(`  URL: ${result.metadata.url}`)
+      }
+    })
+    lines.push("")
+  }
+
   // Sources
   if (results.length > 0) {
     lines.push("## Sources")
     lines.push("")
     results.forEach((result, index) => {
-      const title =
-        result.metadata?.title || result.metadata?.source || `Source ${index + 1}`
+      const title = getSourceTitle(result, index)
       const url = result.metadata?.url
       const score = result.score
       const content = result.content || result.text || ""
@@ -1004,15 +1155,7 @@ function generateMarkdown(
     lines.push("")
     lines.push("```json")
     lines.push(
-      JSON.stringify(
-        {
-          format: options.format,
-          citationStyle: options.citationStyle,
-          exportDate: new Date().toISOString(),
-        },
-        null,
-        2
-      )
+      JSON.stringify(buildExportSettingsSnapshot(options, context), null, 2)
     )
     lines.push("```")
   }

--- a/apps/packages/ui/src/components/Option/KnowledgeQA/SearchBar.tsx
+++ b/apps/packages/ui/src/components/Option/KnowledgeQA/SearchBar.tsx
@@ -34,6 +34,8 @@ type SearchBarProps = {
   className?: string
   autoFocus?: boolean
   showWebToggle?: boolean
+  webFallbackAvailable?: boolean
+  searchBlockedMessage?: string | null
   widthMode?: "compact" | "wide"
 }
 
@@ -77,6 +79,8 @@ export function SearchBar({
   className,
   autoFocus = true,
   showWebToggle = true,
+  webFallbackAvailable = true,
+  searchBlockedMessage = null,
   widthMode = "compact",
 }: SearchBarProps) {
   const {
@@ -103,7 +107,30 @@ export function SearchBar({
   const [activeSuggestionIndex, setActiveSuggestionIndex] = useState(-1)
   const hasResults = results.length > 0 || Boolean(answer)
   const hasSources = settings.sources.length > 0
-  const noSourcesBlocked = !hasSources && !settings.enable_web_fallback
+  const webFallbackUsable = settings.enable_web_fallback && webFallbackAvailable
+  const sourceSelectionBlocked = !hasSources && !webFallbackUsable
+  const explicitSearchBlocked =
+    typeof searchBlockedMessage === "string" &&
+    searchBlockedMessage.trim().length > 0
+  const noSourcesBlocked = sourceSelectionBlocked || explicitSearchBlocked
+  const noSourceBlockMessage = webFallbackAvailable
+    ? "Select source categories or enable web fallback before asking Knowledge QA."
+    : "Web fallback is not available on this server. Select personal-library sources before asking Knowledge QA."
+  const noSourceBlockTooltip = webFallbackAvailable
+    ? "Select source categories or enable web fallback to search"
+    : "Select personal-library sources to search"
+  const searchBlockMessage = explicitSearchBlocked
+    ? searchBlockedMessage
+    : noSourceBlockMessage
+  const searchBlockTooltip = explicitSearchBlocked
+    ? searchBlockedMessage
+    : noSourceBlockTooltip
+  const searchDescriptionIds = [
+    "knowledge-qa-search-description",
+    noSourcesBlocked ? "knowledge-search-no-source-explanation" : null,
+  ]
+    .filter((id): id is string => typeof id === "string")
+    .join(" ")
   const showHintEmphasis = !query && !isSearching && cycleCount === 0
   const showCharacterCount = query.length >= Math.floor(MAX_QUERY_LENGTH * 0.8)
   const historyQueries = useMemo(
@@ -347,7 +374,7 @@ export function SearchBar({
             isSearching && "opacity-75 cursor-not-allowed"
           )}
           aria-label="Search your knowledge base"
-          aria-describedby="knowledge-qa-search-description"
+          aria-describedby={searchDescriptionIds}
           aria-autocomplete="list"
           aria-expanded={shouldShowSuggestions}
           aria-controls={shouldShowSuggestions ? "knowledge-search-suggestions" : undefined}
@@ -399,7 +426,7 @@ export function SearchBar({
         <Tooltip
           title={
             noSourcesBlocked
-              ? "Select source categories or enable web fallback to search"
+              ? searchBlockTooltip
               : null
           }
         >
@@ -407,6 +434,9 @@ export function SearchBar({
             <button
               type="submit"
               disabled={!query.trim() || isSearching || noSourcesBlocked}
+              aria-describedby={
+                noSourcesBlocked ? "knowledge-search-no-source-explanation" : undefined
+              }
               className={cn(
                 "px-4 py-2 rounded-lg",
                 "bg-primary text-white",
@@ -421,6 +451,17 @@ export function SearchBar({
           </span>
         </Tooltip>
       </div>
+
+      {noSourcesBlocked ? (
+        <p
+          id="knowledge-search-no-source-explanation"
+          role="status"
+          aria-live="polite"
+          className="mt-2 rounded-md border border-warn/40 bg-warn/10 px-3 py-2 text-xs text-warn"
+        >
+          {searchBlockMessage}
+        </p>
+      ) : null}
 
       {isSearching && (
         <div
@@ -488,18 +529,29 @@ export function SearchBar({
           {showWebToggle ? (
             <button
               type="button"
-              onClick={() =>
+              onClick={() => {
+                if (!webFallbackAvailable) return
                 updateSetting("enable_web_fallback", !settings.enable_web_fallback)
-              }
+              }}
+              disabled={!webFallbackAvailable}
               className={cn(
                 "inline-flex items-center gap-1 px-2 py-1 rounded-full border transition-colors whitespace-nowrap",
-                settings.enable_web_fallback
+                webFallbackUsable
                   ? "border-primary/40 bg-primary/10 text-primary"
-                  : "border-border bg-surface text-text-subtle hover:bg-hover hover:text-text"
+                  : "border-border bg-surface text-text-subtle hover:bg-hover hover:text-text",
+                !webFallbackAvailable && "opacity-60 cursor-not-allowed hover:bg-surface hover:text-text-subtle"
               )}
-              aria-pressed={settings.enable_web_fallback}
-              title="Falls back to web search when local source relevance is below threshold (configurable in settings)."
-              aria-label={`Web fallback is currently ${settings.enable_web_fallback ? "enabled" : "disabled"}. Click to toggle.`}
+              aria-pressed={webFallbackUsable}
+              title={
+                webFallbackAvailable
+                  ? "Falls back to web search when local source relevance is below threshold (configurable in settings)."
+                  : "Web fallback is not available on this server."
+              }
+              aria-label={
+                webFallbackAvailable
+                  ? `Web fallback is currently ${settings.enable_web_fallback ? "enabled" : "disabled"}. Click to toggle.`
+                  : "Web fallback is not available on this server."
+              }
             >
               <Globe className="w-3.5 h-3.5" />
               Web

--- a/apps/packages/ui/src/components/Option/KnowledgeQA/SearchDetailsPanel.tsx
+++ b/apps/packages/ui/src/components/Option/KnowledgeQA/SearchDetailsPanel.tsx
@@ -17,18 +17,22 @@ type CandidateReasonCategory = {
   className: string
 }
 
-function formatPercent(value: number | null): string {
-  if (value == null || Number.isNaN(value)) return "N/A"
+function isReportedNumber(value: number | null | undefined): value is number {
+  return typeof value === "number" && Number.isFinite(value)
+}
+
+function formatPercent(value: number | null | undefined): string {
+  if (!isReportedNumber(value)) return "Not reported"
   return `${Math.round(value * 100)}%`
 }
 
-function formatInteger(value: number | null): string {
-  if (value == null || Number.isNaN(value)) return "N/A"
+function formatInteger(value: number | null | undefined): string {
+  if (!isReportedNumber(value)) return "Not reported"
   return value.toLocaleString()
 }
 
-function formatScorePercent(value: number | null): string {
-  if (value == null || Number.isNaN(value)) return "N/A"
+function formatScorePercent(value: number | null | undefined): string {
+  if (!isReportedNumber(value)) return "Not reported"
   return `${Math.round(value * 100)}%`
 }
 
@@ -110,10 +114,11 @@ export function SearchDetailsPanel({ className }: SearchDetailsPanelProps) {
     return null
   }
 
+  const expandedQueries = Array.isArray(searchDetails.expandedQueries)
+    ? searchDetails.expandedQueries
+    : []
   const expansionTerms =
-    searchDetails.expandedQueries.length > 0
-      ? searchDetails.expandedQueries.join(", ")
-      : "None"
+    expandedQueries.length > 0 ? expandedQueries.join(", ") : null
   const alsoConsidered = Array.isArray(searchDetails.alsoConsidered)
     ? searchDetails.alsoConsidered
     : []
@@ -123,11 +128,37 @@ export function SearchDetailsPanel({ className }: SearchDetailsPanelProps) {
   const consideredDocuments =
     searchDetails.documentsConsidered ?? searchDetails.candidatesConsidered
   const retainedPercent =
-    consideredCount != null && consideredCount > 0
+    isReportedNumber(consideredCount) &&
+    consideredCount > 0 &&
+    isReportedNumber(returnedCount)
       ? Math.round((returnedCount / consideredCount) * 100)
       : null
   const claimCount =
     searchDetails.faithfulnessTotalClaims ?? searchDetails.verificationTotalClaims
+  const candidateParts: string[] = []
+  if (isReportedNumber(consideredCount)) {
+    candidateParts.push(formatInteger(consideredCount))
+  }
+  if (isReportedNumber(returnedCount)) {
+    candidateParts.push(`returned ${formatInteger(returnedCount)}`)
+  }
+  if (isReportedNumber(searchDetails.candidatesRejected)) {
+    candidateParts.push(`rejected ${formatInteger(searchDetails.candidatesRejected)}`)
+  }
+  if (retainedPercent != null) {
+    candidateParts.push(`retained ${retainedPercent}%`)
+  }
+  const coverageParts: string[] = []
+  if (isReportedNumber(consideredDocuments)) {
+    coverageParts.push(`considered ${formatInteger(consideredDocuments)} documents`)
+  }
+  if (isReportedNumber(searchDetails.chunksConsidered)) {
+    coverageParts.push(`${formatInteger(searchDetails.chunksConsidered)} chunks scanned`)
+  }
+  if (isReportedNumber(searchDetails.documentsReturned)) {
+    coverageParts.push(`returned ${formatInteger(searchDetails.documentsReturned)} sources`)
+  }
+  const hasRetrievalCounts = candidateParts.length > 0 || coverageParts.length > 0
 
   return (
     <details
@@ -143,19 +174,27 @@ export function SearchDetailsPanel({ className }: SearchDetailsPanelProps) {
       </summary>
 
       <div className="grid gap-2 border-t border-border px-4 py-3 text-sm">
-        <div>
-          <span className="font-medium">Query expansion:</span> {expansionTerms}
-        </div>
+        {expansionTerms ? (
+          <div>
+            <span className="font-medium">Query expansion:</span> {expansionTerms}
+          </div>
+        ) : (
+          <p className="text-text-muted">No query expansion terms were reported.</p>
+        )}
         <div>
           <span className="font-medium">Reranking:</span>{" "}
           {searchDetails.rerankingEnabled
-            ? `Enabled (${searchDetails.rerankingStrategy})`
+            ? searchDetails.rerankingStrategy
+              ? `Enabled (${searchDetails.rerankingStrategy})`
+              : "Enabled"
             : "Disabled"}
         </div>
-        <div>
-          <span className="font-medium">Average relevance:</span>{" "}
-          {formatPercent(searchDetails.averageRelevance)}
-        </div>
+        {isReportedNumber(searchDetails.averageRelevance) ? (
+          <div>
+            <span className="font-medium">Average relevance:</span>{" "}
+            {formatPercent(searchDetails.averageRelevance)}
+          </div>
+        ) : null}
         <div>
           <span className="font-medium">Web fallback:</span>{" "}
           {searchDetails.webFallbackEnabled
@@ -194,27 +233,26 @@ export function SearchDetailsPanel({ className }: SearchDetailsPanelProps) {
               : ""}
           </div>
         )}
-        <div>
-          <span className="font-medium">Candidates considered:</span>{" "}
-          {formatInteger(consideredCount)}
-          {" • "}
-          returned {formatInteger(returnedCount)}
-          {searchDetails.candidatesRejected != null
-            ? ` • rejected ${formatInteger(searchDetails.candidatesRejected)}`
-            : ""}
-          {retainedPercent != null
-            ? ` • retained ${retainedPercent}%`
-            : ""}
-        </div>
-        <div>
-          <span className="font-medium">Search coverage:</span>{" "}
-          considered {formatInteger(consideredDocuments)} documents
-          {searchDetails.chunksConsidered != null
-            ? ` • ${formatInteger(searchDetails.chunksConsidered)} chunks scanned`
-            : ""}
-          {" • "}
-          returned {formatInteger(searchDetails.documentsReturned)} sources
-        </div>
+        {hasRetrievalCounts ? (
+          <>
+            {candidateParts.length > 0 ? (
+              <div>
+                <span className="font-medium">Candidates considered:</span>{" "}
+                {candidateParts.join(" • ")}
+              </div>
+            ) : null}
+            {coverageParts.length > 0 ? (
+              <div>
+                <span className="font-medium">Search coverage:</span>{" "}
+                {coverageParts.join(" • ")}
+              </div>
+            ) : null}
+          </>
+        ) : (
+          <p className="text-text-muted">
+            No retrieval counts were reported for this search.
+          </p>
+        )}
         {searchDetails.retrievalLatencyMs != null ? (
           <div>
             <span className="font-medium">Retrieval latency:</span>{" "}
@@ -247,7 +285,11 @@ export function SearchDetailsPanel({ className }: SearchDetailsPanelProps) {
               })}
             </ul>
           </div>
-        ) : null}
+        ) : (
+          <p className="text-text-muted">
+            No closest-miss candidates were reported.
+          </p>
+        )}
       </div>
     </details>
   )

--- a/apps/packages/ui/src/components/Option/KnowledgeQA/SettingsPanel/BasicSettings.tsx
+++ b/apps/packages/ui/src/components/Option/KnowledgeQA/SettingsPanel/BasicSettings.tsx
@@ -57,7 +57,7 @@ export function BasicSettings() {
           className="w-full accent-primary"
         />
         <p className="text-xs text-text-muted">
-          How many documents to retrieve (5-10 for quick, 20+ for thorough)
+          How many documents to retrieve (5-10 for quick, 20+ for deep searches)
         </p>
         {settings.top_k > 30 && preset === "thorough" && (
           <p className="text-xs text-warn">

--- a/apps/packages/ui/src/components/Option/KnowledgeQA/SettingsPanel/PresetSelector.tsx
+++ b/apps/packages/ui/src/components/Option/KnowledgeQA/SettingsPanel/PresetSelector.tsx
@@ -3,7 +3,7 @@
  */
 
 import React, { useRef, useCallback, useState } from "react"
-import { Zap, Scale, Brain, Beaker, Settings } from "lucide-react"
+import { Zap, Scale, Brain, Settings } from "lucide-react"
 import { useKnowledgeQA } from "../KnowledgeQAProvider"
 import { cn } from "@/libs/utils"
 import type { RagPresetName } from "@/services/rag/unified-rag"
@@ -33,8 +33,8 @@ const PRESETS: PresetConfig[] = [
   },
   {
     name: "thorough",
-    label: "Thorough",
-    description: "Most thorough - includes fact-checking",
+    label: "Deep",
+    description: "Deep search - more sources and verification",
     icon: Brain,
     color: "text-accent",
   },
@@ -46,15 +46,6 @@ const PRESETS: PresetConfig[] = [
     color: "text-text-muted",
   },
 ]
-
-// Additional "Research" preset for advanced users
-const RESEARCH_PRESET: PresetConfig = {
-  name: "thorough", // Uses thorough as base with modifications
-  label: "Research",
-  description: "Max verification + citations",
-  icon: Beaker,
-  color: "text-success",
-}
 
 export function PresetSelector() {
   const { preset, setPreset } = useKnowledgeQA()

--- a/apps/packages/ui/src/components/Option/KnowledgeQA/SetupDiagnostics.tsx
+++ b/apps/packages/ui/src/components/Option/KnowledgeQA/SetupDiagnostics.tsx
@@ -1,0 +1,389 @@
+import { useMemo, useState } from "react"
+import {
+  AlertCircle,
+  CheckCircle2,
+  CircleDashed,
+  KeyRound,
+  ShieldAlert,
+  WifiOff,
+} from "lucide-react"
+
+import type { ConnectionState, ConnectionUxState } from "@/types/connection"
+import { requestOptionalHostPermission } from "@/utils/extension-permissions"
+
+type DiagnosticStatus = "complete" | "missing" | "waiting" | "blocked" | "review"
+
+type DiagnosticCheck = {
+  id: string
+  label: string
+  status: DiagnosticStatus
+  description: string
+}
+
+type Props = {
+  connection: Pick<
+    ConnectionState,
+    | "serverUrl"
+    | "configStep"
+    | "errorKind"
+    | "lastError"
+    | "lastStatusCode"
+    | "isChecking"
+  >
+  uxState: ConnectionUxState
+  retryCountdownSeconds: number
+  onOpenSetup: () => void
+  onOpenSettings: () => void
+  onOpenDiagnostics: () => void
+  onRetryConnection: () => void
+}
+
+const BROWSER_ACCESS_BLOCK_PATTERNS = [
+  /absolute url requests are blocked/i,
+  /allowlist/i,
+  /cors/i,
+  /cross-origin/i,
+  /not allowed/i,
+]
+
+const statusLabel: Record<DiagnosticStatus, string> = {
+  complete: "Ready",
+  missing: "Missing",
+  waiting: "Waiting",
+  blocked: "Blocked",
+  review: "Needs review",
+}
+
+const statusClassName: Record<DiagnosticStatus, string> = {
+  complete: "text-success",
+  missing: "text-danger",
+  waiting: "text-text-muted",
+  blocked: "text-danger",
+  review: "text-warning",
+}
+
+const getServerOriginLabel = (serverUrl: string | null | undefined): string | null => {
+  const trimmed = String(serverUrl || "").trim()
+  if (!trimmed) return null
+
+  try {
+    const parsed = new URL(trimmed)
+    return parsed.origin
+  } catch {
+    return trimmed
+  }
+}
+
+const hasExtensionHostPermissionRequest = (): boolean => {
+  try {
+    return Boolean(
+      (globalThis as { chrome?: { permissions?: { request?: unknown } } }).chrome
+        ?.permissions?.request
+    )
+  } catch {
+    return false
+  }
+}
+
+const isBrowserAccessBlocked = (lastError: string | null | undefined): boolean => {
+  const text = String(lastError || "").trim()
+  if (!text) return false
+  return BROWSER_ACCESS_BLOCK_PATTERNS.some((pattern) => pattern.test(text))
+}
+
+const StatusIcon = ({ status }: { status: DiagnosticStatus }) => {
+  if (status === "complete") {
+    return <CheckCircle2 className="h-4 w-4 text-success" aria-hidden />
+  }
+  if (status === "blocked" || status === "missing") {
+    return <AlertCircle className="h-4 w-4 text-danger" aria-hidden />
+  }
+  if (status === "review") {
+    return <ShieldAlert className="h-4 w-4 text-warning" aria-hidden />
+  }
+  return <CircleDashed className="h-4 w-4 text-text-muted" aria-hidden />
+}
+
+export function KnowledgeQASetupDiagnostics({
+  connection,
+  uxState,
+  retryCountdownSeconds,
+  onOpenSetup,
+  onOpenSettings,
+  onOpenDiagnostics,
+  onRetryConnection,
+}: Props) {
+  const [hostPermissionNotice, setHostPermissionNotice] = useState<string | null>(null)
+  const serverLabel = getServerOriginLabel(connection.serverUrl)
+  const hasServerUrl = Boolean(serverLabel)
+  const authMissing =
+    uxState === "configuring_auth" ||
+    uxState === "error_auth" ||
+    connection.configStep === "auth" ||
+    connection.errorKind === "auth"
+  const unreachable =
+    uxState === "error_unreachable" || connection.errorKind === "unreachable"
+  const browserBlocked = hasServerUrl && isBrowserAccessBlocked(connection.lastError)
+  const canRequestHostAccess = hasServerUrl && hasExtensionHostPermissionRequest()
+
+  const checks = useMemo<DiagnosticCheck[]>(() => {
+    const serverUrlCheck: DiagnosticCheck = hasServerUrl
+      ? {
+          id: "server-url",
+          label: "Server URL",
+          status: "complete",
+          description: "Knowledge QA will search against the configured tldw server.",
+        }
+      : {
+          id: "server-url",
+          label: "Server URL",
+          status: "missing",
+          description: "Add a tldw server URL before Knowledge QA can search your library.",
+        }
+
+    const credentialCheck: DiagnosticCheck = !hasServerUrl
+      ? {
+          id: "credentials",
+          label: "Credentials",
+          status: "waiting",
+          description: "Waiting for a server URL before checking credentials.",
+        }
+      : authMissing
+        ? {
+            id: "credentials",
+            label: "Credentials",
+            status: "missing",
+            description: "Add the API key or login token for this tldw server.",
+          }
+        : {
+            id: "credentials",
+            label: "Credentials",
+            status: "complete",
+            description: "Credentials are configured for Knowledge QA requests.",
+          }
+
+    const browserAccessCheck: DiagnosticCheck = !hasServerUrl
+      ? {
+          id: "browser-access",
+          label: "Browser access",
+          status: "waiting",
+          description: "Waiting for a server URL before checking browser access.",
+        }
+      : browserBlocked
+        ? {
+            id: "browser-access",
+            label: "Browser access",
+            status: "blocked",
+            description:
+              "Allowlist this server origin or grant extension host access before retrying.",
+          }
+        : unreachable
+          ? {
+              id: "browser-access",
+              label: "Browser access",
+              status: "review",
+              description:
+                "If you are using the extension, grant host access for this server. In WebUI, ensure the backend allows this browser origin.",
+            }
+          : {
+              id: "browser-access",
+              label: "Browser access",
+              status: "complete",
+              description: "Browser requests can target the configured tldw server.",
+            }
+
+    const backendCheck: DiagnosticCheck = !hasServerUrl
+      ? {
+          id: "backend",
+          label: "Backend reachability",
+          status: "waiting",
+          description: "Waiting for a server URL before checking backend health.",
+        }
+      : authMissing
+        ? {
+            id: "backend",
+            label: "Backend reachability",
+            status: "waiting",
+            description: "Waiting for credentials before checking backend reachability.",
+          }
+        : unreachable
+          ? {
+              id: "backend",
+              label: "Backend reachability",
+              status: "blocked",
+              description:
+                "Start the tldw server, confirm the URL is correct, then retry Knowledge QA.",
+            }
+          : connection.isChecking
+            ? {
+                id: "backend",
+                label: "Backend reachability",
+                status: "waiting",
+                description: "Checking tldw server health...",
+              }
+            : {
+                id: "backend",
+                label: "Backend reachability",
+                status: "complete",
+                description: "The last server health check completed successfully.",
+              }
+
+    return [serverUrlCheck, credentialCheck, browserAccessCheck, backendCheck]
+  }, [authMissing, browserBlocked, connection.isChecking, hasServerUrl, unreachable])
+
+  const title =
+    uxState === "configuring_auth" || uxState === "error_auth"
+      ? "Add your credentials to use Knowledge QA"
+      : unreachable
+        ? "Can't reach your tldw server right now"
+        : "Setup Required"
+
+  const message =
+    uxState === "configuring_auth" || uxState === "error_auth"
+      ? "Your server URL is saved, but Knowledge QA needs valid credentials before it can load."
+      : unreachable
+        ? "Your server settings are saved, but Knowledge QA cannot reach the tldw server right now."
+        : "Complete the server setup to start searching your documents."
+
+  const handleRequestHostAccess = () => {
+    const result = requestOptionalHostPermission(
+      connection.serverUrl,
+      (granted, origin) => {
+        setHostPermissionNotice(
+          granted
+            ? `Host access granted for ${origin}. Retrying connection...`
+            : `Host access was not granted for ${origin}.`
+        )
+        if (granted) {
+          onRetryConnection()
+        }
+      },
+      (error) => setHostPermissionNotice(error.message)
+    )
+
+    if (!result.supported) {
+      setHostPermissionNotice(
+        "Host access must be granted from the browser extension permissions screen."
+      )
+    }
+  }
+
+  return (
+    <div className="flex-1 flex items-center justify-center px-4 py-8">
+      <section
+        className="w-full max-w-2xl text-center"
+        data-testid="knowledge-setup-diagnostics"
+        aria-labelledby="knowledge-setup-title"
+      >
+        <WifiOff className="w-16 h-16 mx-auto mb-4 text-text-muted" aria-hidden />
+        <h2 id="knowledge-setup-title" className="text-xl font-semibold mb-2">
+          {title}
+        </h2>
+        <p className="mx-auto max-w-lg text-text-muted mb-3">{message}</p>
+        {serverLabel && (
+          <p className="mb-4 text-xs text-text-subtle">
+            {`Configured server: ${serverLabel}`}
+          </p>
+        )}
+
+        <div className="mx-auto mb-4 grid max-w-xl gap-2 text-left">
+          {checks.map((check) => (
+            <div
+              key={check.id}
+              data-testid={`knowledge-setup-check-${check.id}`}
+              className="rounded-md border border-border bg-surface px-3 py-2"
+            >
+              <div className="flex items-center justify-between gap-3">
+                <div className="flex min-w-0 items-center gap-2">
+                  <StatusIcon status={check.status} />
+                  <span className="font-medium text-text">{check.label}</span>
+                </div>
+                <span
+                  className={`shrink-0 text-xs font-medium ${statusClassName[check.status]}`}
+                >
+                  {statusLabel[check.status]}
+                </span>
+              </div>
+              <p className="mt-1 text-sm text-text-muted">{check.description}</p>
+            </div>
+          ))}
+        </div>
+
+        {connection.lastError && (
+          <p className="mx-auto mb-4 max-w-xl rounded-md border border-border bg-surface2 px-3 py-2 text-left text-xs text-text-muted">
+            {`Last error: ${connection.lastError}`}
+            {connection.lastStatusCode != null
+              ? ` (status ${connection.lastStatusCode})`
+              : ""}
+          </p>
+        )}
+
+        {hostPermissionNotice && (
+          <p className="mb-4 text-xs text-text-muted">{hostPermissionNotice}</p>
+        )}
+
+        <div className="flex flex-wrap items-center justify-center gap-2">
+          {!hasServerUrl ? (
+            <button
+              type="button"
+              onClick={onOpenSetup}
+              className="px-3 py-1.5 rounded-md border border-border bg-surface text-text-subtle hover:bg-hover hover:text-text transition-colors"
+            >
+              Finish Setup
+            </button>
+          ) : authMissing ? (
+            <button
+              type="button"
+              onClick={onOpenSettings}
+              className="px-3 py-1.5 rounded-md border border-border bg-surface text-text-subtle hover:bg-hover hover:text-text transition-colors"
+            >
+              Open Settings
+            </button>
+          ) : (
+            <button
+              type="button"
+              onClick={onRetryConnection}
+              disabled={connection.isChecking}
+              className="px-3 py-1.5 rounded-md border border-border bg-surface text-text-subtle hover:bg-hover hover:text-text transition-colors disabled:opacity-60 disabled:cursor-not-allowed"
+            >
+              {connection.isChecking ? "Checking connection..." : "Retry connection"}
+            </button>
+          )}
+
+          {canRequestHostAccess && (
+            <button
+              type="button"
+              onClick={handleRequestHostAccess}
+              className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md border border-border bg-surface text-text-subtle hover:bg-hover hover:text-text transition-colors"
+            >
+              <KeyRound className="h-4 w-4" aria-hidden />
+              Request host access
+            </button>
+          )}
+
+          <button
+            type="button"
+            onClick={onOpenSettings}
+            className="px-3 py-1.5 rounded-md border border-border bg-surface text-text-subtle hover:bg-hover hover:text-text transition-colors"
+          >
+            Server settings
+          </button>
+
+          <button
+            type="button"
+            onClick={onOpenDiagnostics}
+            className="px-3 py-1.5 rounded-md border border-border bg-surface text-text-subtle hover:bg-hover hover:text-text transition-colors"
+          >
+            Health & diagnostics
+          </button>
+        </div>
+
+        {unreachable && (
+          <p className="mt-2 text-xs text-text-muted">
+            Retrying automatically in {retryCountdownSeconds}s...
+          </p>
+        )}
+      </section>
+    </div>
+  )
+}

--- a/apps/packages/ui/src/components/Option/KnowledgeQA/__tests__/AnswerModelMenu.test.tsx
+++ b/apps/packages/ui/src/components/Option/KnowledgeQA/__tests__/AnswerModelMenu.test.tsx
@@ -1,0 +1,173 @@
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { tldwClient } from "@/services/tldw/TldwApiClient"
+import { AnswerModelMenu } from "../context/AnswerModelMenu"
+
+vi.mock("@/libs/utils", () => ({
+  cn: (...args: unknown[]) => args.filter(Boolean).join(" "),
+}))
+
+vi.mock("@/utils/provider-registry", () => ({
+  getProviderDisplayName: (provider: string) => provider,
+}))
+
+vi.mock("@/services/tldw/TldwApiClient", () => ({
+  tldwClient: {
+    initialize: vi.fn().mockResolvedValue(undefined),
+    getProviders: vi.fn().mockResolvedValue({
+      default_provider: "openai",
+      providers: [
+        {
+          name: "openai",
+          display_name: "OpenAI",
+          models: ["gpt-4o-mini"],
+          default_model: "gpt-4o-mini",
+        },
+      ],
+    }),
+  },
+}))
+
+function createDeferred<T>() {
+  let resolve!: (value: T) => void
+  let reject!: (reason?: unknown) => void
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res
+    reject = rej
+  })
+  return { promise, resolve, reject }
+}
+
+function renderMenu(overrides: Partial<React.ComponentProps<typeof AnswerModelMenu>> = {}) {
+  return render(
+    <AnswerModelMenu
+      generationProvider={null}
+      generationModel={null}
+      onGenerationProviderChange={vi.fn()}
+      onGenerationModelChange={vi.fn()}
+      {...overrides}
+    />
+  )
+}
+
+describe("AnswerModelMenu", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(tldwClient.initialize).mockResolvedValue(undefined)
+    vi.mocked(tldwClient.getProviders).mockResolvedValue({
+      default_provider: "openai",
+      providers: [
+        {
+          name: "openai",
+          display_name: "OpenAI",
+          models: ["gpt-4o-mini"],
+          default_model: "gpt-4o-mini",
+        },
+      ],
+    })
+  })
+
+  it("shows provider loading state while model metadata is loading", () => {
+    const providerCatalog = createDeferred<{
+      default_provider: string
+      providers: Array<{ name: string; display_name: string }>
+    }>()
+    vi.mocked(tldwClient.getProviders).mockReturnValueOnce(providerCatalog.promise)
+
+    renderMenu()
+    fireEvent.click(screen.getByRole("button", { name: "Choose answer model" }))
+
+    expect(screen.getByText("Loading answer providers...")).toBeInTheDocument()
+
+    act(() => {
+      providerCatalog.resolve({
+        default_provider: "openai",
+        providers: [{ name: "openai", display_name: "OpenAI" }],
+      })
+    })
+  })
+
+  it("shows provider error recovery while preserving manual model entry", async () => {
+    vi.mocked(tldwClient.getProviders).mockRejectedValueOnce(
+      new Error("Provider metadata unavailable")
+    )
+
+    const onGenerationModelChange = vi.fn()
+    renderMenu({ onGenerationModelChange })
+
+    await waitFor(() => {
+      expect(tldwClient.getProviders).toHaveBeenCalled()
+    })
+
+    fireEvent.click(screen.getByRole("button", { name: "Choose answer model" }))
+
+    expect(
+      screen.getByText(
+        "Provider list failed to load. You can still type a model manually."
+      )
+    ).toBeInTheDocument()
+    expect(screen.queryByText("Provider metadata unavailable")).not.toBeInTheDocument()
+
+    fireEvent.change(screen.getByRole("combobox", { name: "Answer model" }), {
+      target: { value: "local-manual-model" },
+    })
+
+    expect(onGenerationModelChange).toHaveBeenCalledWith("local-manual-model")
+  })
+
+  it("loads provider options and suggested models", async () => {
+    const onGenerationProviderChange = vi.fn()
+    renderMenu({ onGenerationProviderChange })
+
+    await waitFor(() => {
+      expect(tldwClient.getProviders).toHaveBeenCalled()
+    })
+
+    fireEvent.click(screen.getByRole("button", { name: "Choose answer model" }))
+    fireEvent.change(screen.getByRole("combobox", { name: "Answer provider" }), {
+      target: { value: "openai" },
+    })
+
+    expect(onGenerationProviderChange).toHaveBeenCalledWith("openai")
+    expect(screen.getByRole("combobox", { name: "Answer model" })).toHaveAttribute(
+      "placeholder",
+      "Default: gpt-4o-mini"
+    )
+  })
+
+  it("clears an explicit provider when Server default is selected", async () => {
+    const onGenerationProviderChange = vi.fn()
+    renderMenu({
+      generationProvider: "openai",
+      onGenerationProviderChange,
+    })
+
+    await waitFor(() => {
+      expect(tldwClient.getProviders).toHaveBeenCalled()
+    })
+
+    fireEvent.click(screen.getByRole("button", { name: "Choose answer model" }))
+    fireEvent.change(screen.getByRole("combobox", { name: "Answer provider" }), {
+      target: { value: "__server_default__" },
+    })
+
+    expect(onGenerationProviderChange).toHaveBeenCalledWith(null)
+  })
+
+  it("summarizes restored manual model selection in the collapsed control", async () => {
+    renderMenu({
+      generationProvider: "openai",
+      generationModel: "gpt-4o-mini",
+    })
+
+    await waitFor(() => {
+      expect(tldwClient.getProviders).toHaveBeenCalled()
+    })
+
+    expect(screen.getByRole("button", { name: "Choose answer model" })).toHaveAttribute(
+      "title",
+      "Answer generation uses gpt-4o-mini"
+    )
+    expect(screen.getByText("AI: gpt-4o-mini")).toBeInTheDocument()
+  })
+})

--- a/apps/packages/ui/src/components/Option/KnowledgeQA/__tests__/AnswerPanel.states.test.tsx
+++ b/apps/packages/ui/src/components/Option/KnowledgeQA/__tests__/AnswerPanel.states.test.tsx
@@ -590,7 +590,7 @@ describe("AnswerPanel state guardrails", () => {
     render(<AnswerPanel />)
     expect(screen.getByText(/Searching documents/i)).toBeInTheDocument()
     expect(
-      screen.getByText(/Thorough preset may take up to 30 seconds/i)
+      screen.getByText(/Deep preset may take up to 30 seconds/i)
     ).toBeInTheDocument()
 
     act(() => {

--- a/apps/packages/ui/src/components/Option/KnowledgeQA/__tests__/CompactToolbar.test.tsx
+++ b/apps/packages/ui/src/components/Option/KnowledgeQA/__tests__/CompactToolbar.test.tsx
@@ -28,6 +28,8 @@ type CompactToolbarTestProps = React.ComponentProps<typeof CompactToolbar>
 
 const defaultProps: CompactToolbarTestProps = {
   sources: [] as RagSource[],
+  includeMediaIds: [] as number[],
+  includeNoteIds: [] as string[],
   preset: "balanced" as const,
   webEnabled: false,
   onToggleWeb: vi.fn(),
@@ -146,6 +148,30 @@ describe("CompactToolbar", () => {
       ] as RagSource[],
     })
     expect(screen.getByText(/Sources:.*All sources/)).toBeDefined()
+  })
+
+  it("shows exact source counts in compact mode", () => {
+    renderToolbar({
+      sources: ["media_db", "notes"],
+      includeMediaIds: [7, 42],
+      includeNoteIds: ["note-a"],
+    })
+
+    expect(screen.getByText(/Specific:.*2 docs.*1 note/)).toBeDefined()
+  })
+
+  it("labels the compact source control as scope and profile access", () => {
+    renderToolbar({
+      sources: ["media_db", "notes"],
+      includeMediaIds: [7],
+      includeNoteIds: ["note-a"],
+    })
+
+    expect(
+      screen.getByRole("button", {
+        name: /Open source scope and saved profiles/i,
+      })
+    ).toHaveAttribute("title", "Open source scope and saved profiles")
   })
 
   it('renders preset label "Balanced" for preset "balanced"', () => {

--- a/apps/packages/ui/src/components/Option/KnowledgeQA/__tests__/ExpertSettings.accessibility.test.tsx
+++ b/apps/packages/ui/src/components/Option/KnowledgeQA/__tests__/ExpertSettings.accessibility.test.tsx
@@ -83,4 +83,30 @@ describe("ExpertSettings accessibility", () => {
     await user.keyboard(" ")
     expect(queryEnhancementToggle).toHaveAttribute("aria-expanded", "false")
   })
+
+  it("filters All Options and reports when no keys match", () => {
+    render(<ExpertSettings />)
+
+    fireEvent.click(screen.getByRole("button", { name: /All Options/i }))
+    fireEvent.change(screen.getByLabelText(/Filter option keys/i), {
+      target: { value: "definitely_no_matching_rag_key" },
+    })
+
+    expect(screen.getByText("No option keys match this filter.")).toBeInTheDocument()
+  })
+
+  it("updates boolean controls from the All Options editor", () => {
+    render(<ExpertSettings />)
+
+    fireEvent.click(screen.getByRole("button", { name: /All Options/i }))
+    fireEvent.change(screen.getByLabelText(/Filter option keys/i), {
+      target: { value: "enable_generation" },
+    })
+    fireEvent.click(screen.getByRole("switch", { name: "enable_generation" }))
+
+    expect(state.updateSetting).toHaveBeenCalledWith(
+      "enable_generation",
+      !DEFAULT_RAG_SETTINGS.enable_generation
+    )
+  })
 })

--- a/apps/packages/ui/src/components/Option/KnowledgeQA/__tests__/ExportDialog.a11y.test.tsx
+++ b/apps/packages/ui/src/components/Option/KnowledgeQA/__tests__/ExportDialog.a11y.test.tsx
@@ -21,8 +21,27 @@ const state = {
   messages: [] as Array<{ role: string; content: string }>,
   currentThreadId: "thread-1" as string | null,
   results: [] as Array<{ id: string }>,
+  citations: [] as Array<{ index: number }>,
   answer: "Test answer" as string | null,
-  query: "What does this source say?"
+  query: "What does this source say?",
+  settings: {
+    sources: ["media_db", "notes"],
+    include_media_ids: [42],
+    include_note_ids: ["note-a"],
+    top_k: 12,
+    generation_provider: "openai",
+    generation_model: "gpt-4o-mini",
+    enable_web_fallback: false,
+  },
+  preset: "balanced",
+  searchDetails: null as null | {
+    expandedQueries?: string[]
+    rerankingEnabled?: boolean
+    rerankingStrategy?: string
+    averageRelevance?: number | null
+    webFallbackTriggered?: boolean
+    webFallbackEngine?: string | null
+  },
 }
 
 vi.mock("../KnowledgeQAProvider", () => ({
@@ -30,8 +49,12 @@ vi.mock("../KnowledgeQAProvider", () => ({
     messages: state.messages,
     currentThreadId: state.currentThreadId,
     results: state.results,
+    citations: state.citations,
     answer: state.answer,
-    query: state.query
+    query: state.query,
+    settings: state.settings,
+    preset: state.preset,
+    searchDetails: state.searchDetails,
   })
 }))
 
@@ -76,8 +99,20 @@ describe("ExportDialog accessibility", () => {
     state.messages = []
     state.currentThreadId = "thread-1"
     state.results = []
+    state.citations = []
     state.answer = "Test answer"
     state.query = "What does this source say?"
+    state.settings = {
+      sources: ["media_db", "notes"],
+      include_media_ids: [42],
+      include_note_ids: ["note-a"],
+      top_k: 12,
+      generation_provider: "openai",
+      generation_model: "gpt-4o-mini",
+      enable_web_fallback: false,
+    }
+    state.preset = "balanced"
+    state.searchDetails = null
   })
 
   it("exposes modal dialog semantics", () => {
@@ -424,6 +459,59 @@ describe("ExportDialog accessibility", () => {
     )
   })
 
+  it("exports citation mappings and optional settings snapshot for grounded review", async () => {
+    state.answer = "The planning document recommends staged rollout [1]."
+    state.citations = [{ index: 1 }]
+    state.results = [
+      {
+        id: "source-1",
+        content: "Staged rollout recommendation and supporting evidence",
+        metadata: {
+          title: "Planning Memo",
+          source: "planning-memo.pdf",
+          url: "https://example.com/planning-memo",
+          page_number: 4,
+        },
+        score: 0.87,
+      } as any,
+    ]
+    state.messages = [
+      { role: "user", content: "What does the planning memo recommend?" },
+      { role: "assistant", content: "It recommends staged rollout [1]." },
+    ]
+    state.searchDetails = {
+      expandedQueries: ["rollout plan", "deployment stages"],
+      rerankingEnabled: true,
+      rerankingStrategy: "hybrid",
+      averageRelevance: 0.87,
+      webFallbackTriggered: false,
+      webFallbackEngine: null,
+    }
+
+    render(<ExportDialog open onClose={vi.fn()} />)
+
+    fireEvent.click(screen.getByLabelText("Settings snapshot"))
+    fireEvent.click(screen.getByRole("button", { name: "Export" }))
+
+    await waitFor(() => expect(screen.getByText("Preview")).toBeInTheDocument())
+
+    const preview = screen.getByText((_, element) => {
+      if (!element || element.tagName.toLowerCase() !== "pre") return false
+      const text = element.textContent || ""
+      return (
+        text.includes("## Citations") &&
+        text.includes("[1] Planning Memo") &&
+        text.includes("maps to Source 1") &&
+        text.includes('"preset": "balanced"') &&
+        text.includes('"sources": [') &&
+        text.includes('"include_media_ids": [') &&
+        text.includes('"expandedQueries": [')
+      )
+    })
+
+    expect(preview).toBeInTheDocument()
+  })
+
   it("shows a user-visible error when Save to Notes fails", async () => {
     createNoteMock.mockRejectedValueOnce(new Error("notes backend unavailable"))
 
@@ -573,6 +661,7 @@ describe("ExportDialog accessibility", () => {
       expect(messageOpenMock).toHaveBeenCalledWith(
         expect.objectContaining({
           type: "warning",
+          content: "Share link created, but copying it to the clipboard failed.",
         })
       )
     )

--- a/apps/packages/ui/src/components/Option/KnowledgeQA/__tests__/KnowledgeQA.connection.test.tsx
+++ b/apps/packages/ui/src/components/Option/KnowledgeQA/__tests__/KnowledgeQA.connection.test.tsx
@@ -4,6 +4,10 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 import { MemoryRouter } from "react-router-dom"
 
 import { KnowledgeQA } from "../index"
+import {
+  createKnowledgeQaStateFixture,
+  type KnowledgeQaStateFixtureName,
+} from "./knowledgeQaStateFixtures"
 
 const state = {
   settingsPanelOpen: false,
@@ -13,10 +17,21 @@ const state = {
   selectSharedThread: vi.fn(),
 }
 
+const stateBaseKeys = new Set(Object.keys(state))
+
 const connectivity = {
   online: true,
   isChecking: false,
   lastCheckedAt: Date.now(),
+  serverUrl: "http://127.0.0.1:8000",
+  configStep: "health" as "none" | "url" | "auth" | "health",
+  errorKind: "none" as "none" | "auth" | "unreachable" | "partial",
+  lastError: null as string | null,
+  lastStatusCode: null as number | null,
+  knowledgeStatus: "ready" as "unknown" | "ready" | "indexing" | "offline" | "empty",
+  knowledgeLastCheckedAt: Date.now() as number | null,
+  knowledgeError: null as string | null,
+  hasCompletedFirstRun: true,
   uxState: "connected_ok" as
     | "connected_ok"
     | "testing"
@@ -76,10 +91,20 @@ vi.mock("@/hooks/useConnectionState", () => ({
   useConnectionState: () => ({
     isChecking: connectivity.isChecking,
     lastCheckedAt: connectivity.lastCheckedAt,
+    serverUrl: connectivity.serverUrl,
+    configStep: connectivity.configStep,
+    errorKind: connectivity.errorKind,
+    lastError: connectivity.lastError,
+    lastStatusCode: connectivity.lastStatusCode,
+  }),
+  useKnowledgeStatus: () => ({
+    knowledgeStatus: connectivity.knowledgeStatus,
+    knowledgeLastCheckedAt: connectivity.knowledgeLastCheckedAt,
+    knowledgeError: connectivity.knowledgeError,
   }),
   useConnectionUxState: () => ({
     uxState: connectivity.uxState,
-    hasCompletedFirstRun: true,
+    hasCompletedFirstRun: connectivity.hasCompletedFirstRun,
   }),
 }))
 
@@ -129,11 +154,11 @@ vi.mock("../ConversationThread", () => ({
 }))
 
 vi.mock("../SettingsPanel", () => ({
-  SettingsPanel: () => <div />
+  SettingsPanel: () => <div data-testid="knowledge-settings-panel" />
 }))
 
 vi.mock("../ExportDialog", () => ({
-  ExportDialog: () => <div />
+  ExportDialog: () => <div data-testid="knowledge-export-dialog" />
 }))
 
 describe("KnowledgeQA connection states", () => {
@@ -143,16 +168,114 @@ describe("KnowledgeQA connection states", () => {
         <KnowledgeQA />
       </MemoryRouter>
     )
+  const resetKnowledgeQaState = () => {
+    const mutableState = state as unknown as Record<string, unknown>
+    for (const key of Object.keys(mutableState)) {
+      if (!stateBaseKeys.has(key)) {
+        delete mutableState[key]
+      }
+    }
+    state.settingsPanelOpen = false
+    state.setSettingsPanelOpen = vi.fn()
+    state.currentThreadId = null
+    state.selectThread = vi.fn()
+    state.selectSharedThread = vi.fn()
+  }
+  const applyStateFixture = (name: KnowledgeQaStateFixtureName) => {
+    const fixture = createKnowledgeQaStateFixture(name)
+    resetKnowledgeQaState()
+    Object.assign(state as unknown as Record<string, unknown>, fixture.knowledgeQa)
+    connectivity.online = fixture.connection.online
+    connectivity.isChecking = fixture.connection.isChecking
+    connectivity.lastCheckedAt = fixture.connection.lastCheckedAt
+    connectivity.uxState = fixture.connection.uxState
+    connectivity.hasCompletedFirstRun = fixture.connection.hasCompletedFirstRun
+    connectivity.serverUrl = fixture.connection.serverUrl
+    connectivity.configStep = fixture.connection.configStep
+    connectivity.errorKind = fixture.connection.errorKind
+    connectivity.lastError = fixture.connection.lastError
+    connectivity.lastStatusCode = fixture.connection.lastStatusCode
+    connectivity.knowledgeStatus =
+      fixture.connection.uxState === "unconfigured" ||
+      fixture.connection.uxState === "configuring_url" ||
+      fixture.connection.uxState === "configuring_auth"
+        ? "unknown"
+        : !fixture.connection.online
+          ? "offline"
+          : fixture.sourceInventory.media.length === 0 &&
+              fixture.sourceInventory.notes.length === 0
+            ? "empty"
+            : "ready"
+    connectivity.knowledgeLastCheckedAt = fixture.connection.lastCheckedAt
+    connectivity.knowledgeError =
+      connectivity.knowledgeStatus === "offline"
+        ? fixture.connection.lastError
+        : null
+    capabilitiesState.loading = fixture.capabilities.loading
+    capabilitiesState.capabilities = fixture.capabilities.capabilities
+  }
 
   beforeEach(() => {
     vi.clearAllMocks()
     vi.useRealTimers()
+    resetKnowledgeQaState()
     connectivity.online = true
     connectivity.isChecking = false
     connectivity.lastCheckedAt = Date.now()
+    connectivity.serverUrl = "http://127.0.0.1:8000"
+    connectivity.configStep = "health"
+    connectivity.errorKind = "none"
+    connectivity.lastError = null
+    connectivity.lastStatusCode = null
+    connectivity.knowledgeStatus = "ready"
+    connectivity.knowledgeLastCheckedAt = Date.now()
+    connectivity.knowledgeError = null
+    connectivity.hasCompletedFirstRun = true
     connectivity.uxState = "connected_ok"
     capabilitiesState.loading = false
     capabilitiesState.capabilities = { hasRag: true }
+  })
+
+  it("renders the backend offline audited state from a deterministic fixture", () => {
+    applyStateFixture("backendOffline")
+
+    renderKnowledgeQa()
+
+    expect(
+      screen.getByText("Can't reach your tldw server right now")
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole("button", { name: "Health & diagnostics" })
+    ).toBeInTheDocument()
+  })
+
+  it("renders the setup required audited state from a deterministic fixture", () => {
+    applyStateFixture("setupRequired")
+
+    renderKnowledgeQa()
+
+    expect(screen.getByText("Setup Required")).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Finish Setup" })).toBeInTheDocument()
+    expect(screen.getByTestId("knowledge-setup-diagnostics")).toBeInTheDocument()
+    expect(screen.getByText("Server URL")).toBeInTheDocument()
+    expect(screen.getByText("Add a tldw server URL before Knowledge QA can search your library.")).toBeInTheDocument()
+  })
+
+  it("renders settings and export audited states from deterministic fixtures", async () => {
+    applyStateFixture("settingsDrawer")
+    const { rerender } = renderKnowledgeQa()
+
+    expect(await screen.findByTestId("knowledge-settings-panel")).toBeInTheDocument()
+
+    applyStateFixture("exportDialog")
+    rerender(
+      <MemoryRouter initialEntries={["/knowledge"]}>
+        <KnowledgeQA />
+      </MemoryRouter>
+    )
+
+    fireEvent.click(await screen.findByRole("button", { name: "Export" }))
+    expect(await screen.findByTestId("knowledge-export-dialog")).toBeInTheDocument()
   })
 
   it("shows credential guidance instead of the generic offline screen", () => {
@@ -173,15 +296,58 @@ describe("KnowledgeQA connection states", () => {
   it("shows setup guidance and routes users to setup", () => {
     connectivity.online = false
     connectivity.uxState = "unconfigured"
+    connectivity.serverUrl = null
+    connectivity.configStep = "url"
+    connectivity.hasCompletedFirstRun = false
 
     renderKnowledgeQa()
 
-    expect(
-      screen.getByText("Finish setup to use Knowledge QA")
-    ).toBeInTheDocument()
+    expect(screen.getByText("Setup Required")).toBeInTheDocument()
+    expect(screen.getByText("Credentials")).toBeInTheDocument()
+    expect(screen.getByText("Waiting for a server URL before checking credentials.")).toBeInTheDocument()
+    expect(screen.queryByLabelText("Search your knowledge base")).not.toBeInTheDocument()
 
     fireEvent.click(screen.getByRole("button", { name: "Finish Setup" }))
     expect(connectivity.navigate).toHaveBeenCalledWith("/")
+  })
+
+  it("shows credential diagnostics when a saved server URL is missing auth", () => {
+    connectivity.online = false
+    connectivity.uxState = "configuring_auth"
+    connectivity.serverUrl = "http://127.0.0.1:8000"
+    connectivity.configStep = "auth"
+
+    renderKnowledgeQa()
+
+    expect(screen.getByText("Add your credentials to use Knowledge QA")).toBeInTheDocument()
+    expect(screen.getByText("Configured server: http://127.0.0.1:8000")).toBeInTheDocument()
+    expect(screen.getByText("Add the API key or login token for this tldw server.")).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole("button", { name: "Open Settings" }))
+    expect(connectivity.navigate).toHaveBeenCalledWith("/settings/tldw")
+  })
+
+  it("calls out browser access and allowlist blockers for extension recovery", () => {
+    connectivity.online = false
+    connectivity.uxState = "error_unreachable"
+    connectivity.serverUrl = "http://127.0.0.1:8000/private?api_key=hidden"
+    connectivity.configStep = "health"
+    connectivity.errorKind = "unreachable"
+    connectivity.lastError =
+      "Absolute URL requests are blocked unless the request origin is explicitly allowlisted."
+    connectivity.lastStatusCode = 400
+
+    renderKnowledgeQa()
+
+    expect(screen.getByText("Configured server: http://127.0.0.1:8000")).toBeInTheDocument()
+    expect(screen.getByText("Browser access")).toBeInTheDocument()
+    expect(
+      screen.getByText(/Allowlist this server origin or grant extension host access/i)
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText(/Absolute URL requests are blocked/i)
+    ).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Health & diagnostics" })).toBeInTheDocument()
   })
 
   it("keeps retry behavior for unreachable servers", () => {

--- a/apps/packages/ui/src/components/Option/KnowledgeQA/__tests__/KnowledgeQA.connection.test.tsx
+++ b/apps/packages/ui/src/components/Option/KnowledgeQA/__tests__/KnowledgeQA.connection.test.tsx
@@ -236,6 +236,18 @@ describe("KnowledgeQA connection states", () => {
     capabilitiesState.capabilities = { hasRag: true }
   })
 
+  it("keeps fixture connection timestamps deterministic", () => {
+    const dateNow = vi.spyOn(Date, "now").mockReturnValue(42)
+
+    try {
+      expect(createKnowledgeQaStateFixture("readySearch").connection.lastCheckedAt).toBe(
+        Date.parse("2026-06-07T12:00:00.000Z")
+      )
+    } finally {
+      dateNow.mockRestore()
+    }
+  })
+
   it("renders the backend offline audited state from a deterministic fixture", () => {
     applyStateFixture("backendOffline")
 

--- a/apps/packages/ui/src/components/Option/KnowledgeQA/__tests__/KnowledgeQA.golden-layout.test.tsx
+++ b/apps/packages/ui/src/components/Option/KnowledgeQA/__tests__/KnowledgeQA.golden-layout.test.tsx
@@ -54,6 +54,7 @@ const connectivity = {
   online: true,
   isChecking: false,
   lastCheckedAt: Date.now(),
+  knowledgeStatus: "ready" as "unknown" | "ready" | "indexing" | "offline" | "empty",
   checkOnce: vi.fn(),
 }
 const capabilitiesState = {
@@ -98,6 +99,9 @@ vi.mock("@/hooks/useConnectionState", () => ({
     uxState: "connected_ok" as const,
     hasCompletedFirstRun: true,
   }),
+  useKnowledgeStatus: () => ({
+    knowledgeStatus: connectivity.knowledgeStatus,
+  }),
 }))
 
 vi.mock("@/hooks/useMediaQuery", () => ({
@@ -131,6 +135,12 @@ vi.mock("../SearchBar", () => ({
 vi.mock("../context/CompactToolbar", () => ({
   CompactToolbar: ({ className }: { className?: string }) => (
     <div data-testid="knowledge-compact-toolbar" data-class-name={className ?? ""} />
+  ),
+}))
+
+vi.mock("../context/KnowledgeContextBar", () => ({
+  KnowledgeContextBar: () => (
+    <div data-testid="knowledge-context-bar">Source Scope</div>
   ),
 }))
 
@@ -229,6 +239,7 @@ describe("KnowledgeQA golden layout guardrails", () => {
     connectivity.online = true
     connectivity.isChecking = false
     connectivity.lastCheckedAt = Date.now()
+    connectivity.knowledgeStatus = "ready"
     capabilitiesState.loading = false
     capabilitiesState.capabilities = { hasRag: true }
     setSimpleMode()
@@ -277,9 +288,10 @@ describe("KnowledgeQA golden layout guardrails", () => {
     renderKnowledgeQa()
 
     expect(screen.getByText("How it works")).toBeInTheDocument()
+    expect(screen.getByText("Web-only search")).toBeInTheDocument()
     expect(
       screen.getByText(
-        /No document sources are selected\. Web fallback uses your configured server default provider\./i
+        /No source categories are selected\. Because web fallback is enabled/i
       )
     ).toBeInTheDocument()
     expect(screen.getByText("How do I add my first source?")).toBeInTheDocument()
@@ -296,12 +308,13 @@ describe("KnowledgeQA golden layout guardrails", () => {
     expect(screen.queryByText("How do I add my first source?")).not.toBeInTheDocument()
   })
 
-  it("opens settings panel from ready-state source action in simple mode", () => {
+  it("opens source scope controls from ready-state source action in simple mode", () => {
     renderKnowledgeQa()
 
     fireEvent.click(screen.getByRole("button", { name: "No sources selected" }))
 
-    expect(state.setSettingsPanelOpen).toHaveBeenCalledWith(true)
+    expect(screen.getByRole("dialog", { name: "Source scope and profiles" })).toBeInTheDocument()
+    expect(screen.getByText("Source Scope")).toBeInTheDocument()
   })
 
   it("restores the newest restorable knowledge session from ready-state", () => {

--- a/apps/packages/ui/src/components/Option/KnowledgeQA/__tests__/KnowledgeQALayout.behavior.test.tsx
+++ b/apps/packages/ui/src/components/Option/KnowledgeQA/__tests__/KnowledgeQALayout.behavior.test.tsx
@@ -208,7 +208,17 @@ vi.mock("../panels/AnswerWorkspace", () => ({
 }))
 
 vi.mock("../panels/NoResultsRecovery", () => ({
-  NoResultsRecovery: () => <div data-testid="knowledge-no-results-recovery" />,
+  NoResultsRecovery: ({
+    onShowNearestMatches,
+  }: {
+    onShowNearestMatches: () => void
+  }) => (
+    <div data-testid="knowledge-no-results-recovery">
+      <button type="button" onClick={onShowNearestMatches}>
+        Show nearest matches
+      </button>
+    </div>
+  ),
 }))
 
 vi.mock("../evidence/EvidenceRail", () => ({
@@ -379,6 +389,20 @@ describe("KnowledgeQALayout evidence-rail transitions", () => {
     expect(await screen.findByTestId("knowledge-ready-state")).toHaveTextContent(
       "knowledge-ready-recovery:web_only"
     )
+  })
+
+  it("opens the details evidence view when showing nearest no-results matches", async () => {
+    applyStateFixture("noResults")
+    state.evidenceRailOpen = false
+    state.evidenceRailTab = "sources"
+
+    renderLayout()
+
+    fireEvent.click(await screen.findByRole("button", { name: "Show nearest matches" }))
+
+    expect(state.setEvidenceRailOpen).toHaveBeenCalledWith(true)
+    expect(state.setEvidenceRailTab).toHaveBeenCalledWith("details")
+    expect(state.focusSource).not.toHaveBeenCalled()
   })
 
   it("passes a visible no-indexed-source block reason to the composer", async () => {

--- a/apps/packages/ui/src/components/Option/KnowledgeQA/__tests__/KnowledgeQALayout.behavior.test.tsx
+++ b/apps/packages/ui/src/components/Option/KnowledgeQA/__tests__/KnowledgeQALayout.behavior.test.tsx
@@ -1,7 +1,11 @@
 import React from "react"
-import { act, fireEvent, render, screen } from "@testing-library/react"
+import { act, fireEvent, render, screen, within } from "@testing-library/react"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 import { KnowledgeQALayout } from "../layout/KnowledgeQALayout"
+import {
+  createKnowledgeQaStateFixture,
+  type KnowledgeQaStateFixtureName,
+} from "./knowledgeQaStateFixtures"
 
 const state = {
   settingsPanelOpen: false,
@@ -12,15 +16,6 @@ const state = {
   isSearching: false,
   error: null as string | null,
   queryStage: "idle" as string,
-  searchDetails: null as null | {
-    alsoConsidered?: Array<{
-      id: string
-      title: string
-      score: number | null
-      reason: string | null
-    }>
-    sourceStatus?: Record<string, unknown>
-  },
   preset: "balanced" as string,
   setPreset: vi.fn(),
   settings: {
@@ -66,20 +61,17 @@ const state = {
     mediaIds: [] as number[],
     noteIds: [] as string[],
   },
-  sourceHealth: {
-    loading: false,
-    error: null as string | null,
-    loadedAt: "2026-05-16T00:00:00Z",
-    sources: [] as unknown[],
-    bySource: {},
-  },
-  refreshSourceHealth: vi.fn(),
 }
 
 const layoutModeState = {
   mode: "simple" as "simple" | "research" | "expert",
   isSimple: true,
   isResearch: false,
+}
+
+const layoutProps = {
+  knowledgeStatus: "ready" as "unknown" | "ready" | "indexing" | "offline" | "empty",
+  webFallbackAvailable: true,
 }
 
 vi.mock("../KnowledgeQAProvider", () => ({
@@ -109,19 +101,43 @@ vi.mock("../history/HistoryPane", () => ({
 vi.mock("../context/KnowledgeContextBar", () => ({
   KnowledgeContextBar: ({
     contextChangedSinceLastRun,
-    sourceHealth,
-    onRefreshSourceHealth,
+    onSourcesChange,
+    onIncludeMediaIdsChange,
+    onIncludeNoteIdsChange,
+    onPresetChange,
+    onToggleWeb,
+    onOpenSettings,
   }: {
     contextChangedSinceLastRun: boolean
-    sourceHealth?: { loadedAt: string | null }
-    onRefreshSourceHealth?: () => void
+    onSourcesChange: (sources: string[]) => void
+    onIncludeMediaIdsChange: (ids: number[]) => void
+    onIncludeNoteIdsChange: (ids: string[]) => void
+    onPresetChange: (preset: string) => void
+    onToggleWeb: () => void
+    onOpenSettings: () => void
   }) => (
     <div data-testid="knowledge-context-bar">
-      {contextChangedSinceLastRun ? "Scope changed" : "Scope unchanged"}
-      <span>{sourceHealth?.loadedAt ?? "No source health"}</span>
-      <button type="button" onClick={onRefreshSourceHealth}>
-        Refresh detailed source health
+      <p>Source Scope</p>
+      <button type="button" onClick={() => onSourcesChange(["media_db", "notes"])}>
+        Select documents and notes
       </button>
+      <button type="button" onClick={() => onIncludeMediaIdsChange([42])}>
+        Select exact document
+      </button>
+      <button type="button" onClick={() => onIncludeNoteIdsChange(["note-a"])}>
+        Select exact note
+      </button>
+      <button type="button" onClick={() => onPresetChange("thorough")}>
+        Use deep preset
+      </button>
+      <button type="button" onClick={onToggleWeb}>
+        Toggle web fallback
+      </button>
+      <button type="button">Profiles</button>
+      <button type="button" onClick={onOpenSettings}>
+        Advanced settings
+      </button>
+      {contextChangedSinceLastRun ? "Scope changed" : "Scope unchanged"}
     </div>
   ),
 }))
@@ -129,41 +145,56 @@ vi.mock("../context/KnowledgeContextBar", () => ({
 vi.mock("../context/CompactToolbar", () => ({
   CompactToolbar: ({
     contextChangedSinceLastRun,
-    sourceHealth,
-    onRefreshSourceHealth,
+    onOpenSourceSelector,
   }: {
     contextChangedSinceLastRun: boolean
-    sourceHealth?: { loadedAt: string | null }
-    onRefreshSourceHealth?: () => void
+    onOpenSourceSelector: () => void
   }) => (
     <div data-testid="knowledge-compact-toolbar">
-      {contextChangedSinceLastRun ? "Scope changed" : "Scope unchanged"}
-      <span>{sourceHealth?.loadedAt ?? "No source health"}</span>
-      <button type="button" onClick={onRefreshSourceHealth}>
-        Refresh compact source health
+      <button type="button" onClick={onOpenSourceSelector}>
+        Open compact sources
       </button>
+      {contextChangedSinceLastRun ? "Scope changed" : "Scope unchanged"}
     </div>
   ),
 }))
 
 vi.mock("../composer/KnowledgeComposer", () => ({
-  KnowledgeComposer: () => (
-    <input
-      id="knowledge-search-input"
-      aria-label="Search your knowledge base"
+  KnowledgeComposer: ({
+    searchBlockedMessage,
+  }: {
+    searchBlockedMessage?: string | null
+  }) => (
+    <div
       data-testid="knowledge-composer"
-    />
+      data-search-blocked-message={searchBlockedMessage ?? ""}
+    >
+      <input
+        id="knowledge-search-input"
+        aria-label="Search your knowledge base"
+      />
+    </div>
   ),
 }))
 
 vi.mock("../empty/KnowledgeReadyState", () => ({
   KnowledgeReadyState: ({
-    sourceHealth,
+    recoveryState,
+    hasSources,
+    webFallbackEnabled,
   }: {
-    sourceHealth?: { loadedAt: string | null }
+    recoveryState?: { kind: string }
+    hasSources: boolean
+    webFallbackEnabled: boolean
   }) => (
     <div data-testid="knowledge-ready-state">
-      {sourceHealth?.loadedAt ?? "No source health"}
+      {recoveryState
+        ? `knowledge-ready-recovery:${recoveryState.kind}`
+        : hasSources
+        ? "Ready with selected sources"
+        : webFallbackEnabled
+          ? "Ready with web fallback only"
+          : "No sources selected"}
     </div>
   ),
 }))
@@ -177,32 +208,7 @@ vi.mock("../panels/AnswerWorkspace", () => ({
 }))
 
 vi.mock("../panels/NoResultsRecovery", () => ({
-  NoResultsRecovery: ({
-    sourceHealth,
-    selectedSources,
-    onOpenQuickIngest,
-    onShowNearestMatches,
-    showNearestMatchesAvailable,
-  }: {
-    sourceHealth?: { loadedAt: string | null }
-    selectedSources?: string[]
-    onOpenQuickIngest?: () => void
-    onShowNearestMatches?: () => void
-    showNearestMatchesAvailable?: boolean
-  }) => (
-    <div data-testid="knowledge-no-results-recovery">
-      <span>{sourceHealth?.loadedAt ?? "No source health"}</span>
-      <span>{selectedSources?.join(",") ?? "No selected sources"}</span>
-      <button type="button" onClick={onOpenQuickIngest}>
-        Open Quick Ingest
-      </button>
-      {showNearestMatchesAvailable ? (
-        <button type="button" onClick={onShowNearestMatches}>
-          Show nearest matches
-        </button>
-      ) : null}
-    </div>
-  ),
+  NoResultsRecovery: () => <div data-testid="knowledge-no-results-recovery" />,
 }))
 
 vi.mock("../evidence/EvidenceRail", () => ({
@@ -225,7 +231,47 @@ vi.mock("../evidence/EvidenceRail", () => ({
 }))
 
 describe("KnowledgeQALayout evidence-rail transitions", () => {
-  const renderLayout = () => render(<KnowledgeQALayout onExportClick={vi.fn()} />)
+  const renderLayoutElement = () => (
+    <KnowledgeQALayout
+      onExportClick={vi.fn()}
+      knowledgeStatus={layoutProps.knowledgeStatus}
+      webFallbackAvailable={layoutProps.webFallbackAvailable}
+    />
+  )
+  const renderLayout = () => render(renderLayoutElement())
+  const applyStateFixture = (name: KnowledgeQaStateFixtureName) => {
+    const fixture = createKnowledgeQaStateFixture(name).knowledgeQa
+    const fullFixture = createKnowledgeQaStateFixture(name)
+    layoutProps.knowledgeStatus =
+      fullFixture.sourceInventory.media.length === 0 &&
+      fullFixture.sourceInventory.notes.length === 0
+        ? "empty"
+        : "ready"
+    layoutProps.webFallbackAvailable =
+      fullFixture.capabilities.capabilities?.hasWebSearch !== false
+    state.settingsPanelOpen = fixture.settingsPanelOpen
+    state.results = fixture.results
+    state.answer = fixture.answer
+    state.citations = fixture.citations
+    state.hasSearched = fixture.hasSearched
+    state.isSearching = fixture.isSearching
+    state.error = fixture.error
+    state.queryStage = fixture.queryStage
+    state.preset = fixture.preset
+    state.settings = {
+      sources: fixture.settings.sources,
+      enable_web_fallback: fixture.settings.enable_web_fallback,
+      top_k: fixture.settings.top_k,
+      include_media_ids: fixture.settings.include_media_ids,
+      include_note_ids: fixture.settings.include_note_ids,
+    }
+    state.searchHistory = fixture.searchHistory
+    state.messages = fixture.messages
+    state.evidenceRailOpen = fixture.evidenceRailOpen
+    state.evidenceRailTab = fixture.evidenceRailTab
+    state.lastSearchScope = fixture.lastSearchScope
+    state.pinnedSourceFilters = fixture.pinnedSourceFilters
+  }
 
   beforeEach(() => {
     vi.clearAllMocks()
@@ -237,7 +283,6 @@ describe("KnowledgeQALayout evidence-rail transitions", () => {
     state.isSearching = false
     state.error = null
     state.queryStage = "idle"
-    state.searchDetails = null
     state.preset = "balanced"
     state.settings.sources = []
     state.settings.enable_web_fallback = true
@@ -251,22 +296,11 @@ describe("KnowledgeQALayout evidence-rail transitions", () => {
     state.lastSearchScope = null
     state.pinnedSourceFilters.mediaIds = []
     state.pinnedSourceFilters.noteIds = []
-    state.sourceHealth.loadedAt = "2026-05-16T00:00:00Z"
-    state.sourceHealth.error = null
-    state.refreshSourceHealth.mockClear()
-    delete (window as Window & { __tldwPendingQuickIngestOpen?: unknown })
-      .__tldwPendingQuickIngestOpen
     layoutModeState.mode = "simple"
     layoutModeState.isSimple = true
     layoutModeState.isResearch = false
-  })
-
-  it("uses a visible label for the persistent simple/detailed mode control", () => {
-    renderLayout()
-
-    expect(
-      screen.getByRole("button", { name: "Switch to detailed view" })
-    ).toHaveTextContent("Detailed")
+    layoutProps.knowledgeStatus = "ready"
+    layoutProps.webFallbackAvailable = true
   })
 
   it("keeps the evidence rail closed while the settings panel is open", async () => {
@@ -294,6 +328,98 @@ describe("KnowledgeQALayout evidence-rail transitions", () => {
     rerender(<KnowledgeQALayout onExportClick={vi.fn()} />)
 
     expect(await screen.findByTestId("knowledge-evidence-rail-closed")).toBeInTheDocument()
+  })
+
+  it.each([
+    ["noIndexedSources", "knowledge-ready-state", "knowledge-ready-recovery:no_indexed_sources"],
+    ["readySearch", "knowledge-ready-state", "knowledge-ready-recovery:ready"],
+    ["noSelectedSources", "knowledge-ready-state", "knowledge-ready-recovery:no_selected_sources"],
+    ["results", "knowledge-results-shell", "knowledge-answer-workspace"],
+    ["noResults", "knowledge-results-shell", "knowledge-no-results-recovery"],
+  ] as const)(
+    "renders the %s audited state from a deterministic fixture",
+    async (fixtureName, testId, expectedMarker) => {
+      applyStateFixture(fixtureName)
+
+      renderLayout()
+
+      const element = await screen.findByTestId(testId)
+      expect(element).toBeInTheDocument()
+      if (expectedMarker.startsWith("knowledge-")) {
+        if (expectedMarker.startsWith("knowledge-ready-recovery:")) {
+          expect(screen.getByText(expectedMarker)).toBeInTheDocument()
+        } else {
+          expect(await screen.findByTestId(expectedMarker)).toBeInTheDocument()
+        }
+      } else {
+        expect(screen.getByText(expectedMarker)).toBeInTheDocument()
+      }
+    }
+  )
+
+  it("classifies no selected sources as blocked when web fallback is unavailable", async () => {
+    applyStateFixture("noSelectedSources")
+    state.settings.enable_web_fallback = true
+    layoutProps.webFallbackAvailable = false
+
+    renderLayout()
+
+    expect(await screen.findByTestId("knowledge-ready-state")).toHaveTextContent(
+      "knowledge-ready-recovery:no_selected_sources"
+    )
+  })
+
+  it("classifies no selected sources as web-only when web fallback is enabled and available", async () => {
+    applyStateFixture("noSelectedSources")
+    state.settings.enable_web_fallback = true
+    layoutProps.webFallbackAvailable = true
+
+    renderLayout()
+
+    expect(await screen.findByTestId("knowledge-ready-state")).toHaveTextContent(
+      "knowledge-ready-recovery:web_only"
+    )
+  })
+
+  it("passes a visible no-indexed-source block reason to the composer", async () => {
+    applyStateFixture("noIndexedSources")
+
+    renderLayout()
+
+    expect(await screen.findByTestId("knowledge-composer")).toHaveAttribute(
+      "data-search-blocked-message",
+      "Add or index library sources before asking Knowledge QA."
+    )
+  })
+
+  it("opens shared source scope and profile controls from the compact source action", async () => {
+    renderLayout()
+
+    fireEvent.click(screen.getByRole("button", { name: "Open compact sources" }))
+
+    const dialog = await screen.findByRole("dialog", {
+      name: "Source scope and profiles",
+    })
+    expect(within(dialog).getByText("Source Scope")).toBeInTheDocument()
+    expect(within(dialog).getByRole("button", { name: "Profiles" })).toBeInTheDocument()
+
+    fireEvent.click(within(dialog).getByRole("button", { name: "Select documents and notes" }))
+    expect(state.updateSetting).toHaveBeenCalledWith("sources", ["media_db", "notes"])
+
+    fireEvent.click(within(dialog).getByRole("button", { name: "Select exact document" }))
+    expect(state.updateSetting).toHaveBeenCalledWith("include_media_ids", [42])
+
+    fireEvent.click(within(dialog).getByRole("button", { name: "Select exact note" }))
+    expect(state.updateSetting).toHaveBeenCalledWith("include_note_ids", ["note-a"])
+
+    fireEvent.click(within(dialog).getByRole("button", { name: "Use deep preset" }))
+    expect(state.setPreset).toHaveBeenCalledWith("thorough")
+
+    fireEvent.click(within(dialog).getByRole("button", { name: "Toggle web fallback" }))
+    expect(state.updateSetting).toHaveBeenCalledWith("enable_web_fallback", false)
+
+    fireEvent.click(within(dialog).getByRole("button", { name: "Advanced settings" }))
+    expect(state.setSettingsPanelOpen).toHaveBeenCalledWith(true)
   })
 
   it("reopens the evidence rail for a new search after a manual close", async () => {
@@ -425,76 +551,5 @@ describe("KnowledgeQALayout evidence-rail transitions", () => {
     renderLayout()
 
     expect(screen.getByText("Scope changed")).toBeInTheDocument()
-  })
-
-  it("passes source health and refresh through the simple toolbar and ready state", async () => {
-    renderLayout()
-
-    expect(screen.getByTestId("knowledge-compact-toolbar")).toHaveTextContent(
-      "2026-05-16T00:00:00Z"
-    )
-    expect(screen.getByTestId("knowledge-ready-state")).toHaveTextContent(
-      "2026-05-16T00:00:00Z"
-    )
-
-    fireEvent.click(screen.getByRole("button", { name: "Refresh compact source health" }))
-
-    expect(state.refreshSourceHealth).toHaveBeenCalledOnce()
-  })
-
-  it("passes source health and refresh through the detailed context bar", () => {
-    layoutModeState.mode = "research"
-    layoutModeState.isSimple = false
-    layoutModeState.isResearch = true
-
-    renderLayout()
-
-    expect(screen.getByTestId("knowledge-context-bar")).toHaveTextContent(
-      "2026-05-16T00:00:00Z"
-    )
-
-    fireEvent.click(screen.getByRole("button", { name: "Refresh detailed source health" }))
-
-    expect(state.refreshSourceHealth).toHaveBeenCalledOnce()
-  })
-
-  it("passes source health and selected scope into no-results recovery", async () => {
-    state.hasSearched = true
-    state.settings.sources = ["media_db"]
-
-    renderLayout()
-
-    const recovery = await screen.findByTestId("knowledge-no-results-recovery")
-    expect(recovery).toHaveTextContent("2026-05-16T00:00:00Z")
-    expect(recovery).toHaveTextContent("media_db")
-
-    fireEvent.click(screen.getByRole("button", { name: "Open Quick Ingest" }))
-    expect(
-      (window as Window & { __tldwPendingQuickIngestOpen?: unknown })
-        .__tldwPendingQuickIngestOpen
-    ).toMatchObject({
-      detail: { source: "knowledge_qa" },
-    })
-  })
-
-  it("shows nearest misses in no-results recovery from search metadata", async () => {
-    state.hasSearched = true
-    state.searchDetails = {
-      alsoConsidered: [
-        {
-          id: "near-1",
-          title: "Near miss",
-          score: 0.42,
-          reason: "below threshold",
-        },
-      ],
-    }
-
-    renderLayout()
-
-    fireEvent.click(await screen.findByRole("button", { name: "Show nearest matches" }))
-    expect(state.setEvidenceRailOpen).toHaveBeenCalledWith(true)
-    expect(state.setEvidenceRailTab).toHaveBeenCalledWith("details")
-    expect(state.focusSource).not.toHaveBeenCalled()
   })
 })

--- a/apps/packages/ui/src/components/Option/KnowledgeQA/__tests__/NoResultsRecovery.test.tsx
+++ b/apps/packages/ui/src/components/Option/KnowledgeQA/__tests__/NoResultsRecovery.test.tsx
@@ -1,0 +1,105 @@
+import { fireEvent, render, screen } from "@testing-library/react"
+import type { ComponentProps } from "react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { MemoryRouter } from "react-router-dom"
+import { NoResultsRecovery } from "../panels/NoResultsRecovery"
+
+let recentlyIngestedDocs: unknown[] = []
+
+function renderNoResultsRecovery(
+  props: ComponentProps<typeof NoResultsRecovery>
+) {
+  return render(
+    <MemoryRouter>
+      <NoResultsRecovery {...props} />
+    </MemoryRouter>
+  )
+}
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (_key: string, fallback: string) => fallback,
+  }),
+}))
+
+vi.mock("@/store/quick-ingest", () => ({
+  useQuickIngestStore: (selector: (state: { recentlyIngestedDocs: unknown[] }) => unknown) =>
+    selector({ recentlyIngestedDocs }),
+}))
+
+describe("NoResultsRecovery", () => {
+  beforeEach(() => {
+    recentlyIngestedDocs = []
+  })
+
+  it("offers source and web recovery while hiding nearest matches without candidates", () => {
+    const onBroadenScope = vi.fn()
+    const onEnableWeb = vi.fn()
+    const onShowNearestMatches = vi.fn()
+
+    renderNoResultsRecovery(
+      {
+        onBroadenScope,
+        onOpenQuickIngest: vi.fn(),
+        onEnableWeb,
+        onShowNearestMatches,
+        webEnabled: false,
+        webAvailable: true,
+        hasNearestMatches: false,
+      }
+    )
+
+    expect(screen.getByText("No results found")).toBeInTheDocument()
+    expect(screen.getByText("Try different keywords or fewer constraints.")).toBeInTheDocument()
+    expect(screen.getByText("Broaden the question before adding details.")).toBeInTheDocument()
+    expect(screen.getByText("Confirm your sources were ingested and indexed.")).toBeInTheDocument()
+    expect(screen.queryByRole("button", { name: "Show nearest matches" })).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole("button", { name: "Broaden source scope" }))
+    fireEvent.click(screen.getByRole("button", { name: "Enable web fallback" }))
+
+    expect(onBroadenScope).toHaveBeenCalledTimes(1)
+    expect(onEnableWeb).toHaveBeenCalledTimes(1)
+    expect(onShowNearestMatches).not.toHaveBeenCalled()
+  })
+
+  it("surfaces nearest matches, web availability, and recent indexing guidance only when relevant", () => {
+    recentlyIngestedDocs = [{ id: "doc-1" }]
+    const onShowNearestMatches = vi.fn()
+    const { rerender } = renderNoResultsRecovery(
+      {
+        onBroadenScope: vi.fn(),
+        onOpenQuickIngest: vi.fn(),
+        onEnableWeb: vi.fn(),
+        onShowNearestMatches,
+        webEnabled: true,
+        webAvailable: true,
+        hasNearestMatches: true,
+      }
+    )
+
+    expect(screen.getByText("Web fallback enabled")).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Show nearest matches" })).toBeEnabled()
+    expect(screen.getByText(/may still be indexing/i)).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole("button", { name: "Show nearest matches" }))
+    expect(onShowNearestMatches).toHaveBeenCalledTimes(1)
+
+    rerender(
+      <MemoryRouter>
+        <NoResultsRecovery
+          onBroadenScope={vi.fn()}
+          onOpenQuickIngest={vi.fn()}
+          onEnableWeb={vi.fn()}
+          onShowNearestMatches={vi.fn()}
+          webEnabled={false}
+          webAvailable={false}
+          hasNearestMatches={false}
+        />
+      </MemoryRouter>
+    )
+
+    expect(screen.getByText("Web fallback unavailable")).toBeInTheDocument()
+    expect(screen.queryByRole("button", { name: "Enable web fallback" })).not.toBeInTheDocument()
+  })
+})

--- a/apps/packages/ui/src/components/Option/KnowledgeQA/__tests__/SearchBar.behavior.test.tsx
+++ b/apps/packages/ui/src/components/Option/KnowledgeQA/__tests__/SearchBar.behavior.test.tsx
@@ -318,7 +318,7 @@ describe("SearchBar behavior", () => {
     })
   })
 
-  it("disables submit when no sources selected and web fallback is off", async () => {
+  it("disables submit with visible inline recovery copy when no sources selected and web fallback is off", async () => {
     state.query = "test query"
     state.settings.sources = []
     state.settings.enable_web_fallback = false
@@ -328,10 +328,53 @@ describe("SearchBar behavior", () => {
     const submit = screen.getByRole("button", { name: "Ask" })
     expect(submit).toBeDisabled()
     expect(submit).not.toHaveAttribute("title")
+    expect(
+      screen.getByText("Select source categories or enable web fallback before asking Knowledge QA.")
+    ).toBeInTheDocument()
+    expect(submit).toHaveAttribute(
+      "aria-describedby",
+      "knowledge-search-no-source-explanation"
+    )
 
     fireEvent.mouseEnter(submit.parentElement!)
     expect(
       await screen.findByText("Select source categories or enable web fallback to search")
+    ).toBeInTheDocument()
+  })
+
+  it("disables submit with server-capability copy when web fallback is unavailable", () => {
+    state.query = "test query"
+    state.settings.sources = []
+    state.settings.enable_web_fallback = true
+
+    render(<SearchBar autoFocus={false} webFallbackAvailable={false} />)
+
+    const submit = screen.getByRole("button", { name: "Ask" })
+    expect(submit).toBeDisabled()
+    expect(
+      screen.getByText(
+        "Web fallback is not available on this server. Select personal-library sources before asking Knowledge QA."
+      )
+    ).toBeInTheDocument()
+    expect(state.search).not.toHaveBeenCalled()
+  })
+
+  it("disables submit with an explicit recovery reason when the library cannot be searched", () => {
+    state.query = "test query"
+    state.settings.sources = ["media_db", "notes"]
+    state.settings.enable_web_fallback = false
+
+    render(
+      <SearchBar
+        autoFocus={false}
+        searchBlockedMessage="Add or index library sources before asking Knowledge QA."
+      />
+    )
+
+    const submit = screen.getByRole("button", { name: "Ask" })
+    expect(submit).toBeDisabled()
+    expect(
+      screen.getByText("Add or index library sources before asking Knowledge QA.")
     ).toBeInTheDocument()
   })
 

--- a/apps/packages/ui/src/components/Option/KnowledgeQA/__tests__/SearchDetailsPanel.test.tsx
+++ b/apps/packages/ui/src/components/Option/KnowledgeQA/__tests__/SearchDetailsPanel.test.tsx
@@ -95,4 +95,32 @@ describe("SearchDetailsPanel", () => {
       screen.getByText(/\(41% • -21 pts vs weakest included\) — Below threshold/i)
     ).toBeInTheDocument()
   })
+
+  it("explains missing retrieval telemetry without rendering N/A rows", () => {
+    state.searchDetails = {
+      expandedQueries: [],
+      rerankingEnabled: false,
+      rerankingStrategy: null,
+      averageRelevance: null,
+      webFallbackEnabled: false,
+      webFallbackTriggered: false,
+      webFallbackEngine: null,
+      documentsConsidered: null,
+      chunksConsidered: null,
+      documentsReturned: null,
+      candidatesConsidered: null,
+      candidatesReturned: null,
+      candidatesRejected: null,
+      retrievalLatencyMs: null,
+      alsoConsidered: [],
+      whyTheseSources: null,
+    }
+
+    render(<SearchDetailsPanel />)
+
+    expect(screen.getByText("No query expansion terms were reported.")).toBeInTheDocument()
+    expect(screen.getByText("No retrieval counts were reported for this search.")).toBeInTheDocument()
+    expect(screen.getByText("No closest-miss candidates were reported.")).toBeInTheDocument()
+    expect(screen.queryByText("N/A")).not.toBeInTheDocument()
+  })
 })

--- a/apps/packages/ui/src/components/Option/KnowledgeQA/__tests__/SettingsPanel.behavior.test.tsx
+++ b/apps/packages/ui/src/components/Option/KnowledgeQA/__tests__/SettingsPanel.behavior.test.tsx
@@ -47,8 +47,10 @@ describe("SettingsPanel behavior and copy guardrails", () => {
       screen.getByText("Recommended - combines text and meaning")
     ).toBeInTheDocument()
     expect(
-      screen.getByText("Most thorough - includes fact-checking")
+      screen.getByText("Deep search - more sources and verification")
     ).toBeInTheDocument()
+    expect(screen.getByRole("radio", { name: /Deep/i })).toBeInTheDocument()
+    expect(screen.queryByRole("radio", { name: /Thorough/i })).not.toBeInTheDocument()
 
     const fastRadio = screen.getByRole("radio", { name: /Fast/i })
     fastRadio.focus()
@@ -118,6 +120,45 @@ describe("SettingsPanel behavior and copy guardrails", () => {
     expect(
       screen.getByText("Changes apply to your next search. Previous answers are not affected.")
     ).toBeInTheDocument()
+  })
+
+  it("resets settings, closes on Escape, and restores focus to the opener", () => {
+    const onClose = vi.fn()
+
+    function Harness() {
+      const [open, setOpen] = React.useState(false)
+      return (
+        <>
+          <button type="button" onClick={() => setOpen(true)}>
+            Open settings
+          </button>
+          <SettingsPanel
+            open={open}
+            onClose={() => {
+              onClose()
+              setOpen(false)
+            }}
+          />
+        </>
+      )
+    }
+
+    render(<Harness />)
+
+    const opener = screen.getByRole("button", { name: "Open settings" })
+    opener.focus()
+    fireEvent.click(opener)
+
+    expect(screen.getByRole("dialog", { name: "RAG Settings" })).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Close settings panel" })).toHaveFocus()
+
+    fireEvent.click(screen.getByRole("button", { name: "Reset to Balanced Defaults" }))
+    expect(state.resetSettings).toHaveBeenCalledTimes(1)
+
+    fireEvent.keyDown(document, { key: "Escape" })
+    expect(onClose).toHaveBeenCalledTimes(1)
+    expect(screen.queryByRole("dialog", { name: "RAG Settings" })).not.toBeInTheDocument()
+    expect(opener).toHaveFocus()
   })
 
   it("does not crash when expert-mode onboarding storage is blocked", () => {

--- a/apps/packages/ui/src/components/Option/KnowledgeQA/__tests__/knowledgeQaStateFixtures.ts
+++ b/apps/packages/ui/src/components/Option/KnowledgeQA/__tests__/knowledgeQaStateFixtures.ts
@@ -65,6 +65,7 @@ export type KnowledgeQaStateFixture = {
 }
 
 const nowIso = "2026-06-07T12:00:00.000Z"
+const nowMs = Date.parse(nowIso)
 
 function createSettings(overrides: Partial<RagSettings> = {}): RagSettings {
   return {
@@ -248,7 +249,7 @@ function createBaseFixture(): KnowledgeQaStateFixture {
     connection: {
       online: true,
       isChecking: false,
-      lastCheckedAt: Date.now(),
+      lastCheckedAt: nowMs,
       serverUrl: "http://127.0.0.1:8000",
       configStep: "health",
       errorKind: "none",

--- a/apps/packages/ui/src/components/Option/KnowledgeQA/__tests__/knowledgeQaStateFixtures.ts
+++ b/apps/packages/ui/src/components/Option/KnowledgeQA/__tests__/knowledgeQaStateFixtures.ts
@@ -1,0 +1,347 @@
+import { vi } from "vitest"
+
+import {
+  DEFAULT_RAG_SETTINGS,
+  type RagSettings,
+} from "@/services/rag/unified-rag"
+import type {
+  KnowledgeQAContextValue,
+  KnowledgeQAMessage,
+  KnowledgeQAThread,
+  RagResult,
+  SearchRuntimeDetails,
+  CitationRef,
+} from "../types"
+
+export type KnowledgeQaStateFixtureName =
+  | "backendOffline"
+  | "setupRequired"
+  | "noIndexedSources"
+  | "noSelectedSources"
+  | "readySearch"
+  | "results"
+  | "noResults"
+  | "settingsDrawer"
+  | "exportDialog"
+
+export type KnowledgeQaConnectionFixture = {
+  online: boolean
+  isChecking: boolean
+  lastCheckedAt: number
+  serverUrl: string | null
+  configStep: "none" | "url" | "auth" | "health"
+  errorKind: "none" | "auth" | "unreachable" | "partial"
+  lastError: string | null
+  lastStatusCode: number | null
+  uxState:
+    | "connected_ok"
+    | "testing"
+    | "configuring_url"
+    | "configuring_auth"
+    | "error_auth"
+    | "error_unreachable"
+    | "unconfigured"
+  hasCompletedFirstRun: boolean
+}
+
+export type KnowledgeQaCapabilityFixture = {
+  loading: boolean
+  capabilities: {
+    hasRag: boolean
+    hasWebSearch?: boolean
+  } | null
+}
+
+export type KnowledgeQaSourceInventoryFixture = {
+  media: Array<{ id: number; title: string }>
+  notes: Array<{ id: string; title: string }>
+}
+
+export type KnowledgeQaStateFixture = {
+  knowledgeQa: KnowledgeQAContextValue
+  connection: KnowledgeQaConnectionFixture
+  capabilities: KnowledgeQaCapabilityFixture
+  sourceInventory: KnowledgeQaSourceInventoryFixture
+}
+
+const nowIso = "2026-06-07T12:00:00.000Z"
+
+function createSettings(overrides: Partial<RagSettings> = {}): RagSettings {
+  return {
+    ...DEFAULT_RAG_SETTINGS,
+    sources: ["media_db", "notes"],
+    enable_web_fallback: false,
+    include_media_ids: [],
+    include_note_ids: [],
+    top_k: 10,
+    ...overrides,
+  }
+}
+
+function createResult(index: number, title = `Knowledge Source ${index}`): RagResult {
+  return {
+    id: `knowledge-source-${index}`,
+    content: `Evidence excerpt ${index}`,
+    excerpt: `Evidence excerpt ${index}`,
+    score: 0.92 - index * 0.03,
+    metadata: {
+      title,
+      source: "media_db",
+      source_type: "media_db",
+      url: `https://example.test/knowledge/${index}`,
+      page_number: index,
+    },
+  }
+}
+
+function createCitation(index: number): CitationRef {
+  return {
+    index,
+    documentId: `knowledge-source-${index}`,
+    excerpt: `Evidence excerpt ${index}`,
+  }
+}
+
+function createSearchDetails(): SearchRuntimeDetails {
+  return {
+    expandedQueries: ["What does the library say about grounded QA?"],
+    rerankingEnabled: true,
+    rerankingStrategy: "cross_encoder",
+    averageRelevance: 0.86,
+    webFallbackEnabled: false,
+    webFallbackTriggered: false,
+    webFallbackEngine: null,
+    tokensUsed: 1240,
+    estimatedCostUsd: 0.004,
+    feedbackId: "feedback-knowledge-1",
+    whyTheseSources: {
+      topicality: 0.91,
+      diversity: 0.72,
+      freshness: 0.63,
+    },
+    faithfulnessScore: 0.9,
+    faithfulnessTotalClaims: 3,
+    faithfulnessSupportedClaims: 3,
+    faithfulnessUnsupportedClaims: 0,
+    verificationRate: 1,
+    verificationCoverage: 0.88,
+    verificationTotalClaims: 3,
+    verificationVerifiedClaims: 3,
+    verificationReportAvailable: true,
+    retrievalLatencyMs: 420,
+    documentsConsidered: 6,
+    chunksConsidered: 24,
+    documentsReturned: 3,
+    candidatesConsidered: 12,
+    candidatesReturned: 3,
+    candidatesRejected: 9,
+    alsoConsidered: [
+      {
+        id: "knowledge-source-4",
+        title: "Related Knowledge Source",
+        score: 0.52,
+        reason: "Lower relevance than cited evidence",
+      },
+    ],
+  }
+}
+
+function createMessages(): KnowledgeQAMessage[] {
+  return [
+    {
+      id: "message-user-1",
+      conversationId: "thread-knowledge-1",
+      role: "user",
+      content: "What does my library say about grounded QA?",
+      timestamp: nowIso,
+    },
+    {
+      id: "message-assistant-1",
+      conversationId: "thread-knowledge-1",
+      role: "assistant",
+      content: "Your library says grounded QA should cite its evidence [1].",
+      timestamp: nowIso,
+    },
+  ]
+}
+
+function createThreads(): KnowledgeQAThread[] {
+  return [
+    {
+      id: "thread-knowledge-1",
+      title: "Grounded QA review",
+      createdAt: nowIso,
+      lastModifiedAt: nowIso,
+      state: "in-progress",
+      messageCount: 2,
+      source: "knowledge_qa",
+    },
+  ]
+}
+
+function createBaseKnowledgeQaState(): KnowledgeQAContextValue {
+  return {
+    query: "What does my library say about grounded QA?",
+    isSearching: false,
+    hasSearched: false,
+    results: [],
+    answer: null,
+    citations: [],
+    searchDetails: null,
+    error: null,
+    queryWarning: null,
+    currentThreadId: null,
+    isLocalOnlyThread: false,
+    messages: [],
+    threads: [],
+    preset: "balanced",
+    settings: createSettings(),
+    expertMode: false,
+    searchHistory: [],
+    historySidebarOpen: false,
+    settingsPanelOpen: false,
+    focusedSourceIndex: null,
+    evidenceRailOpen: false,
+    evidenceRailTab: "sources",
+    queryStage: "idle",
+    lastSearchScope: null,
+    pinnedSourceFilters: {
+      mediaIds: [],
+      noteIds: [],
+    },
+    historyHydrated: true,
+    setQuery: vi.fn(),
+    search: vi.fn(async () => undefined),
+    cancelSearch: vi.fn(),
+    clearResults: vi.fn(),
+    rerunWithTokenLimit: vi.fn(async () => undefined),
+    createNewThread: vi.fn(async () => "thread-knowledge-1"),
+    startNewTopic: vi.fn(async () => "thread-knowledge-1"),
+    selectThread: vi.fn(async () => true),
+    selectSharedThread: vi.fn(async () => true),
+    askFollowUp: vi.fn(async () => undefined),
+    branchFromTurn: vi.fn(async () => undefined),
+    setPreset: vi.fn(),
+    updateSetting: vi.fn() as unknown as KnowledgeQAContextValue["updateSetting"],
+    resetSettings: vi.fn(),
+    toggleExpertMode: vi.fn(),
+    loadSearchHistory: vi.fn(async () => undefined),
+    restoreFromHistory: vi.fn(async () => undefined),
+    deleteHistoryItem: vi.fn(async () => undefined),
+    toggleHistoryPin: vi.fn(),
+    setSettingsPanelOpen: vi.fn(),
+    setHistorySidebarOpen: vi.fn(),
+    focusSource: vi.fn(),
+    setEvidenceRailOpen: vi.fn(),
+    setEvidenceRailTab: vi.fn(),
+    setQueryStage: vi.fn(),
+    setPinnedSourceFilters: vi.fn(),
+    persistRagContext: vi.fn(async () => true),
+    scrollToSource: vi.fn(),
+    scrollToCitation: vi.fn(),
+  }
+}
+
+function createBaseFixture(): KnowledgeQaStateFixture {
+  return {
+    knowledgeQa: createBaseKnowledgeQaState(),
+    connection: {
+      online: true,
+      isChecking: false,
+      lastCheckedAt: Date.now(),
+      serverUrl: "http://127.0.0.1:8000",
+      configStep: "health",
+      errorKind: "none",
+      lastError: null,
+      lastStatusCode: null,
+      uxState: "connected_ok",
+      hasCompletedFirstRun: true,
+    },
+    capabilities: {
+      loading: false,
+      capabilities: {
+        hasRag: true,
+        hasWebSearch: true,
+      },
+    },
+    sourceInventory: {
+      media: [
+        { id: 101, title: "Grounded QA Notes" },
+        { id: 102, title: "Library Search Review" },
+      ],
+      notes: [
+        { id: "note-grounded-qa", title: "Grounded QA checklist" },
+      ],
+    },
+  }
+}
+
+function applyResultsState(fixture: KnowledgeQaStateFixture): void {
+  fixture.knowledgeQa.hasSearched = true
+  fixture.knowledgeQa.queryStage = "complete"
+  fixture.knowledgeQa.currentThreadId = "thread-knowledge-1"
+  fixture.knowledgeQa.messages = createMessages()
+  fixture.knowledgeQa.threads = createThreads()
+  fixture.knowledgeQa.results = [createResult(1), createResult(2), createResult(3)]
+  fixture.knowledgeQa.answer =
+    "Your library says grounded QA should cite answer claims with visible evidence [1]."
+  fixture.knowledgeQa.citations = [createCitation(1)]
+  fixture.knowledgeQa.searchDetails = createSearchDetails()
+  fixture.knowledgeQa.evidenceRailOpen = true
+}
+
+export function createKnowledgeQaStateFixture(
+  name: KnowledgeQaStateFixtureName
+): KnowledgeQaStateFixture {
+  const fixture = createBaseFixture()
+
+  switch (name) {
+    case "backendOffline":
+      fixture.connection.online = false
+      fixture.connection.uxState = "error_unreachable"
+      fixture.connection.errorKind = "unreachable"
+      fixture.connection.lastError = "Network error"
+      fixture.connection.lastStatusCode = 0
+      return fixture
+    case "setupRequired":
+      fixture.connection.online = false
+      fixture.connection.uxState = "unconfigured"
+      fixture.connection.serverUrl = null
+      fixture.connection.configStep = "url"
+      fixture.connection.hasCompletedFirstRun = false
+      return fixture
+    case "noIndexedSources":
+      fixture.knowledgeQa.settings = createSettings({
+        sources: [],
+        enable_web_fallback: false,
+      })
+      fixture.sourceInventory = { media: [], notes: [] }
+      return fixture
+    case "noSelectedSources":
+      fixture.knowledgeQa.settings = createSettings({
+        sources: [],
+        enable_web_fallback: false,
+      })
+      return fixture
+    case "readySearch":
+      return fixture
+    case "results":
+      applyResultsState(fixture)
+      return fixture
+    case "noResults":
+      fixture.knowledgeQa.hasSearched = true
+      fixture.knowledgeQa.queryStage = "complete"
+      fixture.knowledgeQa.results = []
+      fixture.knowledgeQa.answer = null
+      fixture.knowledgeQa.citations = []
+      return fixture
+    case "settingsDrawer":
+      fixture.knowledgeQa.settingsPanelOpen = true
+      return fixture
+    case "exportDialog":
+      applyResultsState(fixture)
+      return fixture
+    default:
+      return fixture
+  }
+}

--- a/apps/packages/ui/src/components/Option/KnowledgeQA/composer/KnowledgeComposer.tsx
+++ b/apps/packages/ui/src/components/Option/KnowledgeQA/composer/KnowledgeComposer.tsx
@@ -5,6 +5,8 @@ type KnowledgeComposerProps = {
   className?: string
   autoFocus?: boolean
   showWebToggle?: boolean
+  webFallbackAvailable?: boolean
+  searchBlockedMessage?: string | null
   widthMode?: "compact" | "wide"
 }
 
@@ -12,6 +14,8 @@ export function KnowledgeComposer({
   className,
   autoFocus = true,
   showWebToggle = false,
+  webFallbackAvailable = true,
+  searchBlockedMessage = null,
   widthMode = "compact",
 }: KnowledgeComposerProps) {
   return (
@@ -19,6 +23,8 @@ export function KnowledgeComposer({
       className={className}
       autoFocus={autoFocus}
       showWebToggle={showWebToggle}
+      webFallbackAvailable={webFallbackAvailable}
+      searchBlockedMessage={searchBlockedMessage}
       widthMode={widthMode}
     />
   )

--- a/apps/packages/ui/src/components/Option/KnowledgeQA/context/AnswerModelMenu.tsx
+++ b/apps/packages/ui/src/components/Option/KnowledgeQA/context/AnswerModelMenu.tsx
@@ -44,6 +44,7 @@ export function AnswerModelMenu({
   const [open, setOpen] = useState(false)
   const [providerCatalog, setProviderCatalog] =
     useState<LlmProvidersResponse | null>(null)
+  const [providerStatus, setProviderStatus] = useState<"loading" | "ready" | "error">("loading")
   const containerRef = useRef<HTMLDivElement | null>(null)
 
   useEffect(() => {
@@ -51,14 +52,17 @@ export function AnswerModelMenu({
 
     void (async () => {
       try {
+        setProviderStatus("loading")
         await tldwClient.initialize()
         const response = (await tldwClient.getProviders()) as LlmProvidersResponse
         if (!cancelled) {
           setProviderCatalog(response)
+          setProviderStatus("ready")
         }
       } catch {
         if (!cancelled) {
           setProviderCatalog(null)
+          setProviderStatus("error")
         }
       }
     })()
@@ -188,6 +192,18 @@ export function AnswerModelMenu({
               Applies to final answer generation for this search session.
             </p>
           </div>
+
+          {providerStatus === "loading" ? (
+            <p role="status" className="mb-2 rounded-md border border-border bg-surface2 px-2 py-1.5 text-xs text-text-muted">
+              Loading answer providers...
+            </p>
+          ) : null}
+
+          {providerStatus === "error" ? (
+            <p role="status" className="mb-2 rounded-md border border-warn/40 bg-warn/10 px-2 py-1.5 text-xs text-warn">
+              Provider list failed to load. You can still type a model manually.
+            </p>
+          ) : null}
 
           <label className="mb-2 block text-[11px] font-medium text-text-muted">
             Provider

--- a/apps/packages/ui/src/components/Option/KnowledgeQA/context/CompactToolbar.tsx
+++ b/apps/packages/ui/src/components/Option/KnowledgeQA/context/CompactToolbar.tsx
@@ -10,8 +10,11 @@ import { buildSourceHealthSummary } from "../sourceHealth"
 
 type CompactToolbarProps = {
   sources: RagSource[]
+  includeMediaIds?: number[]
+  includeNoteIds?: string[]
   preset: RagPresetName
   webEnabled: boolean
+  webFallbackAvailable?: boolean
   onToggleWeb: () => void
   onOpenSourceSelector: () => void
   onAddSources?: () => void
@@ -37,6 +40,21 @@ function summarizeSources(sources: RagSource[]): string {
   return `${sources.length} selected`
 }
 
+function summarizeSpecificSources(mediaIds: number[], noteIds: string[]): string | null {
+  const mediaCount = mediaIds.filter((id) => Number.isFinite(id) && id > 0).length
+  const noteCount = noteIds.filter((id) => typeof id === "string" && id.trim().length > 0).length
+  if (mediaCount === 0 && noteCount === 0) return null
+
+  const parts: string[] = []
+  if (mediaCount > 0) {
+    parts.push(`${mediaCount} doc${mediaCount === 1 ? "" : "s"}`)
+  }
+  if (noteCount > 0) {
+    parts.push(`${noteCount} note${noteCount === 1 ? "" : "s"}`)
+  }
+  return parts.join(" • ")
+}
+
 const PRESET_LABELS: Record<string, string> = {
   fast: "Fast",
   balanced: "Balanced",
@@ -46,8 +64,11 @@ const PRESET_LABELS: Record<string, string> = {
 
 export function CompactToolbar({
   sources,
+  includeMediaIds = [],
+  includeNoteIds = [],
   preset,
   webEnabled,
+  webFallbackAvailable = true,
   onToggleWeb,
   onOpenSourceSelector,
   onAddSources,
@@ -63,6 +84,12 @@ export function CompactToolbar({
   showAddSources = false,
   className,
 }: CompactToolbarProps) {
+  const sourceSummary = summarizeSources(sources)
+  const specificSourceSummary = summarizeSpecificSources(includeMediaIds, includeNoteIds)
+  const sourceControlLabel = `Open source scope and saved profiles. Sources: ${sourceSummary}${
+    specificSourceSummary ? `. Specific: ${specificSourceSummary}` : ""
+  }`
+
   return (
     <div className={cn("flex flex-wrap items-center gap-2", className)}>
       {showAddSources ? (
@@ -80,10 +107,15 @@ export function CompactToolbar({
       <button
         type="button"
         onClick={onOpenSourceSelector}
+        aria-label={sourceControlLabel}
+        title="Open source scope and saved profiles"
         className="inline-flex h-7 items-center gap-1 rounded-full border border-border bg-surface px-2.5 text-[11px] font-medium text-text-muted hover:bg-surface2 hover:text-text transition-colors"
       >
         <Layers className="h-3.5 w-3.5" />
-        Sources: {summarizeSources(sources)}
+        Sources: {sourceSummary}
+        {specificSourceSummary ? (
+          <span className="hidden sm:inline"> • Specific: {specificSourceSummary}</span>
+        ) : null}
         <ChevronDown className="h-3 w-3" />
       </button>
 
@@ -102,17 +134,27 @@ export function CompactToolbar({
       <button
         type="button"
         onClick={onToggleWeb}
+        disabled={!webFallbackAvailable}
         className={cn(
           "inline-flex h-7 items-center gap-1 rounded-full border px-2.5 text-[11px] font-medium transition-colors",
-          webEnabled
+          webEnabled && webFallbackAvailable
             ? "border-primary/40 bg-primary/10 text-primary"
-            : "border-border bg-surface text-text-muted hover:bg-surface2 hover:text-text"
+            : "border-border bg-surface text-text-muted hover:bg-surface2 hover:text-text",
+          !webFallbackAvailable && "opacity-60 cursor-not-allowed hover:bg-surface hover:text-text-muted"
         )}
-        aria-pressed={webEnabled}
-        aria-label={`Web fallback is currently ${webEnabled ? "enabled" : "disabled"}. Click to toggle.`}
-        title="Falls back to web search when local source relevance is below threshold."
+        aria-pressed={webEnabled && webFallbackAvailable}
+        aria-label={
+          webFallbackAvailable
+            ? `Web fallback is currently ${webEnabled ? "enabled" : "disabled"}. Click to toggle.`
+            : "Web fallback is not available on this server."
+        }
+        title={
+          webFallbackAvailable
+            ? "Falls back to web search when local source relevance is below threshold."
+            : "Web fallback is not available on this server."
+        }
       >
-        <Globe className={cn("h-3.5 w-3.5", webEnabled ? "fill-current" : "")} />
+        <Globe className={cn("h-3.5 w-3.5", webEnabled && webFallbackAvailable ? "fill-current" : "")} />
         Web
       </button>
 

--- a/apps/packages/ui/src/components/Option/KnowledgeQA/context/KnowledgeContextBar.tsx
+++ b/apps/packages/ui/src/components/Option/KnowledgeQA/context/KnowledgeContextBar.tsx
@@ -846,7 +846,7 @@ export function KnowledgeContextBar({
       // Note: only a toggle callback is available (no direct setter).
       if (
         webFallbackAvailable &&
-        profile.enableWebFallback !== effectiveWebEnabled
+        (profile.enableWebFallback ?? false) !== effectiveWebEnabled
       ) {
         onToggleWeb()
       }

--- a/apps/packages/ui/src/components/Option/KnowledgeQA/context/KnowledgeContextBar.tsx
+++ b/apps/packages/ui/src/components/Option/KnowledgeQA/context/KnowledgeContextBar.tsx
@@ -140,6 +140,7 @@ type KnowledgeContextBarProps = {
   includeNoteIds: string[]
   onIncludeNoteIdsChange: (ids: string[]) => void
   webEnabled: boolean
+  webFallbackAvailable?: boolean
   onToggleWeb: () => void
   generationProvider: string | null
   generationModel: string | null
@@ -456,6 +457,7 @@ export function KnowledgeContextBar({
   includeNoteIds,
   onIncludeNoteIdsChange,
   webEnabled,
+  webFallbackAvailable = true,
   onToggleWeb,
   generationProvider,
   generationModel,
@@ -541,6 +543,7 @@ export function KnowledgeContextBar({
   const selectedMediaSet = useMemo(() => new Set(normalizedMediaIds), [normalizedMediaIds])
   const selectedNoteSet = useMemo(() => new Set(normalizedNoteIds), [normalizedNoteIds])
   const exportedProfilesJson = useMemo(() => JSON.stringify(savedProfiles, null, 2), [savedProfiles])
+  const effectiveWebEnabled = webEnabled && webFallbackAvailable
 
   const presetDetail = preset === "custom" ? null : PRESET_DETAILS[preset]
   const presetDescription =
@@ -813,7 +816,7 @@ export function KnowledgeContextBar({
       includeMediaIds: [...normalizedMediaIds],
       includeNoteIds: [...normalizedNoteIds],
       preset,
-      enableWebFallback: webEnabled,
+      enableWebFallback: effectiveWebEnabled,
     }
     const updated = [newProfile, ...savedProfiles.filter((p) => p.name !== trimmed)].slice(
       0,
@@ -829,7 +832,7 @@ export function KnowledgeContextBar({
     normalizedMediaIds,
     normalizedNoteIds,
     preset,
-    webEnabled,
+    effectiveWebEnabled,
     savedProfiles,
   ])
 
@@ -841,12 +844,23 @@ export function KnowledgeContextBar({
       onPresetChange(profile.preset)
       // Only toggle web fallback if the profile value differs from current state.
       // Note: only a toggle callback is available (no direct setter).
-      if (profile.enableWebFallback !== webEnabled) {
+      if (
+        webFallbackAvailable &&
+        profile.enableWebFallback !== effectiveWebEnabled
+      ) {
         onToggleWeb()
       }
       setProfileMenuOpen(false)
     },
-    [onIncludeMediaIdsChange, onIncludeNoteIdsChange, onSourcesChange, onPresetChange, onToggleWeb, webEnabled]
+    [
+      effectiveWebEnabled,
+      onIncludeMediaIdsChange,
+      onIncludeNoteIdsChange,
+      onSourcesChange,
+      onPresetChange,
+      onToggleWeb,
+      webFallbackAvailable,
+    ]
   )
 
   const deleteProfile = useCallback(
@@ -1339,20 +1353,38 @@ export function KnowledgeContextBar({
       </div>
 
       <div className="mt-3 flex flex-wrap items-center gap-2">
-        <Tooltip title="When enabled, includes web search results alongside your documents. Useful when your documents don't cover the topic.">
+        <Tooltip
+          title={
+            webFallbackAvailable
+              ? "When enabled, includes web search results alongside your documents. Useful when your documents don't cover the topic."
+              : "Web fallback is not available on this server."
+          }
+        >
           <button
             type="button"
             onClick={onToggleWeb}
+            disabled={!webFallbackAvailable}
             className={cn(
               "inline-flex h-7 items-center gap-1 rounded-full border px-2.5 text-[11px] font-medium transition-colors",
-              webEnabled
+              effectiveWebEnabled
                 ? "border-primary/40 bg-primary/10 text-primaryStrong"
-                : "border-border text-text-muted hover:bg-surface2 hover:text-text"
+                : "border-border text-text-muted hover:bg-surface2 hover:text-text",
+              !webFallbackAvailable &&
+                "cursor-not-allowed opacity-60 hover:bg-surface hover:text-text-muted"
             )}
-            aria-pressed={webEnabled}
-            aria-label={`Web fallback is currently ${webEnabled ? "enabled" : "disabled"}. Click to toggle.`}
+            aria-pressed={effectiveWebEnabled}
+            aria-label={
+              webFallbackAvailable
+                ? `Web fallback is currently ${webEnabled ? "enabled" : "disabled"}. Click to toggle.`
+                : "Web fallback is not available on this server."
+            }
+            title={
+              webFallbackAvailable
+                ? undefined
+                : "Web fallback is not available on this server."
+            }
           >
-            <Globe className={cn("h-3.5 w-3.5", webEnabled ? "fill-current" : "")} />
+            <Globe className={cn("h-3.5 w-3.5", effectiveWebEnabled ? "fill-current" : "")} />
             Web
           </button>
         </Tooltip>

--- a/apps/packages/ui/src/components/Option/KnowledgeQA/empty/KnowledgeReadyState.tsx
+++ b/apps/packages/ui/src/components/Option/KnowledgeQA/empty/KnowledgeReadyState.tsx
@@ -1,9 +1,10 @@
 import React, { useState, useEffect } from "react"
 import { Link } from "react-router-dom"
-import { BookOpen, ChevronDown, ChevronUp, CircleHelp, Clock3, FolderPlus, HelpCircle, MessageSquare, SlidersHorizontal } from "lucide-react"
+import { BookOpen, ChevronDown, ChevronUp, CircleHelp, Clock3, FolderPlus, Globe, HelpCircle, MessageSquare, SlidersHorizontal } from "lucide-react"
 import { cn } from "@/libs/utils"
 import type { RagSource } from "@/services/rag/unified-rag"
 import type { KnowledgeSourceHealthState } from "../types"
+import type { KnowledgeReadyRecoveryState } from "./recoveryState"
 
 type KnowledgeReadyStateProps = {
   suggestedPrompts: string[]
@@ -11,11 +12,13 @@ type KnowledgeReadyStateProps = {
   onContinueRecent: () => void
   onSelectSources: () => void
   onAddSources?: () => void
+  onEnableWebFallback?: () => void
   hasSources: boolean
   selectedSources?: RagSource[]
   sourceHealth?: KnowledgeSourceHealthState
   hasRecentSession: boolean
   webFallbackEnabled?: boolean
+  recoveryState?: KnowledgeReadyRecoveryState
   className?: string
 }
 
@@ -24,6 +27,35 @@ type SourceHealthNotice = {
   tone: "info" | "warn"
   actionLabel: string
   action: "add" | "select"
+}
+
+function createFallbackRecoveryState(
+  hasSources: boolean,
+  webFallbackEnabled: boolean
+): KnowledgeReadyRecoveryState {
+  if (hasSources) {
+    return {
+      kind: "ready",
+      hasIndexedSources: true,
+      hasSelectedSources: true,
+      webFallbackAvailable: true,
+      webFallbackEnabled,
+      canSearchPersonalLibrary: true,
+      canSearchWebOnly: false,
+      searchBlocked: false,
+    }
+  }
+
+  return {
+    kind: webFallbackEnabled ? "web_only" : "no_selected_sources",
+    hasIndexedSources: true,
+    hasSelectedSources: false,
+    webFallbackAvailable: true,
+    webFallbackEnabled,
+    canSearchPersonalLibrary: false,
+    canSearchWebOnly: webFallbackEnabled,
+    searchBlocked: !webFallbackEnabled,
+  }
 }
 
 function buildSourceHealthNotice(
@@ -83,21 +115,67 @@ export function KnowledgeReadyState({
   onContinueRecent,
   onSelectSources,
   onAddSources,
+  onEnableWebFallback,
   hasSources,
   selectedSources = [],
   sourceHealth,
   hasRecentSession,
   webFallbackEnabled = false,
+  recoveryState,
   className,
 }: KnowledgeReadyStateProps) {
   const isReturningUser = hasRecentSession
   const [guideExpanded, setGuideExpanded] = useState(!isReturningUser)
   const handleAddSources = onAddSources ?? onSelectSources
+  const effectiveRecoveryState =
+    recoveryState ?? createFallbackRecoveryState(hasSources, webFallbackEnabled)
+  const hasSelectedSources = effectiveRecoveryState.hasSelectedSources
+  const shouldUseAddSourceAction =
+    !recoveryState && (!hasSources || !effectiveRecoveryState.hasIndexedSources)
   const sourceHealthNotice = buildSourceHealthNotice(
     hasSources,
     selectedSources,
     sourceHealth
   )
+  const showRecoveryNotice = effectiveRecoveryState.kind !== "ready"
+  const canOfferWebFallback =
+    effectiveRecoveryState.webFallbackAvailable &&
+    !effectiveRecoveryState.webFallbackEnabled &&
+    typeof onEnableWebFallback === "function"
+  const recoveryTone = effectiveRecoveryState.searchBlocked ? "warn" : "info"
+  const recoveryTitle = (() => {
+    switch (effectiveRecoveryState.kind) {
+      case "backend_unavailable":
+        return "Library search is offline"
+      case "no_indexed_sources":
+      case "no_indexed_sources_web_only":
+        return "No indexed library sources yet"
+      case "no_selected_sources":
+        return "No source categories selected"
+      case "web_only":
+        return "Web-only search"
+      default:
+        return null
+    }
+  })()
+  const recoveryBody = (() => {
+    switch (effectiveRecoveryState.kind) {
+      case "backend_unavailable":
+        return "The Knowledge QA backend is not reachable, so cited library answers cannot run yet."
+      case "no_indexed_sources":
+        return "Your server is online, but Knowledge QA has no indexed documents, media, or notes to search."
+      case "no_indexed_sources_web_only":
+        return "Your personal library has no indexed sources yet. Because web fallback is enabled, searches will use web results only until you add or index sources."
+      case "no_selected_sources":
+        return effectiveRecoveryState.webFallbackAvailable
+          ? "Your library has indexed sources, but none are selected for this search."
+          : "Your library has indexed sources, but none are selected and web fallback is not available on this server."
+      case "web_only":
+        return "No source categories are selected. Because web fallback is enabled, this search will use web results only and will not cite your personal library until sources are selected."
+      default:
+        return null
+    }
+  })()
 
   // Collapse guide when history finishes loading and reveals a returning user
   useEffect(() => {
@@ -122,9 +200,11 @@ export function KnowledgeReadyState({
             <span>How it works</span>
           </button>
         )}
-        <p className="mt-1 text-base font-medium">Search your documents and get cited answers</p>
+        <p className="mt-1 text-base font-medium">
+          Search selected personal-library sources and get cited answers
+        </p>
         <p className="mt-2 text-sm text-text-muted">
-          Get grounded answers with citations from your selected sources.
+          Knowledge QA searches documents, media, notes, and other selected sources, then grounds answer claims in citations you can inspect.
         </p>
         <p className="mt-2 text-sm text-text-muted">
           This page answers questions over searchable sources. Add or manage sources
@@ -152,7 +232,7 @@ export function KnowledgeReadyState({
             <p className="mt-2 text-sm text-text-muted">
               Select sources, ask a question, review cited answers.
             </p>
-          ) : !hasSources ? (
+          ) : !effectiveRecoveryState.hasIndexedSources ? (
             <ol className="mt-2 grid gap-1 text-sm text-text-muted sm:grid-cols-3 sm:gap-3">
               <li className="flex items-start gap-2">
                 <span className="mt-0.5 inline-flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-primary text-[10px] font-bold text-white">1</span>
@@ -163,7 +243,7 @@ export function KnowledgeReadyState({
                     onClick={handleAddSources}
                     className="font-medium text-primary hover:underline"
                   >
-                    Add searchable sources
+                    Add sources
                   </button>
                 </span>
               </li>
@@ -188,7 +268,15 @@ export function KnowledgeReadyState({
                 <span className="mt-0.5 inline-flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-primary text-[10px] font-bold text-white">1</span>
                 <span>
                   <SlidersHorizontal className="mb-0.5 mr-1 inline h-3.5 w-3.5 text-primary" />
-                  Select sources
+                  {hasSelectedSources ? "Select sources" : (
+                    <button
+                      type="button"
+                      onClick={onSelectSources}
+                      className="font-medium text-primary hover:underline"
+                    >
+                      Select source categories
+                    </button>
+                  )}
                 </span>
               </li>
               <li className="flex items-start gap-2">
@@ -223,41 +311,113 @@ export function KnowledgeReadyState({
         ))}
       </div>
 
-      {sourceHealthNotice || !hasSources ? (
+      {showRecoveryNotice && recoveryTitle && recoveryBody ? (
         <div
           className={cn(
             "mx-auto max-w-2xl rounded-lg px-4 py-3 text-left text-sm",
-            sourceHealthNotice?.tone === "info" || (!sourceHealthNotice && webFallbackEnabled)
+            recoveryTone === "info"
               ? "border border-info/30 bg-info/10 text-info"
               : "border border-warn/30 bg-warn/10 text-warn"
           )}
         >
-          <p>
-            {sourceHealthNotice?.message ??
-            (webFallbackEnabled
-              ? "No document sources are selected. Web fallback uses your configured server default provider."
-              : "No sources are selected. Select source categories to search, or enable web fallback.")}
-          </p>
-          {!sourceHealthNotice ? (
-            <p className="mt-1">
-              Queries stay on your tldw server unless web fallback is enabled.
-            </p>
+          <p className="font-medium">{recoveryTitle}</p>
+          <p className="mt-1">{recoveryBody}</p>
+          {effectiveRecoveryState.webFallbackEnabled ? (
+            <>
+              <p className="mt-1">
+                Web fallback uses your configured server default provider.
+              </p>
+              <p className="mt-1">
+                Queries stay on your tldw server unless web fallback is enabled.
+              </p>
+            </>
           ) : null}
+          <div className="mt-2 flex flex-wrap items-center gap-2">
+            {effectiveRecoveryState.kind === "no_indexed_sources" ||
+            effectiveRecoveryState.kind === "no_indexed_sources_web_only" ? (
+              <>
+                <button
+                  type="button"
+                  onClick={handleAddSources}
+                  className={cn(
+                    "inline-flex items-center rounded-md border px-2.5 py-1 text-xs font-medium transition-colors",
+                    recoveryTone === "info"
+                      ? "border-info/40 hover:bg-info/20"
+                      : "border-warn/40 hover:bg-warn/20"
+                  )}
+                >
+                  Add or index sources
+                </button>
+                <Link
+                  to="/notes"
+                  className={cn(
+                    "inline-flex items-center rounded-md border px-2.5 py-1 text-xs font-medium transition-colors",
+                    recoveryTone === "info"
+                      ? "border-info/40 hover:bg-info/20"
+                      : "border-warn/40 hover:bg-warn/20"
+                  )}
+                >
+                  Create a note
+                </Link>
+              </>
+            ) : (
+              <button
+                type="button"
+                onClick={onSelectSources}
+                className={cn(
+                  "inline-flex items-center rounded-md border px-2.5 py-1 text-xs font-medium transition-colors",
+                  recoveryTone === "info"
+                    ? "border-info/40 hover:bg-info/20"
+                    : "border-warn/40 hover:bg-warn/20"
+                )}
+              >
+                Select source categories
+              </button>
+            )}
+            {canOfferWebFallback ? (
+              <button
+                type="button"
+                onClick={onEnableWebFallback}
+                className={cn(
+                  "inline-flex items-center gap-1 rounded-md border px-2.5 py-1 text-xs font-medium transition-colors",
+                  recoveryTone === "info"
+                    ? "border-info/40 hover:bg-info/20"
+                    : "border-warn/40 hover:bg-warn/20"
+                )}
+              >
+                <Globe className="h-3.5 w-3.5" />
+                Enable web fallback
+              </button>
+            ) : null}
+          </div>
+        </div>
+      ) : null}
+
+      {sourceHealthNotice ? (
+        <div
+          className={cn(
+            "mx-auto max-w-2xl rounded-lg px-4 py-3 text-left text-sm",
+            sourceHealthNotice.tone === "info"
+              ? "border border-info/30 bg-info/10 text-info"
+              : "border border-warn/30 bg-warn/10 text-warn"
+          )}
+        >
+          <p>{sourceHealthNotice.message}</p>
           <button
             type="button"
             onClick={
-              sourceHealthNotice?.action === "select"
+              sourceHealthNotice.action === "select"
                 ? onSelectSources
                 : handleAddSources
             }
             className={cn(
               "mt-2 inline-flex items-center rounded-md border px-2.5 py-1 text-xs font-medium transition-colors",
-              sourceHealthNotice?.tone === "info" || (!sourceHealthNotice && webFallbackEnabled)
+              sourceHealthNotice.tone === "info"
                 ? "border-info/40 hover:bg-info/20"
                 : "border-warn/40 hover:bg-warn/20"
             )}
           >
-            {sourceHealthNotice?.actionLabel ?? "Add sources"}
+            {sourceHealthNotice.actionLabel}
           </button>
         </div>
       ) : null}
@@ -284,16 +444,20 @@ export function KnowledgeReadyState({
         </button>
         <button
           type="button"
-          onClick={onSelectSources}
+          onClick={shouldUseAddSourceAction ? handleAddSources : onSelectSources}
           className={cn(
             "inline-flex h-8 items-center gap-1 rounded-md border px-3 text-sm transition-colors",
-            hasSources
+            hasSelectedSources
               ? "border-border text-text hover:bg-surface2"
               : "border-warn/40 bg-warn/10 text-warn hover:bg-warn/20"
           )}
         >
           <SlidersHorizontal className="h-4 w-4" />
-          {hasSources ? "Select sources" : "No sources selected"}
+          {hasSelectedSources
+            ? "Select sources"
+            : shouldUseAddSourceAction
+              ? "Add sources"
+              : "No sources selected"}
         </button>
       </div>
 

--- a/apps/packages/ui/src/components/Option/KnowledgeQA/empty/recoveryState.ts
+++ b/apps/packages/ui/src/components/Option/KnowledgeQA/empty/recoveryState.ts
@@ -1,0 +1,89 @@
+import type { KnowledgeStatus } from "@/types/connection"
+
+export type KnowledgeReadyRecoveryKind =
+  | "ready"
+  | "backend_unavailable"
+  | "no_indexed_sources"
+  | "no_indexed_sources_web_only"
+  | "no_selected_sources"
+  | "web_only"
+
+export type KnowledgeReadyRecoveryState = {
+  kind: KnowledgeReadyRecoveryKind
+  hasIndexedSources: boolean
+  hasSelectedSources: boolean
+  webFallbackAvailable: boolean
+  webFallbackEnabled: boolean
+  canSearchPersonalLibrary: boolean
+  canSearchWebOnly: boolean
+  searchBlocked: boolean
+}
+
+type ClassifyKnowledgeReadyRecoveryInput = {
+  knowledgeStatus: KnowledgeStatus
+  selectedSourceCount: number
+  webFallbackAvailable: boolean
+  webFallbackEnabled: boolean
+}
+
+export function classifyKnowledgeReadyRecoveryState({
+  knowledgeStatus,
+  selectedSourceCount,
+  webFallbackAvailable,
+  webFallbackEnabled,
+}: ClassifyKnowledgeReadyRecoveryInput): KnowledgeReadyRecoveryState {
+  const hasIndexedSources = knowledgeStatus !== "empty"
+  const hasSelectedSources = selectedSourceCount > 0
+  const canSearchWebOnly = webFallbackAvailable && webFallbackEnabled
+  const canSearchPersonalLibrary = hasIndexedSources && hasSelectedSources
+
+  if (knowledgeStatus === "offline") {
+    return {
+      kind: "backend_unavailable",
+      hasIndexedSources,
+      hasSelectedSources,
+      webFallbackAvailable,
+      webFallbackEnabled,
+      canSearchPersonalLibrary: false,
+      canSearchWebOnly: false,
+      searchBlocked: true,
+    }
+  }
+
+  if (!hasIndexedSources) {
+    return {
+      kind: canSearchWebOnly ? "no_indexed_sources_web_only" : "no_indexed_sources",
+      hasIndexedSources: false,
+      hasSelectedSources,
+      webFallbackAvailable,
+      webFallbackEnabled,
+      canSearchPersonalLibrary: false,
+      canSearchWebOnly,
+      searchBlocked: !canSearchWebOnly,
+    }
+  }
+
+  if (!hasSelectedSources) {
+    return {
+      kind: canSearchWebOnly ? "web_only" : "no_selected_sources",
+      hasIndexedSources,
+      hasSelectedSources: false,
+      webFallbackAvailable,
+      webFallbackEnabled,
+      canSearchPersonalLibrary: false,
+      canSearchWebOnly,
+      searchBlocked: !canSearchWebOnly,
+    }
+  }
+
+  return {
+    kind: "ready",
+    hasIndexedSources,
+    hasSelectedSources,
+    webFallbackAvailable,
+    webFallbackEnabled,
+    canSearchPersonalLibrary,
+    canSearchWebOnly: false,
+    searchBlocked: false,
+  }
+}

--- a/apps/packages/ui/src/components/Option/KnowledgeQA/index.tsx
+++ b/apps/packages/ui/src/components/Option/KnowledgeQA/index.tsx
@@ -8,10 +8,12 @@
 import React, { useEffect, useMemo, useRef, useState } from "react"
 import { KnowledgeQAProvider, useKnowledgeQA } from "./KnowledgeQAProvider"
 import { KnowledgeQALayout } from "./layout/KnowledgeQALayout"
+import { KnowledgeQASetupDiagnostics } from "./SetupDiagnostics"
 import { useServerOnline } from "@/hooks/useServerOnline"
 import { useServerCapabilities } from "@/hooks/useServerCapabilities"
 import {
   useConnectionActions,
+  useKnowledgeStatus,
   useConnectionState,
   useConnectionUxState
 } from "@/hooks/useConnectionState"
@@ -29,8 +31,6 @@ const LazySettingsPanel = React.lazy(() =>
 const LazyExportDialog = React.lazy(() =>
   import("./ExportDialog").then((module) => ({ default: module.ExportDialog })),
 )
-
-export { buildConferenceCollectionKnowledgeQaOptions } from "./conference-scope"
 
 const ROUTE_HYDRATION_RETRY_DELAY_MS = 1500
 const ROUTE_HYDRATION_MAX_RETRIES = 2
@@ -85,11 +85,14 @@ function KnowledgeQAContent() {
   const { capabilities, loading: capabilitiesLoading, refresh: refreshCapabilities } =
     useServerCapabilities()
   const { checkOnce } = useConnectionActions()
-  const { isChecking, lastCheckedAt } = useConnectionState()
+  const connectionState = useConnectionState()
+  const { knowledgeStatus } = useKnowledgeStatus()
+  const { isChecking, lastCheckedAt } = connectionState
   const { uxState } = useConnectionUxState()
 
   // Check if RAG is supported
   const hasRag = capabilities?.hasRag ?? true
+  const webFallbackAvailable = capabilities?.hasWebSearch !== false
   const retryCountdownSeconds = useMemo(
     () =>
       getRetryCountdownSeconds({
@@ -286,83 +289,23 @@ function KnowledgeQAContent() {
   //   5. No RAG        -- server online but embedding model not configured
   // -----------------------------------------------------------------------
   if (!online && uxState !== "testing") {
-    if (uxState === "unconfigured" || uxState === "configuring_url") {
+    if (
+      uxState === "unconfigured" ||
+      uxState === "configuring_url" ||
+      uxState === "configuring_auth" ||
+      uxState === "error_auth" ||
+      uxState === "error_unreachable"
+    ) {
       return (
-        <div className="flex-1 flex items-center justify-center">
-          <div className="text-center max-w-md">
-            <WifiOff className="w-16 h-16 mx-auto mb-4 text-text-muted" />
-            <h2 className="text-xl font-semibold mb-2">
-              Finish setup to use Knowledge QA
-            </h2>
-            <p className="text-text-muted mb-4">
-              Complete the server setup to start searching your documents.
-            </p>
-            <button
-              type="button"
-              onClick={() => navigate("/")}
-              className="px-3 py-1.5 rounded-md border border-border bg-surface text-text-subtle hover:bg-hover hover:text-text transition-colors"
-            >
-              Finish Setup
-            </button>
-          </div>
-        </div>
-      )
-    }
-
-    if (uxState === "error_auth" || uxState === "configuring_auth") {
-      return (
-        <div className="flex-1 flex items-center justify-center">
-          <div className="text-center max-w-md">
-            <WifiOff className="w-16 h-16 mx-auto mb-4 text-text-muted" />
-            <h2 className="text-xl font-semibold mb-2">
-              Add your credentials to use Knowledge QA
-            </h2>
-            <p className="text-text-muted mb-4">
-              Your server is reachable, but Knowledge QA needs valid credentials before it can load.
-            </p>
-            <button
-              type="button"
-              onClick={() => navigate("/settings/tldw")}
-              className="px-3 py-1.5 rounded-md border border-border bg-surface text-text-subtle hover:bg-hover hover:text-text transition-colors"
-            >
-              Open Settings
-            </button>
-          </div>
-        </div>
-      )
-    }
-
-    if (uxState === "error_unreachable") {
-      return (
-        <div className="flex-1 flex items-center justify-center">
-          <div className="text-center max-w-md">
-            <WifiOff className="w-16 h-16 mx-auto mb-4 text-text-muted" />
-            <h2 className="text-xl font-semibold mb-2">Can't reach your tldw server right now</h2>
-            <p className="text-text-muted mb-3">
-              Your server settings are saved, but Knowledge QA cannot reach the tldw server right now.
-            </p>
-            <div className="flex flex-wrap items-center justify-center gap-2">
-              <button
-                type="button"
-                onClick={handleRetryConnection}
-                disabled={isChecking}
-                className="px-3 py-1.5 rounded-md border border-border bg-surface text-text-subtle hover:bg-hover hover:text-text transition-colors disabled:opacity-60 disabled:cursor-not-allowed"
-              >
-                {isChecking ? "Checking connection..." : "Retry connection"}
-              </button>
-              <button
-                type="button"
-                onClick={() => navigate("/settings/health")}
-                className="px-3 py-1.5 rounded-md border border-border bg-surface text-text-subtle hover:bg-hover hover:text-text transition-colors"
-              >
-                Health & diagnostics
-              </button>
-            </div>
-            <p className="mt-2 text-xs text-text-muted">
-              Retrying automatically in {retryCountdownSeconds}s...
-            </p>
-          </div>
-        </div>
+        <KnowledgeQASetupDiagnostics
+          connection={connectionState}
+          uxState={uxState}
+          retryCountdownSeconds={retryCountdownSeconds}
+          onOpenSetup={() => navigate("/")}
+          onOpenSettings={() => navigate("/settings/tldw")}
+          onOpenDiagnostics={() => navigate("/settings/health")}
+          onRetryConnection={handleRetryConnection}
+        />
       )
     }
   }
@@ -436,7 +379,11 @@ function KnowledgeQAContent() {
       data-testid="knowledge-page-root"
       className="relative flex h-full w-full min-w-0 flex-1"
     >
-      <KnowledgeQALayout onExportClick={() => setExportDialogOpen(true)} />
+      <KnowledgeQALayout
+        onExportClick={() => setExportDialogOpen(true)}
+        knowledgeStatus={knowledgeStatus}
+        webFallbackAvailable={webFallbackAvailable}
+      />
 
       {/* Settings panel (drawer) */}
       {settingsPanelOpen ? (
@@ -483,4 +430,5 @@ export { HistorySidebar } from "./HistorySidebar"
 export { SettingsPanel } from "./SettingsPanel"
 export { ExportDialog } from "./ExportDialog"
 export { KnowledgeQALayout } from "./layout/KnowledgeQALayout"
+export { buildConferenceCollectionKnowledgeQaOptions } from "./conference-scope"
 export type * from "./types"

--- a/apps/packages/ui/src/components/Option/KnowledgeQA/layout/KnowledgeQALayout.tsx
+++ b/apps/packages/ui/src/components/Option/KnowledgeQA/layout/KnowledgeQALayout.tsx
@@ -1,5 +1,5 @@
-import React, { useEffect, useMemo, useRef } from "react"
-import { Download, PanelLeftOpen, PanelLeftClose } from "lucide-react"
+import React, { useEffect, useMemo, useRef, useState } from "react"
+import { Download, PanelLeftOpen, PanelLeftClose, X } from "lucide-react"
 import { cn } from "@/libs/utils"
 import { useKnowledgeQA } from "../KnowledgeQAProvider"
 import { DEFAULT_RAG_SETTINGS, type RagSettings } from "@/services/rag/unified-rag"
@@ -8,15 +8,18 @@ import { KnowledgeContextBar } from "../context/KnowledgeContextBar"
 import { CompactToolbar } from "../context/CompactToolbar"
 import { KnowledgeComposer } from "../composer/KnowledgeComposer"
 import { KnowledgeReadyState } from "../empty/KnowledgeReadyState"
+import { classifyKnowledgeReadyRecoveryState } from "../empty/recoveryState"
+import type { KnowledgeReadyRecoveryState } from "../empty/recoveryState"
 import { AnswerWorkspace } from "../panels/AnswerWorkspace"
 import { useLayoutMode } from "../hooks/useLayoutMode"
 import { useMobile } from "@/hooks/useMediaQuery"
+import type { KnowledgeStatus } from "@/types/connection"
+import { requestQuickIngestOpen } from "@/utils/quick-ingest-open"
 import {
   ALL_RAG_SOURCES,
   getRagSourceLabel,
   isRagSource,
 } from "@/services/rag/sourceMetadata"
-import { requestQuickIngestOpen } from "@/utils/quick-ingest-open"
 
 const LazyHistoryPane = React.lazy(() =>
   import("../history/HistoryPane").then((module) => ({ default: module.HistoryPane })),
@@ -37,6 +40,8 @@ const LazyEvidenceRail = React.lazy(() =>
 
 type KnowledgeQALayoutProps = {
   onExportClick: () => void
+  knowledgeStatus?: KnowledgeStatus
+  webFallbackAvailable?: boolean
 }
 
 const READY_STATE_SUGGESTIONS = [
@@ -121,7 +126,23 @@ function getLatestUserTurnKey(
   return null
 }
 
-export function KnowledgeQALayout({ onExportClick }: KnowledgeQALayoutProps) {
+function getReadySearchBlockedMessage(
+  recoveryState: KnowledgeReadyRecoveryState
+): string | null {
+  if (recoveryState.kind === "backend_unavailable") {
+    return "Reconnect the Knowledge QA backend before asking Knowledge QA."
+  }
+  if (recoveryState.kind === "no_indexed_sources") {
+    return "Add or index library sources before asking Knowledge QA."
+  }
+  return null
+}
+
+export function KnowledgeQALayout({
+  onExportClick,
+  knowledgeStatus = "ready",
+  webFallbackAvailable = true,
+}: KnowledgeQALayoutProps) {
   const knowledgeQa = useKnowledgeQA()
   const results = knowledgeQa.results ?? []
   const answer = knowledgeQa.answer ?? null
@@ -155,6 +176,7 @@ export function KnowledgeQALayout({ onExportClick }: KnowledgeQALayoutProps) {
   const evidenceRailTab = knowledgeQa.evidenceRailTab ?? "sources"
   const setEvidenceRailTab = knowledgeQa.setEvidenceRailTab ?? (() => undefined)
   const lastSearchScope = knowledgeQa.lastSearchScope ?? null
+  const searchDetails = knowledgeQa.searchDetails ?? null
   const pinnedSourceFilters = knowledgeQa.pinnedSourceFilters ?? {
     mediaIds: [],
     noteIds: [],
@@ -162,7 +184,8 @@ export function KnowledgeQALayout({ onExportClick }: KnowledgeQALayoutProps) {
   const focusSource = knowledgeQa.focusSource ?? (() => undefined)
   const settingsPanelOpen = knowledgeQa.settingsPanelOpen ?? false
   const sourceHealth = knowledgeQa.sourceHealth
-  const refreshSourceHealth = knowledgeQa.refreshSourceHealth ?? (async () => undefined)
+  const refreshSourceHealth =
+    knowledgeQa.refreshSourceHealth ?? (async () => undefined)
 
   const isMobile = useMobile()
   const { mode, setLayoutMode, isSimple, isResearch, showPromotionToast, dismissPromotion, acceptPromotion } =
@@ -170,16 +193,16 @@ export function KnowledgeQALayout({ onExportClick }: KnowledgeQALayoutProps) {
 
   // Mobile always forces simple mode layout (no sidebars)
   const effectiveSimple = isMobile || isSimple
+  const [compactScopePanelOpen, setCompactScopePanelOpen] = useState(false)
 
   // Track whether user manually closed the evidence rail for this search
   const userClosedRailRef = useRef(false)
   const latestUserTurnKeyRef = useRef<string | null>(null)
+  const compactScopeCloseButtonRef = useRef<HTMLButtonElement | null>(null)
 
   const hasResults = results.length > 0 || Boolean(answer)
   const showNoResultsState =
     hasSearched && !isSearching && !error && results.length === 0 && !answer
-  const nearestMatchesAvailable =
-    (knowledgeQa.searchDetails?.alsoConsidered?.length ?? 0) > 0
   const hasVisibleResultsArea =
     hasResults || showNoResultsState || Boolean(error) || isSearching
   const recentHistoryItem = useMemo(() => {
@@ -208,11 +231,31 @@ export function KnowledgeQALayout({ onExportClick }: KnowledgeQALayoutProps) {
   const isEvidenceRailOpen = canControlEvidence
     ? evidenceRailOpen
     : hasVisibleResultsArea
+  const readyRecoveryState = useMemo(
+    () =>
+      classifyKnowledgeReadyRecoveryState({
+        knowledgeStatus,
+        selectedSourceCount: settings.sources.length,
+        webFallbackAvailable,
+        webFallbackEnabled: settings.enable_web_fallback,
+      }),
+    [
+      knowledgeStatus,
+      settings.enable_web_fallback,
+      settings.sources.length,
+      webFallbackAvailable,
+    ]
+  )
   const readyStateSuggestions =
-    settings.sources.length > 0
+    readyRecoveryState.canSearchPersonalLibrary
       ? READY_STATE_SUGGESTIONS
       : READY_STATE_ONBOARDING_SUGGESTIONS
+  const readySearchBlockedMessage =
+    getReadySearchBlockedMessage(readyRecoveryState)
   const isDesktopReadyState = effectiveSimple && !isMobile && !hasVisibleResultsArea
+  const hasNearestMatches =
+    Array.isArray(searchDetails?.alsoConsidered) &&
+    searchDetails.alsoConsidered.length > 0
 
   const scopeChangeDetails = useMemo<string[]>(() => {
     if (!lastSearchScope) return []
@@ -336,6 +379,31 @@ export function KnowledgeQALayout({ onExportClick }: KnowledgeQALayoutProps) {
     }
   }, [settingsPanelOpen, evidenceRailOpen, setEvidenceRailOpen])
 
+  useEffect(() => {
+    if ((!effectiveSimple || settingsPanelOpen) && compactScopePanelOpen) {
+      setCompactScopePanelOpen(false)
+    }
+  }, [compactScopePanelOpen, effectiveSimple, settingsPanelOpen])
+
+  useEffect(() => {
+    if (!compactScopePanelOpen) return
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        setCompactScopePanelOpen(false)
+      }
+    }
+
+    const frame = requestAnimationFrame(() => {
+      compactScopeCloseButtonRef.current?.focus()
+    })
+    document.addEventListener("keydown", handleKeyDown)
+    return () => {
+      cancelAnimationFrame(frame)
+      document.removeEventListener("keydown", handleKeyDown)
+    }
+  }, [compactScopePanelOpen])
+
   const focusSearchInput = () => {
     const input = document.getElementById(
       "knowledge-search-input"
@@ -358,24 +426,33 @@ export function KnowledgeQALayout({ onExportClick }: KnowledgeQALayoutProps) {
     })
   }
 
+  const handleBroadenScope = () => {
+    updateSetting("top_k", Math.min(50, Math.max(settings.top_k + 5, 10)))
+    setSettingsPanelOpen(true)
+  }
+
   const handleEnableWeb = () => {
-    if (!settings.enable_web_fallback) {
+    if (webFallbackAvailable && !settings.enable_web_fallback) {
       updateSetting("enable_web_fallback", true)
     }
   }
 
+  const handleToggleWebFallback = () => {
+    if (!webFallbackAvailable) return
+    updateSetting("enable_web_fallback", !settings.enable_web_fallback)
+  }
+
   const handleShowNearestMatches = () => {
     setEvidenceRailOpen(true)
-    setEvidenceRailTab(results.length > 0 ? "sources" : "details")
+    setEvidenceRailTab("sources")
     if (results.length > 0) {
       focusSource(0)
     }
   }
 
   const handleOpenSourceSelector = () => {
-    // In simple mode, open settings panel instead of inline source toggle
     if (effectiveSimple) {
-      setSettingsPanelOpen(true)
+      setCompactScopePanelOpen(true)
       return
     }
     const sourceSelectorButton = document.getElementById(
@@ -397,6 +474,11 @@ export function KnowledgeQALayout({ onExportClick }: KnowledgeQALayoutProps) {
     if (!request) {
       handleOpenSourceSelector()
     }
+  }
+
+  const handleOpenSettingsFromScopePanel = () => {
+    setCompactScopePanelOpen(false)
+    setSettingsPanelOpen(true)
   }
 
   return (
@@ -443,11 +525,14 @@ export function KnowledgeQALayout({ onExportClick }: KnowledgeQALayoutProps) {
               {effectiveSimple ? (
                 <CompactToolbar
                   sources={settings.sources}
+                  includeMediaIds={Array.isArray(settings.include_media_ids) ? settings.include_media_ids : []}
+                  includeNoteIds={
+                    Array.isArray(settings.include_note_ids) ? settings.include_note_ids : []
+                  }
                   preset={preset}
                   webEnabled={settings.enable_web_fallback}
-                  onToggleWeb={() =>
-                    updateSetting("enable_web_fallback", !settings.enable_web_fallback)
-                  }
+                  webFallbackAvailable={webFallbackAvailable}
+                  onToggleWeb={handleToggleWebFallback}
                   onOpenSourceSelector={handleOpenSourceSelector}
                   onAddSources={handleAddSources}
                   onOpenSettings={() => setSettingsPanelOpen(true)}
@@ -479,9 +564,8 @@ export function KnowledgeQALayout({ onExportClick }: KnowledgeQALayoutProps) {
                   }
                   onIncludeNoteIdsChange={(ids) => updateSetting("include_note_ids", ids)}
                   webEnabled={settings.enable_web_fallback}
-                  onToggleWeb={() =>
-                    updateSetting("enable_web_fallback", !settings.enable_web_fallback)
-                  }
+                  webFallbackAvailable={webFallbackAvailable}
+                  onToggleWeb={handleToggleWebFallback}
                   generationProvider={settings.generation_provider ?? null}
                   generationModel={settings.generation_model ?? null}
                   onGenerationProviderChange={(provider) =>
@@ -510,11 +594,13 @@ export function KnowledgeQALayout({ onExportClick }: KnowledgeQALayoutProps) {
                     }}
                     onSelectSources={handleOpenSourceSelector}
                     onAddSources={handleAddSources}
+                    onEnableWebFallback={handleEnableWeb}
                     hasSources={settings.sources.length > 0}
-                    selectedSources={settings.sources}
-                    sourceHealth={sourceHealth}
                     hasRecentSession={Boolean(recentHistoryItem)}
                     webFallbackEnabled={settings.enable_web_fallback}
+                    recoveryState={readyRecoveryState}
+                    selectedSources={settings.sources}
+                    sourceHealth={sourceHealth}
                   />
                   {/* Inline recent sessions for returning users in Simple mode */}
                   {effectiveSimple && recentSessions.length > 0 && (
@@ -532,6 +618,8 @@ export function KnowledgeQALayout({ onExportClick }: KnowledgeQALayoutProps) {
               <KnowledgeComposer
                 autoFocus={!hasVisibleResultsArea}
                 showWebToggle={false}
+                webFallbackAvailable={webFallbackAvailable}
+                searchBlockedMessage={readySearchBlockedMessage}
                 widthMode={isDesktopReadyState ? "wide" : effectiveSimple ? "compact" : "wide"}
               />
             </div>
@@ -563,14 +651,16 @@ export function KnowledgeQALayout({ onExportClick }: KnowledgeQALayoutProps) {
                 {showNoResultsState ? (
                   <React.Suspense fallback={null}>
                     <LazyNoResultsRecovery
+                      onBroadenScope={handleBroadenScope}
                       onOpenQuickIngest={handleAddSources}
                       onEnableWeb={handleEnableWeb}
                       onShowNearestMatches={handleShowNearestMatches}
                       webEnabled={settings.enable_web_fallback}
+                      webAvailable={webFallbackAvailable}
+                      hasNearestMatches={hasNearestMatches}
                       selectedSources={settings.sources}
                       sourceHealth={sourceHealth}
-                      sourceStatus={knowledgeQa.searchDetails?.sourceStatus}
-                      showNearestMatchesAvailable={nearestMatchesAvailable}
+                      sourceStatus={searchDetails?.sourceStatus}
                     />
                   </React.Suspense>
                 ) : null}
@@ -600,6 +690,78 @@ export function KnowledgeQALayout({ onExportClick }: KnowledgeQALayoutProps) {
           </React.Suspense>
         ) : null}
       </main>
+
+      {effectiveSimple && compactScopePanelOpen ? (
+        <div
+          className="fixed inset-0 z-40 flex items-start justify-center px-3 py-4 sm:items-center sm:px-4"
+          role="presentation"
+        >
+          <button
+            type="button"
+            aria-hidden="true"
+            tabIndex={-1}
+            className="absolute inset-0 bg-black/40"
+            onClick={() => setCompactScopePanelOpen(false)}
+          />
+          <div
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="knowledge-compact-scope-title"
+            className="relative z-10 flex max-h-[calc(100vh-2rem)] w-full max-w-5xl flex-col overflow-hidden rounded-lg border border-border bg-background shadow-xl"
+          >
+            <div className="flex items-center justify-between gap-3 border-b border-border px-4 py-3">
+              <div className="min-w-0">
+                <h2
+                  id="knowledge-compact-scope-title"
+                  className="text-sm font-semibold text-text"
+                >
+                  Source scope and profiles
+                </h2>
+              </div>
+              <button
+                ref={compactScopeCloseButtonRef}
+                type="button"
+                onClick={() => setCompactScopePanelOpen(false)}
+                className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-md border border-border text-text-muted hover:bg-hover hover:text-text transition-colors"
+                aria-label="Close source scope"
+                title="Close source scope"
+              >
+                <X className="h-4 w-4" />
+              </button>
+            </div>
+            <div className="overflow-y-auto p-3 sm:p-4">
+              <KnowledgeContextBar
+                preset={preset}
+                onPresetChange={setPreset}
+                sources={settings.sources}
+                onSourcesChange={(sources) => updateSetting("sources", sources)}
+                includeMediaIds={Array.isArray(settings.include_media_ids) ? settings.include_media_ids : []}
+                onIncludeMediaIdsChange={(ids) => updateSetting("include_media_ids", ids)}
+                includeNoteIds={
+                  Array.isArray(settings.include_note_ids) ? settings.include_note_ids : []
+                }
+                onIncludeNoteIdsChange={(ids) => updateSetting("include_note_ids", ids)}
+                webEnabled={settings.enable_web_fallback}
+                webFallbackAvailable={webFallbackAvailable}
+                onToggleWeb={handleToggleWebFallback}
+                generationProvider={settings.generation_provider ?? null}
+                generationModel={settings.generation_model ?? null}
+                onGenerationProviderChange={(provider) =>
+                  updateSetting("generation_provider", provider)
+                }
+                onGenerationModelChange={(model) =>
+                  updateSetting("generation_model", model)
+                }
+                contextChangedSinceLastRun={contextChangedSinceLastRun}
+                scopeChangeDetails={scopeChangeDetails}
+                sourceHealth={sourceHealth}
+                onRefreshSourceHealth={refreshSourceHealth}
+                onOpenSettings={handleOpenSettingsFromScopePanel}
+              />
+            </div>
+          </div>
+        </div>
+      ) : null}
 
       {/* Mode toggle + promotion toast + help link */}
       <div className="fixed bottom-4 right-4 z-20 flex flex-col items-end gap-2">
@@ -632,7 +794,7 @@ export function KnowledgeQALayout({ onExportClick }: KnowledgeQALayoutProps) {
           <button
             type="button"
             onClick={() => setLayoutMode(isSimple ? "research" : "simple")}
-            className="inline-flex items-center gap-1.5 rounded-lg border border-border bg-surface px-2.5 py-2 text-xs font-medium text-text-muted shadow-sm hover:bg-hover hover:text-text transition-colors"
+            className="rounded-lg border border-border bg-surface p-2 shadow-sm hover:bg-hover transition-colors"
             title={isSimple ? "Switch to detailed view" : "Switch to simple view"}
             aria-label={isSimple ? "Switch to detailed view" : "Switch to simple view"}
           >
@@ -641,7 +803,6 @@ export function KnowledgeQALayout({ onExportClick }: KnowledgeQALayoutProps) {
             ) : (
               <PanelLeftClose className="h-4 w-4 text-text-muted" />
             )}
-            <span>{isSimple ? "Detailed" : "Simple"}</span>
           </button>
         )}
 

--- a/apps/packages/ui/src/components/Option/KnowledgeQA/layout/KnowledgeQALayout.tsx
+++ b/apps/packages/ui/src/components/Option/KnowledgeQA/layout/KnowledgeQALayout.tsx
@@ -444,7 +444,7 @@ export function KnowledgeQALayout({
 
   const handleShowNearestMatches = () => {
     setEvidenceRailOpen(true)
-    setEvidenceRailTab("sources")
+    setEvidenceRailTab(results.length > 0 ? "sources" : "details")
     if (results.length > 0) {
       focusSource(0)
     }

--- a/apps/packages/ui/src/components/Option/KnowledgeQA/panels/NoResultsRecovery.tsx
+++ b/apps/packages/ui/src/components/Option/KnowledgeQA/panels/NoResultsRecovery.tsx
@@ -13,10 +13,13 @@ import type {
 import { getSourceHealthStatusLabel } from "../sourceHealth"
 
 type NoResultsRecoveryProps = {
+  onBroadenScope?: () => void
   onOpenQuickIngest: () => void
   onEnableWeb: () => void
   onShowNearestMatches: () => void
   webEnabled: boolean
+  webAvailable?: boolean
+  hasNearestMatches?: boolean
   selectedSources?: RagSource[]
   sourceHealth?: KnowledgeSourceHealthState
   sourceStatus?: Record<string, KnowledgeSourceStatus>
@@ -24,10 +27,13 @@ type NoResultsRecoveryProps = {
 }
 
 export function NoResultsRecovery({
+  onBroadenScope,
   onOpenQuickIngest,
   onEnableWeb,
   onShowNearestMatches,
   webEnabled,
+  webAvailable = true,
+  hasNearestMatches = false,
   selectedSources = [],
   sourceHealth,
   sourceStatus,
@@ -55,6 +61,9 @@ export function NoResultsRecovery({
       .map((sourceId) => sourceHealth.bySource[sourceId])
       .filter((source): source is KnowledgeSourceHealth => Boolean(source))
   }, [selectedSources, sourceHealth])
+  const canEnableWebFallback = webAvailable && !webEnabled
+  const shouldOfferNearestMatches =
+    hasNearestMatches || showNearestMatchesAvailable
 
   return (
     <div className="rounded-xl border border-border bg-surface p-6">
@@ -63,7 +72,7 @@ export function NoResultsRecovery({
         <div className="min-w-0 flex-1">
           <h2 className="text-base font-semibold">No results found</h2>
           <p className="mt-1 text-sm text-text-muted">
-            Try broader keywords, check source readiness and search diagnostics, or enable web fallback for recovery.
+            Try broader keywords, broaden the source scope, check source readiness and search diagnostics, or enable web fallback for recovery.
           </p>
           <p className="mt-1 text-sm text-text-muted">
             Web fallback uses your configured server default provider. Queries stay on your
@@ -128,15 +137,29 @@ export function NoResultsRecovery({
             >
               Open source page
             </Link>
-            <button
-              type="button"
-              onClick={onEnableWeb}
-              disabled={webEnabled}
-              className="rounded-md border border-border bg-surface px-3 py-1.5 text-sm text-text-subtle disabled:opacity-60 disabled:cursor-not-allowed hover:bg-hover hover:text-text transition-colors"
-            >
-              {webEnabled ? "Web fallback enabled" : "Enable web fallback"}
-            </button>
-            {showNearestMatchesAvailable ? (
+            {onBroadenScope ? (
+              <button
+                type="button"
+                onClick={onBroadenScope}
+                className="rounded-md border border-border bg-surface px-3 py-1.5 text-sm text-text-subtle hover:bg-hover hover:text-text transition-colors"
+              >
+                Broaden source scope
+              </button>
+            ) : null}
+            {canEnableWebFallback ? (
+              <button
+                type="button"
+                onClick={onEnableWeb}
+                className="rounded-md border border-border bg-surface px-3 py-1.5 text-sm text-text-subtle hover:bg-hover hover:text-text transition-colors"
+              >
+                Enable web fallback
+              </button>
+            ) : (
+              <span className="rounded-md border border-border bg-surface px-3 py-1.5 text-sm text-text-muted">
+                {webAvailable ? "Web fallback enabled" : "Web fallback unavailable"}
+              </span>
+            )}
+            {shouldOfferNearestMatches ? (
               <button
                 type="button"
                 onClick={onShowNearestMatches}

--- a/apps/tldw-frontend/components/networking/ServerReadinessGate.tsx
+++ b/apps/tldw-frontend/components/networking/ServerReadinessGate.tsx
@@ -1,7 +1,10 @@
 import React from "react"
 
 import { resolvePublicApiOrigin, type DeploymentEnv } from "@web/lib/api-base"
-import { StatePanel } from "@tldw/ui/components/ui/state"
+import {
+  StatePanel,
+  type StatePanelDiagnostic,
+} from "@tldw/ui/components/ui/state"
 import { ServerHealthWarningBanner } from "./ServerHealthWarningBanner"
 
 const _env: DeploymentEnv = {
@@ -191,6 +194,81 @@ function emitServerReadinessState(detail: ServerReadinessPublishedState) {
   )
 }
 
+function navigateTo(path: string): void {
+  if (typeof window === "undefined") return
+  window.location.assign(path)
+}
+
+function ReadinessRecoveryPanel({
+  children,
+  diagnostics,
+  onRetry,
+}: {
+  children: React.ReactNode
+  diagnostics: ServerReadinessPublishedState | null
+  onRetry: () => void
+}) {
+  const panelDiagnostics: StatePanelDiagnostic[] = [
+    {
+      label: "Health endpoint",
+      value: HEALTH_URL,
+      code: true,
+    },
+    {
+      label: "Waited",
+      value: `${Math.round(MAX_WAIT_MS / 1000)} seconds`,
+    },
+  ]
+
+  if (diagnostics?.httpStatus != null) {
+    panelDiagnostics.push({
+      label: "HTTP status",
+      value: String(diagnostics.httpStatus),
+    })
+  }
+  if (diagnostics?.healthStatus) {
+    panelDiagnostics.push({
+      label: "Health status",
+      value: diagnostics.healthStatus,
+    })
+  }
+  if (diagnostics?.degradedChecks.length) {
+    panelDiagnostics.push({
+      label: "Degraded checks",
+      value: diagnostics.degradedChecks.join(", "),
+    })
+  }
+
+  return (
+    <>
+      <main className="flex min-h-screen items-center justify-center bg-bg px-4 py-10 text-text">
+        <StatePanel
+          state="unavailable"
+          title="Backend readiness check failed"
+          message="The WebUI could not confirm that the tldw server is ready. You can retry the health check, inspect diagnostics, or update server settings before continuing."
+          diagnostics={panelDiagnostics}
+          primaryAction={{ label: "Retry", onClick: onRetry }}
+          secondaryActions={[
+            {
+              label: "Health & diagnostics",
+              onClick: () => navigateTo("/settings/health"),
+            },
+            {
+              label: "Server settings",
+              onClick: () => navigateTo("/settings/tldw"),
+            },
+          ]}
+          role="alert"
+          aria-live="assertive"
+          className="w-full max-w-3xl"
+          data-testid="server-readiness-recovery"
+        />
+      </main>
+      <div data-testid="server-readiness-route-content">{children}</div>
+    </>
+  )
+}
+
 export const ServerReadinessGate: React.FC<{
   children: React.ReactNode
   allowDegraded?: boolean
@@ -202,6 +280,11 @@ export const ServerReadinessGate: React.FC<{
   const [degradedChecks, setDegradedChecks] = React.useState<string[]>([])
   const [lastReadinessState, setLastReadinessState] =
     React.useState<ServerReadinessPublishedState | null>(null)
+  const [retryVersion, setRetryVersion] = React.useState(0)
+
+  const retryNow = React.useCallback(() => {
+    setRetryVersion((version) => version + 1)
+  }, [])
 
   React.useEffect(() => {
     if (typeof window === "undefined") return
@@ -255,7 +338,7 @@ export const ServerReadinessGate: React.FC<{
       cancelled = true
       if (retryTimer) window.clearTimeout(retryTimer)
     }
-  }, [allowDegraded, bypass])
+  }, [allowDegraded, bypass, retryVersion])
 
   React.useEffect(() => {
     if (typeof window === "undefined" || bypass) return
@@ -292,7 +375,7 @@ export const ServerReadinessGate: React.FC<{
     }
   }, [bypass, degradedChecks, gate, lastReadinessState])
 
-  if (bypass || gate === "ready" || gate === "timeout") {
+  if (bypass || gate === "ready") {
     return <>{children}</>
   }
 
@@ -307,6 +390,17 @@ export const ServerReadinessGate: React.FC<{
           {children}
         </div>
       </div>
+    )
+  }
+
+  if (gate === "timeout") {
+    return (
+      <ReadinessRecoveryPanel
+        diagnostics={lastReadinessState}
+        onRetry={retryNow}
+      >
+        {children}
+      </ReadinessRecoveryPanel>
     )
   }
 

--- a/apps/tldw-frontend/components/networking/__tests__/ServerReadinessGate.test.tsx
+++ b/apps/tldw-frontend/components/networking/__tests__/ServerReadinessGate.test.tsx
@@ -358,6 +358,71 @@ describe("ServerReadinessGate", () => {
     expect(screen.queryByText("App ready")).toBeNull()
   })
 
+  it("shows actionable recovery when health checks fail until timeout", async () => {
+    vi.useFakeTimers()
+    vi.stubEnv("NEXT_PUBLIC_TLDW_DEPLOYMENT_MODE", "advanced")
+    vi.stubEnv("NEXT_PUBLIC_API_URL", "http://127.0.0.1:8000")
+
+    vi.spyOn(globalThis, "fetch").mockResolvedValue({
+      ok: false
+    } as Response)
+
+    const { ServerReadinessGate } = await import("../ServerReadinessGate")
+
+    render(
+      <ServerReadinessGate>
+        <main data-testid="knowledge-main-region" />
+      </ServerReadinessGate>
+    )
+
+    expectReadinessStatus()
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(16_000)
+    })
+
+    expect(screen.getByTestId("knowledge-main-region")).toBeInTheDocument()
+    expect(
+      screen.getByRole("heading", { name: /Backend readiness check failed/i })
+    ).toBeInTheDocument()
+    expect(screen.getByText("http://127.0.0.1:8000/api/v1/health")).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Retry" })).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Health & diagnostics" })).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Server settings" })).toBeInTheDocument()
+  })
+
+  it("shows actionable recovery when the health request stalls until timeout", async () => {
+    vi.useFakeTimers()
+    vi.stubEnv("NEXT_PUBLIC_TLDW_DEPLOYMENT_MODE", "advanced")
+    vi.stubEnv("NEXT_PUBLIC_API_URL", "http://127.0.0.1:8000")
+
+    vi.spyOn(globalThis, "fetch").mockImplementation(
+      () => new Promise<Response>(() => undefined)
+    )
+
+    const { ServerReadinessGate } = await import("../ServerReadinessGate")
+
+    render(
+      <ServerReadinessGate>
+        <main data-testid="knowledge-main-region" />
+      </ServerReadinessGate>
+    )
+
+    expectReadinessStatus()
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(16_000)
+    })
+
+    expect(screen.getByTestId("knowledge-main-region")).toBeInTheDocument()
+    expect(
+      screen.getByRole("heading", { name: /Backend readiness check failed/i })
+    ).toBeInTheDocument()
+    expect(screen.getByText("http://127.0.0.1:8000/api/v1/health")).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Retry" })).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Health & diagnostics" })).toBeInTheDocument()
+  })
+
   it("bypasses health checks when bypass is enabled", async () => {
     const fetchMock = vi.spyOn(globalThis, "fetch")
     const { ServerReadinessGate } = await import("../ServerReadinessGate")

--- a/apps/tldw-frontend/e2e/ux-audit/knowledge-empty-recovery.spec.ts
+++ b/apps/tldw-frontend/e2e/ux-audit/knowledge-empty-recovery.spec.ts
@@ -1,0 +1,175 @@
+import { test, expect, type Page, type Route } from "@playwright/test"
+
+import { seedAuth, TEST_CONFIG } from "../utils/helpers"
+
+const fulfillJson = async (route: Route, payload: unknown, status = 200) => {
+  await route.fulfill({
+    status,
+    contentType: "application/json",
+    body: JSON.stringify(payload),
+  })
+}
+
+async function mockKnowledgeRecoveryApi(
+  page: Page,
+  options: { hasWebSearch?: boolean } = {}
+) {
+  const hasWebSearch = options.hasWebSearch ?? true
+
+  await page.route(/\/api\/v1\/health(?:\?.*)?$/, async (route) => {
+    await fulfillJson(route, { status: "healthy" })
+  })
+
+  await page.route(/\/openapi\.json(?:\?.*)?$/, async (route) => {
+    await fulfillJson(route, {
+      openapi: "3.0.0",
+      paths: {
+        "/api/v1/rag/search": { post: {} },
+        "/api/v1/rag/health": { get: {} },
+        ...(hasWebSearch
+          ? { "/api/v1/research/websearch": { post: {} } }
+          : {}),
+      },
+    })
+  })
+
+  await page.route(/\/api\/v1\/llm\/providers(?:\?.*)?$/, async (route) => {
+    await fulfillJson(route, {
+      providers: [{ name: "server-default", models: ["server-default-model"] }],
+    })
+  })
+
+  await page.route(/\/api\/v1\/characters(?:\/search)?(?:\/)?(?:\?.*)?$/, async (route) => {
+    await fulfillJson(route, [])
+  })
+
+  await page.route(/\/api\/v1\/chats(?:\/)?(?:\?.*)?$/, async (route) => {
+    await fulfillJson(route, { chats: [], total: 0 })
+  })
+
+  await page.route(/\/api\/v1\/chat\/conversations(?:\?.*)?$/, async (route) => {
+    await fulfillJson(route, { conversations: [], total: 0 })
+  })
+
+  await page.route(/\/api\/v1\/media(?:\/)?(?:\?.*)?$/, async (route) => {
+    await fulfillJson(route, {
+      items: [{ id: 101, title: "Grounded QA Notes", media_type: "document" }],
+      total: 1,
+    })
+  })
+
+  await page.route(/\/api\/v1\/notes(?:\/)?(?:\?.*)?$/, async (route) => {
+    await fulfillJson(route, {
+      items: [{ id: "note-grounded-qa", title: "Grounded QA checklist" }],
+      total: 1,
+    })
+  })
+}
+
+async function forceKnowledgeConnectionState(
+  page: Page,
+  knowledgeStatus: "ready" | "empty"
+) {
+  await page.waitForFunction(
+    () => typeof (window as any).__tldw_useConnectionStore?.getState === "function"
+  )
+  await page.evaluate((status) => {
+    const store = (window as any).__tldw_useConnectionStore
+    const prev = store.getState().state
+    const now = Date.now()
+    store.setState({
+      state: {
+        ...prev,
+        phase: "connected",
+        isConnected: true,
+        isChecking: false,
+        offlineBypass: true,
+        errorKind: "none",
+        lastError: null,
+        lastStatusCode: null,
+        lastCheckedAt: now,
+        knowledgeStatus: status,
+        knowledgeLastCheckedAt: now,
+        knowledgeError: null,
+        configStep: "health",
+        hasCompletedFirstRun: true,
+      },
+    })
+  }, knowledgeStatus)
+}
+
+test.describe("Knowledge QA empty recovery", () => {
+  test("WebUI shows add/index recovery when the backend reports no indexed sources", async ({ page }) => {
+    await mockKnowledgeRecoveryApi(page, { hasWebSearch: false })
+    await seedAuth(page, {
+      serverUrl: TEST_CONFIG.serverUrl,
+      allowOffline: true,
+    })
+
+    await page.goto("/knowledge", { waitUntil: "domcontentloaded" })
+    await expect(page.getByRole("heading", { name: /Ask Your Library/i })).toBeVisible()
+    await forceKnowledgeConnectionState(page, "empty")
+
+    await expect(page.getByText("No indexed library sources yet")).toBeVisible()
+    await expect(
+      page.getByRole("button", { name: "Add or index sources" }).last()
+    ).toBeVisible()
+
+    await page.getByLabel(/Search your knowledge base/i).fill("What does my library say?")
+    await expect(page.getByRole("button", { name: /^Ask$/i })).toBeDisabled()
+    await expect(
+      page.getByText("Add or index library sources before asking Knowledge QA.")
+    ).toBeVisible()
+  })
+
+  test("WebUI shows source-selection recovery when indexed sources exist but none are selected", async ({ page }) => {
+    await mockKnowledgeRecoveryApi(page, { hasWebSearch: true })
+    await seedAuth(page, {
+      serverUrl: TEST_CONFIG.serverUrl,
+      allowOffline: true,
+    })
+
+    await page.goto("/knowledge", { waitUntil: "domcontentloaded" })
+    await expect(page.getByRole("heading", { name: /Ask Your Library/i })).toBeVisible()
+    await forceKnowledgeConnectionState(page, "ready")
+
+    const webToggle = page.getByRole("button", {
+      name: /Web fallback is currently/i,
+    })
+    await expect(webToggle).toBeVisible()
+    if ((await webToggle.getAttribute("aria-pressed")) === "true") {
+      await webToggle.click()
+    }
+    await page.getByRole("button", { name: /Open source scope and saved profiles/i }).click()
+    const scopeDialog = page.getByRole("dialog", { name: "Source scope and profiles" })
+    await expect(scopeDialog).toBeVisible()
+    await scopeDialog.getByRole("button", { name: /Sources:/i }).click()
+    for (const label of [
+      "Documents & Media",
+      "Notes",
+      "Characters",
+      "Chats",
+      "Task Boards",
+    ]) {
+      const sourceOption = scopeDialog.getByRole("menuitemcheckbox", {
+        name: new RegExp(label),
+      })
+      if ((await sourceOption.count()) === 0) continue
+      if ((await sourceOption.first().getAttribute("aria-checked")) === "true") {
+        await sourceOption.first().click()
+      }
+    }
+    await scopeDialog.getByRole("button", { name: "Close source scope" }).click()
+
+    await expect(page.getByText("No source categories selected")).toBeVisible()
+    await expect(
+      page.getByRole("button", { name: "Select source categories" }).last()
+    ).toBeVisible()
+
+    await page.getByLabel(/Search your knowledge base/i).fill("What does my library say?")
+    await expect(page.getByRole("button", { name: /^Ask$/i })).toBeDisabled()
+    await expect(
+      page.getByText("Select source categories or enable web fallback before asking Knowledge QA.")
+    ).toBeVisible()
+  })
+})

--- a/apps/tldw-frontend/e2e/ux-audit/knowledge-qa-states.spec.ts
+++ b/apps/tldw-frontend/e2e/ux-audit/knowledge-qa-states.spec.ts
@@ -1,0 +1,215 @@
+import { test, expect, type Page, type Route } from "@playwright/test"
+
+import { seedAuth, TEST_CONFIG } from "../utils/helpers"
+
+type KnowledgeRouteState = "ready" | "results" | "noResults"
+
+const fulfillJson = async (route: Route, payload: unknown, status = 200) => {
+  await route.fulfill({
+    status,
+    contentType: "application/json",
+    body: JSON.stringify(payload),
+  })
+}
+
+async function mockKnowledgeQaApi(page: Page, state: KnowledgeRouteState = "ready") {
+  await page.route(/\/api\/v1\/health(?:\?.*)?$/, async (route) => {
+    await fulfillJson(route, { status: "healthy" })
+  })
+
+  await page.route(/\/openapi\.json(?:\?.*)?$/, async (route) => {
+    await fulfillJson(route, {
+      openapi: "3.0.0",
+      paths: {
+        "/api/v1/rag/search": { post: {} },
+        "/api/v1/rag/health": { get: {} },
+        "/api/v1/research/websearch": { post: {} },
+      },
+    })
+  })
+
+  await page.route(/\/api\/v1\/llm\/providers(?:\?.*)?$/, async (route) => {
+    await fulfillJson(route, {
+      providers: [
+        {
+          name: "server-default",
+          models: ["server-default-model"],
+        },
+      ],
+    })
+  })
+
+  await page.route(/\/api\/v1\/characters\/search(?:\?.*)?$/, async (route) => {
+    await fulfillJson(route, [
+      {
+        id: 1,
+        name: "Helpful AI Assistant",
+      },
+    ])
+  })
+
+  await page.route(/\/api\/v1\/characters(?:\/)?(?:\?.*)?$/, async (route) => {
+    await fulfillJson(route, [
+      {
+        id: 1,
+        name: "Helpful AI Assistant",
+      },
+    ])
+  })
+
+  await page.route(/\/api\/v1\/chats(?:\/)?(?:\?.*)?$/, async (route) => {
+    if (route.request().method() === "POST") {
+      await fulfillJson(route, {
+        id: "knowledge-chat-1",
+        title: "Grounded QA fixture",
+        state: "in-progress",
+        source: "knowledge_qa",
+        version: 1,
+      })
+      return
+    }
+
+    await fulfillJson(route, {
+      chats: [],
+      total: 0,
+    })
+  })
+
+  await page.route(/\/api\/v1\/chats\/knowledge-chat-1\/messages(?:\?.*)?$/, async (route) => {
+    let payload: Record<string, unknown> = {}
+    try {
+      payload = route.request().postDataJSON() as Record<string, unknown>
+    } catch {
+      payload = {}
+    }
+    const role = typeof payload?.role === "string" ? payload.role : "user"
+    await fulfillJson(route, {
+      id: `knowledge-message-${role}`,
+      role,
+      content: typeof payload?.content === "string" ? payload.content : "",
+      created_at: "2026-06-07T00:00:00.000Z",
+    })
+  })
+
+  await page.route(/\/api\/v1\/chat\/conversations(?:\?.*)?$/, async (route) => {
+    await fulfillJson(route, {
+      conversations: [],
+      total: 0,
+    })
+  })
+
+  await page.route(/\/api\/v1\/chat\/conversations\/knowledge-chat-1(?:\?.*)?$/, async (route) => {
+    await fulfillJson(route, {
+      id: "knowledge-chat-1",
+      title: "Grounded QA fixture",
+      state: "in-progress",
+      source: "knowledge_qa",
+      keywords: ["knowledge_qa"],
+      version: 1,
+    })
+  })
+
+  await page.route(/\/api\/v1\/chat\/messages\/[^/]+\/rag-context(?:\?.*)?$/, async (route) => {
+    await fulfillJson(route, {
+      success: true,
+    })
+  })
+
+  await page.route(/\/api\/v1\/media(?:\/)?(?:\?.*)?$/, async (route) => {
+    await fulfillJson(route, {
+      items: [
+        {
+          id: 101,
+          title: "Grounded QA Notes",
+          media_type: "document",
+        },
+      ],
+      total: 1,
+    })
+  })
+
+  await page.route(/\/api\/v1\/notes(?:\/)?(?:\?.*)?$/, async (route) => {
+    await fulfillJson(route, {
+      items: [
+        {
+          id: "note-grounded-qa",
+          title: "Grounded QA checklist",
+        },
+      ],
+      total: 1,
+    })
+  })
+
+  await page.route(/\/api\/v1\/rag\/search\/stream(?:\?.*)?$/, async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "text/plain",
+      body: "",
+    })
+  })
+
+  await page.route(/\/api\/v1\/rag\/search(?:\?.*)?$/, async (route) => {
+    if (state === "noResults") {
+      await fulfillJson(route, {
+        results: [],
+        generated_answer: null,
+      })
+      return
+    }
+
+    await fulfillJson(route, {
+      results: [
+        {
+          id: "knowledge-source-1",
+          content: "Grounded answers should cite visible evidence.",
+          excerpt: "Grounded answers should cite visible evidence.",
+          score: 0.93,
+          metadata: {
+            title: "Grounded QA Notes",
+            source_type: "media_db",
+          },
+        },
+      ],
+      generated_answer: "Grounded answers should cite visible evidence [1].",
+      metadata: {
+        retrieval_metrics: {
+          documents_considered: 1,
+          chunks_considered: 1,
+        },
+      },
+    })
+  })
+}
+
+test.describe("Knowledge QA deterministic route states", () => {
+  test("WebUI renders ready search state without a live backend", async ({ page }) => {
+    await mockKnowledgeQaApi(page, "ready")
+    await seedAuth(page, {
+      serverUrl: TEST_CONFIG.serverUrl,
+      allowOffline: true,
+    })
+
+    await page.goto("/knowledge", { waitUntil: "domcontentloaded" })
+
+    await expect(page.getByRole("heading", { name: /Ask Your Library/i })).toBeVisible()
+    await expect(page.getByLabel(/Search your knowledge base/i)).toBeVisible()
+  })
+
+  test("WebUI can exercise a cited result state with mocked RAG search", async ({ page }) => {
+    await mockKnowledgeQaApi(page, "results")
+    await seedAuth(page, {
+      serverUrl: TEST_CONFIG.serverUrl,
+      allowOffline: true,
+    })
+
+    await page.goto("/knowledge", { waitUntil: "domcontentloaded" })
+
+    const searchBox = page.getByLabel(/Search your knowledge base/i)
+    await expect(searchBox).toBeVisible()
+    await searchBox.fill("What does my library say about grounded answers?")
+    await page.getByRole("button", { name: /^Ask$/i }).click()
+
+    await expect(page.getByText(/Grounded answers should cite visible evidence/i)).toBeVisible()
+    await expect(page.getByRole("button", { name: /Export/i })).toBeVisible()
+  })
+})

--- a/apps/tldw-frontend/e2e/ux-audit/knowledge-readiness-recovery.spec.ts
+++ b/apps/tldw-frontend/e2e/ux-audit/knowledge-readiness-recovery.spec.ts
@@ -1,0 +1,81 @@
+import { test, expect, type Page, type Route } from "@playwright/test"
+
+import { TEST_CONFIG } from "../utils/helpers"
+
+const seedConfiguredAuthWithoutReadinessBypass = async (page: Page) => {
+  await page.addInitScript((cfg) => {
+    const authConfig = {
+      serverUrl: cfg.serverUrl,
+      authMode: "single-user",
+      apiKey: cfg.apiKey,
+    }
+
+    try {
+      localStorage.setItem("tldwConfig", JSON.stringify(authConfig))
+      localStorage.setItem("isMigrated", "true")
+      localStorage.setItem("__tldw_first_run_complete", "true")
+      localStorage.setItem("assistant_setup_dismissed", "true")
+      localStorage.setItem("serverUrl", cfg.serverUrl)
+      localStorage.setItem("tldwServerUrl", cfg.serverUrl)
+      localStorage.setItem("tldw-api-host", cfg.serverUrl)
+      localStorage.setItem("authMode", "single-user")
+      localStorage.setItem("apiKey", cfg.apiKey)
+      localStorage.removeItem("__tldw_allow_offline")
+      localStorage.removeItem("__tldw_test_bypass")
+    } catch {
+      // Storage seeding is best-effort in browser contexts.
+    }
+  }, TEST_CONFIG)
+}
+
+const fulfillJson = async (route: Route, payload: unknown, status = 200) => {
+  await route.fulfill({
+    status,
+    contentType: "application/json",
+    body: JSON.stringify(payload),
+  })
+}
+
+const expectKnowledgeRecovery = async (page: Page) => {
+  await expect(
+    page.getByRole("heading", { name: /Backend readiness check failed/i })
+  ).toBeVisible({ timeout: 20_000 })
+  const recovery = page.getByTestId("server-readiness-recovery")
+  await expect(recovery).toContainText(
+    "http://127.0.0.1:8000/api/v1/health"
+  )
+  await expect(recovery.getByRole("button", { name: "Retry" })).toBeVisible()
+  await expect(recovery.getByRole("button", { name: "Health & diagnostics" })).toBeVisible()
+  await expect(recovery.getByRole("button", { name: "Server settings" })).toBeVisible()
+  await expect(page.getByTestId("server-readiness-route-content")).toBeAttached()
+  await expect
+    .poll(async () => {
+      const text = await recovery.textContent()
+      return text?.trim().length ?? 0
+    })
+    .toBeGreaterThan(0)
+}
+
+test.describe("Knowledge QA readiness recovery", () => {
+  test("WebUI /knowledge shows recovery after failed backend health", async ({ page }) => {
+    await seedConfiguredAuthWithoutReadinessBypass(page)
+    await page.route("**/api/v1/health**", async (route) => {
+      await fulfillJson(route, { status: "unavailable" }, 503)
+    })
+
+    await page.goto("/knowledge", { waitUntil: "domcontentloaded" })
+
+    await expectKnowledgeRecovery(page)
+  })
+
+  test("WebUI /knowledge shows recovery after stalled backend health", async ({ page }) => {
+    await seedConfiguredAuthWithoutReadinessBypass(page)
+    await page.route("**/api/v1/health**", async () => {
+      await new Promise(() => undefined)
+    })
+
+    await page.goto("/knowledge", { waitUntil: "domcontentloaded" })
+
+    await expectKnowledgeRecovery(page)
+  })
+})

--- a/backlog/tasks/task-528 - Plan-knowledge-QA-WebUI-and-extension-remediation-after-UX-audit.md
+++ b/backlog/tasks/task-528 - Plan-knowledge-QA-WebUI-and-extension-remediation-after-UX-audit.md
@@ -1,0 +1,82 @@
+---
+id: TASK-528
+title: Plan /knowledge QA WebUI and extension remediation after UX audit
+status: Done
+assignee: []
+created_date: ''
+updated_date: '2026-06-07 05:48'
+labels:
+  - webui
+  - extension
+  - knowledge
+  - ux
+  - planning
+dependencies: []
+documentation:
+  - >-
+    Docs/superpowers/plans/2026-06-07-knowledge-qa-state-fixtures-and-baseline-plan.md
+  - Docs/superpowers/plans/2026-06-07-knowledge-webui-readiness-recovery-plan.md
+  - >-
+    Docs/superpowers/plans/2026-06-07-knowledge-extension-setup-diagnostics-plan.md
+  - Docs/superpowers/plans/2026-06-07-knowledge-first-run-empty-recovery-plan.md
+  - >-
+    Docs/superpowers/plans/2026-06-07-knowledge-ready-search-source-scope-plan.md
+  - Docs/superpowers/plans/2026-06-07-knowledge-results-evidence-export-plan.md
+  - >-
+    Docs/superpowers/plans/2026-06-07-knowledge-power-user-settings-parity-plan.md
+  - >-
+    Docs/superpowers/plans/2026-06-07-knowledge-uat-regression-guardrails-plan.md
+  - Docs/Plans/2026-06-07-knowledge-qa-uat-checklist.md
+  - Docs/User_Guides/WebUI_Extension/Knowledge_QA_Guide.md
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Create the Backlog task structure and implementation plans for the /knowledge Knowledge QA remediation work identified in the WebUI and extension UX/QA audit. The page remains a Knowledge QA workflow for searching a personal library and reviewing grounded answers with citations. Flashcards, decks, spaced repetition, and study-set behavior are explicitly out of scope for /knowledge because flashcards live on a separate route.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Parent task records the full remediation program and links child tasks for every reviewable work package.
+- [x] #2 Each child task has a corresponding implementation plan document in Docs/superpowers/plans/.
+- [x] #3 Plans preserve the /knowledge QA-only boundary and do not introduce flashcard behavior.
+- [x] #4 Plans cover WebUI readiness recovery, extension setup diagnostics, first-run/no-source recovery, source scope, ready search, results/evidence/export, power-user settings, parity, UAT, and regression coverage.
+- [x] #5 Touched planning files and Backlog records are ready to stage with the related work.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Create a parent Backlog task, create child tasks for each remediation slice, write one implementation plan per child task, then update the tasks with documentation links and implementation-plan references.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+- Created and completed child tasks TASK-528.1 through TASK-528.8 for Knowledge QA state fixtures, WebUI readiness recovery, extension setup diagnostics, first-run/no-source recovery, ready search/source profiles, results/evidence/export, power-user settings/parity, and UAT/regression guardrails.
+- Linked all implementation plans plus the final UAT checklist and Knowledge QA user guide.
+- The remediation series preserves /knowledge as a Knowledge QA workflow for searching a personal library and reviewing grounded answers with citations. Flashcards remain on the separate flashcards route and were not added to /knowledge.
+- Final verification from TASK-528.8: shared Knowledge QA Vitest passed 46 files / 377 tests; WebUI Knowledge QA Playwright route-state checks passed 6 tests; trailing-whitespace guard passed for closeout docs/task files; code/test scope guard found no deck/spaced-repetition/study-set terminology in touched Knowledge QA source or E2E files.
+- Known blocker carried forward: extension runtime E2E/UAT is blocked by the WXT production build stall before browser launch. Extension source specs and documented commands are present, but browser-phase extension behavior was not reverified in the final closeout pass.
+- Bandit is not applicable to the closeout slice because TASK-528.8 touched markdown documentation and Backlog records only.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Completed the /knowledge Knowledge QA remediation program and closeout documentation. The parent task now links all child implementation plans, the UAT checklist, and the user guide. Final shared UI and WebUI regression checks pass, while extension runtime E2E remains explicitly blocked by the WXT production build stall before browser execution.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-528.1 - Add-knowledge-QA-deterministic-state-fixtures-and-baseline-coverage.md
+++ b/backlog/tasks/task-528.1 - Add-knowledge-QA-deterministic-state-fixtures-and-baseline-coverage.md
@@ -1,0 +1,58 @@
+---
+id: TASK-528.1
+title: Add /knowledge QA deterministic state fixtures and baseline coverage
+status: Done
+labels:
+- webui
+- extension
+- knowledge
+- testing
+- ux
+priority: high
+parent_task_id: TASK-528
+documentation:
+- Docs/superpowers/plans/2026-06-07-knowledge-qa-state-fixtures-and-baseline-plan.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Build deterministic test coverage and state fixtures for the /knowledge Knowledge QA audit states before changing the UI. Cover backend offline, setup required, no indexed sources, no selected sources, ready search, results with citations, no results, settings drawer, export, and WebUI versus extension differences. Do not add flashcard behavior to /knowledge.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Deterministic fixtures or mocks exist for every audited /knowledge state.
+- [ ] #2 Baseline coverage captures the current WebUI readiness/blank-state failure before remediation.
+- [ ] #3 WebUI and extension routes can be tested without depending on a live backend.
+- [ ] #4 Test naming and fixture data preserve the Knowledge QA-only scope and do not use flashcard terminology.
+- [ ] #5 Verification commands are recorded in the task notes or plan.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+See Docs/superpowers/plans/2026-06-07-knowledge-qa-state-fixtures-and-baseline-plan.md.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Completed deterministic /knowledge Knowledge QA baseline coverage for TASK-528.1. Added a shared state fixture builder for audited Knowledge QA states, fixture-backed unit coverage for connection/layout states, a WebUI readiness timeout baseline test documenting the current no-recovery behavior, WebUI Playwright route-state coverage for ready search and cited results without a live backend, and extension Playwright route-state coverage for setup-required and connected-ready states. Added TLDW_E2E_SKIP_EXTENSION_BUILD to extension global setup so existing valid builds can be used for targeted e2e verification. Verification: Knowledge QA unit fixtures passed (18 tests), ServerReadinessGate passed (5 tests), WebUI route-state Playwright passed (2 tests), extension route-state Playwright passed (2 tests) when run outside sandbox due Chromium extension launch permissions. Bandit not applicable: no Python files touched.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-528.2 - Fix-knowledge-WebUI-readiness-timeout-and-route-level-recovery.md
+++ b/backlog/tasks/task-528.2 - Fix-knowledge-WebUI-readiness-timeout-and-route-level-recovery.md
@@ -1,0 +1,57 @@
+---
+id: TASK-528.2
+title: Fix /knowledge WebUI readiness timeout and route-level recovery
+status: Done
+labels:
+- webui
+- knowledge
+- ux
+- accessibility
+priority: high
+parent_task_id: TASK-528
+documentation:
+- Docs/superpowers/plans/2026-06-07-knowledge-webui-readiness-recovery-plan.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Fix the WebUI /knowledge blocker where backend readiness failure leads to a blank or visually missing main state. Ensure users get actionable Knowledge QA recovery instead of a dead end. Do not add flashcard behavior to /knowledge.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 WebUI /knowledge never shows a blank main area after backend health timeout.
+- [ ] #2 The recovery state identifies backend readiness, setup, auth, or connectivity failure where possible.
+- [ ] #3 Users can retry, open diagnostics, or navigate to setup/settings from the recovery state.
+- [ ] #4 KnowledgeQA route-level recovery is reachable after global readiness timeout.
+- [ ] #5 Automated coverage verifies stalled health and failed health states.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+See Docs/superpowers/plans/2026-06-07-knowledge-webui-readiness-recovery-plan.md.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Completed WebUI /knowledge readiness recovery. ServerReadinessGate now uses a per-attempt health timeout, preserves healthy-backend behavior, and renders an actionable backend readiness recovery panel after timeout while keeping route children mounted so Knowledge QA route-level recovery remains reachable. Recovery includes the health endpoint, waited duration, Retry, Health & diagnostics, and Server settings actions. Added failed-health and stalled-health unit coverage plus /knowledge Playwright recovery coverage. Verification: ServerReadinessGate Vitest passed (6 tests), KnowledgeQA.connection Vitest passed (7 tests), knowledge-readiness-recovery Playwright passed (2 tests), and the prior knowledge-qa-states Playwright baseline passed (2 tests). A stale existing Next dev server had to be terminated once so Playwright could load the updated bundle. Bandit not applicable: no Python files touched.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-528.3 - Improve-knowledge-extension-setup-diagnostics-and-recovery.md
+++ b/backlog/tasks/task-528.3 - Improve-knowledge-extension-setup-diagnostics-and-recovery.md
@@ -1,0 +1,57 @@
+---
+id: TASK-528.3
+title: Improve /knowledge extension setup diagnostics and recovery
+status: Done
+labels:
+- extension
+- knowledge
+- ux
+- accessibility
+priority: high
+parent_task_id: TASK-528
+documentation:
+- Docs/superpowers/plans/2026-06-07-knowledge-extension-setup-diagnostics-plan.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Improve the extension /knowledge setup-required state so users can tell whether server URL, API key, host permission, allowlist, or backend reachability is blocking Knowledge QA. Keep the page scoped to Knowledge QA and do not add flashcard behavior.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Extension /knowledge setup gate shows concrete configuration and reachability checks.
+- [ ] #2 The UI explains next actions for missing URL, missing API key, missing host permission, and unreachable backend.
+- [ ] #3 The setup/tour interaction does not distract from the blocking recovery path.
+- [ ] #4 Automated coverage verifies setup-required, unconfigured, and unreachable-backend states.
+- [ ] #5 WebUI and extension differences are documented where setup behavior must differ.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+See Docs/superpowers/plans/2026-06-07-knowledge-extension-setup-diagnostics-plan.md.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+TASK-528.3 completed implementation and source coverage. Verification: `bunx vitest run src/components/Option/KnowledgeQA/__tests__/KnowledgeQA.connection.test.tsx src/components/Option/KnowledgeQA/__tests__/KnowledgeQALayout.behavior.test.tsx` passed 20 tests from apps/packages/ui; `bun run compile` passed from apps/extension. Extension runtime Playwright verification was attempted but blocked before browser launch because WXT production build hung twice after duplicated-import warnings; both hung processes were terminated and the blocker is documented in the plan. Bandit not applicable because no Python files were touched.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-528.4 - Clarify-knowledge-first-run-empty-and-no-source-recovery-states.md
+++ b/backlog/tasks/task-528.4 - Clarify-knowledge-first-run-empty-and-no-source-recovery-states.md
@@ -1,0 +1,61 @@
+---
+id: TASK-528.4
+title: Clarify /knowledge first-run empty and no-source recovery states
+status: Done
+assignee: []
+created_date: ''
+updated_date: '2026-06-07 02:54'
+labels:
+  - webui
+  - extension
+  - knowledge
+  - ux
+dependencies: []
+documentation:
+  - Docs/superpowers/plans/2026-06-07-knowledge-first-run-empty-recovery-plan.md
+parent_task_id: TASK-528
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Clarify the /knowledge first-run, empty, no indexed source, no selected source, offline, and failed-search recovery states for beginner users. The page remains Knowledge QA for searching a personal library and reviewing grounded answers with citations.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 First-run copy explains what /knowledge searches and how grounded answers use citations.
+- [x] #2 No indexed sources is distinct from no selected sources.
+- [x] #3 Recovery CTAs route to add/index sources, select sources, retry backend, or enable web fallback only when appropriate.
+- [x] #4 No-source disabled search state has visible inline explanation, not hover-only tooltip.
+- [x] #5 Beginner recovery states are covered by component and route tests.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+See Docs/superpowers/plans/2026-06-07-knowledge-first-run-empty-recovery-plan.md.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented a Knowledge QA ready-state recovery classifier that distinguishes no indexed sources, no selected sources, web-only search, backend unavailable, and ready states. Updated first-run copy to describe searching selected personal-library sources and inspecting citations. Added no-indexed add/index CTAs to existing Media/Notes surfaces, no-selected source selection CTAs, visible inline disabled-search explanations, server-capability-aware web fallback controls, and conditional no-results actions. Added WebUI and extension route specs for empty recovery states; runtime browser execution is documented as blocked by local Chromium/WXT issues.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Clarified /knowledge beginner recovery states without adding flashcard behavior. The page now distinguishes no indexed library sources from no selected source categories, disables Ask with visible inline recovery copy when the library cannot be searched, gates web fallback controls on server capability, and hides nearest-match recovery unless backend candidate data exists. Verification: focused Knowledge QA Vitest suite passed 48 tests; extension TypeScript compile passed; WebUI Playwright route execution was blocked by Chromium MachPort permission denial; extension route execution was blocked by the known WXT production build hang (TASK-306); Bandit was not applicable because no Python files were touched.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-528.5 - Harden-knowledge-ready-search-source-scope-and-saved-profiles.md
+++ b/backlog/tasks/task-528.5 - Harden-knowledge-ready-search-source-scope-and-saved-profiles.md
@@ -1,0 +1,66 @@
+---
+id: TASK-528.5
+title: Harden /knowledge ready search source scope and saved profiles
+status: Done
+assignee: []
+created_date: ''
+updated_date: '2026-06-07 03:05'
+labels:
+  - webui
+  - extension
+  - knowledge
+  - ux
+dependencies: []
+documentation:
+  - >-
+    Docs/superpowers/plans/2026-06-07-knowledge-ready-search-source-scope-plan.md
+parent_task_id: TASK-528
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Harden the ready /knowledge search workflow for source categories, exact document/media and note selection, saved profiles, suggestions, keyboard shortcuts, preset naming, web fallback, and answer model/provider selection. Do not introduce flashcard or study-set behavior.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Ready state supports clear source category and exact document/note selection with accurate selected counts.
+- [x] #2 Saved source/search profiles can be created, restored, deleted, and reached from compact/simple mode or an equivalent drawer.
+- [x] #3 Search suggestions and keyboard shortcuts work without trapping keyboard users.
+- [x] #4 Preset naming is consistent across toolbar, settings, history, and export.
+- [x] #5 Web fallback and answer model/provider controls have clear loading and error states.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+See Docs/superpowers/plans/2026-06-07-knowledge-ready-search-source-scope-plan.md.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+Implemented ready-search source-scope hardening. Saved profiles persist and restore exact media/note filters; compact/simple toolbar shows exact selected counts; answer-model menu now exposes provider loading/error recovery while preserving server-default and manual model entry; user-facing preset naming is Fast/Balanced/Deep/Custom while keeping the internal thorough id. Verification: focused Knowledge QA Vitest suite passed (8 files, 93 tests), git diff --check passed, scope grep found no flashcard/deck/spaced repetition/study set terminology in touched Knowledge QA files, and Bandit is not applicable because no Python files were touched. Known skip: route fixture e2e was not rerun because the previously recorded Chromium launch/WXT build blockers remain from TASK-528.4/TASK-306.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Ready /knowledge search controls are hardened for source categories, exact document/note scope, saved profiles, compact-mode counts, preset naming, web fallback capability state, and answer model loading/error recovery. Targeted Knowledge QA unit/behavior verification passed. Route-level E2E remains blocked by the previously documented browser/runtime issue, not by this implementation.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-528.6 - Validate-knowledge-results-evidence-no-results-and-export-workflows.md
+++ b/backlog/tasks/task-528.6 - Validate-knowledge-results-evidence-no-results-and-export-workflows.md
@@ -1,0 +1,62 @@
+---
+id: TASK-528.6
+title: Validate /knowledge results evidence no-results and export workflows
+status: Done
+assignee: []
+created_date: ''
+updated_date: '2026-06-07 03:30'
+labels:
+  - webui
+  - extension
+  - knowledge
+  - ux
+  - testing
+dependencies: []
+documentation:
+  - Docs/superpowers/plans/2026-06-07-knowledge-results-evidence-export-plan.md
+parent_task_id: TASK-528
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Validate and harden /knowledge answer results, citations, evidence rail, Sources versus Details views, no-results recovery, follow-up search, and export behavior. Keep the workflow focused on grounded Knowledge QA.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Result answers expose visible citations that map to evidence rail sources.
+- [x] #2 Sources and Details evidence views explain source choice, retrieval, reranking, web fallback, and verification when data is available.
+- [x] #3 No-results recovery offers broaden scope, adjust query/settings, enable web fallback when available, or inspect nearest matches only when real candidates exist.
+- [x] #4 Export supports expected formats and includes answer, query, sources, citations, and optional settings snapshot.
+- [x] #5 Automated tests cover cited results, no-results, failed search, and export behavior.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+See Docs/superpowers/plans/2026-06-07-knowledge-results-evidence-export-plan.md.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented TASK-528.6 results/evidence/export hardening. Export Markdown/PDF/Notes generation now includes citation mappings, safe settings snapshot context, preset, and search details when requested. Search details now explains absent telemetry instead of rendering N/A rows. No-results recovery gained focused component coverage. WebUI empty-recovery E2E selectors were hardened after Playwright strict-mode ambiguity.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+TASK-528.6 complete. Verification: focused ExportDialog/SearchDetails Vitest 30 tests passed; NoResultsRecovery Vitest 2 tests passed; broader Knowledge QA Vitest suite 97 tests passed; WebUI Knowledge QA route Playwright suite 4 tests passed after selector hardening; git diff --check passed; out-of-scope terminology guard found no matches in touched Knowledge QA source/test files; Bandit not applicable because no Python backend files changed. Known skip: extension Playwright run was attempted but WXT production build hung before tests executed and had to be terminated. Package-wide tsc remains blocked by existing baseline TypeScript errors outside this slice.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-528.7 - Harden-knowledge-power-user-settings-simple-mode-and-cross-surface-parity.md
+++ b/backlog/tasks/task-528.7 - Harden-knowledge-power-user-settings-simple-mode-and-cross-surface-parity.md
@@ -1,0 +1,67 @@
+---
+id: TASK-528.7
+title: Harden /knowledge power-user settings simple mode and cross-surface parity
+status: Done
+assignee: []
+created_date: ''
+updated_date: '2026-06-07 05:39'
+labels:
+  - webui
+  - extension
+  - knowledge
+  - ux
+  - accessibility
+dependencies: []
+documentation:
+  - >-
+    Docs/superpowers/plans/2026-06-07-knowledge-power-user-settings-parity-plan.md
+parent_task_id: TASK-528
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Harden /knowledge for experienced users with many sources: Basic versus Expert RAG settings, simple versus detailed layouts, provider/model controls, evidence inspection, compact workflow efficiency, and WebUI/extension parity. Do not add flashcard behavior.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Basic and Expert RAG settings are usable, reversible, keyboard-accessible, and focus-safe.
+- [x] #2 Simple/compact mode still exposes source scope, profiles, preset, web fallback, model/provider, and settings efficiently.
+- [x] #3 Provider/model controls handle loading, default, manual entry, and failure states.
+- [x] #4 WebUI and extension behavior is aligned except for documented setup/config differences.
+- [x] #5 Responsive and accessibility checks cover desktop, mobile, and extension options surfaces.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+See Docs/superpowers/plans/2026-06-07-knowledge-power-user-settings-parity-plan.md.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+- Compact simple mode now opens a source scope and profiles dialog that reuses shared KnowledgeContextBar controls for source categories, exact document/note scope, saved profiles, preset, web fallback, answer model/provider, and advanced settings.
+- CompactToolbar now summarizes exact selected document/note scope, labels source/profile access for assistive tech, and respects web fallback availability when rendering the web toggle.
+- Settings/provider coverage now exercises reset defaults, Escape close, focus return, Expert All Options filtering, boolean setting updates, provider failure redaction, server default clearing, manual model entry, and restored manual model summary.
+- WebUI and extension empty-recovery E2E specs were updated for the compact source scope flow. WebUI Chromium E2E passed. Extension E2E was attempted, but the WXT production build stalled before any browser test started; the stuck process tree was terminated and this is recorded as a known verification blocker.
+- Bandit is not applicable for TASK-528.7 because only frontend and E2E files were touched.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Hardened Knowledge QA power-user controls by giving compact/simple mode access to the same source scope, saved profile, preset, web fallback, answer model, and settings controls used in detailed mode. Added focused accessibility, compact parity, provider/model, and recovery-flow coverage. Targeted Vitest and WebUI Playwright checks pass; extension runtime E2E remains blocked by a WXT production build stall before browser execution.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-528.8 - Complete-knowledge-UAT-scripts-documentation-and-regression-guardrails.md
+++ b/backlog/tasks/task-528.8 - Complete-knowledge-UAT-scripts-documentation-and-regression-guardrails.md
@@ -1,0 +1,76 @@
+---
+id: TASK-528.8
+title: Complete /knowledge UAT scripts documentation and regression guardrails
+status: Done
+assignee: []
+created_date: ''
+updated_date: '2026-06-07 05:48'
+labels:
+  - webui
+  - extension
+  - knowledge
+  - qa
+  - documentation
+dependencies: []
+documentation:
+  - >-
+    Docs/superpowers/plans/2026-06-07-knowledge-uat-regression-guardrails-plan.md
+  - Docs/Plans/2026-06-07-knowledge-qa-uat-checklist.md
+  - Docs/User_Guides/WebUI_Extension/Knowledge_QA_Guide.md
+parent_task_id: TASK-528
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Turn the /knowledge UX audit UAT scripts into repeatable release checks with documentation, regression guardrails, and final verification for WebUI and extension. Keep /knowledge scoped to Knowledge QA and do not include flashcard workflows.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 UAT scripts cover backend unavailable, first-run/no-source, successful cited search, no-results, scoped source search, advanced settings, evidence review, and export.
+- [x] #2 WebUI versus extension behavior differences are documented and intentional.
+- [x] #3 Regression test commands are recorded for frontend, extension, and any touched backend scope.
+- [x] #4 Page-specific Knowledge QA help or documentation is updated where needed.
+- [x] #5 Final verification records known skips, blockers, and confirms no flashcard behavior was added to /knowledge.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+See Docs/superpowers/plans/2026-06-07-knowledge-uat-regression-guardrails-plan.md.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+- Added the Knowledge QA UAT checklist at Docs/Plans/2026-06-07-knowledge-qa-uat-checklist.md, covering backend unavailable recovery, first-run/no-source recovery, successful cited search, no-results recovery, scoped document/note search, advanced settings/evidence review, and export.
+- Added the Knowledge QA user guide at Docs/User_Guides/WebUI_Extension/Knowledge_QA_Guide.md, documenting source scope, citations/evidence, presets/settings, web fallback, answer model/provider controls, export, related workflows, and WebUI/extension differences.
+- Recorded consolidated regression commands for shared UI Vitest, WebUI Playwright, extension Playwright, backend pytest/Bandit when applicable, and the Knowledge QA scope terminology guard.
+- Verification: bunx vitest run src/components/Option/KnowledgeQA passed 46 files / 377 tests from apps/packages/ui.
+- Verification: npx playwright test e2e/ux-audit/knowledge-readiness-recovery.spec.ts e2e/ux-audit/knowledge-qa-states.spec.ts e2e/ux-audit/knowledge-empty-recovery.spec.ts --project=chromium passed 6 tests from apps/tldw-frontend.
+- Verification: trailing-whitespace guard passed for TASK-528.8 docs/task files, and the Knowledge QA code/test scope guard found no deck/spaced-repetition/study-set terminology in touched Knowledge QA source or E2E files.
+- Known blocker: extension runtime E2E/UAT remains blocked by the previously recorded WXT production build stall before browser launch. No browser-phase extension evidence was produced in this closeout pass.
+- Bandit is not applicable for TASK-528.8 because only markdown documentation and Backlog records were touched.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Completed the Knowledge QA closeout documentation and regression guardrails. The new UAT checklist and user guide make the WebUI/extension release checks repeatable while preserving the Knowledge QA-only scope. Shared UI Vitest and WebUI Playwright checks pass; extension runtime E2E remains a documented WXT build blocker rather than a verified browser pass.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-528.9 - Address-Knowledge-QA-PR-review-feedback.md
+++ b/backlog/tasks/task-528.9 - Address-Knowledge-QA-PR-review-feedback.md
@@ -1,0 +1,48 @@
+---
+id: TASK-528.9
+title: Address Knowledge QA PR review feedback
+status: Done
+labels:
+- webui
+- knowledge
+- review
+priority: high
+parent_task_id: TASK-528
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Address actionable PR review feedback on the /knowledge Knowledge QA remediation PR after rebasing against latest dev. Verified items include deterministic state fixtures and no-results nearest-match evidence rail behavior. Preserve Knowledge QA-only scope and do not add flashcard behavior.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 PR branch is rebased on latest dev before fixes are pushed.
+- [ ] #2 Deterministic Knowledge QA fixtures do not use Date.now() or other runtime-varying timestamps.
+- [ ] #3 The no-results Show nearest matches recovery action opens the Details evidence view where closest misses are rendered.
+- [ ] #4 Relevant tests are added or updated and pass.
+- [ ] #5 Review feedback disposition and verification are recorded.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Addressed PR review feedback after refreshing latest dev. The branch remains based on origin/dev 5192e3226203e2c0042a57d70bec9d1e868168e8. Fixed Qodo issue 1 by replacing Date.now() in deterministic Knowledge QA fixtures with a fixed timestamp derived from 2026-06-07T12:00:00.000Z and added regression coverage that mocks Date.now(). Fixed Qodo issue 2 by restoring no-results nearest-match behavior so the CTA opens the Details evidence tab where closest misses are rendered, with regression coverage. Gemini's saved-profile web-fallback comment was already resolved on the PR branch. Verification: targeted Vitest 2 files / 26 tests passed; full shared Knowledge QA Vitest 53 files / 423 tests passed; focused WebUI Playwright 6 Chromium tests passed; git diff --check passed; Date.now scan for knowledgeQaStateFixtures returned no matches; Knowledge QA scope guard found no deck/spaced-repetition/study-set terminology. Bandit not applicable because no Python files were touched.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## Change summary

- Hardened `/knowledge` as a Knowledge QA workflow for personal-library search, grounded answers, citations, evidence review, no-source/no-results recovery, export, and source scope control.
- Added deterministic Knowledge QA state fixtures plus WebUI and extension regression coverage for readiness, setup diagnostics, empty/no-source recovery, ready search, results, and no-results states.
- Documented the phased TASK-528 remediation plan, UAT checklist, and WebUI/extension Knowledge QA guide while keeping flashcards out of `/knowledge` scope.

## Verification

- `bunx vitest run src/components/Option/KnowledgeQA` from `apps/packages/ui`: 53 files, 421 tests passed.
- `npx playwright test e2e/ux-audit/knowledge-readiness-recovery.spec.ts e2e/ux-audit/knowledge-qa-states.spec.ts e2e/ux-audit/knowledge-empty-recovery.spec.ts --project=chromium` from `apps/tldw-frontend`: 6 tests passed.
- `git diff --check origin/dev..HEAD`: passed.
- Scope guard: `rg -n "deck|spaced repetition|study-set|study set" apps/packages/ui/src/components/Option/KnowledgeQA apps/tldw-frontend/e2e/ux-audit/knowledge*.spec.ts apps/extension/tests/e2e/knowledge*.spec.ts`: no matches.

## Known limitation

- Extension runtime E2E remains blocked by the existing WXT production build stall documented in the TASK-528 plan/docs. The PR adds extension state/recovery specs and build-extension handling, but the full extension browser run was not completed.

## Scope note

`/knowledge` remains a Knowledge QA route. This PR does not add flashcard review flows, spaced repetition, decks, or study-set behavior.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened the `/knowledge` Knowledge QA workflow with clear recovery paths, setup diagnostics, and stronger tests across WebUI and the extension. Implements TASK-528 to prevent dead ends and improve grounded answers, evidence, and export.

- **New Features**
  - Added deterministic fixtures and regression tests for ready, results, no-results, empty, and setup states in WebUI and extension.
  - Built extension setup diagnostics with actions for missing server URL/API key, host permission, and unreachable backend.
  - Introduced route-level recovery: classifies ready/no-indexed/no-selected/web-only; inline blocked-search copy; detects web fallback availability; context bar disables the web toggle when unsupported; improved “No results” with web fallback, broaden-scope, and scope controls.
  - Upgraded export to include query, settings (sources, exact selections, preset, provider/model), search details, and better citation mapping.
  - Polished source scope: compact toolbar shows exact doc/note counts; preset label is now “Deep”. Added Knowledge QA guide and a UAT checklist.

- **Bug Fixes**
  - WebUI no longer goes blank after health timeout; shows actionable recovery with diagnostics and retry.
  - Search Details now formats missing telemetry as “Not reported” and hides empty rows.
  - Answer Model menu handles provider loading/error states.
  - Addressed review feedback: “Show nearest matches” opens the Details evidence view; deterministic fixtures avoid runtime timestamps.
  - Accessibility and copy tweaks in settings and menus; keyboard focus guards. E2E infra: allow skipping extension build via `TLDW_E2E_SKIP_EXTENSION_BUILD`.

<sup>Written for commit 66bbf947d55eb9bc48e4a07586e514a99859c30c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2289?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

