### PR TITLE
Reuse shared Mermaid preview in research artifacts

### DIFF
--- a/Docs/superpowers/plans/2026-06-07-research-mermaid-artifact-preview-unification-plan.md
+++ b/Docs/superpowers/plans/2026-06-07-research-mermaid-artifact-preview-unification-plan.md
@@ -1,0 +1,122 @@
+# Research Mermaid Artifact Preview Unification Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make Research Workspace mind-map artifact modals use the shared Mermaid diagram preview/action surface already used by assistant-facing chat Mermaid blocks.
+
+**Architecture:** Keep Mermaid detection and raw-output fallback local to the Research Workspace artifact viewer, but delegate valid Mermaid rendering and actions to `MermaidDiagramBlock`. Do not change user-message markdown rendering or chat artifact behavior in this slice.
+
+**Tech Stack:** React, Research Workspace artifact modal components, shared Mermaid UI components, Vitest.
+
+**Backlog Task:** TASK-2278
+
+---
+
+## Boundaries
+
+- Only assistant/generated Research Workspace mind-map artifact modal content is in scope.
+- User messages remain unchanged.
+- The existing raw fallback for non-Mermaid mind-map output remains unchanged.
+- The modal should reuse shared Mermaid preview/copy/SVG-download behavior instead of local zoom/export controls.
+
+## Files
+
+- Modify: `apps/packages/ui/src/components/Option/ResearchWorkspace/StudioPane/ArtifactModalContent.tsx`
+- Modify: `apps/packages/ui/src/components/Option/ResearchWorkspace/__tests__/StudioPane.stage2.test.tsx`
+- Modify: `backlog/tasks/task-2278 - Unify-Research-Workspace-Mermaid-artifact-modal-preview.md`
+
+## Task 1: Capture Shared Modal Contract In Tests
+
+- [x] Update the Research Workspace stage 2 test mock so `MermaidDiagramBlock` can be asserted directly.
+- [x] Change the fenced mind-map modal test to expect shared Mermaid preview/copy/SVG controls.
+- [x] Assert the modal does not expose the chat artifact action or legacy modal-only PNG/SVG export labels.
+- [x] Run the focused test and confirm it fails because the modal still renders bare `Mermaid`.
+
+Result: `bunx vitest run src/components/Option/ResearchWorkspace/__tests__/StudioPane.stage2.test.tsx -t "renders mind map diagrams from fenced mermaid content"` failed with `Unable to find an element by: [data-testid="research-shared-mermaid-block"]`, confirming the test catches the old bare Mermaid path.
+
+## Task 2: Reuse Shared Mermaid Diagram Block
+
+- [x] Replace the valid Mermaid branch in `MindMapArtifactViewer` with `MermaidDiagramBlock`.
+- [x] Pass `enableArtifactAction={false}` so the modal does not create a nested chat artifact action.
+- [x] Remove now-unused local zoom/export state, refs, and icon imports.
+- [x] Keep the raw non-Mermaid fallback branch intact.
+- [x] Run the focused mind-map modal tests and confirm they pass.
+
+Result: `bunx vitest run src/components/Option/ResearchWorkspace/__tests__/StudioPane.stage2.test.tsx -t "renders mind map diagrams from fenced mermaid content"` passed after the modal delegated valid Mermaid content to `MermaidDiagramBlock`.
+
+## Task 3: Verify And Close
+
+- [x] Run the Research Workspace focused test file or focused mind-map pattern.
+- [x] Run shared Mermaid component tests to guard the reused action surface.
+- [x] Run `git diff --check`.
+- [x] Run UI type-check and record any existing baseline failures separately from this slice.
+- [x] Record Bandit as not applicable because only TypeScript/React/docs/Backlog files are touched.
+- [x] Update TASK-2278 with verification results, final summary, and PR link.
+
+Verification:
+
+```bash
+bunx vitest run src/components/Option/ResearchWorkspace/__tests__/StudioPane.stage2.test.tsx -t "mind map"
+```
+
+Result: 1 file, 4 tests passed.
+
+```bash
+bunx vitest run src/components/Option/ResearchWorkspace/__tests__/StudioPane.stage2.test.tsx
+```
+
+Result: 1 file, 26 tests passed.
+
+```bash
+bunx vitest run src/components/Common/__tests__/Mermaid.test.tsx src/components/Common/__tests__/MermaidDiagramBlock.test.tsx src/components/Common/__tests__/MermaidPreviewDialog.test.tsx
+```
+
+Result: 3 files, 27 tests passed.
+
+```bash
+git diff --check
+```
+
+Result: passed.
+
+```bash
+env NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit
+```
+
+Result: failed on existing unrelated KnowledgeQA fixture type errors in `KnowledgeQALayout.behavior.test.tsx` and `knowledgeQaStateFixtures.ts`; no diagnostics were reported for touched Research Workspace or Mermaid files.
+
+Bandit: not applicable for this frontend-only TypeScript/React/docs/Backlog slice.
+
+Pull Request: https://github.com/rmusser01/tldw_server/pull/2293
+
+## PR Review Follow-Up
+
+- [x] Rebased onto latest `origin/dev` after PR #2294 merged.
+- [x] Addressed CodeRabbit prop-contract comment by removing the now-unused `title` prop from `MindMapArtifactViewer` and its call site.
+- [x] Reran focused Research Workspace mind-map tests, shared Mermaid tests, `git diff --check`, and higher-heap UI type-check.
+
+Review verification:
+
+```bash
+bunx vitest run src/components/Option/ResearchWorkspace/__tests__/StudioPane.stage2.test.tsx -t "mind map"
+```
+
+Result: 1 file, 4 tests passed.
+
+```bash
+bunx vitest run src/components/Common/__tests__/Mermaid.test.tsx src/components/Common/__tests__/MermaidDiagramBlock.test.tsx src/components/Common/__tests__/MermaidPreviewDialog.test.tsx
+```
+
+Result: 3 files, 27 tests passed.
+
+```bash
+git diff --check
+```
+
+Result: passed.
+
+```bash
+env NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit
+```
+
+Result: failed on the existing unrelated KnowledgeQA fixture type errors in `KnowledgeQALayout.behavior.test.tsx` and `knowledgeQaStateFixtures.ts`; no diagnostics were reported for touched Research Workspace or Mermaid files.

