### PR TITLE
Unify Mermaid artifact preview actions

### DIFF
--- a/Docs/superpowers/plans/2026-06-07-mermaid-artifact-preview-unification-plan.md
+++ b/Docs/superpowers/plans/2026-06-07-mermaid-artifact-preview-unification-plan.md
@@ -1,0 +1,53 @@
+# Mermaid Artifact Preview Unification Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make Mermaid diagram artifacts in the chat artifact panel use the same preview/action surface as assistant Mermaid markdown blocks.
+
+**Architecture:** Reuse `MermaidDiagramBlock` as the shared diagram artifact surface inside `ArtifactsPanel` instead of rendering bare `Mermaid`. Keep artifact-panel footer actions intact for existing panel-level behavior, and pass `enableArtifactAction={false}` so the panel does not show a recursive artifact-open control.
+
+**Tech Stack:** React 18, TypeScript, Ant Design tooltips/modal mocks, Vitest/JSDOM, existing shared UI Mermaid components.
+
+---
+
+### Stage 1: Artifact Panel Contract Tests
+**Goal**: Prove diagram artifacts use shared Mermaid block controls.
+**Success Criteria**: The artifact-panel Mermaid test fails until the panel renders `MermaidDiagramBlock` controls for preview/copy/download and omits the recursive artifact action.
+**Tests**: `bunx vitest run src/components/Sidepanel/Chat/__tests__/ArtifactsPanel.mermaid.test.tsx`
+**Status**: Complete
+
+- [x] Add a test/mock contract for `MermaidDiagramBlock` in `ArtifactsPanel.mermaid.test.tsx`.
+- [x] Assert the panel renders shared controls: `Open Mermaid preview`, `Copy Mermaid source`, and `Download Mermaid SVG`.
+- [x] Assert the panel does not render `View Mermaid diagram`.
+- [x] Run the focused test and confirm it fails before implementation.
+
+### Stage 2: Panel Rendering Change
+**Goal**: Replace bare panel Mermaid rendering with the shared Mermaid diagram block.
+**Success Criteria**: Diagram artifacts render through `MermaidDiagramBlock` with artifact actions disabled.
+**Tests**: Focused artifact-panel Mermaid test.
+**Status**: Complete
+
+- [x] Import `MermaidDiagramBlock` in `ArtifactsPanel.tsx`.
+- [x] Use it for `active.kind === "diagram"` with `source={active.content}` and `enableArtifactAction={false}`.
+- [x] Remove the now-unused bare `Mermaid` import.
+- [x] Run the focused test and confirm it passes.
+
+### Stage 3: Verification And Task Closeout
+**Goal**: Verify the focused Mermaid/chat scope and record known skips.
+**Success Criteria**: Relevant tests pass, whitespace check passes, task status records verification.
+**Tests**:
+- `bunx vitest run src/components/Sidepanel/Chat/__tests__/ArtifactsPanel.mermaid.test.tsx src/components/Common/__tests__/MermaidDiagramBlock.test.tsx src/components/Common/__tests__/MermaidPreviewDialog.test.tsx`
+- `git diff --check`
+**Status**: Complete
+
+- [x] Run the focused regression set.
+- [x] Run `git diff --check`.
+- [x] Run Bandit only if backend Python is touched; otherwise record frontend-only skip.
+- [x] Update `TASK-2277` with results and final summary.
+
+Verification results:
+- Initial focused test failed as expected because the panel still rendered bare `Mermaid` and no `shared-mermaid-diagram-block`.
+- Focused artifact-panel test passed after implementation: 1 file, 2 tests.
+- Focused shared Mermaid regression set passed: 3 files, 25 tests.
+- `git diff --check` passed.
+- `env NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit --project tsconfig.json` failed in existing latest-`dev` KnowledgeQA test fixtures outside this change: `KnowledgeQALayout.behavior.test.tsx` and `knowledgeQaStateFixtures.ts`.

--- a/apps/packages/ui/src/components/Sidepanel/Chat/ArtifactsPanel.tsx
+++ b/apps/packages/ui/src/components/Sidepanel/Chat/ArtifactsPanel.tsx
@@ -16,7 +16,7 @@ import { Highlight, themes } from "prism-react-renderer"
 import { browser } from "wxt/browser"
 import { useArtifactsStore } from "@/store/artifacts"
 import { useStoreMessageOption } from "@/store/option"
-import { Mermaid } from "@/components/Common/Mermaid"
+import { MermaidDiagramBlock } from "@/components/Common/MermaidDiagramBlock"
 import type { DataTable, DataTableColumn, DataTableSource } from "@/types/data-tables"
 import { queueDataTablesPrefill } from "@/utils/data-tables-prefill"
 
