### PR TITLE
feat: add workspace assistant defaults storage

### DIFF
--- a/backlog/tasks/task-2278 - Implement-Workspace-Assistant-Defaults-backend-storage.md
+++ b/backlog/tasks/task-2278 - Implement-Workspace-Assistant-Defaults-backend-storage.md
@@ -2,6 +2,11 @@
 id: TASK-2278
 title: Implement Workspace Assistant Defaults backend storage
 status: In Progress
+assignee: []
+created_date: ''
+updated_date: '2026-06-08 00:37'
+labels: []
+dependencies: []
 ---
 
 ## Description
@@ -21,6 +26,7 @@ Implement the first Workspace Assistant Defaults V1 slice from #1911: backend st
 
 ## Implementation Notes
 
+<!-- SECTION:NOTES:BEGIN -->
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
 - Added Workspace Assistant Defaults Pydantic schema types with Persona-only `assistant_kind`, read-only/read-write memory modes, and explicit null-only deferred fields.
 - Added ChaChaNotes schema v49 with `assistant_defaults_json` storage for SQLite and PostgreSQL creation/migration paths.
@@ -33,6 +39,10 @@ Implement the first Workspace Assistant Defaults V1 slice from #1911: backend st
   - `git diff --check` passed.
   - Production Bandit passed with 0 findings for `workspace_schemas.py` and `ChaChaNotes_DB.py`; full touched-scope Bandit only reported pytest `assert` warnings in the new test file.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+- PR review follow-up after rebase onto origin/dev: mapped API assistant_defaults patches to assistant_defaults_json, consumed confirmation-only request metadata, enforced read_write confirmation in WorkspacePatchRequest, added effective assistant default status validation, made malformed write payloads raise InputError while logging malformed stored DB values, and rejected unknown-only DB updates.
+- Review verification: focused regression pytest passed (11 passed); broader workspace/DB pytest passed (111 passed); py_compile passed for touched app files; git diff --check passed; Bandit passed on touched app files with 0 findings.
+<!-- SECTION:NOTES:END -->
 
 ## Final Summary
 

--- a/backlog/tasks/task-2278 - Implement-Workspace-Assistant-Defaults-backend-storage.md
+++ b/backlog/tasks/task-2278 - Implement-Workspace-Assistant-Defaults-backend-storage.md
@@ -1,0 +1,51 @@
+---
+id: TASK-2278
+title: Implement Workspace Assistant Defaults backend storage
+status: In Progress
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement the first Workspace Assistant Defaults V1 slice from #1911: backend storage/schema support for a Persona-only, reference-backed assistant_defaults_json Workspace field in ChaChaNotes DB, with migration coverage and no Persona snapshots.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 ChaChaNotes workspace schema includes `assistant_defaults_json` for new SQLite/Postgres databases and v48-to-v49 migrations.
+- [x] #2 Workspace create/read/update paths preserve and normalize `assistant_defaults_json` as a dict while storing JSON text internally.
+- [x] #3 Storage rejects or clears malformed/unsupported assistant default payloads without persisting Persona display snapshots.
+- [x] #4 Focused backend tests cover migration/new DB behavior, create/read/update round trips, malformed JSON handling, and no snapshot fields.
+- [x] #5 Verification commands and Bandit results are recorded before commit.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+- Added Workspace Assistant Defaults Pydantic schema types with Persona-only `assistant_kind`, read-only/read-write memory modes, and explicit null-only deferred fields.
+- Added ChaChaNotes schema v49 with `assistant_defaults_json` storage for SQLite and PostgreSQL creation/migration paths.
+- Centralized workspace row normalization so DB callers receive `assistant_defaults_json` as `dict | None` while DB rows store compact JSON text.
+- Added focused tests in `tldw_Server_API/tests/ChaChaNotesDB/test_workspace_assistant_defaults_db.py`.
+- Verification:
+  - Red test: `python -m pytest tldw_Server_API/tests/ChaChaNotesDB/test_workspace_assistant_defaults_db.py -q --tb=short --disable-warnings` failed on missing `WorkspaceAssistantDefaults` import before implementation.
+  - `python -m py_compile tldw_Server_API/app/api/v1/schemas/workspace_schemas.py tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py` passed.
+  - `python -m pytest tldw_Server_API/tests/ChaChaNotesDB/test_workspace_assistant_defaults_db.py tldw_Server_API/tests/ChaChaNotesDB/test_workspace_sub_resources_db.py -q --tb=short --disable-warnings` passed: 31 passed, 6 warnings.
+  - `git diff --check` passed.
+  - Production Bandit passed with 0 findings for `workspace_schemas.py` and `ChaChaNotes_DB.py`; full touched-scope Bandit only reported pytest `assert` warnings in the new test file.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Implemented the backend storage foundation for Workspace Assistant Defaults V1: schema contracts, v49 migrations, JSON normalization helpers, and focused DB tests. The slice remains Persona-only and reference-backed, with no Persona display snapshots stored.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/tldw_Server_API/app/api/v1/endpoints/workspaces.py
+++ b/tldw_Server_API/app/api/v1/endpoints/workspaces.py
@@ -128,6 +128,7 @@ def _ws_to_response(ws: dict) -> WorkspaceResponse:
         audio_model=ws.get("audio_model"),
         audio_voice=ws.get("audio_voice"),
         audio_speed=ws.get("audio_speed"),
+        assistant_defaults=ws.get("assistant_defaults_json"),
         created_at=str(ws.get("created_at", "")),
         last_modified=str(ws.get("last_modified", "")),
         version=ws.get("version", 1),
@@ -950,6 +951,9 @@ async def patch_workspace(
 ):
     """Update workspace fields with optimistic locking."""
     updates = body.model_dump(exclude_unset=True, exclude={"version"})
+    if "assistant_defaults" in updates:
+        updates["assistant_defaults_json"] = updates.pop("assistant_defaults")
+    updates.pop("confirm_read_write_assistant_default", None)
     if not updates:
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,

--- a/tldw_Server_API/app/api/v1/schemas/workspace_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/workspace_schemas.py
@@ -80,6 +80,8 @@ class WorkspaceUpsertRequest(BaseModel):
 
 
 class WorkspaceAssistantDefaults(BaseModel):
+    """Persisted default assistant selection for new Workspace-scoped chats."""
+
     assistant_kind: WorkspaceAssistantKind
     assistant_id: str = Field(..., min_length=1, max_length=128)
     persona_memory_mode: WorkspacePersonaMemoryMode = "read_only"