--- a/apps/packages/ui/src/components/Option/ResearchWorkspace/StudioPane/ArtifactModalContent.tsx
+++ b/apps/packages/ui/src/components/Option/ResearchWorkspace/StudioPane/ArtifactModalContent.tsx
@@ -1,16 +1,10 @@
-import React, { useRef, useState } from "react"
+import React, { useState } from "react"
 import { useTranslation } from "react-i18next"
 import { Button, Input, Table as AntTable, message } from "antd"
-import {
-  Plus,
-  Save,
-  Search,
-  ZoomIn,
-  ZoomOut,
-} from "lucide-react"
+import { Plus, Save, Search } from "lucide-react"
 
+import { MermaidDiagramBlock } from "@/components/Common/MermaidDiagramBlock"
 import { MarkdownPreview } from "@/components/Common/MarkdownPreview"
-import Mermaid from "@/components/Common/Mermaid"
 import type { GeneratedArtifact } from "@/types/workspace"
 
 import {
@@ -34,38 +28,13 @@ import { buildProposalDeepResearchVerificationSections } from "./proposal-deep-r
 const MAX_DISPLAYED_UNRESOLVED_QUESTIONS = 3
 
 export const MindMapArtifactViewer: React.FC<{
-  title: string
   content: string
-}> = ({ title, content }) => {
-  const [zoom, setZoom] = useState(1)
-  const containerRef = useRef<HTMLDivElement | null>(null)
+}> = ({ content }) => {
   const mermaidCode = React.useMemo(() => extractMermaidCode(content), [content])
   const canRenderMermaid = React.useMemo(
     () => isLikelyMermaidDiagram(mermaidCode),
     [mermaidCode]
   )
-
-  const handleExportSvg = () => {
-    const svg = containerRef.current?.querySelector("svg")
-    if (!svg) return
-    const svgBlob = new Blob([svg.outerHTML], {
-      type: "image/svg+xml;charset=utf-8"
-    })
-    downloadBlobFile(svgBlob, `${title || "mind-map"}.svg`)
-  }
-
-  const handleExportPng = async () => {
-    if (!containerRef.current) return
-    const html2canvas = (await import("html2canvas")).default
-    const canvas = await html2canvas(containerRef.current, {
-      backgroundColor: "#ffffff",
-      scale: 2
-    })
-    canvas.toBlob((blob) => {
-      if (!blob) return
-      downloadBlobFile(blob, `${title || "mind-map"}.png`)
-    }, "image/png")
-  }
 
   if (!canRenderMermaid) {
     return (
@@ -81,47 +50,8 @@ export const MindMapArtifactViewer: React.FC<{
   }
 
   return (
-    <div className="flex max-h-[70vh] flex-col gap-3">
-      <div className="flex flex-wrap items-center gap-2">
-        <Button
-          size="small"
-          icon={<ZoomOut className="h-3.5 w-3.5" />}
-          onClick={() => setZoom((prev) => Math.max(0.5, Number((prev - 0.1).toFixed(2))))}
-        >
-          Zoom out
-        </Button>
-        <span className="text-xs text-text-muted">{Math.round(zoom * 100)}%</span>
-        <Button
-          size="small"
-          icon={<ZoomIn className="h-3.5 w-3.5" />}
-          onClick={() => setZoom((prev) => Math.min(2.5, Number((prev + 0.1).toFixed(2))))}
-        >
-          Zoom in
-        </Button>
-        <Button size="small" onClick={() => setZoom(1)}>
-          Reset
-        </Button>
-        <Button size="small" onClick={handleExportSvg}>
-          Export SVG
-        </Button>
-        <Button size="small" onClick={() => void handleExportPng()}>
-          Export PNG
-        </Button>
-      </div>
-
-      <div className="rounded border border-border bg-surface2/40 p-2 text-xs text-text-muted">
-        Scroll to pan the diagram when zoomed in.
-      </div>
-
-      <div className="max-h-[56vh] overflow-auto rounded border border-border bg-surface p-4">
-        <div
-          ref={containerRef}
-          style={{ transform: `scale(${zoom})`, transformOrigin: "top left" }}
-          className="inline-block min-w-full"
-        >
-          <Mermaid code={mermaidCode} />
-        </div>
-      </div>
+    <div className="max-h-[70vh] overflow-y-auto">
+      <MermaidDiagramBlock source={mermaidCode} enableArtifactAction={false} />
     </div>
   )
 }

--- a/apps/packages/ui/src/components/Option/ResearchWorkspace/StudioPane/index.tsx
+++ b/apps/packages/ui/src/components/Option/ResearchWorkspace/StudioPane/index.tsx
@@ -1191,7 +1191,7 @@ export const StudioPane: React.FC<StudioPaneProps> = ({
       Modal.info({
         title: artifact.title,
         content: renderArtifactModalContent(
-          <MindMapArtifactViewer title={artifact.title} content={artifact.content} />,
+          <MindMapArtifactViewer content={artifact.content} />,
           t("playground:studio.loadingOutputViewer", "Loading output viewer...")
         ),
         ...responsiveModalProps(960),

--- a/apps/packages/ui/src/components/Option/ResearchWorkspace/__tests__/StudioPane.stage2.test.tsx
+++ b/apps/packages/ui/src/components/Option/ResearchWorkspace/__tests__/StudioPane.stage2.test.tsx
@@ -4,12 +4,15 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import { Modal } from "antd"
 import type { WorkspaceSource } from "@/types/workspace"
 import { StudioPane } from "../StudioPane"
-const { mockScheduleWorkspaceUndoAction, mockUndoWorkspaceAction } = vi.hoisted(
-  () => ({
-    mockScheduleWorkspaceUndoAction: vi.fn(),
-    mockUndoWorkspaceAction: vi.fn()
-  })
-)
+const {
+  mockScheduleWorkspaceUndoAction,
+  mockUndoWorkspaceAction,
+  mockMermaidDiagramBlock
+} = vi.hoisted(() => ({
+  mockScheduleWorkspaceUndoAction: vi.fn(),
+  mockUndoWorkspaceAction: vi.fn(),
+  mockMermaidDiagramBlock: vi.fn()
+}))
 
 const {
   mockGenerateQuiz,
@@ -284,6 +287,29 @@ vi.mock("@/store/workspace", () => ({
 
 vi.mock("@/components/Common/Mermaid", () => ({
   default: ({ code }: { code: string }) => <div data-testid="mermaid">{code}</div>
+}))
+
+vi.mock("@/components/Common/MermaidDiagramBlock", () => ({
+  MermaidDiagramBlock: (props: {
+    source: string
+    enableArtifactAction?: boolean
+  }) => {
+    mockMermaidDiagramBlock(props)
+
+    return (
+      <section data-testid="research-shared-mermaid-block">
+        <div role="img" aria-label="Mock research Mermaid diagram">
+          {props.source}
+        </div>
+        {props.enableArtifactAction ? (
+          <button type="button">View Mermaid diagram</button>
+        ) : null}
+        <button type="button">Open Mermaid preview</button>
+        <button type="button">Copy Mermaid source</button>
+        <button type="button">Download Mermaid SVG</button>
+      </section>
+    )
+  }
 }))
 
 vi.mock("../undo-manager", () => ({
@@ -749,12 +775,38 @@ describe("StudioPane Stage 2 workflows", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "View" }))
 
-    expect(await screen.findByTestId("mermaid")).toHaveTextContent(
+    expect(
+      await screen.findByTestId("research-shared-mermaid-block")
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole("img", { name: "Mock research Mermaid diagram" })
+    ).toHaveTextContent(
       /mindmap\s+root\(\(Workspace\)\)\s+Findings/
     )
+    expect(mockMermaidDiagramBlock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        source: expect.stringContaining("mindmap"),
+        enableArtifactAction: false
+      })
+    )
     expect(
-      await screen.findByRole("button", { name: "Export SVG" })
+      screen.getByRole("button", { name: "Open Mermaid preview" })
     ).toBeInTheDocument()
+    expect(
+      screen.getByRole("button", { name: "Copy Mermaid source" })
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole("button", { name: "Download Mermaid SVG" })
+    ).toBeInTheDocument()
+    expect(
+      screen.queryByRole("button", { name: "View Mermaid diagram" })
+    ).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole("button", { name: "Export SVG" })
+    ).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole("button", { name: "Export PNG" })
+    ).not.toBeInTheDocument()
   })
 
   it("falls back to raw content for non-mermaid mind map output", async () => {

--- a/backlog/tasks/task-2278 - Unify-Research-Workspace-Mermaid-artifact-modal-preview.md
+++ b/backlog/tasks/task-2278 - Unify-Research-Workspace-Mermaid-artifact-modal-preview.md
@@ -1,0 +1,72 @@
+---
+id: TASK-2278
+title: Unify Research Workspace Mermaid artifact modal preview
+status: Done
+assignee:
+- '@codex'
+created_date: ''
+updated_date: 2026-06-07 16:57
+labels:
+- frontend
+- mermaid
+- research-workspace
+- artifacts
+dependencies: []
+references:
+- Docs/superpowers/specs/2026-06-04-chat-mermaid-diagrams-design.md
+- https://github.com/rmusser01/tldw_server/pull/2292
+- https://github.com/rmusser01/tldw_server/pull/2293
+- https://github.com/rmusser01/tldw_server/pull/2293#pullrequestreview-3332723163
+priority: medium
+modified_files:
+- apps/packages/ui/src/components/Option/ResearchWorkspace/StudioPane/ArtifactModalContent.tsx
+- apps/packages/ui/src/components/Option/ResearchWorkspace/StudioPane/index.tsx
+- apps/packages/ui/src/components/Option/ResearchWorkspace/__tests__/StudioPane.stage2.test.tsx
+- Docs/superpowers/plans/2026-06-07-research-mermaid-artifact-preview-unification-plan.md
+- backlog/tasks/task-2278 - Unify-Research-Workspace-Mermaid-artifact-modal-preview.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Unify the Research Workspace Mermaid artifact modal path with the shared Mermaid preview/action components used by chat Mermaid blocks and chat artifact cards, without changing user-message rendering behavior.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Research Workspace Mermaid artifact modal reuses the shared Mermaid preview/action component path or a shared wrapper instead of maintaining separate Mermaid preview controls.
+- [x] #2 Existing raw-output fallback for non-Mermaid or invalid mind-map output remains intact.
+- [x] #3 Focused tests cover the shared preview controls for Mermaid artifact modal content.
+- [x] #4 No user-message Mermaid rendering behavior changes are introduced.
+- [x] #5 Verification results and any known skips are recorded.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Docs/superpowers/plans/2026-06-07-research-mermaid-artifact-preview-unification-plan.md
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented via the existing shared MermaidDiagramBlock path in MindMapArtifactViewer. Valid Research Workspace Mermaid mind-map artifact modal content delegates preview, copy, and SVG-download controls to the shared block with enableArtifactAction=false. The raw fallback branch for invalid or non-Mermaid output is unchanged, and no user-message markdown rendering paths were changed. Verification recorded: RED focused Vitest failed before implementation on missing research-shared-mermaid-block, Research Workspace mind map focused Vitest passed 4 tests, full StudioPane.stage2 passed 26 tests, shared Mermaid tests passed 27 tests, git diff --check passed, higher-heap tsc failed only on existing unrelated KnowledgeQA fixture errors, and Bandit is not applicable for frontend-only TypeScript docs and Backlog changes.
+
+PR review follow-up: rebased PR #2293 onto latest origin/dev after PR #2294 merged. Addressed CodeRabbit's prop-contract comment by removing the now-unused title prop from MindMapArtifactViewer and the corresponding title prop at the modal call site. Verification after the review fix: Research Workspace mind map focused Vitest passed 4 tests, shared Mermaid tests passed 27 tests, git diff --check passed, and higher-heap UI type-check still fails only on existing unrelated KnowledgeQA fixture errors with no diagnostics in touched files.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Research Workspace Mermaid mind-map artifact modals now reuse the shared Mermaid diagram block used by assistant-facing Markdown surfaces. The modal keeps its raw fallback for invalid/non-Mermaid output, disables nested artifact actions, and removes the previous modal-local zoom/PNG/export control path in favor of shared preview/copy/SVG-download behavior.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## Summary

- Reused the shared `MermaidDiagramBlock` for valid Research Workspace mind-map artifact modal content.
- Kept the raw fallback path for invalid/non-Mermaid mind-map output.
- Added focused modal coverage for shared preview/copy/SVG-download controls and disabled nested artifact actions.

## Test Plan

- [x] `bunx vitest run src/components/Option/ResearchWorkspace/__tests__/StudioPane.stage2.test.tsx -t "mind map"`
- [x] `bunx vitest run src/components/Common/__tests__/Mermaid.test.tsx src/components/Common/__tests__/MermaidDiagramBlock.test.tsx src/components/Common/__tests__/MermaidPreviewDialog.test.tsx`
- [x] `git diff --check HEAD~1..HEAD`
- [ ] `env NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit` fails on existing unrelated KnowledgeQA fixture type errors in `KnowledgeQALayout.behavior.test.tsx` and `knowledgeQaStateFixtures.ts`; no touched Research Workspace or Mermaid files report diagnostics.

## Change Summary

Required before merge: a human requester or maintainer should replace this section with their own explanation of what changed and why these implementation choices were made.

## Backlog

- TASK-2278

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies Research Workspace mind‑map artifact modals by reusing the shared `MermaidDiagramBlock` for valid Mermaid. Keeps the raw fallback and removes the old zoom/PNG/SVG controls. Addresses `TASK-2278`.

- **Refactors**
  - Swapped local Mermaid rendering and modal zoom/PNG/SVG export for `MermaidDiagramBlock` with `enableArtifactAction={false}`; removed the unused `title` prop from `MindMapArtifactViewer` and its call site.
  - Updated tests to assert shared preview/copy/SVG controls and no nested artifact action; preserved the non‑Mermaid raw fallback.

<sup>Written for commit 9ad3c1b030a22b776d75abeda36c8397e7a67dd8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2293?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