@@ -301,9 +301,9 @@ export const ArtifactsPanel = () => {
       </div>
       <div className="flex-1 overflow-auto px-4 py-3">
         {active.kind === "diagram" ? (
-          <Mermaid
-            code={active.content}
-            className="rounded-xl border border-border bg-surface2/60 px-4 py-3"
+          <MermaidDiagramBlock
+            enableArtifactAction={false}
+            source={active.content}
           />
         ) : isCodeArtifact ? (
           <Highlight

--- a/apps/packages/ui/src/components/Sidepanel/Chat/__tests__/ArtifactsPanel.mermaid.test.tsx
+++ b/apps/packages/ui/src/components/Sidepanel/Chat/__tests__/ArtifactsPanel.mermaid.test.tsx
@@ -5,6 +5,15 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import { ArtifactsPanel } from "../ArtifactsPanel"
 import { useArtifactsStore, type ArtifactItem } from "@/store/artifacts"
 
+const mermaidDiagramBlockMock = vi.hoisted(() => vi.fn())
+
+type MermaidDiagramBlockMockProps = {
+  source: string
+  blockIndex?: number
+  artifactContextId?: string
+  enableArtifactAction?: boolean
+}
+
 vi.mock("react-i18next", () => ({
   useTranslation: () => ({
     t: (_key: string, fallback?: string) => fallback || _key
@@ -41,27 +50,23 @@ vi.mock("@/store/option", () => ({
     })
 }))
 
-vi.mock("@/components/Common/Mermaid", () => ({
-  Mermaid: ({
-    code,
-    className
-  }: {
-    code: string
-    className?: string
-  }) => (
-    <div
-      aria-label="Mock artifact Mermaid diagram"
-      className={className}
-      role="img"
-    >
-      {code}
-    </div>
-  ),
-  default: ({ code }: { code: string }) => (
-    <div aria-label="Mock artifact Mermaid diagram" role="img">
-      {code}
-    </div>
-  )
+vi.mock("@/components/Common/MermaidDiagramBlock", () => ({
+  MermaidDiagramBlock: (props: MermaidDiagramBlockMockProps) => {
+    mermaidDiagramBlockMock(props)
+    return (
+      <section data-testid="shared-mermaid-diagram-block">
+        <div aria-label="Mock shared Mermaid diagram" role="img">
+          {props.source}
+        </div>
+        {props.enableArtifactAction && (
+          <button type="button">View Mermaid diagram</button>
+        )}
+        <button type="button">Open Mermaid preview</button>
+        <button type="button">Copy Mermaid source</button>
+        <button type="button">Download Mermaid SVG</button>
+      </section>
+    )
+  }
 }))
 
 const diagramArtifact: ArtifactItem = {
@@ -86,6 +91,7 @@ const resetArtifactsStore = () => {
 
 describe("ArtifactsPanel Mermaid artifacts", () => {
   beforeEach(() => {
+    mermaidDiagramBlockMock.mockClear()
     resetArtifactsStore()
   })
 
@@ -96,7 +102,7 @@ describe("ArtifactsPanel Mermaid artifacts", () => {
     resetArtifactsStore()
   })
 
-  it("renders diagram artifacts with the shared Mermaid renderer", () => {
+  it("renders diagram artifacts with the shared Mermaid block actions", () => {
     useArtifactsStore.getState().openArtifact(diagramArtifact)
 
     render(<ArtifactsPanel />)
@@ -104,10 +110,29 @@ describe("ArtifactsPanel Mermaid artifacts", () => {
     expect(screen.getByTestId("artifacts-panel")).toBeInTheDocument()
     expect(screen.getByText("Mermaid diagram 1")).toBeInTheDocument()
     expect(
-      screen.getByRole("img", { name: "Mock artifact Mermaid diagram" })
+      screen.getByTestId("shared-mermaid-diagram-block")
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole("img", { name: "Mock shared Mermaid diagram" })
     ).toHaveTextContent("graph TD A-->B")
-    expect(screen.getByRole("button", { name: /copy/i })).toBeInTheDocument()
-    expect(screen.getByRole("button", { name: /download/i })).toBeInTheDocument()
+    expect(
+      screen.getByRole("button", { name: "Open Mermaid preview" })
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole("button", { name: "Copy Mermaid source" })
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole("button", { name: "Download Mermaid SVG" })
+    ).toBeInTheDocument()
+    expect(
+      screen.queryByRole("button", { name: "View Mermaid diagram" })
+    ).not.toBeInTheDocument()
+    expect(mermaidDiagramBlockMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        enableArtifactAction: false,
+        source: diagramArtifact.content
+      })
+    )
   })
 
   it("jumps to the matching Mermaid artifact origin", () => {

--- a/backlog/tasks/task-2277 - Unify-Mermaid-artifact-panel-with-shared-preview-actions.md
+++ b/backlog/tasks/task-2277 - Unify-Mermaid-artifact-panel-with-shared-preview-actions.md
@@ -1,0 +1,70 @@
+---
+id: TASK-2277
+title: Unify Mermaid artifact panel with shared preview actions
+status: Done
+assignee:
+- '@codex'
+labels:
+- frontend
+- chat
+- mermaid
+- artifacts
+priority: medium
+references:
+- Docs/superpowers/specs/2026-06-04-chat-mermaid-diagrams-design.md
+- Docs/superpowers/plans/2026-06-04-chat-mermaid-diagrams-implementation-plan.md
+- https://github.com/rmusser01/tldw_server/pull/2284
+- https://github.com/rmusser01/tldw_server/pull/2292
+modified_files:
+- Docs/superpowers/plans/2026-06-07-mermaid-artifact-preview-unification-plan.md
+- apps/packages/ui/src/components/Sidepanel/Chat/ArtifactsPanel.tsx
+- apps/packages/ui/src/components/Sidepanel/Chat/__tests__/ArtifactsPanel.mermaid.test.tsx
+- backlog/tasks/task-2277 - Unify-Mermaid-artifact-panel-with-shared-preview-actions.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Unify diagram artifacts in the chat artifact panel with the shared Mermaid preview/action surface used by assistant markdown Mermaid blocks. Keep user messages unchanged and avoid broad non-chat markdown behavior changes.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Artifact panel diagram rendering reuses the shared Mermaid action/preview surface or a shared wrapper rather than bespoke action behavior.
+- [x] #2 Diagram artifacts keep copy/download/open behavior consistent with assistant Mermaid blocks.
+- [x] #3 Focused tests cover artifact-panel diagram rendering and preview actions.
+- [x] #4 No changes are made to user-message Mermaid rendering behavior.
+- [x] #5 Verification results and any known skips are recorded.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+- Added `Docs/superpowers/plans/2026-06-07-mermaid-artifact-preview-unification-plan.md` for the three-stage implementation checklist.
+- Updated `ArtifactsPanel` diagram rendering to use `MermaidDiagramBlock` with `enableArtifactAction={false}` instead of bare `Mermaid`.
+- Updated `ArtifactsPanel.mermaid.test.tsx` with a shared-block contract test for preview/copy/download controls and absence of the recursive `View Mermaid diagram` action.
+- TDD red run: `bunx vitest run src/components/Sidepanel/Chat/__tests__/ArtifactsPanel.mermaid.test.tsx` failed because `shared-mermaid-diagram-block` was absent while the panel still rendered bare `Mermaid`.
+- Verification:
+  - `bunx vitest run src/components/Sidepanel/Chat/__tests__/ArtifactsPanel.mermaid.test.tsx` passed: 1 file, 2 tests.
+  - `bunx vitest run src/components/Sidepanel/Chat/__tests__/ArtifactsPanel.mermaid.test.tsx src/components/Common/__tests__/MermaidDiagramBlock.test.tsx src/components/Common/__tests__/MermaidPreviewDialog.test.tsx` passed: 3 files, 25 tests.
+  - `git diff --check` passed.
+  - `env NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit --project tsconfig.json` failed in existing latest-`dev` KnowledgeQA test fixtures outside this change: `KnowledgeQALayout.behavior.test.tsx` and `knowledgeQaStateFixtures.ts`.
+- Bandit not run: touched scope is frontend TypeScript tests/components plus Markdown task/plan metadata only.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Mermaid diagram artifacts in the chat artifact panel now reuse the shared `MermaidDiagramBlock` action/preview surface instead of rendering bare `Mermaid`. The panel keeps its existing footer actions while the embedded diagram block supplies consistent Mermaid preview, source-copy, and SVG-download controls without exposing the recursive artifact-open action. Focused Mermaid tests and whitespace checks passed; full UI type-check remains blocked by existing latest-`dev` KnowledgeQA fixture errors outside this change.
+Draft PR: https://github.com/rmusser01/tldw_server/pull/2292
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## Summary
- Reuses the shared MermaidDiagramBlock inside the chat artifact panel for diagram artifacts.
- Keeps the panel footer actions while sharing preview, source-copy, and SVG-download behavior with assistant Mermaid blocks.
- Adds TASK-2277 and a focused implementation plan for this Mermaid artifact-card slice.

## Test Plan
- PASS: bunx vitest run src/components/Sidepanel/Chat/__tests__/ArtifactsPanel.mermaid.test.tsx
- PASS: bunx vitest run src/components/Sidepanel/Chat/__tests__/ArtifactsPanel.mermaid.test.tsx src/components/Common/__tests__/MermaidDiagramBlock.test.tsx src/components/Common/__tests__/MermaidPreviewDialog.test.tsx
- PASS: git diff --check
- KNOWN BASELINE: env NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit --project tsconfig.json fails in latest-dev KnowledgeQA test fixtures outside this PR diff.

## Change summary
Human-authored change summary required before marking ready for review/merge.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies Mermaid diagram artifacts in the chat artifacts panel by reusing the shared `MermaidDiagramBlock`, aligning preview/copy/SVG-download with assistant blocks. Keeps panel footer actions and disables the recursive artifact-open. Addresses TASK-2277.

- **Refactors**
  - Switched `ArtifactsPanel` to `MermaidDiagramBlock` with `enableArtifactAction={false}` for diagram artifacts.
  - Expanded `ArtifactsPanel.mermaid.test.tsx` to assert shared preview/copy/download actions and absence of “View Mermaid diagram”; added plan and task record for TASK-2277.

<sup>Written for commit 5f5c47e3957505a2b4177f099ca552ca1c5bfe96. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2292?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

