### PR TITLE
Guard Mermaid artifact rendering by language

### DIFF
--- a/apps/packages/ui/src/components/Common/CodeBlock.tsx
+++ b/apps/packages/ui/src/components/Common/CodeBlock.tsx
@@ -17,7 +17,6 @@ import DOMPurify from "dompurify"
 import { useUiModeStore } from "@/store/ui-mode"
 import { useArtifactsStore } from "@/store/artifacts"
 import { normalizeLanguage, resolveTheme, safeLanguage } from "@/utils/code-theme"
-// import Mermaid from "./Mermaid"
 
 interface Props {
   language: string
@@ -70,13 +69,11 @@ export const CodeBlock: FC<Props> = ({ language, value, blockIndex }) => {
   const { openArtifact, isPinned } = useArtifactsStore()
   const { t } = useTranslation("common")
 
-  const isDiagramLanguage = ["mermaid", "diagram", "graphviz", "dot"].includes(
-    normalizedLanguage
-  )
+  const isMermaidLanguage = normalizedLanguage === "mermaid"
   const artifactId = computeKey()
-  const artifactKind = isDiagramLanguage ? "diagram" : "code"
+  const artifactKind = isMermaidLanguage ? "diagram" : "code"
   const artifactOriginId = `artifact-origin-${artifactId}`
-  const viewLabel = isDiagramLanguage
+  const viewLabel = isMermaidLanguage
     ? t("view", "View")
     : t("artifactsView", "View code")
   const downloadLabel = t("downloadCode", "Download code")
@@ -317,7 +314,7 @@ export const CodeBlock: FC<Props> = ({ language, value, blockIndex }) => {
     if (!isProMode) {
       return
     }
-    if (!isDiagramLanguage && totalLines <= artifactAutoThreshold) {
+    if (!isMermaidLanguage && totalLines <= artifactAutoThreshold) {
       return
     }
     if (autoOpenStateMap.get(artifactId)) {
@@ -345,7 +342,7 @@ export const CodeBlock: FC<Props> = ({ language, value, blockIndex }) => {
     artifactId,
     artifactAutoThreshold,
     autoOpenStateMap,
-    isDiagramLanguage,
+    isMermaidLanguage,
     isPinned,
     isProMode,
     normalizedLanguage,

--- a/apps/packages/ui/src/components/Common/Markdown.tsx
+++ b/apps/packages/ui/src/components/Common/Markdown.tsx
@@ -409,13 +409,21 @@ export function Markdown({
                           fontFamily: "var(--font-mono)",
                         }}
                       >
-                        {tokens.map((line, i) => (
-                          <div key={i} {...getLineProps({ line, key: i })}>
-                            {line.map((token, key) => (
-                              <span key={key} {...getTokenProps({ token, key })} />
-                            ))}
-                          </div>
-                        ))}
+                        {tokens.map((line, i) => {
+                          const { key: _lineKey, ...lineProps } = getLineProps({
+                            line,
+                            key: i
+                          })
+                          return (
+                            <div key={i} {...lineProps}>
+                              {line.map((token, key) => {
+                                const { key: _tokenKey, ...tokenProps } =
+                                  getTokenProps({ token, key })
+                                return <span key={key} {...tokenProps} />
+                              })}
+                            </div>
+                          )
+                        })}
                       </pre>
                     )}
                   </Highlight>
@@ -445,13 +453,21 @@ export function Markdown({
                           fontFamily: "var(--font-mono)"
                         }}
                       >
-                        {tokens.map((line, i) => (
-                          <div key={i} {...getLineProps({ line, key: i })}>
-                            {line.map((token, key) => (
-                              <span key={key} {...getTokenProps({ token, key })} />
-                            ))}
-                          </div>
-                        ))}
+                        {tokens.map((line, i) => {
+                          const { key: _lineKey, ...lineProps } = getLineProps({
+                            line,
+                            key: i
+                          })
+                          return (
+                            <div key={i} {...lineProps}>
+                              {line.map((token, key) => {
+                                const { key: _tokenKey, ...tokenProps } =
+                                  getTokenProps({ token, key })
+                                return <span key={key} {...tokenProps} />
+                              })}
+                            </div>
+                          )
+                        })}
                       </pre>
                     )}
                   </Highlight>

--- a/apps/packages/ui/src/components/Common/__tests__/CodeBlock.artifacts.test.tsx
+++ b/apps/packages/ui/src/components/Common/__tests__/CodeBlock.artifacts.test.tsx
@@ -1,0 +1,75 @@
+// @vitest-environment jsdom
+import React from "react"
+import { fireEvent, render, screen } from "@testing-library/react"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { CodeBlock } from "../CodeBlock"
+import { useArtifactsStore } from "@/store/artifacts"
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (_key: string, fallback?: string) => fallback || _key
+  })
+}))
+
+vi.mock("@plasmohq/storage/hook", () => ({
+  useStorage: (_key: string, defaultValue: unknown) =>
+    React.useState(defaultValue)
+}))
+
+vi.mock("antd", () => ({
+  Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>
+}))
+
+const resetArtifactsStore = () => {
+  useArtifactsStore.setState((state) => ({
+    ...state,
+    active: null,
+    isOpen: false,
+    isPinned: false,
+    history: [],
+    unreadCount: 0
+  }))
+}
+
+describe("CodeBlock artifacts", () => {
+  beforeEach(() => {
+    resetArtifactsStore()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    resetArtifactsStore()
+  })
+
+  it.each([
+    ["graphviz", "digraph G {\n  A -> B\n}"],
+    ["dot", "digraph G {\n  A -> B\n}"],
+    ["diagram", "box A -> box B"]
+  ])("keeps %s fences as code artifacts instead of Mermaid diagrams", (language, value) => {
+    render(<CodeBlock language={language} value={value} />)
+
+    fireEvent.click(screen.getByRole("button", { name: /view/i }))
+
+    expect(useArtifactsStore.getState().active).toEqual(
+      expect.objectContaining({
+        content: value,
+        kind: "code",
+        language
+      })
+    )
+  })
+
+  it("opens Mermaid fences as diagram artifacts", () => {
+    render(<CodeBlock language="mermaid" value={"graph TD\n  A-->B"} />)
+
+    fireEvent.click(screen.getByRole("button", { name: /view/i }))
+
+    expect(useArtifactsStore.getState().active).toEqual(
+      expect.objectContaining({
+        content: "graph TD\n  A-->B",
+        kind: "diagram",
+        language: "mermaid"
+      })
+    )
+  })
+})