@@ -96,6 +98,8 @@ class WorkspaceAssistantDefaults(BaseModel):
 
 
 class WorkspaceEffectiveAssistantDefault(BaseModel):
+    """Resolved Workspace assistant default exposed to clients with degradation state."""
+
     status: WorkspaceEffectiveAssistantDefaultStatus
     source: WorkspaceEffectiveAssistantDefaultSource
     assistant_kind: WorkspaceAssistantKind | None = None
@@ -103,6 +107,33 @@ class WorkspaceEffectiveAssistantDefault(BaseModel):
     label: str | None = None
     persona_memory_mode: WorkspacePersonaMemoryMode | None = None
     degraded_reason: WorkspaceAssistantDefaultDegradedReason | None = None
+
+    @model_validator(mode="after")
+    def _validate_status_relations(self) -> "WorkspaceEffectiveAssistantDefault":
+        if self.status == "available":
+            if self.assistant_kind is None or self.assistant_id is None:
+                raise ValueError("available assistant defaults require assistant_kind and assistant_id")
+            if self.degraded_reason is not None:
+                raise ValueError("available assistant defaults must not include degraded_reason")
+            return self
+        if self.status == "unavailable":
+            if self.degraded_reason is None:
+                raise ValueError("unavailable assistant defaults require degraded_reason")
+            return self
+        populated_none_fields = [
+            field_name
+            for field_name in (
+                "assistant_kind",
+                "assistant_id",
+                "label",
+                "persona_memory_mode",
+                "degraded_reason",
+            )
+            if getattr(self, field_name) is not None
+        ]
+        if populated_none_fields:
+            raise ValueError("none assistant defaults must not include assistant or degradation fields")
+        return self
 
 
 class WorkspacePatchRequest(BaseModel):
@@ -120,6 +151,20 @@ class WorkspacePatchRequest(BaseModel):
     assistant_defaults: WorkspaceAssistantDefaults | None = None
     confirm_read_write_assistant_default: StrictBool | None = None
     version: int = Field(..., description="Current version for optimistic locking")
+
+    @model_validator(mode="after")
+    def _validate_assistant_default_confirmation(self) -> "WorkspacePatchRequest":
+        if self.assistant_defaults is None:
+            if self.confirm_read_write_assistant_default is not None:
+                raise ValueError("confirm_read_write_assistant_default only applies to assistant_defaults")
+            return self
+        if self.assistant_defaults.persona_memory_mode == "read_write":
+            if self.confirm_read_write_assistant_default is not True:
+                raise ValueError("read_write assistant defaults require confirm_read_write_assistant_default=true")
+            return self
+        if self.confirm_read_write_assistant_default is not None:
+            raise ValueError("confirm_read_write_assistant_default only applies to read_write assistant defaults")
+        return self
 
 
 class WorkspaceResponse(BaseModel):

--- a/tldw_Server_API/app/api/v1/schemas/workspace_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/workspace_schemas.py
@@ -5,7 +5,7 @@ import json
 import re
 from typing import Any, Literal
 
-from pydantic import BaseModel, ConfigDict, Field, StrictBool, field_validator, model_validator
+from pydantic import BaseModel, ConfigDict, Field, StrictBool, ValidationInfo, field_validator, model_validator
 
 
 WORKSPACE_MIGRATION_MAX_MANIFEST_BYTES = 256 * 1024
@@ -17,6 +17,18 @@ _SHA256_RE = re.compile(r"^[a-fA-F0-9]{64}$")
 
 WorkspaceProfile = Literal["research", "project"]
 WorkspaceKind = Literal["research_workspace", "project_workspace"]
