### PR TITLE
Guard WebUI extension copilot lazy entrypoint

### DIFF
--- a/apps/extension/tests/unit/copilot-entrypoint-lazy-import.test.ts
+++ b/apps/extension/tests/unit/copilot-entrypoint-lazy-import.test.ts
@@ -11,6 +11,9 @@ describe("copilot content entrypoint", () => {
   test("keeps shared popup implementation behind runtime import", () => {
     const source = readFileSync(entrypointPath, "utf8")
 
+    expect(source).toContain(
+      'import { defineContentScript } from "wxt/utils/define-content-script"'
+    )
     expect(source).toContain("defineContentScript")
     expect(source).toMatch(
       /import\(\s*["']@tldw\/ui\/entries\/copilot-popup\.content["']\s*\)/

--- a/apps/extension/tests/unit/copilot-entrypoint-lazy-import.test.ts
+++ b/apps/extension/tests/unit/copilot-entrypoint-lazy-import.test.ts
@@ -11,8 +11,8 @@ describe("copilot content entrypoint", () => {
   test("keeps shared popup implementation behind runtime import", () => {
     const source = readFileSync(entrypointPath, "utf8")
 
-    expect(source).toContain(
-      'import { defineContentScript } from "wxt/utils/define-content-script"'
+    expect(source).toMatch(
+      /import\s*\{\s*defineContentScript\s*\}\s*from\s*["']wxt\/utils\/define-content-script["']/
     )
     expect(source).toContain("defineContentScript")
     expect(source).toMatch(

--- a/backlog/tasks/task-2277 - Fix-WebUI-extension-WXT-copilot-build-hang.md
+++ b/backlog/tasks/task-2277 - Fix-WebUI-extension-WXT-copilot-build-hang.md
@@ -1,0 +1,56 @@
+---
+id: TASK-2277
+title: Fix WebUI extension WXT copilot build hang
+status: Done
+labels:
+- extension
+- webui
+- build
+- wxt
+priority: high
+references:
+- apps/extension/entrypoints/copilot-popup.content.tsx
+- apps/extension/tests/unit/copilot-entrypoint-lazy-import.test.ts
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Port the current WebUI/browser extension build fix onto a clean branch from dev. Keep scope limited to the copilot content-script wrapper, a focused regression guard, and verification that extension production builds no longer hang.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Confirm the dev-branch copilot wrapper state and whether a code change is still needed.
+2. Preserve the WXT metadata wrapper that dynamically imports the shared copilot content script in main().
+3. Add a focused source guard to prevent static re-export regressions.
+4. Verify with the focused test, compile, and browser production builds needed for the PR.
+5. Record verification and Bandit applicability in the task.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Strengthened the existing regression guard for the WebUI extension copilot content-script wrapper by requiring the WXT defineContentScript import explicitly. The current origin/dev wrapper already uses defineContentScript with a runtime dynamic import, so this PR preserves that fix and prevents regression to the static re-export that caused WXT metadata discovery/build hangs. Verification: bun test tests/unit/copilot-entrypoint-lazy-import.test.ts passed; bun run compile passed; bun run build:chrome:prod passed; bun run build:firefox:prod passed; bun run build:edge:prod passed. Bandit was invoked on the touched TS test path via the project venv and produced zero findings; it reported the TypeScript file as non-Python syntax, as expected.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## Summary
- Strengthens the copilot entrypoint regression test so it requires the WXT `defineContentScript` wrapper import explicitly.
- Records TASK-2277 with the investigation and verification notes.
- Confirms `origin/dev` already contains the runtime dynamic import wrapper that avoids WXT metadata-discovery build hangs.

## Verification
- `bun test tests/unit/copilot-entrypoint-lazy-import.test.ts`
- `bun run compile`
- `bun run build:chrome:prod`
- `bun run build:firefox:prod`
- `bun run build:edge:prod`
- Bandit via project venv on the touched TypeScript test path: zero findings; Bandit reported the TS file as non-Python syntax, as expected.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Strengthens the copilot content-script entrypoint test to assert the `defineContentScript` import from `wxt/utils/define-content-script` and the runtime dynamic import. Records and verifies the WXT metadata-discovery build-hang fix for TASK-2277 already on `dev`.

<sup>Written for commit f14d9f94434683db2153dd4f3a6e720217b4b4e2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2291?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