--- a/apps/packages/ui/src/components/Sidepanel/Chat/ArtifactsPanel.tsx
+++ b/apps/packages/ui/src/components/Sidepanel/Chat/ArtifactsPanel.tsx
@@ -172,9 +172,12 @@ export const ArtifactsPanel = () => {
     return null
   }
 
-  const isCodeArtifact = active.kind === "code" || active.kind === "diagram"
-  const highlightLanguage =
-    active.kind === "diagram" ? "markdown" : normalizedLanguage
+  const isMermaidDiagramArtifact =
+    active.kind === "diagram" && normalizedLanguage === "mermaid"
+  const isCodeArtifact =
+    active.kind === "code" ||
+    (active.kind === "diagram" && !isMermaidDiagramArtifact)
+  const highlightLanguage = normalizedLanguage
 
   const handleCopy = () => {
     navigator.clipboard.writeText(active.content)
@@ -300,7 +303,7 @@ export const ArtifactsPanel = () => {
         </div>
       </div>
       <div className="flex-1 overflow-auto px-4 py-3">
-        {active.kind === "diagram" ? (
+        {isMermaidDiagramArtifact ? (
           <MermaidDiagramBlock
             enableArtifactAction={false}
             source={active.content}
@@ -323,21 +326,26 @@ export const ArtifactsPanel = () => {
                   ...style,
                   fontFamily: "var(--font-mono)"
                 }}>
-                {tokens.map((line, i) => (
-                  <div
-                    key={i}
-                    {...getLineProps({ line, key: i })}
-                    className="table w-full">
-                    <span className="table-cell select-none pr-3 text-right text-xs text-text-subtle">
-                      {i + 1}
-                    </span>
-                    <span className="table-cell whitespace-pre-wrap">
-                      {line.map((token, key) => (
-                        <span key={key} {...getTokenProps({ token, key })} />
-                      ))}
-                    </span>
-                  </div>
-                ))}
+                {tokens.map((line, i) => {
+                  const { key: _lineKey, ...lineProps } = getLineProps({
+                    line,
+                    key: i
+                  })
+                  return (
+                    <div key={i} {...lineProps} className="table w-full">
+                      <span className="table-cell select-none pr-3 text-right text-xs text-text-subtle">
+                        {i + 1}
+                      </span>
+                      <span className="table-cell whitespace-pre-wrap">
+                        {line.map((token, key) => {
+                          const { key: _tokenKey, ...tokenProps } =
+                            getTokenProps({ token, key })
+                          return <span key={key} {...tokenProps} />
+                        })}
+                      </span>
+                    </div>
+                  )
+                })}
               </pre>
             )}
           </Highlight>

--- a/apps/packages/ui/src/components/Sidepanel/Chat/__tests__/ArtifactsPanel.mermaid.test.tsx
+++ b/apps/packages/ui/src/components/Sidepanel/Chat/__tests__/ArtifactsPanel.mermaid.test.tsx
@@ -78,6 +78,15 @@ const diagramArtifact: ArtifactItem = {
   lineCount: 2
 }
 
+const graphvizArtifact: ArtifactItem = {
+  id: "graphviz-assistant-message-1-segment-0-block-0-abc123",
+  title: "Graphviz diagram 1",
+  content: "digraph G {\n  A -> B\n}",
+  kind: "diagram",
+  language: "graphviz",
+  lineCount: 3
+}
+
 const resetArtifactsStore = () => {
   useArtifactsStore.setState((state) => ({
     ...state,
@@ -133,6 +142,20 @@ describe("ArtifactsPanel Mermaid artifacts", () => {
         source: diagramArtifact.content
       })
     )
+  })
+
+  it("does not render non-Mermaid diagram artifacts with the Mermaid block", () => {
+    useArtifactsStore.getState().openArtifact(graphvizArtifact)
+
+    const { container } = render(<ArtifactsPanel />)
+
+    expect(screen.getByText("Graphviz diagram 1")).toBeInTheDocument()
+    expect(
+      screen.queryByTestId("shared-mermaid-diagram-block")
+    ).not.toBeInTheDocument()
+    expect(container).toHaveTextContent("digraph G")
+    expect(container).toHaveTextContent("A -> B")
+    expect(mermaidDiagramBlockMock).not.toHaveBeenCalled()
   })
 
   it("jumps to the matching Mermaid artifact origin", () => {

--- a/backlog/tasks/task-2279 - Guard-Mermaid-artifact-rendering-by-fence-language.md
+++ b/backlog/tasks/task-2279 - Guard-Mermaid-artifact-rendering-by-fence-language.md
@@ -1,0 +1,51 @@
+---
+id: TASK-2279
+title: Guard Mermaid artifact rendering by fence language
+status: Done
+references:
+- Docs/superpowers/specs/2026-06-04-chat-mermaid-diagrams-design.md
+- Docs/superpowers/plans/2026-06-04-chat-mermaid-diagrams-implementation-plan.md
+modified_files:
+- apps/packages/ui/src/components/Common/CodeBlock.tsx
+- apps/packages/ui/src/components/Common/Markdown.tsx
+- apps/packages/ui/src/components/Common/__tests__/CodeBlock.artifacts.test.tsx
+- apps/packages/ui/src/components/Sidepanel/Chat/ArtifactsPanel.tsx
+- apps/packages/ui/src/components/Sidepanel/Chat/__tests__/ArtifactsPanel.mermaid.test.tsx
+documentation:
+- Docs/superpowers/specs/2026-06-04-chat-mermaid-diagrams-design.md
+- Docs/superpowers/plans/2026-06-04-chat-mermaid-diagrams-implementation-plan.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Prevent non-Mermaid diagram-like code fences such as graphviz, dot, and generic diagram from opening as Mermaid diagram artifacts after the shared chat artifact renderer landed. Mermaid fences should still render through the shared MermaidDiagramBlock path; non-Mermaid diagram languages should remain code artifacts until dedicated renderers exist.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Implemented language guards in CodeBlock and ArtifactsPanel so only normalized Mermaid fences/artifacts route to MermaidDiagramBlock. Graphviz, DOT, and generic diagram fences now open as code artifacts, and non-Mermaid diagram-kind artifacts fall back to highlighted code display. Added focused regression coverage for CodeBlock artifact classification and ArtifactsPanel language-gated rendering, and removed Prism key-prop spreading in touched highlighted code paths.
+
+Verification after rebasing onto origin/dev: RED tests first failed for graphviz/dot/diagram opening as diagram artifacts and for graphviz diagram-kind artifacts rendering via MermaidDiagramBlock. GREEN verification passed with `bunx vitest run src/components/Common/__tests__/CodeBlock.artifacts.test.tsx src/components/Common/__tests__/Markdown.mermaid.test.tsx src/components/Common/__tests__/MermaidDiagramBlock.test.tsx src/components/Common/Playground/__tests__/Message.mermaid-rendering.test.tsx src/components/Common/QuickChatHelper/__tests__/QuickChatMessage.mermaid.test.tsx src/components/Sidepanel/Chat/__tests__/ArtifactsPanel.mermaid.test.tsx` (54 tests). `git diff --check origin/dev...HEAD` passed. `env NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit` still fails in unrelated KnowledgeQA test fixtures (`KnowledgeQALayout.behavior.test.tsx`, `knowledgeQaStateFixtures.ts`) with the existing missing/optional id/sourceStatus/sourceHealth errors. Bandit skipped because the touched implementation is frontend TypeScript/Markdown task metadata, not Python.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## Summary

- Guard chat code-block artifact creation so only normalized `mermaid` fences create `diagram` artifacts.
- Guard the chat artifacts panel so only `kind: "diagram"` plus `language: "mermaid"` renders through `MermaidDiagramBlock`; non-Mermaid diagram-kind artifacts fall back to highlighted code.
- Add regressions for Graphviz, DOT, generic diagram, and legacy/non-CodeBlock diagram artifacts.
- Remove Prism `key` prop spreading in touched highlighted-code render paths.

## Verification

- RED: `CodeBlock.artifacts.test.tsx` first failed because `graphviz`, `dot`, and `diagram` opened as `kind: "diagram"`.
- RED: `ArtifactsPanel.mermaid.test.tsx` first failed because a Graphviz diagram-kind artifact rendered through `MermaidDiagramBlock`.
- GREEN: `bunx vitest run src/components/Common/__tests__/CodeBlock.artifacts.test.tsx src/components/Common/__tests__/Markdown.mermaid.test.tsx src/components/Common/__tests__/MermaidDiagramBlock.test.tsx src/components/Common/Playground/__tests__/Message.mermaid-rendering.test.tsx src/components/Common/QuickChatHelper/__tests__/QuickChatMessage.mermaid.test.tsx src/components/Sidepanel/Chat/__tests__/ArtifactsPanel.mermaid.test.tsx` passed, 54 tests.
- `git diff --check origin/dev...HEAD` passed.
- `env NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit` still fails in unrelated KnowledgeQA test fixtures: `KnowledgeQALayout.behavior.test.tsx` and `knowledgeQaStateFixtures.ts` missing/optional `id`, `sourceStatus`, and `sourceHealth` fixture fields.
- Bandit skipped: touched implementation is frontend TypeScript plus Backlog metadata, not Python.

## Change summary

Human maintainer must replace this section before merge with their own summary explaining what changed and why these implementation choices were made.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Guard Mermaid diagram artifacts by language to prevent non‑Mermaid fences from rendering via Mermaid. Only `mermaid` fences create `diagram` artifacts; others render as code (addresses Linear TASK-2279).

- **Bug Fixes**
  - `CodeBlock`: classify as `diagram` only for normalized `mermaid`; `graphviz`, `dot`, and `diagram` fences stay `code`.
  - `ArtifactsPanel`: use `MermaidDiagramBlock` only when `kind: "diagram"` and `language: "mermaid"`; otherwise show highlighted code.
  - Added regressions for Graphviz/DOT/generic diagram and non-CodeBlock artifacts; removed Prism `key` prop spreading in highlighted code paths.

<sup>Written for commit d0a5b947844b6ea718cec5169d8c17461e97c23f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2298?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