+WorkspaceAssistantKind = Literal["persona"]
+WorkspacePersonaMemoryMode = Literal["read_only", "read_write"]
+WorkspaceEffectiveAssistantDefaultStatus = Literal["available", "unavailable", "none"]
+WorkspaceEffectiveAssistantDefaultSource = Literal["workspace", "none"]
+WorkspaceAssistantDefaultDegradedReason = Literal[
+    "persona_deleted",
+    "persona_unavailable",
+    "persona_feature_disabled",
+    "permission_denied",
+    "invalid_default",
+    "unsupported_assistant_kind",
+]
 WorkspaceResolutionStatus = Literal["complete", "partial", "failed"]
 WorkspaceAttentionState = Literal[
     "ready",
@@ -67,6 +79,32 @@ class WorkspaceUpsertRequest(BaseModel):
     workspace_profile: WorkspaceProfile = "research"
 
 
+class WorkspaceAssistantDefaults(BaseModel):
+    assistant_kind: WorkspaceAssistantKind
+    assistant_id: str = Field(..., min_length=1, max_length=128)
+    persona_memory_mode: WorkspacePersonaMemoryMode = "read_only"
+    voice: None = None
+    style: None = None
+    tool_policy_profile_id: None = None
+
+    @field_validator("voice", "style", "tool_policy_profile_id", mode="before")
+    @classmethod
+    def _deferred_fields_must_be_null(cls, value: Any, info: ValidationInfo) -> None:
+        if value is not None:
+            raise ValueError(f"{info.field_name} must be null")
+        return None
+
+
+class WorkspaceEffectiveAssistantDefault(BaseModel):
+    status: WorkspaceEffectiveAssistantDefaultStatus
+    source: WorkspaceEffectiveAssistantDefaultSource
+    assistant_kind: WorkspaceAssistantKind | None = None
+    assistant_id: str | None = None
+    label: str | None = None
+    persona_memory_mode: WorkspacePersonaMemoryMode | None = None
+    degraded_reason: WorkspaceAssistantDefaultDegradedReason | None = None
+
+
 class WorkspacePatchRequest(BaseModel):
     name: str | None = None
     archived: bool | None = None
@@ -79,6 +117,8 @@ class WorkspacePatchRequest(BaseModel):
     audio_model: str | None = None
     audio_voice: str | None = None
     audio_speed: float | None = None
+    assistant_defaults: WorkspaceAssistantDefaults | None = None
+    confirm_read_write_assistant_default: StrictBool | None = None
     version: int = Field(..., description="Current version for optimistic locking")
 
 
@@ -96,6 +136,8 @@ class WorkspaceResponse(BaseModel):
     audio_model: str | None = None
     audio_voice: str | None = None
     audio_speed: float | None = None
+    assistant_defaults: WorkspaceAssistantDefaults | None = None
+    effective_assistant_default: WorkspaceEffectiveAssistantDefault | None = None
     created_at: str
     last_modified: str
     version: int

--- a/tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py
+++ b/tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py
@@ -596,7 +596,7 @@ class CharactersRAGDB:
         is_memory_db (bool): True if the database is in-memory.
         db_path_str (str): String representation of the database path for SQLite connection.
     """
-    _CURRENT_SCHEMA_VERSION = 48  # Schema v48 adds Notes task-backed checklist storage
+    _CURRENT_SCHEMA_VERSION = 49  # Schema v49 adds Workspace Assistant Defaults storage
     _SCHEMA_NAME = "rag_char_chat_schema"  # Used for the db_schema_version table
     _ALLOWED_CONVERSATION_STATES: tuple[str, ...] = ("in-progress", "resolved", "backlog", "non-viable")
     _ALLOWED_CONVERSATION_CHARACTER_SCOPES: tuple[str, ...] = ("all", "character", "non_character")
@@ -3323,7 +3323,8 @@ CREATE TABLE IF NOT EXISTS workspaces (
     last_modified TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
     deleted       BOOLEAN NOT NULL DEFAULT false,
     client_id     TEXT    NOT NULL DEFAULT 'unknown',
-    version       INTEGER NOT NULL DEFAULT 1
+    version       INTEGER NOT NULL DEFAULT 1,
+    assistant_defaults_json TEXT
 );
 
 ALTER TABLE conversations
@@ -5584,6 +5585,16 @@ UPDATE db_schema_version
    AND version < 48;
 """
 
+    _MIGRATION_SQL_V48_TO_V49 = """
+/*───────────────────────────────────────────────────────────────
+  Migration to Version 49 — Workspace Assistant Defaults storage (2026-06-07)
+───────────────────────────────────────────────────────────────*/
+UPDATE db_schema_version
+   SET version = 49
+ WHERE schema_name = 'rag_char_chat_schema'
+   AND version < 49;
+"""
+
     _MIGRATION_SQL_V47_TO_V48_POSTGRES = """
 /*───────────────────────────────────────────────────────────────
   Migration to Version 48 — Notes task-backed checklist storage (2026-06-05) [Postgres]
@@ -5689,6 +5700,18 @@ UPDATE db_schema_version
    SET version = 48
  WHERE schema_name = 'rag_char_chat_schema'
    AND version < 48;
+"""
+
+    _MIGRATION_SQL_V48_TO_V49_POSTGRES = """
+/*───────────────────────────────────────────────────────────────
+  Migration to Version 49 — Workspace Assistant Defaults storage (2026-06-07) [Postgres]
+───────────────────────────────────────────────────────────────*/
+ALTER TABLE workspaces ADD COLUMN IF NOT EXISTS assistant_defaults_json TEXT;
+
+UPDATE db_schema_version
+   SET version = 49
+ WHERE schema_name = 'rag_char_chat_schema'
+   AND version < 49;
 """
 
     _MIGRATION_SQL_V10_TO_V11_POSTGRES = """
@@ -7583,7 +7606,8 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
                     last_modified DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
                     deleted       BOOLEAN  NOT NULL DEFAULT 0,
                     client_id     TEXT    NOT NULL DEFAULT 'unknown',
-                    version       INTEGER  NOT NULL DEFAULT 1
+                    version       INTEGER  NOT NULL DEFAULT 1,
+                    assistant_defaults_json TEXT
                 )
             """)
 
@@ -7887,6 +7911,27 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
         except _CHACHA_NONCRITICAL_EXCEPTIONS as e:
             logger.error(f"[{self._SCHEMA_NAME}] Unexpected error during migration V47->V48: {e}", exc_info=True)
             raise SchemaError(f"Unexpected error migrating to V48 for '{self._SCHEMA_NAME}': {e}") from e  # noqa: TRY003
+
+    def _migrate_from_v48_to_v49(self, conn: sqlite3.Connection) -> None:
+        """Migrate schema from V48 to V49 (Workspace Assistant Defaults storage)."""
+        logger.info(f"Migrating '{self._SCHEMA_NAME}' schema from V48 to V49 for DB: {self.db_path_str}...")
+        try:
+            self._ensure_workspace_assistant_defaults_schema_sqlite(conn)
+            conn.executescript(self._MIGRATION_SQL_V48_TO_V49)
+            final_version = self._get_db_version(conn)
+            if final_version != 49:
+                raise SchemaError(  # noqa: TRY003, TRY301
+                    f"[{self._SCHEMA_NAME}] Migration V48->V49 failed version check. Expected 49, got: {final_version}"
+                )
+            logger.info(f"[{self._SCHEMA_NAME}] Migration to V49 completed.")
+        except sqlite3.Error as e:
+            logger.error(f"[{self._SCHEMA_NAME}] Migration V48->V49 failed: {e}", exc_info=True)
+            raise SchemaError(f"Migration V48->V49 failed for '{self._SCHEMA_NAME}': {e}") from e  # noqa: TRY003
+        except SchemaError:
+            raise
+        except _CHACHA_NONCRITICAL_EXCEPTIONS as e:
+            logger.error(f"[{self._SCHEMA_NAME}] Unexpected error during migration V48->V49: {e}", exc_info=True)
+            raise SchemaError(f"Unexpected error migrating to V49 for '{self._SCHEMA_NAME}': {e}") from e  # noqa: TRY003
 
     def _ensure_persona_persistence_schema_sqlite(self, conn: sqlite3.Connection) -> None:
         """Ensure persona persistence tables and columns exist for drifted SQLite schemas."""
@@ -8874,6 +8919,7 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
                 "audio_model": "TEXT",
                 "audio_voice": "TEXT",
                 "audio_speed": "REAL DEFAULT 1.0",
+                "assistant_defaults_json": "TEXT",
             }
             for col_name, col_type in new_ws_cols.items():
                 if col_name not in ws_cols:
@@ -9065,6 +9111,15 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
         except sqlite3.Error as exc:
             raise SchemaError(f"Failed ensuring SQLite workspace sub-resource schema: {exc}") from exc  # noqa: TRY003
 
+    def _ensure_workspace_assistant_defaults_schema_sqlite(self, conn: sqlite3.Connection) -> None:
+        """Ensure Workspace Assistant Defaults storage exists for SQLite."""
+        try:
+            ws_cols = {row[1] for row in conn.execute("PRAGMA table_info('workspaces')").fetchall()}
+            if "assistant_defaults_json" not in ws_cols:
+                conn.execute("ALTER TABLE workspaces ADD COLUMN assistant_defaults_json TEXT")
+        except sqlite3.Error as exc:
+            raise SchemaError(f"Failed ensuring SQLite workspace assistant defaults schema: {exc}") from exc  # noqa: TRY003
+
     def _ensure_workspace_subresource_schema_postgres(self, conn: Any) -> None:
         """Ensure workspace settings columns and sub-resource tables exist for PostgreSQL."""
         if not hasattr(self.backend, "execute"):
@@ -9081,6 +9136,7 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
             "ALTER TABLE workspaces ADD COLUMN IF NOT EXISTS audio_model TEXT",
             "ALTER TABLE workspaces ADD COLUMN IF NOT EXISTS audio_voice TEXT",
             "ALTER TABLE workspaces ADD COLUMN IF NOT EXISTS audio_speed REAL DEFAULT 1.0",
+            "ALTER TABLE workspaces ADD COLUMN IF NOT EXISTS assistant_defaults_json TEXT",
             """
             CREATE TABLE IF NOT EXISTS workspace_project_roots (
                 root_id              TEXT PRIMARY KEY NOT NULL,
@@ -9681,6 +9737,7 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
                     self._ensure_recent_voice_command_schema_sqlite(conn)
                     self._ensure_note_folder_schema_sqlite(conn)
                     self._ensure_note_studio_schema_sqlite(conn)
+                    self._ensure_workspace_assistant_defaults_schema_sqlite(conn)
                     # Seed/heal character_cards_fts before request traffic. Schema V4
                     # inserts "Default Assistant" before FTS triggers are created.
                     self._self_heal_character_cards_fts_sqlite(conn)
@@ -9824,6 +9881,9 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
                         current_db_version = self._get_db_version(conn)
                     if target_version >= 48 and current_db_version == 47:
                         self._migrate_from_v47_to_v48(conn)
+                        current_db_version = self._get_db_version(conn)
+                    if target_version >= 49 and current_db_version == 48:
+                        self._migrate_from_v48_to_v49(conn)
                         current_db_version = self._get_db_version(conn)
                 # Ensure helpful indexes that may have been introduced post-creation
                 try:
@@ -10176,6 +10236,8 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
                                 self._migrate_from_v46_to_v47(conn)
                             elif fallback_version == 47:
                                 self._migrate_from_v47_to_v48(conn)
+                            elif fallback_version == 48:
+                                self._migrate_from_v48_to_v49(conn)
                             else:
                                 raise SchemaError(  # noqa: TRY003, TRY301
                                     f"Migration path undefined for '{self._SCHEMA_NAME}' from version {current_initial_version} to {target_version}. "
@@ -10296,12 +10358,16 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
                 if target_version >= 48 and current_db_version == 47:
                     self._migrate_from_v47_to_v48(conn)
                     current_db_version = self._get_db_version(conn)
+                if target_version >= 49 and current_db_version == 48:
+                    self._migrate_from_v48_to_v49(conn)
+                    current_db_version = self._get_db_version(conn)
 
                 self._ensure_recent_persona_schema_sqlite(conn)
                 self._ensure_recent_voice_command_schema_sqlite(conn)
                 self._ensure_note_folder_schema_sqlite(conn)
                 self._ensure_note_studio_schema_sqlite(conn)
                 self._ensure_web_clipper_schema_sqlite(conn)
+                self._ensure_workspace_assistant_defaults_schema_sqlite(conn)
 
                 final_version_check = self._get_db_version(conn)
                 if final_version_check != target_version:
@@ -14131,6 +14197,9 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
             if current_version < 48:
                 self._apply_postgres_migration_script(self._MIGRATION_SQL_V47_TO_V48_POSTGRES, conn, expected_version=48)
                 current_version = 48
+            if current_version < 49:
+                self._apply_postgres_migration_script(self._MIGRATION_SQL_V48_TO_V49_POSTGRES, conn, expected_version=49)
+                current_version = 49
 
             if current_version > target_version:
                 raise SchemaError(  # noqa: TRY003
@@ -14743,7 +14812,8 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
                 last_modified TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
                 deleted       BOOLEAN NOT NULL DEFAULT false,
                 client_id     TEXT    NOT NULL DEFAULT 'unknown',
-                version       INTEGER NOT NULL DEFAULT 1
+                version       INTEGER NOT NULL DEFAULT 1,
+                assistant_defaults_json TEXT
             )
             """,
             connection=conn,
@@ -15721,6 +15791,52 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
             )
         return CharactersRAGDBError(f"Workspace project root write failed: {exc}")  # noqa: TRY003
 
+    @classmethod
+    def _serialize_workspace_assistant_defaults_json(cls, value: Any) -> str | None:
+        """Serialize Workspace Assistant Defaults for DB storage."""
+        if value is None:
+            return None
+        if isinstance(value, str):
+            stripped = value.strip()
+            if not stripped:
+                return None
+            try:
+                parsed = json.loads(stripped)
+            except (json.JSONDecodeError, ValueError):
+                return None
+            return stripped if isinstance(parsed, Mapping) else None
+        if not isinstance(value, Mapping):
+            return None
+        try:
+            return json.dumps(dict(value), ensure_ascii=True, sort_keys=True, separators=(",", ":"))
+        except (TypeError, ValueError):
+            return None
+
+    @classmethod
+    def _load_workspace_assistant_defaults_json(cls, value: Any) -> dict[str, Any] | None:
+        """Load Workspace Assistant Defaults from DB storage."""
+        if value is None:
+            return None
+        if isinstance(value, Mapping):
+            return dict(value)
+        if not isinstance(value, str) or not value.strip():
+            return None
+        try:
+            parsed = json.loads(value)
+        except (json.JSONDecodeError, ValueError):
+            return None
+        return dict(parsed) if isinstance(parsed, Mapping) else None
+
+    @classmethod
+    def _workspace_row_to_dict(cls, row: Any) -> dict[str, Any]:
+        """Convert a workspace DB row to the public DB-layer dict shape."""
+        workspace = dict(row)
+        if "assistant_defaults_json" in workspace:
+            workspace["assistant_defaults_json"] = cls._load_workspace_assistant_defaults_json(
+                workspace["assistant_defaults_json"]
+            )
+        return workspace
+
     def upsert_workspace(
         self,
         workspace_id: str,
@@ -15807,13 +15923,13 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
         query = "SELECT * FROM workspaces WHERE id = ? AND deleted = 0"
         cursor = self.execute_query(query, (workspace_id,))
         row = cursor.fetchone()
-        return dict(row) if row else None
+        return self._workspace_row_to_dict(row) if row else None
 
     def list_workspaces(self) -> list[dict[str, Any]]:
         """Return all non-deleted workspaces ordered by name."""
         query = "SELECT * FROM workspaces WHERE deleted = 0 ORDER BY name"
         cursor = self.execute_query(query, ())
-        return [dict(row) for row in cursor.fetchall()]
+        return [self._workspace_row_to_dict(row) for row in cursor.fetchall()]
 
     def update_workspace(
         self,
@@ -15851,11 +15967,14 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
             "name", "description", "metadata_json", "study_materials_policy", "workspace_profile", "archived", "tag",
             "banner_title", "banner_subtitle", "banner_color",
             "audio_provider", "audio_model", "audio_voice", "audio_speed",
+            "assistant_defaults_json",
         ):
             if col in update_data:
                 set_clauses.append(f"{col} = ?")
                 if col == "workspace_profile":
                     params.append(self._validate_workspace_profile(update_data[col]))
+                elif col == "assistant_defaults_json":
+                    params.append(self._serialize_workspace_assistant_defaults_json(update_data[col]))
                 else:
                     params.append(update_data[col])
 

--- a/tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py
+++ b/tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py
@@ -15802,15 +15802,17 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
                 return None
             try:
                 parsed = json.loads(stripped)
-            except (json.JSONDecodeError, ValueError):
-                return None
-            return stripped if isinstance(parsed, Mapping) else None
+            except (json.JSONDecodeError, ValueError) as exc:
+                raise InputError("assistant_defaults_json must be valid JSON when provided as a string.") from exc
+            if not isinstance(parsed, Mapping):
+                raise InputError("assistant_defaults_json must be a JSON object or null.")  # noqa: TRY003
+            return stripped
         if not isinstance(value, Mapping):
-            return None
+            raise InputError("assistant_defaults_json must be a mapping, JSON object string, or null.")  # noqa: TRY003
         try:
             return json.dumps(dict(value), ensure_ascii=True, sort_keys=True, separators=(",", ":"))
-        except (TypeError, ValueError):
-            return None
+        except (TypeError, ValueError) as exc:
+            raise InputError("assistant_defaults_json must be JSON serializable.") from exc
 
     @classmethod
     def _load_workspace_assistant_defaults_json(cls, value: Any) -> dict[str, Any] | None:
@@ -15824,8 +15826,12 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
         try:
             parsed = json.loads(value)
         except (json.JSONDecodeError, ValueError):
+            logger.warning("Ignoring malformed workspace assistant_defaults_json stored in the database.")
             return None
-        return dict(parsed) if isinstance(parsed, Mapping) else None
+        if not isinstance(parsed, Mapping):
+            logger.warning("Ignoring non-object workspace assistant_defaults_json stored in the database.")
+            return None
+        return dict(parsed)
 
     @classmethod
     def _workspace_row_to_dict(cls, row: Any) -> dict[str, Any]:
@@ -15960,15 +15966,19 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
             )
 
         now = self._get_current_utc_timestamp_iso()
-        set_clauses = ["last_modified = ?", "version = ?"]
-        params: list[Any] = [now, expected_version + 1]
-
-        for col in (
+        workspace_update_columns = (
             "name", "description", "metadata_json", "study_materials_policy", "workspace_profile", "archived", "tag",
             "banner_title", "banner_subtitle", "banner_color",
             "audio_provider", "audio_model", "audio_voice", "audio_speed",
             "assistant_defaults_json",
-        ):
+        )
+        if not any(col in update_data for col in workspace_update_columns):
+            raise InputError("No recognized workspace fields to update.")  # noqa: TRY003
+
+        set_clauses = ["last_modified = ?", "version = ?"]
+        params: list[Any] = [now, expected_version + 1]
+
+        for col in workspace_update_columns:
             if col in update_data:
                 set_clauses.append(f"{col} = ?")
                 if col == "workspace_profile":

--- a/tldw_Server_API/tests/ChaChaNotesDB/test_workspace_assistant_defaults_db.py
+++ b/tldw_Server_API/tests/ChaChaNotesDB/test_workspace_assistant_defaults_db.py
@@ -1,7 +1,6 @@
 """Tests for Workspace Assistant Defaults schema and ChaChaNotes storage."""
 from __future__ import annotations
 
-import json
 import sqlite3
 from pathlib import Path
 
@@ -9,12 +8,22 @@ import pytest
 from pydantic import ValidationError
 
 from tldw_Server_API.app.api.v1.schemas.workspace_schemas import WorkspaceAssistantDefaults
-from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import CharactersRAGDB
+from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import CharactersRAGDB, InputError
 
 
 def _workspace_columns(db_path: Path) -> set[str]:
     with sqlite3.connect(str(db_path)) as conn:
         return {row[1] for row in conn.execute("PRAGMA table_info('workspaces')").fetchall()}
+
+
+@pytest.fixture
+def chacha_db(tmp_path: Path) -> CharactersRAGDB:
+    """Provide a fresh ChaChaNotes DB for workspace assistant-default tests."""
+    db = CharactersRAGDB(db_path=str(tmp_path / "chacha.db"), client_id="user-1")
+    try:
+        yield db
+    finally:
+        db.close_connection()
 
 
 def test_workspace_assistant_defaults_accepts_persona_read_only() -> None:
@@ -41,13 +50,13 @@ def test_workspace_assistant_defaults_rejects_deferred_fields() -> None:
         )
 
 
-def test_new_sqlite_db_has_workspace_assistant_defaults_column(tmp_path: Path) -> None:
+def test_new_sqlite_db_has_workspace_assistant_defaults_column(
+    chacha_db: CharactersRAGDB,
+    tmp_path: Path,
+) -> None:
     db_path = tmp_path / "chacha.db"
-    db = CharactersRAGDB(db_path=str(db_path), client_id="user-1")
-    try:
-        assert "assistant_defaults_json" in _workspace_columns(db_path)
-    finally:
-        db.close_connection()
+    assert chacha_db is not None
+    assert "assistant_defaults_json" in _workspace_columns(db_path)
 
 
 def test_v48_sqlite_migration_adds_workspace_assistant_defaults_column(tmp_path: Path) -> None:
@@ -58,6 +67,8 @@ def test_v48_sqlite_migration_adds_workspace_assistant_defaults_column(tmp_path:
     with sqlite3.connect(str(db_path)) as conn:
         columns = _workspace_columns(db_path)
         if "assistant_defaults_json" in columns:
+            if sqlite3.sqlite_version_info < (3, 35, 0):
+                pytest.skip("SQLite version does not support DROP COLUMN")
             conn.execute("ALTER TABLE workspaces DROP COLUMN assistant_defaults_json")
         conn.execute(
             "UPDATE db_schema_version SET version = ? WHERE schema_name = ?",
@@ -77,65 +88,79 @@ def test_v48_sqlite_migration_adds_workspace_assistant_defaults_column(tmp_path:
         migrated.close_connection()
 
 
-def test_workspace_assistant_defaults_round_trip_and_increment_version(tmp_path: Path) -> None:
-    db = CharactersRAGDB(db_path=str(tmp_path / "chacha.db"), client_id="user-1")
-    try:
-        created = db.upsert_workspace("ws-1", "Research")
-        assert created["assistant_defaults_json"] is None
+def test_workspace_assistant_defaults_round_trip_and_increment_version(chacha_db: CharactersRAGDB) -> None:
+    created = chacha_db.upsert_workspace("ws-1", "Research")
+    assert created["assistant_defaults_json"] is None
 
-        assistant_defaults = {
-            "assistant_kind": "persona",
-            "assistant_id": "persona-1",
-            "persona_memory_mode": "read_only",
-        }
-        updated = db.update_workspace(
+    assistant_defaults = {
+        "assistant_kind": "persona",
+        "assistant_id": "persona-1",
+        "persona_memory_mode": "read_only",
+    }
+    updated = chacha_db.update_workspace(
+        "ws-1",
+        {"assistant_defaults_json": assistant_defaults},
+        expected_version=created["version"],
+    )
+
+    assert updated["version"] == created["version"] + 1
+    assert updated["assistant_defaults_json"] == assistant_defaults
+    assert "persona_name" not in updated["assistant_defaults_json"]
+    assert "source_persona" not in updated["assistant_defaults_json"]
+
+    reloaded = chacha_db.get_workspace("ws-1")
+    assert reloaded is not None
+    assert reloaded["assistant_defaults_json"] == assistant_defaults
+
+
+def test_workspace_assistant_defaults_clear_and_malformed_json_returns_none(chacha_db: CharactersRAGDB) -> None:
+    created = chacha_db.upsert_workspace("ws-1", "Research")
+    updated = chacha_db.update_workspace(
+        "ws-1",
+        {
+            "assistant_defaults_json": {
+                "assistant_kind": "persona",
+                "assistant_id": "persona-1",
+                "persona_memory_mode": "read_only",
+            }
+        },
+        expected_version=created["version"],
+    )
+    cleared = chacha_db.update_workspace(
+        "ws-1",
+        {"assistant_defaults_json": None},
+        expected_version=updated["version"],
+    )
+    assert cleared["assistant_defaults_json"] is None
+
+    with chacha_db.transaction() as conn:
+        conn.execute(
+            "UPDATE workspaces SET assistant_defaults_json = ? WHERE id = ?",
+            ("{bad-json", "ws-1"),
+        )
+
+    reloaded = chacha_db.get_workspace("ws-1")
+    assert reloaded is not None
+    assert reloaded["assistant_defaults_json"] is None
+
+
+def test_workspace_assistant_defaults_update_rejects_invalid_json_string(chacha_db: CharactersRAGDB) -> None:
+    created = chacha_db.upsert_workspace("ws-1", "Research")
+
+    with pytest.raises(InputError, match="assistant_defaults_json must be valid JSON"):
+        chacha_db.update_workspace(
             "ws-1",
-            {"assistant_defaults_json": assistant_defaults},
+            {"assistant_defaults_json": "{bad-json"},
             expected_version=created["version"],
         )
 
-        assert updated["version"] == created["version"] + 1
-        assert updated["assistant_defaults_json"] == assistant_defaults
-        assert "persona_name" not in json.dumps(updated["assistant_defaults_json"])
-        assert "source_persona" not in json.dumps(updated["assistant_defaults_json"])
 
-        reloaded = db.get_workspace("ws-1")
-        assert reloaded is not None
-        assert reloaded["assistant_defaults_json"] == assistant_defaults
-    finally:
-        db.close_connection()
+def test_workspace_update_rejects_unknown_only_payload(chacha_db: CharactersRAGDB) -> None:
+    created = chacha_db.upsert_workspace("ws-1", "Research")
 
-
-def test_workspace_assistant_defaults_clear_and_malformed_json_returns_none(tmp_path: Path) -> None:
-    db = CharactersRAGDB(db_path=str(tmp_path / "chacha.db"), client_id="user-1")
-    try:
-        created = db.upsert_workspace("ws-1", "Research")
-        updated = db.update_workspace(
+    with pytest.raises(InputError, match="No recognized workspace fields to update"):
+        chacha_db.update_workspace(
             "ws-1",
-            {
-                "assistant_defaults_json": {
-                    "assistant_kind": "persona",
-                    "assistant_id": "persona-1",
-                    "persona_memory_mode": "read_only",
-                }
-            },
+            {"assistant_defaults": {"assistant_kind": "persona", "assistant_id": "persona-1"}},
             expected_version=created["version"],
         )
-        cleared = db.update_workspace(
-            "ws-1",
-            {"assistant_defaults_json": None},
-            expected_version=updated["version"],
-        )
-        assert cleared["assistant_defaults_json"] is None
-
-        with db.transaction() as conn:
-            conn.execute(
-                "UPDATE workspaces SET assistant_defaults_json = ? WHERE id = ?",
-                ("{bad-json", "ws-1"),
-            )
-
-        reloaded = db.get_workspace("ws-1")
-        assert reloaded is not None
-        assert reloaded["assistant_defaults_json"] is None
-    finally:
-        db.close_connection()

--- a/tldw_Server_API/tests/ChaChaNotesDB/test_workspace_assistant_defaults_db.py
+++ b/tldw_Server_API/tests/ChaChaNotesDB/test_workspace_assistant_defaults_db.py
@@ -1,0 +1,141 @@
+"""Tests for Workspace Assistant Defaults schema and ChaChaNotes storage."""
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+from tldw_Server_API.app.api.v1.schemas.workspace_schemas import WorkspaceAssistantDefaults
+from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import CharactersRAGDB
+
+
+def _workspace_columns(db_path: Path) -> set[str]:
+    with sqlite3.connect(str(db_path)) as conn:
+        return {row[1] for row in conn.execute("PRAGMA table_info('workspaces')").fetchall()}
+
+
+def test_workspace_assistant_defaults_accepts_persona_read_only() -> None:
+    payload = WorkspaceAssistantDefaults(
+        assistant_kind="persona",
+        assistant_id="persona-1",
+        persona_memory_mode="read_only",
+    )
+
+    assert payload.model_dump(exclude_none=True) == {
+        "assistant_kind": "persona",
+        "assistant_id": "persona-1",
+        "persona_memory_mode": "read_only",
+    }
+
+
+def test_workspace_assistant_defaults_rejects_deferred_fields() -> None:
+    with pytest.raises(ValidationError, match="voice must be null"):
+        WorkspaceAssistantDefaults(
+            assistant_kind="persona",
+            assistant_id="persona-1",
+            persona_memory_mode="read_only",
+            voice={"provider": "openai"},
+        )
+
+
+def test_new_sqlite_db_has_workspace_assistant_defaults_column(tmp_path: Path) -> None:
+    db_path = tmp_path / "chacha.db"
+    db = CharactersRAGDB(db_path=str(db_path), client_id="user-1")
+    try:
+        assert "assistant_defaults_json" in _workspace_columns(db_path)
+    finally:
+        db.close_connection()
+
+
+def test_v48_sqlite_migration_adds_workspace_assistant_defaults_column(tmp_path: Path) -> None:
+    db_path = tmp_path / "chacha.db"
+    db = CharactersRAGDB(db_path=str(db_path), client_id="user-1")
+    db.close_connection()
+
+    with sqlite3.connect(str(db_path)) as conn:
+        columns = _workspace_columns(db_path)
+        if "assistant_defaults_json" in columns:
+            conn.execute("ALTER TABLE workspaces DROP COLUMN assistant_defaults_json")
+        conn.execute(
+            "UPDATE db_schema_version SET version = ? WHERE schema_name = ?",
+            (48, CharactersRAGDB._SCHEMA_NAME),
+        )
+        conn.commit()
+
+    migrated = CharactersRAGDB(db_path=str(db_path), client_id="user-1")
+    try:
+        assert "assistant_defaults_json" in _workspace_columns(db_path)
+        version_row = migrated.execute_query(
+            "SELECT version FROM db_schema_version WHERE schema_name = ?",
+            (CharactersRAGDB._SCHEMA_NAME,),
+        ).fetchone()
+        assert version_row["version"] == CharactersRAGDB._CURRENT_SCHEMA_VERSION
+    finally:
+        migrated.close_connection()
+
+
+def test_workspace_assistant_defaults_round_trip_and_increment_version(tmp_path: Path) -> None:
+    db = CharactersRAGDB(db_path=str(tmp_path / "chacha.db"), client_id="user-1")
+    try:
+        created = db.upsert_workspace("ws-1", "Research")
+        assert created["assistant_defaults_json"] is None
+
+        assistant_defaults = {
+            "assistant_kind": "persona",
+            "assistant_id": "persona-1",
+            "persona_memory_mode": "read_only",
+        }
+        updated = db.update_workspace(
+            "ws-1",
+            {"assistant_defaults_json": assistant_defaults},
+            expected_version=created["version"],
+        )
+
+        assert updated["version"] == created["version"] + 1
+        assert updated["assistant_defaults_json"] == assistant_defaults
+        assert "persona_name" not in json.dumps(updated["assistant_defaults_json"])
+        assert "source_persona" not in json.dumps(updated["assistant_defaults_json"])
+
+        reloaded = db.get_workspace("ws-1")
+        assert reloaded is not None
+        assert reloaded["assistant_defaults_json"] == assistant_defaults
+    finally:
+        db.close_connection()
+
+
+def test_workspace_assistant_defaults_clear_and_malformed_json_returns_none(tmp_path: Path) -> None:
+    db = CharactersRAGDB(db_path=str(tmp_path / "chacha.db"), client_id="user-1")
+    try:
+        created = db.upsert_workspace("ws-1", "Research")
+        updated = db.update_workspace(
+            "ws-1",
+            {
+                "assistant_defaults_json": {
+                    "assistant_kind": "persona",
+                    "assistant_id": "persona-1",
+                    "persona_memory_mode": "read_only",
+                }
+            },
+            expected_version=created["version"],
+        )
+        cleared = db.update_workspace(
+            "ws-1",
+            {"assistant_defaults_json": None},
+            expected_version=updated["version"],
+        )
+        assert cleared["assistant_defaults_json"] is None
+
+        with db.transaction() as conn:
+            conn.execute(
+                "UPDATE workspaces SET assistant_defaults_json = ? WHERE id = ?",
+                ("{bad-json", "ws-1"),
+            )
+
+        reloaded = db.get_workspace("ws-1")
+        assert reloaded is not None
+        assert reloaded["assistant_defaults_json"] is None
+    finally:
+        db.close_connection()

--- a/tldw_Server_API/tests/Workspaces/test_workspaces_api.py
+++ b/tldw_Server_API/tests/Workspaces/test_workspaces_api.py
@@ -372,6 +372,154 @@ def test_workspace_api_accepts_and_returns_study_materials_policy(workspace_fast
 
 
 @pytest.mark.integration
+def test_workspace_api_patches_assistant_defaults(workspace_fastapi_app, db):
+    from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import User
+
+    async def _allow_rate_limit() -> None:
+        return None
+
+    async def _user() -> User:
+        return User(
+            id=1,
+            username="testuser",
+            email="test@example.com",
+            is_active=True,
+            roles=["admin"],
+            is_admin=True,
+        )
+
+    workspace = db.upsert_workspace("ws-assistant", "Assistant Defaults")
+    workspace_fastapi_app.dependency_overrides[get_request_user] = _user
+    workspace_fastapi_app.dependency_overrides[get_chacha_db_for_user] = lambda: db
+    workspace_fastapi_app.dependency_overrides[WORKSPACES_WRITE_RATE_LIMIT] = _allow_rate_limit
+    try:
+        with TestClient(workspace_fastapi_app, raise_server_exceptions=False) as client:
+            response = client.patch(
+                "/api/v1/workspaces/ws-assistant",
+                json={
+                    "version": workspace["version"],
+                    "assistant_defaults": {
+                        "assistant_kind": "persona",
+                        "assistant_id": "persona-1",
+                        "persona_memory_mode": "read_only",
+                    },
+                },
+            )
+        assert response.status_code == 200, response.text
+        payload = response.json()
+        assert payload["assistant_defaults"]["assistant_kind"] == "persona"
+        assert payload["assistant_defaults"]["assistant_id"] == "persona-1"
+        assert payload["assistant_defaults"]["persona_memory_mode"] == "read_only"
+        assert payload["assistant_defaults"]["voice"] is None
+        assert payload["assistant_defaults"]["style"] is None
+        assert payload["assistant_defaults"]["tool_policy_profile_id"] is None
+        persisted = db.get_workspace("ws-assistant")
+        assert persisted is not None
+        assert persisted["assistant_defaults_json"] == {
+            "assistant_kind": "persona",
+            "assistant_id": "persona-1",
+            "persona_memory_mode": "read_only",
+        }
+    finally:
+        workspace_fastapi_app.dependency_overrides.pop(get_request_user, None)
+        workspace_fastapi_app.dependency_overrides.pop(get_chacha_db_for_user, None)
+        workspace_fastapi_app.dependency_overrides.pop(WORKSPACES_WRITE_RATE_LIMIT, None)
+
+
+@pytest.mark.integration
+def test_workspace_api_requires_confirmation_for_read_write_assistant_default(workspace_fastapi_app, db):
+    from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import User
+
+    async def _allow_rate_limit() -> None:
+        return None
+
+    async def _user() -> User:
+        return User(
+            id=1,
+            username="testuser",
+            email="test@example.com",
+            is_active=True,
+            roles=["admin"],
+            is_admin=True,
+        )
+
+    workspace = db.upsert_workspace("ws-assistant", "Assistant Defaults")
+    workspace_fastapi_app.dependency_overrides[get_request_user] = _user
+    workspace_fastapi_app.dependency_overrides[get_chacha_db_for_user] = lambda: db
+    workspace_fastapi_app.dependency_overrides[WORKSPACES_WRITE_RATE_LIMIT] = _allow_rate_limit
+    try:
+        with TestClient(workspace_fastapi_app, raise_server_exceptions=False) as client:
+            missing_confirmation = client.patch(
+                "/api/v1/workspaces/ws-assistant",
+                json={
+                    "version": workspace["version"],
+                    "assistant_defaults": {
+                        "assistant_kind": "persona",
+                        "assistant_id": "persona-1",
+                        "persona_memory_mode": "read_write",
+                    },
+                },
+            )
+            assert missing_confirmation.status_code == 422, missing_confirmation.text
+
+            confirmed = client.patch(
+                "/api/v1/workspaces/ws-assistant",
+                json={
+                    "version": workspace["version"],
+                    "assistant_defaults": {
+                        "assistant_kind": "persona",
+                        "assistant_id": "persona-1",
+                        "persona_memory_mode": "read_write",
+                    },
+                    "confirm_read_write_assistant_default": True,
+                },
+            )
+        assert confirmed.status_code == 200, confirmed.text
+        assert confirmed.json()["assistant_defaults"]["persona_memory_mode"] == "read_write"
+    finally:
+        workspace_fastapi_app.dependency_overrides.pop(get_request_user, None)
+        workspace_fastapi_app.dependency_overrides.pop(get_chacha_db_for_user, None)
+        workspace_fastapi_app.dependency_overrides.pop(WORKSPACES_WRITE_RATE_LIMIT, None)
+
+
+@pytest.mark.integration
+def test_workspace_api_rejects_confirmation_only_patch(workspace_fastapi_app, db):
+    from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import User
+
+    async def _allow_rate_limit() -> None:
+        return None
+
+    async def _user() -> User:
+        return User(
+            id=1,
+            username="testuser",
+            email="test@example.com",
+            is_active=True,
+            roles=["admin"],
+            is_admin=True,
+        )
+
+    workspace = db.upsert_workspace("ws-assistant", "Assistant Defaults")
+    workspace_fastapi_app.dependency_overrides[get_request_user] = _user
+    workspace_fastapi_app.dependency_overrides[get_chacha_db_for_user] = lambda: db
+    workspace_fastapi_app.dependency_overrides[WORKSPACES_WRITE_RATE_LIMIT] = _allow_rate_limit
+    try:
+        with TestClient(workspace_fastapi_app, raise_server_exceptions=False) as client:
+            response = client.patch(
+                "/api/v1/workspaces/ws-assistant",
+                json={
+                    "version": workspace["version"],
+                    "confirm_read_write_assistant_default": True,
+                },
+            )
+        assert response.status_code == 422, response.text
+    finally:
+        workspace_fastapi_app.dependency_overrides.pop(get_request_user, None)
+        workspace_fastapi_app.dependency_overrides.pop(get_chacha_db_for_user, None)
+        workspace_fastapi_app.dependency_overrides.pop(WORKSPACES_WRITE_RATE_LIMIT, None)
+
+
+@pytest.mark.integration
 def test_workspace_root_endpoints_happy_path(workspace_fastapi_app, db):
     from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import User
 


### PR DESCRIPTION
## Summary
- Adds Workspace Assistant Defaults schema types for Persona-only V1 defaults, read/write memory modes, and null-only deferred fields.
- Adds ChaChaNotes schema v49 storage/migration support for reference-backed `assistant_defaults_json` on workspaces.
- Normalizes workspace rows so callers get `dict | None` while the DB stores compact JSON text, with focused migration/round-trip tests.

## Test Plan
- [x] `python -m py_compile tldw_Server_API/app/api/v1/schemas/workspace_schemas.py tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py`
- [x] `python -m pytest tldw_Server_API/tests/ChaChaNotesDB/test_workspace_assistant_defaults_db.py tldw_Server_API/tests/ChaChaNotesDB/test_workspace_sub_resources_db.py -q --tb=short --disable-warnings`
- [x] `python -m bandit -r tldw_Server_API/app/api/v1/schemas/workspace_schemas.py tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py -f json -o /tmp/bandit_workspace_assistant_defaults_storage_app_final.json`

Change summary: This PR implements the backend storage foundation for Workspace Assistant Defaults V1. The storage remains reference-backed and Persona-only by adding a compact JSON column to workspaces rather than copying Persona display data into Workspace rows. The DB layer parses malformed stored values to `None` to keep old or drifted rows from crashing readers, and API schema fields for deferred voice/style/tool-policy values are explicitly null-only until later PRD slices define those contracts.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Workspace Assistant Defaults V1 storage and API fields, with schema v49 migrations for SQLite/Postgres and JSON normalization. Addresses TASK-2278.

- **New Features**
  - API: adds `WorkspaceAssistantDefaults` (Persona-only) and `WorkspaceEffectiveAssistantDefault` types; PATCH accepts `assistant_defaults` and requires `confirm_read_write_assistant_default=true` for `read_write`; response returns `assistant_defaults`; confirmation flag is consumed, not stored.
  - DB: adds `assistant_defaults_json` with serializer/loader; rejects invalid JSON strings with InputError; treats malformed stored values as None; no Persona display snapshots.
  - Migrations: upgrades to v49 on SQLite/Postgres; new DBs include the column; drift healing ensures the column exists.
  - Tests: cover new DB creation, v48→v49 migration, round-trips and clearing, invalid JSON write rejection, unknown-only update rejection, and API validation for read_write confirmation.

<sup>Written for commit 7f29031b7791425f641295fe8aead1511c7e7b56. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2295?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

