### PR TITLE
Add MCP profile policy decision core

### DIFF
--- a/Docs/superpowers/plans/2026-06-07-mcp-policy-decision-core-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-06-07-mcp-policy-decision-core-implementation-plan.md
@@ -1,0 +1,830 @@
+# MCP Policy Decision Core Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement the first MCP/profile policy-decision slice: a package-owned `deny`/`ask`/`allow` decision core, compatibility compilation from existing profile policy fields, and a redacted explain/simulation contract.
+
+**Architecture:** Keep the executable core in `mcp_unified` so the standalone package and tldw_server host share one decision model. Add new decision primitives in a focused `mcp_unified/profiles/decisions.py` module, then thread optional decision metadata through `mcp_unified/profiles/resolution.py` without changing existing runtime allow/deny behavior. Catalog visibility, path-pattern compilation, external MCP wildcard enforcement, hooks, and shell hardening are deliberately deferred to later slices.
+
+**Tech Stack:** Python 3.10+, Pydantic v2 models, existing `mcp_unified.profiles` package, pytest, Bandit.
+
+---
+
+## Context
+
+Spec: `Docs/superpowers/specs/2026-06-07-mcp-profile-policy-decision-model-design.md`
+
+Planning Backlog task: `TASK-2307`
+
+Implementation Backlog task: `TASK-2308`
+
+Branch/worktree: `codex/mcp-profile-policy-decision-design` at `.worktrees/mcp-profile-policy-decision-design`
+
+The current package has:
+
+- `mcp_unified/profiles/models.py`
+  - `ProfilePolicy` with `extra="allow"`, so new fields such as `tool_rules`,
+    `command_rules`, and `permission_mode` can be read before first-class schema
+    fields are added.
+- `mcp_unified/profiles/resolution.py`
+  - `EffectivePolicy`, `EffectivePolicyResult`, and
+    `build_effective_policy_result(...)`.
+  - Existing behavior returns `status="denied"` for explicit denied tools and
+    unlisted tool execution.
+- `mcp_unified/gateway/profile_runtime.py`
+  - already consumes `EffectivePolicyResult` for profile-aware gateway runtime
+    filtering/calls.
+- `tldw_Server_API/app/core/MCP_unified/protocol.py`
+  - independently filters by `canExecute` and effective policy; do not change it
+    in this slice.
+
+## Scope
+
+In scope:
+
+- Decision model: outcome, visibility, call state, subject, matched rules,
+  reason code, approval metadata, redaction flag.
+- Merge helper with `deny > ask > allow` precedence.
+- Compatibility compiler for existing `allowed_tools`, `denied_tools`, and
+  legacy `Bash(...)` command-pattern entries.
+- Structured rule support for profile extra fields:
+  - `tool_rules`
+  - `command_rules`
+  - `mcp_rules` only as data model/compile output, not runtime enforcement.
+- Optional decision metadata on `EffectivePolicyResult`.
+- Package-local explain/simulation helper for tool decisions.
+- Exports and focused tests.
+
+Out of scope:
+
+- No runtime catalog visibility changes.
+- No path matcher compiler.
+- No external MCP wildcard enforcement.
+- No shell parser/runtime changes.
+- No hook integration.
+- No FastAPI routes or CLI commands.
+- No behavior change for current allow/deny runtime decisions except richer
+  metadata attached to results.
+
+## File Structure
+
+- Create `mcp_unified/profiles/decisions.py`
+  - Owns package-neutral Pydantic models, rule compilation, merge, and explain
+    helpers.
+- Modify `mcp_unified/profiles/resolution.py`
+  - Adds optional decision metadata to `EffectivePolicyResult`.
+  - Uses decision helper when a `tool_name` is supplied.
+  - Preserves existing `status` and `reason_code` outputs for compatibility.
+- Modify `mcp_unified/profiles/__init__.py`
+  - Re-export public decision models/helpers.
+- Create `tldw_Server_API/app/core/MCP_unified/tests/test_profile_policy_decisions.py`
+  - Focused tests for new decision primitives and compiler behavior.
+- Modify `tldw_Server_API/app/core/MCP_unified/tests/test_profile_structured_resolution.py`
+  - Add assertions that existing resolution results now carry compatible
+    decision metadata.
+- Modify `backlog/tasks/task-2308 - Implement-MCP-policy-decision-core.md`
+  - Track implementation outcome and validation when executing this plan.
+
+## Behavioral Contracts
+
+Decision outcomes:
+
+```python
+PolicyDecisionOutcome = Literal["deny", "ask", "allow"]
+```
+
+Outcome-derived defaults:
+
+| Outcome | visibility | call_state | requires_approval |
+| --- | --- | --- | --- |
+| `deny` | `hidden` | `blocked` | `False` |
+| `ask` | `direct` | `approval_required` | `True` |
+| `allow` | `direct` | `callable` | `False` |
+
+Merge precedence:
+
+```text
+deny > ask > allow
+```
+
+Compatibility requirements:
+
+- Existing `denied_tools` entries compile to `tool` deny rules.
+- Existing `allowed_tools` entries compile to `tool` allow rules.
+- Existing `Bash(git *)` entries compile to `command` rules with
+  `argv=("git", "*")`.
+- `Bash(*)` should compile as invalid/rejected for this first slice.
+- Existing `build_effective_policy_result(...)` status/reason behavior remains
+  unchanged for current callers.
+- Decision/explain data must not include raw tool arguments, file content, raw
+  diffs, read receipts, credential values, environment values, or absolute host
+  paths.
+
+## Task 1: Add Decision Model Primitives
+
+**Files:**
+- Create: `mcp_unified/profiles/decisions.py`
+- Create: `tldw_Server_API/app/core/MCP_unified/tests/test_profile_policy_decisions.py`
+
+- [ ] **Step 1: Write failing model tests**
+
+Add tests:
+
+```python
+from mcp_unified.profiles.decisions import (
+    PolicyDecision,
+    PolicyDecisionSubject,
+)
+
+
+def test_policy_decision_defaults_for_ask() -> None:
+    decision = PolicyDecision(
+        outcome="ask",
+        reason_code="approval_required",
+        subject=PolicyDecisionSubject(type="tool", normalized="fs.patch"),
+    )
+
+    assert decision.visibility == "direct"
+    assert decision.call_state == "approval_required"
+    assert decision.requires_approval is True
+
+
+def test_policy_decision_defaults_for_deny() -> None:
+    decision = PolicyDecision(
+        outcome="deny",
+        reason_code="tool_denied",
+        subject=PolicyDecisionSubject(type="tool", normalized="fs.write"),
+    )
+
+    assert decision.visibility == "hidden"
+    assert decision.call_state == "blocked"
+    assert decision.requires_approval is False
+```
+
+- [ ] **Step 2: Run tests to verify failure**
+
+Run:
+
+```bash
+source ../../.venv/bin/activate && python -m pytest \
+  tldw_Server_API/app/core/MCP_unified/tests/test_profile_policy_decisions.py \
+  -q
+```
+
+Expected: FAIL because `mcp_unified.profiles.decisions` does not exist.
+
+- [ ] **Step 3: Implement model primitives**
+
+Create `mcp_unified/profiles/decisions.py` with these public models:
+
+```python
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+PolicyDecisionOutcome = Literal["deny", "ask", "allow"]
+PolicyDecisionVisibility = Literal["hidden", "direct", "deferred", "debug_only"]
+PolicyDecisionCallState = Literal["blocked", "approval_required", "callable"]
+
+
+class PolicyDecisionSubject(BaseModel):
+    """Normalized policy subject used by decision and explain payloads."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    type: str
+    normalized: str
+    display_name: str | None = None
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+
+class PolicyMatchedRule(BaseModel):
+    """Redacted summary of one rule that contributed to a decision."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    source: str
+    rule_type: str
+    pattern: str | None = None
+    outcome: PolicyDecisionOutcome
+    reason_code: str | None = None
+
+
+class PolicyDecision(BaseModel):
+    """Final or intermediate permission decision for one policy subject."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    outcome: PolicyDecisionOutcome
+    reason_code: str
+    subject: PolicyDecisionSubject
+    matched_rules: list[PolicyMatchedRule] = Field(default_factory=list)
+    visibility: PolicyDecisionVisibility | None = None
+    call_state: PolicyDecisionCallState | None = None
+    requires_approval: bool | None = None
+    explainable: bool = True
+    redacted: bool = True
+
+    @model_validator(mode="after")
+    def _derive_defaults(self) -> "PolicyDecision":
+        defaults = _DEFAULTS_BY_OUTCOME[self.outcome]
+        if self.visibility is None:
+            self.visibility = defaults["visibility"]
+        if self.call_state is None:
+            self.call_state = defaults["call_state"]
+        if self.requires_approval is None:
+            self.requires_approval = bool(defaults["requires_approval"])
+        return self
+```
+
+Use an internal `_DEFAULTS_BY_OUTCOME` mapping to avoid scattering default
+logic.
+
+- [ ] **Step 4: Run focused tests**
+
+Run the same pytest command.
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mcp_unified/profiles/decisions.py \
+  tldw_Server_API/app/core/MCP_unified/tests/test_profile_policy_decisions.py
+git commit -m "feat: add mcp policy decision models"
+```
+
+## Task 2: Add Decision Merge And Rule Compilation
+
+**Files:**
+- Modify: `mcp_unified/profiles/decisions.py`
+- Modify: `tldw_Server_API/app/core/MCP_unified/tests/test_profile_policy_decisions.py`
+
+- [ ] **Step 1: Write failing merge/compiler tests**
+
+Add tests:
+
+```python
+from mcp_unified.profiles.decisions import (
+    compile_profile_policy_rules,
+    merge_policy_decisions,
+)
+from mcp_unified.profiles.models import ProfilePolicy
+
+
+def test_merge_policy_decisions_uses_deny_over_ask_over_allow() -> None:
+    subject = PolicyDecisionSubject(type="tool", normalized="fs.write")
+    merged = merge_policy_decisions(
+        [
+            PolicyDecision(outcome="allow", reason_code="allowed", subject=subject),
+            PolicyDecision(outcome="ask", reason_code="approval_required", subject=subject),
+            PolicyDecision(outcome="deny", reason_code="tool_denied", subject=subject),
+        ],
+        subject=subject,
+    )
+
+    assert merged.outcome == "deny"
+    assert merged.reason_code == "tool_denied"
+    assert merged.call_state == "blocked"
+
+
+def test_compile_profile_policy_rules_preserves_legacy_tool_fields() -> None:
+    rules = compile_profile_policy_rules(
+        ProfilePolicy(
+            allowed_tools=["fs.read"],
+            denied_tools=["fs.write"],
+        )
+    )
+
+    assert [(rule.rule_type, rule.pattern, rule.outcome) for rule in rules] == [
+        ("tool", "fs.write", "deny"),
+        ("tool", "fs.read", "allow"),
+    ]
+
+
+def test_compile_profile_policy_rules_converts_legacy_bash_pattern_to_argv_rule() -> None:
+    rules = compile_profile_policy_rules(ProfilePolicy(allowed_tools=["Bash(git *)"]))
+
+    command_rule = rules[0]
+    assert command_rule.rule_type == "command"
+    assert command_rule.argv == ("git", "*")
+    assert command_rule.outcome == "allow"
+```
+
+- [ ] **Step 2: Run tests to verify failure**
+
+Run:
+
+```bash
+source ../../.venv/bin/activate && python -m pytest \
+  tldw_Server_API/app/core/MCP_unified/tests/test_profile_policy_decisions.py \
+  -q
+```
+
+Expected: FAIL because merge/compiler helpers do not exist.
+
+- [ ] **Step 3: Implement rule model and merge helper**
+
+Add:
+
+```python
+PolicyRuleType = Literal["tool", "command", "mcp", "capability", "risk_class"]
+
+
+class PolicyDecisionRule(BaseModel):
+    """Compiled rule from legacy or structured profile policy."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    rule_type: PolicyRuleType
+    outcome: PolicyDecisionOutcome
+    source: str
+    pattern: str | None = None
+    argv: tuple[str, ...] | None = None
+    reason_code: str | None = None
+```
+
+Add:
+
+```python
+def merge_policy_decisions(
+    decisions: list[PolicyDecision],
+    *,
+    subject: PolicyDecisionSubject,
+    default_reason_code: str = "no_matching_rule",
+) -> PolicyDecision:
+    ...
+```
+
+Implementation rules:
+
+- Empty list returns `deny` with `default_reason_code`.
+- Highest precedence outcome wins.
+- Keep matched rules from all decisions in the merged payload.
+- Use the first decision at the winning precedence as the reason source.
+
+- [ ] **Step 4: Implement compatibility compiler**
+
+Add:
+
+```python
+def compile_profile_policy_rules(policy_document: Any) -> list[PolicyDecisionRule]:
+    ...
+```
+
+Implementation rules:
+
+- Read `denied_tools` first so output order records deny precedence.
+- Read `allowed_tools` second.
+- Accept `ProfilePolicy` or mapping-like objects.
+- Compile plain strings to `rule_type="tool"`.
+- Compile `Bash(git *)` to `rule_type="command"`, `argv=("git", "*")`.
+- Reject or skip `Bash(*)` with a validation warning model only if warnings are
+  added now; otherwise raise `ValueError("broad bash patterns are not allowed")`.
+- Compile structured extra `tool_rules`, `command_rules`, and `mcp_rules` when
+  present, but do not integrate them into runtime enforcement yet.
+- Read structured extra fields through `getattr(policy_document, key, None)`
+  or `policy_document.model_extra` so Pydantic `extra="allow"` values are
+  handled consistently.
+
+Keep helper functions small:
+
+- `_compile_legacy_tool_pattern(pattern, *, outcome, source)`
+- `_compile_bash_pattern(inner, *, outcome, source)`
+- `_as_sequence(value)`
+
+- [ ] **Step 5: Run focused tests**
+
+Run the same pytest command.
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add mcp_unified/profiles/decisions.py \
+  tldw_Server_API/app/core/MCP_unified/tests/test_profile_policy_decisions.py
+git commit -m "feat: compile mcp profile decision rules"
+```
+
+## Task 3: Evaluate Tool Decisions And Preserve Resolution Compatibility
+
+**Files:**
+- Modify: `mcp_unified/profiles/decisions.py`
+- Modify: `mcp_unified/profiles/resolution.py`
+- Modify: `tldw_Server_API/app/core/MCP_unified/tests/test_profile_policy_decisions.py`
+- Modify: `tldw_Server_API/app/core/MCP_unified/tests/test_profile_structured_resolution.py`
+
+- [ ] **Step 1: Write failing evaluation tests**
+
+Add decision-level tests:
+
+```python
+from mcp_unified.profiles.decisions import evaluate_profile_tool_decision
+from mcp_unified.profiles.models import MCPProfile, ProfilePolicy
+
+
+def test_evaluate_profile_tool_decision_denied_tool_wins() -> None:
+    profile = MCPProfile(
+        id="strict",
+        name="Strict",
+        policy_document=ProfilePolicy(
+            allowed_tools=["fs.write"],
+            denied_tools=["fs.write"],
+        ),
+    )
+
+    decision = evaluate_profile_tool_decision(profile, "fs.write")
+
+    assert decision.outcome == "deny"
+    assert decision.reason_code == "tool_denied"
+
+
+def test_evaluate_profile_tool_decision_allowed_tool_allows() -> None:
+    profile = MCPProfile(
+        id="reader",
+        name="Reader",
+        policy_document=ProfilePolicy(allowed_tools=["fs.read"]),
+    )
+
+    decision = evaluate_profile_tool_decision(profile, "fs.read")
+
+    assert decision.outcome == "allow"
+    assert decision.call_state == "callable"
+
+
+def test_evaluate_profile_tool_decision_structured_ask_rule_requires_approval() -> None:
+    profile = MCPProfile(
+        id="default-ask",
+        name="Default Ask",
+        policy_document=ProfilePolicy.model_validate(
+            {"tool_rules": [{"pattern": "fs.patch", "outcome": "ask"}]}
+        ),
+    )
+
+    decision = evaluate_profile_tool_decision(profile, "fs.patch")
+
+    assert decision.outcome == "ask"
+    assert decision.call_state == "approval_required"
+```
+
+Add resolution compatibility assertions to existing tests:
+
+```python
+assert result.decision is not None
+assert result.decision.outcome == "deny"
+```
+
+for denied tool cases, and:
+
+```python
+assert result.decision is not None
+assert result.decision.outcome == "allow"
+```
+
+for allowed tool cases.
+
+- [ ] **Step 2: Run tests to verify failure**
+
+Run:
+
+```bash
+source ../../.venv/bin/activate && python -m pytest \
+  tldw_Server_API/app/core/MCP_unified/tests/test_profile_policy_decisions.py \
+  tldw_Server_API/app/core/MCP_unified/tests/test_profile_structured_resolution.py \
+  -q
+```
+
+Expected: FAIL because evaluation helper and `EffectivePolicyResult.decision`
+do not exist.
+
+- [ ] **Step 3: Implement tool decision evaluation**
+
+Add:
+
+```python
+def evaluate_profile_tool_decision(
+    profile: MCPProfile,
+    tool_name: str,
+    *,
+    capability: str | None = None,
+) -> PolicyDecision:
+    ...
+```
+
+Implementation rules:
+
+- Subject is `PolicyDecisionSubject(type="tool", normalized=tool_name)`.
+- Blank tool names raise `ValueError`.
+- Explicit denied tool returns `deny/tool_denied`.
+- Structured tool rule with `outcome="ask"` returns ask.
+- Explicit allowed tool returns `allow/tool_allowed`.
+- If no allowed tools exist but capability is provided and allowed, return
+  `allow/capability_allowed`.
+- Otherwise return `deny/tool_not_allowed`.
+- Keep existing capability-deny behavior compatible when called from
+  resolution.
+
+- [ ] **Step 4: Thread decision metadata through resolution**
+
+Modify `EffectivePolicyResult`:
+
+```python
+decision: PolicyDecision | None = None
+```
+
+In `build_effective_policy_result(...)`:
+
+- Compute `decision` when `tool_name is not None`.
+- Preserve existing `status` and `reason_code` mappings:
+  - decision `deny/tool_denied` -> `status="denied"`, `reason_code="tool_denied"`.
+  - decision `deny/tool_not_allowed` -> `status="denied"`, `reason_code="tool_not_allowed"`.
+  - decision `ask/*` -> `status="approval_required"`, `reason_code=decision.reason_code`.
+  - decision `allow/*` -> continue normal capability checks and return `resolved`.
+- Return the decision on both denied and resolved results.
+
+Do not alter workspace-binding denial behavior except to leave `decision=None`
+for that non-tool subject in this first slice.
+
+- [ ] **Step 5: Run focused tests**
+
+Run the same pytest command.
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add mcp_unified/profiles/decisions.py mcp_unified/profiles/resolution.py \
+  tldw_Server_API/app/core/MCP_unified/tests/test_profile_policy_decisions.py \
+  tldw_Server_API/app/core/MCP_unified/tests/test_profile_structured_resolution.py
+git commit -m "feat: attach mcp profile policy decisions"
+```
+
+## Task 4: Add Explain/Simulation Contract
+
+**Files:**
+- Modify: `mcp_unified/profiles/decisions.py`
+- Modify: `tldw_Server_API/app/core/MCP_unified/tests/test_profile_policy_decisions.py`
+
+- [ ] **Step 1: Write failing explain tests**
+
+Add tests:
+
+```python
+from mcp_unified.profiles.decisions import explain_profile_tool_decision
+
+
+def test_explain_profile_tool_decision_returns_redacted_payload() -> None:
+    profile = MCPProfile(
+        id="qa",
+        name="QA",
+        policy_document=ProfilePolicy(denied_tools=["fs.write"]),
+    )
+
+    explanation = explain_profile_tool_decision(profile, "fs.write")
+
+    assert explanation.final_outcome == "deny"
+    assert explanation.reason_code == "tool_denied"
+    assert explanation.profile_id == "qa"
+    assert explanation.subject.normalized == "fs.write"
+    assert explanation.redacted is True
+    assert explanation.matches[0].source == "policy_document.denied_tools"
+```
+
+- [ ] **Step 2: Run tests to verify failure**
+
+Run:
+
+```bash
+source ../../.venv/bin/activate && python -m pytest \
+  tldw_Server_API/app/core/MCP_unified/tests/test_profile_policy_decisions.py \
+  -q
+```
+
+Expected: FAIL because explain models/helpers do not exist.
+
+- [ ] **Step 3: Implement explain models**
+
+Add:
+
+```python
+class PolicyExplanation(BaseModel):
+    """Redacted operator/debug explanation for one simulated policy decision."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    final_outcome: PolicyDecisionOutcome
+    reason_code: str
+    subject: PolicyDecisionSubject
+    matches: list[PolicyMatchedRule] = Field(default_factory=list)
+    profile_id: str | None = None
+    permission_mode: str | None = None
+    visibility: PolicyDecisionVisibility
+    call_state: PolicyDecisionCallState
+    requires_approval: bool
+    hook_results: list[dict[str, Any]] = Field(default_factory=list)
+    sandbox: dict[str, Any] = Field(default_factory=dict)
+    redacted: bool = True
+```
+
+Add:
+
+```python
+def explain_profile_tool_decision(
+    profile: MCPProfile,
+    tool_name: str,
+    *,
+    capability: str | None = None,
+) -> PolicyExplanation:
+    ...
+```
+
+Implementation rules:
+
+- Call `evaluate_profile_tool_decision(...)`.
+- Copy only safe scalar metadata.
+- Include `permission_mode` if present as an extra field on the policy document.
+- Keep `hook_results=[]` and `sandbox={}` in this slice.
+
+- [ ] **Step 4: Run focused tests**
+
+Run the same pytest command.
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mcp_unified/profiles/decisions.py \
+  tldw_Server_API/app/core/MCP_unified/tests/test_profile_policy_decisions.py
+git commit -m "feat: add mcp policy explanation contract"
+```
+
+## Task 5: Export Public Decision API And Verify Package Boundary
+
+**Files:**
+- Modify: `mcp_unified/profiles/__init__.py`
+- Modify: `tldw_Server_API/app/core/MCP_unified/tests/test_profile_policy_decisions.py`
+- Optional Modify: `tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py`
+
+- [ ] **Step 1: Write failing export test**
+
+Add:
+
+```python
+def test_profile_decision_api_exports_from_profiles_package() -> None:
+    from mcp_unified.profiles import (
+        PolicyDecision,
+        PolicyDecisionSubject,
+        explain_profile_tool_decision,
+    )
+
+    assert PolicyDecision is not None
+    assert PolicyDecisionSubject is not None
+    assert explain_profile_tool_decision is not None
+```
+
+If package-boundary tests already cover this import style, add a small assertion
+there instead of duplicating.
+
+- [ ] **Step 2: Run tests to verify failure**
+
+Run:
+
+```bash
+source ../../.venv/bin/activate && python -m pytest \
+  tldw_Server_API/app/core/MCP_unified/tests/test_profile_policy_decisions.py \
+  -q
+```
+
+Expected: FAIL because exports are missing.
+
+- [ ] **Step 3: Add exports**
+
+Modify `mcp_unified/profiles/__init__.py` to export:
+
+- `PolicyDecision`
+- `PolicyDecisionCallState`
+- `PolicyDecisionOutcome`
+- `PolicyDecisionRule`
+- `PolicyDecisionSubject`
+- `PolicyDecisionVisibility`
+- `PolicyExplanation`
+- `PolicyMatchedRule`
+- `compile_profile_policy_rules`
+- `evaluate_profile_tool_decision`
+- `explain_profile_tool_decision`
+- `merge_policy_decisions`
+
+- [ ] **Step 4: Run focused tests**
+
+Run:
+
+```bash
+source ../../.venv/bin/activate && python -m pytest \
+  tldw_Server_API/app/core/MCP_unified/tests/test_profile_policy_decisions.py \
+  tldw_Server_API/app/core/MCP_unified/tests/test_profile_structured_resolution.py \
+  -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mcp_unified/profiles/__init__.py \
+  tldw_Server_API/app/core/MCP_unified/tests/test_profile_policy_decisions.py \
+  tldw_Server_API/app/core/MCP_unified/tests/test_profile_structured_resolution.py
+git commit -m "feat: export mcp policy decision api"
+```
+
+## Task 6: Final Validation And Backlog Closeout
+
+**Files:**
+- Modify: `backlog/tasks/task-2308 - Implement-MCP-policy-decision-core.md`
+
+- [ ] **Step 1: Run targeted tests**
+
+Run:
+
+```bash
+source ../../.venv/bin/activate && python -m pytest \
+  tldw_Server_API/app/core/MCP_unified/tests/test_profile_policy_decisions.py \
+  tldw_Server_API/app/core/MCP_unified/tests/test_profile_structured_resolution.py \
+  tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py::test_gateway_profile_runtime_filters_and_allows_default_profile_tools \
+  tldw_Server_API/app/core/MCP_unified/tests/test_protocol_allowed_tools.py::test_protocol_tools_call_blocks_tool_denied_by_effective_policy \
+  -q
+```
+
+Expected: PASS. The gateway/protocol tests are smoke coverage that existing
+runtime policy behavior did not regress.
+
+- [ ] **Step 2: Run Bandit on touched code**
+
+Run:
+
+```bash
+source ../../.venv/bin/activate && python -m bandit -r \
+  mcp_unified/profiles/decisions.py \
+  mcp_unified/profiles/resolution.py \
+  mcp_unified/profiles/__init__.py \
+  -f json -o /tmp/bandit_mcp_policy_decision_core.json
+```
+
+Expected: exit 0 or only documented non-touched/baseline findings. Fix any new
+touched-code findings before continuing.
+
+- [ ] **Step 3: Run diff hygiene**
+
+Run:
+
+```bash
+git diff --check
+```
+
+Expected: no whitespace errors.
+
+- [ ] **Step 4: Update Backlog task**
+
+Record:
+
+- implementation summary;
+- test commands and outcomes;
+- Bandit output path and outcome;
+- known skips/blockers;
+- touched files.
+
+- [ ] **Step 5: Commit final task update**
+
+```bash
+git add "backlog/tasks/task-2308 - Implement-MCP-policy-decision-core.md"
+git commit -m "chore: close mcp policy decision core task"
+```
+
+## Risk Review
+
+- **Runtime behavior drift:** This slice must not change existing allow/deny
+  enforcement except adding metadata. Keep runtime catalog and approval changes
+  for later slices.
+- **Ambiguous command patterns:** Compile legacy `Bash(...)` into argv-token
+  rules only. Do not add raw shell authorization.
+- **Over-modeling:** Keep path, MCP wildcard, hooks, sandbox, and catalog
+  changes out of this slice except for fields needed by the shared schema.
+- **Trace leakage:** Explain payloads must stay redacted and argument-free.
+- **Pydantic compatibility:** Existing model construction patterns include
+  `model_construct(...)` with `None` fields. Preserve safe defaults and avoid
+  validators that break legacy tests.
+
+## Completion Criteria
+
+- New decision primitives are package-owned and exported from
+  `mcp_unified.profiles`.
+- Existing profile resolution behavior remains compatible.
+- Denied, ask, and allowed decisions carry structured metadata.
+- Legacy `allowed_tools`/`denied_tools` and `Bash(...)` policy strings compile
+  into typed rules.
+- A package-local explain helper returns redacted decision explanations.
+- Targeted tests, Bandit, and diff hygiene pass and are recorded in `TASK-2308`.

--- a/Docs/superpowers/plans/2026-06-07-mcp-safe-file-tools-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-06-07-mcp-safe-file-tools-implementation-plan.md
@@ -67,10 +67,15 @@ Path grants:
   "path_scope_mode": "enforce",
   "path_grants": [
     {"path": "documents", "actions": ["read", "edit", "write"]},
+    {"path": "documents/private", "actions": ["edit", "write"], "effect": "deny"},
     {"path": "downloads", "actions": ["read"]}
   ]
 }
 ```
+
+`effect` is optional and defaults to `allow`. Deny grants take precedence over allow grants for the same path/action. The runtime enforcer should consume a flat effective grant list; future hierarchical authoring can compile into that flat list.
+
+Reserved future path actions are `delete`, `rename`, `move`, `share`, `export`, `chmod`, `admin`, and `lock`. The first implementation enforces only `read`, `edit`, and `write`, but these names should be rejected as first-slice executable actions instead of being folded into `write`.
 
 Candidate shape:
 
@@ -110,6 +115,9 @@ The writing-plans skill normally asks for a separate plan-review subagent. This 
 
 - The protocol seam must remain compatible with old test fakes and host enforcers. It may fall back to the old enforcer call shape only when no derived candidates are required; if derived candidates exist and the enforcer cannot accept them, fail closed.
 - If `path_grants` is present, malformed or non-matching grants must not fall through to broader legacy allowlists. Legacy `path_allowlist_prefixes` is a fallback only when `path_grants` is absent.
+- Deny grants should be supported in the first implementation so private subtrees can override broader writable parent grants.
+- Path-enforcement results should expose safe structured decision metadata now, because permission previews, simulations, audit events, and troubleshooting can build on the same contract later.
+- Denial payloads should be actionable but redacted: reason code, requested action, normalized workspace-relative path, required grant class, matched grant effect/source when available, and no absolute host path.
 - Read receipts must bind to normalized workspace-relative paths, not raw user input or absolute filesystem paths.
 - Patch and write flows must check configured byte limits before loading or writing content, including existing-file preimages.
 - Tests should use explicit receipt secrets so receipt assertions are deterministic and do not depend on process-global random state.
@@ -229,6 +237,31 @@ Add tests for three profiles over one temporary workspace:
 
 Also add regression coverage that `path_allowlist_prefixes` still authorizes legacy tools without `path_grants`.
 
+Add deny precedence coverage:
+
+- `documents/**` is writable through an allow grant.
+- `documents/private/**` has a deny grant for `edit` and `write`.
+- `fs.read` for `documents/private/notes.md` remains allowed when read is not denied.
+- `fs.patch` or `fs.write` for `documents/private/notes.md` is denied with a safe reason payload.
+
+Add decision-metadata coverage:
+
+```python
+result = await service.evaluate_tool_call(...)
+assert result["allowed"] is False
+assert result["reason_code"] == "path_action_denied"
+assert result["path_decisions"][0] == {
+    "requested_action": "write",
+    "normalized_path": "documents/private/notes.md",
+    "grant_outcome": "denied",
+    "grant_source": "path_grants",
+    "matched_grant_prefix": "documents/private",
+    "matched_grant_effect": "deny",
+    "redacted": True,
+}
+assert "/Users/" not in repr(result)
+```
+
 - [ ] **Step 2: Run tests to verify failure**
 
 Run: `source .venv/bin/activate && python -m pytest tldw_Server_API/tests/MCP_unified/test_mcp_hub_path_enforcement_service.py -q`
@@ -241,11 +274,15 @@ Implement helpers near `_policy_allowlist_prefixes(...)`:
 
 ```python
 _PATH_GRANT_ACTIONS = {"read", "edit", "write"}
+_RESERVED_PATH_GRANT_ACTIONS = {"delete", "rename", "move", "share", "export", "chmod", "admin", "lock"}
 
 def _policy_path_grants(policy_document: Mapping[str, Any]) -> list[dict[str, Any]]:
     ...
 
 def _candidate_action(tool_def: Mapping[str, Any], candidate: PathScopeCandidate | None) -> str:
+    ...
+
+def _path_permission_decision(...) -> dict[str, Any]:
     ...
 ```
 
@@ -253,14 +290,23 @@ Accepted grant forms:
 
 - `{"path": "documents", "actions": ["read", "edit"]}`
 - `{"prefix": "documents", "actions": ["read"]}` for compatibility with naming variants
+- `{"prefix": "documents/private", "actions": ["edit", "write"], "effect": "deny"}`
 
-Reject invalid grant entries by ignoring them, not by broadening access.
+Reject invalid grant entries by ignoring them, not by broadening access. If a grant uses a reserved future action, ignore that action for first-slice enforcement and return a safe invalid-policy decision only when the request depends on that unsupported action.
 
 - [ ] **Step 4: Evaluate derived candidates first**
 
 If `path_scope_candidates` is non-empty, evaluate only those candidates instead of extracting paths from `path_argument_hints`. Each candidate must match a grant for its own action.
 
 For non-derived paths, infer the action from `tool_def.metadata.path_scope_action`, defaulting to `write` for write-capable tools and `read` for read-only tools.
+
+Decision behavior:
+
+- Normalize all checked paths to workspace-relative display paths before returning metadata.
+- Never return absolute host paths.
+- If any matching deny grant applies, deny with `reason_code="path_action_denied"`.
+- If no allow grant applies and no deny grant applies, deny with `reason_code="path_action_not_granted"`.
+- Include `path_decisions` in the service result for both allowed and denied requests.
 
 - [ ] **Step 5: Preserve current fallback behavior**
 
@@ -464,6 +510,7 @@ Cover:
 
 - Catalog descriptor includes `path_scope_candidate_source="module"` and write metadata.
 - Candidate extraction returns `edit` for existing-file modification and `write` for create.
+- Candidate paths are normalized to workspace-relative paths before read-receipt validation and permission-decision metadata.
 - Existing-file patch in strict mode requires `expected_sha256_by_path` or `read_receipt_by_path`.
 - Valid expected hash applies the patch and returns metadata without content.
 - Valid read receipt applies the patch.
@@ -613,6 +660,7 @@ Cover:
 - `fs.read_text` declares `path_scope_action="read"` and legacy metadata.
 - `fs.write_text` declares `path_scope_action="write"` and legacy metadata.
 - Tool-use reporting for filesystem tools records metadata fields only and never records returned file content, raw diffs, absolute paths, or receipts.
+- Permission decision metadata is allowed in tool-use reporting only through safe scalar fields or redacted relative path summaries.
 
 - [ ] **Step 2: Run tests to verify failure**
 
@@ -681,6 +729,8 @@ Add a section covering:
 - How `expected_sha256` and read receipts protect against stale edits.
 - Why `fs.patch` is preferred over raw whole-file writes.
 - Example `path_grants` for read-only, edit-only, and write-enabled profiles.
+- Example deny override for a private subtree under a broader writable parent.
+- Safe permission decision payloads and denial reason codes.
 - Compatibility status of `fs.read_text` and `fs.write_text`.
 
 - [ ] **Step 2: Run targeted tests**
@@ -760,6 +810,7 @@ git commit -m "docs: document mcp safe file tools"
 ## Risk Review
 
 - **Path-scope bypass through patch paths:** `fs.patch` must never use caller-provided path hints. It must parse diff paths and pass module-derived candidates before execution.
+- **Deny override bypass:** When `path_grants` is present, deny effects must take precedence over allow effects and must not fall through to `path_allowlist_prefixes`.
 - **Symlink escapes:** Use existing no-follow resolution and reject symlink targets for mutating tools. Do not follow symlinks during write or patch.
 - **Stale edits:** Strict mode requires a matching hash or read receipt before mutating existing files.
 - **Receipt secrecy:** Receipts must not embed file content, absolute paths, or secrets. Sign canonical JSON with HMAC and compare signatures with `hmac.compare_digest`.
@@ -772,6 +823,7 @@ git commit -m "docs: document mcp safe file tools"
 - `fs.read`, `fs.patch`, and `fs.write` are in the filesystem catalog with schemas, metadata, and eval metadata.
 - `fs.patch` uses module-derived path candidates and fails closed when candidate extraction is unavailable.
 - `path_grants` enforce `read`, `edit`, and `write` separately while preserving legacy allowlist behavior.
+- Deny path grants override broader allow grants and return safe denial metadata.
 - Existing-file `fs.patch` and `fs.write replace` require `expected_sha256` or a valid read receipt.
 - Legacy tools still work and are marked as compatibility tools.
 - Profile presets prefer canonical file tools without accidentally expanding roles that had no file access.

--- a/Docs/superpowers/plans/2026-06-07-mcp-safe-file-tools-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-06-07-mcp-safe-file-tools-implementation-plan.md
@@ -1,6 +1,6 @@
 # MCP Safe File Tools Implementation Plan
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [x]`) syntax for tracking.
 
 **Goal:** Implement workspace-scoped `fs.read`, `fs.patch`, and `fs.write` with action-aware path grants, read receipts, module-derived path enforcement, redacted observability metadata, and legacy compatibility.
 
@@ -42,7 +42,7 @@ Existing protocol path-scope call site: `tldw_Server_API/app/core/MCP_unified/pr
   - Adds descriptors, validation, candidate extraction, and execution for `fs.read`, `fs.patch`, and `fs.write`.
 - Modify `mcp_unified/profiles/presets.py`
   - Adds canonical file-tool buckets while keeping legacy tools explicit.
-- Modify `Docs/MCP_UNIFIED_USER_GUIDE.md`
+- Modify `mcp_unified/USER_GUIDE.md`
   - Documents canonical file tools, read-before-mutate flow, and path grants.
 - Test files:
   - `tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_module.py`
@@ -130,7 +130,7 @@ The writing-plans skill normally asks for a separate plan-review subagent. This 
 - Modify: `tldw_Server_API/app/core/MCP_unified/modules/base.py`
 - Test: `tldw_Server_API/app/core/MCP_unified/tests/test_protocol_path_scope_candidates.py`
 
-- [ ] **Step 1: Write failing interface tests**
+- [x] **Step 1: Write failing interface tests**
 
 Add protocol-focused tests that assert a module marked with `path_scope_candidate_source: "module"` is asked for candidates before path enforcement, and that missing candidates fail closed.
 
@@ -157,13 +157,13 @@ async def test_protocol_fails_closed_when_module_candidates_unavailable() -> Non
         await protocol.prepare_tool_call("fs.patch", {"diff": _PATCH}, _context())
 ```
 
-- [ ] **Step 2: Run tests to verify failure**
+- [x] **Step 2: Run tests to verify failure**
 
 Run: `source .venv/bin/activate && python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_protocol_path_scope_candidates.py -q`
 
 Expected: FAIL because `PathScopeCandidate` and the protocol extraction seam do not exist.
 
-- [ ] **Step 3: Add the interface model**
+- [x] **Step 3: Add the interface model**
 
 Create `mcp_unified/interfaces/path_scope.py` with `PathScopeAction`, `PathScopeCandidate`, `normalize_path_scope_candidate(raw)`, and `normalize_path_scope_candidates(raw_items)`.
 
@@ -174,7 +174,7 @@ Implementation requirements:
 - Reject blank paths and actions outside `read`, `edit`, `write`.
 - Keep paths as caller-provided strings; path resolution remains inside the enforcer.
 
-- [ ] **Step 4: Extend the protocols and base module**
+- [x] **Step 4: Extend the protocols and base module**
 
 Modify `mcp_unified/interfaces/policy.py` so `PathScopeEnforcer.evaluate_tool_call(...)` accepts:
 
@@ -194,7 +194,7 @@ async def extract_path_scope_candidates(
     raise NotImplementedError(f"Path scope candidate extraction not implemented for {tool_name}")
 ```
 
-- [ ] **Step 5: Wire protocol extraction**
+- [x] **Step 5: Wire protocol extraction**
 
 In `MCPProtocol.prepare_tool_call(...)`, after schema validation and before `_evaluate_path_scope(...)`, detect `tool_def["metadata"]["path_scope_candidate_source"] == "module"`. Call `module.extract_path_scope_candidates(...)`, normalize results, and pass the candidates into `_evaluate_path_scope(...)`.
 
@@ -206,13 +206,13 @@ For compatibility with old enforcer test doubles and host adapters:
 - If derived candidates are required and the enforcer cannot accept them, raise `PermissionError("path_scope_candidates_unsupported")`.
 - Do not swallow `TypeError` raised from inside the enforcer body; only fallback on an unexpected `path_scope_candidates` keyword error.
 
-- [ ] **Step 6: Run focused tests**
+- [x] **Step 6: Run focused tests**
 
 Run: `source .venv/bin/activate && python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_protocol_path_scope_candidates.py -q`
 
 Expected: PASS.
 
-- [ ] **Step 7: Commit**
+- [x] **Step 7: Commit**
 
 Run:
 
@@ -227,7 +227,7 @@ git commit -m "feat: add mcp path scope candidate seam"
 - Modify: `tldw_Server_API/app/services/mcp_hub_path_enforcement_service.py`
 - Test: `tldw_Server_API/tests/MCP_unified/test_mcp_hub_path_enforcement_service.py`
 
-- [ ] **Step 1: Write failing grant tests**
+- [x] **Step 1: Write failing grant tests**
 
 Add tests for three profiles over one temporary workspace:
 
@@ -262,13 +262,13 @@ assert result["path_decisions"][0] == {
 assert "/Users/" not in repr(result)
 ```
 
-- [ ] **Step 2: Run tests to verify failure**
+- [x] **Step 2: Run tests to verify failure**
 
 Run: `source .venv/bin/activate && python -m pytest tldw_Server_API/tests/MCP_unified/test_mcp_hub_path_enforcement_service.py -q`
 
 Expected: FAIL on missing `path_grants` behavior.
 
-- [ ] **Step 3: Add grant normalization helpers**
+- [x] **Step 3: Add grant normalization helpers**
 
 Implement helpers near `_policy_allowlist_prefixes(...)`:
 
@@ -294,7 +294,7 @@ Accepted grant forms:
 
 Reject invalid grant entries by ignoring them, not by broadening access. If a grant uses a reserved future action, ignore that action for first-slice enforcement and return a safe invalid-policy decision only when the request depends on that unsupported action.
 
-- [ ] **Step 4: Evaluate derived candidates first**
+- [x] **Step 4: Evaluate derived candidates first**
 
 If `path_scope_candidates` is non-empty, evaluate only those candidates instead of extracting paths from `path_argument_hints`. Each candidate must match a grant for its own action.
 
@@ -308,19 +308,19 @@ Decision behavior:
 - If no allow grant applies and no deny grant applies, deny with `reason_code="path_action_not_granted"`.
 - Include `path_decisions` in the service result for both allowed and denied requests.
 
-- [ ] **Step 5: Preserve current fallback behavior**
+- [x] **Step 5: Preserve current fallback behavior**
 
 When `path_grants` is absent, keep the current `path_allowlist_prefixes` and multi-root behavior unchanged. This is the compatibility path for existing profiles and tests.
 
 When `path_grants` is present, do not fall back to `path_allowlist_prefixes` for candidates that fail to match an action grant. This prevents a profile from accidentally broadening action-specific policy by carrying an older allowlist field.
 
-- [ ] **Step 6: Run focused tests**
+- [x] **Step 6: Run focused tests**
 
 Run: `source .venv/bin/activate && python -m pytest tldw_Server_API/tests/MCP_unified/test_mcp_hub_path_enforcement_service.py -q`
 
 Expected: PASS.
 
-- [ ] **Step 7: Commit**
+- [x] **Step 7: Commit**
 
 Run:
 
@@ -336,7 +336,7 @@ git commit -m "feat: enforce mcp action aware path grants"
 - Modify: `tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_module.py`
 - Test: `tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_module.py`
 
-- [ ] **Step 1: Write failing `fs.read` tests**
+- [x] **Step 1: Write failing `fs.read` tests**
 
 Cover:
 
@@ -345,13 +345,13 @@ Cover:
 - Truncated reads set `truncated=True`, include a truncation reason, and omit `read_receipt`.
 - Binary/NUL, non-UTF-8, symlink, directory, and outside-workspace paths are rejected.
 
-- [ ] **Step 2: Run tests to verify failure**
+- [x] **Step 2: Run tests to verify failure**
 
 Run: `source .venv/bin/activate && python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_module.py -q`
 
 Expected: FAIL because `fs.read` is not registered.
 
-- [ ] **Step 3: Implement `filesystem_receipts.py`**
+- [x] **Step 3: Implement `filesystem_receipts.py`**
 
 Use stateless HMAC receipts:
 
@@ -375,7 +375,7 @@ class ReadReceiptManager:
     def validate(...)
 ```
 
-- [ ] **Step 4: Implement `fs.read`**
+- [x] **Step 4: Implement `fs.read`**
 
 In `filesystem_module.py`:
 
@@ -388,7 +388,7 @@ In `filesystem_module.py`:
 - Return a receipt only when the full hash is available and the read is not truncated.
 - Use the normalized workspace-relative path in the response and receipt, and keep absolute paths out of all returned metadata.
 
-- [ ] **Step 5: Add eval metadata to results**
+- [x] **Step 5: Add eval metadata to results**
 
 Return an `eval` map using `build_execution_eval_metadata(...)`:
 
@@ -404,13 +404,13 @@ Return an `eval` map using `build_execution_eval_metadata(...)`:
 
 Do not include file content, absolute paths, or receipt contents in eval metadata.
 
-- [ ] **Step 6: Run focused tests**
+- [x] **Step 6: Run focused tests**
 
 Run: `source .venv/bin/activate && python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_module.py -q`
 
 Expected: PASS.
 
-- [ ] **Step 7: Commit**
+- [x] **Step 7: Commit**
 
 Run:
 
@@ -425,7 +425,7 @@ git commit -m "feat: add mcp fs read tool"
 - Create: `tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_diff.py`
 - Test: `tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_patch_parser.py`
 
-- [ ] **Step 1: Write parser tests first**
+- [x] **Step 1: Write parser tests first**
 
 Cover:
 
@@ -435,13 +435,13 @@ Cover:
 - Applies a simple modify patch in memory and returns the exact expected text.
 - Detects context mismatch with a stable reason code.
 
-- [ ] **Step 2: Run tests to verify failure**
+- [x] **Step 2: Run tests to verify failure**
 
 Run: `source .venv/bin/activate && python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_patch_parser.py -q`
 
 Expected: FAIL because the parser file does not exist.
 
-- [ ] **Step 3: Implement parser dataclasses**
+- [x] **Step 3: Implement parser dataclasses**
 
 Create:
 
@@ -467,7 +467,7 @@ class PatchFile:
     hunks: tuple[PatchHunk, ...]
 ```
 
-- [ ] **Step 4: Implement parser and planner**
+- [x] **Step 4: Implement parser and planner**
 
 Expose:
 
@@ -481,13 +481,13 @@ def apply_patch_to_text(original: str, patch_file: PatchFile) -> str:
 
 Keep all path normalization lexical and portable; workspace resolution still belongs to `FilesystemModule`.
 
-- [ ] **Step 5: Run parser tests**
+- [x] **Step 5: Run parser tests**
 
 Run: `source .venv/bin/activate && python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_patch_parser.py -q`
 
 Expected: PASS.
 
-- [ ] **Step 6: Commit**
+- [x] **Step 6: Commit**
 
 Run:
 
@@ -504,7 +504,7 @@ git commit -m "feat: add mcp filesystem unified diff parser"
 - Test: `tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_module.py`
 - Test: `tldw_Server_API/app/core/MCP_unified/tests/test_protocol_path_scope_candidates.py`
 
-- [ ] **Step 1: Write failing `fs.patch` tests**
+- [x] **Step 1: Write failing `fs.patch` tests**
 
 Cover:
 
@@ -517,13 +517,13 @@ Cover:
 - Stale hash, stale receipt, mismatched receipt path, context mismatch, symlink, and outside-workspace paths are rejected.
 - Dry-run returns the planned changes and does not write.
 
-- [ ] **Step 2: Run tests to verify failure**
+- [x] **Step 2: Run tests to verify failure**
 
 Run: `source .venv/bin/activate && python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_module.py tldw_Server_API/app/core/MCP_unified/tests/test_protocol_path_scope_candidates.py -q`
 
 Expected: FAIL because `fs.patch` is not implemented.
 
-- [ ] **Step 3: Implement candidate extraction**
+- [x] **Step 3: Implement candidate extraction**
 
 Override `FilesystemModule.extract_path_scope_candidates(...)`.
 
@@ -536,7 +536,7 @@ For `fs.patch`:
 
 For other tools, delegate to the base default only if they declare module-derived candidates.
 
-- [ ] **Step 4: Implement execution**
+- [x] **Step 4: Implement execution**
 
 Implementation order inside `execute_tool("fs.patch", ...)`:
 
@@ -552,17 +552,17 @@ Implementation order inside `execute_tool("fs.patch", ...)`:
 10. Write via temp file in the target directory, then atomic replace.
 11. Return per-file metadata: path, action, created, bytes_before, bytes_after, sha256_before, sha256_after.
 
-- [ ] **Step 5: Add rollback handling**
+- [x] **Step 5: Add rollback handling**
 
 Track parent directories created for new files. If a later file write fails, remove only empty directories created by this call and never remove pre-existing directories.
 
-- [ ] **Step 6: Run focused tests**
+- [x] **Step 6: Run focused tests**
 
 Run: `source .venv/bin/activate && python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_module.py tldw_Server_API/app/core/MCP_unified/tests/test_protocol_path_scope_candidates.py -q`
 
 Expected: PASS.
 
-- [ ] **Step 7: Commit**
+- [x] **Step 7: Commit**
 
 Run:
 
@@ -577,7 +577,7 @@ git commit -m "feat: add mcp fs patch tool"
 - Modify: `tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_module.py`
 - Test: `tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_module.py`
 
-- [ ] **Step 1: Write failing `fs.write` tests**
+- [x] **Step 1: Write failing `fs.write` tests**
 
 Cover:
 
@@ -588,13 +588,13 @@ Cover:
 - Path escape, symlink, directory, binary/NUL content, and oversized content are rejected.
 - Dry-run returns metadata and does not write.
 
-- [ ] **Step 2: Run tests to verify failure**
+- [x] **Step 2: Run tests to verify failure**
 
 Run: `source .venv/bin/activate && python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_module.py -q`
 
 Expected: FAIL because `fs.write` is not implemented.
 
-- [ ] **Step 3: Implement descriptor and validation**
+- [x] **Step 3: Implement descriptor and validation**
 
 Add input schema fields:
 
@@ -605,7 +605,7 @@ Add input schema fields:
 - `read_receipt` string, optional.
 - `dry_run` boolean, optional default `False`.
 
-- [ ] **Step 4: Implement execution**
+- [x] **Step 4: Implement execution**
 
 Use the same workspace and no-follow path helpers as `fs.patch`.
 
@@ -626,13 +626,13 @@ For both:
 - Write through a temp file in the target directory and atomic replace.
 - Return metadata only, including `sha256_after`.
 
-- [ ] **Step 5: Run focused tests**
+- [x] **Step 5: Run focused tests**
 
 Run: `source .venv/bin/activate && python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_module.py -q`
 
 Expected: PASS.
 
-- [ ] **Step 6: Commit**
+- [x] **Step 6: Commit**
 
 Run:
 
@@ -649,7 +649,7 @@ git commit -m "feat: add mcp fs write tool"
 - Modify: `tldw_Server_API/app/core/MCP_unified/tests/test_tool_use_reporting_protocol.py`
 - Test: `tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_module.py`
 
-- [ ] **Step 1: Write failing metadata/profile tests**
+- [x] **Step 1: Write failing metadata/profile tests**
 
 Cover:
 
@@ -662,13 +662,13 @@ Cover:
 - Tool-use reporting for filesystem tools records metadata fields only and never records returned file content, raw diffs, absolute paths, or receipts.
 - Permission decision metadata is allowed in tool-use reporting only through safe scalar fields or redacted relative path summaries.
 
-- [ ] **Step 2: Run tests to verify failure**
+- [x] **Step 2: Run tests to verify failure**
 
 Run: `source .venv/bin/activate && python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_module.py tldw_Server_API/app/core/MCP_unified/tests/test_tool_use_reporting_protocol.py -q`
 
 Expected: FAIL on missing profile buckets or metadata.
 
-- [ ] **Step 3: Update profile buckets conservatively**
+- [x] **Step 3: Update profile buckets conservatively**
 
 Implement the spec buckets:
 
@@ -682,7 +682,7 @@ _LEGACY_FILES_WRITE_TOOLS = ["fs.write_text"]
 
 Do not grant file tools to any profile that currently lacks equivalent file access.
 
-- [ ] **Step 4: Add legacy metadata**
+- [x] **Step 4: Add legacy metadata**
 
 `fs.read_text` metadata should include:
 
@@ -696,17 +696,17 @@ Do not grant file tools to any profile that currently lacks equivalent file acce
 {"legacy_tool": True, "replacement_tools": ["fs.patch", "fs.write"], "path_scope_action": "write"}
 ```
 
-- [ ] **Step 5: Verify reporting remains metadata-only**
+- [x] **Step 5: Verify reporting remains metadata-only**
 
 If the current `ToolUseEvent` model already prevents content capture, add regression tests rather than expanding the model. If filesystem result metadata needs a nested `mcp_tool_use` envelope for gateway propagation, include only allowlisted scalar fields from the spec.
 
-- [ ] **Step 6: Run focused tests**
+- [x] **Step 6: Run focused tests**
 
 Run: `source .venv/bin/activate && python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_module.py tldw_Server_API/app/core/MCP_unified/tests/test_tool_use_reporting_protocol.py -q`
 
 Expected: PASS.
 
-- [ ] **Step 7: Commit**
+- [x] **Step 7: Commit**
 
 Run:
 
@@ -718,10 +718,10 @@ git commit -m "feat: wire mcp safe file tools into profiles"
 ## Task 8: Update Documentation And Run Full Validation
 
 **Files:**
-- Modify: `Docs/MCP_UNIFIED_USER_GUIDE.md`
+- Modify: `mcp_unified/USER_GUIDE.md`
 - Modify: `backlog/tasks/task-2297 - Implement-MCP-safe-file-tools.md`
 
-- [ ] **Step 1: Document the user workflow**
+- [x] **Step 1: Document the user workflow**
 
 Add a section covering:
 
@@ -733,7 +733,7 @@ Add a section covering:
 - Safe permission decision payloads and denial reason codes.
 - Compatibility status of `fs.read_text` and `fs.write_text`.
 
-- [ ] **Step 2: Run targeted tests**
+- [x] **Step 2: Run targeted tests**
 
 Run:
 
@@ -749,7 +749,7 @@ source .venv/bin/activate && python -m pytest \
 
 Expected: PASS.
 
-- [ ] **Step 3: Run broader MCP smoke tests**
+- [x] **Step 3: Run broader MCP smoke tests**
 
 Run:
 
@@ -763,7 +763,7 @@ source .venv/bin/activate && python -m pytest \
 
 Expected: PASS.
 
-- [ ] **Step 4: Run Bandit on touched code**
+- [x] **Step 4: Run Bandit on touched code**
 
 Run:
 
@@ -783,13 +783,13 @@ source .venv/bin/activate && python -m bandit -r \
 
 Expected: PASS or only baseline findings outside changed lines. Fix any new touched-code findings before continuing.
 
-- [ ] **Step 5: Run diff hygiene**
+- [x] **Step 5: Run diff hygiene**
 
 Run: `git diff --check`
 
 Expected: no whitespace errors.
 
-- [ ] **Step 6: Update Backlog task**
+- [x] **Step 6: Update Backlog task**
 
 Record:
 
@@ -798,12 +798,12 @@ Record:
 - Bandit output path and outcome.
 - Any known skips with reasons.
 
-- [ ] **Step 7: Final commit**
+- [x] **Step 7: Final commit**
 
 Run:
 
 ```bash
-git add Docs/MCP_UNIFIED_USER_GUIDE.md "backlog/tasks/task-2297 - Implement-MCP-safe-file-tools.md"
+git add mcp_unified/USER_GUIDE.md "backlog/tasks/task-2297 - Implement-MCP-safe-file-tools.md"
 git commit -m "docs: document mcp safe file tools"
 ```
 

--- a/Docs/superpowers/plans/2026-06-07-mcp-safe-file-tools-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-06-07-mcp-safe-file-tools-implementation-plan.md
@@ -1,0 +1,778 @@
+# MCP Safe File Tools Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement workspace-scoped `fs.read`, `fs.patch`, and `fs.write` with action-aware path grants, read receipts, module-derived path enforcement, redacted observability metadata, and legacy compatibility.
+
+**Architecture:** Extend the existing filesystem module instead of replacing it, but split patch parsing and read-receipt logic into focused helpers so `filesystem_module.py` does not absorb all of the complexity. The protocol asks modules for derived path candidates only when a tool declares that requirement, and the hub path enforcer evaluates those candidates against action-aware `path_grants` while preserving the existing `path_allowlist_prefixes` fallback.
+
+**Tech Stack:** Python 3.10+, FastAPI-era MCP Unified runtime, Pydantic-compatible dict contracts, stdlib `pathlib`/`hashlib`/`hmac`, pytest, Bandit.
+
+---
+
+## Context
+
+Primary spec: `Docs/superpowers/specs/2026-06-07-mcp-fs-patch-write-safe-edit-tools-design.md`
+
+Backlog task: `TASK-2297`
+
+Existing filesystem module: `tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_module.py`
+
+Existing path enforcement service: `tldw_Server_API/app/services/mcp_hub_path_enforcement_service.py`
+
+Existing protocol path-scope call site: `tldw_Server_API/app/core/MCP_unified/protocol.py`
+
+## File Structure
+
+- Create `mcp_unified/interfaces/path_scope.py`
+  - Owns `PathScopeAction`, `PathScopeCandidate`, and helper normalization for module-derived path candidates.
+- Modify `mcp_unified/interfaces/policy.py`
+  - Adds the optional `path_scope_candidates` parameter to the `PathScopeEnforcer` protocol.
+- Modify `tldw_Server_API/app/core/MCP_unified/modules/base.py`
+  - Adds optional `extract_path_scope_candidates(...)` with a fail-closed default.
+- Modify `tldw_Server_API/app/core/MCP_unified/protocol.py`
+  - Calls module candidate extraction for tools declaring `metadata.path_scope_candidate_source == "module"` and passes candidates to the path enforcer.
+- Modify `tldw_Server_API/app/services/mcp_hub_path_enforcement_service.py`
+  - Supports action-aware `policy_document.path_grants` and derived candidates while retaining existing allowlist behavior.
+- Create `tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_diff.py`
+  - Parses unified diffs and plans in-memory patch application. No filesystem IO.
+- Create `tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_receipts.py`
+  - Creates and validates short-lived HMAC read receipts. No file content in receipts.
+- Modify `tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_module.py`
+  - Adds descriptors, validation, candidate extraction, and execution for `fs.read`, `fs.patch`, and `fs.write`.
+- Modify `mcp_unified/profiles/presets.py`
+  - Adds canonical file-tool buckets while keeping legacy tools explicit.
+- Modify `Docs/MCP_UNIFIED_USER_GUIDE.md`
+  - Documents canonical file tools, read-before-mutate flow, and path grants.
+- Test files:
+  - `tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_module.py`
+  - `tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_patch_parser.py`
+  - `tldw_Server_API/app/core/MCP_unified/tests/test_protocol_path_scope_candidates.py`
+  - `tldw_Server_API/tests/MCP_unified/test_mcp_hub_path_enforcement_service.py`
+  - `tldw_Server_API/app/core/MCP_unified/tests/test_tool_use_reporting_protocol.py`
+
+## Behavioral Contracts
+
+Canonical tools:
+
+- `fs.read` reads bounded UTF-8 text and returns content, byte counts, line counts, truncation state, newline style, SHA-256 when available, and a short-lived read receipt for complete hashed reads.
+- `fs.patch` is the preferred existing-file edit primitive. It accepts unified diff text, derives affected paths from the diff, applies patches in memory first, then writes only after path scope and preimage checks pass.
+- `fs.write` creates or replaces a whole file. `mode="create"` fails if the file exists. `mode="replace"` requires `expected_sha256` or a valid read receipt for the same path and preimage.
+- `fs.read_text` and `fs.write_text` keep their current behavior but declare `path_scope_action` and legacy metadata.
+
+Path grants:
+
+```json
+{
+  "path_scope_mode": "enforce",
+  "path_grants": [
+    {"path": "documents", "actions": ["read", "edit", "write"]},
+    {"path": "downloads", "actions": ["read"]}
+  ]
+}
+```
+
+Candidate shape:
+
+```python
+from dataclasses import dataclass
+from typing import Literal
+
+PathScopeAction = Literal["read", "edit", "write"]
+
+@dataclass(frozen=True)
+class PathScopeCandidate:
+    path: str
+    action: PathScopeAction
+    source: str
+    display_path: str | None = None
+    requires_existing_file: bool = False
+    creates_file: bool = False
+    workspace_id: str | None = None
+```
+
+`fs.patch` must declare:
+
+```python
+metadata={
+    "category": "filesystem",
+    "readOnlyHint": False,
+    "write_capable": True,
+    "path_scope_candidate_source": "module",
+}
+```
+
+If a tool declares `path_scope_candidate_source: "module"` and candidates cannot be extracted, the request fails before execution with reason code `path_scope_candidates_unavailable`.
+
+## Local Plan Review Pass
+
+The writing-plans skill normally asks for a separate plan-review subagent. This thread does not have explicit user approval to spawn subagents, so this pass records the local review items incorporated before implementation:
+
+- The protocol seam must remain compatible with old test fakes and host enforcers. It may fall back to the old enforcer call shape only when no derived candidates are required; if derived candidates exist and the enforcer cannot accept them, fail closed.
+- If `path_grants` is present, malformed or non-matching grants must not fall through to broader legacy allowlists. Legacy `path_allowlist_prefixes` is a fallback only when `path_grants` is absent.
+- Read receipts must bind to normalized workspace-relative paths, not raw user input or absolute filesystem paths.
+- Patch and write flows must check configured byte limits before loading or writing content, including existing-file preimages.
+- Tests should use explicit receipt secrets so receipt assertions are deterministic and do not depend on process-global random state.
+
+## Task 1: Add The Derived Path-Candidate Interface
+
+**Files:**
+- Create: `mcp_unified/interfaces/path_scope.py`
+- Modify: `mcp_unified/interfaces/policy.py`
+- Modify: `tldw_Server_API/app/core/MCP_unified/modules/base.py`
+- Test: `tldw_Server_API/app/core/MCP_unified/tests/test_protocol_path_scope_candidates.py`
+
+- [ ] **Step 1: Write failing interface tests**
+
+Add protocol-focused tests that assert a module marked with `path_scope_candidate_source: "module"` is asked for candidates before path enforcement, and that missing candidates fail closed.
+
+```python
+async def test_protocol_passes_module_path_candidates_to_enforcer() -> None:
+    module = _CandidateModule(
+        candidates=[PathScopeCandidate(path="src/app.py", action="edit", source="module")]
+    )
+    enforcer = _RecordingPathEnforcer()
+    protocol = _protocol_with(module=module, path_scope_enforcer=enforcer)
+
+    await protocol.prepare_tool_call("fs.patch", {"diff": _PATCH}, _context())
+
+    assert enforcer.received_candidates == [
+        PathScopeCandidate(path="src/app.py", action="edit", source="module")
+    ]
+
+
+async def test_protocol_fails_closed_when_module_candidates_unavailable() -> None:
+    module = _NoCandidateModule()
+    protocol = _protocol_with(module=module, path_scope_enforcer=_RecordingPathEnforcer())
+
+    with pytest.raises(PermissionError, match="path_scope_candidates_unavailable"):
+        await protocol.prepare_tool_call("fs.patch", {"diff": _PATCH}, _context())
+```
+
+- [ ] **Step 2: Run tests to verify failure**
+
+Run: `source .venv/bin/activate && python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_protocol_path_scope_candidates.py -q`
+
+Expected: FAIL because `PathScopeCandidate` and the protocol extraction seam do not exist.
+
+- [ ] **Step 3: Add the interface model**
+
+Create `mcp_unified/interfaces/path_scope.py` with `PathScopeAction`, `PathScopeCandidate`, `normalize_path_scope_candidate(raw)`, and `normalize_path_scope_candidates(raw_items)`.
+
+Implementation requirements:
+
+- Accept already-instantiated `PathScopeCandidate` objects.
+- Accept dicts with `path`, `action`, `source`, `display_path`, `requires_existing_file`, `creates_file`, and `workspace_id`.
+- Reject blank paths and actions outside `read`, `edit`, `write`.
+- Keep paths as caller-provided strings; path resolution remains inside the enforcer.
+
+- [ ] **Step 4: Extend the protocols and base module**
+
+Modify `mcp_unified/interfaces/policy.py` so `PathScopeEnforcer.evaluate_tool_call(...)` accepts:
+
+```python
+path_scope_candidates: list[PathScopeCandidate] | None = None
+```
+
+Modify `BaseModule` with:
+
+```python
+async def extract_path_scope_candidates(
+    self,
+    tool_name: str,
+    arguments: dict[str, Any],
+    context: Optional[Any] = None,
+) -> list[PathScopeCandidate]:
+    raise NotImplementedError(f"Path scope candidate extraction not implemented for {tool_name}")
+```
+
+- [ ] **Step 5: Wire protocol extraction**
+
+In `MCPProtocol.prepare_tool_call(...)`, after schema validation and before `_evaluate_path_scope(...)`, detect `tool_def["metadata"]["path_scope_candidate_source"] == "module"`. Call `module.extract_path_scope_candidates(...)`, normalize results, and pass the candidates into `_evaluate_path_scope(...)`.
+
+Keep the seam inert for existing tools that do not declare this metadata.
+
+For compatibility with old enforcer test doubles and host adapters:
+
+- If no derived candidates are required and the enforcer rejects the new keyword shape with an unexpected-keyword `TypeError`, call the old signature.
+- If derived candidates are required and the enforcer cannot accept them, raise `PermissionError("path_scope_candidates_unsupported")`.
+- Do not swallow `TypeError` raised from inside the enforcer body; only fallback on an unexpected `path_scope_candidates` keyword error.
+
+- [ ] **Step 6: Run focused tests**
+
+Run: `source .venv/bin/activate && python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_protocol_path_scope_candidates.py -q`
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+Run:
+
+```bash
+git add mcp_unified/interfaces/path_scope.py mcp_unified/interfaces/policy.py tldw_Server_API/app/core/MCP_unified/modules/base.py tldw_Server_API/app/core/MCP_unified/protocol.py tldw_Server_API/app/core/MCP_unified/tests/test_protocol_path_scope_candidates.py
+git commit -m "feat: add mcp path scope candidate seam"
+```
+
+## Task 2: Implement Action-Aware Path Grants
+
+**Files:**
+- Modify: `tldw_Server_API/app/services/mcp_hub_path_enforcement_service.py`
+- Test: `tldw_Server_API/tests/MCP_unified/test_mcp_hub_path_enforcement_service.py`
+
+- [ ] **Step 1: Write failing grant tests**
+
+Add tests for three profiles over one temporary workspace:
+
+- Profile A can `read`, `edit`, and `write` under `documents/` but is denied under `downloads/`.
+- Profile B can `read`, `edit`, and `write` under both directories.
+- Profile C can `read` under `downloads/` but is denied for `edit` and `write`.
+
+Also add regression coverage that `path_allowlist_prefixes` still authorizes legacy tools without `path_grants`.
+
+- [ ] **Step 2: Run tests to verify failure**
+
+Run: `source .venv/bin/activate && python -m pytest tldw_Server_API/tests/MCP_unified/test_mcp_hub_path_enforcement_service.py -q`
+
+Expected: FAIL on missing `path_grants` behavior.
+
+- [ ] **Step 3: Add grant normalization helpers**
+
+Implement helpers near `_policy_allowlist_prefixes(...)`:
+
+```python
+_PATH_GRANT_ACTIONS = {"read", "edit", "write"}
+
+def _policy_path_grants(policy_document: Mapping[str, Any]) -> list[dict[str, Any]]:
+    ...
+
+def _candidate_action(tool_def: Mapping[str, Any], candidate: PathScopeCandidate | None) -> str:
+    ...
+```
+
+Accepted grant forms:
+
+- `{"path": "documents", "actions": ["read", "edit"]}`
+- `{"prefix": "documents", "actions": ["read"]}` for compatibility with naming variants
+
+Reject invalid grant entries by ignoring them, not by broadening access.
+
+- [ ] **Step 4: Evaluate derived candidates first**
+
+If `path_scope_candidates` is non-empty, evaluate only those candidates instead of extracting paths from `path_argument_hints`. Each candidate must match a grant for its own action.
+
+For non-derived paths, infer the action from `tool_def.metadata.path_scope_action`, defaulting to `write` for write-capable tools and `read` for read-only tools.
+
+- [ ] **Step 5: Preserve current fallback behavior**
+
+When `path_grants` is absent, keep the current `path_allowlist_prefixes` and multi-root behavior unchanged. This is the compatibility path for existing profiles and tests.
+
+When `path_grants` is present, do not fall back to `path_allowlist_prefixes` for candidates that fail to match an action grant. This prevents a profile from accidentally broadening action-specific policy by carrying an older allowlist field.
+
+- [ ] **Step 6: Run focused tests**
+
+Run: `source .venv/bin/activate && python -m pytest tldw_Server_API/tests/MCP_unified/test_mcp_hub_path_enforcement_service.py -q`
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+Run:
+
+```bash
+git add tldw_Server_API/app/services/mcp_hub_path_enforcement_service.py tldw_Server_API/tests/MCP_unified/test_mcp_hub_path_enforcement_service.py
+git commit -m "feat: enforce mcp action aware path grants"
+```
+
+## Task 3: Add Read Receipts And `fs.read`
+
+**Files:**
+- Create: `tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_receipts.py`
+- Modify: `tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_module.py`
+- Test: `tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_module.py`
+
+- [ ] **Step 1: Write failing `fs.read` tests**
+
+Cover:
+
+- Tool catalog contains `fs.read` with `readOnlyHint=True`, `path_scope_action="read"`, eval metadata, and strict schema.
+- Complete text read returns `content`, `sha256`, `read_receipt`, `bytes_read`, `bytes_total`, `line_count`, and `newline_style`.
+- Truncated reads set `truncated=True`, include a truncation reason, and omit `read_receipt`.
+- Binary/NUL, non-UTF-8, symlink, directory, and outside-workspace paths are rejected.
+
+- [ ] **Step 2: Run tests to verify failure**
+
+Run: `source .venv/bin/activate && python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_module.py -q`
+
+Expected: FAIL because `fs.read` is not registered.
+
+- [ ] **Step 3: Implement `filesystem_receipts.py`**
+
+Use stateless HMAC receipts:
+
+- Payload fields: `v`, `path`, `sha256`, `size`, `issued_at`, `expires_at`, optional `workspace_id`, optional safe `session_id`.
+- Signature: `hmac.new(secret, canonical_json, hashlib.sha256).hexdigest()`.
+- Encoding: URL-safe base64 of `canonical_json.signature`.
+- Default TTL: 1,800 seconds.
+- Secret source: module config key `read_receipt_secret`; if absent, use a per-process random secret and document that receipts do not survive restart.
+- Receipt `path` must be the normalized workspace-relative path returned by `_to_workspace_relative_path(...)`. Do not store raw user input or an absolute host path in the receipt payload.
+- Unit tests should configure a fixed `read_receipt_secret` through the module config to avoid nondeterminism.
+
+Expose:
+
+```python
+class ReadReceiptError(ValueError):
+    reason_code: str
+
+
+class ReadReceiptManager:
+    def issue(...)
+    def validate(...)
+```
+
+- [ ] **Step 4: Implement `fs.read`**
+
+In `filesystem_module.py`:
+
+- Add `_TOOL_NAME_READ = "fs.read"` if tool constants exist, otherwise keep local string constants.
+- Add descriptor in `get_tools()`.
+- Add validation for `path`, optional `start_line`, optional `end_line`, optional `max_bytes`, and optional `include_receipt`.
+- Use existing workspace-root resolution helpers.
+- Read bytes with a hard cap, reject NUL and decode failures, return bounded UTF-8 text.
+- Compute full-file SHA-256 only when the full file is within the configured hash limit.
+- Return a receipt only when the full hash is available and the read is not truncated.
+- Use the normalized workspace-relative path in the response and receipt, and keep absolute paths out of all returned metadata.
+
+- [ ] **Step 5: Add eval metadata to results**
+
+Return an `eval` map using `build_execution_eval_metadata(...)`:
+
+```python
+"eval": {
+    "tool_name": "fs.read",
+    "action_family": "read",
+    "result_kind": "bounded_text_file",
+    "path_filter_used": True,
+    "truncated": result["truncated"],
+}
+```
+
+Do not include file content, absolute paths, or receipt contents in eval metadata.
+
+- [ ] **Step 6: Run focused tests**
+
+Run: `source .venv/bin/activate && python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_module.py -q`
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+Run:
+
+```bash
+git add tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_receipts.py tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_module.py tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_module.py
+git commit -m "feat: add mcp fs read tool"
+```
+
+## Task 4: Add Unified Diff Parser And In-Memory Planner
+
+**Files:**
+- Create: `tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_diff.py`
+- Test: `tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_patch_parser.py`
+
+- [ ] **Step 1: Write parser tests first**
+
+Cover:
+
+- Parses `--- a/path` / `+++ b/path` headers and hunk ranges.
+- Handles modify, create (`--- /dev/null`), and delete (`+++ /dev/null`) headers, but delete is rejected for this first implementation.
+- Rejects absolute paths, drive-qualified paths, `..` traversal, empty paths, and diffs exceeding configured file/hunk limits.
+- Applies a simple modify patch in memory and returns the exact expected text.
+- Detects context mismatch with a stable reason code.
+
+- [ ] **Step 2: Run tests to verify failure**
+
+Run: `source .venv/bin/activate && python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_patch_parser.py -q`
+
+Expected: FAIL because the parser file does not exist.
+
+- [ ] **Step 3: Implement parser dataclasses**
+
+Create:
+
+```python
+@dataclass(frozen=True)
+class PatchHunkLine:
+    kind: Literal["context", "add", "remove"]
+    text: str
+
+@dataclass(frozen=True)
+class PatchHunk:
+    old_start: int
+    old_count: int
+    new_start: int
+    new_count: int
+    lines: tuple[PatchHunkLine, ...]
+
+@dataclass(frozen=True)
+class PatchFile:
+    old_path: str | None
+    new_path: str | None
+    action: Literal["modify", "create"]
+    hunks: tuple[PatchHunk, ...]
+```
+
+- [ ] **Step 4: Implement parser and planner**
+
+Expose:
+
+```python
+def parse_unified_diff(diff_text: str, *, max_files: int, max_hunks: int, max_bytes: int) -> tuple[PatchFile, ...]:
+    ...
+
+def apply_patch_to_text(original: str, patch_file: PatchFile) -> str:
+    ...
+```
+
+Keep all path normalization lexical and portable; workspace resolution still belongs to `FilesystemModule`.
+
+- [ ] **Step 5: Run parser tests**
+
+Run: `source .venv/bin/activate && python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_patch_parser.py -q`
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+Run:
+
+```bash
+git add tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_diff.py tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_patch_parser.py
+git commit -m "feat: add mcp filesystem unified diff parser"
+```
+
+## Task 5: Add `fs.patch`
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_module.py`
+- Modify: `tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_diff.py`
+- Test: `tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_module.py`
+- Test: `tldw_Server_API/app/core/MCP_unified/tests/test_protocol_path_scope_candidates.py`
+
+- [ ] **Step 1: Write failing `fs.patch` tests**
+
+Cover:
+
+- Catalog descriptor includes `path_scope_candidate_source="module"` and write metadata.
+- Candidate extraction returns `edit` for existing-file modification and `write` for create.
+- Existing-file patch in strict mode requires `expected_sha256_by_path` or `read_receipt_by_path`.
+- Valid expected hash applies the patch and returns metadata without content.
+- Valid read receipt applies the patch.
+- Stale hash, stale receipt, mismatched receipt path, context mismatch, symlink, and outside-workspace paths are rejected.
+- Dry-run returns the planned changes and does not write.
+
+- [ ] **Step 2: Run tests to verify failure**
+
+Run: `source .venv/bin/activate && python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_module.py tldw_Server_API/app/core/MCP_unified/tests/test_protocol_path_scope_candidates.py -q`
+
+Expected: FAIL because `fs.patch` is not implemented.
+
+- [ ] **Step 3: Implement candidate extraction**
+
+Override `FilesystemModule.extract_path_scope_candidates(...)`.
+
+For `fs.patch`:
+
+- Parse the diff.
+- Return one candidate per affected file.
+- `modify`: `action="edit"`, `requires_existing_file=True`, `creates_file=False`.
+- `create`: `action="write"`, `requires_existing_file=False`, `creates_file=True`.
+
+For other tools, delegate to the base default only if they declare module-derived candidates.
+
+- [ ] **Step 4: Implement execution**
+
+Implementation order inside `execute_tool("fs.patch", ...)`:
+
+1. Resolve workspace root.
+2. Parse diff.
+3. Resolve each patch file path with `_resolve_workspace_path_no_follow(...)`.
+4. Reject symlinks and unsupported file types.
+5. Check existing-file size against the configured patch preimage byte limit before reading.
+6. Read existing files and validate preimage hash or receipt before mutation.
+7. Apply hunks in memory.
+8. Check resulting content size against the configured write byte limit.
+9. If `dry_run=True`, return plan metadata only.
+10. Write via temp file in the target directory, then atomic replace.
+11. Return per-file metadata: path, action, created, bytes_before, bytes_after, sha256_before, sha256_after.
+
+- [ ] **Step 5: Add rollback handling**
+
+Track parent directories created for new files. If a later file write fails, remove only empty directories created by this call and never remove pre-existing directories.
+
+- [ ] **Step 6: Run focused tests**
+
+Run: `source .venv/bin/activate && python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_module.py tldw_Server_API/app/core/MCP_unified/tests/test_protocol_path_scope_candidates.py -q`
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+Run:
+
+```bash
+git add tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_module.py tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_diff.py tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_module.py tldw_Server_API/app/core/MCP_unified/tests/test_protocol_path_scope_candidates.py
+git commit -m "feat: add mcp fs patch tool"
+```
+
+## Task 6: Add `fs.write`
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_module.py`
+- Test: `tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_module.py`
+
+- [ ] **Step 1: Write failing `fs.write` tests**
+
+Cover:
+
+- Catalog descriptor includes `path_scope_action="write"` and write metadata.
+- `mode="create"` creates a new UTF-8 text file and fails when the file already exists.
+- `mode="replace"` requires `expected_sha256` or `read_receipt`.
+- `mode="replace"` rejects stale hashes and mismatched receipts.
+- Path escape, symlink, directory, binary/NUL content, and oversized content are rejected.
+- Dry-run returns metadata and does not write.
+
+- [ ] **Step 2: Run tests to verify failure**
+
+Run: `source .venv/bin/activate && python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_module.py -q`
+
+Expected: FAIL because `fs.write` is not implemented.
+
+- [ ] **Step 3: Implement descriptor and validation**
+
+Add input schema fields:
+
+- `path` string, required.
+- `content` string, required.
+- `mode` enum `["create", "replace"]`, required.
+- `expected_sha256` string, optional.
+- `read_receipt` string, optional.
+- `dry_run` boolean, optional default `False`.
+
+- [ ] **Step 4: Implement execution**
+
+Use the same workspace and no-follow path helpers as `fs.patch`.
+
+For replace:
+
+- Reject missing target.
+- Reject symlinks.
+- Compute current SHA-256.
+- Accept either matching `expected_sha256` or valid receipt for the same path/hash.
+
+For create:
+
+- Reject if target exists or is a symlink.
+- Create parents only after path checks pass.
+
+For both:
+
+- Write through a temp file in the target directory and atomic replace.
+- Return metadata only, including `sha256_after`.
+
+- [ ] **Step 5: Run focused tests**
+
+Run: `source .venv/bin/activate && python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_module.py -q`
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+Run:
+
+```bash
+git add tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_module.py tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_module.py
+git commit -m "feat: add mcp fs write tool"
+```
+
+## Task 7: Update Profiles, Legacy Metadata, And Reporting Safety
+
+**Files:**
+- Modify: `mcp_unified/profiles/presets.py`
+- Modify: `tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_module.py`
+- Modify: `tldw_Server_API/app/core/MCP_unified/tests/test_tool_use_reporting_protocol.py`
+- Test: `tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_module.py`
+
+- [ ] **Step 1: Write failing metadata/profile tests**
+
+Cover:
+
+- `_FILES_READ_TOOLS` includes `fs.read` and no longer relies only on `fs.read_text`.
+- `_FILES_EDIT_TOOLS` includes `fs.patch`.
+- `_FILES_WRITE_TOOLS` includes `fs.write`.
+- Legacy buckets keep `fs.read_text` and `fs.write_text` explicit.
+- `fs.read_text` declares `path_scope_action="read"` and legacy metadata.
+- `fs.write_text` declares `path_scope_action="write"` and legacy metadata.
+- Tool-use reporting for filesystem tools records metadata fields only and never records returned file content, raw diffs, absolute paths, or receipts.
+
+- [ ] **Step 2: Run tests to verify failure**
+
+Run: `source .venv/bin/activate && python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_module.py tldw_Server_API/app/core/MCP_unified/tests/test_tool_use_reporting_protocol.py -q`
+
+Expected: FAIL on missing profile buckets or metadata.
+
+- [ ] **Step 3: Update profile buckets conservatively**
+
+Implement the spec buckets:
+
+```python
+_FILES_READ_TOOLS = ["fs.list", "fs.read", "fs.stat", "fs.glob", "fs.grep"]
+_FILES_EDIT_TOOLS = [*_FILES_READ_TOOLS, "fs.patch"]
+_FILES_WRITE_TOOLS = [*_FILES_EDIT_TOOLS, "fs.write"]
+_LEGACY_FILES_READ_TOOLS = ["fs.read_text"]
+_LEGACY_FILES_WRITE_TOOLS = ["fs.write_text"]
+```
+
+Do not grant file tools to any profile that currently lacks equivalent file access.
+
+- [ ] **Step 4: Add legacy metadata**
+
+`fs.read_text` metadata should include:
+
+```python
+{"legacy_tool": True, "replacement_tool": "fs.read", "path_scope_action": "read"}
+```
+
+`fs.write_text` metadata should include:
+
+```python
+{"legacy_tool": True, "replacement_tools": ["fs.patch", "fs.write"], "path_scope_action": "write"}
+```
+
+- [ ] **Step 5: Verify reporting remains metadata-only**
+
+If the current `ToolUseEvent` model already prevents content capture, add regression tests rather than expanding the model. If filesystem result metadata needs a nested `mcp_tool_use` envelope for gateway propagation, include only allowlisted scalar fields from the spec.
+
+- [ ] **Step 6: Run focused tests**
+
+Run: `source .venv/bin/activate && python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_module.py tldw_Server_API/app/core/MCP_unified/tests/test_tool_use_reporting_protocol.py -q`
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+Run:
+
+```bash
+git add mcp_unified/profiles/presets.py tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_module.py tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_module.py tldw_Server_API/app/core/MCP_unified/tests/test_tool_use_reporting_protocol.py
+git commit -m "feat: wire mcp safe file tools into profiles"
+```
+
+## Task 8: Update Documentation And Run Full Validation
+
+**Files:**
+- Modify: `Docs/MCP_UNIFIED_USER_GUIDE.md`
+- Modify: `backlog/tasks/task-2297 - Implement-MCP-safe-file-tools.md`
+
+- [ ] **Step 1: Document the user workflow**
+
+Add a section covering:
+
+- `fs.read` before `fs.patch` or `fs.write replace`.
+- How `expected_sha256` and read receipts protect against stale edits.
+- Why `fs.patch` is preferred over raw whole-file writes.
+- Example `path_grants` for read-only, edit-only, and write-enabled profiles.
+- Compatibility status of `fs.read_text` and `fs.write_text`.
+
+- [ ] **Step 2: Run targeted tests**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m pytest \
+  tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_module.py \
+  tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_patch_parser.py \
+  tldw_Server_API/app/core/MCP_unified/tests/test_protocol_path_scope_candidates.py \
+  tldw_Server_API/tests/MCP_unified/test_mcp_hub_path_enforcement_service.py \
+  tldw_Server_API/app/core/MCP_unified/tests/test_tool_use_reporting_protocol.py \
+  -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Run broader MCP smoke tests**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m pytest \
+  tldw_Server_API/app/core/MCP_unified/tests/test_protocol_preexec_validation.py \
+  tldw_Server_API/app/core/MCP_unified/tests/test_write_tools_validators.py \
+  tldw_Server_API/app/core/MCP_unified/tests/test_tool_observability.py \
+  -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Run Bandit on touched code**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m bandit -r \
+  tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_module.py \
+  tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_diff.py \
+  tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_receipts.py \
+  tldw_Server_API/app/core/MCP_unified/protocol.py \
+  tldw_Server_API/app/core/MCP_unified/modules/base.py \
+  tldw_Server_API/app/services/mcp_hub_path_enforcement_service.py \
+  mcp_unified/interfaces/path_scope.py \
+  mcp_unified/interfaces/policy.py \
+  mcp_unified/profiles/presets.py \
+  -f json -o /tmp/bandit_mcp_safe_file_tools.json
+```
+
+Expected: PASS or only baseline findings outside changed lines. Fix any new touched-code findings before continuing.
+
+- [ ] **Step 5: Run diff hygiene**
+
+Run: `git diff --check`
+
+Expected: no whitespace errors.
+
+- [ ] **Step 6: Update Backlog task**
+
+Record:
+
+- Implementation summary.
+- Test commands and outcomes.
+- Bandit output path and outcome.
+- Any known skips with reasons.
+
+- [ ] **Step 7: Final commit**
+
+Run:
+
+```bash
+git add Docs/MCP_UNIFIED_USER_GUIDE.md "backlog/tasks/task-2297 - Implement-MCP-safe-file-tools.md"
+git commit -m "docs: document mcp safe file tools"
+```
+
+## Risk Review
+
+- **Path-scope bypass through patch paths:** `fs.patch` must never use caller-provided path hints. It must parse diff paths and pass module-derived candidates before execution.
+- **Symlink escapes:** Use existing no-follow resolution and reject symlink targets for mutating tools. Do not follow symlinks during write or patch.
+- **Stale edits:** Strict mode requires a matching hash or read receipt before mutating existing files.
+- **Receipt secrecy:** Receipts must not embed file content, absolute paths, or secrets. Sign canonical JSON with HMAC and compare signatures with `hmac.compare_digest`.
+- **Trace leakage:** Tool-use reporting must stay metadata-only. Do not add content, raw diff, receipts, or absolute paths to eval metadata.
+- **Profile broadening:** Add canonical tools only where equivalent legacy file authority already existed, unless the profile is explicitly intended to gain that capability.
+- **Large-file behavior:** Avoid hashing or loading unbounded data. `fs.patch` and `fs.write` must enforce configured byte limits before mutation.
+
+## Completion Criteria
+
+- `fs.read`, `fs.patch`, and `fs.write` are in the filesystem catalog with schemas, metadata, and eval metadata.
+- `fs.patch` uses module-derived path candidates and fails closed when candidate extraction is unavailable.
+- `path_grants` enforce `read`, `edit`, and `write` separately while preserving legacy allowlist behavior.
+- Existing-file `fs.patch` and `fs.write replace` require `expected_sha256` or a valid read receipt.
+- Legacy tools still work and are marked as compatibility tools.
+- Profile presets prefer canonical file tools without accidentally expanding roles that had no file access.
+- Targeted tests, MCP smoke tests, Bandit touched-scope scan, and `git diff --check` are recorded in `TASK-2297`.

--- a/Docs/superpowers/specs/2026-06-07-mcp-fs-patch-write-safe-edit-tools-design.md
+++ b/Docs/superpowers/specs/2026-06-07-mcp-fs-patch-write-safe-edit-tools-design.md
@@ -1,19 +1,22 @@
-# MCP fs.patch And fs.write Safe Edit Tools Design
+# MCP fs.read, fs.patch, And fs.write Safe File Tools Design
 
 ## Status
 
 Draft specification for TASK-2277.
 
-This is the next MCP filesystem write-safety slice after metadata-only
-tool-use reporting. It adds a diff-first edit primitive and a deliberate
-whole-file write primitive while tightening path policy so profiles can grant
-different read, edit, and write access by workspace subpath.
+This is the next MCP filesystem safety slice after metadata-only tool-use
+reporting. It adds a canonical bounded read primitive, a diff-first edit
+primitive, and a deliberate whole-file write primitive while tightening path
+policy so profiles can grant different read, edit, and write access by
+workspace subpath.
 
 ## Summary
 
-Add two paired filesystem primitives to the workspace-bounded MCP filesystem
-module:
+Add three filesystem primitives to the workspace-bounded MCP filesystem module:
 
+- `fs.read`: canonical bounded UTF-8 text read primitive. It returns file
+  content with hash and truncation metadata so later `fs.patch` and `fs.write`
+  calls can be guarded against stale preimages.
 - `fs.patch`: preferred edit primitive. It accepts unified diffs, parses them
   in process, derives touched paths before execution, applies hunks with
   conflict detection, and never invokes a host shell or platform patch tool.
@@ -21,9 +24,10 @@ module:
   creating a complete file or intentionally replacing a complete file, not for
   incremental edits. Existing files require an expected content hash.
 
-`fs.write_text` remains as a compatibility surface for existing callers, but
-new role profiles, docs, and model guidance should prefer `fs.patch` for
-modifying existing files and `fs.write` for intentional whole-file writes.
+`fs.read_text` and `fs.write_text` remain as compatibility surfaces for
+existing callers, but new role profiles, docs, and model guidance should prefer
+`fs.read` for file inspection, `fs.patch` for modifying existing files, and
+`fs.write` for intentional whole-file writes.
 `fs.write` is intentionally higher impact than `fs.patch`: it creates or
 replaces a whole file and therefore requires the explicit `write` path action,
 including for replacements.
@@ -35,6 +39,8 @@ write multiple workspace roots only when explicitly granted.
 ## Goals
 
 - Prefer unified-diff editing over raw text replacement whenever possible.
+- Provide a canonical read primitive that pairs with hash-guarded patch/write
+  flows.
 - Keep all file mutation workspace-bounded and profile/path-scope governed.
 - Support granular path grants such as:
   - Profile A can read/edit/write `documents/` but cannot access `downloads/`.
@@ -57,8 +63,8 @@ write multiple workspace roots only when explicitly granted.
 - No AST-aware code refactoring.
 - No collaborative merge algorithm.
 - No UI implementation.
-- No change to the existing `fs.write_text` behavior beyond metadata/path-scope
-  participation needed for policy consistency.
+- No change to the existing `fs.read_text` or `fs.write_text` behavior beyond
+  metadata/path-scope participation needed for policy consistency.
 
 ## Existing Context
 
@@ -79,7 +85,7 @@ and uses metadata such as `uses_filesystem`, `path_boundable`, and
 `MCPProtocol.prepare_tool_call()` already validates tool schemas, determines
 write status, asks the injected `PathScopeEnforcer` to evaluate path scope, and
 then runs approval checks before execution. That is the correct boundary for
-`fs.patch` and `fs.write`.
+`fs.read`, `fs.patch`, and `fs.write`.
 
 The current `McpHubPathEnforcementService` supports:
 
@@ -110,7 +116,22 @@ Rejected alternatives:
 - Only improving `fs.write_text`: insufficient because full-file writes are too
   broad for routine edits.
 
-### 2. `fs.write` as the paired whole-file primitive
+### 2. `fs.read` as the canonical read-side primitive
+
+`fs.read` should become the preferred file-inspection primitive for text files.
+It pairs with `fs.patch` and `fs.write` by returning the file hash, newline
+style, size, and truncation state needed for conflict-aware follow-up calls.
+
+It must not become an unbounded content exfiltration path:
+
+- Reads require the explicit `read` path action.
+- Returned content is UTF-8 text only and subject to byte/line limits.
+- Large reads must report truncation clearly rather than silently returning a
+  partial file that looks complete.
+- The tool response may include file content for the active model call, but
+  tool-use reporting and evaluation traces must not persist that raw content.
+
+### 3. `fs.write` as the write-side whole-file primitive
 
 `fs.write` is useful when the model is creating a new file or deliberately
 replacing an entire file, such as writing a generated Markdown story, a new
@@ -126,7 +147,7 @@ It must not become a silent overwrite escape hatch:
 - `mode: "replace"` uses the `write` action rather than `edit`, because it
   replaces the whole file and does not carry hunk-level context.
 
-### 3. Action-aware path grants
+### 4. Action-aware path grants
 
 Path grants must include action semantics. Existing path-only allowlists cannot
 express "read downloads, edit documents" without overgranting.
@@ -152,8 +173,8 @@ First-slice grant rules:
 - `actions` is an explicit list from `read`, `edit`, `write`.
 - Actions do not imply one another. A grant with `write` alone does not allow
   reads or contextual patch edits unless `read` or `edit` is also listed.
-- `read` authorizes read tools such as `fs.read_text`, `fs.stat`, `fs.glob`,
-  and `fs.grep`.
+- `read` authorizes read tools such as `fs.read`, `fs.read_text`, `fs.stat`,
+  `fs.glob`, and `fs.grep`.
 - `edit` authorizes `fs.patch` modifications to existing files. The tool may
   read existing file content internally for conflict checks, but it must not
   return raw current content unless the caller also invokes a read tool.
@@ -173,6 +194,63 @@ First-slice grant rules:
   profiles should prefer explicit `path_grants`.
 
 ## Tool Contracts
+
+### `fs.read`
+
+Purpose: read a workspace-scoped UTF-8 text file with bounded output and
+preimage metadata for later `fs.patch` or `fs.write` calls.
+
+Arguments:
+
+- `path: string` required.
+- `start_line: integer` optional, one-based, default `1`.
+- `max_lines: integer` optional, default `read_default_max_lines`, bounded by
+  `read_max_lines`.
+- `max_bytes: integer` optional, default `read_default_max_bytes`, bounded by
+  `read_max_bytes`.
+- `include_line_numbers: boolean` optional, default `false`.
+
+Response:
+
+- `path`
+- `content`
+- `start_line`
+- `end_line`
+- `line_count_total` when cheap to compute within limits
+- `bytes_read`
+- `bytes_total`
+- `sha256`
+- `newline_style`: `lf`, `crlf`, `cr`, or `mixed`
+- `truncated`: boolean
+- `truncation_reason`: `max_bytes`, `max_lines`, or absent
+
+Failure response or exception reason codes should be stable:
+
+- `path_outside_workspace_scope`
+- `path_outside_allowlist_scope`
+- `path_action_not_granted`
+- `file_missing`
+- `file_not_regular`
+- `binary_content_not_supported`
+- `file_too_large`
+- `read_too_large`
+- `invalid_line_range`
+
+Behavior:
+
+- Requires the `read` path action.
+- Resolves and validates the path with the same workspace/path-scope rules as
+  other filesystem tools.
+- Reads regular files only; symlink targets are rejected in the first slice.
+- Rejects binary/NUL content and non-UTF-8 files with
+  `binary_content_not_supported`.
+- Applies byte and line limits before returning content.
+- Returns `sha256` for the complete file, not only the returned slice, when the
+  file is within `read_hash_max_file_bytes`.
+- If the file is too large to hash under configured limits, returns a stable
+  reason such as `hash_omitted_file_too_large` and keeps `sha256` absent.
+- Does not persist returned `content` in tool-use reporting, audit summaries, or
+  evaluation traces.
 
 ### `fs.patch`
 
@@ -313,6 +391,18 @@ Behavior:
 - Content is UTF-8 only and subject to `write_max_bytes`.
 - Writes use temporary files and atomic replace where supported by the OS.
 
+### `fs.read_text`
+
+`fs.read_text` remains for compatibility. It should keep its current request
+shape and behavior unless a later migration explicitly deprecates it.
+
+For policy consistency:
+
+- It must remain path-boundable.
+- It requires the `read` path action when action-aware grants are enabled.
+- New profile recommendations should prefer `fs.read`.
+- Strict new profiles may omit `fs.read_text` while keeping `fs.read`.
+
 ### `fs.write_text`
 
 `fs.write_text` remains for compatibility. It should keep its current request
@@ -371,8 +461,8 @@ Compatibility requirement:
 - `fs.patch` must fail closed when the protocol cannot pass derived candidates
   to the active enforcer, because metadata hints cannot prove which files the
   diff touches.
-- `fs.write` may continue to use ordinary path hints because its path is an
-  explicit schema field.
+- `fs.read` and `fs.write` may continue to use ordinary path hints because each
+  tool path is an explicit schema field.
 
 Path enforcer behavior:
 
@@ -392,6 +482,23 @@ belongs to the execution planner, and both phases should share the same parser
 library so they cannot disagree about target paths.
 
 ## Tool Metadata
+
+`fs.read` metadata:
+
+```json
+{
+  "category": "management",
+  "uses_filesystem": true,
+  "path_boundable": true,
+  "capabilities": ["filesystem.read"],
+  "path_argument_hints": ["path"],
+  "path_scope_action": "read",
+  "eval": {
+    "action_family": "filesystem_read",
+    "expected_result_kind": "structured_filesystem_read"
+  }
+}
+```
 
 `fs.patch` metadata:
 
@@ -427,6 +534,7 @@ library so they cannot disagree about target paths.
 ```
 
 Read tools should declare `path_scope_action: "read"`. Existing
+`fs.read_text` should declare `path_scope_action: "read"`, and existing
 `fs.write_text` should declare `path_scope_action: "write"`.
 
 For `fs.patch`, the module-derived candidates decide each file action:
@@ -437,22 +545,26 @@ For `fs.write`, both `create` and `replace` require `write`.
 
 Package defaults should keep current compatibility but move toward:
 
-- `_FILES_READ_TOOLS`: `fs.list`, `fs.read_text`, `fs.stat`, `fs.glob`,
-  `fs.grep`
+- `_FILES_READ_TOOLS`: `fs.list`, `fs.read`, `fs.stat`, `fs.glob`, `fs.grep`
 - `_FILES_EDIT_TOOLS`: `_FILES_READ_TOOLS`, `fs.patch`
 - `_FILES_WRITE_TOOLS`: `_FILES_EDIT_TOOLS`, `fs.write`
+- `_LEGACY_FILES_READ_TOOLS`: `fs.read_text`
 - `_LEGACY_FILES_WRITE_TOOLS`: `fs.write_text`
 
-Profiles that need routine source/document edits should receive `fs.patch`.
-Profiles that generate complete files should receive `fs.write`. Existing
-profiles that currently have `fs.write_text` can keep it until a compatibility
-review decides whether to replace it.
+Profiles that inspect files should receive `fs.read`. Profiles that need
+routine source/document edits should receive `fs.patch`. Profiles that generate
+complete files should receive `fs.write`. Existing profiles that currently have
+`fs.read_text` or `fs.write_text` can keep them until a compatibility review
+decides whether to replace them.
 
 The default preset update should avoid silently broadening existing roles. If a
-role currently has no file mutation capability, adding `fs.patch` or `fs.write`
-must be a deliberate preset change backed by an explicit path grant. If a role
-already has `fs.write_text`, the migration may add `fs.patch` and `fs.write`
-while keeping `fs.write_text` temporarily for compatibility.
+role currently has no file read capability, adding `fs.read` must be a
+deliberate preset change backed by an explicit `read` path grant. If a role
+currently has no file mutation capability, adding `fs.patch` or `fs.write` must
+be a deliberate preset change backed by an explicit path grant. If a role
+already has `fs.read_text` or `fs.write_text`, the migration may add `fs.read`,
+`fs.patch`, and `fs.write` while keeping the legacy tool temporarily for
+compatibility.
 
 Example policy snippets:
 
@@ -460,7 +572,7 @@ Profile A:
 
 ```json
 {
-  "allowed_tools": ["fs.read_text", "fs.patch", "fs.write"],
+  "allowed_tools": ["fs.read", "fs.patch", "fs.write"],
   "policy_document": {
     "path_scope_mode": "workspace_root",
     "path_grants": [
@@ -474,7 +586,7 @@ Profile B:
 
 ```json
 {
-  "allowed_tools": ["fs.read_text", "fs.patch", "fs.write"],
+  "allowed_tools": ["fs.read", "fs.patch", "fs.write"],
   "policy_document": {
     "path_scope_mode": "workspace_root",
     "path_grants": [
@@ -489,7 +601,7 @@ Profile C:
 
 ```json
 {
-  "allowed_tools": ["fs.read_text", "fs.stat", "fs.glob", "fs.grep"],
+  "allowed_tools": ["fs.read", "fs.stat", "fs.glob", "fs.grep"],
   "policy_document": {
     "path_scope_mode": "workspace_root",
     "path_grants": [
@@ -503,6 +615,7 @@ Profile C:
 
 The governed `run`/`bash`/`shell` runtime may later add commands such as:
 
+- `cat <path>` or `sed -n ...` -> `fs.read`
 - `patch < diff.patch` -> `fs.patch`
 - `write-file <path> ...` -> `fs.write`
 
@@ -521,10 +634,12 @@ Safe metadata:
 - requested tool
 - effective tool
 - action family
+- bytes read/written
+- line range when applicable
 - file count
 - hunk count
 - additions/deletions counts
-- created/edited/write booleans
+- read/created/edited/write booleans
 - dry-run flag
 - status
 - reason code
@@ -535,14 +650,22 @@ Safe metadata:
 - profile or mode id after existing sanitization
 
 Evaluation traces for all filesystem tools should use the same redaction
-contract. `fs.patch`, `fs.write`, `fs.write_text`, and read tools may report
-structured outcomes and scoped path summaries, but they must not persist
-content-bearing arguments or returned file text in tool-use evaluation records.
+contract. `fs.read`, `fs.read_text`, `fs.patch`, `fs.write`, `fs.write_text`,
+and other read tools may report structured outcomes and scoped path summaries,
+but they must not persist content-bearing arguments or returned file text in
+tool-use evaluation records.
+For `fs.read`, this means traces can record byte counts, truncation state,
+hash-present/hash-omitted status, and scoped path summaries, but not `content`.
 
 ## Limits
 
 Recommended settings:
 
+- `read_max_bytes`
+- `read_max_lines`
+- `read_default_max_bytes`
+- `read_default_max_lines`
+- `read_hash_max_file_bytes`
 - `patch_max_bytes`
 - `patch_max_files`
 - `patch_max_hunks`
@@ -553,14 +676,21 @@ Recommended settings:
 
 All limits must fail closed with stable reason codes.
 
-Limits should be evaluated before expensive work where possible. The diff byte
-limit can be checked before parsing, file and hunk count limits during parsing,
-and file-size limits before loading each target file.
+Limits should be evaluated before expensive work where possible. Read byte and
+line caps should be applied before returning content. The diff byte limit can be
+checked before parsing, file and hunk count limits during parsing, and file-size
+limits before loading each target file.
 
 ## Testing Strategy
 
 Filesystem module tests:
 
+- `fs.read` descriptor includes metadata, strict schema, and eval metadata.
+- `fs.read` returns UTF-8 content, full-file hash, byte counts, newline style,
+  and truncation metadata.
+- `fs.read` enforces byte/line limits and clearly marks truncated responses.
+- `fs.read` rejects path escapes, symlinks, binary/NUL content, non-UTF-8
+  content, oversized hash requests, and unsupported arguments.
 - `fs.patch` descriptor includes metadata, strict schema, and eval metadata.
 - `fs.write` descriptor includes metadata, strict schema, and eval metadata.
 - Unified diff parser accepts standard single-file and multi-file hunks.
@@ -606,6 +736,7 @@ Protocol tests:
 - Path-scope denials happen before filesystem reads/writes.
 - Approval payloads include bounded path-scope summaries.
 - Tool-use reporting records status/reason/action metadata without raw diffs.
+- Tool-use reporting records `fs.read` metadata without returned file content.
 
 Command runtime tests are deferred until command aliases are added.
 
@@ -616,10 +747,11 @@ Recommended implementation slices:
 1. Action-aware path grants in `McpHubPathEnforcementService`, with compatibility
    fallback for `path_allowlist_prefixes`.
 2. Protocol/module derived path-candidate seam.
-3. Unified diff parser and in-memory patch planner.
-4. `fs.patch` tool execution and tests.
-5. `fs.write` tool execution and tests.
-6. Profile metadata, docs, and package-boundary verification.
+3. `fs.read` tool execution and tests.
+4. Unified diff parser and in-memory patch planner.
+5. `fs.patch` tool execution and tests.
+6. `fs.write` tool execution and tests.
+7. Profile metadata, docs, and package-boundary verification.
 
 Each slice should use TDD and focused security scans on touched Python code.
 
@@ -629,6 +761,9 @@ Each slice should use TDD and focused security scans on touched Python code.
   seam is required.
 - Path grants must be action-aware to support read-only, edit-only, and
   write-capable folders.
+- `fs.read` should be a first-class bounded primitive rather than relying only
+  on legacy `fs.read_text`, because safe patch/write flows need hashes,
+  truncation state, and consistent read-action policy.
 - `fs.write` must be treated as a separate whole-file primitive with explicit
   create/replace modes, required replace hashes, and `write` action semantics.
 - Unified diff support must be intentionally narrow and reject unsupported

--- a/Docs/superpowers/specs/2026-06-07-mcp-fs-patch-write-safe-edit-tools-design.md
+++ b/Docs/superpowers/specs/2026-06-07-mcp-fs-patch-write-safe-edit-tools-design.md
@@ -1,0 +1,646 @@
+# MCP fs.patch And fs.write Safe Edit Tools Design
+
+## Status
+
+Draft specification for TASK-2277.
+
+This is the next MCP filesystem write-safety slice after metadata-only
+tool-use reporting. It adds a diff-first edit primitive and a deliberate
+whole-file write primitive while tightening path policy so profiles can grant
+different read, edit, and write access by workspace subpath.
+
+## Summary
+
+Add two paired filesystem primitives to the workspace-bounded MCP filesystem
+module:
+
+- `fs.patch`: preferred edit primitive. It accepts unified diffs, parses them
+  in process, derives touched paths before execution, applies hunks with
+  conflict detection, and never invokes a host shell or platform patch tool.
+- `fs.write`: deliberate whole-file create or replace primitive. It is for
+  creating a complete file or intentionally replacing a complete file, not for
+  incremental edits. Existing files require an expected content hash.
+
+`fs.write_text` remains as a compatibility surface for existing callers, but
+new role profiles, docs, and model guidance should prefer `fs.patch` for
+modifying existing files and `fs.write` for intentional whole-file writes.
+`fs.write` is intentionally higher impact than `fs.patch`: it creates or
+replaces a whole file and therefore requires the explicit `write` path action,
+including for replacements.
+
+This slice also makes path constraints action-aware. A profile can read a path
+without being allowed to edit it, edit one folder without writing another, or
+write multiple workspace roots only when explicitly granted.
+
+## Goals
+
+- Prefer unified-diff editing over raw text replacement whenever possible.
+- Keep all file mutation workspace-bounded and profile/path-scope governed.
+- Support granular path grants such as:
+  - Profile A can read/edit/write `documents/` but cannot access `downloads/`.
+  - Profile B can read/edit/write `documents/` and `downloads/`.
+  - Profile C can read `downloads/` but cannot edit or write there.
+- Parse patch paths during protocol preflight so policy checks use paths
+  derived from the diff, not caller-supplied path hints.
+- Make every write/edit operation conflict-aware, bounded, UTF-8 only, and
+  observable through the existing MCP tool-use metadata contract.
+- Preserve the current no-shell, no-subprocess filesystem safety model.
+
+## Non-Goals
+
+- No raw shell execution, `patch`, `git apply`, PowerShell, platform diff tools,
+  or subprocess delegation.
+- No arbitrary binary patching.
+- No chmod, chown, symlink creation, rename, copy, delete, or mode-only patch
+  support in the first slice.
+- No fuzzy hunk matching, three-way merge, or best-effort context relocation.
+- No AST-aware code refactoring.
+- No collaborative merge algorithm.
+- No UI implementation.
+- No change to the existing `fs.write_text` behavior beyond metadata/path-scope
+  participation needed for policy consistency.
+
+## Existing Context
+
+`FilesystemModule` currently exposes:
+
+- `fs.list`
+- `fs.read_text`
+- `fs.write_text`
+- `fs.stat`
+- `fs.glob`
+- `fs.grep`
+
+The module already resolves a trusted workspace root, rejects path escapes,
+offloads blocking file I/O with `asyncio.to_thread`, rejects binary text reads,
+and uses metadata such as `uses_filesystem`, `path_boundable`, and
+`path_argument_hints` for path-scope policy.
+
+`MCPProtocol.prepare_tool_call()` already validates tool schemas, determines
+write status, asks the injected `PathScopeEnforcer` to evaluate path scope, and
+then runs approval checks before execution. That is the correct boundary for
+`fs.patch` and `fs.write`.
+
+The current `McpHubPathEnforcementService` supports:
+
+- workspace-root and cwd-descendant path scope modes
+- multi-root workspace bundles
+- path-only `path_allowlist_prefixes`
+- metadata-driven extraction of explicit path arguments
+
+The missing pieces are action-aware grants and derived path extraction for
+diff-based tools.
+
+## Design Decisions
+
+### 1. Diff-first edits
+
+Models should use `fs.patch` for existing-file edits. Unified diffs carry
+context, changed lines, target paths, and enough structure to detect conflicts.
+They are safer than raw search/replace operations because the tool can reject a
+patch when the file no longer matches the expected context.
+
+Rejected alternatives:
+
+- Raw exact-text edit primitive first: easier to implement, but it encourages
+  brittle unstructured edits and does not match the user's preferred diff-first
+  direction.
+- Host `patch` or `git apply`: familiar, but violates the no-shell/no-process
+  filesystem model and is harder to make portable, bounded, and policy-aware.
+- Only improving `fs.write_text`: insufficient because full-file writes are too
+  broad for routine edits.
+
+### 2. `fs.write` as the paired whole-file primitive
+
+`fs.write` is useful when the model is creating a new file or deliberately
+replacing an entire file, such as writing a generated Markdown story, a new
+configuration example, or a complete new test file.
+
+It must not become a silent overwrite escape hatch:
+
+- Callers must choose `mode: "create"` or `mode: "replace"`.
+- `mode: "create"` fails if the file already exists.
+- `mode: "replace"` fails if the file is missing and requires
+  `expected_sha256`.
+- No default upsert mode in the first slice.
+- `mode: "replace"` uses the `write` action rather than `edit`, because it
+  replaces the whole file and does not carry hunk-level context.
+
+### 3. Action-aware path grants
+
+Path grants must include action semantics. Existing path-only allowlists cannot
+express "read downloads, edit documents" without overgranting.
+
+The new policy shape should be:
+
+```json
+{
+  "path_scope_mode": "workspace_root",
+  "path_scope_enforcement": "approval_required_when_unenforceable",
+  "path_grants": [
+    { "prefix": "documents", "actions": ["read", "edit", "write"] },
+    { "prefix": "downloads", "actions": ["read"] }
+  ]
+}
+```
+
+First-slice grant rules:
+
+- `prefix` is workspace-relative and uses `/` separators.
+- Absolute paths, drive-qualified paths, UNC roots, and parent traversal are
+  rejected.
+- `actions` is an explicit list from `read`, `edit`, `write`.
+- Actions do not imply one another. A grant with `write` alone does not allow
+  reads or contextual patch edits unless `read` or `edit` is also listed.
+- `read` authorizes read tools such as `fs.read_text`, `fs.stat`, `fs.glob`,
+  and `fs.grep`.
+- `edit` authorizes `fs.patch` modifications to existing files. The tool may
+  read existing file content internally for conflict checks, but it must not
+  return raw current content unless the caller also invokes a read tool.
+- `write` authorizes `fs.write` create/replace operations and `fs.patch`
+  creations.
+- A candidate path must match at least one grant prefix that includes the
+  required action.
+- Prefix matching is path-segment aware. A grant for `documents` matches
+  `documents/spec.md` and `documents/nested/file.md`, but not
+  `documents-private/file.md`.
+- If `path_grants` is present, it is authoritative.
+- Existing `path_allowlist_prefixes` remains a compatibility fallback only when
+  `path_grants` is absent. It behaves as a path-only scope for whatever tools
+  the policy otherwise grants.
+- A policy with neither `path_grants` nor `path_allowlist_prefixes` keeps the
+  existing path-scope behavior for backward compatibility; strict bundled
+  profiles should prefer explicit `path_grants`.
+
+## Tool Contracts
+
+### `fs.patch`
+
+Purpose: apply one unified diff to workspace-scoped UTF-8 text files.
+
+Arguments:
+
+- `diff: string` required. Unified diff text.
+- `expected_sha256_by_path: object[string,string]` optional. Workspace-relative
+  paths mapped to expected preimage hashes.
+- `create_parent_directories: boolean` optional, default `false`.
+- `allow_create: boolean` optional, default `false`.
+- `dry_run: boolean` optional, default `false`.
+
+Response:
+
+- `applied`: boolean.
+- `dry_run`: boolean.
+- `files`: list of per-file results:
+  - `path`
+  - `action`: `edit` or `write`
+  - `created`
+  - `hunks_applied`
+  - `additions`
+  - `deletions`
+  - `bytes_written` when applied
+  - `sha256_before` when the file existed
+  - `sha256_after`
+- `summary`: aggregate file, hunk, addition, and deletion counts.
+- `reason_code` on failure.
+
+Failure response or exception reason codes should be stable:
+
+- `invalid_unified_diff`
+- `unsupported_diff`
+- `path_outside_workspace_scope`
+- `path_outside_allowlist_scope`
+- `path_action_not_granted`
+- `patch_conflict`
+- `expected_hash_mismatch`
+- `file_missing`
+- `file_already_exists`
+- `binary_content_not_supported`
+- `file_too_large`
+- `patch_too_large`
+- `too_many_files`
+- `too_many_hunks`
+- `partial_write_rollback_attempted`
+
+Supported unified diff subset:
+
+- `diff --git a/path b/path` headers are accepted.
+- `--- a/path` and `+++ b/path` headers are accepted.
+- Standard `@@ -old_start,old_count +new_start,new_count @@` hunks are
+  required.
+- Context, removal, and addition lines use standard leading ` `, `-`, and `+`.
+- `a/` and `b/` prefixes are stripped only when they are conventional diff
+  prefixes.
+- `/dev/null` is accepted only for file creation when `allow_create=true`.
+- `\ No newline at end of file` is supported and reflected in the in-memory
+  result.
+- Multiple file sections targeting the same normalized path are rejected in the
+  first slice. A single file section may still contain multiple hunks.
+- Diff paths use POSIX `/` separators regardless of host OS. Backslash paths are
+  rejected in the first slice to avoid Windows escape and drive-prefix
+  ambiguity.
+
+Rejected in the first slice:
+
+- binary patches
+- renames
+- copies
+- deletes
+- mode-only changes
+- symlink path writes
+- absolute paths
+- Windows drive-qualified paths
+- UNC paths
+- parent traversal
+- malformed hunk counts
+- mixed file headers that disagree about the target path
+
+Patch application behavior:
+
+- Parse the entire diff before any file I/O.
+- Derive every touched path and required action from the parsed diff.
+- Run path/action policy before reading or writing target files.
+- Normalize parsed paths to a workspace-relative display path and a resolved
+  filesystem path before policy checks. Only workspace-relative display paths
+  may appear in responses, approval payloads, or telemetry.
+- Read existing target files as UTF-8 bytes with binary/NUL detection.
+- Reject files over `patch_max_file_bytes`.
+- Apply all hunks in memory before writing any file.
+- Match hunk context against the current file; conflicts fail before writes.
+- Preserve existing dominant newline style for edited files.
+- Default new files to LF.
+- Use temporary files plus replace for each write.
+- For multi-file writes, dry-run all files before commit. If a write fails
+  during commit, attempt rollback from in-memory backups and return or raise
+  `partial_write_rollback_attempted`. The tool must not claim crash-proof
+  filesystem transactions.
+
+### `fs.write`
+
+Purpose: create or deliberately replace a complete UTF-8 text file.
+
+Arguments:
+
+- `path: string` required.
+- `content: string` required.
+- `mode: "create" | "replace"` required.
+- `expected_sha256: string` required for `mode="replace"`.
+- `create_parent_directories: boolean` optional, default `false`.
+- `dry_run: boolean` optional, default `false`.
+
+Response:
+
+- `path`
+- `mode`
+- `applied`
+- `dry_run`
+- `created`
+- `bytes_written`
+- `sha256_before` when replacing
+- `sha256_after`
+
+Behavior:
+
+- `create` requires the path to be absent.
+- `replace` requires the path to exist, be a regular file, be UTF-8 text, and
+  match `expected_sha256`.
+- No upsert mode in the first slice.
+- Parent directories are created only for `mode="create"` when
+  `create_parent_directories=true` and all parent paths remain inside the
+  allowed workspace/path grant. `mode="replace"` requires the file and parent
+  directory to already exist.
+- Symlink targets are rejected in the first slice.
+- Content is UTF-8 only and subject to `write_max_bytes`.
+- Writes use temporary files and atomic replace where supported by the OS.
+
+### `fs.write_text`
+
+`fs.write_text` remains for compatibility. It should keep its current request
+shape and behavior unless a later migration explicitly deprecates it.
+
+For policy consistency:
+
+- It must remain path-boundable.
+- It requires the `write` path action when action-aware grants are enabled.
+- New profile recommendations should prefer `fs.write`.
+- Strict new profiles may omit `fs.write_text` while keeping `fs.write` and
+  `fs.patch`.
+
+## Path Scope Preflight
+
+`fs.patch` cannot rely on `path_argument_hints` because the paths are embedded
+inside `diff`. The protocol and module need a derived path-candidate seam.
+
+Add an optional module hook:
+
+```python
+def extract_path_scope_candidates(
+    self,
+    tool_name: str,
+    arguments: dict[str, Any],
+) -> list[dict[str, str]]:
+    ...
+```
+
+Candidate shape:
+
+```json
+{
+  "path": "documents/spec.md",
+  "action": "edit",
+  "source": "unified_diff"
+}
+```
+
+Protocol behavior:
+
+1. Sanitize and validate tool arguments.
+2. If the module implements `extract_path_scope_candidates`, call it before
+   path enforcement.
+3. Treat extraction failures as invalid params.
+4. Pass the derived candidates to `PathScopeEnforcer`.
+5. Ensure approval and governance payloads include only bounded relative paths
+   or path-scope summaries, not raw diff text.
+
+Compatibility requirement:
+
+- Extend `PathScopeEnforcer.evaluate_tool_call` in a backward-compatible way,
+  for example by adding an optional `derived_candidates` argument or a small
+  companion method. Existing enforcers that only understand metadata hints
+  should continue to work for ordinary tools.
+- `fs.patch` must fail closed when the protocol cannot pass derived candidates
+  to the active enforcer, because metadata hints cannot prove which files the
+  diff touches.
+- `fs.write` may continue to use ordinary path hints because its path is an
+  explicit schema field.
+
+Path enforcer behavior:
+
+- Use derived candidates when present.
+- Fall back to metadata path hints for ordinary tools.
+- Check every candidate path against workspace root, cwd scope, multi-root
+  workspace bundle, and action-aware `path_grants`.
+- Deny the whole request when any candidate is outside scope or lacks its
+  required action.
+
+This is required for security. The caller must not provide a separate `paths`
+field for `fs.patch`, because that lets the request lie about the diff.
+
+Candidate extraction should parse only enough of the diff to identify file
+sections and intended actions during preflight. Full hunk application still
+belongs to the execution planner, and both phases should share the same parser
+library so they cannot disagree about target paths.
+
+## Tool Metadata
+
+`fs.patch` metadata:
+
+```json
+{
+  "category": "management",
+  "uses_filesystem": true,
+  "path_boundable": true,
+  "capabilities": ["filesystem.edit"],
+  "path_scope_candidate_source": "module",
+  "eval": {
+    "action_family": "filesystem_patch",
+    "expected_result_kind": "structured_filesystem_edit"
+  }
+}
+```
+
+`fs.write` metadata:
+
+```json
+{
+  "category": "management",
+  "uses_filesystem": true,
+  "path_boundable": true,
+  "capabilities": ["filesystem.write"],
+  "path_argument_hints": ["path"],
+  "path_scope_action": "write",
+  "eval": {
+    "action_family": "filesystem_write",
+    "expected_result_kind": "structured_filesystem_write"
+  }
+}
+```
+
+Read tools should declare `path_scope_action: "read"`. Existing
+`fs.write_text` should declare `path_scope_action: "write"`.
+
+For `fs.patch`, the module-derived candidates decide each file action:
+existing-file modifications require `edit`, and file creations require `write`.
+For `fs.write`, both `create` and `replace` require `write`.
+
+## Profile And Preset Guidance
+
+Package defaults should keep current compatibility but move toward:
+
+- `_FILES_READ_TOOLS`: `fs.list`, `fs.read_text`, `fs.stat`, `fs.glob`,
+  `fs.grep`
+- `_FILES_EDIT_TOOLS`: `_FILES_READ_TOOLS`, `fs.patch`
+- `_FILES_WRITE_TOOLS`: `_FILES_EDIT_TOOLS`, `fs.write`
+- `_LEGACY_FILES_WRITE_TOOLS`: `fs.write_text`
+
+Profiles that need routine source/document edits should receive `fs.patch`.
+Profiles that generate complete files should receive `fs.write`. Existing
+profiles that currently have `fs.write_text` can keep it until a compatibility
+review decides whether to replace it.
+
+The default preset update should avoid silently broadening existing roles. If a
+role currently has no file mutation capability, adding `fs.patch` or `fs.write`
+must be a deliberate preset change backed by an explicit path grant. If a role
+already has `fs.write_text`, the migration may add `fs.patch` and `fs.write`
+while keeping `fs.write_text` temporarily for compatibility.
+
+Example policy snippets:
+
+Profile A:
+
+```json
+{
+  "allowed_tools": ["fs.read_text", "fs.patch", "fs.write"],
+  "policy_document": {
+    "path_scope_mode": "workspace_root",
+    "path_grants": [
+      { "prefix": "documents", "actions": ["read", "edit", "write"] }
+    ]
+  }
+}
+```
+
+Profile B:
+
+```json
+{
+  "allowed_tools": ["fs.read_text", "fs.patch", "fs.write"],
+  "policy_document": {
+    "path_scope_mode": "workspace_root",
+    "path_grants": [
+      { "prefix": "documents", "actions": ["read", "edit", "write"] },
+      { "prefix": "downloads", "actions": ["read", "edit", "write"] }
+    ]
+  }
+}
+```
+
+Profile C:
+
+```json
+{
+  "allowed_tools": ["fs.read_text", "fs.stat", "fs.glob", "fs.grep"],
+  "policy_document": {
+    "path_scope_mode": "workspace_root",
+    "path_grants": [
+      { "prefix": "downloads", "actions": ["read"] }
+    ]
+  }
+}
+```
+
+## Command Runtime Follow-Up
+
+The governed `run`/`bash`/`shell` runtime may later add commands such as:
+
+- `patch < diff.patch` -> `fs.patch`
+- `write-file <path> ...` -> `fs.write`
+
+That should be a separate follow-up. This slice should ship typed MCP tools and
+policy first. The command runtime must continue to call typed MCP tools through
+`prepare_tool_call` so path grants, approval, and tool-use reporting remain in
+force.
+
+## Observability And Evaluation
+
+Tool-use events and metrics must not persist raw diffs, raw file contents,
+absolute paths, or raw errors.
+
+Safe metadata:
+
+- requested tool
+- effective tool
+- action family
+- file count
+- hunk count
+- additions/deletions counts
+- created/edited/write booleans
+- dry-run flag
+- status
+- reason code
+- conflict flag
+- path-scope status
+- truncation/limit flags
+- duration bucket
+- profile or mode id after existing sanitization
+
+Evaluation traces for all filesystem tools should use the same redaction
+contract. `fs.patch`, `fs.write`, `fs.write_text`, and read tools may report
+structured outcomes and scoped path summaries, but they must not persist
+content-bearing arguments or returned file text in tool-use evaluation records.
+
+## Limits
+
+Recommended settings:
+
+- `patch_max_bytes`
+- `patch_max_files`
+- `patch_max_hunks`
+- `patch_max_changed_lines`
+- `patch_max_file_bytes`
+- `write_max_bytes`
+- `write_create_parent_directories_default`
+
+All limits must fail closed with stable reason codes.
+
+Limits should be evaluated before expensive work where possible. The diff byte
+limit can be checked before parsing, file and hunk count limits during parsing,
+and file-size limits before loading each target file.
+
+## Testing Strategy
+
+Filesystem module tests:
+
+- `fs.patch` descriptor includes metadata, strict schema, and eval metadata.
+- `fs.write` descriptor includes metadata, strict schema, and eval metadata.
+- Unified diff parser accepts standard single-file and multi-file hunks.
+- Parser rejects binary, rename, copy, delete, mode-only, malformed count,
+  absolute, drive-qualified, UNC, and parent traversal patches.
+- Parser rejects backslash paths, duplicate target file sections, and segment
+  prefix collisions that would bypass grants such as `documents` versus
+  `documents-private`.
+- Patch applies cleanly to an existing UTF-8 file.
+- Patch creates a file only with `allow_create=true` and write action.
+- Patch detects context conflict without writing.
+- Patch detects expected hash mismatch without writing.
+- Multi-file patch writes nothing when one file conflicts.
+- Multi-file patch writes nothing when one file is outside path grant.
+- Symlink patch targets fail closed.
+- UTF-8, NUL/binary, file-size, patch-size, hunk-count, and changed-line limits.
+- No-newline marker behavior.
+- Dry run returns planned results without writes.
+- `fs.write create` writes a new file and fails if it exists.
+- `fs.write replace` requires and validates `expected_sha256`.
+- `fs.write` rejects path escapes, symlinks, binary/NUL content, oversized
+  content, missing parents unless enabled, and unsupported mode.
+
+Policy/path-scope tests:
+
+- Profile A can read/edit/write `documents/` and cannot access `downloads/`.
+- Profile B can read/edit/write both `documents/` and `downloads/`.
+- Profile C can read `downloads/` and is denied for `fs.patch` and `fs.write`.
+- Action inheritance is absent: `write` without `read` denies read tools, and
+  `read` without `edit` or `write` denies mutation tools.
+- `fs.patch` path checks use derived diff paths, not caller-supplied hints.
+- Any denied path/action denies the entire multi-file patch.
+- Existing `path_allowlist_prefixes` behavior remains compatible when
+  `path_grants` is absent.
+- Multi-root workspace bundle enforcement still maps each path to an allowed
+  workspace root before action grant checks.
+
+Protocol tests:
+
+- `prepare_tool_call` calls module path-candidate extraction before path
+  enforcement.
+- Extraction errors map to invalid params.
+- Path-scope denials happen before filesystem reads/writes.
+- Approval payloads include bounded path-scope summaries.
+- Tool-use reporting records status/reason/action metadata without raw diffs.
+
+Command runtime tests are deferred until command aliases are added.
+
+## Rollout
+
+Recommended implementation slices:
+
+1. Action-aware path grants in `McpHubPathEnforcementService`, with compatibility
+   fallback for `path_allowlist_prefixes`.
+2. Protocol/module derived path-candidate seam.
+3. Unified diff parser and in-memory patch planner.
+4. `fs.patch` tool execution and tests.
+5. `fs.write` tool execution and tests.
+6. Profile metadata, docs, and package-boundary verification.
+
+Each slice should use TDD and focused security scans on touched Python code.
+
+## Design Review Findings Incorporated
+
+- `path_argument_hints` alone cannot secure `fs.patch`; a derived path-candidate
+  seam is required.
+- Path grants must be action-aware to support read-only, edit-only, and
+  write-capable folders.
+- `fs.write` must be treated as a separate whole-file primitive with explicit
+  create/replace modes, required replace hashes, and `write` action semantics.
+- Unified diff support must be intentionally narrow and reject unsupported
+  patch features.
+- Atomicity must be described as dry-run plus best-effort rollback, not
+  crash-proof multi-file transactions.
+- Conflict detection requires hunk context and optional expected hashes.
+- Encoding and newline behavior must be specified.
+- Symlinks should fail closed in the first slice.
+- Tool-use reporting must avoid raw diffs and contents.
+- Tests must include a Profile A/B/C permission matrix and denial no-write
+  assertions.
+- Cross-platform path handling must reject ambiguous diff paths and perform
+  path-segment-aware grants so policy behavior is consistent across macOS,
+  Linux, and Windows hosts.

--- a/Docs/superpowers/specs/2026-06-07-mcp-fs-patch-write-safe-edit-tools-design.md
+++ b/Docs/superpowers/specs/2026-06-07-mcp-fs-patch-write-safe-edit-tools-design.md
@@ -32,6 +32,12 @@ existing callers, but new role profiles, docs, and model guidance should prefer
 replaces a whole file and therefore requires the explicit `write` path action,
 including for replacements.
 
+Claude Code's file tools are the behavioral north star for this surface. The
+MCP design should copy the useful safety properties: read-before-mutate for
+existing files, exact/no-fuzzy edit semantics, full-file writes only through a
+dedicated write tool, and consistent permission/path matching for read and
+write-like operations.
+
 This slice also makes path constraints action-aware. A profile can read a path
 without being allowed to edit it, edit one folder without writing another, or
 write multiple workspace roots only when explicitly granted.
@@ -41,6 +47,8 @@ write multiple workspace roots only when explicitly granted.
 - Prefer unified-diff editing over raw text replacement whenever possible.
 - Provide a canonical read primitive that pairs with hash-guarded patch/write
   flows.
+- Enforce read-before-mutate semantics for existing files through read receipts
+  or expected hashes.
 - Keep all file mutation workspace-bounded and profile/path-scope governed.
 - Support granular path grants such as:
   - Profile A can read/edit/write `documents/` but cannot access `downloads/`.
@@ -110,7 +118,9 @@ Rejected alternatives:
 
 - Raw exact-text edit primitive first: easier to implement, but it encourages
   brittle unstructured edits and does not match the user's preferred diff-first
-  direction.
+  direction. A Claude Code-compatible exact string `fs.edit` can be a later
+  compatibility slice if model behavior shows diffs are too expensive for small
+  edits.
 - Host `patch` or `git apply`: familiar, but violates the no-shell/no-process
   filesystem model and is harder to make portable, bounded, and policy-aware.
 - Only improving `fs.write_text`: insufficient because full-file writes are too
@@ -120,7 +130,8 @@ Rejected alternatives:
 
 `fs.read` should become the preferred file-inspection primitive for text files.
 It pairs with `fs.patch` and `fs.write` by returning the file hash, newline
-style, size, and truncation state needed for conflict-aware follow-up calls.
+style, size, truncation state, and optional read receipt needed for
+conflict-aware follow-up calls.
 
 It must not become an unbounded content exfiltration path:
 
@@ -130,6 +141,9 @@ It must not become an unbounded content exfiltration path:
   partial file that looks complete.
 - The tool response may include file content for the active model call, but
   tool-use reporting and evaluation traces must not persist that raw content.
+- Reading a file through `fs.read` should create a short-lived read receipt when
+  the complete file can be hashed within configured limits. That receipt can be
+  supplied to `fs.patch` or `fs.write` instead of copying hashes manually.
 
 ### 3. `fs.write` as the write-side whole-file primitive
 
@@ -142,10 +156,15 @@ It must not become a silent overwrite escape hatch:
 - Callers must choose `mode: "create"` or `mode: "replace"`.
 - `mode: "create"` fails if the file already exists.
 - `mode: "replace"` fails if the file is missing and requires
-  `expected_sha256`.
+  `expected_sha256` or a valid read receipt for the same path and content hash.
 - No default upsert mode in the first slice.
 - `mode: "replace"` uses the `write` action rather than `edit`, because it
   replaces the whole file and does not carry hunk-level context.
+
+This follows Claude Code's Write behavior: full-file overwrite is separate from
+partial edit, and overwriting an existing file requires that the file was read
+first in the current working session. In MCP terms, `expected_sha256` and
+server-issued read receipts are the enforceable version of that rule.
 
 ### 4. Action-aware path grants
 
@@ -219,7 +238,8 @@ Response:
 - `line_count_total` when cheap to compute within limits
 - `bytes_read`
 - `bytes_total`
-- `sha256`
+- `sha256` when available
+- `read_receipt` when a complete-file preimage receipt is available
 - `newline_style`: `lf`, `crlf`, `cr`, or `mixed`
 - `truncated`: boolean
 - `truncation_reason`: `max_bytes`, `max_lines`, or absent
@@ -235,6 +255,7 @@ Failure response or exception reason codes should be stable:
 - `file_too_large`
 - `read_too_large`
 - `invalid_line_range`
+- `hash_omitted_file_too_large`
 
 Behavior:
 
@@ -247,8 +268,15 @@ Behavior:
 - Applies byte and line limits before returning content.
 - Returns `sha256` for the complete file, not only the returned slice, when the
   file is within `read_hash_max_file_bytes`.
-- If the file is too large to hash under configured limits, returns a stable
-  reason such as `hash_omitted_file_too_large` and keeps `sha256` absent.
+- Returns `read_receipt` only when the complete-file hash is available. The
+  receipt must bind at least the workspace id, normalized path, file size,
+  content hash, issued-at timestamp, and profile/session identity through a
+  server-side signature or opaque store entry.
+- If the file is too large to hash under configured limits, returns
+  `hash_omitted_file_too_large` and keeps both `sha256` and `read_receipt`
+  absent. In that case `fs.write replace` and strict `fs.patch` cannot proceed
+  unless the caller supplies a valid `expected_sha256` from another trusted
+  channel.
 - Does not persist returned `content` in tool-use reporting, audit summaries, or
   evaluation traces.
 
@@ -261,6 +289,8 @@ Arguments:
 - `diff: string` required. Unified diff text.
 - `expected_sha256_by_path: object[string,string]` optional. Workspace-relative
   paths mapped to expected preimage hashes.
+- `read_receipt_by_path: object[string,string]` optional. Workspace-relative
+  paths mapped to receipts returned by `fs.read`.
 - `create_parent_directories: boolean` optional, default `false`.
 - `allow_create: boolean` optional, default `false`.
 - `dry_run: boolean` optional, default `false`.
@@ -291,6 +321,8 @@ Failure response or exception reason codes should be stable:
 - `path_action_not_granted`
 - `patch_conflict`
 - `expected_hash_mismatch`
+- `read_receipt_invalid`
+- `read_before_mutate_required`
 - `file_missing`
 - `file_already_exists`
 - `binary_content_not_supported`
@@ -341,6 +373,10 @@ Patch application behavior:
 - Normalize parsed paths to a workspace-relative display path and a resolved
   filesystem path before policy checks. Only workspace-relative display paths
   may appear in responses, approval payloads, or telemetry.
+- For existing-file edits in strict/default mode, require either a matching
+  `expected_sha256_by_path` entry or valid `read_receipt_by_path` entry before
+  hunk matching. Compatibility mode may allow context-only patching, but bundled
+  strict profiles should keep read-before-mutate enabled.
 - Read existing target files as UTF-8 bytes with binary/NUL detection.
 - Reject files over `patch_max_file_bytes`.
 - Apply all hunks in memory before writing any file.
@@ -352,6 +388,9 @@ Patch application behavior:
   during commit, attempt rollback from in-memory backups and return or raise
   `partial_write_rollback_attempted`. The tool must not claim crash-proof
   filesystem transactions.
+- Track parent directories created by `fs.patch`. If commit fails after creating
+  directories, attempt best-effort cleanup of directories that are still empty
+  and were created by this call. Never remove pre-existing directories.
 
 ### `fs.write`
 
@@ -362,7 +401,10 @@ Arguments:
 - `path: string` required.
 - `content: string` required.
 - `mode: "create" | "replace"` required.
-- `expected_sha256: string` required for `mode="replace"`.
+- `expected_sha256: string` optional for `mode="replace"` when `read_receipt`
+  is supplied; otherwise required for `mode="replace"`.
+- `read_receipt: string` optional for `mode="replace"` as an alternative to
+  `expected_sha256`.
 - `create_parent_directories: boolean` optional, default `false`.
 - `dry_run: boolean` optional, default `false`.
 
@@ -381,7 +423,7 @@ Behavior:
 
 - `create` requires the path to be absent.
 - `replace` requires the path to exist, be a regular file, be UTF-8 text, and
-  match `expected_sha256`.
+  match `expected_sha256` or a valid `read_receipt`.
 - No upsert mode in the first slice.
 - Parent directories are created only for `mode="create"` when
   `create_parent_directories=true` and all parent paths remain inside the
@@ -390,6 +432,9 @@ Behavior:
 - Symlink targets are rejected in the first slice.
 - Content is UTF-8 only and subject to `write_max_bytes`.
 - Writes use temporary files and atomic replace where supported by the OS.
+- Parent directories created for `create` are tracked and cleaned up on
+  best-effort failure only when they are still empty and were created by the
+  current call.
 
 ### `fs.read_text`
 
@@ -413,22 +458,23 @@ For policy consistency:
 - It must remain path-boundable.
 - It requires the `write` path action when action-aware grants are enabled.
 - New profile recommendations should prefer `fs.write`.
-- Strict new profiles may omit `fs.write_text` while keeping `fs.write` and
-  `fs.patch`.
+- Strict new profiles should omit `fs.write_text` while keeping `fs.write` and
+  `fs.patch`. Compatibility profiles that keep `fs.write_text` should require
+  approval for existing-file overwrites until the legacy tool can be retired.
 
 ## Path Scope Preflight
 
 `fs.patch` cannot rely on `path_argument_hints` because the paths are embedded
 inside `diff`. The protocol and module need a derived path-candidate seam.
 
-Add an optional module hook:
+Add a module hook:
 
 ```python
 def extract_path_scope_candidates(
     self,
     tool_name: str,
     arguments: dict[str, Any],
-) -> list[dict[str, str]]:
+) -> list[PathScopeCandidate]:
     ...
 ```
 
@@ -438,14 +484,28 @@ Candidate shape:
 {
   "path": "documents/spec.md",
   "action": "edit",
-  "source": "unified_diff"
+  "source": "unified_diff",
+  "display_path": "documents/spec.md",
+  "requires_existing_file": true
 }
 ```
+
+The implementation should define a small package-level `PathScopeCandidate`
+typed model or dataclass with at least:
+
+- `path`: normalized workspace-relative path.
+- `action`: `read`, `edit`, `write`, or future `delete`.
+- `source`: `argument`, `unified_diff`, `legacy_hint`, or `hook_rewrite`.
+- `display_path`: redaction-safe relative path for policy payloads.
+- `requires_existing_file`: boolean when known.
+- `creates_file`: boolean when known.
+- `workspace_id`: optional for multi-root candidates.
 
 Protocol behavior:
 
 1. Sanitize and validate tool arguments.
-2. If the module implements `extract_path_scope_candidates`, call it before
+2. If tool metadata declares `path_scope_candidate_source: "module"`, require
+   the module to implement `extract_path_scope_candidates` and call it before
    path enforcement.
 3. Treat extraction failures as invalid params.
 4. Pass the derived candidates to `PathScopeEnforcer`.
@@ -454,10 +514,9 @@ Protocol behavior:
 
 Compatibility requirement:
 
-- Extend `PathScopeEnforcer.evaluate_tool_call` in a backward-compatible way,
-  for example by adding an optional `derived_candidates` argument or a small
-  companion method. Existing enforcers that only understand metadata hints
-  should continue to work for ordinary tools.
+- Extend `PathScopeEnforcer.evaluate_tool_call` in a backward-compatible way by
+  adding an optional `derived_candidates` argument. Existing enforcers that only
+  understand metadata hints should continue to work for ordinary tools.
 - `fs.patch` must fail closed when the protocol cannot pass derived candidates
   to the active enforcer, because metadata hints cannot prove which files the
   diff touches.
@@ -468,6 +527,9 @@ Path enforcer behavior:
 
 - Use derived candidates when present.
 - Fall back to metadata path hints for ordinary tools.
+- If tool metadata declares `path_scope_candidate_source: "module"` but no
+  derived candidates are present, deny with
+  `path_scope_candidates_unavailable`.
 - Check every candidate path against workspace root, cwd scope, multi-root
   workspace bundle, and action-aware `path_grants`.
 - Deny the whole request when any candidate is outside scope or lacks its
@@ -566,6 +628,13 @@ already has `fs.read_text` or `fs.write_text`, the migration may add `fs.read`,
 `fs.patch`, and `fs.write` while keeping the legacy tool temporarily for
 compatibility.
 
+Canonical storage for action-aware grants is `policy_document.path_grants`.
+Existing `MCPProfile.path_scopes` remains an attachment/listing surface for
+named scope objects, and `resource_constraints` remains for non-path
+constraints such as `requires_workspace_binding`. Import/export, snapshots, and
+admin APIs should normalize `path_grants` in `policy_document` and only mirror
+them elsewhere for display if needed.
+
 Example policy snippets:
 
 Profile A:
@@ -657,22 +726,36 @@ tool-use evaluation records.
 For `fs.read`, this means traces can record byte counts, truncation state,
 hash-present/hash-omitted status, and scoped path summaries, but not `content`.
 
+Result sanitization must be implemented through an explicit per-tool allowlist:
+
+- `fs.read`: `path`, `start_line`, `end_line`, `bytes_read`, `bytes_total`,
+  `truncated`, `truncation_reason`, `sha256_present`, `read_receipt_present`,
+  `newline_style`.
+- `fs.patch`: `applied`, `dry_run`, per-file `path`, `action`, `created`,
+  `hunks_applied`, `additions`, `deletions`, `bytes_written`, hash-present
+  booleans, `reason_code`.
+- `fs.write`: `path`, `mode`, `applied`, `dry_run`, `created`,
+  `bytes_written`, hash-present booleans, `reason_code`.
+- `fs.read_text` and `fs.write_text`: compatibility metadata only; never record
+  returned text or submitted content.
+
 ## Limits
 
 Recommended settings:
 
-- `read_max_bytes`
-- `read_max_lines`
-- `read_default_max_bytes`
-- `read_default_max_lines`
-- `read_hash_max_file_bytes`
-- `patch_max_bytes`
-- `patch_max_files`
-- `patch_max_hunks`
-- `patch_max_changed_lines`
-- `patch_max_file_bytes`
-- `write_max_bytes`
-- `write_create_parent_directories_default`
+- `read_default_max_bytes`: `200_000`.
+- `read_max_bytes`: `1_000_000`.
+- `read_default_max_lines`: `2_000`.
+- `read_max_lines`: `20_000`.
+- `read_hash_max_file_bytes`: `5_000_000`.
+- `read_receipt_ttl_seconds`: `1_800`.
+- `patch_max_bytes`: `1_000_000`.
+- `patch_max_files`: `20`.
+- `patch_max_hunks`: `200`.
+- `patch_max_changed_lines`: `10_000`.
+- `patch_max_file_bytes`: `5_000_000`.
+- `write_max_bytes`: `1_000_000`.
+- `write_create_parent_directories_default`: `false`.
 
 All limits must fail closed with stable reason codes.
 
@@ -691,6 +774,8 @@ Filesystem module tests:
 - `fs.read` enforces byte/line limits and clearly marks truncated responses.
 - `fs.read` rejects path escapes, symlinks, binary/NUL content, non-UTF-8
   content, oversized hash requests, and unsupported arguments.
+- `fs.read` produces a receipt for complete hashed reads and omits it with a
+  stable reason when the full preimage cannot be hashed.
 - `fs.patch` descriptor includes metadata, strict schema, and eval metadata.
 - `fs.write` descriptor includes metadata, strict schema, and eval metadata.
 - Unified diff parser accepts standard single-file and multi-file hunks.
@@ -703,6 +788,8 @@ Filesystem module tests:
 - Patch creates a file only with `allow_create=true` and write action.
 - Patch detects context conflict without writing.
 - Patch detects expected hash mismatch without writing.
+- Patch requires read receipt or expected hash in strict/default mode for
+  existing-file edits.
 - Multi-file patch writes nothing when one file conflicts.
 - Multi-file patch writes nothing when one file is outside path grant.
 - Symlink patch targets fail closed.
@@ -710,7 +797,10 @@ Filesystem module tests:
 - No-newline marker behavior.
 - Dry run returns planned results without writes.
 - `fs.write create` writes a new file and fails if it exists.
-- `fs.write replace` requires and validates `expected_sha256`.
+- `fs.write replace` requires and validates `expected_sha256` or a read
+  receipt.
+- `fs.write replace` also accepts a valid read receipt and rejects stale,
+  wrong-path, wrong-workspace, expired, or wrong-profile receipts.
 - `fs.write` rejects path escapes, symlinks, binary/NUL content, oversized
   content, missing parents unless enabled, and unsupported mode.
 
@@ -725,6 +815,9 @@ Policy/path-scope tests:
 - Any denied path/action denies the entire multi-file patch.
 - Existing `path_allowlist_prefixes` behavior remains compatible when
   `path_grants` is absent.
+- `policy_document.path_grants` is the canonical grant location; imports,
+  snapshots, and admin updates preserve it without moving data into
+  `path_scopes` or `resource_constraints`.
 - Multi-root workspace bundle enforcement still maps each path to an allowed
   workspace root before action grant checks.
 
@@ -759,11 +852,18 @@ Each slice should use TDD and focused security scans on touched Python code.
 
 - `path_argument_hints` alone cannot secure `fs.patch`; a derived path-candidate
   seam is required.
+- Module-derived path scope needs a concrete `PathScopeCandidate` contract and
+  fail-closed behavior for tools marked `path_scope_candidate_source: "module"`.
 - Path grants must be action-aware to support read-only, edit-only, and
   write-capable folders.
+- `policy_document.path_grants` is the canonical storage shape; profile
+  `path_scopes` and `resource_constraints` should not carry duplicate
+  executable grants.
 - `fs.read` should be a first-class bounded primitive rather than relying only
   on legacy `fs.read_text`, because safe patch/write flows need hashes,
   truncation state, and consistent read-action policy.
+- Existing-file mutation should follow Claude Code's read-before-edit/write
+  posture by requiring hashes or read receipts.
 - `fs.write` must be treated as a separate whole-file primitive with explicit
   create/replace modes, required replace hashes, and `write` action semantics.
 - Unified diff support must be intentionally narrow and reject unsupported
@@ -774,8 +874,19 @@ Each slice should use TDD and focused security scans on touched Python code.
 - Encoding and newline behavior must be specified.
 - Symlinks should fail closed in the first slice.
 - Tool-use reporting must avoid raw diffs and contents.
+- Tool-use reporting needs a per-tool result allowlist, not only prose
+  redaction rules.
 - Tests must include a Profile A/B/C permission matrix and denial no-write
   assertions.
 - Cross-platform path handling must reject ambiguous diff paths and perform
   path-segment-aware grants so policy behavior is consistent across macOS,
   Linux, and Windows hosts.
+- Parent directory creation must be tracked separately from file writes with
+  best-effort cleanup only for directories created by the current call.
+
+## External References
+
+- Claude Code tools reference:
+  <https://code.claude.com/docs/en/tools-reference#edit-tool-behavior>
+- Claude Code hooks guide:
+  <https://code.claude.com/docs/en/hooks-guide>

--- a/Docs/superpowers/specs/2026-06-07-mcp-fs-patch-write-safe-edit-tools-design.md
+++ b/Docs/superpowers/specs/2026-06-07-mcp-fs-patch-write-safe-edit-tools-design.md
@@ -179,6 +179,7 @@ The new policy shape should be:
   "path_scope_enforcement": "approval_required_when_unenforceable",
   "path_grants": [
     { "prefix": "documents", "actions": ["read", "edit", "write"] },
+    { "prefix": "documents/private", "actions": ["edit", "write"], "effect": "deny" },
     { "prefix": "downloads", "actions": ["read"] }
   ]
 }
@@ -190,6 +191,8 @@ First-slice grant rules:
 - Absolute paths, drive-qualified paths, UNC roots, and parent traversal are
   rejected.
 - `actions` is an explicit list from `read`, `edit`, `write`.
+- `effect` is optional and defaults to `allow`. The only accepted values are
+  `allow` and `deny`.
 - Actions do not imply one another. A grant with `write` alone does not allow
   reads or contextual patch edits unless `read` or `edit` is also listed.
 - `read` authorizes read tools such as `fs.read`, `fs.read_text`, `fs.stat`,
@@ -201,6 +204,8 @@ First-slice grant rules:
   creations.
 - A candidate path must match at least one grant prefix that includes the
   required action.
+- Deny grants take precedence over allow grants. If both an allow and deny
+  grant match a candidate/action, deny wins regardless of ordering.
 - Prefix matching is path-segment aware. A grant for `documents` matches
   `documents/spec.md` and `documents/nested/file.md`, but not
   `documents-private/file.md`.
@@ -211,6 +216,26 @@ First-slice grant rules:
 - A policy with neither `path_grants` nor `path_allowlist_prefixes` keeps the
   existing path-scope behavior for backward compatibility; strict bundled
   profiles should prefer explicit `path_grants`.
+
+The executable core remains flat. A future admin authoring layer may support
+hierarchical org -> workspace -> folder -> file policy and compile it into this
+flat effective grant list, but the runtime enforcer should only depend on
+normalized effective grants.
+
+Reserved future actions:
+
+- `delete`
+- `rename`
+- `move`
+- `share`
+- `export`
+- `chmod`
+- `admin`
+- `lock`
+
+These names are reserved so future file-operation tools do not overload
+`write`. In particular, `share` and `export` are exfiltration-sensitive and
+must not be bundled under write authority.
 
 ## Tool Contracts
 
@@ -534,6 +559,27 @@ Path enforcer behavior:
   workspace bundle, and action-aware `path_grants`.
 - Deny the whole request when any candidate is outside scope or lacks its
   required action.
+- Return or attach structured permission-decision metadata for every checked
+  candidate. This data must be safe for logs and troubleshooting and must not
+  include absolute host paths.
+
+Permission-decision metadata should include:
+
+- `requested_action`
+- `normalized_path`, workspace-relative
+- `grant_outcome`: `allowed`, `denied`, or `not_granted`
+- `grant_source`: `path_grants`, `path_allowlist_prefixes`, `cwd_scope`,
+  `workspace_bundle`, or `none`
+- `matched_grant_prefix` when safe and workspace-relative
+- `matched_grant_effect`: `allow` or `deny`
+- `reason_code`
+- `redacted`: boolean
+
+Denial responses should be safe but actionable. The stable payload should
+include `reason_code`, `requested_action`, `normalized_path`,
+`required_grant_action`, `grant_outcome`, and the safe matched grant fields
+above when available. It must not include raw absolute paths, raw diff text, or
+file contents.
 
 This is required for security. The caller must not provide a separate `paths`
 field for `fs.patch`, because that lets the request lie about the diff.
@@ -717,6 +763,12 @@ Safe metadata:
 - truncation/limit flags
 - duration bucket
 - profile or mode id after existing sanitization
+- permission decision metadata: requested action, normalized workspace-relative
+  path, grant outcome, grant source, matched grant effect, denial reason, and
+  redaction flag
+- before/after hash-present booleans for mutating tools, and before/after hash
+  values only when the existing tool-use redaction contract explicitly permits
+  hashes
 
 Evaluation traces for all filesystem tools should use the same redaction
 contract. `fs.read`, `fs.read_text`, `fs.patch`, `fs.write`, `fs.write_text`,
@@ -833,12 +885,36 @@ Protocol tests:
 
 Command runtime tests are deferred until command aliases are added.
 
+## Deferred Operational Follow-Ups
+
+The following Fastio-inspired enhancements are relevant, but should not expand
+the first safe-file-tools implementation slice:
+
+- Effective permission preview surfaces for explaining why a profile can or
+  cannot perform a path/action.
+- Hierarchical policy authoring that compiles org, workspace, folder, and file
+  inheritance into the flat `path_grants` runtime model.
+- File lock leases such as `fs.lock_acquire` and `fs.lock_release`, with
+  optional lock validation for `fs.patch` and `fs.write` when policy requires
+  it.
+- TTL-bound temporary session grants for one run or a short time window.
+- File-policy audit reporting for safe decision metadata, hashes, redaction
+  state, and denial reasons.
+- Policy simulation CLI/admin tooling for validating profiles before exposing
+  them to agents.
+- Governance hooks and audit trails for permission changes, especially grants
+  involving future `write`, `delete`, `share`, `export`, `admin`, or `lock`
+  actions.
+- Expanded file-operation actions and tools for delete, rename, move,
+  share/export, chmod/admin, and lock semantics.
+
 ## Rollout
 
 Recommended implementation slices:
 
-1. Action-aware path grants in `McpHubPathEnforcementService`, with compatibility
-   fallback for `path_allowlist_prefixes`.
+1. Action-aware path grants in `McpHubPathEnforcementService`, with deny
+   precedence, structured permission-decision metadata, and compatibility
+   fallback for `path_allowlist_prefixes` only when `path_grants` is absent.
 2. Protocol/module derived path-candidate seam.
 3. `fs.read` tool execution and tests.
 4. Unified diff parser and in-memory patch planner.

--- a/Docs/superpowers/specs/2026-06-07-mcp-profile-policy-decision-model-design.md
+++ b/Docs/superpowers/specs/2026-06-07-mcp-profile-policy-decision-model-design.md
@@ -96,6 +96,22 @@ A local review pass found and incorporated four important clarifications:
   intentionally exposes them. Large external catalogs should still use
   progressive disclosure rather than dumping all askable tools into context.
 
+A second review pass added implementation-critical clarifications:
+
+- `ask` must not be represented only as `canExecute=false`, because current
+  virtual CLI catalog filtering treats `canExecute=false` as hidden. Askable
+  tools need explicit approval metadata while remaining callable into the
+  approval path.
+- Sandbox/process assertions can downgrade `allow` to `ask` or `deny`, so they
+  must run before final approval routing.
+- Hooks need explicit denied-call semantics: blocking hooks do not run to
+  loosen already-denied calls; managed observer hooks may receive redacted deny
+  events for audit.
+- Gitignore-style path policies compile to a flat matcher IR, not to enumerated
+  filesystem paths.
+- Command policy should use argv-token matchers rather than shell-string
+  matchers.
+
 ## Core Decision Contract
 
 The shared decision result should have exactly three outcomes:
@@ -111,6 +127,7 @@ The shared decision result should have exactly three outcomes:
   "matched_rules": [],
   "requires_approval": false,
   "visibility": "hidden",
+  "call_state": "blocked",
   "explainable": true
 }
 ```
@@ -124,6 +141,25 @@ Outcomes:
 - `allow`: the policy layer has no objection. This is not sufficient if a
   sandbox, credential grant, path rule, hook, or runtime preflight later denies
   the call.
+
+Catalog and call-state fields are derived from the outcome plus profile
+visibility rules:
+
+- `visibility`: one of `hidden`, `direct`, `deferred`, or `debug_only`.
+- `call_state`: one of `blocked`, `approval_required`, or `callable`.
+- `requires_approval`: `true` only when `call_state="approval_required"`.
+
+Compatibility rule for existing `tools/list` payloads:
+
+- `deny` should normally omit the tool from model-facing catalogs. If a debug
+  surface includes it, `canExecute=false` is appropriate.
+- `ask` should not rely on `canExecute=false` when the tool must remain visible.
+  Use `canExecute=true` plus `requiresApproval=true` and
+  `decision.outcome="ask"` so existing call paths can route into approval.
+- `allow` uses `canExecute=true` and `requiresApproval=false`.
+
+This avoids hiding askable tools from adapters such as the current virtual CLI,
+which filters out tools where `canExecute` is false.
 
 Precedence is always:
 
@@ -188,14 +224,20 @@ Tool-call preparation should produce an ordered policy trace:
 1. Normalize subject identifiers: tool name, external MCP server/tool name,
    path candidates, domains, command invocations, and credential slots.
 2. Resolve the effective profile and session policy.
-3. Evaluate explicit deny rules.
-4. Evaluate allow/ask rules by subject type.
-5. Evaluate path, domain, credential, external MCP, and process constraints.
-6. Run pre-tool hooks that are allowed for this deployment.
-7. Re-run validation and derived candidate extraction if a hook rewrites input.
-8. Evaluate runtime approval based on the final `ask` decision.
-9. Check sandbox/process assertions for tools that spawn or delegate work.
-10. Produce a final decision plus redacted explanation metadata.
+3. Validate schema and derive path/command/external candidates needed for
+   policy evaluation.
+4. Evaluate server-wide disabled-tool settings and explicit deny rules.
+5. If the call is already denied, skip blocking hooks and route only redacted
+   observer/audit hooks that are configured for deny events.
+6. Evaluate allow/ask rules by subject type.
+7. Evaluate path, domain, credential, external MCP, and process constraints.
+8. Run blocking pre-tool hooks that are allowed for this deployment.
+9. If a hook rewrites input, re-run schema validation, candidate extraction,
+   explicit deny checks, and scoped policy checks.
+10. Check sandbox/process assertions for tools that spawn or delegate work.
+11. Merge all decisions, applying `deny > ask > allow`.
+12. Evaluate runtime approval if the final call state is `approval_required`.
+13. Produce a final decision plus redacted explanation metadata.
 
 Rules should be deterministic and stable. The policy trace should record enough
 detail to explain a decision without storing raw file content, raw diffs,
@@ -243,9 +285,9 @@ New policy documents may add a structured rule list:
     {"pattern": "fs.write", "outcome": "deny"}
   ],
   "command_rules": [
-    {"pattern": "git status", "outcome": "allow"},
-    {"pattern": "git *", "outcome": "ask"},
-    {"pattern": "rm *", "outcome": "deny"}
+    {"argv": ["git", "status"], "outcome": "allow"},
+    {"argv": ["git", "*"], "outcome": "ask"},
+    {"argv": ["rm", "*"], "outcome": "deny"}
   ],
   "mcp_rules": [
     {"pattern": "mcp__github", "outcome": "ask"},
@@ -261,8 +303,9 @@ New policy documents may add a structured rule list:
 from execution:
 
 - `deny`: hidden from normal model catalog and tool search.
-- `ask`: visible with `canExecute=false` or `requiresApproval=true`, depending
-  on the existing response contract for the surface.
+- `ask`: visible only when directly granted or explicitly promoted, with
+  `requiresApproval=true`, `decision.outcome="ask"`, and a call path that
+  routes into approval.
 - `allow`: visible and executable if all other constraints pass.
 
 Default visibility rule:
@@ -274,6 +317,12 @@ Default visibility rule:
   and
 - denied tools stay hidden outside admin/debug views.
 
+Existing clients that only understand `canExecute` need a compatibility rule:
+`canExecute=false` means hidden/blocked, not "askable". Askable direct tools
+should keep `canExecute=true` and add approval metadata. Newer clients should
+prefer `decision.outcome` and `call_state` over inferring behavior from
+`canExecute` alone.
+
 Admin/debug surfaces may include hidden denied tools when requested, but only
 with explanation metadata and without sensitive tool arguments.
 
@@ -283,9 +332,10 @@ requires approval.
 
 ## Path Rule Semantics
 
-The executable runtime should continue consuming a flat effective grant list,
-but the authored policy layer should support richer patterns that compile into
-flat rules.
+The executable runtime should continue consuming a flat effective grant list or
+matcher list, but the authored policy layer should support richer patterns that
+compile into a flat matcher IR. The compiler must not expand `**` patterns into
+filesystem enumerations.
 
 Recommended authored shape:
 
@@ -314,12 +364,27 @@ Pattern rules:
   trusted workspace-root resolver into a workspace-relative path.
 - Matching is segment-aware and must not let `docs` match `docs-private`.
 
+Compiled matcher IR should preserve:
+
+- normalized pattern;
+- action set;
+- outcome;
+- source profile/policy id;
+- anchor mode;
+- case-folding mode for the target platform;
+- original authored pattern for explanations; and
+- validation warnings, if any.
+
 Symlink rules:
 
 - For reads and writes, evaluate both the symlink path as requested and the
   resolved target path.
 - Allow only if both paths are allowed for the requested action.
 - Deny if either path matches a deny rule.
+- Deny if the target cannot be resolved safely.
+- Deny if the resolved target leaves the trusted workspace/root set.
+- Normal explain payloads may include only redacted or workspace-relative
+  symlink target summaries, never absolute host target paths.
 - Mutating tools should continue rejecting symlink targets unless a future
   design adds a tightly scoped symlink-follow mode.
 
@@ -330,6 +395,15 @@ External MCP tools should have normalized names that are safe to match:
 - `mcp__server` means the server as a subject, for lifecycle/discovery grants.
 - `mcp__server__*` means every exposed tool for that server.
 - `mcp__server__tool` means one concrete external tool.
+
+Canonicalization:
+
+- server ids and tool ids are lowercased for matching;
+- spaces and non-identifier separators normalize to `_`;
+- repeated separators collapse to one `_`;
+- literal `__` in upstream ids is escaped before joining server/tool segments;
+- collisions fail closed and require an explicit admin alias; and
+- the original upstream display name is preserved only for UI/explain output.
 
 Rules:
 
@@ -390,6 +464,16 @@ Hooks may tighten policy but cannot bypass:
 A blocking hook failure should be configurable as fail-closed by default for
 managed hooks and fail-open only for explicitly non-critical observer hooks.
 
+Denied-call behavior:
+
+- Blocking hooks do not run to reconsider calls already denied by explicit
+  policy, server-wide disablement, or path/credential/external grants.
+- Managed observer hooks may receive redacted deny events for audit and
+  metrics, but their output cannot change the final decision.
+- Hook rewrites create a new candidate set and restart scoped evaluation; the
+  original and rewritten candidates should both be represented in explain
+  metadata using redacted summaries.
+
 ## Shell Alias And Virtual CLI Hardening
 
 The existing `run` module exposes `run`, `bash`, and `shell` as governed virtual
@@ -411,7 +495,7 @@ Rules:
 
 Legacy `Bash(...)` pattern rules:
 
-- `Bash(git *)` means command subject pattern `git *` for governed
+- `Bash(git *)` compiles to command argv pattern `["git", "*"]` for governed
   `run`/`bash`/`shell` aliases.
 - The pattern applies to one parsed command invocation, not the whole raw
   command string.
@@ -444,6 +528,38 @@ Dedicated tools should be preferred for:
 - deployment actions.
 
 Shell-style string matching is too fragile for these behaviors.
+
+Command matcher grammar:
+
+- Match parsed argv tokens, not raw command strings.
+- `*` matches one argv token, not arbitrary text.
+- `**` is not supported for commands in the first slice.
+- Quoted tokens are compared after parsing and normalization.
+- Environment assignment syntax, command substitution, shell functions,
+  redirection, heredocs, glob expansion, variable expansion, and subshells are
+  rejected unless a future parser explicitly models them.
+
+## Canonical Risk Classes
+
+Permission modes should use canonical risk classes from tool metadata rather
+than free-form labels.
+
+| Risk class | Typical tools | Default posture |
+| --- | --- | --- |
+| `read` | `fs.read`, search/list/describe tools | allow in most modes |
+| `bounded_edit` | `fs.patch` on existing files with preimage checks | ask by default, allow in `accept-edits` with path grants |
+| `whole_write` | `fs.write`, file create/replace | ask or deny unless explicitly granted |
+| `destructive` | delete, purge, reset, revoke, deploy rollback | deny unless explicitly granted |
+| `process` | test runners, package commands, external process launch | ask unless sandboxed and explicitly granted |
+| `network_read` | web fetch/search, remote metadata reads | ask or allow based on provider configuration |
+| `network_write` | issue creation, API mutation, CI/deploy actions | ask or deny unless explicitly granted |
+| `credentialed` | calls using stored credential grants | ask unless the grant and profile explicitly allow |
+| `browser_control` | CDP navigation, clicking, form entry | ask unless scoped to inspection/read-only |
+| `memory_write` | Graphiti/memory mutation tools | ask or deny unless role explicitly owns memory writes |
+| `admin` | profile, grant, server, secret, snapshot mutation | deny outside admin profiles |
+
+Tools may carry multiple risk classes. The most restrictive resulting decision
+wins.
 
 ## Sandbox Semantics
 
@@ -556,6 +672,8 @@ dedicated tool exists.
 ### Slice 1: Decision Core And Explain Contract
 
 - Add package-level decision dataclasses/Pydantic models.
+- Include `outcome`, `visibility`, `call_state`, `requires_approval`,
+  `matched_rules`, and redaction metadata in the core response schema.
 - Compile existing profile fields into decision rules.
 - Add `deny > ask > allow` merge tests.
 - Add explain response schema and a package-local simulation API.
@@ -566,13 +684,18 @@ dedicated tool exists.
 - Add `permission_mode` handling.
 - Update tool listing/search/category surfaces to hide denied tools and mark
   ask-scoped tools.
+- Preserve visible askable tools with `canExecute=true`,
+  `requiresApproval=true`, and `decision.outcome="ask"` so existing adapters do
+  not hide them accidentally.
 - Add regression coverage for `locked/dontAsk` converting ask to deny.
 
 ### Slice 3: Path Pattern Compiler
 
-- Add authored gitignore-style path patterns that compile to flat grants.
+- Add authored gitignore-style path patterns that compile to flat matcher IR.
 - Preserve current flat grants as executable runtime input.
 - Add Windows normalization and symlink double-evaluation tests.
+- Add tests for unresolved symlinks, out-of-workspace symlink targets, and
+  redacted explain payloads.
 
 ### Slice 4: External MCP Wildcard Grants
 
@@ -580,29 +703,35 @@ dedicated tool exists.
 - Keep server install/start, credential use, and tool execution as separate
   subjects.
 - Add deny-over-wildcard-allow tests.
+- Add canonicalization and collision tests for server/tool ids containing
+  spaces, case differences, separators, and literal `__`.
 
 ### Slice 5: Shell Alias Hardening
 
 - Extend parser/preflight tests for command chains and wrappers.
+- Replace command-string matching with argv-token policy rules.
 - Add conservative wrapper modeling for `timeout`, `time`, and `nice` only if
   their grammars are small enough to validate.
 - Deny or recommend dedicated tools for high-risk wrappers and package runners.
+- Add regression tests for `Bash(git *)` matching `git status` but not
+  `git status && rm -rf build`.
 
 ### Slice 6: Hooks Enforcement Integration
 
 - Make hook outputs use the shared decision model.
 - Ensure hook `allow` cannot bypass explicit denies.
 - Include hook outcomes in explain and tool-use reporting.
+- Add denied-call observer hook behavior and fail-closed managed hook tests.
 
 ## Open Questions
 
-1. Should `ask` tools be included in the model's normal tool list with
-   `requiresApproval=true`, or should they only appear through tool search and
-   category disclosure?
+1. Which direct profile tools should be promoted as visible askable tools versus
+   deferred behind category/search disclosure?
 2. Should the first explain API live in the standalone package CLI only, or also
    expose a FastAPI admin route in the same PR?
-3. Should permission modes be profile-only, session-only, or allow session
-   overrides that can only tighten the profile mode?
+3. Where should tightening-only session overrides be stored and audited:
+   request metadata, session records, profile assignments, or ACP session
+   state?
 4. How much shell wrapper support is worth shipping before dedicated git/test
    and package-manager tools make most wrappers unnecessary?
 

--- a/Docs/superpowers/specs/2026-06-07-mcp-profile-policy-decision-model-design.md
+++ b/Docs/superpowers/specs/2026-06-07-mcp-profile-policy-decision-model-design.md
@@ -1,0 +1,629 @@
+# MCP Profile Policy Decision Model And Shell Alias Hardening Design
+
+Date: 2026-06-07
+Status: Draft specification for TASK-2306
+Branch: codex/mcp-profile-policy-decision-design
+
+## Summary
+
+Add a cross-cutting MCP/profile policy model built around explicit
+`deny`, `ask`, and `allow` decisions. The decision model should become the
+shared vocabulary for profile grants, tool catalog visibility, path grants,
+external MCP server grants, pre-tool hooks, shell/run aliases, sandbox
+assertions, approval flows, audit events, and effective-permission debugging.
+
+This is a follow-up design slice, not an amendment to the completed safe file
+tools implementation. The safe file tools branch added action-aware path grants
+and guarded `fs.read`, `fs.patch`, and `fs.write`. This spec generalizes that
+work into a broader policy layer and hardens adjacent surfaces such as
+`run`, `bash`, `shell`, hooks, and external MCP wildcard grants.
+
+## Source Feedback Incorporated
+
+This spec incorporates senior review feedback that the MCP/profile design
+should:
+
+- add explicit permission outcomes: `deny`, `ask`, and `allow`;
+- define named permission modes such as read-only, ask-by-default, accept-edits,
+  locked, and sandboxed-auto;
+- strengthen path-rule semantics with gitignore-style patterns, Windows
+  normalization, and symlink target checks;
+- treat shell aliasing as a parser problem, including independent checks for
+  compound commands;
+- handle shell wrappers conservatively;
+- prefer dedicated structured tools over shell escape hatches;
+- make hooks part of enforcement rather than only workflow automation;
+- separate permission decisions from defense-in-depth sandboxing;
+- support external MCP server/tool wildcard grants; and
+- add effective-permission explanations for operators and debuggers.
+
+## Related Existing Designs
+
+- `Docs/superpowers/specs/2026-06-07-mcp-fs-patch-write-safe-edit-tools-design.md`
+- `Docs/superpowers/specs/2026-06-07-mcp-tool-call-hooks-design.md`
+- `Docs/superpowers/specs/2026-06-03-mcp-default-profile-tooling-presets-design.md`
+- `Docs/superpowers/specs/2026-06-01-mcp-stdio-process-policy-design.md`
+- `Docs/superpowers/specs/2026-06-06-mcp-tool-use-eval-reporting-design.md`
+
+## Goals
+
+- Define one permission-decision contract usable across package and host code.
+- Preserve compatibility with existing `allowed_tools`, `denied_tools`, path
+  grants, profile presets, and approval policy fields.
+- Preserve compatibility with existing Claude-style command patterns such as
+  `Bash(git *)` without treating them as raw shell authorization.
+- Make deny precedence explicit and testable.
+- Distinguish tool visibility from tool execution.
+- Allow model-visible "ask" tools without silently granting execution.
+- Make path grants expressive enough for realistic workspace policies while
+  compiling to a flat effective policy for runtime enforcement.
+- Harden the existing governed `run`, `bash`, and `shell` aliases against
+  command-chain bypasses.
+- Treat hooks as policy participants that can tighten but not loosen configured
+  policy.
+- Model sandbox state as a separate enforcement layer, not as a replacement for
+  permissions.
+- Provide an admin/debug explanation surface for tool, path, domain, external
+  MCP, and shell-command decisions.
+
+## Non-Goals
+
+- No raw host shell execution.
+- No broad bypass, superuser, or "YOLO" profile mode.
+- No implementation in this spec-only branch.
+- No UI implementation, though API/CLI surfaces are specified.
+- No complete shell language implementation. The governed CLI parser remains a
+  bounded virtual command language.
+- No attempt to make string allowlists for arbitrary Bash safe. Dedicated tools
+  remain the preferred surface for files, URLs, git, packages, tests, browser
+  inspection, and deployment actions.
+- No tldw_server-specific imports in the standalone `mcp_unified` policy core.
+  Host adapters can expose FastAPI routes and persistence later.
+
+## Local Design Review Adjustments
+
+A local review pass found and incorporated four important clarifications:
+
+- Rules need an explicit subject type so `fs.write`, `mcp__server__tool`, and
+  `Bash(git *)` are not matched by the same ambiguous wildcard machinery.
+- Existing `Bash(...)`/shell-style policy strings should compile into command
+  rules for the governed virtual CLI only. They must never authorize raw host
+  shell execution.
+- Session-level overrides should only tighten the effective profile policy.
+  They may convert `allow` to `ask` or `deny`, and `ask` to `deny`, but never
+  the reverse.
+- Ask-scoped tools should be visible by default only when the active profile
+  intentionally exposes them. Large external catalogs should still use
+  progressive disclosure rather than dumping all askable tools into context.
+
+## Core Decision Contract
+
+The shared decision result should have exactly three outcomes:
+
+```json
+{
+  "outcome": "deny",
+  "reason_code": "tool_explicitly_denied",
+  "subject": {
+    "type": "tool",
+    "normalized": "fs.write"
+  },
+  "matched_rules": [],
+  "requires_approval": false,
+  "visibility": "hidden",
+  "explainable": true
+}
+```
+
+Outcomes:
+
+- `deny`: execution is blocked. Denied tools are hidden from normal model tool
+  context unless an admin/debug caller explicitly asks for hidden entries.
+- `ask`: execution requires an approval flow. The tool may remain visible to
+  the model, but catalog metadata must indicate that execution is gated.
+- `allow`: the policy layer has no objection. This is not sufficient if a
+  sandbox, credential grant, path rule, hook, or runtime preflight later denies
+  the call.
+
+Precedence is always:
+
+```text
+deny > ask > allow
+```
+
+This applies across all merged inputs. If one matching rule says `deny`, no
+other rule or hook can convert the decision to `ask` or `allow`. If no deny
+matches but any applicable rule or hook returns `ask`, the final result is
+`ask`. `allow` only wins when all applicable checks allow or abstain.
+
+## Permission Modes
+
+Profiles and sessions should be able to select a high-level mode that maps to
+default decisions. The mode supplies defaults only; explicit denies always win.
+
+### `plan/read-only`
+
+- Read, search, inspect, list, describe, and planning tools may be `allow`.
+- Mutating, process, browser-control, credentialed, network-write, memory-write,
+  deploy, and destructive tools default to `deny`.
+- Good default for architects, product owners, documentation planning, and code
+  reviewers when no edits are intended.
+
+### `default/ask`
+
+- Read and low-risk inspect tools may be `allow`.
+- File edits, test execution, browser interaction, package operations, external
+  MCP calls with credentials, and memory writes default to `ask`.
+- Destructive operations default to `deny` unless explicitly configured.
+- Recommended default for most interactive agentic sessions.
+
+### `accept-edits`
+
+- Bounded edit tools such as `fs.patch` can be `allow` when profile grants and
+  path grants allow the exact target.
+- Whole-file writes, creates, package commands, process execution, and
+  destructive actions remain `ask` unless explicitly allowed.
+- Good fit for developer modes once a workspace root and path grants are bound.
+
+### `locked/dontAsk`
+
+- Runtime approval prompts are disabled.
+- Any decision that would be `ask` becomes `deny`.
+- Useful for unattended automation, CI, server-side ACP sessions, and hosted
+  deployments where a model cannot ask a human interactively.
+
+### `sandboxed-auto`
+
+- Allows bounded operations only when both policy grants and sandbox assertions
+  pass.
+- If the runtime cannot prove sandbox isolation for the tool class, the decision
+  degrades to `ask` or `deny` according to profile settings.
+- This is the closest safe equivalent to "auto" mode and should not be treated
+  as a bypass.
+
+## Evaluation Pipeline
+
+Tool-call preparation should produce an ordered policy trace:
+
+1. Normalize subject identifiers: tool name, external MCP server/tool name,
+   path candidates, domains, command invocations, and credential slots.
+2. Resolve the effective profile and session policy.
+3. Evaluate explicit deny rules.
+4. Evaluate allow/ask rules by subject type.
+5. Evaluate path, domain, credential, external MCP, and process constraints.
+6. Run pre-tool hooks that are allowed for this deployment.
+7. Re-run validation and derived candidate extraction if a hook rewrites input.
+8. Evaluate runtime approval based on the final `ask` decision.
+9. Check sandbox/process assertions for tools that spawn or delegate work.
+10. Produce a final decision plus redacted explanation metadata.
+
+Rules should be deterministic and stable. The policy trace should record enough
+detail to explain a decision without storing raw file content, raw diffs,
+secrets, full environment values, or absolute host paths unless the caller is an
+authorized local admin and the endpoint is explicitly in debug mode.
+
+## Compatibility With Current Policy Fields
+
+Existing fields remain valid:
+
+- `allowed_tools`
+- `denied_tools`
+- `capabilities`
+- `approval_policy`
+- `path_grants`
+- `path_allowlist_prefixes`
+- `external_server_grants`
+- `credential_grants`
+
+Compatibility mapping:
+
+- `denied_tools` compiles to tool rules with `outcome="deny"`.
+- `allowed_tools` compiles to tool rules with `outcome="allow"` unless a
+  profile mode or approval policy upgrades the operation to `ask`.
+- Existing command-pattern entries such as `Bash(git *)` compile to command
+  rules for `run`/`bash`/`shell` aliases. They do not grant a raw Bash tool and
+  do not match across command separators such as `&&`, `||`, `;`, or `|`.
+- Existing approval policies compile to `ask` rules or mode-level defaults.
+- Existing path grants with `effect="deny"` compile to `deny`; grants with
+  `effect="allow"` compile to `allow`.
+- New `outcome` fields supersede legacy `effect` fields when both are present,
+  but conflicting values should fail validation rather than silently choosing
+  one.
+- If no decision model fields are present, existing behavior remains the
+  compatibility fallback.
+
+New policy documents may add a structured rule list:
+
+```json
+{
+  "permission_mode": "default/ask",
+  "tool_rules": [
+    {"pattern": "fs.read", "outcome": "allow"},
+    {"pattern": "fs.patch", "outcome": "ask"},
+    {"pattern": "fs.write", "outcome": "deny"}
+  ],
+  "command_rules": [
+    {"pattern": "git status", "outcome": "allow"},
+    {"pattern": "git *", "outcome": "ask"},
+    {"pattern": "rm *", "outcome": "deny"}
+  ],
+  "mcp_rules": [
+    {"pattern": "mcp__github", "outcome": "ask"},
+    {"pattern": "mcp__github__*", "outcome": "ask"},
+    {"pattern": "mcp__github__delete_repo", "outcome": "deny"}
+  ]
+}
+```
+
+## Tool Visibility Semantics
+
+`tools/list` and progressive-disclosure surfaces should distinguish visibility
+from execution:
+
+- `deny`: hidden from normal model catalog and tool search.
+- `ask`: visible with `canExecute=false` or `requiresApproval=true`, depending
+  on the existing response contract for the surface.
+- `allow`: visible and executable if all other constraints pass.
+
+Default visibility rule:
+
+- direct profile tools that resolve to `ask` may remain visible with approval
+  metadata;
+- external, plugin, or large category tools that resolve to `ask` should stay
+  behind profile-scoped search/category disclosure unless explicitly promoted;
+  and
+- denied tools stay hidden outside admin/debug views.
+
+Admin/debug surfaces may include hidden denied tools when requested, but only
+with explanation metadata and without sensitive tool arguments.
+
+This distinction matters because a model should not waste context on tools it
+can never call, but it should understand when a useful scoped tool exists and
+requires approval.
+
+## Path Rule Semantics
+
+The executable runtime should continue consuming a flat effective grant list,
+but the authored policy layer should support richer patterns that compile into
+flat rules.
+
+Recommended authored shape:
+
+```json
+{
+  "path_policy_version": 2,
+  "path_grants": [
+    {"pattern": "/documents/**", "actions": ["read", "edit", "write"], "outcome": "allow"},
+    {"pattern": "/documents/private/**", "actions": ["edit", "write"], "outcome": "deny"},
+    {"pattern": "/downloads/**", "actions": ["read"], "outcome": "allow"}
+  ]
+}
+```
+
+Pattern rules:
+
+- Patterns are workspace-relative by default.
+- Leading `/` anchors to the workspace root.
+- `**` matches across path segments; `*` matches within one segment.
+- Bare directory patterns should be normalized to their subtree form only when
+  explicitly documented by the compiler.
+- Parent traversal, drive-qualified paths, UNC roots, and absolute host paths
+  are rejected in authored grants.
+- Windows separators are normalized to `/` for policy matching.
+- Windows drive and UNC inputs are denied unless they are translated by a
+  trusted workspace-root resolver into a workspace-relative path.
+- Matching is segment-aware and must not let `docs` match `docs-private`.
+
+Symlink rules:
+
+- For reads and writes, evaluate both the symlink path as requested and the
+  resolved target path.
+- Allow only if both paths are allowed for the requested action.
+- Deny if either path matches a deny rule.
+- Mutating tools should continue rejecting symlink targets unless a future
+  design adds a tightly scoped symlink-follow mode.
+
+## External MCP Server And Tool Wildcards
+
+External MCP tools should have normalized names that are safe to match:
+
+- `mcp__server` means the server as a subject, for lifecycle/discovery grants.
+- `mcp__server__*` means every exposed tool for that server.
+- `mcp__server__tool` means one concrete external tool.
+
+Rules:
+
+- Exact tool denies win over server or wildcard allows.
+- Server-level grants are not credential grants.
+- Tool grants are not install/start grants.
+- Installation, runtime start, credential use, and tool execution are separate
+  subjects that can each be `deny`, `ask`, or `allow`.
+- Wildcards should be simple and explicit. Avoid regex unless the pattern is
+  prefixed with `re:` and accepted by an admin-only validation path.
+
+## Session Overrides
+
+Session policy may narrow a profile but should not widen it. This lets an ACP
+session, temporary workspace, or frontend mode reduce risk without mutating the
+profile preset.
+
+Allowed session changes:
+
+- convert `allow` to `ask`;
+- convert `allow` or `ask` to `deny`;
+- reduce visible categories;
+- reduce path/domain/MCP server scope;
+- require approval for a normally automatic tool; and
+- require stronger sandbox assertions.
+
+Rejected session changes:
+
+- convert `deny` to `ask` or `allow`;
+- convert `ask` to `allow`;
+- add paths, domains, tools, credential slots, or MCP servers not present in
+  the profile's effective policy; and
+- disable managed hooks or sandbox requirements.
+
+## Hooks As Enforcement
+
+Pre-tool hooks participate in policy after schema validation and candidate
+extraction, before approval and execution.
+
+Hook decisions:
+
+- `deny`: blocks execution and wins over `ask` or `allow`.
+- `ask`: requires approval unless the session is `locked/dontAsk`, in which
+  case it becomes `deny`.
+- `allow`: means the hook has no objection. It does not authorize the call by
+  itself.
+
+Hooks may tighten policy but cannot bypass:
+
+- explicit deny rules;
+- profile grants;
+- path grants;
+- credential grants;
+- external MCP grants;
+- sandbox/process policy; or
+- server-wide disabled-tool settings.
+
+A blocking hook failure should be configurable as fail-closed by default for
+managed hooks and fail-open only for explicitly non-critical observer hooks.
+
+## Shell Alias And Virtual CLI Hardening
+
+The existing `run` module exposes `run`, `bash`, and `shell` as governed virtual
+CLI entry points. They are not raw host shells. This design keeps that stance
+and hardens the alias surface.
+
+Rules:
+
+- Parse command text into a command chain before authorization.
+- Split compound commands and evaluate every subcommand independently.
+- `safe-cmd && dangerous-cmd` must not pass because `safe-cmd` is allowed.
+- Pipelines require every governed command and pure transform in the pipeline to
+  be visible and allowed.
+- Command aliases inherit the strictest decision of their expanded commands.
+- Preflight should prepare every governed step before execution starts when a
+  chain contains any governed step.
+- Unknown commands return a bounded error rather than falling through to a host
+  shell.
+
+Legacy `Bash(...)` pattern rules:
+
+- `Bash(git *)` means command subject pattern `git *` for governed
+  `run`/`bash`/`shell` aliases.
+- The pattern applies to one parsed command invocation, not the whole raw
+  command string.
+- `Bash(git *)` may match `git status` but not
+  `git status && rm -rf build`, because the `rm` invocation is evaluated
+  independently.
+- `Bash(*)` should be rejected in hosted/default profiles and allowed only in
+  tightly sandboxed local development modes with an explicit admin override.
+
+Wrapper handling:
+
+- Conservative unwrapping may support wrappers such as `timeout`, `time`, and
+  `nice` only when their option grammar is explicitly modeled.
+- Wrappers that can hide arbitrary execution should not be unwrapped by default:
+  `docker exec`, `podman exec`, `npx`, `bunx`, `uvx`, `devbox run`,
+  `nix develop --command`, `ssh`, `sudo`, language REPL runners, and package
+  manager script runners.
+- If a wrapper is not modeled, treat the wrapper itself as the requested
+  command and deny it unless a dedicated structured tool exists.
+
+Dedicated tools should be preferred for:
+
+- file reads/writes/patches;
+- URL fetch/search;
+- git status/diff/log;
+- package installs and scripts;
+- test execution;
+- browser/CDP inspection;
+- CI/CD operations; and
+- deployment actions.
+
+Shell-style string matching is too fragile for these behaviors.
+
+## Sandbox Semantics
+
+Permissions and sandboxing solve different problems:
+
+- Permissions decide whether a model may request a tool/action.
+- Sandboxing constrains what spawned or delegated processes can actually touch.
+
+For process-like tools, final `allow` should require both:
+
+- policy allow for the requested tool/action; and
+- a sandbox/process assertion compatible with the requested risk class.
+
+Example assertions:
+
+```json
+{
+  "sandbox": {
+    "filesystem": "workspace-write",
+    "network": "restricted",
+    "process": "no-shell",
+    "cwd": "workspace-root",
+    "allowed_roots": ["."]
+  }
+}
+```
+
+If the runtime cannot prove the necessary sandbox state, `sandboxed-auto`
+degrades to `ask` or `deny`.
+
+## Effective-Permission Explanation
+
+Add an admin/debug surface that can answer:
+
+- Why is this tool visible or hidden?
+- Why is this tool call allowed, denied, or asking?
+- Why is this path/domain/external MCP tool allowed or denied?
+- Which profile, grant, hook, sandbox assertion, or deny rule decided it?
+
+Suggested CLI/API:
+
+```text
+mcp policy explain --profile backend-engineer --tool fs.patch --path src/app.py --action edit
+mcp policy explain --profile qa-engineer --tool bash --command "git status && rm -rf build"
+mcp policy explain --profile devops --mcp-tool mcp__github__create_issue
+```
+
+Response shape:
+
+```json
+{
+  "final_outcome": "deny",
+  "reason_code": "command_step_denied",
+  "profile_id": "qa-engineer",
+  "permission_mode": "default/ask",
+  "subject": {
+    "type": "command",
+    "normalized": "rm",
+    "step_index": 1
+  },
+  "matches": [
+    {
+      "source": "profile.denied_tools",
+      "rule_type": "tool",
+      "pattern": "rm",
+      "outcome": "deny"
+    }
+  ],
+  "hook_results": [],
+  "sandbox": {
+    "required": "no-host-shell",
+    "status": "satisfied"
+  }
+}
+```
+
+Redaction requirements:
+
+- no raw file content;
+- no raw diffs;
+- no read receipts;
+- no credential values;
+- no full environment values;
+- no absolute host paths in normal responses;
+- bounded command previews; and
+- explicit `redacted=true` markers where fields are omitted.
+
+## Observability And Evaluation
+
+Tool-use reporting should record safe policy metadata for every tool family:
+
+- final outcome;
+- reason code;
+- permission mode;
+- normalized subject type;
+- matched rule source/type;
+- whether a hook participated;
+- whether approval was required;
+- sandbox assertion status;
+- redaction status; and
+- elapsed time.
+
+This should apply to all tools, not just filesystem or git tools. The metadata
+should support evaluations of whether models select the right tool, understand
+approval boundaries, recover from denies, and avoid shell escape hatches when a
+dedicated tool exists.
+
+## Implementation Slices
+
+### Slice 1: Decision Core And Explain Contract
+
+- Add package-level decision dataclasses/Pydantic models.
+- Compile existing profile fields into decision rules.
+- Add `deny > ask > allow` merge tests.
+- Add explain response schema and a package-local simulation API.
+- Keep runtime behavior compatibility unless the new explain path is invoked.
+
+### Slice 2: Catalog Visibility And Permission Modes
+
+- Add `permission_mode` handling.
+- Update tool listing/search/category surfaces to hide denied tools and mark
+  ask-scoped tools.
+- Add regression coverage for `locked/dontAsk` converting ask to deny.
+
+### Slice 3: Path Pattern Compiler
+
+- Add authored gitignore-style path patterns that compile to flat grants.
+- Preserve current flat grants as executable runtime input.
+- Add Windows normalization and symlink double-evaluation tests.
+
+### Slice 4: External MCP Wildcard Grants
+
+- Normalize `mcp__server`, `mcp__server__*`, and `mcp__server__tool` matching.
+- Keep server install/start, credential use, and tool execution as separate
+  subjects.
+- Add deny-over-wildcard-allow tests.
+
+### Slice 5: Shell Alias Hardening
+
+- Extend parser/preflight tests for command chains and wrappers.
+- Add conservative wrapper modeling for `timeout`, `time`, and `nice` only if
+  their grammars are small enough to validate.
+- Deny or recommend dedicated tools for high-risk wrappers and package runners.
+
+### Slice 6: Hooks Enforcement Integration
+
+- Make hook outputs use the shared decision model.
+- Ensure hook `allow` cannot bypass explicit denies.
+- Include hook outcomes in explain and tool-use reporting.
+
+## Open Questions
+
+1. Should `ask` tools be included in the model's normal tool list with
+   `requiresApproval=true`, or should they only appear through tool search and
+   category disclosure?
+2. Should the first explain API live in the standalone package CLI only, or also
+   expose a FastAPI admin route in the same PR?
+3. Should permission modes be profile-only, session-only, or allow session
+   overrides that can only tighten the profile mode?
+4. How much shell wrapper support is worth shipping before dedicated git/test
+   and package-manager tools make most wrappers unnecessary?
+
+## Risks And Mitigations
+
+- **Policy model churn:** keep old fields supported and compile them into the
+  new model rather than replacing them in one step.
+- **Overexposing ask tools:** make catalog visibility configurable and default
+  conservative for hosted deployments.
+- **Shell parser false confidence:** keep the language small, reject unknown
+  syntax, and prefer dedicated tools over Bash-like matching.
+- **Path pattern ambiguity:** document anchors and segment matching precisely,
+  and add property-based path normalization tests.
+- **Hook bypass bugs:** enforce precedence in one shared merge function and test
+  every hook/profile/path combination against it.
+- **Sandbox drift:** record sandbox assertions separately so an allow decision
+  cannot be mistaken for an OS-level containment guarantee.
+
+## Definition Of Ready For Implementation
+
+- The owner chooses the first implementation slice.
+- The spec review confirms no cross-slice dependency is missing.
+- Backlog tasks are split so each PR can be reviewed independently.
+- Tests are defined before each slice starts.

--- a/Docs/superpowers/specs/2026-06-07-mcp-tool-call-hooks-design.md
+++ b/Docs/superpowers/specs/2026-06-07-mcp-tool-call-hooks-design.md
@@ -1,0 +1,536 @@
+# MCP Tool-Call Hooks Design
+
+## Status
+
+Draft specification for TASK-2278.
+
+This design adds a hook layer around MCP tool calls so operators can run
+policy, logging, validation, and automation before, during, and after tool
+execution. Claude Code's hook system is the reference model, but this MCP
+server should adapt it to profile policy, path scope, tool-use reporting, and
+standalone-library embedding.
+
+## Reference Notes
+
+Claude Code's tools reference treats tool names as policy and hook match
+targets. It also uses separate Read, Edit, and Write semantics: Write is a
+full-file operation, Edit is targeted replacement, and existing-file mutation
+requires read-before-edit/write. Its hooks guide and hooks reference define
+tool-call lifecycle events, matcher groups, handler types, decision output,
+timeouts, and the rule that hooks can tighten permissions but should not bypass
+denies.
+
+Useful behaviors to copy:
+
+- Tool names are stable policy/hook identifiers.
+- Tool-event matchers can target exact tools or patterns.
+- Pre-tool hooks can deny, ask, or add context before execution.
+- Post-tool hooks can observe success/failure but cannot undo side effects.
+- Hook input is structured JSON with session, cwd, tool name, and tool input.
+- Multiple matching hooks are merged with the most restrictive decision winning.
+- Hook output must be explicit and machine-readable for policy decisions.
+- Hook results and tool-use telemetry must avoid persisting secrets or raw file
+  contents.
+
+Intentional differences:
+
+- MCP should use deterministic ordering for input-rewriting hooks instead of
+  nondeterministic "last finisher wins" behavior.
+- Shell/command hooks are high risk in a server context and should be disabled
+  unless an operator explicitly enables them for a trusted local deployment.
+- Hook allow decisions never bypass RBAC, profile policy, deny rules,
+  path-scope enforcement, credential grants, or external-server grants.
+
+References:
+
+- Claude Code tools reference:
+  <https://code.claude.com/docs/en/tools-reference#edit-tool-behavior>
+- Claude Code hooks guide:
+  <https://code.claude.com/docs/en/hooks-guide>
+- Claude Code hooks reference:
+  <https://code.claude.com/docs/en/hooks>
+
+## Goals
+
+- Add operator-configurable hooks for tool-call lifecycle events.
+- Support before, during, after-success, after-failure, and batch-level
+  observability.
+- Let hooks deny, request approval, add model-visible context, or rewrite safe
+  arguments before execution.
+- Ensure hooks can tighten policy but cannot loosen configured denies or
+  profile/path/credential boundaries.
+- Keep hook inputs and outputs structured, redacted, bounded, and auditable.
+- Support standalone package embedders without requiring tldw_server-specific
+  imports.
+- Make hook results available to tool-use metrics/evaluations without storing
+  sensitive payloads.
+
+## Non-Goals
+
+- No UI implementation in this slice.
+- No prompt or agent hooks in the first implementation slice.
+- No command/shell hook execution by default in server deployments.
+- No hooks that can execute arbitrary MCP tools recursively without loop guards.
+- No post-tool rollback guarantee. Post hooks run after effects already
+  happened.
+- No replacement for profile policy, RBAC, approval, path scope, or credential
+  grants.
+
+## Existing Context
+
+`MCPProtocol.prepare_tool_call()` already centralizes tool lookup,
+sanitization, input-schema validation, write classification, RBAC/tool
+permission checks, path-scope evaluation, runtime approval, governance
+preflight, idempotency, and prepared-call integrity.
+
+`execute_prepared_tool_call()` owns execution and tool-use reporting. That gives
+the hook system two natural integration points:
+
+- pre-execution hooks inside `prepare_tool_call()` after sanitization and
+  candidate extraction, before runtime approval and execution
+- post-execution hooks inside `execute_prepared_tool_call()` after success or
+  failure classification, before/alongside tool-use reporting
+
+Filesystem hooks must respect the new safe file tools design:
+
+- `fs.read`, `fs.patch`, and `fs.write` are canonical.
+- `fs.patch` uses module-derived path candidates.
+- `fs.patch` and `fs.write replace` require read receipts or expected hashes in
+  strict/default mode.
+- legacy `fs.read_text` and `fs.write_text` remain compatibility surfaces.
+
+## Hook Lifecycle
+
+First-slice events:
+
+- `PreToolUse`: fires after tool lookup, argument hardening/sanitization,
+  schema validation, write classification, external-source discovery, and
+  path-candidate extraction. It fires before approval and before execution.
+  Blocking decisions apply here.
+- `ToolUseStarted`: fires after approval and prepared-call integrity are
+  established, immediately before calling the module. Observation only.
+- `ToolUseProgress`: optional during execution for modules that emit structured
+  progress. Observation only in the first slice.
+- `PostToolUse`: fires after a tool call succeeds. It can add context or
+  telemetry but cannot undo the tool's effects.
+- `PostToolUseFailure`: fires after a tool call fails or is denied. It can add
+  model-visible feedback or telemetry.
+- `PostToolBatch`: future event after parallel/batched tool calls resolve. The
+  first slice should reserve the event schema but does not need full batching
+  support.
+
+Lifecycle ordering:
+
+1. Resolve tool and sanitize arguments.
+2. Validate schema.
+3. Classify read/write risk.
+4. Extract path candidates when needed.
+5. Run `PreToolUse` hooks.
+6. Re-run validation, write classification, path extraction, and path/policy
+   evaluation if any hook rewrites input.
+7. Run RBAC/profile/path/credential/approval checks. A hook allow cannot bypass
+   these checks.
+8. Run governance preflight and build prepared-call integrity tag.
+9. Emit `ToolUseStarted`.
+10. Execute the module.
+11. Emit `PostToolUse` or `PostToolUseFailure`.
+12. Record tool-use event with hook outcome metadata.
+
+Security ordering rule:
+
+- A `deny` from `PreToolUse` is final unless a higher-trust managed policy hook
+  explicitly returns a documented override. User/project hooks should not
+  override deny.
+- A hook `allow` means "no objection from this hook"; it does not authorize the
+  call by itself.
+- Hook rewrites must never skip schema, path-scope, approval, or prepared-call
+  integrity checks.
+
+## Hook Configuration
+
+Canonical shape:
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "fs.patch|fs.write",
+        "handlers": [
+          {
+            "id": "block-generated-lockfiles",
+            "type": "http",
+            "url": "http://127.0.0.1:9801/hooks/files",
+            "timeout_seconds": 10,
+            "mode": "blocking"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+Configuration sources, in decreasing trust:
+
+- managed/admin policy hooks
+- package/plugin-provided hooks
+- workspace/project hooks
+- user-local hooks
+- profile-scoped hook grants
+
+First-slice storage should be package-neutral:
+
+- `HookConfigStore` interface in `mcp_unified.interfaces`
+- tldw_server adapter may store configs in the existing MCP Hub policy/admin
+  storage
+- standalone package can accept in-memory or file-backed config
+
+Managed hooks can be marked `immutable: true` and `required: true`. A server
+setting should support "managed hooks only" for locked-down deployments.
+
+## Matchers
+
+Matcher fields:
+
+- `matcher`: tool-name matcher. Empty or `*` means all tools.
+- `if`: optional rule expression that can match tool name plus selected,
+  redacted argument fields.
+- `risk_classes`: optional list that matches write/destructive/network risk.
+- `capabilities`: optional list that matches tool metadata capabilities.
+
+Tool-name matcher syntax:
+
+- plain tool name: exact match, for example `fs.read`
+- pipe-separated names: exact any match, for example `fs.patch|fs.write`
+- regex when prefixed with `re:`, for example `re:^mcp__.*__write`
+- external MCP tool names should be matched after gateway normalization, for
+  example `mcp__filesystem__read_file`
+
+Avoid implicit regex based only on punctuation. A required `re:` prefix keeps
+configuration predictable and avoids surprising matches.
+
+## Handler Types
+
+First-slice handler types:
+
+- `http`: POST hook input JSON to an allowlisted HTTP endpoint. Recommended for
+  server deployments.
+- `mcp_tool`: call a hook tool exposed by an already-connected, explicitly
+  granted MCP server. Must include recursion guards.
+- `command`: run a local executable with hook input on stdin. Disabled by
+  default and allowed only for trusted local deployments.
+
+Deferred handler types:
+
+- `prompt`: single-turn model decision hook.
+- `agent`: multi-turn verifier with tool access.
+
+Command hook constraints:
+
+- disabled unless `hooks.command.enabled=true`
+- command path must be absolute or workspace-relative under an allowed hook
+  directory
+- no shell-form commands in first slice; use exec-form argv only
+- explicit environment allowlist
+- fixed cwd from hook config or request workspace
+- stdout/stderr size caps
+- timeout required with server maximum
+
+HTTP hook constraints:
+
+- URL scheme allowlist, default `http://127.0.0.1` and `https`
+- optional host allowlist
+- explicit environment interpolation allowlist for headers
+- response body size cap
+- timeout required with server maximum
+
+MCP tool hook constraints:
+
+- hook target server/tool must be granted by profile or admin policy
+- hook tool cannot call back into the same hook event without a recursion token
+- hook tool result is sanitized through the same output contract as other
+  handlers
+
+## Hook Input
+
+Common input fields:
+
+```json
+{
+  "hook_event_name": "PreToolUse",
+  "hook_invocation_id": "uuid",
+  "session_id": "session-1",
+  "request_id": "request-1",
+  "profile_id": "frontend-engineer",
+  "workspace_id": "workspace-1",
+  "cwd": "/workspace/project",
+  "tool_name": "fs.patch",
+  "tool_input": {},
+  "tool_metadata": {},
+  "risk": {
+    "is_write": true,
+    "risk_classes": ["filesystem_edit"],
+    "capabilities": ["filesystem.edit"]
+  },
+  "path_scope": {
+    "candidate_count": 1,
+    "display_paths": ["src/app.py"],
+    "actions": ["edit"]
+  }
+}
+```
+
+Redaction rules:
+
+- `tool_input` is included only after the tool-specific argument sanitizer runs.
+- Content-bearing fields are replaced with summaries by default:
+  - `diff`: byte count, file count, hunk count, display paths
+  - `content`: byte count and hash-present boolean
+  - `fs.read.content`: never included
+  - secrets and credential slot values: never included
+- Hook configs can request full arguments only for specific low-risk tools, and
+  never for known secret/content fields.
+- Absolute paths are replaced with workspace-relative display paths where
+  possible.
+
+Event-specific fields:
+
+- `PreToolUse`: sanitized input, derived path candidates, approval context,
+  current policy mode
+- `ToolUseStarted`: prepared-call id, sanitized summaries, no ability to block
+- `ToolUseProgress`: module-emitted progress summary
+- `PostToolUse`: sanitized result allowlist, duration, status
+- `PostToolUseFailure`: sanitized error class, reason code, governance/path
+  summary, duration
+- `PostToolBatch`: aggregate statuses and per-tool safe summaries
+
+## Hook Output
+
+Preferred JSON output:
+
+```json
+{
+  "decision": "deny",
+  "reason": "Writes to lockfiles require manual approval",
+  "additional_context": "Use fs.patch on package.json only.",
+  "updated_input": null,
+  "metadata": {
+    "policy_id": "lockfile-guard"
+  }
+}
+```
+
+Decision values:
+
+- `no_decision`: default when output is empty or decision absent
+- `allow`: no objection; does not bypass ordinary policy
+- `ask`: force runtime approval with reason
+- `deny`: block execution
+- `rewrite`: replace input with `updated_input`, then re-run validation and all
+  policy checks
+
+Merging rules:
+
+- all matching blocking hooks run to completion within timeout
+- most restrictive decision wins: `deny` > `ask` > `rewrite` > `allow` >
+  `no_decision`
+- only one `rewrite` can apply; if multiple hooks return rewrite, deny with
+  `multiple_hook_rewrites`
+- managed hooks run before lower-trust hooks; observer hooks may run in
+  parallel
+- `additional_context` is concatenated after size limits and sent to the model
+  as hook feedback only when safe
+
+Exit-code compatibility for command hooks:
+
+- exit `0` with no JSON means `no_decision`
+- exit `2` with stderr means `deny` with stderr as reason
+- any other nonzero exit is a hook error and does not block unless the hook is
+  configured `fail_closed: true`
+
+## Failure And Timeout Behavior
+
+Per-handler settings:
+
+- `timeout_seconds`
+- `fail_closed`
+- `mode`: `blocking` or `async`
+- `max_stdout_bytes`
+- `max_stderr_bytes`
+- `max_response_bytes`
+
+Defaults:
+
+- blocking HTTP/MCP/command hooks: 10 seconds
+- prompt hooks when added later: 30 seconds
+- agent hooks when added later: 60 seconds
+- async hooks cannot block, rewrite, or ask
+
+When a blocking hook times out:
+
+- if `fail_closed=true`, deny with `hook_timeout`
+- otherwise continue with a warning metadata entry
+
+Post hooks cannot undo tool effects. If a post hook denies or fails closed, the
+result should be surfaced as hook feedback and tool-use telemetry, not as a
+rollback.
+
+## During-Execution Hooks
+
+The first slice should define but keep during-execution behavior conservative.
+
+`ToolUseStarted` and `ToolUseProgress` are observation events:
+
+- they cannot block, ask, or rewrite
+- they can emit telemetry, notifications, or async follow-up work
+- they receive only summarized inputs/progress
+- modules opt into progress events through a `HookProgressEmitter` interface
+
+Cancellation can be a later slice. A future `ToolUseProgress` hook may request
+cooperative cancellation for long-running tools, but only for tools that expose
+safe cancellation points.
+
+## Integration Points
+
+New package interfaces:
+
+- `HookConfigStore`: resolves effective hook config for context/profile.
+- `HookEvaluator`: runs hook lifecycle events and returns merged decisions.
+- `HookHandlerRunner`: runs HTTP, MCP tool, or command handlers.
+- `HookInputSanitizer`: builds safe event payloads.
+- `HookDecisionMerger`: deterministic merge and precedence rules.
+
+Protocol integration:
+
+- Inject hooks through `MCPRuntimeDependencies`.
+- Call `HookEvaluator.evaluate("PreToolUse", ...)` from
+  `MCPProtocol.prepare_tool_call()` after schema validation and path candidate
+  extraction.
+- If `updated_input` is returned, restart validation/path/policy evaluation
+  once. Reject repeated rewrites with `hook_rewrite_loop`.
+- Call `ToolUseStarted` and post events from `execute_prepared_tool_call()`.
+- Include hook decision summaries in `ToolUseEvent` metadata.
+
+Gateway/admin integration:
+
+- Add admin CRUD APIs for hook configs after the core package interface is
+  stable.
+- Import/export snapshots should include hook configs with secrets redacted.
+- Hook configs that reference credentials should use credential grants, not raw
+  secret values.
+
+Profile integration:
+
+- Profiles may allow, deny, or require hook groups.
+- A profile cannot disable managed required hooks.
+- Profiles may grant `mcp_tool` hook targets separately from model-visible
+  tools to avoid accidental recursive capability expansion.
+
+## Security Model
+
+Hooks are privileged automation. They can observe tool intent and sometimes
+alter or block execution, so they need a stricter model than ordinary tools.
+
+Rules:
+
+- Hooks can tighten permissions but cannot loosen policy.
+- Hook config mutation is admin-only.
+- Command hooks are local-trusted and disabled by default.
+- HTTP hooks require URL allowlists and no implicit secret interpolation.
+- MCP tool hooks require explicit hook-target grants and recursion guards.
+- All hook inputs and outputs are size capped.
+- Hook output shown to the model is sanitized and length capped.
+- Hook errors are logged with class/reason, not raw sensitive payloads.
+- Managed hooks may be required for compliance and cannot be bypassed by user
+  profile selection.
+
+## Observability And Evaluation
+
+Hook telemetry should be metadata-only:
+
+- event name
+- matcher id
+- handler id/type
+- decision
+- reason code
+- duration bucket
+- timeout flag
+- fail-open/fail-closed flag
+- rewrite occurred boolean
+- denied/asked boolean
+- additional-context byte count
+
+Do not persist:
+
+- raw hook input
+- raw hook output
+- file contents
+- raw diffs
+- secrets
+- absolute paths when a workspace-relative path is available
+
+Tool-use evaluation should be able to compare:
+
+- model success with and without hooks
+- hook false positives and false negatives
+- frequency of denials, asks, rewrites, and timeouts
+- per-profile hook impact
+- per-tool hook impact
+
+## Testing Strategy
+
+Unit tests:
+
+- matcher exact, pipe, wildcard, and `re:` behavior
+- handler config validation by type
+- hook input redaction for `fs.read`, `fs.patch`, `fs.write`, command tools,
+  and credential-backed external tools
+- decision merge precedence
+- multiple rewrite denial
+- timeout fail-open and fail-closed behavior
+- command hook disabled by default
+- HTTP header env allowlist behavior
+- MCP tool hook recursion guard
+
+Protocol tests:
+
+- `PreToolUse deny` blocks before execution
+- `PreToolUse allow` does not bypass profile/path denial
+- `PreToolUse ask` forces approval
+- `PreToolUse rewrite` re-runs schema/path/policy checks
+- hook additional context is surfaced safely
+- `ToolUseStarted`, `PostToolUse`, and `PostToolUseFailure` fire in order
+- hook metadata appears in tool-use reporting without raw payloads
+
+Integration tests:
+
+- filesystem hook blocks `fs.write` outside operator policy
+- hook rewrite cannot move an `fs.patch` diff outside path grants
+- post hook failure does not roll back a successful write
+- managed required hook cannot be disabled by profile
+- snapshot import/export redacts hook secrets
+
+## Rollout
+
+Recommended implementation slices:
+
+1. Package interfaces and typed hook config models.
+2. Hook input sanitizer and decision merger.
+3. `PreToolUse` blocking hooks with HTTP handler support.
+4. Protocol integration and tool-use metadata.
+5. `PostToolUse` and `PostToolUseFailure` observer hooks.
+6. MCP tool hook handler with recursion guards.
+7. Command hook handler behind explicit local-trusted config.
+8. Admin routes, CLI, import/export, and docs.
+9. Optional prompt/agent hooks and cooperative cancellation.
+
+## Open Questions
+
+- Should project/workspace hook configs be committed files, database records, or
+  both?
+- Should managed hooks be loaded only by admin config, or can package plugins
+  provide required hooks?
+- Should prompt/agent hooks use local model providers, configured remote models,
+  or only externally supplied hook MCP tools?
+- What is the first UI surface: admin settings, profile editor, or CLI only?

--- a/backlog/tasks/task-2277 - Design-MCP-fs.patch-and-safe-edit-tools.md
+++ b/backlog/tasks/task-2277 - Design-MCP-fs.patch-and-safe-edit-tools.md
@@ -1,0 +1,52 @@
+---
+id: TASK-2277
+title: Design MCP fs.patch and safe edit tools
+status: In Progress
+labels:
+- mcp
+- filesystem
+- security
+- design
+references:
+- Docs/superpowers/specs/2026-06-06-mcp-tool-use-eval-reporting-design.md
+- Docs/superpowers/specs/2026-06-04-mcp-filesystem-helper-tools-design.md
+- Docs/superpowers/specs/2026-03-28-mcp-virtual-cli-run-command-design.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Create the design/spec for the next MCP slice after tool-use reporting: native fs.patch and safer workspace-bounded write-edit tools. The design must preserve profile/policy enforcement, path-scope controls, conflict detection, cross-platform behavior, audit/eval metadata, and avoid raw shell or unsafe arbitrary filesystem mutation.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Spec defines fs.patch as the preferred unified-diff edit primitive with parser scope, conflict detection, limits, atomicity caveats, and no shell/subprocess delegation.
+- [x] #2 Spec defines fs.write as the paired whole-file create/replace primitive with explicit modes, required replacement hashes, UTF-8 bounds, and write-action path grants.
+- [x] #3 Spec defines action-aware path_grants for read/edit/write and includes Profile A/B/C permission examples.
+- [x] #4 Spec covers protocol/module derived path-candidate preflight for diff-embedded paths and fail-closed behavior when candidates cannot be enforced.
+- [x] #5 Spec covers observability/evaluation redaction so raw diffs and file contents are not persisted.
+- [x] #6 Spec includes rollout and testing strategy for parser, filesystem module, path-scope, protocol, and profile coverage.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Design review pass incorporated fs.write as the paired primitive, explicit action semantics, segment-aware path grant matching, cross-platform diff path rejection, fail-closed derived path enforcement for fs.patch, preset migration guidance, and filesystem-wide eval redaction.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Created the MCP fs.patch/fs.write safe edit design spec at Docs/superpowers/specs/2026-06-07-mcp-fs-patch-write-safe-edit-tools-design.md. The design covers unified-diff parsing, fs.write create/replace semantics, action-aware path grants, derived path preflight, cross-platform path constraints, observability redaction, rollout slices, and focused tests. Validation: git diff --cached --check passed; placeholder scan found no outstanding marker text. Bandit was skipped because this task changed only documentation and Backlog task metadata.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-2277 - Design-MCP-fs.patch-and-safe-edit-tools.md
+++ b/backlog/tasks/task-2277 - Design-MCP-fs.patch-and-safe-edit-tools.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-2277
 title: Design MCP fs.read, fs.patch, and safe write tools
-status: In Progress
+status: Done
 labels:
 - mcp
 - filesystem
@@ -28,18 +28,19 @@ Create the design/spec for the next MCP slice after tool-use reporting: native f
 - [x] #5 Spec covers observability/evaluation redaction so raw diffs and file contents are not persisted.
 - [x] #6 Spec includes rollout and testing strategy for parser, filesystem module, path-scope, protocol, and profile coverage.
 - [x] #7 Spec defines fs.read as the paired canonical bounded text-read primitive with hash/truncation metadata and read-action path grants.
+- [x] #8 Spec incorporates final design review findings and Claude Code read/edit/write reference behavior.
 <!-- AC:END -->
 
 ## Implementation Notes
 
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
-Design review pass incorporated fs.read as the canonical read-side primitive, fs.write as the paired whole-file write primitive, explicit action semantics, segment-aware path grant matching, cross-platform diff path rejection, fail-closed derived path enforcement for fs.patch, preset migration guidance, and filesystem-wide eval redaction.
+Design review pass incorporated fs.read as the canonical read-side primitive, fs.write as the paired whole-file write primitive, explicit action semantics, segment-aware path grant matching, cross-platform diff path rejection, fail-closed derived path enforcement for fs.patch, preset migration guidance, filesystem-wide eval redaction, read receipts, concrete PathScopeCandidate requirements, canonical path_grants storage, legacy fs.write_text approval guidance, directory cleanup rules, and Claude Code read-before-edit/write reference behavior.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Created and revised the MCP fs.read/fs.patch/fs.write safe file tools design spec at Docs/superpowers/specs/2026-06-07-mcp-fs-patch-write-safe-edit-tools-design.md. The design covers bounded text reads with hashes, unified-diff parsing, fs.write create/replace semantics, action-aware path grants, derived path preflight, cross-platform path constraints, observability redaction, rollout slices, and focused tests. Validation: git diff --cached --check passed; placeholder scan found no outstanding marker text. Bandit was skipped because this task changed only documentation and Backlog task metadata.
+Created and revised the MCP fs.read/fs.patch/fs.write safe file tools design spec at Docs/superpowers/specs/2026-06-07-mcp-fs-patch-write-safe-edit-tools-design.md. The design covers bounded text reads with hashes/read receipts, unified-diff parsing, read-before-mutate semantics, fs.write create/replace semantics, action-aware path grants, concrete derived path preflight, cross-platform path constraints, result redaction allowlists, rollout slices, focused tests, and Claude Code reference behavior. Validation: git diff --cached --check passed; placeholder scan found no outstanding marker text. Bandit was skipped because this task changed only documentation and Backlog task metadata.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-2277 - Design-MCP-fs.patch-and-safe-edit-tools.md
+++ b/backlog/tasks/task-2277 - Design-MCP-fs.patch-and-safe-edit-tools.md
@@ -1,6 +1,6 @@
 ---
 id: TASK-2277
-title: Design MCP fs.patch and safe edit tools
+title: Design MCP fs.read, fs.patch, and safe write tools
 status: In Progress
 labels:
 - mcp
@@ -16,7 +16,7 @@ references:
 ## Description
 
 <!-- SECTION:DESCRIPTION:BEGIN -->
-Create the design/spec for the next MCP slice after tool-use reporting: native fs.patch and safer workspace-bounded write-edit tools. The design must preserve profile/policy enforcement, path-scope controls, conflict detection, cross-platform behavior, audit/eval metadata, and avoid raw shell or unsafe arbitrary filesystem mutation.
+Create the design/spec for the next MCP slice after tool-use reporting: native fs.read, fs.patch, and safer workspace-bounded write-edit tools. The design must preserve profile/policy enforcement, path-scope controls, conflict detection, cross-platform behavior, audit/eval metadata, and avoid raw shell or unsafe arbitrary filesystem mutation.
 <!-- SECTION:DESCRIPTION:END -->
 
 ## Acceptance Criteria
@@ -27,18 +27,19 @@ Create the design/spec for the next MCP slice after tool-use reporting: native f
 - [x] #4 Spec covers protocol/module derived path-candidate preflight for diff-embedded paths and fail-closed behavior when candidates cannot be enforced.
 - [x] #5 Spec covers observability/evaluation redaction so raw diffs and file contents are not persisted.
 - [x] #6 Spec includes rollout and testing strategy for parser, filesystem module, path-scope, protocol, and profile coverage.
+- [x] #7 Spec defines fs.read as the paired canonical bounded text-read primitive with hash/truncation metadata and read-action path grants.
 <!-- AC:END -->
 
 ## Implementation Notes
 
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
-Design review pass incorporated fs.write as the paired primitive, explicit action semantics, segment-aware path grant matching, cross-platform diff path rejection, fail-closed derived path enforcement for fs.patch, preset migration guidance, and filesystem-wide eval redaction.
+Design review pass incorporated fs.read as the canonical read-side primitive, fs.write as the paired whole-file write primitive, explicit action semantics, segment-aware path grant matching, cross-platform diff path rejection, fail-closed derived path enforcement for fs.patch, preset migration guidance, and filesystem-wide eval redaction.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Created the MCP fs.patch/fs.write safe edit design spec at Docs/superpowers/specs/2026-06-07-mcp-fs-patch-write-safe-edit-tools-design.md. The design covers unified-diff parsing, fs.write create/replace semantics, action-aware path grants, derived path preflight, cross-platform path constraints, observability redaction, rollout slices, and focused tests. Validation: git diff --cached --check passed; placeholder scan found no outstanding marker text. Bandit was skipped because this task changed only documentation and Backlog task metadata.
+Created and revised the MCP fs.read/fs.patch/fs.write safe file tools design spec at Docs/superpowers/specs/2026-06-07-mcp-fs-patch-write-safe-edit-tools-design.md. The design covers bounded text reads with hashes, unified-diff parsing, fs.write create/replace semantics, action-aware path grants, derived path preflight, cross-platform path constraints, observability redaction, rollout slices, and focused tests. Validation: git diff --cached --check passed; placeholder scan found no outstanding marker text. Bandit was skipped because this task changed only documentation and Backlog task metadata.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-2278 - Design-MCP-tool-call-hooks-integration.md
+++ b/backlog/tasks/task-2278 - Design-MCP-tool-call-hooks-integration.md
@@ -1,0 +1,52 @@
+---
+id: TASK-2278
+title: Design MCP tool-call hooks integration
+status: Done
+labels:
+- mcp
+- hooks
+- policy
+- design
+references:
+- https://code.claude.com/docs/en/tools-reference#edit-tool-behavior
+- https://code.claude.com/docs/en/hooks-guide
+- https://code.claude.com/docs/en/hooks
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Create a design/spec for MCP server tool-call hooks inspired by Claude Code hooks. The design must cover before/during/after tool-call lifecycle events, hook handler types, matcher semantics, permission/policy ordering, input/output schemas, redaction, timeouts, failure behavior, and integration with tool-use reporting and profile policy.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Spec defines MCP tool-call hook lifecycle events for before, during, after-success, after-failure, and batch-level observation.
+- [x] #2 Spec defines hook configuration sources, matcher semantics, handler types, and security constraints.
+- [x] #3 Spec defines structured hook input/output schemas, decision merge rules, timeout/failure behavior, and redaction rules.
+- [x] #4 Spec covers protocol integration points for prepare_tool_call and execute_prepared_tool_call.
+- [x] #5 Spec explains how hooks interact with RBAC, profiles, path scope, approvals, credential grants, and tool-use reporting.
+- [x] #6 Spec references Claude Code tools/hooks behavior and records intentional differences for MCP server safety.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Created Docs/superpowers/specs/2026-06-07-mcp-tool-call-hooks-design.md. The design uses Claude Code hooks as the reference model while adapting behavior for MCP server policy boundaries: hooks can tighten but not loosen policy, PreToolUse can deny/ask/rewrite, during hooks are observer-only in the first slice, post hooks cannot roll back side effects, command hooks are disabled by default, and all hook inputs/outputs are redacted and bounded.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Created the MCP tool-call hooks design spec at Docs/superpowers/specs/2026-06-07-mcp-tool-call-hooks-design.md. Validation: git diff --cached --check passed; placeholder scan found no outstanding marker text. Bandit was skipped because this task changed only documentation and Backlog task metadata.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-2279 - Add-Claude-style-exact-fs.edit-primitive.md
+++ b/backlog/tasks/task-2279 - Add-Claude-style-exact-fs.edit-primitive.md
@@ -1,0 +1,45 @@
+---
+id: TASK-2279
+title: Add Claude-style exact fs.edit primitive
+status: To Do
+labels:
+- mcp
+- filesystem
+- tools
+- agentic-execution
+references:
+- https://code.claude.com/docs/en/tools-reference#edit-tool-behavior
+- Docs/superpowers/specs/2026-06-07-mcp-fs-patch-write-safe-edit-tools-design.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Design and implement a Claude-style fs.edit primitive for exact string replacement as a complement to fs.patch. The tool should enforce read-before-edit via read receipts or hashes, require exact old_string matching, reject fuzzy/regex behavior, require uniqueness unless replace_all is explicit, follow action-aware path grants, and integrate with tool-use redaction and hooks.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-2280 - Bring-fs.glob-and-fs.grep-to-Claude-Code-parity.md
+++ b/backlog/tasks/task-2280 - Bring-fs.glob-and-fs.grep-to-Claude-Code-parity.md
@@ -1,0 +1,45 @@
+---
+id: TASK-2280
+title: Bring fs.glob and fs.grep to Claude Code parity
+status: To Do
+labels:
+- mcp
+- filesystem
+- search
+- tools
+- agentic-execution
+references:
+- https://code.claude.com/docs/en/tools-reference
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Enhance filesystem search tools to match useful Claude Code Glob/Grep behavior. Cover mtime-sorted capped glob results with truncation, configurable gitignore handling, grep output modes (files_with_matches, content, count), language/type filters, multiline support where safe, direct-file searches for ignored files, path grants, redacted telemetry, and focused tests.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-2281 - Add-LSP-backed-code-intelligence-MCP-tools.md
+++ b/backlog/tasks/task-2281 - Add-LSP-backed-code-intelligence-MCP-tools.md
@@ -1,0 +1,45 @@
+---
+id: TASK-2281
+title: Add LSP-backed code intelligence MCP tools
+status: To Do
+labels:
+- mcp
+- code-intelligence
+- lsp
+- tools
+- agentic-execution
+references:
+- https://code.claude.com/docs/en/tools-reference
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Design and implement LSP-backed MCP tools inspired by Claude Code's LSP tool: definitions, references, hover/type info, document symbols, workspace symbol search, implementations, call hierarchy, and post-edit diagnostics. The design should support optional language-server plugins, workspace/path grants, bounded output, diagnostics after fs.edit/fs.patch/fs.write, and fallback behavior when no server is configured.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-2282 - Add-NotebookEdit-style-notebook-file-tools.md
+++ b/backlog/tasks/task-2282 - Add-NotebookEdit-style-notebook-file-tools.md
@@ -1,0 +1,45 @@
+---
+id: TASK-2282
+title: Add NotebookEdit-style notebook file tools
+status: To Do
+labels:
+- mcp
+- filesystem
+- notebooks
+- tools
+- agentic-execution
+references:
+- https://code.claude.com/docs/en/tools-reference
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Design and implement notebook-safe MCP tools modeled after Claude Code NotebookEdit. Support reading notebook structure and editing cells by cell id with replace, insert, and delete modes; require notebook path grants; preserve JSON validity; avoid raw whole-notebook overwrites for cell edits; include validation, diff summaries, redacted telemetry, and tests for Jupyter notebooks.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-2283 - Add-Claude-style-governed-Bash-and-PowerShell-runtime-tools.md
+++ b/backlog/tasks/task-2283 - Add-Claude-style-governed-Bash-and-PowerShell-runtime-tools.md
@@ -1,0 +1,46 @@
+---
+id: TASK-2283
+title: Add Claude-style governed Bash and PowerShell runtime tools
+status: To Do
+labels:
+- mcp
+- command-runtime
+- security
+- tools
+- agentic-execution
+references:
+- https://code.claude.com/docs/en/tools-reference
+- Docs/superpowers/specs/2026-03-28-mcp-virtual-cli-run-command-design.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Design and implement Claude-style governed shell runtime parity for Bash and PowerShell where appropriate. Cover command pattern permissions, per-command timeouts, output caps with full-output artifacts, cwd carry-over constrained to workspace/additional dirs, env-file support, shell selection, PowerShell platform behavior, hook integration, telemetry redaction, and safe denial of unsupported shell features.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-2284 - Add-Monitor-style-background-observation-tools.md
+++ b/backlog/tasks/task-2284 - Add-Monitor-style-background-observation-tools.md
@@ -1,0 +1,45 @@
+---
+id: TASK-2284
+title: Add Monitor-style background observation tools
+status: To Do
+labels:
+- mcp
+- monitoring
+- command-runtime
+- tools
+- agentic-execution
+references:
+- https://code.claude.com/docs/en/tools-reference
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Design and implement Monitor-style MCP tools for long-running background observation. Support starting a bounded monitor for logs, command output, CI/PR polling, or watched files; stream or queue output lines back into the agentic session; list/stop monitors; enforce command/path/network permissions; integrate hooks, telemetry, output caps, and cleanup on session end.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-2285 - Add-agentic-task-and-checklist-management-tools.md
+++ b/backlog/tasks/task-2285 - Add-agentic-task-and-checklist-management-tools.md
@@ -1,0 +1,44 @@
+---
+id: TASK-2285
+title: Add agentic task and checklist management tools
+status: To Do
+labels:
+- mcp
+- tasks
+- agentic-execution
+- tools
+references:
+- https://code.claude.com/docs/en/tools-reference
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Design and implement MCP tools analogous to Claude Code TaskCreate, TaskGet, TaskList, TaskUpdate, TaskStop/TaskOutput compatibility, and TodoWrite migration. The tools should manage session/workspace-scoped agent checklists and background task records, expose stable status/detail schemas, integrate with existing Jobs/Scheduler where appropriate, and avoid confusing these with Backlog.md project tasks unless explicitly bridged.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-2286 - Add-agentic-scheduling-and-wakeup-tools.md
+++ b/backlog/tasks/task-2286 - Add-agentic-scheduling-and-wakeup-tools.md
@@ -1,0 +1,44 @@
+---
+id: TASK-2286
+title: Add agentic scheduling and wakeup tools
+status: To Do
+labels:
+- mcp
+- scheduler
+- agentic-execution
+- tools
+references:
+- https://code.claude.com/docs/en/tools-reference
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Design and implement session/workspace-scoped scheduling tools analogous to Claude Code CronCreate, CronDelete, CronList, ScheduleWakeup, and remote trigger concepts where useful. Integrate with tldw_server Jobs/Scheduler, support one-shot and recurring prompts, resume/continue semantics, permissions, quotas, hook events, cancellation, and status inspection.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-2287 - Add-agentic-notification-tools.md
+++ b/backlog/tasks/task-2287 - Add-agentic-notification-tools.md
@@ -1,0 +1,44 @@
+---
+id: TASK-2287
+title: Add agentic notification tools
+status: To Do
+labels:
+- mcp
+- notifications
+- agentic-execution
+- tools
+references:
+- https://code.claude.com/docs/en/tools-reference
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Design and implement notification tools inspired by Claude Code PushNotification and Notification hook events. Support local/self-hosted notification sinks, optional remote/webhook notification channels, long-running task completion alerts, permission controls, privacy-preserving payloads, and integration with scheduler/monitor/task tools.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-2288 - Add-subagent-and-agent-team-orchestration-tools.md
+++ b/backlog/tasks/task-2288 - Add-subagent-and-agent-team-orchestration-tools.md
@@ -1,0 +1,44 @@
+---
+id: TASK-2288
+title: Add subagent and agent-team orchestration tools
+status: To Do
+labels:
+- mcp
+- agents
+- agentic-execution
+- tools
+references:
+- https://code.claude.com/docs/en/tools-reference
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Design and implement Agent/SendMessage/Team-style orchestration tools for tldw_server agentic execution. Cover spawning subagents with scoped tool/profile access, foreground/background permission behavior, message passing/resume, team creation/deletion where useful, max-turn limits, isolation options, telemetry, and prevention of capability expansion beyond parent policy.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-2289 - Add-plan-mode-and-worktree-session-tools.md
+++ b/backlog/tasks/task-2289 - Add-plan-mode-and-worktree-session-tools.md
@@ -1,0 +1,45 @@
+---
+id: TASK-2289
+title: Add plan-mode and worktree session tools
+status: To Do
+labels:
+- mcp
+- worktrees
+- planning
+- agentic-execution
+- tools
+references:
+- https://code.claude.com/docs/en/tools-reference
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Design and implement plan/worktree tools inspired by EnterPlanMode, ExitPlanMode, EnterWorktree, and ExitWorktree. Cover explicit planning gates, approval to leave plan mode, isolated git worktree creation/switching/removal, workspace/path constraints, subagent restrictions, cleanup behavior, hooks, and tool-use telemetry.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-2290 - Add-MCP-resource-discovery-and-read-tools-parity.md
+++ b/backlog/tasks/task-2290 - Add-MCP-resource-discovery-and-read-tools-parity.md
@@ -1,0 +1,45 @@
+---
+id: TASK-2290
+title: Add MCP resource discovery and read tools parity
+status: To Do
+labels:
+- mcp
+- resources
+- gateway
+- tools
+- agentic-execution
+references:
+- https://code.claude.com/docs/en/tools-reference
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Design and implement Claude-style ListMcpResourcesTool, ReadMcpResourceTool, and WaitForMcpServers parity for the standalone gateway and tldw_server MCP hub. Cover resource listing/reading across internal and external MCP servers, server readiness waiting, profile grants, pagination, redacted resource metadata, errors for unavailable servers, and hooks/tool-use reporting.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-2291 - Add-WebFetch-MCP-tool-with-domain-policy-controls.md
+++ b/backlog/tasks/task-2291 - Add-WebFetch-MCP-tool-with-domain-policy-controls.md
@@ -1,0 +1,45 @@
+---
+id: TASK-2291
+title: Add WebFetch MCP tool with domain policy controls
+status: To Do
+labels:
+- mcp
+- web
+- research
+- tools
+- agentic-execution
+references:
+- https://code.claude.com/docs/en/tools-reference
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Design and implement a WebFetch-style MCP tool for fetching and extracting URL content for agentic workflows. Cover domain allow/deny/ask rules, robots/outbound safety alignment with existing research/web scraping policy, Markdown-preferred extraction, cache/redirect behavior, size/time limits, prompt-free and prompt-assisted summarization modes, hooks, and metadata-only telemetry.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-2292 - Add-WebSearch-MCP-tool-over-tldw-research-providers.md
+++ b/backlog/tasks/task-2292 - Add-WebSearch-MCP-tool-over-tldw-research-providers.md
@@ -1,0 +1,46 @@
+---
+id: TASK-2292
+title: Add WebSearch MCP tool over tldw research providers
+status: To Do
+labels:
+- mcp
+- web
+- research
+- search
+- tools
+- agentic-execution
+references:
+- https://code.claude.com/docs/en/tools-reference
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Design and implement a WebSearch-style MCP tool backed by tldw_server research/websearch providers. Support query refinement within bounded calls, allowed_domains or blocked_domains but not both, result title/url/snippet metadata, no page fetching in search responses, follow-up WebFetch workflow, profile/network grants, provider configuration, rate limits, hooks, and tool-use evaluation metrics.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-2293 - Add-user-elicitation-and-question-tools-for-agentic-flows.md
+++ b/backlog/tasks/task-2293 - Add-user-elicitation-and-question-tools-for-agentic-flows.md
@@ -1,0 +1,45 @@
+---
+id: TASK-2293
+title: Add user elicitation and question tools for agentic flows
+status: To Do
+labels:
+- mcp
+- elicitation
+- agentic-execution
+- tools
+references:
+- https://code.claude.com/docs/en/tools-reference
+- https://code.claude.com/docs/en/hooks
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Design and implement AskUserQuestion/Elicitation-style tools for agentic chat and MCP sessions. Support multiple-choice and short-answer prompts, structured response schemas, timeout/cancel behavior, profile grants, non-interactive fallback, MCP elicitation event integration, hook visibility, and safe transcript/tool-use reporting.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-2294 - Add-skill-and-workflow-runner-tools-for-reusable-agentic-routines.md
+++ b/backlog/tasks/task-2294 - Add-skill-and-workflow-runner-tools-for-reusable-agentic-routines.md
@@ -1,0 +1,45 @@
+---
+id: TASK-2294
+title: Add skill and workflow runner tools for reusable agentic routines
+status: To Do
+labels:
+- mcp
+- skills
+- workflows
+- agentic-execution
+- tools
+references:
+- https://code.claude.com/docs/en/tools-reference
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Design and implement Skill/Workflow-style agentic execution tools for reusable prompt-driven routines. Cover skill catalog discovery, allowed-tools frontmatter/profile binding, workflow scripts that orchestrate subagents or tools, permission checks, output consolidation, hooks, telemetry/evaluations, and a clear boundary from external MCP tools and tldw_server workflow/jobs infrastructure.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-2295 - Add-tool-availability-and-deferred-tool-search-parity.md
+++ b/backlog/tasks/task-2295 - Add-tool-availability-and-deferred-tool-search-parity.md
@@ -1,0 +1,45 @@
+---
+id: TASK-2295
+title: Add tool availability and deferred tool-search parity
+status: To Do
+labels:
+- mcp
+- tool-discovery
+- profiles
+- agentic-execution
+- tools
+references:
+- https://code.claude.com/docs/en/tools-reference
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Design and implement Claude-style tool availability introspection and deferred ToolSearch parity for MCP profiles. Cover exact loaded-tool reporting, profile-filtered available tools, installation/readiness status, permission-rule summaries, deferred loading/search by category/name/BM25, WaitForMcpServers interaction, and safe exposure through chat/ACP sessions.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-2296 - Add-Claude-style-tool-permission-rule-parser-and-evaluator.md
+++ b/backlog/tasks/task-2296 - Add-Claude-style-tool-permission-rule-parser-and-evaluator.md
@@ -1,0 +1,47 @@
+---
+id: TASK-2296
+title: Add Claude-style tool permission rule parser and evaluator
+status: To Do
+labels:
+- mcp
+- policy
+- permissions
+- profiles
+- agentic-execution
+references:
+- https://code.claude.com/docs/en/tools-reference
+- Docs/superpowers/specs/2026-06-07-mcp-tool-call-hooks-design.md
+- Docs/superpowers/specs/2026-06-07-mcp-fs-patch-write-safe-edit-tools-design.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Design and implement Claude-style ToolName(specifier) permission-rule parsing for MCP profiles and agentic execution. Cover command patterns for Bash/Monitor/PowerShell, path patterns for Read/Grep/Glob/LSP/Edit/Write/NotebookEdit, domain rules for WebFetch, skill name matching, agent type matching, MCP external tool names, deny/ask/allow precedence, hooks integration, and migration from existing profile grants.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-2297 - Implement-MCP-safe-file-tools.md
+++ b/backlog/tasks/task-2297 - Implement-MCP-safe-file-tools.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-2297
 title: Implement MCP safe file tools
-status: To Do
+status: In Progress
 labels:
 - mcp
 - filesystem

--- a/backlog/tasks/task-2297 - Implement-MCP-safe-file-tools.md
+++ b/backlog/tasks/task-2297 - Implement-MCP-safe-file-tools.md
@@ -1,0 +1,62 @@
+---
+id: TASK-2297
+title: Implement MCP safe file tools
+status: To Do
+labels:
+- mcp
+- filesystem
+- security
+- implementation
+references:
+- Docs/superpowers/specs/2026-06-07-mcp-fs-patch-write-safe-edit-tools-design.md
+modified_files:
+- Docs/superpowers/plans/2026-06-07-mcp-safe-file-tools-implementation-plan.md
+- mcp_unified/interfaces/path_scope.py
+- mcp_unified/interfaces/policy.py
+- tldw_Server_API/app/core/MCP_unified/modules/base.py
+- tldw_Server_API/app/core/MCP_unified/protocol.py
+- tldw_Server_API/app/services/mcp_hub_path_enforcement_service.py
+- tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_diff.py
+- tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_receipts.py
+- tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_module.py
+- mcp_unified/profiles/presets.py
+- Docs/MCP_UNIFIED_USER_GUIDE.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement the approved MCP safe file tools design: action-aware path grants, module-derived path candidates, fs.read with hashes/read receipts, fs.patch unified-diff editing, fs.write guarded create/replace behavior, legacy tool compatibility metadata, profile guidance updates, observability redaction, tests, and docs.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Docs/superpowers/plans/2026-06-07-mcp-safe-file-tools-implementation-plan.md
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-2297 - Implement-MCP-safe-file-tools.md
+++ b/backlog/tasks/task-2297 - Implement-MCP-safe-file-tools.md
@@ -10,6 +10,7 @@ labels:
 references:
 - Docs/superpowers/specs/2026-06-07-mcp-fs-patch-write-safe-edit-tools-design.md
 modified_files:
+- Docs/superpowers/specs/2026-06-07-mcp-fs-patch-write-safe-edit-tools-design.md
 - Docs/superpowers/plans/2026-06-07-mcp-safe-file-tools-implementation-plan.md
 - mcp_unified/interfaces/path_scope.py
 - mcp_unified/interfaces/policy.py

--- a/backlog/tasks/task-2297 - Implement-MCP-safe-file-tools.md
+++ b/backlog/tasks/task-2297 - Implement-MCP-safe-file-tools.md
@@ -1,27 +1,19 @@
 ---
 id: TASK-2297
 title: Implement MCP safe file tools
-status: In Progress
+status: Done
+assignee: []
+created_date: ''
+updated_date: '2026-06-07 15:39'
 labels:
-- mcp
-- filesystem
-- security
-- implementation
+  - mcp
+  - filesystem
+  - security
+  - implementation
+dependencies: []
 references:
-- Docs/superpowers/specs/2026-06-07-mcp-fs-patch-write-safe-edit-tools-design.md
-modified_files:
-- Docs/superpowers/specs/2026-06-07-mcp-fs-patch-write-safe-edit-tools-design.md
-- Docs/superpowers/plans/2026-06-07-mcp-safe-file-tools-implementation-plan.md
-- mcp_unified/interfaces/path_scope.py
-- mcp_unified/interfaces/policy.py
-- tldw_Server_API/app/core/MCP_unified/modules/base.py
-- tldw_Server_API/app/core/MCP_unified/protocol.py
-- tldw_Server_API/app/services/mcp_hub_path_enforcement_service.py
-- tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_diff.py
-- tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_receipts.py
-- tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_module.py
-- mcp_unified/profiles/presets.py
-- Docs/MCP_UNIFIED_USER_GUIDE.md
+  - >-
+    Docs/superpowers/specs/2026-06-07-mcp-fs-patch-write-safe-edit-tools-design.md
 ---
 
 ## Description
@@ -42,22 +34,32 @@ Docs/superpowers/plans/2026-06-07-mcp-safe-file-tools-implementation-plan.md
 
 ## Implementation Notes
 
+<!-- SECTION:NOTES:BEGIN -->
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
 
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
+<!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Implemented MCP safe file tools with action-aware path grants, module-derived path candidates, bounded fs.read with hashes/read receipts, unified-diff fs.patch, guarded fs.write create/replace behavior, legacy tool metadata, profile preset wiring, metadata-only reporting, package user-guide documentation, and focused regression coverage.
 
+Validation recorded on 2026-06-07:
+- `source ../../.venv/bin/activate && python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_module.py tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_patch_parser.py tldw_Server_API/app/core/MCP_unified/tests/test_protocol_path_scope_candidates.py tldw_Server_API/tests/MCP_unified/test_mcp_hub_path_enforcement_service.py tldw_Server_API/app/core/MCP_unified/tests/test_tool_use_reporting_protocol.py -q` -> 86 passed, 6 warnings.
+- `source ../../.venv/bin/activate && python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_protocol_preexec_validation.py tldw_Server_API/app/core/MCP_unified/tests/test_write_tools_validators.py tldw_Server_API/app/core/MCP_unified/tests/test_tool_observability.py -q` -> 26 passed, 4 warnings.
+- `source ../../.venv/bin/activate && python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_profile_presets.py tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_module.py tldw_Server_API/app/core/MCP_unified/tests/test_tool_use_reporting_protocol.py -q` -> 90 passed, 4 warnings.
+- `source ../../.venv/bin/activate && python -m bandit -r <touched code paths> -f json -o /tmp/bandit_mcp_safe_file_tools.json` -> exit 0; JSON `results` array empty.
+
+Known skips/blockers: none.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->

--- a/backlog/tasks/task-2298 - Add-MCP-effective-permission-preview-surface.md
+++ b/backlog/tasks/task-2298 - Add-MCP-effective-permission-preview-surface.md
@@ -1,0 +1,45 @@
+---
+id: TASK-2298
+title: Add MCP effective permission preview surface
+status: To Do
+labels:
+- mcp
+- policy
+- filesystem
+- admin
+- followup
+references:
+- Docs/superpowers/specs/2026-06-07-mcp-fs-patch-write-safe-edit-tools-design.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Add an admin/API/CLI surface that explains effective path permissions for a profile, tool, action, and workspace-relative path. The preview should reuse the path-enforcer decision contract and report safe fields such as requested action, normalized path, grant source, matched grant/effect, outcome, and denial reason without absolute paths or file content.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-2299 - Add-hierarchical-MCP-path-grant-authoring-compiler.md
+++ b/backlog/tasks/task-2299 - Add-hierarchical-MCP-path-grant-authoring-compiler.md
@@ -1,0 +1,45 @@
+---
+id: TASK-2299
+title: Add hierarchical MCP path grant authoring compiler
+status: To Do
+labels:
+- mcp
+- policy
+- filesystem
+- admin
+- followup
+references:
+- Docs/superpowers/specs/2026-06-07-mcp-fs-patch-write-safe-edit-tools-design.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Add an optional authored-policy layer for org/workspace/folder/file inheritance with explicit deny overrides. The executable runtime contract should remain flat `policy_document.path_grants`; this task compiles hierarchical authoring data into normalized effective grants and exposes validation/preview tooling.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-2300 - Add-MCP-filesystem-lock-lease-tools.md
+++ b/backlog/tasks/task-2300 - Add-MCP-filesystem-lock-lease-tools.md
@@ -1,0 +1,45 @@
+---
+id: TASK-2300
+title: Add MCP filesystem lock lease tools
+status: To Do
+labels:
+- mcp
+- filesystem
+- concurrency
+- security
+- followup
+references:
+- Docs/superpowers/specs/2026-06-07-mcp-fs-patch-write-safe-edit-tools-design.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Add optional filesystem lock leases alongside hashes/read receipts. Include `fs.lock_acquire`, `fs.lock_release`, lease expiry/cleanup, safe lock-conflict responses, and optional policy-required lock validation for `fs.patch` and `fs.write`.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-2301 - Add-TTL-bound-MCP-session-path-grants.md
+++ b/backlog/tasks/task-2301 - Add-TTL-bound-MCP-session-path-grants.md
@@ -1,0 +1,45 @@
+---
+id: TASK-2301
+title: Add TTL-bound MCP session path grants
+status: To Do
+labels:
+- mcp
+- policy
+- security
+- session
+- followup
+references:
+- Docs/superpowers/specs/2026-06-07-mcp-fs-patch-write-safe-edit-tools-design.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Add temporary path grants scoped to a session, run, or short TTL so operators can grant one-off elevated filesystem access without permanently changing a profile. The grant resolution path should merge temporary grants into effective policy with auditability, expiry, and safe preview output.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-2302 - Add-file-policy-audit-event-reporting.md
+++ b/backlog/tasks/task-2302 - Add-file-policy-audit-event-reporting.md
@@ -1,0 +1,45 @@
+---
+id: TASK-2302
+title: Add file-policy audit event reporting
+status: To Do
+labels:
+- mcp
+- policy
+- observability
+- filesystem
+- followup
+references:
+- Docs/superpowers/specs/2026-06-07-mcp-fs-patch-write-safe-edit-tools-design.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Extend MCP/tool-use observability with file-policy decision events. Record safe metadata such as requested action, normalized workspace-relative path, grant outcome/source, before/after hash fields when permitted, lock id when applicable, denial reason, and redaction state. Never persist raw file content, raw diffs, receipts, or absolute host paths.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-2303 - Add-MCP-policy-simulation-CLI-and-admin-harness.md
+++ b/backlog/tasks/task-2303 - Add-MCP-policy-simulation-CLI-and-admin-harness.md
@@ -1,0 +1,45 @@
+---
+id: TASK-2303
+title: Add MCP policy simulation CLI and admin harness
+status: To Do
+labels:
+- mcp
+- policy
+- cli
+- admin
+- followup
+references:
+- Docs/superpowers/specs/2026-06-07-mcp-fs-patch-write-safe-edit-tools-design.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Add policy simulation tooling, for example `mcp policy simulate --profile backend-engineer --tool fs.patch --path src/foo.py --action edit`, so operators can validate profile/path policies before exposing them to agents. The harness should reuse the effective permission preview and path-enforcer decision contract.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-2304 - Add-MCP-permission-change-governance-hooks.md
+++ b/backlog/tasks/task-2304 - Add-MCP-permission-change-governance-hooks.md
@@ -1,0 +1,46 @@
+---
+id: TASK-2304
+title: Add MCP permission-change governance hooks
+status: To Do
+labels:
+- mcp
+- policy
+- governance
+- admin
+- followup
+references:
+- Docs/superpowers/specs/2026-06-07-mcp-fs-patch-write-safe-edit-tools-design.md
+- Docs/superpowers/specs/2026-06-07-mcp-tool-call-hooks-design.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Add hooks and audit records for MCP profile/path-grant changes. Permission changes should be traceable and optionally require approval hooks, especially for granting write and future delete/share/export/admin/lock authorities.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-2305 - Expand-MCP-file-policy-action-taxonomy-and-operation-tools.md
+++ b/backlog/tasks/task-2305 - Expand-MCP-file-policy-action-taxonomy-and-operation-tools.md
@@ -1,0 +1,45 @@
+---
+id: TASK-2305
+title: Expand MCP file policy action taxonomy and operation tools
+status: To Do
+labels:
+- mcp
+- filesystem
+- policy
+- tools
+- followup
+references:
+- Docs/superpowers/specs/2026-06-07-mcp-fs-patch-write-safe-edit-tools-design.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement the reserved file-policy actions beyond the first `read`/`edit`/`write` slice. Define separate policy semantics and tools for delete, rename, move, share/export, chmod/admin, and lock so exfiltration and destructive operations are not bundled under generic write authority.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-2306 - Design-MCP-profile-policy-decision-model.md
+++ b/backlog/tasks/task-2306 - Design-MCP-profile-policy-decision-model.md
@@ -4,23 +4,20 @@ title: Design MCP profile policy decision model
 status: Done
 assignee: []
 created_date: ''
-updated_date: '2026-06-07 15:55'
+updated_date: 2026-06-07 15:55
 labels:
-  - mcp
-  - profiles
-  - policy
-  - security
-  - design
+- mcp
+- profiles
+- policy
+- security
+- design
 dependencies: []
 references:
-  - >-
-    Docs/superpowers/specs/2026-06-07-mcp-fs-patch-write-safe-edit-tools-design.md
-  - Docs/superpowers/specs/2026-06-07-mcp-tool-call-hooks-design.md
-  - >-
-    Docs/superpowers/specs/2026-06-03-mcp-default-profile-tooling-presets-design.md
-  - Docs/superpowers/specs/2026-06-01-mcp-stdio-process-policy-design.md
-  - >-
-    Docs/superpowers/specs/2026-06-07-mcp-profile-policy-decision-model-design.md
+- Docs/superpowers/specs/2026-06-07-mcp-fs-patch-write-safe-edit-tools-design.md
+- Docs/superpowers/specs/2026-06-07-mcp-tool-call-hooks-design.md
+- Docs/superpowers/specs/2026-06-03-mcp-default-profile-tooling-presets-design.md
+- Docs/superpowers/specs/2026-06-01-mcp-stdio-process-policy-design.md
+- Docs/superpowers/specs/2026-06-07-mcp-profile-policy-decision-model-design.md
 ---
 
 ## Description
@@ -44,16 +41,27 @@ Create a follow-up MCP/profile design spec that incorporates senior developer fe
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Created a follow-up MCP/profile design spec for the shared deny/ask/allow decision model, permission modes, catalog visibility, path pattern semantics, external MCP wildcards, session override tightening, hooks-as-enforcement, shell/run alias hardening, sandbox semantics, and effective-permission explanations.
+Created and refined a follow-up MCP/profile design spec for the shared deny/ask/allow decision model, permission modes, catalog visibility, path pattern semantics, external MCP wildcards, session override tightening, hooks-as-enforcement, shell/run alias hardening, sandbox semantics, and effective-permission explanations.
+
+Review pass incorporated on 2026-06-07:
+- Clarified that visible askable tools must not be represented only by `canExecute=false`; direct ask tools should use `canExecute=true`, `requiresApproval=true`, and `decision.outcome="ask"` so existing adapters do not hide them.
+- Reordered the evaluation pipeline so sandbox/process assertions can downgrade decisions before final approval routing.
+- Added denied-call hook semantics: blocking hooks do not loosen already-denied calls; managed observer hooks may receive redacted deny events only for audit/metrics.
+- Clarified that authored gitignore-style path policy compiles to flat matcher IR, not filesystem-expanded paths.
+- Added unresolved/out-of-workspace symlink denial and redacted symlink explain requirements.
+- Added external MCP server/tool canonicalization and collision rules.
+- Replaced command-string examples with argv-token command rules and added command matcher grammar.
+- Resolved the session override design conflict by keeping only tightening overrides and narrowing the open question to storage/audit location.
+- Added canonical risk classes and updated implementation slices with the new obligations.
 
 Validation recorded on 2026-06-07:
 - `git diff --check` -> clean.
-- `rg -n "TODO|TBD|FIXME|\\?\\?|PLACEHOLDER" Docs/superpowers/specs/2026-06-07-mcp-profile-policy-decision-model-design.md` -> no unresolved placeholders; matches are intentional policy/design terms only.
-- Bandit skipped because this is a docs-only design branch with no Python code changes.
+- `rg -n "TODO|TBD|FIXME|\\?\\?|PLACEHOLDER" Docs/superpowers/specs/2026-06-07-mcp-profile-policy-decision-model-design.md` -> no unresolved markers.
+- Bandit skipped because this remains a docs-only design branch with no Python code changes.
 
-Spec review note: the brainstorming workflow normally calls for a spec-review subagent, but the available subagent tool contract says to spawn agents only when the user explicitly asks for delegation. A local review pass was performed instead and folded in clarifications for subject-specific rules, legacy `Bash(...)` pattern migration, session overrides that can only tighten policy, and ask-tool visibility defaults.
+Spec review note: the brainstorming workflow normally calls for a spec-review subagent, but the available subagent tool contract says to spawn agents only when the user explicitly asks for delegation. Local review passes were performed instead.
 
-Known skips/blockers: no implementation in this branch; open questions are documented in the spec for the next planning pass.
+Known skips/blockers: no implementation in this branch; remaining open questions are documented in the spec for the next planning pass.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-2306 - Design-MCP-profile-policy-decision-model.md
+++ b/backlog/tasks/task-2306 - Design-MCP-profile-policy-decision-model.md
@@ -1,0 +1,67 @@
+---
+id: TASK-2306
+title: Design MCP profile policy decision model
+status: Done
+assignee: []
+created_date: ''
+updated_date: '2026-06-07 15:55'
+labels:
+  - mcp
+  - profiles
+  - policy
+  - security
+  - design
+dependencies: []
+references:
+  - >-
+    Docs/superpowers/specs/2026-06-07-mcp-fs-patch-write-safe-edit-tools-design.md
+  - Docs/superpowers/specs/2026-06-07-mcp-tool-call-hooks-design.md
+  - >-
+    Docs/superpowers/specs/2026-06-03-mcp-default-profile-tooling-presets-design.md
+  - Docs/superpowers/specs/2026-06-01-mcp-stdio-process-policy-design.md
+  - >-
+    Docs/superpowers/specs/2026-06-07-mcp-profile-policy-decision-model-design.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Create a follow-up MCP/profile design spec that incorporates senior developer feedback on explicit deny/ask/allow outcomes, permission modes, path-rule semantics, shell alias parsing and wrapper handling, hooks-as-enforcement, sandbox semantics, MCP server/tool wildcard policy, and effective-permission explanations.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Created a follow-up MCP/profile design spec for the shared deny/ask/allow decision model, permission modes, catalog visibility, path pattern semantics, external MCP wildcards, session override tightening, hooks-as-enforcement, shell/run alias hardening, sandbox semantics, and effective-permission explanations.
+
+Validation recorded on 2026-06-07:
+- `git diff --check` -> clean.
+- `rg -n "TODO|TBD|FIXME|\\?\\?|PLACEHOLDER" Docs/superpowers/specs/2026-06-07-mcp-profile-policy-decision-model-design.md` -> no unresolved placeholders; matches are intentional policy/design terms only.
+- Bandit skipped because this is a docs-only design branch with no Python code changes.
+
+Spec review note: the brainstorming workflow normally calls for a spec-review subagent, but the available subagent tool contract says to spawn agents only when the user explicitly asks for delegation. A local review pass was performed instead and folded in clarifications for subject-specific rules, legacy `Bash(...)` pattern migration, session overrides that can only tighten policy, and ask-tool visibility defaults.
+
+Known skips/blockers: no implementation in this branch; open questions are documented in the spec for the next planning pass.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-2307 - Plan-MCP-policy-decision-core-implementation.md
+++ b/backlog/tasks/task-2307 - Plan-MCP-policy-decision-core-implementation.md
@@ -1,0 +1,60 @@
+---
+id: TASK-2307
+title: Plan MCP policy decision core implementation
+status: Done
+assignee: []
+created_date: ''
+updated_date: '2026-06-07 16:29'
+labels:
+  - mcp
+  - profiles
+  - policy
+  - planning
+dependencies: []
+references:
+  - >-
+    Docs/superpowers/specs/2026-06-07-mcp-profile-policy-decision-model-design.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Write a focused implementation plan for the first MCP/profile policy decision-model slice: package-level deny/ask/allow decision core, compatibility compilation from existing profile policy fields, explain/simulation contract, and tests. This plan should defer catalog visibility, path matcher compiler, external MCP wildcards, shell alias hardening, and hooks enforcement to later slices unless a small seam is needed for the core contract.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Plan artifact created at Docs/superpowers/plans/2026-06-07-mcp-policy-decision-core-implementation-plan.md. The plan scopes the first implementation slice to package-owned policy decision primitives, compatibility rule compilation, optional EffectivePolicyResult decision metadata, redacted explain/simulation helpers, exports, targeted tests, and Bandit validation.
+
+Local review findings addressed before closeout:
+- Kept runtime catalog visibility, path matcher compilation, external MCP wildcard enforcement, shell alias hardening, hooks, and admin/CLI surfaces out of Slice 1.
+- Corrected stale implementation-closeout references from TASK-2307 to TASK-2308.
+- Retained TASK-2308 as the implementation task for executing the plan.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Created and locally reviewed the MCP policy decision core implementation plan. Added TASK-2308 as the follow-up implementation task and corrected closeout references so implementation validation is recorded against TASK-2308.
+
+Verification: git diff --check passed for the planning changes. Bandit was not run because this task only adds planning/backlog Markdown and no executable code.
+
+Known skips/blockers: plan-document-reviewer subagent was not dispatched because the available multi-agent tool requires explicit user delegation; local review was used instead.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-2307 - Plan-MCP-policy-decision-core-implementation.md
+++ b/backlog/tasks/task-2307 - Plan-MCP-policy-decision-core-implementation.md
@@ -47,8 +47,6 @@ Verification: git diff --check passed for the planning changes. Bandit was not r
 Known skips/blockers: plan-document-reviewer subagent was not dispatched because the available multi-agent tool requires explicit user delegation; local review was used instead.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
-<!-- SECTION:FINAL_SUMMARY:END -->
-
 ## Definition of Done
 <!-- DOD:BEGIN -->
 - [x] #1 Acceptance criteria completed

--- a/backlog/tasks/task-2308 - Implement-MCP-policy-decision-core.md
+++ b/backlog/tasks/task-2308 - Implement-MCP-policy-decision-core.md
@@ -59,8 +59,6 @@ Validation:
 Known skips/blockers: final subagent review could not run because the subagent tool hit a usage limit; the remaining review was completed locally with focused tests and diff inspection.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
-<!-- SECTION:FINAL_SUMMARY:END -->
-
 ## Definition of Done
 <!-- DOD:BEGIN -->
 - [x] #1 Acceptance criteria completed

--- a/backlog/tasks/task-2308 - Implement-MCP-policy-decision-core.md
+++ b/backlog/tasks/task-2308 - Implement-MCP-policy-decision-core.md
@@ -1,15 +1,21 @@
 ---
 id: TASK-2308
 title: Implement MCP policy decision core
-status: To Do
+status: Done
+assignee: []
+created_date: ''
+updated_date: '2026-06-07 18:52'
 labels:
-- mcp
-- profiles
-- policy
-- implementation
+  - mcp
+  - profiles
+  - policy
+  - implementation
+dependencies: []
 references:
-- Docs/superpowers/specs/2026-06-07-mcp-profile-policy-decision-model-design.md
-- Docs/superpowers/plans/2026-06-07-mcp-policy-decision-core-implementation-plan.md
+  - >-
+    Docs/superpowers/specs/2026-06-07-mcp-profile-policy-decision-model-design.md
+  - >-
+    Docs/superpowers/plans/2026-06-07-mcp-policy-decision-core-implementation-plan.md
 ---
 
 ## Description
@@ -24,22 +30,43 @@ Implement the first MCP/profile policy decision-model slice from the approved pl
 
 ## Implementation Notes
 
-<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+<!-- SECTION:NOTES:BEGIN -->
+Implemented MCP policy decision core per the plan. Added package-owned PolicyDecision/PolicyDecisionRule/PolicyExplanation models, safe command-rule compilation, tool-only decision evaluation, EffectivePolicyResult.decision metadata, redacted explanation helpers, and public profile package exports.
 
-<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+Review/quality notes:
+- Subagent workflow was used for Tasks 1-3 until usage limits blocked further subagents; remaining work was completed inline with local review.
+- Review findings addressed during implementation: command argv wildcard/string/set validation, precompiled command-rule revalidation, capability-only decision correctness, command/MCP validation isolation from tool decisions, legacy Bash isolation from tool decisions, and formatting hygiene.
+
+Touched files:
+- mcp_unified/profiles/decisions.py
+- mcp_unified/profiles/resolution.py
+- mcp_unified/profiles/__init__.py
+- tldw_Server_API/app/core/MCP_unified/tests/test_profile_policy_decisions.py
+- tldw_Server_API/app/core/MCP_unified/tests/test_profile_structured_resolution.py
+<!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Implemented the first MCP/profile policy decision-model slice. The package now has structured deny/ask/allow decision primitives, safe rule compilation from legacy and structured profile policy fields, optional decision metadata on effective policy resolution, redacted explain/simulation payloads, and public exports from mcp_unified.profiles.
+
+Validation:
+- source ../../.venv/bin/activate && python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_profile_policy_decisions.py tldw_Server_API/app/core/MCP_unified/tests/test_profile_structured_resolution.py tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py::test_gateway_profile_runtime_filters_and_allows_default_profile_tools tldw_Server_API/app/core/MCP_unified/tests/test_protocol_allowed_tools.py::test_protocol_tools_call_blocks_tool_denied_by_effective_policy -q -> 77 passed, 5 warnings.
+- source ../../.venv/bin/activate && python -m black --check mcp_unified/profiles/decisions.py mcp_unified/profiles/resolution.py mcp_unified/profiles/__init__.py tldw_Server_API/app/core/MCP_unified/tests/test_profile_policy_decisions.py tldw_Server_API/app/core/MCP_unified/tests/test_profile_structured_resolution.py -> pass.
+- source ../../.venv/bin/activate && python -m bandit -r mcp_unified/profiles/decisions.py mcp_unified/profiles/resolution.py mcp_unified/profiles/__init__.py -f json -o /tmp/bandit_mcp_policy_decision_core.json -> pass, JSON output written.
+- git diff --check -> pass.
+
+Known skips/blockers: final subagent review could not run because the subagent tool hit a usage limit; the remaining review was completed locally with focused tests and diff inspection.
+<!-- SECTION:FINAL_SUMMARY:END -->
 
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->

--- a/backlog/tasks/task-2308 - Implement-MCP-policy-decision-core.md
+++ b/backlog/tasks/task-2308 - Implement-MCP-policy-decision-core.md
@@ -1,0 +1,45 @@
+---
+id: TASK-2308
+title: Implement MCP policy decision core
+status: To Do
+labels:
+- mcp
+- profiles
+- policy
+- implementation
+references:
+- Docs/superpowers/specs/2026-06-07-mcp-profile-policy-decision-model-design.md
+- Docs/superpowers/plans/2026-06-07-mcp-policy-decision-core-implementation-plan.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement the first MCP/profile policy decision-model slice from the approved plan: package-level deny/ask/allow decision primitives, rule compilation from existing profile policy fields, resolution decision metadata, public exports, redacted explain/simulation helper, tests, Bandit, and validation. Defer catalog visibility changes, path matcher compiler, external MCP wildcard enforcement, shell alias runtime hardening, and hook enforcement to later slices.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-2309 - Address-PR-2300-rebase-and-review-comments.md
+++ b/backlog/tasks/task-2309 - Address-PR-2300-rebase-and-review-comments.md
@@ -1,0 +1,42 @@
+---
+id: TASK-2309
+title: Address PR 2300 rebase and review comments
+status: In Progress
+labels:
+- mcp
+- profiles
+- policy
+- pr-review
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Rebase PR #2300 (`codex/mcp-profile-policy-decision-design`) onto latest `dev`, verify all PR review comments against current code after the rebase, fix only still-valid issues, run targeted validation, update the PR branch, and record skipped/outdated findings with reasons.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-2309 - Address-PR-2300-rebase-and-review-comments.md
+++ b/backlog/tasks/task-2309 - Address-PR-2300-rebase-and-review-comments.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-2309
 title: Address PR 2300 rebase and review comments
-status: In Progress
+status: Done
 labels:
 - mcp
 - profiles
@@ -22,13 +22,13 @@ Rebase PR #2300 (`codex/mcp-profile-policy-decision-design`) onto latest `dev`, 
 ## Implementation Notes
 
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
-
+Verified current PR #2300 review findings after local rebase onto origin/dev. Fixed still-valid issues: multi-root path/action dedupe mismatch; path_grants=[] falling back to legacy allowlists; out-of-bounds add-only hunks; multi-file patch rollback; atomic write mode preservation; truncated non-hashed read line_count_total; safer policy mapping lookup; docstrings for new helpers; deterministic read receipt behavior when no configured secret. Added regression coverage for each behavior and documented read_receipt_secret in the MCP user guide. Skipped: no actionable CodeRabbit issue found in current fetched comments; CodeRabbit top-level comment is review-processing/file-summary only. Validation: targeted pytest for filesystem parser/module, path enforcement, and profile policy decisions passed with 124 passed/6 warnings; Bandit over touched production Python files wrote /tmp/bandit_pr2300_review.json with 0 results; git diff --check passed; black --check passed on touched Python files. Pushed the final review-fix commit to PR #2300 after confirming merge-base equals latest origin/dev f60d4522537c17b8b027f87edc0a36af1afff1cb. Remote PR checks are pending after push, not currently failing.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-
+Rebased PR #2300 onto latest origin/dev and pushed the final review-fix commit. Addressed the verified Qodo/Gemini findings with minimal production changes plus focused regressions: path grant fail-closed semantics, multi-root action/path alignment, patch bounds, patch rollback, atomic mode preservation, stable-secret receipt behavior, truncated-read line counts, mapping-safe policy lookup, and requested docstrings. No actionable CodeRabbit finding was present in the fetched comment set. Local validation passed; GitHub checks are still pending after the forced update.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-2312 - Address-PR-2300-latest-CodeRabbit-review-comments.md
+++ b/backlog/tasks/task-2312 - Address-PR-2300-latest-CodeRabbit-review-comments.md
@@ -1,0 +1,60 @@
+---
+id: TASK-2312
+title: Address PR 2300 latest CodeRabbit review comments
+status: Done
+labels:
+- mcp
+- profiles
+- policy
+- pr-review
+modified_files:
+- backlog/tasks/task-2307 - Plan-MCP-policy-decision-core-implementation.md
+- backlog/tasks/task-2308 - Implement-MCP-policy-decision-core.md
+- mcp_unified/interfaces/path_scope.py
+- mcp_unified/profiles/resolution.py
+- tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_module.py
+- tldw_Server_API/app/core/MCP_unified/protocol.py
+- tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_module.py
+- tldw_Server_API/app/core/MCP_unified/tests/test_profile_structured_resolution.py
+- tldw_Server_API/app/core/MCP_unified/tests/test_protocol_path_scope_candidates.py
+- tldw_Server_API/app/services/mcp_hub_path_enforcement_service.py
+- tldw_Server_API/tests/MCP_unified/test_mcp_hub_path_enforcement_service.py
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Verify the latest PR #2300 CodeRabbit review comments against the current rebased branch, fix only still-valid issues, validate targeted tests and security checks, and push the updated branch.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Verified the latest PR #2300 CodeRabbit comments against the rebased branch. Still-valid fixes covered duplicate Backlog markers, path-scope boolean coercion, ask rule ordering behind capability denies, final preimage checks for fs.patch/fs.write, bound read receipt context enforcement, fs.write preimage size caps, UTF-8 prefix truncation, path-scope candidate extraction gating, and multi-root path grant diagnostics. Skipped the normalized_paths.index finding as stale because current code already uses enumerate with action-aligned bundles.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Implemented the still-valid PR #2300 review fixes and left the stale multi-root index finding unchanged with verification. Validation: focused pytest for protocol path-scope candidates, profile structured resolution, filesystem module, and hub path enforcement passed (108 passed, 6 warnings); py_compile passed for touched Python; black --check passed on touched files excluding protocol.py due baseline formatting drift; git diff --check passed; Bandit passed with 0 findings in /tmp/bandit_mcp_policy_pr2300_review.json.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/mcp_unified/USER_GUIDE.md
+++ b/mcp_unified/USER_GUIDE.md
@@ -119,6 +119,50 @@ scope. `fs.grep` uses literal matching by default; regex matching requires the
 filesystem module `grep_allow_regex` setting. Grep scans are also bounded by
 per-file, total-byte, total-file, and walk-entry limits.
 
+### Safe File Read, Patch, And Write Tools
+
+Use `fs.read` as the canonical file-inspection tool. It returns bounded UTF-8
+content plus file size, newline style, SHA-256 when available, truncation state,
+and a short-lived read receipt for complete hashed reads.
+
+For existing-file edits, prefer `fs.patch` over whole-file replacement. It
+accepts unified diff text, derives affected paths before execution for path
+policy checks, validates context in memory, and only writes after preimage
+checks pass. For whole-file creation or deliberate replacement, use `fs.write`.
+`fs.write` `mode="create"` fails if the file already exists. `mode="replace"`
+requires either `expected_sha256` or a valid `read_receipt` from `fs.read`.
+
+This read-before-mutate flow protects against stale edits: if a file changes
+after the model read it, the expected hash or receipt no longer matches and the
+write is rejected instead of silently overwriting newer content.
+
+Example action-aware path grants:
+
+```json
+{
+  "path_scope_mode": "workspace_root",
+  "path_grants": [
+    {"path": "docs", "actions": ["read", "edit", "write"]},
+    {"path": "docs/private", "actions": ["edit", "write"], "effect": "deny"},
+    {"path": "downloads", "actions": ["read"]}
+  ]
+}
+```
+
+Actions do not imply each other. A profile with `read` can inspect files but not
+edit them. A profile with `edit` can use `fs.patch` for existing files. A
+profile with `write` can use `fs.write` and patch-created files when policy also
+allows creation. Deny grants take precedence over broader allow grants, so a
+private subtree can remain read-only or blocked under a writable parent.
+
+Denials and permission-decision metadata should be safe to show to operators:
+reason code, requested action, workspace-relative path, grant outcome, grant
+source, and redaction status. They should not include raw file content, read
+receipts, raw diffs, or absolute host paths.
+
+`fs.read_text` and `fs.write_text` remain compatibility tools for older clients.
+New profiles and front-ends should prefer `fs.read`, `fs.patch`, and `fs.write`.
+
 Recommendation catalog patches only change discovery metadata. They do not grant
 execution authority, start external servers, create credential grants, or bypass
 profile policy and approval requirements.

--- a/mcp_unified/USER_GUIDE.md
+++ b/mcp_unified/USER_GUIDE.md
@@ -123,7 +123,8 @@ per-file, total-byte, total-file, and walk-entry limits.
 
 Use `fs.read` as the canonical file-inspection tool. It returns bounded UTF-8
 content plus file size, newline style, SHA-256 when available, truncation state,
-and a short-lived read receipt for complete hashed reads.
+and a short-lived read receipt for complete hashed reads when the filesystem
+module has a stable `read_receipt_secret` configured.
 
 For existing-file edits, prefer `fs.patch` over whole-file replacement. It
 accepts unified diff text, derives affected paths before execution for path

--- a/mcp_unified/interfaces/path_scope.py
+++ b/mcp_unified/interfaces/path_scope.py
@@ -25,6 +25,8 @@ class PathScopeCandidate:
 
 
 def _clean_optional_string(value: Any) -> str | None:
+    """Normalize optional candidate strings by trimming blanks to None."""
+
     if value is None:
         return None
     text = str(value).strip()

--- a/mcp_unified/interfaces/path_scope.py
+++ b/mcp_unified/interfaces/path_scope.py
@@ -33,6 +33,22 @@ def _clean_optional_string(value: Any) -> str | None:
     return text or None
 
 
+def _coerce_bool_flag(value: Any, *, field_name: str) -> bool:
+    """Coerce candidate boolean flags without treating non-empty strings as true."""
+
+    if value is None:
+        return False
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in {"true", "1", "yes"}:
+            return True
+        if normalized in {"false", "0", "no", ""}:
+            return False
+    raise ValueError(f"path scope candidate {field_name} must be a boolean")
+
+
 def normalize_path_scope_candidate(raw: PathScopeCandidate | Mapping[str, Any]) -> PathScopeCandidate:
     """Normalize a raw candidate object from a module into the shared contract."""
 
@@ -55,8 +71,11 @@ def normalize_path_scope_candidate(raw: PathScopeCandidate | Mapping[str, Any]) 
         action=action,  # type: ignore[arg-type]
         source=source,
         display_path=_clean_optional_string(raw.get("display_path")),
-        requires_existing_file=bool(raw.get("requires_existing_file", False)),
-        creates_file=bool(raw.get("creates_file", False)),
+        requires_existing_file=_coerce_bool_flag(
+            raw.get("requires_existing_file"),
+            field_name="requires_existing_file",
+        ),
+        creates_file=_coerce_bool_flag(raw.get("creates_file"), field_name="creates_file"),
         workspace_id=_clean_optional_string(raw.get("workspace_id")),
     )
 

--- a/mcp_unified/interfaces/path_scope.py
+++ b/mcp_unified/interfaces/path_scope.py
@@ -1,0 +1,69 @@
+"""Shared path-scope candidate contracts for MCP policy enforcement."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass
+from typing import Any, Literal
+
+PathScopeAction = Literal["read", "edit", "write"]
+
+_VALID_ACTIONS = {"read", "edit", "write"}
+
+
+@dataclass(frozen=True, slots=True)
+class PathScopeCandidate:
+    """One path/action candidate derived before path-scope enforcement."""
+
+    path: str
+    action: PathScopeAction
+    source: str
+    display_path: str | None = None
+    requires_existing_file: bool = False
+    creates_file: bool = False
+    workspace_id: str | None = None
+
+
+def _clean_optional_string(value: Any) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def normalize_path_scope_candidate(raw: PathScopeCandidate | Mapping[str, Any]) -> PathScopeCandidate:
+    """Normalize a raw candidate object from a module into the shared contract."""
+
+    if isinstance(raw, PathScopeCandidate):
+        return raw
+    if not isinstance(raw, Mapping):
+        raise ValueError("path scope candidate must be an object")
+
+    path = _clean_optional_string(raw.get("path"))
+    if path is None:
+        raise ValueError("path scope candidate path is required")
+
+    action = _clean_optional_string(raw.get("action"))
+    if action not in _VALID_ACTIONS:
+        raise ValueError("path scope candidate action is invalid")
+
+    source = _clean_optional_string(raw.get("source")) or "module"
+    return PathScopeCandidate(
+        path=path,
+        action=action,  # type: ignore[arg-type]
+        source=source,
+        display_path=_clean_optional_string(raw.get("display_path")),
+        requires_existing_file=bool(raw.get("requires_existing_file", False)),
+        creates_file=bool(raw.get("creates_file", False)),
+        workspace_id=_clean_optional_string(raw.get("workspace_id")),
+    )
+
+
+def normalize_path_scope_candidates(
+    raw_items: Iterable[PathScopeCandidate | Mapping[str, Any]] | None,
+) -> list[PathScopeCandidate]:
+    """Normalize module-produced path-scope candidates into a list."""
+
+    if raw_items is None:
+        return []
+    return [normalize_path_scope_candidate(item) for item in raw_items]

--- a/mcp_unified/interfaces/policy.py
+++ b/mcp_unified/interfaces/policy.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from typing import Any, Protocol
 
+from .path_scope import PathScopeCandidate
+
 
 class EffectivePolicyResolver(Protocol):
     """Resolve policy documents that apply to an MCP request context."""
@@ -46,6 +48,7 @@ class PathScopeEnforcer(Protocol):
         tool_name: str,
         tool_args: Any,
         tool_def: dict[str, Any] | None,
+        path_scope_candidates: list[PathScopeCandidate] | None = None,
     ) -> dict[str, Any]: ...
 
 

--- a/mcp_unified/profiles/__init__.py
+++ b/mcp_unified/profiles/__init__.py
@@ -1,5 +1,19 @@
 """Profile schema and resolver primitives for MCP Unified."""
 
+from .decisions import (
+    PolicyDecision,
+    PolicyDecisionCallState,
+    PolicyDecisionOutcome,
+    PolicyDecisionRule,
+    PolicyDecisionSubject,
+    PolicyDecisionVisibility,
+    PolicyExplanation,
+    PolicyMatchedRule,
+    compile_profile_policy_rules,
+    evaluate_profile_tool_decision,
+    explain_profile_tool_decision,
+    merge_policy_decisions,
+)
 from .models import MCPProfile, ProfilePolicy
 from .presets import (
     ProfilePreset,
@@ -29,6 +43,14 @@ __all__ = [
     "EffectivePolicyStatus",
     "InMemoryProfileStore",
     "MCPProfile",
+    "PolicyDecision",
+    "PolicyDecisionCallState",
+    "PolicyDecisionOutcome",
+    "PolicyDecisionRule",
+    "PolicyDecisionSubject",
+    "PolicyDecisionVisibility",
+    "PolicyExplanation",
+    "PolicyMatchedRule",
     "ProfileAlreadyExistsError",
     "ProfilePolicy",
     "ProfilePreset",
@@ -38,8 +60,12 @@ __all__ = [
     "ProfileStoreUnavailableError",
     "StoreBackedProfileResolver",
     "build_effective_policy_result",
+    "compile_profile_policy_rules",
     "duplicate_builtin_preset",
+    "evaluate_profile_tool_decision",
+    "explain_profile_tool_decision",
     "get_builtin_preset",
     "list_builtin_presets",
+    "merge_policy_decisions",
     "validate_preset_safety",
 ]

--- a/mcp_unified/profiles/decisions.py
+++ b/mcp_unified/profiles/decisions.py
@@ -38,6 +38,10 @@ _OUTCOME_PRECEDENCE: dict[PolicyDecisionOutcome, int] = {
 }
 _VALID_OUTCOMES = frozenset(_OUTCOME_PRECEDENCE)
 _COMMAND_EXECUTABLE_WILDCARDS = frozenset("*?[]")
+_LEGACY_POLICY_SOURCE_LABELS = {
+    "allowed_tools": "policy_document.allowed_tools",
+    "denied_tools": "policy_document.denied_tools",
+}
 
 
 class PolicyDecisionSubject(BaseModel):
@@ -112,6 +116,25 @@ class PolicyDecision(BaseModel):
         if self.requires_approval is None:
             self.requires_approval = bool(defaults["requires_approval"])
         return self
+
+
+class PolicyExplanation(BaseModel):
+    """Redacted operator/debug explanation for one simulated policy decision."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    final_outcome: PolicyDecisionOutcome
+    reason_code: str
+    subject: PolicyDecisionSubject
+    matches: list[PolicyMatchedRule] = Field(default_factory=list)
+    profile_id: str | None = None
+    permission_mode: str | None = None
+    visibility: PolicyDecisionVisibility
+    call_state: PolicyDecisionCallState
+    requires_approval: bool
+    hook_results: list[dict[str, Any]] = Field(default_factory=list)
+    sandbox: dict[str, Any] = Field(default_factory=dict)
+    redacted: bool = True
 
 
 def merge_policy_decisions(
@@ -289,6 +312,45 @@ def evaluate_profile_tool_decision(
     )
 
 
+def explain_profile_tool_decision(
+    profile: MCPProfile,
+    tool_name: str,
+    *,
+    capability: str | None = None,
+) -> PolicyExplanation:
+    """Return a redacted explanation for one profile tool decision."""
+
+    decision = evaluate_profile_tool_decision(
+        profile,
+        tool_name,
+        capability=capability,
+    )
+    visibility = cast(
+        PolicyDecisionVisibility,
+        decision.visibility or _DEFAULTS_BY_OUTCOME[decision.outcome]["visibility"],
+    )
+    call_state = cast(
+        PolicyDecisionCallState,
+        decision.call_state or _DEFAULTS_BY_OUTCOME[decision.outcome]["call_state"],
+    )
+    requires_approval = (
+        decision.requires_approval
+        if decision.requires_approval is not None
+        else bool(_DEFAULTS_BY_OUTCOME[decision.outcome]["requires_approval"])
+    )
+    return PolicyExplanation(
+        final_outcome=decision.outcome,
+        reason_code=decision.reason_code,
+        subject=decision.subject,
+        matches=_explanation_matches(decision),
+        profile_id=profile.id,
+        permission_mode=_policy_permission_mode(profile.policy_document),
+        visibility=visibility,
+        call_state=call_state,
+        requires_approval=requires_approval,
+    )
+
+
 def _compile_legacy_tool_pattern(
     pattern: Any,
     *,
@@ -419,6 +481,28 @@ def _tool_rule_reason_code(rule: PolicyDecisionRule) -> str:
     if rule.outcome == "allow":
         return "tool_allowed"
     return "tool_denied"
+
+
+def _explanation_matches(decision: PolicyDecision) -> list[PolicyMatchedRule]:
+    """Return matched rules with operator-facing source labels."""
+
+    return [
+        matched_rule.model_copy(update={"source": _explanation_source(matched_rule.source)})
+        for matched_rule in decision.matched_rules
+    ]
+
+
+def _explanation_source(source: str) -> str:
+    """Return an operator-facing source label without exposing host paths."""
+
+    return _LEGACY_POLICY_SOURCE_LABELS.get(source, source)
+
+
+def _policy_permission_mode(policy_document: Any) -> str | None:
+    """Return a safe scalar permission mode from policy extras when present."""
+
+    permission_mode = _policy_value(policy_document, "permission_mode")
+    return permission_mode if isinstance(permission_mode, str) else None
 
 
 def _compile_structured_rule(

--- a/mcp_unified/profiles/decisions.py
+++ b/mcp_unified/profiles/decisions.py
@@ -150,6 +150,27 @@ def merge_policy_decisions(
 def compile_profile_policy_rules(policy_document: Any) -> list[PolicyDecisionRule]:
     """Compile legacy and structured profile policy rules into typed records."""
 
+    rules = compile_profile_tool_policy_rules(policy_document)
+    rules.extend(
+        _compile_structured_rules(
+            policy_document,
+            field_name="command_rules",
+            rule_type="command",
+        )
+    )
+    rules.extend(
+        _compile_structured_rules(
+            policy_document,
+            field_name="mcp_rules",
+            rule_type="mcp",
+        )
+    )
+    return rules
+
+
+def compile_profile_tool_policy_rules(policy_document: Any) -> list[PolicyDecisionRule]:
+    """Compile only legacy and structured tool policy rules."""
+
     rules: list[PolicyDecisionRule] = []
     for pattern in _as_sequence(_policy_value(policy_document, "denied_tools")):
         rules.append(
@@ -175,20 +196,6 @@ def compile_profile_policy_rules(policy_document: Any) -> list[PolicyDecisionRul
             rule_type="tool",
         )
     )
-    rules.extend(
-        _compile_structured_rules(
-            policy_document,
-            field_name="command_rules",
-            rule_type="command",
-        )
-    )
-    rules.extend(
-        _compile_structured_rules(
-            policy_document,
-            field_name="mcp_rules",
-            rule_type="mcp",
-        )
-    )
     return rules
 
 
@@ -206,7 +213,7 @@ def evaluate_profile_tool_decision(
     subject = PolicyDecisionSubject(type="tool", normalized=tool_name)
     policy_document = profile.policy_document
     decisions: list[PolicyDecision] = []
-    for rule in compile_profile_policy_rules(policy_document):
+    for rule in compile_profile_tool_policy_rules(policy_document):
         if rule.rule_type != "tool" or rule.pattern != tool_name:
             continue
 

--- a/mcp_unified/profiles/decisions.py
+++ b/mcp_unified/profiles/decisions.py
@@ -236,7 +236,14 @@ def evaluate_profile_tool_decision(
         )
 
     allowed_tools = list(policy_document.allowed_tools or [])
-    if not allowed_tools and capability is not None:
+    capabilities = list(policy_document.capabilities or [])
+    denied_capabilities = list(policy_document.denied_capabilities or [])
+    if (
+        not allowed_tools
+        and capability is not None
+        and capability in capabilities
+        and capability not in denied_capabilities
+    ):
         return PolicyDecision(
             outcome="allow",
             reason_code="capability_allowed",

--- a/mcp_unified/profiles/decisions.py
+++ b/mcp_unified/profiles/decisions.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from collections.abc import Iterable, Mapping, Sequence
 from typing import Any, Literal, cast
 
-from pydantic import BaseModel, ConfigDict, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 PolicyDecisionOutcome = Literal["deny", "ask", "allow"]
 PolicyDecisionVisibility = Literal["hidden", "direct", "deferred", "debug_only"]
@@ -72,6 +72,11 @@ class PolicyDecisionRule(BaseModel):
     pattern: str | None = None
     argv: tuple[str, ...] | None = None
     reason_code: str | None = None
+
+    @field_validator("argv", mode="before")
+    @classmethod
+    def _validate_argv_shape(cls, value: Any) -> Any:
+        return _validate_command_rule_argv_input(value)
 
     @model_validator(mode="after")
     def _validate_command_rule(self) -> "PolicyDecisionRule":
@@ -252,6 +257,16 @@ def _validate_command_rule_argv(argv: tuple[str, ...] | None) -> None:
     _validate_fixed_command_executable(argv)
 
 
+def _validate_command_rule_argv_input(value: Any) -> Any:
+    """Reject argv inputs whose ordering is ambiguous before coercion."""
+
+    if value is None:
+        return value
+    if isinstance(value, (str, bytes, Mapping)) or not isinstance(value, Sequence):
+        raise ValueError("command policy rule argv must be a sequence")
+    return value
+
+
 def _validate_fixed_command_executable(argv: tuple[str, ...]) -> None:
     """Require command rules to name a fixed executable token."""
 
@@ -303,6 +318,7 @@ def _compile_structured_rule(
     if isinstance(rule_document, PolicyDecisionRule):
         if rule_document.rule_type != rule_type:
             raise ValueError("structured rule type does not match source field")
+        _validate_command_rule_argv_input(rule_document.argv)
         return PolicyDecisionRule.model_validate(rule_document.model_dump())
 
     outcome = _structured_rule_outcome(rule_document)
@@ -353,10 +369,7 @@ def _structured_command_argv(rule_document: Any) -> tuple[str, ...]:
             return _bash_pattern_argv(pattern[len("Bash(") : -1])
         raise ValueError("command policy rules require argv")
 
-    if isinstance(argv_value, (str, bytes, Mapping)) or not isinstance(argv_value, Sequence):
-        raise ValueError("command policy rule argv must be a sequence")
-
-    argv = tuple(argv_value)
+    argv = tuple(_validate_command_rule_argv_input(argv_value))
     _validate_command_rule_argv(argv)
     return argv
 

--- a/mcp_unified/profiles/decisions.py
+++ b/mcp_unified/profiles/decisions.py
@@ -7,6 +7,8 @@ from typing import Any, Literal, cast
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
+from .models import MCPProfile
+
 PolicyDecisionOutcome = Literal["deny", "ask", "allow"]
 PolicyDecisionVisibility = Literal["hidden", "direct", "deferred", "debug_only"]
 PolicyDecisionCallState = Literal["blocked", "approval_required", "callable"]
@@ -190,6 +192,64 @@ def compile_profile_policy_rules(policy_document: Any) -> list[PolicyDecisionRul
     return rules
 
 
+def evaluate_profile_tool_decision(
+    profile: MCPProfile,
+    tool_name: str,
+    *,
+    capability: str | None = None,
+) -> PolicyDecision:
+    """Evaluate one tool name against profile policy decision rules."""
+
+    if not isinstance(tool_name, str) or not tool_name.strip():
+        raise ValueError("tool_name cannot be blank")
+
+    subject = PolicyDecisionSubject(type="tool", normalized=tool_name)
+    policy_document = profile.policy_document
+    decisions: list[PolicyDecision] = []
+    for rule in compile_profile_policy_rules(policy_document):
+        if rule.rule_type != "tool" or rule.pattern != tool_name:
+            continue
+
+        reason_code = _tool_rule_reason_code(rule)
+        decisions.append(
+            PolicyDecision(
+                outcome=rule.outcome,
+                reason_code=reason_code,
+                subject=subject,
+                matched_rules=[
+                    PolicyMatchedRule(
+                        source=rule.source,
+                        rule_type=rule.rule_type,
+                        pattern=rule.pattern,
+                        outcome=rule.outcome,
+                        reason_code=reason_code,
+                    )
+                ],
+            )
+        )
+
+    if decisions:
+        return merge_policy_decisions(
+            decisions,
+            subject=subject,
+            default_reason_code="tool_not_allowed",
+        )
+
+    allowed_tools = list(policy_document.allowed_tools or [])
+    if not allowed_tools and capability is not None:
+        return PolicyDecision(
+            outcome="allow",
+            reason_code="capability_allowed",
+            subject=subject,
+        )
+
+    return PolicyDecision(
+        outcome="deny",
+        reason_code="tool_not_allowed",
+        subject=subject,
+    )
+
+
 def _compile_legacy_tool_pattern(
     pattern: Any,
     *,
@@ -305,6 +365,18 @@ def _compile_structured_rules(
             )
         )
     return rules
+
+
+def _tool_rule_reason_code(rule: PolicyDecisionRule) -> str:
+    """Return the default runtime reason code for a matched tool rule."""
+
+    if rule.reason_code is not None:
+        return rule.reason_code
+    if rule.outcome == "ask":
+        return "approval_required"
+    if rule.outcome == "allow":
+        return "tool_allowed"
+    return "tool_denied"
 
 
 def _compile_structured_rule(

--- a/mcp_unified/profiles/decisions.py
+++ b/mcp_unified/profiles/decisions.py
@@ -73,6 +73,12 @@ class PolicyDecisionRule(BaseModel):
     argv: tuple[str, ...] | None = None
     reason_code: str | None = None
 
+    @model_validator(mode="after")
+    def _validate_command_rule(self) -> "PolicyDecisionRule":
+        if self.rule_type == "command":
+            _validate_command_rule_argv(self.argv)
+        return self
+
 
 class PolicyDecision(BaseModel):
     """Final or intermediate permission decision for one policy subject."""
@@ -232,8 +238,18 @@ def _bash_pattern_argv(inner: str) -> tuple[str, ...]:
     argv = tuple(normalized.split())
     if not argv:
         raise ValueError("bash patterns must include a command")
-    _validate_fixed_command_executable(argv)
+    _validate_command_rule_argv(argv)
     return argv
+
+
+def _validate_command_rule_argv(argv: tuple[str, ...] | None) -> None:
+    """Validate command argv shape and fixed executable token."""
+
+    if argv is None:
+        raise ValueError("command policy rule argv is required")
+    if not argv or not all(isinstance(item, str) and item for item in argv):
+        raise ValueError("command policy rule argv must be non-empty strings")
+    _validate_fixed_command_executable(argv)
 
 
 def _validate_fixed_command_executable(argv: tuple[str, ...]) -> None:
@@ -287,7 +303,7 @@ def _compile_structured_rule(
     if isinstance(rule_document, PolicyDecisionRule):
         if rule_document.rule_type != rule_type:
             raise ValueError("structured rule type does not match source field")
-        return rule_document
+        return PolicyDecisionRule.model_validate(rule_document.model_dump())
 
     outcome = _structured_rule_outcome(rule_document)
     reason_code = _optional_string(_policy_value(rule_document, "reason_code"))
@@ -341,9 +357,7 @@ def _structured_command_argv(rule_document: Any) -> tuple[str, ...]:
         raise ValueError("command policy rule argv must be a sequence")
 
     argv = tuple(argv_value)
-    if not argv or not all(isinstance(item, str) and item for item in argv):
-        raise ValueError("command policy rule argv must be non-empty strings")
-    _validate_fixed_command_executable(argv)
+    _validate_command_rule_argv(argv)
     return argv
 
 

--- a/mcp_unified/profiles/decisions.py
+++ b/mcp_unified/profiles/decisions.py
@@ -150,7 +150,17 @@ def merge_policy_decisions(
 def compile_profile_policy_rules(policy_document: Any) -> list[PolicyDecisionRule]:
     """Compile legacy and structured profile policy rules into typed records."""
 
-    rules = compile_profile_tool_policy_rules(policy_document)
+    rules = _compile_legacy_tool_rules(
+        policy_document,
+        include_legacy_bash=True,
+    )
+    rules.extend(
+        _compile_structured_rules(
+            policy_document,
+            field_name="tool_rules",
+            rule_type="tool",
+        )
+    )
     rules.extend(
         _compile_structured_rules(
             policy_document,
@@ -171,24 +181,10 @@ def compile_profile_policy_rules(policy_document: Any) -> list[PolicyDecisionRul
 def compile_profile_tool_policy_rules(policy_document: Any) -> list[PolicyDecisionRule]:
     """Compile only legacy and structured tool policy rules."""
 
-    rules: list[PolicyDecisionRule] = []
-    for pattern in _as_sequence(_policy_value(policy_document, "denied_tools")):
-        rules.append(
-            _compile_legacy_tool_pattern(
-                pattern,
-                outcome="deny",
-                source="denied_tools",
-            )
-        )
-    for pattern in _as_sequence(_policy_value(policy_document, "allowed_tools")):
-        rules.append(
-            _compile_legacy_tool_pattern(
-                pattern,
-                outcome="allow",
-                source="allowed_tools",
-            )
-        )
-
+    rules = _compile_legacy_tool_rules(
+        policy_document,
+        include_legacy_bash=False,
+    )
     rules.extend(
         _compile_structured_rules(
             policy_document,
@@ -196,6 +192,35 @@ def compile_profile_tool_policy_rules(policy_document: Any) -> list[PolicyDecisi
             rule_type="tool",
         )
     )
+    return rules
+
+
+def _compile_legacy_tool_rules(
+    policy_document: Any,
+    *,
+    include_legacy_bash: bool,
+) -> list[PolicyDecisionRule]:
+    """Compile legacy allowed and denied fields with optional Bash rule support."""
+
+    rules: list[PolicyDecisionRule] = []
+    for pattern in _as_sequence(_policy_value(policy_document, "denied_tools")):
+        rule = _compile_legacy_tool_pattern(
+            pattern,
+            outcome="deny",
+            source="denied_tools",
+            include_legacy_bash=include_legacy_bash,
+        )
+        if rule is not None:
+            rules.append(rule)
+    for pattern in _as_sequence(_policy_value(policy_document, "allowed_tools")):
+        rule = _compile_legacy_tool_pattern(
+            pattern,
+            outcome="allow",
+            source="allowed_tools",
+            include_legacy_bash=include_legacy_bash,
+        )
+        if rule is not None:
+            rules.append(rule)
     return rules
 
 
@@ -269,7 +294,8 @@ def _compile_legacy_tool_pattern(
     *,
     outcome: PolicyDecisionOutcome,
     source: str,
-) -> PolicyDecisionRule:
+    include_legacy_bash: bool,
+) -> PolicyDecisionRule | None:
     """Compile one legacy allowed or denied tool pattern."""
 
     if not isinstance(pattern, str):
@@ -277,6 +303,8 @@ def _compile_legacy_tool_pattern(
     if not pattern.strip():
         raise ValueError("legacy tool policy patterns cannot be empty")
     if pattern.startswith("Bash(") and pattern.endswith(")"):
+        if not include_legacy_bash:
+            return None
         return _compile_bash_pattern(
             pattern[len("Bash(") : -1],
             outcome=outcome,

--- a/mcp_unified/profiles/decisions.py
+++ b/mcp_unified/profiles/decisions.py
@@ -594,6 +594,9 @@ def _optional_string(value: Any) -> str | None:
 def _policy_value(policy_document: Any, key: str) -> Any:
     """Read a field from objects, Pydantic extras, or mapping documents."""
 
+    if isinstance(policy_document, Mapping):
+        return policy_document.get(key)
+
     value = getattr(policy_document, key, None)
     if value is not None:
         return value
@@ -601,6 +604,4 @@ def _policy_value(policy_document: Any, key: str) -> Any:
     model_extra = getattr(policy_document, "model_extra", None)
     if isinstance(model_extra, Mapping) and key in model_extra:
         return model_extra[key]
-    if isinstance(policy_document, Mapping):
-        return policy_document.get(key)
     return None

--- a/mcp_unified/profiles/decisions.py
+++ b/mcp_unified/profiles/decisions.py
@@ -2,13 +2,15 @@
 
 from __future__ import annotations
 
-from typing import Any, Literal
+from collections.abc import Iterable, Mapping
+from typing import Any, Literal, cast
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 PolicyDecisionOutcome = Literal["deny", "ask", "allow"]
 PolicyDecisionVisibility = Literal["hidden", "direct", "deferred", "debug_only"]
 PolicyDecisionCallState = Literal["blocked", "approval_required", "callable"]
+PolicyRuleType = Literal["tool", "command", "mcp", "capability", "risk_class"]
 
 _DEFAULTS_BY_OUTCOME: dict[PolicyDecisionOutcome, dict[str, Any]] = {
     "deny": {
@@ -27,6 +29,12 @@ _DEFAULTS_BY_OUTCOME: dict[PolicyDecisionOutcome, dict[str, Any]] = {
         "requires_approval": False,
     },
 }
+_OUTCOME_PRECEDENCE: dict[PolicyDecisionOutcome, int] = {
+    "allow": 1,
+    "ask": 2,
+    "deny": 3,
+}
+_VALID_OUTCOMES = frozenset(_OUTCOME_PRECEDENCE)
 
 
 class PolicyDecisionSubject(BaseModel):
@@ -49,6 +57,19 @@ class PolicyMatchedRule(BaseModel):
     rule_type: str
     pattern: str | None = None
     outcome: PolicyDecisionOutcome
+    reason_code: str | None = None
+
+
+class PolicyDecisionRule(BaseModel):
+    """Compiled rule from legacy or structured profile policy."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    rule_type: PolicyRuleType
+    outcome: PolicyDecisionOutcome
+    source: str
+    pattern: str | None = None
+    argv: tuple[str, ...] | None = None
     reason_code: str | None = None
 
 
@@ -77,3 +98,271 @@ class PolicyDecision(BaseModel):
         if self.requires_approval is None:
             self.requires_approval = bool(defaults["requires_approval"])
         return self
+
+
+def merge_policy_decisions(
+    decisions: list[PolicyDecision],
+    *,
+    subject: PolicyDecisionSubject,
+    default_reason_code: str = "no_matching_rule",
+) -> PolicyDecision:
+    """Merge intermediate decisions using deny, ask, then allow precedence."""
+
+    if not decisions:
+        return PolicyDecision(
+            outcome="deny",
+            reason_code=default_reason_code,
+            subject=subject,
+        )
+
+    winning_decision = max(
+        decisions,
+        key=lambda decision: _OUTCOME_PRECEDENCE[decision.outcome],
+    )
+    matched_rules = [matched_rule for decision in decisions for matched_rule in decision.matched_rules]
+    return PolicyDecision(
+        outcome=winning_decision.outcome,
+        reason_code=winning_decision.reason_code,
+        subject=subject,
+        matched_rules=matched_rules,
+        visibility=winning_decision.visibility,
+        call_state=winning_decision.call_state,
+        requires_approval=winning_decision.requires_approval,
+        explainable=winning_decision.explainable,
+        redacted=winning_decision.redacted,
+    )
+
+
+def compile_profile_policy_rules(policy_document: Any) -> list[PolicyDecisionRule]:
+    """Compile legacy and structured profile policy rules into typed records."""
+
+    rules: list[PolicyDecisionRule] = []
+    for pattern in _as_sequence(_policy_value(policy_document, "denied_tools")):
+        rules.append(
+            _compile_legacy_tool_pattern(
+                pattern,
+                outcome="deny",
+                source="denied_tools",
+            )
+        )
+    for pattern in _as_sequence(_policy_value(policy_document, "allowed_tools")):
+        rules.append(
+            _compile_legacy_tool_pattern(
+                pattern,
+                outcome="allow",
+                source="allowed_tools",
+            )
+        )
+
+    rules.extend(
+        _compile_structured_rules(
+            policy_document,
+            field_name="tool_rules",
+            rule_type="tool",
+        )
+    )
+    rules.extend(
+        _compile_structured_rules(
+            policy_document,
+            field_name="command_rules",
+            rule_type="command",
+        )
+    )
+    rules.extend(
+        _compile_structured_rules(
+            policy_document,
+            field_name="mcp_rules",
+            rule_type="mcp",
+        )
+    )
+    return rules
+
+
+def _compile_legacy_tool_pattern(
+    pattern: Any,
+    *,
+    outcome: PolicyDecisionOutcome,
+    source: str,
+) -> PolicyDecisionRule:
+    """Compile one legacy allowed or denied tool pattern."""
+
+    if not isinstance(pattern, str):
+        raise ValueError("legacy tool policy patterns must be strings")
+    if pattern.startswith("Bash(") and pattern.endswith(")"):
+        return _compile_bash_pattern(
+            pattern[len("Bash(") : -1],
+            outcome=outcome,
+            source=source,
+        )
+    return PolicyDecisionRule(
+        rule_type="tool",
+        outcome=outcome,
+        source=source,
+        pattern=pattern,
+    )
+
+
+def _compile_bash_pattern(
+    inner: str,
+    *,
+    outcome: PolicyDecisionOutcome,
+    source: str,
+) -> PolicyDecisionRule:
+    """Compile a legacy Bash(...) pattern into a command argv rule."""
+
+    return PolicyDecisionRule(
+        rule_type="command",
+        outcome=outcome,
+        source=source,
+        pattern=f"Bash({inner})",
+        argv=_bash_pattern_argv(inner),
+    )
+
+
+def _bash_pattern_argv(inner: str) -> tuple[str, ...]:
+    """Return argv tokens for a legacy Bash(...) pattern."""
+
+    normalized = inner.strip()
+    if normalized == "*":
+        raise ValueError("broad bash patterns are not allowed")
+
+    argv = tuple(normalized.split())
+    if not argv:
+        raise ValueError("bash patterns must include a command")
+    return argv
+
+
+def _as_sequence(value: Any) -> list[Any]:
+    """Return value as a list while treating strings and mappings as scalars."""
+
+    if value is None:
+        return []
+    if isinstance(value, (str, bytes, Mapping)):
+        return [value]
+    if isinstance(value, Iterable):
+        return list(value)
+    return [value]
+
+
+def _compile_structured_rules(
+    policy_document: Any,
+    *,
+    field_name: str,
+    rule_type: PolicyRuleType,
+) -> list[PolicyDecisionRule]:
+    """Compile one structured profile-policy rule list."""
+
+    rules: list[PolicyDecisionRule] = []
+    for index, rule_document in enumerate(_as_sequence(_policy_value(policy_document, field_name))):
+        rules.append(
+            _compile_structured_rule(
+                rule_document,
+                rule_type=rule_type,
+                source=f"{field_name}[{index}]",
+            )
+        )
+    return rules
+
+
+def _compile_structured_rule(
+    rule_document: Any,
+    *,
+    rule_type: PolicyRuleType,
+    source: str,
+) -> PolicyDecisionRule:
+    """Compile one structured rule entry into a typed rule."""
+
+    if isinstance(rule_document, PolicyDecisionRule):
+        if rule_document.rule_type != rule_type:
+            raise ValueError("structured rule type does not match source field")
+        return rule_document
+
+    outcome = _structured_rule_outcome(rule_document)
+    reason_code = _optional_string(_policy_value(rule_document, "reason_code"))
+    if rule_type == "command":
+        argv = _structured_command_argv(rule_document)
+        pattern = _optional_string(_policy_value(rule_document, "pattern"))
+        return PolicyDecisionRule(
+            rule_type="command",
+            outcome=outcome,
+            source=source,
+            pattern=pattern,
+            argv=argv,
+            reason_code=reason_code,
+        )
+
+    pattern = _required_pattern(rule_document, rule_type=rule_type)
+    return PolicyDecisionRule(
+        rule_type=rule_type,
+        outcome=outcome,
+        source=source,
+        pattern=pattern,
+        reason_code=reason_code,
+    )
+
+
+def _structured_rule_outcome(rule_document: Any) -> PolicyDecisionOutcome:
+    """Return the validated deny, ask, or allow outcome for a rule."""
+
+    outcome = _policy_value(rule_document, "outcome")
+    effect = _policy_value(rule_document, "effect")
+    if outcome is not None and effect is not None and outcome != effect:
+        raise ValueError("conflicting policy rule outcome and effect")
+
+    raw_outcome = outcome if outcome is not None else effect
+    if not isinstance(raw_outcome, str) or raw_outcome not in _VALID_OUTCOMES:
+        raise ValueError("policy rule outcome must be deny, ask, or allow")
+    return cast(PolicyDecisionOutcome, raw_outcome)
+
+
+def _structured_command_argv(rule_document: Any) -> tuple[str, ...]:
+    """Return validated argv for a structured command rule."""
+
+    argv_value = _policy_value(rule_document, "argv")
+    if argv_value is None:
+        pattern = _policy_value(rule_document, "pattern")
+        if isinstance(pattern, str) and pattern.startswith("Bash(") and pattern.endswith(")"):
+            return _bash_pattern_argv(pattern[len("Bash(") : -1])
+        raise ValueError("command policy rules require argv")
+
+    if isinstance(argv_value, str):
+        argv = tuple(argv_value.split())
+    else:
+        argv = tuple(_as_sequence(argv_value))
+    if not argv or not all(isinstance(item, str) and item for item in argv):
+        raise ValueError("command policy rule argv must be non-empty strings")
+    return argv
+
+
+def _required_pattern(rule_document: Any, *, rule_type: PolicyRuleType) -> str:
+    """Return the required string pattern for a non-command rule."""
+
+    pattern = _policy_value(rule_document, "pattern")
+    if not isinstance(pattern, str) or not pattern:
+        raise ValueError(f"{rule_type} policy rules require a pattern")
+    return pattern
+
+
+def _optional_string(value: Any) -> str | None:
+    """Return an optional string field, rejecting non-string values."""
+
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise ValueError("policy rule string fields must be strings")
+    return value
+
+
+def _policy_value(policy_document: Any, key: str) -> Any:
+    """Read a field from objects, Pydantic extras, or mapping documents."""
+
+    value = getattr(policy_document, key, None)
+    if value is not None:
+        return value
+
+    model_extra = getattr(policy_document, "model_extra", None)
+    if isinstance(model_extra, Mapping) and key in model_extra:
+        return model_extra[key]
+    if isinstance(policy_document, Mapping):
+        return policy_document.get(key)
+    return None

--- a/mcp_unified/profiles/decisions.py
+++ b/mcp_unified/profiles/decisions.py
@@ -1,0 +1,79 @@
+"""Decision primitives for MCP profile policy evaluation."""
+
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+PolicyDecisionOutcome = Literal["deny", "ask", "allow"]
+PolicyDecisionVisibility = Literal["hidden", "direct", "deferred", "debug_only"]
+PolicyDecisionCallState = Literal["blocked", "approval_required", "callable"]
+
+_DEFAULTS_BY_OUTCOME: dict[PolicyDecisionOutcome, dict[str, Any]] = {
+    "deny": {
+        "visibility": "hidden",
+        "call_state": "blocked",
+        "requires_approval": False,
+    },
+    "ask": {
+        "visibility": "direct",
+        "call_state": "approval_required",
+        "requires_approval": True,
+    },
+    "allow": {
+        "visibility": "direct",
+        "call_state": "callable",
+        "requires_approval": False,
+    },
+}
+
+
+class PolicyDecisionSubject(BaseModel):
+    """Normalized policy subject used by decision and explain payloads."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    type: str
+    normalized: str
+    display_name: str | None = None
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+
+class PolicyMatchedRule(BaseModel):
+    """Redacted summary of one rule that contributed to a decision."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    source: str
+    rule_type: str
+    pattern: str | None = None
+    outcome: PolicyDecisionOutcome
+    reason_code: str | None = None
+
+
+class PolicyDecision(BaseModel):
+    """Final or intermediate permission decision for one policy subject."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    outcome: PolicyDecisionOutcome
+    reason_code: str
+    subject: PolicyDecisionSubject
+    matched_rules: list[PolicyMatchedRule] = Field(default_factory=list)
+    visibility: PolicyDecisionVisibility | None = None
+    call_state: PolicyDecisionCallState | None = None
+    requires_approval: bool | None = None
+    explainable: bool = True
+    redacted: bool = True
+
+    @model_validator(mode="after")
+    def _derive_defaults(self) -> "PolicyDecision":
+        defaults = _DEFAULTS_BY_OUTCOME[self.outcome]
+        if self.visibility is None:
+            self.visibility = defaults["visibility"]
+        if self.call_state is None:
+            self.call_state = defaults["call_state"]
+        if self.requires_approval is None:
+            self.requires_approval = bool(defaults["requires_approval"])
+        return self

--- a/mcp_unified/profiles/decisions.py
+++ b/mcp_unified/profiles/decisions.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterable, Mapping
+from collections.abc import Iterable, Mapping, Sequence
 from typing import Any, Literal, cast
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
@@ -35,6 +35,7 @@ _OUTCOME_PRECEDENCE: dict[PolicyDecisionOutcome, int] = {
     "deny": 3,
 }
 _VALID_OUTCOMES = frozenset(_OUTCOME_PRECEDENCE)
+_COMMAND_EXECUTABLE_WILDCARDS = frozenset("*?[]")
 
 
 class PolicyDecisionSubject(BaseModel):
@@ -188,6 +189,8 @@ def _compile_legacy_tool_pattern(
 
     if not isinstance(pattern, str):
         raise ValueError("legacy tool policy patterns must be strings")
+    if not pattern.strip():
+        raise ValueError("legacy tool policy patterns cannot be empty")
     if pattern.startswith("Bash(") and pattern.endswith(")"):
         return _compile_bash_pattern(
             pattern[len("Bash(") : -1],
@@ -229,7 +232,16 @@ def _bash_pattern_argv(inner: str) -> tuple[str, ...]:
     argv = tuple(normalized.split())
     if not argv:
         raise ValueError("bash patterns must include a command")
+    _validate_fixed_command_executable(argv)
     return argv
+
+
+def _validate_fixed_command_executable(argv: tuple[str, ...]) -> None:
+    """Require command rules to name a fixed executable token."""
+
+    executable = argv[0]
+    if any(character in _COMMAND_EXECUTABLE_WILDCARDS for character in executable):
+        raise ValueError("command executable must be fixed")
 
 
 def _as_sequence(value: Any) -> list[Any]:
@@ -325,12 +337,13 @@ def _structured_command_argv(rule_document: Any) -> tuple[str, ...]:
             return _bash_pattern_argv(pattern[len("Bash(") : -1])
         raise ValueError("command policy rules require argv")
 
-    if isinstance(argv_value, str):
-        argv = tuple(argv_value.split())
-    else:
-        argv = tuple(_as_sequence(argv_value))
+    if isinstance(argv_value, (str, bytes, Mapping)) or not isinstance(argv_value, Sequence):
+        raise ValueError("command policy rule argv must be a sequence")
+
+    argv = tuple(argv_value)
     if not argv or not all(isinstance(item, str) and item for item in argv):
         raise ValueError("command policy rule argv must be non-empty strings")
+    _validate_fixed_command_executable(argv)
     return argv
 
 

--- a/mcp_unified/profiles/presets.py
+++ b/mcp_unified/profiles/presets.py
@@ -186,8 +186,11 @@ _TOOL_DISCOVERY_TOOLS = [
     "tool_describe",
     "profile.tools.list",
 ]
-_FILES_READ_TOOLS = ["fs.list", "fs.read_text", "fs.stat", "fs.glob", "fs.grep"]
-_FILES_WRITE_TOOLS = [*_FILES_READ_TOOLS, "fs.write_text"]
+_FILES_READ_TOOLS = ["fs.list", "fs.read", "fs.stat", "fs.glob", "fs.grep"]
+_FILES_EDIT_TOOLS = [*_FILES_READ_TOOLS, "fs.patch"]
+_FILES_WRITE_TOOLS = [*_FILES_EDIT_TOOLS, "fs.write"]
+_LEGACY_FILES_READ_TOOLS = ["fs.read_text"]
+_LEGACY_FILES_WRITE_TOOLS = ["fs.write_text"]
 _CODE_READ_TOOLS = ["code.search", "code.symbols", "code.references"]
 _DOCS_READ_TOOLS = ["docs.search", "docs.read"]
 _DOCS_WRITE_TOOLS = [*_DOCS_READ_TOOLS, "docs.write"]
@@ -559,11 +562,11 @@ _BUILTIN_PRESETS: tuple[ProfilePreset, ...] = (
                 "files",
                 "code",
                 "git",
-                "tests",
                 "backend",
                 "tool_discovery",
             ],
             deferred_categories=[
+                "tests",
                 "safe_test_runner",
                 "issue_tracker",
                 "browser",
@@ -629,12 +632,12 @@ _BUILTIN_PRESETS: tuple[ProfilePreset, ...] = (
             direct_categories=[
                 "files",
                 "code",
-                "tests",
                 "browser",
                 "frontend",
                 "tool_discovery",
             ],
             deferred_categories=[
+                "tests",
                 "git",
                 "safe_test_runner",
                 "issue_tracker",

--- a/mcp_unified/profiles/resolution.py
+++ b/mcp_unified/profiles/resolution.py
@@ -166,12 +166,8 @@ def build_effective_policy_result(
             resource_constraints=(policy_document.resource_constraints or {}).copy(),
             approval_policy=(profile.approval_policy or {}).copy(),
             path_scopes=[scope.copy() for scope in (profile.path_scopes or [])],
-            external_server_grants=[
-                grant.copy() for grant in (profile.external_server_grants or [])
-            ],
-            credential_grants=[
-                grant.copy() for grant in (profile.credential_grants or [])
-            ],
+            external_server_grants=[grant.copy() for grant in (profile.external_server_grants or [])],
+            credential_grants=[grant.copy() for grant in (profile.credential_grants or [])],
         ),
         decision=decision,
         provenance=provenance,
@@ -187,8 +183,7 @@ def _requires_workspace_binding(profile: MCPProfile) -> bool:
 
     capabilities = policy_document.capabilities or []
     if any(
-        any(token in str(capability).lower() for token in ("write", "mutate", "delete"))
-        for capability in capabilities
+        any(token in str(capability).lower() for token in ("write", "mutate", "delete")) for capability in capabilities
     ):
         return True
 
@@ -214,10 +209,7 @@ def _mapping_has_workspace_binding(mapping: dict[str, Any] | None) -> bool:
     """Return whether a mapping carries a recognized non-empty workspace binding."""
     if not mapping:
         return False
-    return any(
-        _has_workspace_binding_value(mapping.get(key))
-        for key in _WORKSPACE_BINDING_KEYS
-    )
+    return any(_has_workspace_binding_value(mapping.get(key)) for key in _WORKSPACE_BINDING_KEYS)
 
 
 def _has_workspace_binding_value(value: Any) -> bool:

--- a/mcp_unified/profiles/resolution.py
+++ b/mcp_unified/profiles/resolution.py
@@ -119,7 +119,11 @@ def build_effective_policy_result(
             tool_name,
             capability=capability,
         )
-        if decision.outcome == "deny":
+        if decision.outcome == "deny" and not _should_continue_capability_checks(
+            decision,
+            allowed_tools=allowed_tools,
+            capability=capability,
+        ):
             return EffectivePolicyResult(
                 status="denied",
                 reason_code=decision.reason_code,
@@ -225,6 +229,21 @@ def _has_workspace_binding_value(value: Any) -> bool:
     if isinstance(value, list):
         return any(_has_workspace_binding_value(item) for item in value)
     return bool(value)
+
+
+def _should_continue_capability_checks(
+    decision: PolicyDecision,
+    *,
+    allowed_tools: list[str],
+    capability: str | None,
+) -> bool:
+    """Return whether an unmatched capability-only tool decision needs capability checks."""
+    return (
+        decision.reason_code == "tool_not_allowed"
+        and not decision.matched_rules
+        and not allowed_tools
+        and capability is not None
+    )
 
 
 def _capability_allowed(capability: str, capabilities: list[str]) -> bool:

--- a/mcp_unified/profiles/resolution.py
+++ b/mcp_unified/profiles/resolution.py
@@ -113,6 +113,7 @@ def build_effective_policy_result(
     denied_capabilities = list(policy_document.denied_capabilities or [])
 
     decision: PolicyDecision | None = None
+    approval_required = False
     if tool_name is not None:
         decision = evaluate_profile_tool_decision(
             profile,
@@ -131,12 +132,7 @@ def build_effective_policy_result(
                 provenance={**provenance, "tool_name": tool_name},
             )
         if decision.outcome == "ask":
-            return EffectivePolicyResult(
-                status="approval_required",
-                reason_code=decision.reason_code,
-                decision=decision,
-                provenance={**provenance, "tool_name": tool_name},
-            )
+            approval_required = True
 
     if capability is not None:
         if capability in denied_capabilities:
@@ -153,6 +149,16 @@ def build_effective_policy_result(
                 decision=decision,
                 provenance={**provenance, "capability": capability},
             )
+
+    if approval_required:
+        if decision is None:
+            raise RuntimeError("approval_required set without a policy decision")
+        return EffectivePolicyResult(
+            status="approval_required",
+            reason_code=decision.reason_code,
+            decision=decision,
+            provenance={**provenance, "tool_name": tool_name},
+        )
 
     return EffectivePolicyResult(
         status="resolved",

--- a/mcp_unified/profiles/resolution.py
+++ b/mcp_unified/profiles/resolution.py
@@ -6,6 +6,7 @@ from typing import Any, Literal
 
 from pydantic import BaseModel, Field
 
+from .decisions import PolicyDecision, evaluate_profile_tool_decision
 from .models import MCPProfile
 
 _WORKSPACE_BINDING_KEYS = (
@@ -64,6 +65,7 @@ class EffectivePolicyResult(BaseModel):
     status: EffectivePolicyStatus
     reason_code: str
     policy: EffectivePolicy | None = None
+    decision: PolicyDecision | None = None
     provenance: dict[str, Any] = Field(default_factory=dict)
     warnings: list[dict[str, Any]] = Field(default_factory=list)
 
@@ -110,17 +112,25 @@ def build_effective_policy_result(
     capabilities = list(policy_document.capabilities or [])
     denied_capabilities = list(policy_document.denied_capabilities or [])
 
+    decision: PolicyDecision | None = None
     if tool_name is not None:
-        if tool_name in denied_tools:
+        decision = evaluate_profile_tool_decision(
+            profile,
+            tool_name,
+            capability=capability,
+        )
+        if decision.outcome == "deny":
             return EffectivePolicyResult(
                 status="denied",
-                reason_code="tool_denied",
+                reason_code=decision.reason_code,
+                decision=decision,
                 provenance={**provenance, "tool_name": tool_name},
             )
-        if not _tool_allowed(tool_name, allowed_tools, capability):
+        if decision.outcome == "ask":
             return EffectivePolicyResult(
-                status="denied",
-                reason_code="tool_not_allowed",
+                status="approval_required",
+                reason_code=decision.reason_code,
+                decision=decision,
                 provenance={**provenance, "tool_name": tool_name},
             )
 
@@ -129,12 +139,14 @@ def build_effective_policy_result(
             return EffectivePolicyResult(
                 status="denied",
                 reason_code="capability_denied",
+                decision=decision,
                 provenance={**provenance, "capability": capability},
             )
         if not _capability_allowed(capability, capabilities):
             return EffectivePolicyResult(
                 status="denied",
                 reason_code="capability_not_allowed",
+                decision=decision,
                 provenance={**provenance, "capability": capability},
             )
 
@@ -157,6 +169,7 @@ def build_effective_policy_result(
                 grant.copy() for grant in (profile.credential_grants or [])
             ],
         ),
+        decision=decision,
         provenance=provenance,
     )
 
@@ -212,17 +225,6 @@ def _has_workspace_binding_value(value: Any) -> bool:
     if isinstance(value, list):
         return any(_has_workspace_binding_value(item) for item in value)
     return bool(value)
-
-
-def _tool_allowed(
-    tool_name: str,
-    allowed_tools: list[str],
-    capability: str | None,
-) -> bool:
-    """Return whether a requested tool is allowed by explicit profile policy."""
-    if allowed_tools:
-        return tool_name in allowed_tools
-    return capability is not None
 
 
 def _capability_allowed(capability: str, capabilities: list[str]) -> bool:

--- a/tldw_Server_API/app/core/MCP_unified/modules/base.py
+++ b/tldw_Server_API/app/core/MCP_unified/modules/base.py
@@ -16,6 +16,8 @@ from typing import Any, Optional, TypeVar
 
 from loguru import logger
 
+from mcp_unified.interfaces.path_scope import PathScopeCandidate
+
 from ..tool_observability import ensure_tool_definition_eval_metadata
 
 T = TypeVar("T")
@@ -598,6 +600,17 @@ class BaseModule(ABC):
         """
         # Basic validation - check required fields
         pass
+
+    async def extract_path_scope_candidates(
+        self,
+        tool_name: str,
+        arguments: dict[str, Any],
+        context: Optional[Any] = None,
+    ) -> list[PathScopeCandidate]:
+        """Return module-derived path/action candidates for path-scope enforcement."""
+
+        del arguments, context
+        raise NotImplementedError(f"Path scope candidate extraction not implemented for {tool_name}")
 
     def sanitize_input(self, input_data: Any, _depth: int = 0) -> Any:
         """

--- a/tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_diff.py
+++ b/tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_diff.py
@@ -1,0 +1,241 @@
+"""Unified diff parsing and in-memory patch planning for filesystem tools."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Literal
+
+
+PatchLineKind = Literal["context", "add", "remove"]
+PatchFileAction = Literal["modify", "create"]
+
+_HUNK_HEADER = re.compile(r"^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@(?: .*)?$")
+
+
+class FilesystemPatchError(ValueError):
+    """Raised when a unified diff cannot be parsed or applied safely."""
+
+    def __init__(self, reason_code: str) -> None:
+        super().__init__(reason_code)
+        self.reason_code = reason_code
+
+
+@dataclass(frozen=True, slots=True)
+class PatchHunkLine:
+    """One context, addition, or removal line inside a unified-diff hunk."""
+
+    kind: PatchLineKind
+    text: str
+
+
+@dataclass(frozen=True, slots=True)
+class PatchHunk:
+    """Parsed unified-diff hunk with old and new line ranges."""
+
+    old_start: int
+    old_count: int
+    new_start: int
+    new_count: int
+    lines: tuple[PatchHunkLine, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class PatchFile:
+    """One file-level patch from a unified diff."""
+
+    old_path: str | None
+    new_path: str | None
+    action: PatchFileAction
+    hunks: tuple[PatchHunk, ...]
+
+
+def parse_unified_diff(
+    diff_text: str,
+    *,
+    max_files: int,
+    max_hunks: int,
+    max_bytes: int,
+) -> tuple[PatchFile, ...]:
+    """Parse bounded unified diff text into file-level patch plans."""
+
+    if not isinstance(diff_text, str) or not diff_text.strip():
+        raise FilesystemPatchError("invalid_diff")
+    if len(diff_text.encode("utf-8")) > max(1, int(max_bytes)):
+        raise FilesystemPatchError("diff_too_large")
+
+    lines = diff_text.splitlines()
+    files: list[PatchFile] = []
+    hunk_count = 0
+    index = 0
+
+    while index < len(lines):
+        if not lines[index].startswith("--- "):
+            index += 1
+            continue
+
+        old_path = _parse_header_path(lines[index][4:])
+        index += 1
+        if index >= len(lines) or not lines[index].startswith("+++ "):
+            raise FilesystemPatchError("invalid_diff")
+        new_path = _parse_header_path(lines[index][4:])
+        index += 1
+
+        if old_path is None and new_path is None:
+            raise FilesystemPatchError("invalid_patch_path")
+        if new_path is None:
+            raise FilesystemPatchError("delete_not_supported")
+        if old_path is None:
+            action: PatchFileAction = "create"
+        else:
+            if old_path != new_path:
+                raise FilesystemPatchError("rename_not_supported")
+            action = "modify"
+
+        hunks: list[PatchHunk] = []
+        while index < len(lines) and not lines[index].startswith("--- "):
+            if not lines[index].startswith("@@ "):
+                raise FilesystemPatchError("invalid_diff")
+            hunk, index = _parse_hunk(lines, index)
+            hunks.append(hunk)
+            hunk_count += 1
+            if hunk_count > max(1, int(max_hunks)):
+                raise FilesystemPatchError("diff_hunk_limit_exceeded")
+
+        if not hunks:
+            raise FilesystemPatchError("invalid_diff")
+        files.append(PatchFile(old_path=old_path, new_path=new_path, action=action, hunks=tuple(hunks)))
+        if len(files) > max(1, int(max_files)):
+            raise FilesystemPatchError("diff_file_limit_exceeded")
+
+    if not files:
+        raise FilesystemPatchError("invalid_diff")
+    return tuple(files)
+
+
+def apply_patch_to_text(original: str, patch_file: PatchFile) -> str:
+    """Apply one parsed file patch to original text without touching the filesystem."""
+
+    original_lines = original.splitlines(keepends=True)
+    newline = _detect_output_newline(original_lines)
+    output: list[str] = []
+    cursor = 0
+
+    for hunk in patch_file.hunks:
+        hunk_start = max(0, hunk.old_start - 1)
+        if hunk_start < cursor:
+            raise FilesystemPatchError("patch_context_mismatch")
+        output.extend(original_lines[cursor:hunk_start])
+        cursor = hunk_start
+
+        for hunk_line in hunk.lines:
+            if hunk_line.kind == "add":
+                output.append(f"{hunk_line.text}{newline}")
+                continue
+
+            if cursor >= len(original_lines):
+                raise FilesystemPatchError("patch_context_mismatch")
+            if _line_body(original_lines[cursor]) != hunk_line.text:
+                raise FilesystemPatchError("patch_context_mismatch")
+            if hunk_line.kind == "context":
+                output.append(original_lines[cursor])
+            cursor += 1
+
+    output.extend(original_lines[cursor:])
+    return "".join(output)
+
+
+def _parse_hunk(lines: list[str], start_index: int) -> tuple[PatchHunk, int]:
+    match = _HUNK_HEADER.match(lines[start_index])
+    if match is None:
+        raise FilesystemPatchError("invalid_hunk_header")
+
+    old_start = int(match.group(1))
+    old_count = int(match.group(2) or "1")
+    new_start = int(match.group(3))
+    new_count = int(match.group(4) or "1")
+    hunk_lines: list[PatchHunkLine] = []
+    old_seen = 0
+    new_seen = 0
+    index = start_index + 1
+
+    while index < len(lines) and not lines[index].startswith("@@ ") and not lines[index].startswith("--- "):
+        raw_line = lines[index]
+        index += 1
+        if raw_line == r"\ No newline at end of file":
+            continue
+        if not raw_line:
+            raise FilesystemPatchError("invalid_hunk_line")
+
+        prefix = raw_line[0]
+        text = raw_line[1:]
+        if prefix == " ":
+            hunk_lines.append(PatchHunkLine(kind="context", text=text))
+            old_seen += 1
+            new_seen += 1
+        elif prefix == "-":
+            hunk_lines.append(PatchHunkLine(kind="remove", text=text))
+            old_seen += 1
+        elif prefix == "+":
+            hunk_lines.append(PatchHunkLine(kind="add", text=text))
+            new_seen += 1
+        else:
+            raise FilesystemPatchError("invalid_hunk_line")
+
+    if old_seen != old_count or new_seen != new_count:
+        raise FilesystemPatchError("invalid_hunk_line_count")
+    return (
+        PatchHunk(
+            old_start=old_start,
+            old_count=old_count,
+            new_start=new_start,
+            new_count=new_count,
+            lines=tuple(hunk_lines),
+        ),
+        index,
+    )
+
+
+def _parse_header_path(raw_path: str) -> str | None:
+    candidate = raw_path.strip().split("\t", 1)[0].strip()
+    if " " in candidate:
+        candidate = candidate.split(" ", 1)[0].strip()
+    if candidate == "/dev/null":
+        return None
+    if candidate.startswith("a/") or candidate.startswith("b/"):
+        candidate = candidate[2:]
+    return _normalize_patch_path(candidate)
+
+
+def _normalize_patch_path(raw_path: str) -> str:
+    candidate = raw_path.strip().replace("\\", "/")
+    if not candidate or candidate in {".", "/"}:
+        raise FilesystemPatchError("invalid_patch_path")
+    if candidate.startswith("/") or candidate.startswith("//"):
+        raise FilesystemPatchError("invalid_patch_path")
+    if len(candidate) >= 2 and candidate[1] == ":" and candidate[0].isalpha():
+        raise FilesystemPatchError("invalid_patch_path")
+
+    parts = candidate.split("/")
+    if any(part in {"", ".", ".."} for part in parts):
+        raise FilesystemPatchError("invalid_patch_path")
+    return "/".join(parts)
+
+
+def _detect_output_newline(lines: list[str]) -> str:
+    for line in lines:
+        if line.endswith("\r\n"):
+            return "\r\n"
+        if line.endswith("\n"):
+            return "\n"
+        if line.endswith("\r"):
+            return "\r"
+    return "\n"
+
+
+def _line_body(line: str) -> str:
+    if line.endswith("\r\n"):
+        return line[:-2]
+    if line.endswith("\n") or line.endswith("\r"):
+        return line[:-1]
+    return line

--- a/tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_diff.py
+++ b/tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_diff.py
@@ -123,7 +123,7 @@ def apply_patch_to_text(original: str, patch_file: PatchFile) -> str:
 
     for hunk in patch_file.hunks:
         hunk_start = max(0, hunk.old_start - 1)
-        if hunk_start < cursor:
+        if hunk_start < cursor or hunk_start > len(original_lines):
             raise FilesystemPatchError("patch_context_mismatch")
         output.extend(original_lines[cursor:hunk_start])
         cursor = hunk_start
@@ -146,6 +146,8 @@ def apply_patch_to_text(original: str, patch_file: PatchFile) -> str:
 
 
 def _parse_hunk(lines: list[str], start_index: int) -> tuple[PatchHunk, int]:
+    """Parse one unified-diff hunk and return the next unread line index."""
+
     match = _HUNK_HEADER.match(lines[start_index])
     if match is None:
         raise FilesystemPatchError("invalid_hunk_header")

--- a/tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_module.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import asyncio
 import fnmatch
+import hashlib
 import os
 import re
 import stat as stat_module
@@ -28,7 +29,9 @@ from tldw_Server_API.app.services.mcp_hub_workspace_root_resolver import (
     McpHubWorkspaceRootResolver,
 )
 
+from ...tool_observability import build_execution_eval_metadata
 from ..base import BaseModule, ModuleConfig, create_tool_definition
+from .filesystem_receipts import ReadReceiptManager
 
 
 def _first_nonempty(*values: Any) -> str | None:
@@ -51,6 +54,10 @@ class FilesystemModule(BaseModule):
     ) -> None:
         super().__init__(config)
         self._workspace_root_resolver = workspace_root_resolver or McpHubWorkspaceRootResolver()
+        self._read_receipts = ReadReceiptManager(
+            secret=config.settings.get("read_receipt_secret"),
+            ttl_seconds=self._setting_positive_int("read_receipt_ttl_seconds", 1_800),
+        )
 
     async def on_initialize(self) -> None:
         logger.info(f"Initializing Filesystem module: {self.name}")
@@ -104,6 +111,34 @@ class FilesystemModule(BaseModule):
             },
         )
         read_text_tool["inputSchema"]["additionalProperties"] = False
+
+        read_tool = create_tool_definition(
+            name="fs.read",
+            description="Read a bounded UTF-8 text file with hash metadata under the active trusted workspace root.",
+            parameters={
+                "properties": {
+                    "path": {"type": "string", "description": "Workspace-relative or absolute file path"},
+                    "start_line": {"type": "integer", "minimum": 1, "default": 1},
+                    "max_lines": {"type": "integer", "minimum": 1},
+                    "max_bytes": {"type": "integer", "minimum": 1},
+                    "include_line_numbers": {"type": "boolean", "default": False},
+                    "include_receipt": {"type": "boolean", "default": True},
+                },
+                "required": ["path"],
+            },
+            metadata={
+                "category": "retrieval",
+                "readOnlyHint": True,
+                "capabilities": ["filesystem.read"],
+                "path_scope_action": "read",
+                "eval": {
+                    "task_families": ["filesystem_read"],
+                    "expected_result_kind": "structured_filesystem_read",
+                },
+                **shared_path_metadata,
+            },
+        )
+        read_tool["inputSchema"]["additionalProperties"] = False
 
         write_text_tool = create_tool_definition(
             name="fs.write_text",
@@ -204,7 +239,7 @@ class FilesystemModule(BaseModule):
         )
         grep_tool["inputSchema"]["additionalProperties"] = False
 
-        return [list_tool, read_text_tool, write_text_tool, stat_tool, glob_tool, grep_tool]
+        return [list_tool, read_tool, read_text_tool, write_text_tool, stat_tool, glob_tool, grep_tool]
 
     async def execute_tool(self, tool_name: str, arguments: dict[str, Any], context: Any | None = None) -> Any:
         args = self.sanitize_input(arguments or {})
@@ -228,6 +263,50 @@ class FilesystemModule(BaseModule):
                 "path": self._to_workspace_relative_path(workspace_root, target),
                 "text": read_result["text"],
             }
+
+        if tool_name == "fs.read":
+            target = self._resolve_workspace_path_no_follow(workspace_root, str(args.get("path")))
+            rel_path = self._to_workspace_relative_path(workspace_root, target)
+            read_result = await asyncio.to_thread(
+                self._read_file,
+                target,
+                start_line=int(args.get("start_line", 1)),
+                max_lines=self._bounded_positive_int(
+                    args.get("max_lines"),
+                    self._setting_positive_int("read_default_max_lines", 2_000),
+                    maximum=self._setting_positive_int("read_max_lines", 20_000),
+                ),
+                max_bytes=self._bounded_positive_int(
+                    args.get("max_bytes"),
+                    self._setting_positive_int("read_default_max_bytes", self._max_read_bytes()),
+                    maximum=self._setting_positive_int("read_max_bytes", self._max_read_bytes()),
+                ),
+                hash_max_file_bytes=self._setting_positive_int("read_hash_max_file_bytes", 5_000_000),
+                include_line_numbers=bool(args.get("include_line_numbers", False)),
+            )
+            result = {"path": rel_path, **read_result}
+            if (
+                bool(args.get("include_receipt", True))
+                and not result.get("truncated")
+                and isinstance(result.get("sha256"), str)
+            ):
+                result["read_receipt"] = self._read_receipts.issue(
+                    path=rel_path,
+                    sha256=str(result["sha256"]),
+                    size=int(result.get("bytes_total") or 0),
+                    workspace_id=self._context_metadata_value(context, "workspace_id"),
+                    session_id=_first_nonempty(getattr(context, "session_id", None), self._context_metadata_value(context, "session_id")),
+                )
+            result["eval"] = build_execution_eval_metadata(
+                tool_name="fs.read",
+                tool_prompt_id="mcp.fs.read.v1",
+                tool_prompt_version="2026.06.04",
+                action_family="filesystem_read",
+                result_kind="structured_filesystem_read",
+                path_filter_used=True,
+                truncated=bool(result.get("truncated", False)),
+            )
+            return result
 
         if tool_name == "fs.write_text":
             target = self._resolve_workspace_path(workspace_root, str(args.get("path")))
@@ -371,6 +450,30 @@ class FilesystemModule(BaseModule):
             path = arguments.get("path")
             if not isinstance(path, str) or not path.strip():
                 raise ValueError("path is required")
+            return
+
+        if tool_name == "fs.read":
+            unknown = sorted(
+                set(arguments)
+                - {
+                    "path",
+                    "start_line",
+                    "max_lines",
+                    "max_bytes",
+                    "include_line_numbers",
+                    "include_receipt",
+                }
+            )
+            if unknown:
+                raise ValueError(f"unknown arguments: {', '.join(unknown)}")
+            path = arguments.get("path")
+            if not isinstance(path, str) or not path.strip():
+                raise ValueError("path is required")
+            self._validate_positive_int_argument(arguments, "start_line")
+            self._validate_positive_int_argument(arguments, "max_lines")
+            self._validate_positive_int_argument(arguments, "max_bytes")
+            self._validate_bool_argument(arguments, "include_line_numbers")
+            self._validate_bool_argument(arguments, "include_receipt")
             return
 
         if tool_name == "fs.write_text":
@@ -540,6 +643,13 @@ class FilesystemModule(BaseModule):
         return Path(workspace_root_raw).expanduser().resolve(strict=False)
 
     @staticmethod
+    def _context_metadata_value(context: Any | None, key: str) -> str | None:
+        metadata = getattr(context, "metadata", None)
+        if not isinstance(metadata, dict):
+            return None
+        return _first_nonempty(metadata.get(key))
+
+    @staticmethod
     def _resolve_workspace_path(workspace_root: Path, raw_path: str) -> Path:
         candidate = Path(raw_path).expanduser()
         if not candidate.is_absolute():
@@ -570,12 +680,16 @@ class FilesystemModule(BaseModule):
         return resolved
 
     @staticmethod
-    def _bounded_positive_int(value: Any, default: int) -> int:
+    def _bounded_positive_int(value: Any, default: int, *, maximum: int | None = None) -> int:
         if value is None:
-            return max(1, int(default))
-        if not isinstance(value, int) or isinstance(value, bool) or value <= 0:
-            raise ValueError("limit must be a positive integer")
-        return value
+            limit = max(1, int(default))
+        else:
+            if not isinstance(value, int) or isinstance(value, bool) or value <= 0:
+                raise ValueError("limit must be a positive integer")
+            limit = value
+        if maximum is not None:
+            limit = min(limit, max(1, int(maximum)))
+        return limit
 
     @staticmethod
     def _normalize_portable_pattern(pattern: str) -> str:
@@ -1025,6 +1139,99 @@ class FilesystemModule(BaseModule):
             return candidate.name
         rel_text = relative.as_posix()
         return rel_text if rel_text not in {"", "."} else "."
+
+    @staticmethod
+    def _read_file(
+        target: Path,
+        *,
+        start_line: int,
+        max_lines: int,
+        max_bytes: int,
+        hash_max_file_bytes: int,
+        include_line_numbers: bool,
+    ) -> dict[str, Any]:
+        if target.is_symlink():
+            raise ValueError(f"path is not a regular file: {target}")
+        if not target.exists():
+            raise FileNotFoundError(f"path not found: {target}")
+        if not target.is_file():
+            raise ValueError(f"path is not a file: {target}")
+
+        file_size = target.stat(follow_symlinks=False).st_size
+        can_hash = file_size <= hash_max_file_bytes
+        if can_hash:
+            payload = target.read_bytes()
+            output_payload = payload[:max_bytes]
+        else:
+            with target.open("rb") as handle:
+                output_payload = handle.read(max_bytes)
+            payload = output_payload
+        if b"\x00" in payload:
+            raise ValueError("binary content is not supported by fs.read")
+
+        byte_truncated = file_size > len(output_payload)
+        if can_hash:
+            full_text = FilesystemModule._decode_utf8_text(payload, allow_prefix=False)
+        else:
+            full_text = None
+        text = FilesystemModule._decode_utf8_text(output_payload, allow_prefix=byte_truncated)
+        newline_style = FilesystemModule._detect_newline_style(output_payload)
+        all_lines = text.splitlines(keepends=True)
+        line_count_total = len((full_text if full_text is not None else text).splitlines())
+        start_index = max(0, start_line - 1)
+        selected_lines = all_lines[start_index : start_index + max_lines]
+        line_truncated = start_index + max_lines < len(all_lines)
+        selected_content = "".join(selected_lines)
+        content = FilesystemModule._numbered_lines(selected_lines, start_line) if include_line_numbers else selected_content
+        end_line = start_line + len(selected_lines) - 1 if selected_lines else start_line - 1
+
+        result: dict[str, Any] = {
+            "content": content,
+            "start_line": start_line,
+            "end_line": end_line,
+            "line_count_total": line_count_total,
+            "bytes_read": len(selected_content.encode("utf-8")),
+            "bytes_total": file_size,
+            "newline_style": newline_style,
+            "truncated": bool(byte_truncated or line_truncated),
+        }
+        if byte_truncated:
+            result["truncation_reason"] = "max_bytes"
+        elif line_truncated:
+            result["truncation_reason"] = "max_lines"
+        if can_hash:
+            result["sha256"] = hashlib.sha256(payload).hexdigest()
+        else:
+            result["hash_omitted_reason"] = "hash_omitted_file_too_large"
+        return result
+
+    @staticmethod
+    def _decode_utf8_text(payload: bytes, *, allow_prefix: bool) -> str:
+        try:
+            return payload.decode("utf-8")
+        except UnicodeDecodeError as exc:
+            if allow_prefix and exc.reason == "unexpected end of data" and exc.start > 0:
+                return payload[: exc.start].decode("utf-8")
+            raise ValueError("binary content is not supported by fs.read") from exc
+
+    @staticmethod
+    def _numbered_lines(lines: list[str], start_line: int) -> str:
+        return "".join(f"{line_number}\t{line}" for line_number, line in enumerate(lines, start=start_line))
+
+    @staticmethod
+    def _detect_newline_style(payload: bytes) -> str:
+        crlf = payload.count(b"\r\n")
+        without_crlf = payload.replace(b"\r\n", b"")
+        lf = without_crlf.count(b"\n")
+        cr = without_crlf.count(b"\r")
+        styles = sum(1 for count in (crlf, lf, cr) if count > 0)
+        if styles > 1:
+            return "mixed"
+        if crlf:
+            return "crlf"
+        if cr:
+            return "cr"
+        return "lf"
 
     @staticmethod
     def _read_text_file(target: Path, max_read_bytes: int) -> dict[str, Any]:

--- a/tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_module.py
@@ -376,13 +376,16 @@ class FilesystemModule(BaseModule):
                 bool(args.get("include_receipt", True))
                 and not result.get("truncated")
                 and isinstance(result.get("sha256"), str)
+                and self._read_receipts.enabled
             ):
                 result["read_receipt"] = self._read_receipts.issue(
                     path=rel_path,
                     sha256=str(result["sha256"]),
                     size=int(result.get("bytes_total") or 0),
                     workspace_id=self._context_metadata_value(context, "workspace_id"),
-                    session_id=_first_nonempty(getattr(context, "session_id", None), self._context_metadata_value(context, "session_id")),
+                    session_id=_first_nonempty(
+                        getattr(context, "session_id", None), self._context_metadata_value(context, "session_id")
+                    ),
                 )
             result["eval"] = build_execution_eval_metadata(
                 tool_name="fs.read",
@@ -746,9 +749,7 @@ class FilesystemModule(BaseModule):
                     raise ValueError("regex grep is disabled by module configuration")
                 max_pattern_length = self._setting_positive_int("grep_max_pattern_length", 512)
                 if len(pattern) > max_pattern_length:
-                    raise ValueError(
-                        f"pattern exceeds grep regex length limit ({len(pattern)} > {max_pattern_length})"
-                    )
+                    raise ValueError(f"pattern exceeds grep regex length limit ({len(pattern)} > {max_pattern_length})")
             return
 
         raise ValueError(f"Unknown tool: {tool_name}")
@@ -771,8 +772,7 @@ class FilesystemModule(BaseModule):
         if value is None:
             return
         if not isinstance(value, dict) or not all(
-            isinstance(map_key, str) and isinstance(map_value, str)
-            for map_key, map_value in value.items()
+            isinstance(map_key, str) and isinstance(map_value, str) for map_key, map_value in value.items()
         ):
             raise ValueError(f"{key} must be an object with string values")
 
@@ -782,6 +782,8 @@ class FilesystemModule(BaseModule):
         arguments: dict[str, Any],
         context: Any | None = None,
     ) -> list[PathScopeCandidate]:
+        """Derive per-file path/action candidates for patch tools before enforcement."""
+
         del context
         if tool_name != "fs.patch":
             return await super().extract_path_scope_candidates(tool_name, arguments, None)
@@ -1062,9 +1064,8 @@ class FilesystemModule(BaseModule):
                 else:
                     candidate_type = candidate_kind
 
-                include_candidate = (
-                    (candidate_kind == "file" and include_files)
-                    or (candidate_kind == "directory" and include_directories)
+                include_candidate = (candidate_kind == "file" and include_files) or (
+                    candidate_kind == "directory" and include_directories
                 )
                 if not include_candidate:
                     continue
@@ -1404,11 +1405,25 @@ class FilesystemModule(BaseModule):
         ]
 
         if not dry_run:
-            for plan in plans:
-                target = plan["_target"]
-                if plan["_create_parent_directories"]:
-                    target.parent.mkdir(parents=True, exist_ok=True)
-                self._atomic_write_text_file(target, str(plan["_text_after"]))
+            written: list[dict[str, Any]] = []
+            try:
+                for plan in plans:
+                    target = plan["_target"]
+                    if plan["_create_parent_directories"]:
+                        target.parent.mkdir(parents=True, exist_ok=True)
+                    self._atomic_write_text_file(target, str(plan["_text_after"]))
+                    written.append(plan)
+            except Exception as exc:
+                for plan in reversed(written):
+                    target = plan["_target"]
+                    try:
+                        if plan["_existed_before"]:
+                            self._atomic_write_text_file(target, str(plan["_text_before"]))
+                        else:
+                            target.unlink(missing_ok=True)
+                    except Exception:
+                        logger.exception("Failed to roll back partial fs.patch write for {}", target.name)
+                raise ValueError("partial_write_rollback_attempted") from exc
 
         file_results = []
         for plan in plans:
@@ -1470,6 +1485,7 @@ class FilesystemModule(BaseModule):
             bytes_before = 0
             created = True
             action = "write"
+            text_before = None
         else:
             if target.is_symlink():
                 raise ValueError("file_not_regular")
@@ -1499,6 +1515,7 @@ class FilesystemModule(BaseModule):
             )
             created = False
             action = "edit"
+            text_before = original_text
 
         try:
             text_after = apply_patch_to_text(original_text, patch_file)
@@ -1511,6 +1528,8 @@ class FilesystemModule(BaseModule):
         return {
             "_target": target,
             "_text_after": text_after,
+            "_text_before": text_before,
+            "_existed_before": not created,
             "_create_parent_directories": create_parent_directories,
             "result": {
                 "path": response_path,
@@ -1585,10 +1604,17 @@ class FilesystemModule(BaseModule):
 
     @staticmethod
     def _atomic_write_text_file(target: Path, text: str) -> None:
+        """Atomically replace a text file while preserving existing file mode."""
+
+        existing_mode: int | None = None
+        if target.exists() and not target.is_symlink():
+            existing_mode = stat_module.S_IMODE(target.stat(follow_symlinks=False).st_mode)
         fd, tmp_name = tempfile.mkstemp(prefix=f".{target.name}.", suffix=".tmp", dir=target.parent)
         tmp_path = Path(tmp_name)
         try:
             with os.fdopen(fd, "wb") as handle:
+                if existing_mode is not None:
+                    os.fchmod(handle.fileno(), existing_mode)
                 handle.write(text.encode("utf-8"))
             os.replace(tmp_path, target)
         finally:
@@ -1758,12 +1784,18 @@ class FilesystemModule(BaseModule):
         text = FilesystemModule._decode_utf8_text(output_payload, allow_prefix=byte_truncated)
         newline_style = FilesystemModule._detect_newline_style(output_payload)
         all_lines = text.splitlines(keepends=True)
-        line_count_total = len((full_text if full_text is not None else text).splitlines())
+        line_count_total = (
+            len((full_text if full_text is not None else text).splitlines())
+            if full_text is not None or not byte_truncated
+            else None
+        )
         start_index = max(0, start_line - 1)
         selected_lines = all_lines[start_index : start_index + max_lines]
         line_truncated = start_index + max_lines < len(all_lines)
         selected_content = "".join(selected_lines)
-        content = FilesystemModule._numbered_lines(selected_lines, start_line) if include_line_numbers else selected_content
+        content = (
+            FilesystemModule._numbered_lines(selected_lines, start_line) if include_line_numbers else selected_content
+        )
         end_line = start_line + len(selected_lines) - 1 if selected_lines else start_line - 1
 
         result: dict[str, Any] = {
@@ -1823,9 +1855,7 @@ class FilesystemModule(BaseModule):
 
         file_size = target.stat().st_size
         if file_size > max_read_bytes:
-            raise ValueError(
-                f"file exceeds fs.read_text limit ({file_size} bytes > {max_read_bytes} bytes)"
-            )
+            raise ValueError(f"file exceeds fs.read_text limit ({file_size} bytes > {max_read_bytes} bytes)")
 
         payload = target.read_bytes()
         if b"\x00" in payload:

--- a/tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_module.py
@@ -426,6 +426,7 @@ class FilesystemModule(BaseModule):
                 args.get("read_receipt"),
                 bool(args.get("dry_run", False)),
                 self._setting_positive_int("write_max_bytes", 5_000_000),
+                self._setting_positive_int("write_preimage_max_bytes", 5_000_000),
                 context,
             )
 
@@ -1411,9 +1412,16 @@ class FilesystemModule(BaseModule):
                     target = plan["_target"]
                     if plan["_create_parent_directories"]:
                         target.parent.mkdir(parents=True, exist_ok=True)
+                    self._assert_preimage_unchanged(
+                        target,
+                        plan["result"].get("sha256_before"),
+                        int(plan["result"].get("bytes_before") or 0),
+                    )
                     self._atomic_write_text_file(target, str(plan["_text_after"]))
                     written.append(plan)
             except Exception as exc:
+                if not written:
+                    raise ValueError(str(exc)) from exc
                 for plan in reversed(written):
                     target = plan["_target"]
                     try:
@@ -1581,13 +1589,13 @@ class FilesystemModule(BaseModule):
             raise ValueError("patch_read_receipt_mismatch")
 
         context_workspace_id = self._context_metadata_value(context, "workspace_id")
-        if payload.workspace_id and context_workspace_id and payload.workspace_id != context_workspace_id:
+        if payload.workspace_id and payload.workspace_id != context_workspace_id:
             raise ValueError("patch_read_receipt_mismatch")
         context_session_id = _first_nonempty(
             getattr(context, "session_id", None),
             self._context_metadata_value(context, "session_id"),
         )
-        if payload.session_id and context_session_id and payload.session_id != context_session_id:
+        if payload.session_id and payload.session_id != context_session_id:
             raise ValueError("patch_read_receipt_mismatch")
 
     @staticmethod
@@ -1601,6 +1609,20 @@ class FilesystemModule(BaseModule):
                 elif line.kind == "remove":
                     deletions += 1
         return additions, deletions
+
+    @staticmethod
+    def _assert_preimage_unchanged(target: Path, expected_sha256: str | None, expected_size: int) -> None:
+        """Recheck the authorized file preimage immediately before committing writes."""
+
+        if expected_sha256 is None:
+            if expected_size == 0 and (target.exists() or target.is_symlink()):
+                raise ValueError("preimage_changed_during_commit")
+            return
+        if target.is_symlink() or not target.exists() or not target.is_file():
+            raise ValueError("preimage_changed_during_commit")
+        payload = target.read_bytes()
+        if len(payload) != expected_size or hashlib.sha256(payload).hexdigest() != expected_sha256:
+            raise ValueError("preimage_changed_during_commit")
 
     @staticmethod
     def _atomic_write_text_file(target: Path, text: str) -> None:
@@ -1632,6 +1654,7 @@ class FilesystemModule(BaseModule):
         read_receipt: Any,
         dry_run: bool,
         write_max_bytes: int,
+        preimage_max_bytes: int,
         context: Any | None,
     ) -> dict[str, Any]:
         if "\x00" in content:
@@ -1655,6 +1678,9 @@ class FilesystemModule(BaseModule):
                 raise FileNotFoundError(f"path not found: {target}")
             if not target.is_file():
                 raise ValueError("file_not_regular")
+            file_size = target.stat(follow_symlinks=False).st_size
+            if file_size > preimage_max_bytes:
+                raise ValueError("write_preimage_too_large")
             payload = target.read_bytes()
             if b"\x00" in payload:
                 raise ValueError("binary content is not supported by fs.write")
@@ -1676,6 +1702,7 @@ class FilesystemModule(BaseModule):
         sha256_after = hashlib.sha256(data_after).hexdigest()
         if not dry_run:
             target.parent.mkdir(parents=True, exist_ok=True)
+            self._assert_preimage_unchanged(target, sha256_before, bytes_before)
             self._atomic_write_text_file(target, content)
 
         result: dict[str, Any] = {
@@ -1738,13 +1765,13 @@ class FilesystemModule(BaseModule):
             raise ValueError("write_read_receipt_mismatch")
 
         context_workspace_id = self._context_metadata_value(context, "workspace_id")
-        if payload.workspace_id and context_workspace_id and payload.workspace_id != context_workspace_id:
+        if payload.workspace_id and payload.workspace_id != context_workspace_id:
             raise ValueError("write_read_receipt_mismatch")
         context_session_id = _first_nonempty(
             getattr(context, "session_id", None),
             self._context_metadata_value(context, "session_id"),
         )
-        if payload.session_id and context_session_id and payload.session_id != context_session_id:
+        if payload.session_id and payload.session_id != context_session_id:
             raise ValueError("write_read_receipt_mismatch")
 
     @staticmethod
@@ -1823,7 +1850,7 @@ class FilesystemModule(BaseModule):
         try:
             return payload.decode("utf-8")
         except UnicodeDecodeError as exc:
-            if allow_prefix and exc.reason == "unexpected end of data" and exc.start > 0:
+            if allow_prefix and exc.reason == "unexpected end of data":
                 return payload[: exc.start].decode("utf-8")
             raise ValueError("binary content is not supported by fs.read") from exc
 

--- a/tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_module.py
@@ -110,6 +110,9 @@ class FilesystemModule(BaseModule):
                 "category": "retrieval",
                 "readOnlyHint": True,
                 "capabilities": ["filesystem.read"],
+                "path_scope_action": "read",
+                "legacy_tool": True,
+                "replacement_tool": "fs.read",
                 **shared_path_metadata,
             },
         )
@@ -221,7 +224,12 @@ class FilesystemModule(BaseModule):
             },
             metadata={
                 "category": "management",
+                "readOnlyHint": False,
+                "write_capable": True,
                 "capabilities": ["filesystem.write"],
+                "path_scope_action": "write",
+                "legacy_tool": True,
+                "replacement_tools": ["fs.patch", "fs.write"],
                 **shared_path_metadata,
             },
         )

--- a/tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_module.py
@@ -179,6 +179,36 @@ class FilesystemModule(BaseModule):
         )
         patch_tool["inputSchema"]["additionalProperties"] = False
 
+        write_tool = create_tool_definition(
+            name="fs.write",
+            description="Create or replace a whole UTF-8 text file under the active trusted workspace root.",
+            parameters={
+                "properties": {
+                    "path": {"type": "string", "description": "Workspace-relative or absolute file path"},
+                    "content": {"type": "string"},
+                    "mode": {"type": "string", "enum": ["create", "replace"]},
+                    "expected_sha256": {"type": "string"},
+                    "read_receipt": {"type": "string"},
+                    "dry_run": {"type": "boolean", "default": False},
+                },
+                "required": ["path", "content", "mode"],
+            },
+            metadata={
+                "category": "management",
+                "readOnlyHint": False,
+                "write_capable": True,
+                "capabilities": ["filesystem.write"],
+                "path_scope_action": "write",
+                "eval": {
+                    "task_families": ["filesystem_write"],
+                    "expected_result_kind": "structured_filesystem_write",
+                    "success_signals": ["completed_requested_mutation"],
+                },
+                **shared_path_metadata,
+            },
+        )
+        write_tool["inputSchema"]["additionalProperties"] = False
+
         write_text_tool = create_tool_definition(
             name="fs.write_text",
             description="Write UTF-8 text content to a file under the active trusted workspace root.",
@@ -278,7 +308,17 @@ class FilesystemModule(BaseModule):
         )
         grep_tool["inputSchema"]["additionalProperties"] = False
 
-        return [list_tool, read_tool, read_text_tool, patch_tool, write_text_tool, stat_tool, glob_tool, grep_tool]
+        return [
+            list_tool,
+            read_tool,
+            read_text_tool,
+            patch_tool,
+            write_tool,
+            write_text_tool,
+            stat_tool,
+            glob_tool,
+            grep_tool,
+        ]
 
     async def execute_tool(self, tool_name: str, arguments: dict[str, Any], context: Any | None = None) -> Any:
         args = self.sanitize_input(arguments or {})
@@ -360,6 +400,21 @@ class FilesystemModule(BaseModule):
                 bool(args.get("dry_run", False)),
                 self._setting_positive_int("patch_preimage_max_bytes", 5_000_000),
                 self._setting_positive_int("patch_write_max_bytes", 5_000_000),
+                context,
+            )
+
+        if tool_name == "fs.write":
+            target = self._resolve_workspace_path_no_follow(workspace_root, str(args.get("path")))
+            return await asyncio.to_thread(
+                self._write_file,
+                workspace_root,
+                target,
+                str(args.get("content")),
+                str(args.get("mode")),
+                args.get("expected_sha256"),
+                args.get("read_receipt"),
+                bool(args.get("dry_run", False)),
+                self._setting_positive_int("write_max_bytes", 5_000_000),
                 context,
             )
 
@@ -552,6 +607,36 @@ class FilesystemModule(BaseModule):
             self._validate_optional_string_map_argument(arguments, "read_receipt_by_path")
             self._validate_bool_argument(arguments, "create_parent_directories")
             self._validate_bool_argument(arguments, "allow_create")
+            self._validate_bool_argument(arguments, "dry_run")
+            return
+
+        if tool_name == "fs.write":
+            unknown = sorted(
+                set(arguments)
+                - {
+                    "path",
+                    "content",
+                    "mode",
+                    "expected_sha256",
+                    "read_receipt",
+                    "dry_run",
+                }
+            )
+            if unknown:
+                raise ValueError(f"unknown arguments: {', '.join(unknown)}")
+            path = arguments.get("path")
+            content = arguments.get("content")
+            mode = arguments.get("mode")
+            if not isinstance(path, str) or not path.strip():
+                raise ValueError("path is required")
+            if not isinstance(content, str):
+                raise ValueError("content must be a string")
+            if mode not in {"create", "replace"}:
+                raise ValueError("mode must be create or replace")
+            for key in ("expected_sha256", "read_receipt"):
+                value = arguments.get(key)
+                if value is not None and not isinstance(value, str):
+                    raise ValueError(f"{key} must be a string")
             self._validate_bool_argument(arguments, "dry_run")
             return
 
@@ -1502,6 +1587,131 @@ class FilesystemModule(BaseModule):
             with suppress(OSError):
                 if tmp_path.exists():
                     tmp_path.unlink()
+
+    def _write_file(
+        self,
+        workspace_root: Path,
+        target: Path,
+        content: str,
+        mode: str,
+        expected_sha256: Any,
+        read_receipt: Any,
+        dry_run: bool,
+        write_max_bytes: int,
+        context: Any | None,
+    ) -> dict[str, Any]:
+        if "\x00" in content:
+            raise ValueError("binary content is not supported by fs.write")
+        data_after = content.encode("utf-8")
+        if len(data_after) > write_max_bytes:
+            raise ValueError("write_content_too_large")
+
+        rel_path = self._to_workspace_relative_path(workspace_root, target)
+        created = mode == "create"
+        sha256_before = None
+        bytes_before = 0
+
+        if mode == "create":
+            if target.exists() or target.is_symlink():
+                raise ValueError("write_target_exists")
+        else:
+            if target.is_symlink():
+                raise ValueError("file_not_regular")
+            if not target.exists():
+                raise FileNotFoundError(f"path not found: {target}")
+            if not target.is_file():
+                raise ValueError("file_not_regular")
+            payload = target.read_bytes()
+            if b"\x00" in payload:
+                raise ValueError("binary content is not supported by fs.write")
+            try:
+                payload.decode("utf-8")
+            except UnicodeDecodeError as exc:
+                raise ValueError("binary content is not supported by fs.write") from exc
+            sha256_before = hashlib.sha256(payload).hexdigest()
+            bytes_before = len(payload)
+            self._authorize_write_preimage(
+                rel_path,
+                sha256_before,
+                bytes_before,
+                expected_sha256,
+                read_receipt,
+                context,
+            )
+
+        sha256_after = hashlib.sha256(data_after).hexdigest()
+        if not dry_run:
+            target.parent.mkdir(parents=True, exist_ok=True)
+            self._atomic_write_text_file(target, content)
+
+        result: dict[str, Any] = {
+            "path": rel_path,
+            "mode": mode,
+            "written": not dry_run,
+            "dry_run": dry_run,
+            "created": created,
+            "bytes_before": bytes_before,
+            "bytes_after": len(data_after),
+            "sha256_before": sha256_before,
+            "sha256_after": sha256_after,
+            "eval": build_execution_eval_metadata(
+                tool_name="fs.write",
+                tool_prompt_id="mcp.fs.write.v1",
+                tool_prompt_version="2026.06.04",
+                action_family="filesystem_write",
+                result_kind="structured_filesystem_write",
+                path_filter_used=True,
+                truncated=False,
+            ),
+        }
+        if not dry_run:
+            result["bytes_written"] = len(data_after)
+        return result
+
+    def _authorize_write_preimage(
+        self,
+        rel_path: str,
+        sha256_before: str,
+        bytes_before: int,
+        expected_sha256: Any,
+        read_receipt: Any,
+        context: Any | None,
+    ) -> None:
+        has_expected = isinstance(expected_sha256, str) and bool(expected_sha256)
+        has_receipt = isinstance(read_receipt, str) and bool(read_receipt)
+        if not has_expected and not has_receipt:
+            raise ValueError("write_preimage_required")
+        if has_expected and str(expected_sha256) == sha256_before:
+            return
+        if has_receipt:
+            self._validate_write_read_receipt(str(read_receipt), rel_path, sha256_before, bytes_before, context)
+            return
+        raise ValueError("write_preimage_mismatch")
+
+    def _validate_write_read_receipt(
+        self,
+        receipt: str,
+        rel_path: str,
+        sha256_before: str,
+        bytes_before: int,
+        context: Any | None,
+    ) -> None:
+        try:
+            payload = self._read_receipts.validate(receipt)
+        except ReadReceiptError as exc:
+            raise ValueError(exc.reason_code) from exc
+        if payload.path != rel_path or payload.sha256 != sha256_before or payload.size != bytes_before:
+            raise ValueError("write_read_receipt_mismatch")
+
+        context_workspace_id = self._context_metadata_value(context, "workspace_id")
+        if payload.workspace_id and context_workspace_id and payload.workspace_id != context_workspace_id:
+            raise ValueError("write_read_receipt_mismatch")
+        context_session_id = _first_nonempty(
+            getattr(context, "session_id", None),
+            self._context_metadata_value(context, "session_id"),
+        )
+        if payload.session_id and context_session_id and payload.session_id != context_session_id:
+            raise ValueError("write_read_receipt_mismatch")
 
     @staticmethod
     def _read_file(

--- a/tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_module.py
@@ -18,6 +18,7 @@ import hashlib
 import os
 import re
 import stat as stat_module
+import tempfile
 from contextlib import suppress
 from datetime import datetime, timezone
 from pathlib import Path
@@ -25,13 +26,15 @@ from typing import Any
 
 from loguru import logger
 
+from mcp_unified.interfaces.path_scope import PathScopeCandidate
 from tldw_Server_API.app.services.mcp_hub_workspace_root_resolver import (
     McpHubWorkspaceRootResolver,
 )
 
 from ...tool_observability import build_execution_eval_metadata
 from ..base import BaseModule, ModuleConfig, create_tool_definition
-from .filesystem_receipts import ReadReceiptManager
+from .filesystem_diff import FilesystemPatchError, PatchFile, apply_patch_to_text, parse_unified_diff
+from .filesystem_receipts import ReadReceiptError, ReadReceiptManager
 
 
 def _first_nonempty(*values: Any) -> str | None:
@@ -140,6 +143,42 @@ class FilesystemModule(BaseModule):
         )
         read_tool["inputSchema"]["additionalProperties"] = False
 
+        patch_tool = create_tool_definition(
+            name="fs.patch",
+            description="Apply a bounded unified diff to workspace files after preimage checks.",
+            parameters={
+                "properties": {
+                    "diff": {"type": "string", "description": "Unified diff text"},
+                    "expected_sha256_by_path": {
+                        "type": "object",
+                        "additionalProperties": {"type": "string"},
+                    },
+                    "read_receipt_by_path": {
+                        "type": "object",
+                        "additionalProperties": {"type": "string"},
+                    },
+                    "create_parent_directories": {"type": "boolean", "default": False},
+                    "allow_create": {"type": "boolean", "default": False},
+                    "dry_run": {"type": "boolean", "default": False},
+                },
+                "required": ["diff"],
+            },
+            metadata={
+                "category": "management",
+                "readOnlyHint": False,
+                "write_capable": True,
+                "capabilities": ["filesystem.edit", "filesystem.write"],
+                "path_scope_candidate_source": "module",
+                "eval": {
+                    "task_families": ["filesystem_edit"],
+                    "expected_result_kind": "structured_filesystem_edit",
+                    "success_signals": ["completed_requested_mutation"],
+                },
+                **shared_fs_metadata,
+            },
+        )
+        patch_tool["inputSchema"]["additionalProperties"] = False
+
         write_text_tool = create_tool_definition(
             name="fs.write_text",
             description="Write UTF-8 text content to a file under the active trusted workspace root.",
@@ -239,7 +278,7 @@ class FilesystemModule(BaseModule):
         )
         grep_tool["inputSchema"]["additionalProperties"] = False
 
-        return [list_tool, read_tool, read_text_tool, write_text_tool, stat_tool, glob_tool, grep_tool]
+        return [list_tool, read_tool, read_text_tool, patch_tool, write_text_tool, stat_tool, glob_tool, grep_tool]
 
     async def execute_tool(self, tool_name: str, arguments: dict[str, Any], context: Any | None = None) -> Any:
         args = self.sanitize_input(arguments or {})
@@ -307,6 +346,22 @@ class FilesystemModule(BaseModule):
                 truncated=bool(result.get("truncated", False)),
             )
             return result
+
+        if tool_name == "fs.patch":
+            patch_files = self._parse_patch_diff(str(args.get("diff") or ""))
+            return await asyncio.to_thread(
+                self._apply_patch_files,
+                workspace_root,
+                patch_files,
+                self._string_map_argument(args.get("expected_sha256_by_path")),
+                self._string_map_argument(args.get("read_receipt_by_path")),
+                bool(args.get("allow_create", False)),
+                bool(args.get("create_parent_directories", False)),
+                bool(args.get("dry_run", False)),
+                self._setting_positive_int("patch_preimage_max_bytes", 5_000_000),
+                self._setting_positive_int("patch_write_max_bytes", 5_000_000),
+                context,
+            )
 
         if tool_name == "fs.write_text":
             target = self._resolve_workspace_path(workspace_root, str(args.get("path")))
@@ -476,6 +531,30 @@ class FilesystemModule(BaseModule):
             self._validate_bool_argument(arguments, "include_receipt")
             return
 
+        if tool_name == "fs.patch":
+            unknown = sorted(
+                set(arguments)
+                - {
+                    "diff",
+                    "expected_sha256_by_path",
+                    "read_receipt_by_path",
+                    "create_parent_directories",
+                    "allow_create",
+                    "dry_run",
+                }
+            )
+            if unknown:
+                raise ValueError(f"unknown arguments: {', '.join(unknown)}")
+            diff = arguments.get("diff")
+            if not isinstance(diff, str) or not diff.strip():
+                raise ValueError("diff is required")
+            self._validate_optional_string_map_argument(arguments, "expected_sha256_by_path")
+            self._validate_optional_string_map_argument(arguments, "read_receipt_by_path")
+            self._validate_bool_argument(arguments, "create_parent_directories")
+            self._validate_bool_argument(arguments, "allow_create")
+            self._validate_bool_argument(arguments, "dry_run")
+            return
+
         if tool_name == "fs.write_text":
             unknown = sorted(set(arguments) - {"path", "content"})
             if unknown:
@@ -592,6 +671,52 @@ class FilesystemModule(BaseModule):
         value = arguments.get(key)
         if value is not None and (not isinstance(value, int) or isinstance(value, bool) or value <= 0):
             raise ValueError(f"{key} must be a positive integer")
+
+    @staticmethod
+    def _validate_optional_string_map_argument(arguments: dict[str, Any], key: str) -> None:
+        value = arguments.get(key)
+        if value is None:
+            return
+        if not isinstance(value, dict) or not all(
+            isinstance(map_key, str) and isinstance(map_value, str)
+            for map_key, map_value in value.items()
+        ):
+            raise ValueError(f"{key} must be an object with string values")
+
+    async def extract_path_scope_candidates(
+        self,
+        tool_name: str,
+        arguments: dict[str, Any],
+        context: Any | None = None,
+    ) -> list[PathScopeCandidate]:
+        del context
+        if tool_name != "fs.patch":
+            return await super().extract_path_scope_candidates(tool_name, arguments, None)
+
+        candidates: list[PathScopeCandidate] = []
+        for patch_file in self._parse_patch_diff(str((arguments or {}).get("diff") or "")):
+            path = patch_file.new_path
+            if path is None:
+                raise ValueError("invalid_patch_path")
+            if patch_file.action == "create":
+                candidates.append(
+                    PathScopeCandidate(
+                        path=path,
+                        action="write",
+                        source="filesystem_diff",
+                        creates_file=True,
+                    )
+                )
+            else:
+                candidates.append(
+                    PathScopeCandidate(
+                        path=path,
+                        action="edit",
+                        source="filesystem_diff",
+                        requires_existing_file=True,
+                    )
+                )
+        return candidates
 
     def sanitize_input(self, input_data: Any, _depth: int = 0) -> Any:
         """Sanitize filesystem inputs while allowing portable glob syntax."""
@@ -1139,6 +1264,244 @@ class FilesystemModule(BaseModule):
             return candidate.name
         rel_text = relative.as_posix()
         return rel_text if rel_text not in {"", "."} else "."
+
+    def _parse_patch_diff(self, diff_text: str) -> tuple[PatchFile, ...]:
+        try:
+            return parse_unified_diff(
+                diff_text,
+                max_files=self._setting_positive_int("patch_max_files", 20),
+                max_hunks=self._setting_positive_int("patch_max_hunks", 200),
+                max_bytes=self._setting_positive_int("patch_max_diff_bytes", 1_000_000),
+            )
+        except FilesystemPatchError as exc:
+            raise ValueError(exc.reason_code) from exc
+
+    @staticmethod
+    def _string_map_argument(value: Any) -> dict[str, str]:
+        if value is None:
+            return {}
+        return {str(key): str(map_value) for key, map_value in dict(value).items()}
+
+    def _apply_patch_files(
+        self,
+        workspace_root: Path,
+        patch_files: tuple[PatchFile, ...],
+        expected_sha256_by_path: dict[str, str],
+        read_receipt_by_path: dict[str, str],
+        allow_create: bool,
+        create_parent_directories: bool,
+        dry_run: bool,
+        preimage_max_bytes: int,
+        write_max_bytes: int,
+        context: Any | None,
+    ) -> dict[str, Any]:
+        plans = [
+            self._plan_patch_file(
+                workspace_root,
+                patch_file,
+                expected_sha256_by_path,
+                read_receipt_by_path,
+                allow_create,
+                create_parent_directories,
+                preimage_max_bytes,
+                write_max_bytes,
+                context,
+            )
+            for patch_file in patch_files
+        ]
+
+        if not dry_run:
+            for plan in plans:
+                target = plan["_target"]
+                if plan["_create_parent_directories"]:
+                    target.parent.mkdir(parents=True, exist_ok=True)
+                self._atomic_write_text_file(target, str(plan["_text_after"]))
+
+        file_results = []
+        for plan in plans:
+            record = dict(plan["result"])
+            if not dry_run:
+                record["bytes_written"] = record["bytes_after"]
+            file_results.append(record)
+
+        summary = {
+            "files": len(file_results),
+            "hunks": sum(int(item["hunks_applied"]) for item in file_results),
+            "additions": sum(int(item["additions"]) for item in file_results),
+            "deletions": sum(int(item["deletions"]) for item in file_results),
+        }
+        return {
+            "applied": not dry_run,
+            "dry_run": dry_run,
+            "files": file_results,
+            "summary": summary,
+            "eval": build_execution_eval_metadata(
+                tool_name="fs.patch",
+                tool_prompt_id="mcp.fs.patch.v1",
+                tool_prompt_version="2026.06.04",
+                action_family="filesystem_edit",
+                result_kind="structured_filesystem_edit",
+                path_filter_used=True,
+                truncated=False,
+            ),
+        }
+
+    def _plan_patch_file(
+        self,
+        workspace_root: Path,
+        patch_file: PatchFile,
+        expected_sha256_by_path: dict[str, str],
+        read_receipt_by_path: dict[str, str],
+        allow_create: bool,
+        create_parent_directories: bool,
+        preimage_max_bytes: int,
+        write_max_bytes: int,
+        context: Any | None,
+    ) -> dict[str, Any]:
+        rel_path = patch_file.new_path
+        if rel_path is None:
+            raise ValueError("invalid_patch_path")
+        target = self._resolve_workspace_path_no_follow(workspace_root, rel_path)
+        response_path = self._to_workspace_relative_path(workspace_root, target)
+        additions, deletions = self._patch_line_counts(patch_file)
+
+        if patch_file.action == "create":
+            if not allow_create:
+                raise ValueError("patch_create_not_allowed")
+            if target.exists() or target.is_symlink():
+                raise ValueError("patch_create_target_exists")
+            if not target.parent.exists() and not create_parent_directories:
+                raise ValueError("patch_parent_missing")
+            original_text = ""
+            sha256_before = None
+            bytes_before = 0
+            created = True
+            action = "write"
+        else:
+            if target.is_symlink():
+                raise ValueError("file_not_regular")
+            if not target.exists():
+                raise FileNotFoundError(f"path not found: {target}")
+            if not target.is_file():
+                raise ValueError("file_not_regular")
+            file_size = target.stat(follow_symlinks=False).st_size
+            if file_size > preimage_max_bytes:
+                raise ValueError("patch_preimage_too_large")
+            payload = target.read_bytes()
+            if b"\x00" in payload:
+                raise ValueError("binary content is not supported by fs.patch")
+            try:
+                original_text = payload.decode("utf-8")
+            except UnicodeDecodeError as exc:
+                raise ValueError("binary content is not supported by fs.patch") from exc
+            sha256_before = hashlib.sha256(payload).hexdigest()
+            bytes_before = len(payload)
+            self._authorize_patch_preimage(
+                response_path,
+                sha256_before,
+                bytes_before,
+                expected_sha256_by_path,
+                read_receipt_by_path,
+                context,
+            )
+            created = False
+            action = "edit"
+
+        try:
+            text_after = apply_patch_to_text(original_text, patch_file)
+        except FilesystemPatchError as exc:
+            raise ValueError(exc.reason_code) from exc
+        data_after = text_after.encode("utf-8")
+        if len(data_after) > write_max_bytes:
+            raise ValueError("patch_write_too_large")
+
+        return {
+            "_target": target,
+            "_text_after": text_after,
+            "_create_parent_directories": create_parent_directories,
+            "result": {
+                "path": response_path,
+                "action": action,
+                "created": created,
+                "hunks_applied": len(patch_file.hunks),
+                "additions": additions,
+                "deletions": deletions,
+                "bytes_before": bytes_before,
+                "bytes_after": len(data_after),
+                "sha256_before": sha256_before,
+                "sha256_after": hashlib.sha256(data_after).hexdigest(),
+            },
+        }
+
+    def _authorize_patch_preimage(
+        self,
+        rel_path: str,
+        sha256_before: str,
+        bytes_before: int,
+        expected_sha256_by_path: dict[str, str],
+        read_receipt_by_path: dict[str, str],
+        context: Any | None,
+    ) -> None:
+        expected_sha256 = expected_sha256_by_path.get(rel_path)
+        receipt = read_receipt_by_path.get(rel_path)
+        if expected_sha256 is None and receipt is None:
+            raise ValueError("patch_preimage_required")
+        if expected_sha256 is not None and expected_sha256 == sha256_before:
+            return
+        if receipt is not None:
+            self._validate_patch_read_receipt(receipt, rel_path, sha256_before, bytes_before, context)
+            return
+        raise ValueError("patch_preimage_mismatch")
+
+    def _validate_patch_read_receipt(
+        self,
+        receipt: str,
+        rel_path: str,
+        sha256_before: str,
+        bytes_before: int,
+        context: Any | None,
+    ) -> None:
+        try:
+            payload = self._read_receipts.validate(receipt)
+        except ReadReceiptError as exc:
+            raise ValueError(exc.reason_code) from exc
+        if payload.path != rel_path or payload.sha256 != sha256_before or payload.size != bytes_before:
+            raise ValueError("patch_read_receipt_mismatch")
+
+        context_workspace_id = self._context_metadata_value(context, "workspace_id")
+        if payload.workspace_id and context_workspace_id and payload.workspace_id != context_workspace_id:
+            raise ValueError("patch_read_receipt_mismatch")
+        context_session_id = _first_nonempty(
+            getattr(context, "session_id", None),
+            self._context_metadata_value(context, "session_id"),
+        )
+        if payload.session_id and context_session_id and payload.session_id != context_session_id:
+            raise ValueError("patch_read_receipt_mismatch")
+
+    @staticmethod
+    def _patch_line_counts(patch_file: PatchFile) -> tuple[int, int]:
+        additions = 0
+        deletions = 0
+        for hunk in patch_file.hunks:
+            for line in hunk.lines:
+                if line.kind == "add":
+                    additions += 1
+                elif line.kind == "remove":
+                    deletions += 1
+        return additions, deletions
+
+    @staticmethod
+    def _atomic_write_text_file(target: Path, text: str) -> None:
+        fd, tmp_name = tempfile.mkstemp(prefix=f".{target.name}.", suffix=".tmp", dir=target.parent)
+        tmp_path = Path(tmp_name)
+        try:
+            with os.fdopen(fd, "wb") as handle:
+                handle.write(text.encode("utf-8"))
+            os.replace(tmp_path, target)
+        finally:
+            with suppress(OSError):
+                if tmp_path.exists():
+                    tmp_path.unlink()
 
     @staticmethod
     def _read_file(

--- a/tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_receipts.py
+++ b/tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_receipts.py
@@ -6,7 +6,6 @@ import base64
 import hashlib
 import hmac
 import json
-import secrets
 import time
 from dataclasses import dataclass
 from typing import Any
@@ -38,12 +37,19 @@ class ReadReceiptManager:
     def __init__(self, *, secret: str | bytes | None = None, ttl_seconds: int = 1_800) -> None:
         if isinstance(secret, bytes):
             secret_bytes = secret
-        elif isinstance(secret, str) and secret:
-            secret_bytes = secret.encode("utf-8")
+        elif isinstance(secret, str) and secret.strip():
+            secret_bytes = secret.strip().encode("utf-8")
         else:
-            secret_bytes = secrets.token_bytes(32)
+            secret_bytes = b""
         self._secret = secret_bytes
+        self._enabled = bool(secret_bytes)
         self._ttl_seconds = max(1, int(ttl_seconds))
+
+    @property
+    def enabled(self) -> bool:
+        """Return whether a stable receipt-signing secret is configured."""
+
+        return self._enabled
 
     def issue(
         self,
@@ -56,6 +62,8 @@ class ReadReceiptManager:
     ) -> str:
         """Return a signed receipt for a complete file preimage."""
 
+        if not self._enabled:
+            raise ReadReceiptError("read_receipt_secret_unconfigured")
         now = int(time.time())
         payload: dict[str, Any] = {
             "v": 1,
@@ -77,6 +85,8 @@ class ReadReceiptManager:
     def validate(self, receipt: str) -> ReadReceiptPayload:
         """Validate and decode a signed receipt."""
 
+        if not self._enabled:
+            raise ReadReceiptError("read_receipt_secret_unconfigured")
         try:
             envelope_bytes = base64.urlsafe_b64decode(receipt.encode("ascii"))
             envelope = json.loads(envelope_bytes.decode("utf-8"))
@@ -105,4 +115,6 @@ class ReadReceiptManager:
 
 
 def _canonical_json(payload: dict[str, Any]) -> bytes:
+    """Serialize JSON bytes with stable key ordering for HMAC signing."""
+
     return json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True).encode("utf-8")

--- a/tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_receipts.py
+++ b/tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_receipts.py
@@ -1,0 +1,108 @@
+"""Stateless read receipts for MCP filesystem tools."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import json
+import secrets
+import time
+from dataclasses import dataclass
+from typing import Any
+
+
+class ReadReceiptError(ValueError):
+    """Raised when a read receipt cannot be validated."""
+
+    def __init__(self, reason_code: str) -> None:
+        super().__init__(reason_code)
+        self.reason_code = reason_code
+
+
+@dataclass(frozen=True, slots=True)
+class ReadReceiptPayload:
+    """Decoded read receipt payload."""
+
+    path: str
+    sha256: str
+    size: int
+    expires_at: int
+    workspace_id: str | None = None
+    session_id: str | None = None
+
+
+class ReadReceiptManager:
+    """Issue and validate HMAC-signed read receipts."""
+
+    def __init__(self, *, secret: str | bytes | None = None, ttl_seconds: int = 1_800) -> None:
+        if isinstance(secret, bytes):
+            secret_bytes = secret
+        elif isinstance(secret, str) and secret:
+            secret_bytes = secret.encode("utf-8")
+        else:
+            secret_bytes = secrets.token_bytes(32)
+        self._secret = secret_bytes
+        self._ttl_seconds = max(1, int(ttl_seconds))
+
+    def issue(
+        self,
+        *,
+        path: str,
+        sha256: str,
+        size: int,
+        workspace_id: str | None = None,
+        session_id: str | None = None,
+    ) -> str:
+        """Return a signed receipt for a complete file preimage."""
+
+        now = int(time.time())
+        payload: dict[str, Any] = {
+            "v": 1,
+            "path": path,
+            "sha256": sha256,
+            "size": int(size),
+            "issued_at": now,
+            "expires_at": now + self._ttl_seconds,
+        }
+        if workspace_id:
+            payload["workspace_id"] = str(workspace_id)
+        if session_id:
+            payload["session_id"] = str(session_id)
+        payload_bytes = _canonical_json(payload)
+        signature = hmac.new(self._secret, payload_bytes, hashlib.sha256).hexdigest()
+        envelope = {"payload": payload, "signature": signature}
+        return base64.urlsafe_b64encode(_canonical_json(envelope)).decode("ascii")
+
+    def validate(self, receipt: str) -> ReadReceiptPayload:
+        """Validate and decode a signed receipt."""
+
+        try:
+            envelope_bytes = base64.urlsafe_b64decode(receipt.encode("ascii"))
+            envelope = json.loads(envelope_bytes.decode("utf-8"))
+        except (UnicodeDecodeError, ValueError, TypeError) as exc:
+            raise ReadReceiptError("read_receipt_invalid") from exc
+        if not isinstance(envelope, dict):
+            raise ReadReceiptError("read_receipt_invalid")
+        payload = envelope.get("payload")
+        signature = envelope.get("signature")
+        if not isinstance(payload, dict) or not isinstance(signature, str):
+            raise ReadReceiptError("read_receipt_invalid")
+        expected = hmac.new(self._secret, _canonical_json(payload), hashlib.sha256).hexdigest()
+        if not hmac.compare_digest(signature, expected):
+            raise ReadReceiptError("read_receipt_invalid")
+        expires_at = int(payload.get("expires_at") or 0)
+        if expires_at < int(time.time()):
+            raise ReadReceiptError("read_receipt_expired")
+        return ReadReceiptPayload(
+            path=str(payload.get("path") or ""),
+            sha256=str(payload.get("sha256") or ""),
+            size=int(payload.get("size") or 0),
+            expires_at=expires_at,
+            workspace_id=str(payload.get("workspace_id") or "") or None,
+            session_id=str(payload.get("session_id") or "") or None,
+        )
+
+
+def _canonical_json(payload: dict[str, Any]) -> bytes:
+    return json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True).encode("utf-8")

--- a/tldw_Server_API/app/core/MCP_unified/protocol.py
+++ b/tldw_Server_API/app/core/MCP_unified/protocol.py
@@ -2707,13 +2707,25 @@ class MCPProtocol:
             # by raising a sentinel exception handled by process_request
             raise InvalidParamsException(str(ve)) from ve
 
-        path_scope_candidates = await self._extract_path_scope_candidates(
-            module=module,
-            tool_name=tool_name,
-            tool_args=tool_args,
-            context=context,
-            tool_def=tool_def if isinstance(tool_def, dict) else None,
-        )
+        policy_document = (effective_policy or {}).get("policy_document")
+        path_scope_mode = ""
+        if isinstance(policy_document, dict):
+            path_scope_mode = str(policy_document.get("path_scope_mode") or "").strip()
+        elif isinstance(policy_document, BaseModel):
+            if hasattr(policy_document, "model_dump"):
+                policy_document_payload = policy_document.model_dump()
+            else:  # pragma: no cover - pydantic v1 compatibility
+                policy_document_payload = policy_document.dict()
+            path_scope_mode = str(policy_document_payload.get("path_scope_mode") or "").strip()
+        path_scope_candidates = None
+        if bool((effective_policy or {}).get("enabled")) and path_scope_mode not in {"", "none"}:
+            path_scope_candidates = await self._extract_path_scope_candidates(
+                module=module,
+                tool_name=tool_name,
+                tool_args=tool_args,
+                context=context,
+                tool_def=tool_def if isinstance(tool_def, dict) else None,
+            )
         path_scope_result = await self._evaluate_path_scope(
             effective_policy=effective_policy,
             tool_name=tool_name,

--- a/tldw_Server_API/app/core/MCP_unified/protocol.py
+++ b/tldw_Server_API/app/core/MCP_unified/protocol.py
@@ -34,6 +34,10 @@ except ImportError:  # Fallback for v1
 
 from loguru import logger
 
+from mcp_unified.interfaces.path_scope import (
+    PathScopeCandidate,
+    normalize_path_scope_candidates,
+)
 from mcp_unified.tool_use_reporting.builders import (
     classify_tool_use_exception,
     extract_safe_context_dimensions,
@@ -146,6 +150,16 @@ def _is_truthy(value: Any) -> bool:
         return str(value or "").strip().lower() in _TRUTHY_VALUES
     except _MCP_PROTOCOL_NONCRITICAL_EXCEPTIONS:
         return False
+
+
+def _is_unexpected_keyword_type_error(exc: TypeError, keyword: str) -> bool:
+    """Return True when a TypeError reports an unsupported keyword argument."""
+
+    message = str(exc)
+    return (
+        f"unexpected keyword argument '{keyword}'" in message
+        or f'unexpected keyword argument "{keyword}"' in message
+    )
 
 
 async def _no_redis_client_factory(**_kwargs: Any) -> None:
@@ -2273,6 +2287,7 @@ class MCPProtocol:
         tool_args: Any,
         context: RequestContext,
         tool_def: dict[str, Any] | None,
+        path_scope_candidates: list[PathScopeCandidate] | None = None,
     ) -> dict[str, Any]:
         policy = dict(effective_policy or {})
         policy_document = dict(policy.get("policy_document") or {})
@@ -2296,13 +2311,31 @@ class MCPProtocol:
                 "scope_payload": {"path_scope_mode": path_scope_mode, "reason": "policy_unavailable"},
             }
         try:
-            return await self.dependencies.path_scope_enforcer.evaluate_tool_call(
-                effective_policy=policy,
-                context=context,
-                tool_name=tool_name,
-                tool_args=tool_args,
-                tool_def=tool_def,
-            )
+            try:
+                return await self.dependencies.path_scope_enforcer.evaluate_tool_call(
+                    effective_policy=policy,
+                    context=context,
+                    tool_name=tool_name,
+                    tool_args=tool_args,
+                    tool_def=tool_def,
+                    path_scope_candidates=path_scope_candidates,
+                )
+            except TypeError as exc:
+                if not _is_unexpected_keyword_type_error(exc, "path_scope_candidates"):
+                    raise
+                if path_scope_candidates:
+                    raise PermissionError("path_scope_candidates_unsupported") from exc
+                return await self.dependencies.path_scope_enforcer.evaluate_tool_call(
+                    effective_policy=policy,
+                    context=context,
+                    tool_name=tool_name,
+                    tool_args=tool_args,
+                    tool_def=tool_def,
+                )
+        except PermissionError:
+            raise
+        except TypeError:
+            raise
         except _MCP_PROTOCOL_NONCRITICAL_EXCEPTIONS as exc:
             logger.debug("Failed to evaluate MCP Hub path scope: {}", exc)
             return {
@@ -2313,6 +2346,35 @@ class MCPProtocol:
                 "normalized_paths": [],
                 "scope_payload": {"path_scope_mode": path_scope_mode, "reason": "path_scope_unavailable"},
             }
+
+    async def _extract_path_scope_candidates(
+        self,
+        *,
+        module: BaseModule,
+        tool_name: str,
+        tool_args: Any,
+        context: RequestContext,
+        tool_def: dict[str, Any] | None,
+    ) -> list[PathScopeCandidate] | None:
+        metadata = tool_def.get("metadata") if isinstance(tool_def, dict) else None
+        if not isinstance(metadata, dict) or metadata.get("path_scope_candidate_source") != "module":
+            return None
+        if not isinstance(tool_args, dict):
+            raise PermissionError("path_scope_candidates_unavailable")
+        extractor = getattr(module, "extract_path_scope_candidates", None)
+        if not callable(extractor):
+            raise PermissionError("path_scope_candidates_unavailable")
+        try:
+            candidates = normalize_path_scope_candidates(
+                await extractor(tool_name, tool_args, context)
+            )
+        except NotImplementedError as exc:
+            raise PermissionError("path_scope_candidates_unavailable") from exc
+        except _MCP_PROTOCOL_NONCRITICAL_EXCEPTIONS as exc:
+            raise InvalidParamsException(str(exc)) from exc
+        if not candidates:
+            raise PermissionError("path_scope_candidates_unavailable")
+        return candidates
 
     async def _evaluate_external_access(
         self,
@@ -2645,12 +2707,20 @@ class MCPProtocol:
             # by raising a sentinel exception handled by process_request
             raise InvalidParamsException(str(ve)) from ve
 
+        path_scope_candidates = await self._extract_path_scope_candidates(
+            module=module,
+            tool_name=tool_name,
+            tool_args=tool_args,
+            context=context,
+            tool_def=tool_def if isinstance(tool_def, dict) else None,
+        )
         path_scope_result = await self._evaluate_path_scope(
             effective_policy=effective_policy,
             tool_name=tool_name,
             tool_args=tool_args,
             context=context,
             tool_def=tool_def if isinstance(tool_def, dict) else None,
+            path_scope_candidates=path_scope_candidates,
         )
         within_resolved_scope = bool(path_scope_result.get("within_scope", True)) and bool(
             external_access_result.get("within_scope", True)

--- a/tldw_Server_API/app/core/MCP_unified/protocol.py
+++ b/tldw_Server_API/app/core/MCP_unified/protocol.py
@@ -2966,6 +2966,18 @@ class MCPProtocol:
                     profile_id=profile_id,
                     duration_ms=duration_ms,
                 )
+                result_eval = self._tool_use_eval_metadata(payload=result if isinstance(result, dict) else None)
+                for key in (
+                    "tool_prompt_id",
+                    "tool_prompt_version",
+                    "action_family",
+                    "result_kind",
+                    "path_filter_used",
+                    "truncated",
+                    "reason_code",
+                ):
+                    if key in result_eval:
+                        execution_eval[key] = result_eval[key]
                 if isinstance(result, str):
                     content = [{"type": "text", "text": result}]
                 elif isinstance(result, list):

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_module.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 from pathlib import Path
 from typing import Any
 
@@ -28,7 +29,7 @@ class _FakeWorkspaceRootResolver:
 class _FilesystemRegistry:
     def __init__(self, module: FilesystemModule) -> None:
         self.module = module
-        self._tool_names = {"fs.list", "fs.read_text", "fs.write_text", "fs.stat", "fs.glob", "fs.grep"}
+        self._tool_names = {"fs.list", "fs.read", "fs.read_text", "fs.write_text", "fs.stat", "fs.glob", "fs.grep"}
 
     async def find_module_for_tool(self, tool_name: str):  # noqa: ANN001
         if tool_name in self._tool_names:
@@ -173,14 +174,21 @@ async def test_filesystem_tools_include_path_scope_metadata() -> None:
     tools = await mod.get_tools()
     by_name = {tool["name"]: tool for tool in tools}
 
-    assert {"fs.list", "fs.read_text", "fs.write_text"} <= set(by_name)  # nosec B101
+    assert {"fs.list", "fs.read", "fs.read_text", "fs.write_text"} <= set(by_name)  # nosec B101
 
-    for tool_name in ("fs.list", "fs.read_text", "fs.write_text"):
+    for tool_name in ("fs.list", "fs.read", "fs.read_text", "fs.write_text"):
         metadata = by_name[tool_name]["metadata"]
         assert metadata["uses_filesystem"] is True  # nosec B101
         assert metadata["path_boundable"] is True  # nosec B101
         assert metadata["path_argument_hints"] == ["path"]  # nosec B101
 
+    read_metadata = by_name["fs.read"]["metadata"]
+    assert read_metadata["readOnlyHint"] is True  # nosec B101
+    assert read_metadata["path_scope_action"] == "read"  # nosec B101
+    assert "filesystem.read" in read_metadata["capabilities"]  # nosec B101
+    assert read_metadata["eval"]["task_families"] == ["filesystem_read"]  # nosec B101
+    assert read_metadata["eval"]["expected_result_kind"] == "structured_filesystem_read"  # nosec B101
+    assert by_name["fs.read"]["inputSchema"]["additionalProperties"] is False  # nosec B101
     assert by_name["fs.write_text"]["metadata"]["category"] == "management"  # nosec B101
 
 
@@ -315,7 +323,182 @@ async def test_filesystem_list_read_and_write_text_within_workspace(tmp_path: Pa
     assert write_result["path"] == "docs/new.txt"  # nosec B101
     assert write_result["bytes_written"] == len(b"created by fs.write_text")  # nosec B101
     assert (docs_dir / "new.txt").read_text(encoding="utf-8") == "created by fs.write_text"  # nosec B101
-    assert len(resolver.calls) == 3  # nosec B101
+
+
+@pytest.mark.asyncio
+async def test_filesystem_read_returns_content_hash_and_receipt(tmp_path: Path) -> None:
+    workspace_root = tmp_path / "workspace"
+    docs_dir = workspace_root / "docs"
+    docs_dir.mkdir(parents=True, exist_ok=True)
+    content = "alpha\nbeta\ngamma\n"
+    (docs_dir / "story.txt").write_text(content, encoding="utf-8")
+    resolver = _FakeWorkspaceRootResolver(
+        {
+            "workspace_root": str(workspace_root),
+            "workspace_id": "workspace-1",
+            "source": "sandbox_workspace_lookup",
+            "reason": None,
+        }
+    )
+    mod = FilesystemModule(
+        ModuleConfig(name="filesystem", settings={"read_receipt_secret": "unit-test-secret"}),
+        workspace_root_resolver=resolver,
+    )
+    context = RequestContext(request_id="req-fs-read", user_id="1", metadata={})
+
+    result = await mod.execute_tool("fs.read", {"path": "docs/story.txt"}, context=context)
+
+    assert result["path"] == "docs/story.txt"  # nosec B101
+    assert result["content"] == content  # nosec B101
+    assert result["start_line"] == 1  # nosec B101
+    assert result["end_line"] == 3  # nosec B101
+    assert result["line_count_total"] == 3  # nosec B101
+    assert result["bytes_read"] == len(content.encode("utf-8"))  # nosec B101
+    assert result["bytes_total"] == len(content.encode("utf-8"))  # nosec B101
+    assert result["sha256"] == hashlib.sha256(content.encode("utf-8")).hexdigest()  # nosec B101
+    assert result["read_receipt"]  # nosec B101
+    assert result["newline_style"] == "lf"  # nosec B101
+    assert result["truncated"] is False  # nosec B101
+    assert result["eval"] == {  # nosec B101
+        "tool_name": "fs.read",
+        "tool_prompt_id": "mcp.fs.read.v1",
+        "tool_prompt_version": "2026.06.04",
+        "action_family": "filesystem_read",
+        "result_kind": "structured_filesystem_read",
+        "path_filter_used": True,
+        "truncated": False,
+    }
+
+
+@pytest.mark.asyncio
+async def test_filesystem_read_truncates_and_omits_receipt(tmp_path: Path) -> None:
+    workspace_root = tmp_path / "workspace"
+    workspace_root.mkdir(parents=True, exist_ok=True)
+    (workspace_root / "long.txt").write_text("abcdef\n", encoding="utf-8")
+    resolver = _FakeWorkspaceRootResolver(
+        {
+            "workspace_root": str(workspace_root),
+            "workspace_id": "workspace-1",
+            "source": "sandbox_workspace_lookup",
+            "reason": None,
+        }
+    )
+    mod = FilesystemModule(
+        ModuleConfig(name="filesystem", settings={"read_receipt_secret": "unit-test-secret"}),
+        workspace_root_resolver=resolver,
+    )
+    context = RequestContext(request_id="req-fs-read-truncated", user_id="1", metadata={})
+
+    result = await mod.execute_tool("fs.read", {"path": "long.txt", "max_bytes": 3}, context=context)
+
+    assert result["content"] == "abc"  # nosec B101
+    assert result["bytes_read"] == 3  # nosec B101
+    assert result["truncated"] is True  # nosec B101
+    assert result["truncation_reason"] == "max_bytes"  # nosec B101
+    assert "read_receipt" not in result  # nosec B101
+    assert result["eval"]["truncated"] is True  # nosec B101
+    assert result["eval"]["path_filter_used"] is True  # nosec B101
+
+
+@pytest.mark.asyncio
+async def test_filesystem_read_can_include_line_numbers(tmp_path: Path) -> None:
+    workspace_root = tmp_path / "workspace"
+    workspace_root.mkdir(parents=True, exist_ok=True)
+    content = "alpha\nbeta\ngamma\n"
+    (workspace_root / "story.txt").write_text(content, encoding="utf-8")
+    resolver = _FakeWorkspaceRootResolver(
+        {
+            "workspace_root": str(workspace_root),
+            "workspace_id": "workspace-1",
+            "source": "sandbox_workspace_lookup",
+            "reason": None,
+        }
+    )
+    mod = FilesystemModule(
+        ModuleConfig(name="filesystem", settings={"read_receipt_secret": "unit-test-secret"}),
+        workspace_root_resolver=resolver,
+    )
+    context = RequestContext(request_id="req-fs-read-numbered", user_id="1", metadata={})
+
+    result = await mod.execute_tool(
+        "fs.read",
+        {"path": "story.txt", "start_line": 2, "max_lines": 2, "include_line_numbers": True},
+        context=context,
+    )
+
+    assert result["content"] == "2\tbeta\n3\tgamma\n"  # nosec B101
+    assert result["start_line"] == 2  # nosec B101
+    assert result["end_line"] == 3  # nosec B101
+    assert result["line_count_total"] == 3  # nosec B101
+    assert result["bytes_read"] == len("beta\ngamma\n".encode("utf-8"))  # nosec B101
+    assert result["truncated"] is False  # nosec B101
+
+
+@pytest.mark.asyncio
+async def test_filesystem_read_applies_configured_caps(tmp_path: Path) -> None:
+    workspace_root = tmp_path / "workspace"
+    workspace_root.mkdir(parents=True, exist_ok=True)
+    (workspace_root / "story.txt").write_text("one\ntwo\nthree\n", encoding="utf-8")
+    resolver = _FakeWorkspaceRootResolver(
+        {
+            "workspace_root": str(workspace_root),
+            "workspace_id": "workspace-1",
+            "source": "sandbox_workspace_lookup",
+            "reason": None,
+        }
+    )
+    byte_capped_mod = FilesystemModule(
+        ModuleConfig(
+            name="filesystem",
+            settings={
+                "read_max_bytes": 4,
+                "read_receipt_secret": "unit-test-secret",
+            },
+        ),
+        workspace_root_resolver=resolver,
+    )
+    line_capped_mod = FilesystemModule(
+        ModuleConfig(
+            name="filesystem",
+            settings={
+                "read_max_lines": 2,
+                "read_receipt_secret": "unit-test-secret",
+            },
+        ),
+        workspace_root_resolver=resolver,
+    )
+    context = RequestContext(request_id="req-fs-read-capped", user_id="1", metadata={})
+
+    byte_capped = await byte_capped_mod.execute_tool("fs.read", {"path": "story.txt", "max_bytes": 100}, context=context)
+    line_capped = await line_capped_mod.execute_tool("fs.read", {"path": "story.txt", "max_lines": 100}, context=context)
+
+    assert byte_capped["content"] == "one\n"  # nosec B101
+    assert byte_capped["bytes_read"] == 4  # nosec B101
+    assert byte_capped["truncation_reason"] == "max_bytes"  # nosec B101
+    assert "read_receipt" not in byte_capped  # nosec B101
+    assert line_capped["content"] == "one\ntwo\n"  # nosec B101
+    assert line_capped["truncation_reason"] == "max_lines"  # nosec B101
+
+
+@pytest.mark.asyncio
+async def test_filesystem_read_rejects_binary_payload(tmp_path: Path) -> None:
+    workspace_root = tmp_path / "workspace"
+    workspace_root.mkdir(parents=True, exist_ok=True)
+    (workspace_root / "blob.bin").write_bytes(b"abc\x00def")
+    resolver = _FakeWorkspaceRootResolver(
+        {
+            "workspace_root": str(workspace_root),
+            "workspace_id": "workspace-1",
+            "source": "sandbox_workspace_lookup",
+            "reason": None,
+        }
+    )
+    mod = FilesystemModule(ModuleConfig(name="filesystem"), workspace_root_resolver=resolver)
+    context = RequestContext(request_id="req-fs-read-binary", user_id="1", metadata={})
+
+    with pytest.raises(ValueError, match="binary content is not supported"):
+        await mod.execute_tool("fs.read", {"path": "blob.bin"}, context=context)
+    assert len(resolver.calls) == 1  # nosec B101
 
 
 @pytest.mark.asyncio

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_module.py
@@ -35,6 +35,7 @@ class _FilesystemRegistry:
             "fs.read",
             "fs.read_text",
             "fs.patch",
+            "fs.write",
             "fs.write_text",
             "fs.stat",
             "fs.glob",
@@ -201,9 +202,9 @@ async def test_filesystem_tools_include_path_scope_metadata() -> None:
     tools = await mod.get_tools()
     by_name = {tool["name"]: tool for tool in tools}
 
-    assert {"fs.list", "fs.read", "fs.read_text", "fs.patch", "fs.write_text"} <= set(by_name)  # nosec B101
+    assert {"fs.list", "fs.read", "fs.read_text", "fs.patch", "fs.write", "fs.write_text"} <= set(by_name)  # nosec B101
 
-    for tool_name in ("fs.list", "fs.read", "fs.read_text", "fs.patch", "fs.write_text"):
+    for tool_name in ("fs.list", "fs.read", "fs.read_text", "fs.patch", "fs.write", "fs.write_text"):
         metadata = by_name[tool_name]["metadata"]
         assert metadata["uses_filesystem"] is True  # nosec B101
         assert metadata["path_boundable"] is True  # nosec B101
@@ -222,6 +223,13 @@ async def test_filesystem_tools_include_path_scope_metadata() -> None:
     assert patch_metadata["eval"]["task_families"] == ["filesystem_edit"]  # nosec B101
     assert patch_metadata["eval"]["expected_result_kind"] == "structured_filesystem_edit"  # nosec B101
     assert by_name["fs.patch"]["inputSchema"]["additionalProperties"] is False  # nosec B101
+    write_metadata = by_name["fs.write"]["metadata"]
+    assert write_metadata["path_argument_hints"] == ["path"]  # nosec B101
+    assert write_metadata["path_scope_action"] == "write"  # nosec B101
+    assert write_metadata["write_capable"] is True  # nosec B101
+    assert write_metadata["eval"]["task_families"] == ["filesystem_write"]  # nosec B101
+    assert write_metadata["eval"]["expected_result_kind"] == "structured_filesystem_write"  # nosec B101
+    assert by_name["fs.write"]["inputSchema"]["additionalProperties"] is False  # nosec B101
     assert by_name["fs.write_text"]["metadata"]["category"] == "management"  # nosec B101
 
 
@@ -716,6 +724,141 @@ async def test_filesystem_patch_can_create_file_when_allowed(tmp_path: Path) -> 
     assert result["files"][0]["path"] == "docs/notes.txt"  # nosec B101
     assert result["files"][0]["action"] == "write"  # nosec B101
     assert result["files"][0]["created"] is True  # nosec B101
+
+
+@pytest.mark.asyncio
+async def test_filesystem_write_create_creates_new_text_file(tmp_path: Path) -> None:
+    workspace_root = tmp_path / "workspace"
+    workspace_root.mkdir(parents=True, exist_ok=True)
+    resolver = _FakeWorkspaceRootResolver({"workspace_root": str(workspace_root)})
+    mod = FilesystemModule(ModuleConfig(name="filesystem"), workspace_root_resolver=resolver)
+    context = RequestContext(request_id="req-fs-write-create", user_id="1", metadata={})
+
+    result = await mod.execute_tool(
+        "fs.write",
+        {"path": "docs/new.txt", "content": "created\n", "mode": "create"},
+        context=context,
+    )
+
+    assert (workspace_root / "docs" / "new.txt").read_text(encoding="utf-8") == "created\n"  # nosec B101
+    assert result["path"] == "docs/new.txt"  # nosec B101
+    assert result["written"] is True  # nosec B101
+    assert result["created"] is True  # nosec B101
+    assert result["bytes_written"] == len("created\n".encode("utf-8"))  # nosec B101
+    assert result["eval"]["action_family"] == "filesystem_write"  # nosec B101
+
+    with pytest.raises(ValueError, match="write_target_exists"):
+        await mod.execute_tool(
+            "fs.write",
+            {"path": "docs/new.txt", "content": "again\n", "mode": "create"},
+            context=context,
+        )
+
+
+@pytest.mark.asyncio
+async def test_filesystem_write_replace_requires_preimage(tmp_path: Path) -> None:
+    workspace_root = tmp_path / "workspace"
+    workspace_root.mkdir(parents=True, exist_ok=True)
+    (workspace_root / "story.txt").write_text("old\n", encoding="utf-8")
+    resolver = _FakeWorkspaceRootResolver({"workspace_root": str(workspace_root)})
+    mod = FilesystemModule(ModuleConfig(name="filesystem"), workspace_root_resolver=resolver)
+    context = RequestContext(request_id="req-fs-write-preimage", user_id="1", metadata={})
+
+    with pytest.raises(ValueError, match="write_preimage_required"):
+        await mod.execute_tool(
+            "fs.write",
+            {"path": "story.txt", "content": "new\n", "mode": "replace"},
+            context=context,
+        )
+
+
+@pytest.mark.asyncio
+async def test_filesystem_write_replace_with_expected_hash(tmp_path: Path) -> None:
+    workspace_root = tmp_path / "workspace"
+    workspace_root.mkdir(parents=True, exist_ok=True)
+    target = workspace_root / "story.txt"
+    target.write_text("old\n", encoding="utf-8")
+    resolver = _FakeWorkspaceRootResolver({"workspace_root": str(workspace_root)})
+    mod = FilesystemModule(ModuleConfig(name="filesystem"), workspace_root_resolver=resolver)
+    context = RequestContext(request_id="req-fs-write-expected", user_id="1", metadata={})
+    expected_sha = hashlib.sha256("old\n".encode("utf-8")).hexdigest()
+
+    result = await mod.execute_tool(
+        "fs.write",
+        {"path": "story.txt", "content": "new\n", "mode": "replace", "expected_sha256": expected_sha},
+        context=context,
+    )
+
+    assert target.read_text(encoding="utf-8") == "new\n"  # nosec B101
+    assert result["written"] is True  # nosec B101
+    assert result["created"] is False  # nosec B101
+    assert result["sha256_before"] == expected_sha  # nosec B101
+    assert result["sha256_after"] == hashlib.sha256("new\n".encode("utf-8")).hexdigest()  # nosec B101
+
+
+@pytest.mark.asyncio
+async def test_filesystem_write_replace_with_read_receipt(tmp_path: Path) -> None:
+    workspace_root = tmp_path / "workspace"
+    workspace_root.mkdir(parents=True, exist_ok=True)
+    target = workspace_root / "story.txt"
+    target.write_text("old\n", encoding="utf-8")
+    resolver = _FakeWorkspaceRootResolver({"workspace_root": str(workspace_root), "workspace_id": "ws-1"})
+    mod = FilesystemModule(
+        ModuleConfig(name="filesystem", settings={"read_receipt_secret": "unit-test-secret"}),
+        workspace_root_resolver=resolver,
+    )
+    context = RequestContext(request_id="req-fs-write-receipt", user_id="1", metadata={"workspace_id": "ws-1"})
+    read_result = await mod.execute_tool("fs.read", {"path": "story.txt"}, context=context)
+
+    result = await mod.execute_tool(
+        "fs.write",
+        {
+            "path": "story.txt",
+            "content": "new\n",
+            "mode": "replace",
+            "read_receipt": read_result["read_receipt"],
+        },
+        context=context,
+    )
+
+    assert target.read_text(encoding="utf-8") == "new\n"  # nosec B101
+    assert result["sha256_before"] == read_result["sha256"]  # nosec B101
+
+
+@pytest.mark.asyncio
+async def test_filesystem_write_rejects_stale_hash_and_dry_run_does_not_write(tmp_path: Path) -> None:
+    workspace_root = tmp_path / "workspace"
+    workspace_root.mkdir(parents=True, exist_ok=True)
+    target = workspace_root / "story.txt"
+    target.write_text("old\n", encoding="utf-8")
+    resolver = _FakeWorkspaceRootResolver({"workspace_root": str(workspace_root)})
+    mod = FilesystemModule(ModuleConfig(name="filesystem"), workspace_root_resolver=resolver)
+    context = RequestContext(request_id="req-fs-write-stale", user_id="1", metadata={})
+    expected_sha = hashlib.sha256("old\n".encode("utf-8")).hexdigest()
+
+    with pytest.raises(ValueError, match="write_preimage_mismatch"):
+        await mod.execute_tool(
+            "fs.write",
+            {"path": "story.txt", "content": "new\n", "mode": "replace", "expected_sha256": "0" * 64},
+            context=context,
+        )
+
+    result = await mod.execute_tool(
+        "fs.write",
+        {
+            "path": "story.txt",
+            "content": "dry-run\n",
+            "mode": "replace",
+            "expected_sha256": expected_sha,
+            "dry_run": True,
+        },
+        context=context,
+    )
+
+    assert target.read_text(encoding="utf-8") == "old\n"  # nosec B101
+    assert result["written"] is False  # nosec B101
+    assert result["dry_run"] is True  # nosec B101
+    assert result["sha256_after"] == hashlib.sha256("dry-run\n".encode("utf-8")).hexdigest()  # nosec B101
 
 
 @pytest.mark.asyncio

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_module.py
@@ -6,6 +6,7 @@ from typing import Any
 
 import pytest
 
+from mcp_unified.interfaces.path_scope import PathScopeCandidate
 from tldw_Server_API.app.core.MCP_unified.modules.base import ModuleConfig
 from tldw_Server_API.app.core.MCP_unified.modules.implementations.filesystem_module import (
     FilesystemModule,
@@ -29,7 +30,16 @@ class _FakeWorkspaceRootResolver:
 class _FilesystemRegistry:
     def __init__(self, module: FilesystemModule) -> None:
         self.module = module
-        self._tool_names = {"fs.list", "fs.read", "fs.read_text", "fs.write_text", "fs.stat", "fs.glob", "fs.grep"}
+        self._tool_names = {
+            "fs.list",
+            "fs.read",
+            "fs.read_text",
+            "fs.patch",
+            "fs.write_text",
+            "fs.stat",
+            "fs.glob",
+            "fs.grep",
+        }
 
     async def find_module_for_tool(self, tool_name: str):  # noqa: ANN001
         if tool_name in self._tool_names:
@@ -68,6 +78,23 @@ class _FakeSharedRegistryRepo:
         if workspace_id is not None:
             rows = [row for row in rows if row.get("workspace_id") == workspace_id]
         return rows
+
+
+_PATCH_MODIFY_STORY = """--- a/docs/story.txt
++++ b/docs/story.txt
+@@ -1,3 +1,3 @@
+ alpha
+-beta
++BETTA
+ gamma
+"""
+
+_PATCH_CREATE_NOTES = """--- /dev/null
++++ b/docs/notes.txt
+@@ -0,0 +1,2 @@
++first
++second
+"""
 
 
 @pytest.mark.asyncio
@@ -174,21 +201,27 @@ async def test_filesystem_tools_include_path_scope_metadata() -> None:
     tools = await mod.get_tools()
     by_name = {tool["name"]: tool for tool in tools}
 
-    assert {"fs.list", "fs.read", "fs.read_text", "fs.write_text"} <= set(by_name)  # nosec B101
+    assert {"fs.list", "fs.read", "fs.read_text", "fs.patch", "fs.write_text"} <= set(by_name)  # nosec B101
 
-    for tool_name in ("fs.list", "fs.read", "fs.read_text", "fs.write_text"):
+    for tool_name in ("fs.list", "fs.read", "fs.read_text", "fs.patch", "fs.write_text"):
         metadata = by_name[tool_name]["metadata"]
         assert metadata["uses_filesystem"] is True  # nosec B101
         assert metadata["path_boundable"] is True  # nosec B101
-        assert metadata["path_argument_hints"] == ["path"]  # nosec B101
 
     read_metadata = by_name["fs.read"]["metadata"]
+    assert read_metadata["path_argument_hints"] == ["path"]  # nosec B101
     assert read_metadata["readOnlyHint"] is True  # nosec B101
     assert read_metadata["path_scope_action"] == "read"  # nosec B101
     assert "filesystem.read" in read_metadata["capabilities"]  # nosec B101
     assert read_metadata["eval"]["task_families"] == ["filesystem_read"]  # nosec B101
     assert read_metadata["eval"]["expected_result_kind"] == "structured_filesystem_read"  # nosec B101
     assert by_name["fs.read"]["inputSchema"]["additionalProperties"] is False  # nosec B101
+    patch_metadata = by_name["fs.patch"]["metadata"]
+    assert patch_metadata["path_scope_candidate_source"] == "module"  # nosec B101
+    assert patch_metadata["write_capable"] is True  # nosec B101
+    assert patch_metadata["eval"]["task_families"] == ["filesystem_edit"]  # nosec B101
+    assert patch_metadata["eval"]["expected_result_kind"] == "structured_filesystem_edit"  # nosec B101
+    assert by_name["fs.patch"]["inputSchema"]["additionalProperties"] is False  # nosec B101
     assert by_name["fs.write_text"]["metadata"]["category"] == "management"  # nosec B101
 
 
@@ -499,6 +532,190 @@ async def test_filesystem_read_rejects_binary_payload(tmp_path: Path) -> None:
     with pytest.raises(ValueError, match="binary content is not supported"):
         await mod.execute_tool("fs.read", {"path": "blob.bin"}, context=context)
     assert len(resolver.calls) == 1  # nosec B101
+
+
+@pytest.mark.asyncio
+async def test_filesystem_patch_extracts_path_scope_candidates() -> None:
+    resolver = _FakeWorkspaceRootResolver({"workspace_root": "/workspace/root"})
+    mod = FilesystemModule(ModuleConfig(name="filesystem"), workspace_root_resolver=resolver)
+
+    modify_candidates = await mod.extract_path_scope_candidates(
+        "fs.patch",
+        {"diff": _PATCH_MODIFY_STORY},
+    )
+    create_candidates = await mod.extract_path_scope_candidates(
+        "fs.patch",
+        {"diff": _PATCH_CREATE_NOTES},
+    )
+
+    assert modify_candidates == [  # nosec B101
+        PathScopeCandidate(
+            path="docs/story.txt",
+            action="edit",
+            source="filesystem_diff",
+            requires_existing_file=True,
+        )
+    ]
+    assert create_candidates == [  # nosec B101
+        PathScopeCandidate(
+            path="docs/notes.txt",
+            action="write",
+            source="filesystem_diff",
+            creates_file=True,
+        )
+    ]
+
+
+@pytest.mark.asyncio
+async def test_filesystem_patch_requires_preimage_for_existing_file(tmp_path: Path) -> None:
+    workspace_root = tmp_path / "workspace"
+    docs_dir = workspace_root / "docs"
+    docs_dir.mkdir(parents=True, exist_ok=True)
+    (docs_dir / "story.txt").write_text("alpha\nbeta\ngamma\n", encoding="utf-8")
+    resolver = _FakeWorkspaceRootResolver({"workspace_root": str(workspace_root)})
+    mod = FilesystemModule(ModuleConfig(name="filesystem"), workspace_root_resolver=resolver)
+    context = RequestContext(request_id="req-fs-patch-preimage", user_id="1", metadata={})
+
+    with pytest.raises(ValueError, match="patch_preimage_required"):
+        await mod.execute_tool("fs.patch", {"diff": _PATCH_MODIFY_STORY}, context=context)
+
+
+@pytest.mark.asyncio
+async def test_filesystem_patch_applies_existing_file_with_expected_hash(tmp_path: Path) -> None:
+    workspace_root = tmp_path / "workspace"
+    docs_dir = workspace_root / "docs"
+    docs_dir.mkdir(parents=True, exist_ok=True)
+    original = "alpha\nbeta\ngamma\n"
+    target = docs_dir / "story.txt"
+    target.write_text(original, encoding="utf-8")
+    resolver = _FakeWorkspaceRootResolver({"workspace_root": str(workspace_root), "workspace_id": "ws-1"})
+    mod = FilesystemModule(ModuleConfig(name="filesystem"), workspace_root_resolver=resolver)
+    context = RequestContext(request_id="req-fs-patch-expected", user_id="1", metadata={"workspace_id": "ws-1"})
+
+    result = await mod.execute_tool(
+        "fs.patch",
+        {
+            "diff": _PATCH_MODIFY_STORY,
+            "expected_sha256_by_path": {"docs/story.txt": hashlib.sha256(original.encode("utf-8")).hexdigest()},
+        },
+        context=context,
+    )
+
+    assert target.read_text(encoding="utf-8") == "alpha\nBETTA\ngamma\n"  # nosec B101
+    assert result["applied"] is True  # nosec B101
+    assert result["dry_run"] is False  # nosec B101
+    assert result["files"][0]["path"] == "docs/story.txt"  # nosec B101
+    assert result["files"][0]["action"] == "edit"  # nosec B101
+    assert result["files"][0]["created"] is False  # nosec B101
+    assert "content" not in str(result)  # nosec B101
+    assert result["eval"]["action_family"] == "filesystem_edit"  # nosec B101
+    assert result["eval"]["path_filter_used"] is True  # nosec B101
+
+
+@pytest.mark.asyncio
+async def test_filesystem_patch_dry_run_does_not_write(tmp_path: Path) -> None:
+    workspace_root = tmp_path / "workspace"
+    docs_dir = workspace_root / "docs"
+    docs_dir.mkdir(parents=True, exist_ok=True)
+    original = "alpha\nbeta\ngamma\n"
+    target = docs_dir / "story.txt"
+    target.write_text(original, encoding="utf-8")
+    resolver = _FakeWorkspaceRootResolver({"workspace_root": str(workspace_root)})
+    mod = FilesystemModule(ModuleConfig(name="filesystem"), workspace_root_resolver=resolver)
+    context = RequestContext(request_id="req-fs-patch-dry-run", user_id="1", metadata={})
+
+    result = await mod.execute_tool(
+        "fs.patch",
+        {
+            "diff": _PATCH_MODIFY_STORY,
+            "expected_sha256_by_path": {"docs/story.txt": hashlib.sha256(original.encode("utf-8")).hexdigest()},
+            "dry_run": True,
+        },
+        context=context,
+    )
+
+    assert target.read_text(encoding="utf-8") == original  # nosec B101
+    assert result["applied"] is False  # nosec B101
+    assert result["dry_run"] is True  # nosec B101
+    assert result["files"][0]["sha256_after"] == hashlib.sha256("alpha\nBETTA\ngamma\n".encode("utf-8")).hexdigest()  # nosec B101
+
+
+@pytest.mark.asyncio
+async def test_filesystem_patch_applies_existing_file_with_read_receipt(tmp_path: Path) -> None:
+    workspace_root = tmp_path / "workspace"
+    docs_dir = workspace_root / "docs"
+    docs_dir.mkdir(parents=True, exist_ok=True)
+    target = docs_dir / "story.txt"
+    target.write_text("alpha\nbeta\ngamma\n", encoding="utf-8")
+    resolver = _FakeWorkspaceRootResolver({"workspace_root": str(workspace_root), "workspace_id": "ws-1"})
+    mod = FilesystemModule(
+        ModuleConfig(name="filesystem", settings={"read_receipt_secret": "unit-test-secret"}),
+        workspace_root_resolver=resolver,
+    )
+    context = RequestContext(request_id="req-fs-patch-receipt", user_id="1", metadata={"workspace_id": "ws-1"})
+    read_result = await mod.execute_tool("fs.read", {"path": "docs/story.txt"}, context=context)
+
+    result = await mod.execute_tool(
+        "fs.patch",
+        {"diff": _PATCH_MODIFY_STORY, "read_receipt_by_path": {"docs/story.txt": read_result["read_receipt"]}},
+        context=context,
+    )
+
+    assert target.read_text(encoding="utf-8") == "alpha\nBETTA\ngamma\n"  # nosec B101
+    assert result["files"][0]["sha256_before"] == read_result["sha256"]  # nosec B101
+
+
+@pytest.mark.asyncio
+async def test_filesystem_patch_rejects_stale_hash_and_context_mismatch(tmp_path: Path) -> None:
+    workspace_root = tmp_path / "workspace"
+    docs_dir = workspace_root / "docs"
+    docs_dir.mkdir(parents=True, exist_ok=True)
+    target = docs_dir / "story.txt"
+    target.write_text("alpha\nchanged\ngamma\n", encoding="utf-8")
+    resolver = _FakeWorkspaceRootResolver({"workspace_root": str(workspace_root)})
+    mod = FilesystemModule(ModuleConfig(name="filesystem"), workspace_root_resolver=resolver)
+    context = RequestContext(request_id="req-fs-patch-stale", user_id="1", metadata={})
+
+    with pytest.raises(ValueError, match="patch_preimage_mismatch"):
+        await mod.execute_tool(
+            "fs.patch",
+            {
+                "diff": _PATCH_MODIFY_STORY,
+                "expected_sha256_by_path": {"docs/story.txt": "0" * 64},
+            },
+            context=context,
+        )
+
+    current_sha = hashlib.sha256(target.read_bytes()).hexdigest()
+    with pytest.raises(ValueError, match="patch_context_mismatch"):
+        await mod.execute_tool(
+            "fs.patch",
+            {
+                "diff": _PATCH_MODIFY_STORY,
+                "expected_sha256_by_path": {"docs/story.txt": current_sha},
+            },
+            context=context,
+        )
+
+
+@pytest.mark.asyncio
+async def test_filesystem_patch_can_create_file_when_allowed(tmp_path: Path) -> None:
+    workspace_root = tmp_path / "workspace"
+    workspace_root.mkdir(parents=True, exist_ok=True)
+    resolver = _FakeWorkspaceRootResolver({"workspace_root": str(workspace_root)})
+    mod = FilesystemModule(ModuleConfig(name="filesystem"), workspace_root_resolver=resolver)
+    context = RequestContext(request_id="req-fs-patch-create", user_id="1", metadata={})
+
+    result = await mod.execute_tool(
+        "fs.patch",
+        {"diff": _PATCH_CREATE_NOTES, "allow_create": True, "create_parent_directories": True},
+        context=context,
+    )
+
+    assert (workspace_root / "docs" / "notes.txt").read_text(encoding="utf-8") == "first\nsecond\n"  # nosec B101
+    assert result["files"][0]["path"] == "docs/notes.txt"  # nosec B101
+    assert result["files"][0]["action"] == "write"  # nosec B101
+    assert result["files"][0]["created"] is True  # nosec B101
 
 
 @pytest.mark.asyncio

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_module.py
@@ -230,6 +230,14 @@ async def test_filesystem_tools_include_path_scope_metadata() -> None:
     assert write_metadata["eval"]["task_families"] == ["filesystem_write"]  # nosec B101
     assert write_metadata["eval"]["expected_result_kind"] == "structured_filesystem_write"  # nosec B101
     assert by_name["fs.write"]["inputSchema"]["additionalProperties"] is False  # nosec B101
+    read_text_metadata = by_name["fs.read_text"]["metadata"]
+    assert read_text_metadata["legacy_tool"] is True  # nosec B101
+    assert read_text_metadata["replacement_tool"] == "fs.read"  # nosec B101
+    assert read_text_metadata["path_scope_action"] == "read"  # nosec B101
+    write_text_metadata = by_name["fs.write_text"]["metadata"]
+    assert write_text_metadata["legacy_tool"] is True  # nosec B101
+    assert write_text_metadata["replacement_tools"] == ["fs.patch", "fs.write"]  # nosec B101
+    assert write_text_metadata["path_scope_action"] == "write"  # nosec B101
     assert by_name["fs.write_text"]["metadata"]["category"] == "management"  # nosec B101
 
 

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_module.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import hashlib
+import os
+import stat
 from pathlib import Path
 from typing import Any
 
@@ -10,6 +12,10 @@ from mcp_unified.interfaces.path_scope import PathScopeCandidate
 from tldw_Server_API.app.core.MCP_unified.modules.base import ModuleConfig
 from tldw_Server_API.app.core.MCP_unified.modules.implementations.filesystem_module import (
     FilesystemModule,
+)
+from tldw_Server_API.app.core.MCP_unified.modules.implementations.filesystem_receipts import (
+    ReadReceiptError,
+    ReadReceiptManager,
 )
 from tldw_Server_API.app.core.MCP_unified.protocol import InvalidParamsException, MCPProtocol, RequestContext
 from tldw_Server_API.app.services.mcp_hub_workspace_root_resolver import (
@@ -419,6 +425,37 @@ async def test_filesystem_read_returns_content_hash_and_receipt(tmp_path: Path) 
     }
 
 
+def test_read_receipts_require_configured_stable_secret() -> None:
+    manager = ReadReceiptManager(secret=None)
+
+    with pytest.raises(ReadReceiptError, match="read_receipt_secret_unconfigured"):
+        manager.issue(path="story.txt", sha256="0" * 64, size=1)
+    with pytest.raises(ReadReceiptError, match="read_receipt_secret_unconfigured"):
+        manager.validate("not-a-valid-receipt")
+
+
+@pytest.mark.asyncio
+async def test_filesystem_read_omits_receipt_without_configured_secret(tmp_path: Path) -> None:
+    workspace_root = tmp_path / "workspace"
+    workspace_root.mkdir(parents=True, exist_ok=True)
+    (workspace_root / "story.txt").write_text("alpha\n", encoding="utf-8")
+    resolver = _FakeWorkspaceRootResolver(
+        {
+            "workspace_root": str(workspace_root),
+            "workspace_id": "workspace-1",
+            "source": "sandbox_workspace_lookup",
+            "reason": None,
+        }
+    )
+    mod = FilesystemModule(ModuleConfig(name="filesystem"), workspace_root_resolver=resolver)
+    context = RequestContext(request_id="req-fs-read-no-receipt-secret", user_id="1", metadata={})
+
+    result = await mod.execute_tool("fs.read", {"path": "story.txt"}, context=context)
+
+    assert result["sha256"] == hashlib.sha256(b"alpha\n").hexdigest()  # nosec B101
+    assert "read_receipt" not in result  # nosec B101
+
+
 @pytest.mark.asyncio
 async def test_filesystem_read_truncates_and_omits_receipt(tmp_path: Path) -> None:
     workspace_root = tmp_path / "workspace"
@@ -447,6 +484,32 @@ async def test_filesystem_read_truncates_and_omits_receipt(tmp_path: Path) -> No
     assert "read_receipt" not in result  # nosec B101
     assert result["eval"]["truncated"] is True  # nosec B101
     assert result["eval"]["path_filter_used"] is True  # nosec B101
+
+
+@pytest.mark.asyncio
+async def test_filesystem_read_omits_total_line_count_when_large_file_is_byte_truncated(tmp_path: Path) -> None:
+    workspace_root = tmp_path / "workspace"
+    workspace_root.mkdir(parents=True, exist_ok=True)
+    (workspace_root / "long.txt").write_text("one\ntwo\nthree\n", encoding="utf-8")
+    resolver = _FakeWorkspaceRootResolver({"workspace_root": str(workspace_root), "workspace_id": "workspace-1"})
+    mod = FilesystemModule(
+        ModuleConfig(
+            name="filesystem",
+            settings={
+                "read_hash_max_file_bytes": 3,
+                "read_receipt_secret": "unit-test-secret",
+            },
+        ),
+        workspace_root_resolver=resolver,
+    )
+    context = RequestContext(request_id="req-fs-read-large-truncated", user_id="1", metadata={})
+
+    result = await mod.execute_tool("fs.read", {"path": "long.txt", "max_bytes": 4}, context=context)
+
+    assert result["content"] == "one\n"  # nosec B101
+    assert result["truncated"] is True  # nosec B101
+    assert result["line_count_total"] is None  # nosec B101
+    assert result["hash_omitted_reason"] == "hash_omitted_file_too_large"  # nosec B101
 
 
 @pytest.mark.asyncio
@@ -518,8 +581,12 @@ async def test_filesystem_read_applies_configured_caps(tmp_path: Path) -> None:
     )
     context = RequestContext(request_id="req-fs-read-capped", user_id="1", metadata={})
 
-    byte_capped = await byte_capped_mod.execute_tool("fs.read", {"path": "story.txt", "max_bytes": 100}, context=context)
-    line_capped = await line_capped_mod.execute_tool("fs.read", {"path": "story.txt", "max_lines": 100}, context=context)
+    byte_capped = await byte_capped_mod.execute_tool(
+        "fs.read", {"path": "story.txt", "max_bytes": 100}, context=context
+    )
+    line_capped = await line_capped_mod.execute_tool(
+        "fs.read", {"path": "story.txt", "max_lines": 100}, context=context
+    )
 
     assert byte_capped["content"] == "one\n"  # nosec B101
     assert byte_capped["bytes_read"] == 4  # nosec B101
@@ -629,6 +696,63 @@ async def test_filesystem_patch_applies_existing_file_with_expected_hash(tmp_pat
 
 
 @pytest.mark.asyncio
+async def test_filesystem_patch_rolls_back_previous_writes_on_partial_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace_root = tmp_path / "workspace"
+    docs_dir = workspace_root / "docs"
+    docs_dir.mkdir(parents=True, exist_ok=True)
+    first = docs_dir / "one.txt"
+    second = docs_dir / "two.txt"
+    first_original = "alpha\n"
+    second_original = "beta\n"
+    first.write_text(first_original, encoding="utf-8")
+    second.write_text(second_original, encoding="utf-8")
+    resolver = _FakeWorkspaceRootResolver({"workspace_root": str(workspace_root)})
+    mod = FilesystemModule(ModuleConfig(name="filesystem"), workspace_root_resolver=resolver)
+    context = RequestContext(request_id="req-fs-patch-rollback", user_id="1", metadata={})
+    original_atomic_write = FilesystemModule._atomic_write_text_file
+
+    def _fail_on_second_write(target: Path, text: str) -> None:
+        if target.name == "two.txt":
+            raise OSError("simulated write failure")
+        original_atomic_write(target, text)
+
+    monkeypatch.setattr(
+        FilesystemModule,
+        "_atomic_write_text_file",
+        staticmethod(_fail_on_second_write),
+    )
+
+    with pytest.raises(ValueError, match="partial_write_rollback_attempted"):
+        await mod.execute_tool(
+            "fs.patch",
+            {
+                "diff": """--- a/docs/one.txt
++++ b/docs/one.txt
+@@ -1 +1 @@
+-alpha
++ALPHA
+--- a/docs/two.txt
++++ b/docs/two.txt
+@@ -1 +1 @@
+-beta
++BETA
+""",
+                "expected_sha256_by_path": {
+                    "docs/one.txt": hashlib.sha256(first_original.encode("utf-8")).hexdigest(),
+                    "docs/two.txt": hashlib.sha256(second_original.encode("utf-8")).hexdigest(),
+                },
+            },
+            context=context,
+        )
+
+    assert first.read_text(encoding="utf-8") == first_original  # nosec B101
+    assert second.read_text(encoding="utf-8") == second_original  # nosec B101
+
+
+@pytest.mark.asyncio
 async def test_filesystem_patch_dry_run_does_not_write(tmp_path: Path) -> None:
     workspace_root = tmp_path / "workspace"
     docs_dir = workspace_root / "docs"
@@ -653,7 +777,9 @@ async def test_filesystem_patch_dry_run_does_not_write(tmp_path: Path) -> None:
     assert target.read_text(encoding="utf-8") == original  # nosec B101
     assert result["applied"] is False  # nosec B101
     assert result["dry_run"] is True  # nosec B101
-    assert result["files"][0]["sha256_after"] == hashlib.sha256("alpha\nBETTA\ngamma\n".encode("utf-8")).hexdigest()  # nosec B101
+    assert (
+        result["files"][0]["sha256_after"] == hashlib.sha256("alpha\nBETTA\ngamma\n".encode("utf-8")).hexdigest()
+    )  # nosec B101
 
 
 @pytest.mark.asyncio
@@ -802,6 +928,32 @@ async def test_filesystem_write_replace_with_expected_hash(tmp_path: Path) -> No
     assert result["created"] is False  # nosec B101
     assert result["sha256_before"] == expected_sha  # nosec B101
     assert result["sha256_after"] == hashlib.sha256("new\n".encode("utf-8")).hexdigest()  # nosec B101
+
+
+@pytest.mark.asyncio
+async def test_filesystem_write_replace_preserves_existing_file_mode(tmp_path: Path) -> None:
+    workspace_root = tmp_path / "workspace"
+    workspace_root.mkdir(parents=True, exist_ok=True)
+    target = workspace_root / "script.sh"
+    target.write_text("#!/bin/sh\necho old\n", encoding="utf-8")
+    os.chmod(target, 0o755)
+    resolver = _FakeWorkspaceRootResolver({"workspace_root": str(workspace_root)})
+    mod = FilesystemModule(ModuleConfig(name="filesystem"), workspace_root_resolver=resolver)
+    context = RequestContext(request_id="req-fs-write-mode", user_id="1", metadata={})
+    expected_sha = hashlib.sha256(target.read_bytes()).hexdigest()
+
+    await mod.execute_tool(
+        "fs.write",
+        {
+            "path": "script.sh",
+            "content": "#!/bin/sh\necho new\n",
+            "mode": "replace",
+            "expected_sha256": expected_sha,
+        },
+        context=context,
+    )
+
+    assert stat.S_IMODE(target.stat(follow_symlinks=False).st_mode) == 0o755  # nosec B101
 
 
 @pytest.mark.asyncio
@@ -1268,9 +1420,7 @@ async def test_filesystem_glob_returns_symlink_directories_without_traversing(tm
 
     result = await mod.execute_tool("fs.glob", {"pattern": "*"}, context=context)
 
-    assert result["matches"] == [  # nosec B101
-        {"path": "outside-link", "type": "symlink"}
-    ]
+    assert result["matches"] == [{"path": "outside-link", "type": "symlink"}]  # nosec B101
 
 
 @pytest.mark.asyncio
@@ -1728,7 +1878,9 @@ async def test_filesystem_read_text_rejects_binary_payload(tmp_path: Path) -> No
 
 
 @pytest.mark.asyncio
-async def test_filesystem_read_text_rejects_files_over_size_limit(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_filesystem_read_text_rejects_files_over_size_limit(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     workspace_root = tmp_path / "workspace"
     workspace_root.mkdir(parents=True, exist_ok=True)
     large_path = workspace_root / "large.txt"

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_module.py
@@ -487,6 +487,22 @@ async def test_filesystem_read_truncates_and_omits_receipt(tmp_path: Path) -> No
 
 
 @pytest.mark.asyncio
+async def test_filesystem_read_truncated_first_utf8_codepoint_returns_prefix(tmp_path: Path) -> None:
+    workspace_root = tmp_path / "workspace"
+    workspace_root.mkdir(parents=True, exist_ok=True)
+    (workspace_root / "accent.txt").write_text("éclair\n", encoding="utf-8")
+    resolver = _FakeWorkspaceRootResolver({"workspace_root": str(workspace_root)})
+    mod = FilesystemModule(ModuleConfig(name="filesystem"), workspace_root_resolver=resolver)
+    context = RequestContext(request_id="req-fs-read-utf8-prefix", user_id="1", metadata={})
+
+    result = await mod.execute_tool("fs.read", {"path": "accent.txt", "max_bytes": 1}, context=context)
+
+    assert result["content"] == ""  # nosec B101
+    assert result["truncated"] is True  # nosec B101
+    assert result["truncation_reason"] == "max_bytes"  # nosec B101
+
+
+@pytest.mark.asyncio
 async def test_filesystem_read_omits_total_line_count_when_large_file_is_byte_truncated(tmp_path: Path) -> None:
     workspace_root = tmp_path / "workspace"
     workspace_root.mkdir(parents=True, exist_ok=True)
@@ -783,6 +799,50 @@ async def test_filesystem_patch_dry_run_does_not_write(tmp_path: Path) -> None:
 
 
 @pytest.mark.asyncio
+async def test_filesystem_patch_rechecks_preimage_immediately_before_write(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace_root = tmp_path / "workspace"
+    docs_dir = workspace_root / "docs"
+    docs_dir.mkdir(parents=True, exist_ok=True)
+    original = "alpha\nbeta\ngamma\n"
+    target = docs_dir / "story.txt"
+    target.write_text(original, encoding="utf-8")
+    resolver = _FakeWorkspaceRootResolver({"workspace_root": str(workspace_root)})
+    mod = FilesystemModule(ModuleConfig(name="filesystem"), workspace_root_resolver=resolver)
+    context = RequestContext(request_id="req-fs-patch-race", user_id="1", metadata={})
+    original_assert = FilesystemModule._assert_preimage_unchanged
+
+    def _mutate_before_final_preimage_check(
+        check_target: Path,
+        expected_sha256: str | None,
+        expected_size: int,
+    ) -> None:
+        if check_target == target:
+            target.write_text("concurrent\n", encoding="utf-8")
+        original_assert(check_target, expected_sha256, expected_size)
+
+    monkeypatch.setattr(
+        FilesystemModule,
+        "_assert_preimage_unchanged",
+        staticmethod(_mutate_before_final_preimage_check),
+    )
+
+    with pytest.raises(ValueError, match="preimage_changed_during_commit"):
+        await mod.execute_tool(
+            "fs.patch",
+            {
+                "diff": _PATCH_MODIFY_STORY,
+                "expected_sha256_by_path": {"docs/story.txt": hashlib.sha256(original.encode("utf-8")).hexdigest()},
+            },
+            context=context,
+        )
+
+    assert target.read_text(encoding="utf-8") == "concurrent\n"  # nosec B101
+
+
+@pytest.mark.asyncio
 async def test_filesystem_patch_applies_existing_file_with_read_receipt(tmp_path: Path) -> None:
     workspace_root = tmp_path / "workspace"
     docs_dir = workspace_root / "docs"
@@ -805,6 +865,37 @@ async def test_filesystem_patch_applies_existing_file_with_read_receipt(tmp_path
 
     assert target.read_text(encoding="utf-8") == "alpha\nBETTA\ngamma\n"  # nosec B101
     assert result["files"][0]["sha256_before"] == read_result["sha256"]  # nosec B101
+
+
+@pytest.mark.asyncio
+async def test_filesystem_patch_rejects_bound_read_receipt_without_matching_context(tmp_path: Path) -> None:
+    workspace_root = tmp_path / "workspace"
+    docs_dir = workspace_root / "docs"
+    docs_dir.mkdir(parents=True, exist_ok=True)
+    target = docs_dir / "story.txt"
+    target.write_text("alpha\nbeta\ngamma\n", encoding="utf-8")
+    resolver = _FakeWorkspaceRootResolver({"workspace_root": str(workspace_root), "workspace_id": "ws-1"})
+    mod = FilesystemModule(
+        ModuleConfig(name="filesystem", settings={"read_receipt_secret": "unit-test-secret"}),
+        workspace_root_resolver=resolver,
+    )
+    bound_context = RequestContext(
+        request_id="req-fs-patch-receipt-bound",
+        user_id="1",
+        session_id="session-1",
+        metadata={"workspace_id": "ws-1"},
+    )
+    unbound_context = RequestContext(request_id="req-fs-patch-receipt-unbound", user_id="1", metadata={})
+    read_result = await mod.execute_tool("fs.read", {"path": "docs/story.txt"}, context=bound_context)
+
+    with pytest.raises(ValueError, match="patch_read_receipt_mismatch"):
+        await mod.execute_tool(
+            "fs.patch",
+            {"diff": _PATCH_MODIFY_STORY, "read_receipt_by_path": {"docs/story.txt": read_result["read_receipt"]}},
+            context=unbound_context,
+        )
+
+    assert target.read_text(encoding="utf-8") == "alpha\nbeta\ngamma\n"  # nosec B101
 
 
 @pytest.mark.asyncio
@@ -907,6 +998,33 @@ async def test_filesystem_write_replace_requires_preimage(tmp_path: Path) -> Non
 
 
 @pytest.mark.asyncio
+async def test_filesystem_write_replace_rejects_large_preimage_before_reading(tmp_path: Path) -> None:
+    workspace_root = tmp_path / "workspace"
+    workspace_root.mkdir(parents=True, exist_ok=True)
+    target = workspace_root / "story.txt"
+    target.write_text("large\n", encoding="utf-8")
+    resolver = _FakeWorkspaceRootResolver({"workspace_root": str(workspace_root)})
+    mod = FilesystemModule(
+        ModuleConfig(
+            name="filesystem",
+            settings={"write_preimage_max_bytes": 3},
+        ),
+        workspace_root_resolver=resolver,
+    )
+    context = RequestContext(request_id="req-fs-write-large-preimage", user_id="1", metadata={})
+    expected_sha = hashlib.sha256(target.read_bytes()).hexdigest()
+
+    with pytest.raises(ValueError, match="write_preimage_too_large"):
+        await mod.execute_tool(
+            "fs.write",
+            {"path": "story.txt", "content": "new\n", "mode": "replace", "expected_sha256": expected_sha},
+            context=context,
+        )
+
+    assert target.read_text(encoding="utf-8") == "large\n"  # nosec B101
+
+
+@pytest.mark.asyncio
 async def test_filesystem_write_replace_with_expected_hash(tmp_path: Path) -> None:
     workspace_root = tmp_path / "workspace"
     workspace_root.mkdir(parents=True, exist_ok=True)
@@ -928,6 +1046,46 @@ async def test_filesystem_write_replace_with_expected_hash(tmp_path: Path) -> No
     assert result["created"] is False  # nosec B101
     assert result["sha256_before"] == expected_sha  # nosec B101
     assert result["sha256_after"] == hashlib.sha256("new\n".encode("utf-8")).hexdigest()  # nosec B101
+
+
+@pytest.mark.asyncio
+async def test_filesystem_write_rechecks_preimage_immediately_before_replace(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace_root = tmp_path / "workspace"
+    workspace_root.mkdir(parents=True, exist_ok=True)
+    target = workspace_root / "story.txt"
+    target.write_text("old\n", encoding="utf-8")
+    resolver = _FakeWorkspaceRootResolver({"workspace_root": str(workspace_root)})
+    mod = FilesystemModule(ModuleConfig(name="filesystem"), workspace_root_resolver=resolver)
+    context = RequestContext(request_id="req-fs-write-race", user_id="1", metadata={})
+    expected_sha = hashlib.sha256(target.read_bytes()).hexdigest()
+    original_assert = FilesystemModule._assert_preimage_unchanged
+
+    def _mutate_before_final_preimage_check(
+        check_target: Path,
+        expected_sha256: str | None,
+        expected_size: int,
+    ) -> None:
+        if check_target == target:
+            target.write_text("concurrent\n", encoding="utf-8")
+        original_assert(check_target, expected_sha256, expected_size)
+
+    monkeypatch.setattr(
+        FilesystemModule,
+        "_assert_preimage_unchanged",
+        staticmethod(_mutate_before_final_preimage_check),
+    )
+
+    with pytest.raises(ValueError, match="preimage_changed_during_commit"):
+        await mod.execute_tool(
+            "fs.write",
+            {"path": "story.txt", "content": "new\n", "mode": "replace", "expected_sha256": expected_sha},
+            context=context,
+        )
+
+    assert target.read_text(encoding="utf-8") == "concurrent\n"  # nosec B101
 
 
 @pytest.mark.asyncio
@@ -983,6 +1141,41 @@ async def test_filesystem_write_replace_with_read_receipt(tmp_path: Path) -> Non
 
     assert target.read_text(encoding="utf-8") == "new\n"  # nosec B101
     assert result["sha256_before"] == read_result["sha256"]  # nosec B101
+
+
+@pytest.mark.asyncio
+async def test_filesystem_write_rejects_bound_read_receipt_without_matching_context(tmp_path: Path) -> None:
+    workspace_root = tmp_path / "workspace"
+    workspace_root.mkdir(parents=True, exist_ok=True)
+    target = workspace_root / "story.txt"
+    target.write_text("old\n", encoding="utf-8")
+    resolver = _FakeWorkspaceRootResolver({"workspace_root": str(workspace_root), "workspace_id": "ws-1"})
+    mod = FilesystemModule(
+        ModuleConfig(name="filesystem", settings={"read_receipt_secret": "unit-test-secret"}),
+        workspace_root_resolver=resolver,
+    )
+    bound_context = RequestContext(
+        request_id="req-fs-write-receipt-bound",
+        user_id="1",
+        session_id="session-1",
+        metadata={"workspace_id": "ws-1"},
+    )
+    unbound_context = RequestContext(request_id="req-fs-write-receipt-unbound", user_id="1", metadata={})
+    read_result = await mod.execute_tool("fs.read", {"path": "story.txt"}, context=bound_context)
+
+    with pytest.raises(ValueError, match="write_read_receipt_mismatch"):
+        await mod.execute_tool(
+            "fs.write",
+            {
+                "path": "story.txt",
+                "content": "new\n",
+                "mode": "replace",
+                "read_receipt": read_result["read_receipt"],
+            },
+            context=unbound_context,
+        )
+
+    assert target.read_text(encoding="utf-8") == "old\n"  # nosec B101
 
 
 @pytest.mark.asyncio

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_patch_parser.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_patch_parser.py
@@ -1,0 +1,159 @@
+from __future__ import annotations
+
+import pytest
+
+from tldw_Server_API.app.core.MCP_unified.modules.implementations.filesystem_diff import (
+    FilesystemPatchError,
+    apply_patch_to_text,
+    parse_unified_diff,
+)
+
+
+def test_parse_unified_diff_modify_headers_and_hunk_ranges() -> None:
+    parsed = parse_unified_diff(
+        """--- a/docs/story.txt
++++ b/docs/story.txt
+@@ -1,3 +1,3 @@
+ alpha
+-beta
++BETTA
+ gamma
+""",
+        max_files=10,
+        max_hunks=10,
+        max_bytes=10_000,
+    )
+
+    assert len(parsed) == 1  # nosec B101
+    patch_file = parsed[0]
+    assert patch_file.old_path == "docs/story.txt"  # nosec B101
+    assert patch_file.new_path == "docs/story.txt"  # nosec B101
+    assert patch_file.action == "modify"  # nosec B101
+    assert len(patch_file.hunks) == 1  # nosec B101
+    hunk = patch_file.hunks[0]
+    assert (hunk.old_start, hunk.old_count, hunk.new_start, hunk.new_count) == (1, 3, 1, 3)  # nosec B101
+    assert [line.kind for line in hunk.lines] == ["context", "remove", "add", "context"]  # nosec B101
+    assert [line.text for line in hunk.lines] == ["alpha", "beta", "BETTA", "gamma"]  # nosec B101
+
+
+def test_parse_unified_diff_create_and_reject_delete() -> None:
+    created = parse_unified_diff(
+        """--- /dev/null
++++ b/docs/new.txt
+@@ -0,0 +1,2 @@
++alpha
++beta
+""",
+        max_files=10,
+        max_hunks=10,
+        max_bytes=10_000,
+    )
+
+    assert created[0].old_path is None  # nosec B101
+    assert created[0].new_path == "docs/new.txt"  # nosec B101
+    assert created[0].action == "create"  # nosec B101
+
+    with pytest.raises(FilesystemPatchError) as exc_info:
+        parse_unified_diff(
+            """--- a/docs/old.txt
++++ /dev/null
+@@ -1 +0,0 @@
+-alpha
+""",
+            max_files=10,
+            max_hunks=10,
+            max_bytes=10_000,
+        )
+    assert exc_info.value.reason_code == "delete_not_supported"  # nosec B101
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/etc/passwd",
+        "C:/Users/alice/secret.txt",
+        "../secret.txt",
+        "docs/../secret.txt",
+        "",
+    ],
+)
+def test_parse_unified_diff_rejects_unsafe_paths(path: str) -> None:
+    with pytest.raises(FilesystemPatchError) as exc_info:
+        parse_unified_diff(
+            f"""--- a/docs/story.txt
++++ b/{path}
+@@ -1 +1 @@
+-alpha
++beta
+""",
+            max_files=10,
+            max_hunks=10,
+            max_bytes=10_000,
+        )
+    assert exc_info.value.reason_code == "invalid_patch_path"  # nosec B101
+
+
+def test_parse_unified_diff_enforces_limits() -> None:
+    two_file_diff = """--- a/one.txt
++++ b/one.txt
+@@ -1 +1 @@
+-one
++ONE
+--- a/two.txt
++++ b/two.txt
+@@ -1 +1 @@
+-two
++TWO
+"""
+
+    with pytest.raises(FilesystemPatchError) as size_exc:
+        parse_unified_diff(two_file_diff, max_files=10, max_hunks=10, max_bytes=3)
+    assert size_exc.value.reason_code == "diff_too_large"  # nosec B101
+
+    with pytest.raises(FilesystemPatchError) as file_exc:
+        parse_unified_diff(two_file_diff, max_files=1, max_hunks=10, max_bytes=10_000)
+    assert file_exc.value.reason_code == "diff_file_limit_exceeded"  # nosec B101
+
+    with pytest.raises(FilesystemPatchError) as hunk_exc:
+        parse_unified_diff(two_file_diff, max_files=10, max_hunks=1, max_bytes=10_000)
+    assert hunk_exc.value.reason_code == "diff_hunk_limit_exceeded"  # nosec B101
+
+
+def test_apply_patch_to_text_modifies_content_in_memory() -> None:
+    parsed = parse_unified_diff(
+        """--- a/docs/story.txt
++++ b/docs/story.txt
+@@ -1,3 +1,3 @@
+ alpha
+-beta
++BETTA
+ gamma
+""",
+        max_files=10,
+        max_hunks=10,
+        max_bytes=10_000,
+    )
+
+    result = apply_patch_to_text("alpha\nbeta\ngamma\n", parsed[0])
+
+    assert result == "alpha\nBETTA\ngamma\n"  # nosec B101
+
+
+def test_apply_patch_to_text_detects_context_mismatch() -> None:
+    parsed = parse_unified_diff(
+        """--- a/docs/story.txt
++++ b/docs/story.txt
+@@ -1,3 +1,3 @@
+ alpha
+-beta
++BETTA
+ gamma
+""",
+        max_files=10,
+        max_hunks=10,
+        max_bytes=10_000,
+    )
+
+    with pytest.raises(FilesystemPatchError) as exc_info:
+        apply_patch_to_text("alpha\nchanged\ngamma\n", parsed[0])
+    assert exc_info.value.reason_code == "patch_context_mismatch"  # nosec B101

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_patch_parser.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_patch_parser.py
@@ -119,6 +119,24 @@ def test_parse_unified_diff_enforces_limits() -> None:
     assert hunk_exc.value.reason_code == "diff_hunk_limit_exceeded"  # nosec B101
 
 
+def test_apply_patch_rejects_add_only_hunk_beyond_end_of_file() -> None:
+    parsed = parse_unified_diff(
+        """--- a/docs/story.txt
++++ b/docs/story.txt
+@@ -50,0 +50,1 @@
++late
+""",
+        max_files=10,
+        max_hunks=10,
+        max_bytes=10_000,
+    )
+
+    with pytest.raises(FilesystemPatchError) as exc_info:
+        apply_patch_to_text("alpha\n", parsed[0])
+
+    assert exc_info.value.reason_code == "patch_context_mismatch"  # nosec B101
+
+
 def test_apply_patch_to_text_modifies_content_in_memory() -> None:
     parsed = parse_unified_diff(
         """--- a/docs/story.txt

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_profile_policy_decisions.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_profile_policy_decisions.py
@@ -10,9 +10,10 @@ from mcp_unified.profiles.decisions import (
     PolicyDecisionSubject,
     PolicyMatchedRule,
     compile_profile_policy_rules,
+    evaluate_profile_tool_decision,
     merge_policy_decisions,
 )
-from mcp_unified.profiles.models import ProfilePolicy
+from mcp_unified.profiles.models import MCPProfile, ProfilePolicy
 
 
 def test_policy_decision_defaults_for_ask() -> None:
@@ -49,6 +50,50 @@ def test_policy_decision_defaults_for_allow() -> None:
     assert decision.visibility == "direct"
     assert decision.call_state == "callable"
     assert decision.requires_approval is False
+
+
+def test_evaluate_profile_tool_decision_denied_tool_wins() -> None:
+    profile = MCPProfile(
+        id="strict",
+        name="Strict",
+        policy_document=ProfilePolicy(
+            allowed_tools=["fs.write"],
+            denied_tools=["fs.write"],
+        ),
+    )
+
+    decision = evaluate_profile_tool_decision(profile, "fs.write")
+
+    assert decision.outcome == "deny"
+    assert decision.reason_code == "tool_denied"
+
+
+def test_evaluate_profile_tool_decision_allowed_tool_allows() -> None:
+    profile = MCPProfile(
+        id="reader",
+        name="Reader",
+        policy_document=ProfilePolicy(allowed_tools=["fs.read"]),
+    )
+
+    decision = evaluate_profile_tool_decision(profile, "fs.read")
+
+    assert decision.outcome == "allow"
+    assert decision.call_state == "callable"
+
+
+def test_evaluate_profile_tool_decision_structured_ask_rule_requires_approval() -> None:
+    profile = MCPProfile(
+        id="default-ask",
+        name="Default Ask",
+        policy_document=ProfilePolicy.model_validate(
+            {"tool_rules": [{"pattern": "fs.patch", "outcome": "ask"}]}
+        ),
+    )
+
+    decision = evaluate_profile_tool_decision(profile, "fs.patch")
+
+    assert decision.outcome == "ask"
+    assert decision.call_state == "approval_required"
 
 
 def test_merge_policy_decisions_uses_deny_over_ask_over_allow() -> None:

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_profile_policy_decisions.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_profile_policy_decisions.py
@@ -239,6 +239,37 @@ def test_policy_decision_rule_rejects_command_wildcard_executable() -> None:
         )
 
 
+def test_policy_decision_rule_rejects_command_set_argv_before_coercion() -> None:
+    with pytest.raises(ValueError, match="command policy rule argv must be a sequence"):
+        PolicyDecisionRule(
+            rule_type="command",
+            outcome="allow",
+            source="precompiled",
+            argv={"*", "--version"},
+        )
+
+
+def test_policy_decision_rule_rejects_command_string_argv_before_coercion() -> None:
+    with pytest.raises(ValueError, match="command policy rule argv must be a sequence"):
+        PolicyDecisionRule(
+            rule_type="command",
+            outcome="allow",
+            source="precompiled",
+            argv="git status",
+        )
+
+
+def test_policy_decision_rule_accepts_command_list_argv() -> None:
+    rule = PolicyDecisionRule(
+        rule_type="command",
+        outcome="allow",
+        source="precompiled",
+        argv=["git", "status"],
+    )
+
+    assert rule.argv == ("git", "status")
+
+
 @pytest.mark.parametrize("argv", [None, (), ("git", "")])
 def test_policy_decision_rule_rejects_invalid_command_argv(
     argv: tuple[str, ...] | None,
@@ -261,6 +292,18 @@ def test_compile_profile_policy_rules_revalidates_precompiled_command_rules() ->
     )
 
     with pytest.raises(ValueError, match="command executable must be fixed"):
+        compile_profile_policy_rules({"command_rules": [invalid_rule]})
+
+
+def test_compile_profile_policy_rules_revalidates_precompiled_unordered_command_argv() -> None:
+    invalid_rule = PolicyDecisionRule.model_construct(
+        rule_type="command",
+        outcome="allow",
+        source="precompiled",
+        argv={"*", "--version"},
+    )
+
+    with pytest.raises(ValueError, match="command policy rule argv must be a sequence"):
         compile_profile_policy_rules({"command_rules": [invalid_rule]})
 
 

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_profile_policy_decisions.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_profile_policy_decisions.py
@@ -112,6 +112,21 @@ def test_merge_policy_decisions_defaults_to_deny_without_matches() -> None:
     assert merged.call_state == "blocked"
 
 
+def test_merge_policy_decisions_keeps_first_same_precedence_reason() -> None:
+    subject = PolicyDecisionSubject(type="tool", normalized="fs.write")
+    merged = merge_policy_decisions(
+        [
+            PolicyDecision(outcome="ask", reason_code="profile_ask", subject=subject),
+            PolicyDecision(outcome="ask", reason_code="workspace_ask", subject=subject),
+        ],
+        subject=subject,
+    )
+
+    assert merged.outcome == "ask"
+    assert merged.reason_code == "profile_ask"
+    assert merged.call_state == "approval_required"
+
+
 def test_compile_profile_policy_rules_preserves_legacy_tool_fields() -> None:
     rules = compile_profile_policy_rules(
         ProfilePolicy(
@@ -140,6 +155,28 @@ def test_compile_profile_policy_rules_rejects_broad_bash_pattern() -> None:
         compile_profile_policy_rules(ProfilePolicy(allowed_tools=["Bash(*)"]))
 
 
+@pytest.mark.parametrize(
+    "pattern",
+    [
+        "Bash(* *)",
+        "Bash(* --version)",
+        "Bash(git* status)",
+        "Bash(?sh -lc)",
+        "Bash([gr]it status)",
+    ],
+)
+def test_compile_profile_policy_rules_rejects_wildcard_executable_patterns(
+    pattern: str,
+) -> None:
+    with pytest.raises(ValueError, match="command executable must be fixed"):
+        compile_profile_policy_rules(ProfilePolicy(allowed_tools=[pattern]))
+
+
+def test_compile_profile_policy_rules_rejects_empty_legacy_tool_pattern() -> None:
+    with pytest.raises(ValueError, match="legacy tool policy patterns cannot be empty"):
+        compile_profile_policy_rules(ProfilePolicy(allowed_tools=[""]))
+
+
 def test_compile_profile_policy_rules_includes_structured_extra_rules() -> None:
     rules = compile_profile_policy_rules(
         {
@@ -154,3 +191,29 @@ def test_compile_profile_policy_rules_includes_structured_extra_rules() -> None:
         ("command", None, ("git", "status"), "allow"),
         ("mcp", "mcp__github__*", None, "deny"),
     ]
+
+
+def test_compile_profile_policy_rules_rejects_structured_command_string_argv() -> None:
+    with pytest.raises(ValueError, match="command policy rule argv must be a sequence"):
+        compile_profile_policy_rules({"command_rules": [{"argv": "git status", "outcome": "allow"}]})
+
+
+def test_compile_profile_policy_rules_rejects_structured_command_set_argv() -> None:
+    with pytest.raises(ValueError, match="command policy rule argv must be a sequence"):
+        compile_profile_policy_rules({"command_rules": [{"argv": {"git"}, "outcome": "allow"}]})
+
+
+@pytest.mark.parametrize(
+    "argv",
+    [
+        ["*", "--version"],
+        ["git*", "status"],
+        ["?sh", "-lc"],
+        ["[gr]it", "status"],
+    ],
+)
+def test_compile_profile_policy_rules_rejects_structured_wildcard_executables(
+    argv: list[str],
+) -> None:
+    with pytest.raises(ValueError, match="command executable must be fixed"):
+        compile_profile_policy_rules({"command_rules": [{"argv": argv, "outcome": "allow"}]})

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_profile_policy_decisions.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_profile_policy_decisions.py
@@ -261,6 +261,18 @@ def test_explain_profile_tool_decision_includes_permission_mode() -> None:
     assert explanation.permission_mode == "plan/read-only"
 
 
+def test_profile_decision_api_exports_from_profiles_package() -> None:
+    from mcp_unified.profiles import (
+        PolicyDecision,
+        PolicyDecisionSubject,
+        explain_profile_tool_decision,
+    )
+
+    assert PolicyDecision is not None
+    assert PolicyDecisionSubject is not None
+    assert explain_profile_tool_decision is not None
+
+
 def test_merge_policy_decisions_uses_deny_over_ask_over_allow() -> None:
     subject = PolicyDecisionSubject(type="tool", normalized="fs.write")
     merged = merge_policy_decisions(

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_profile_policy_decisions.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_profile_policy_decisions.py
@@ -81,6 +81,67 @@ def test_evaluate_profile_tool_decision_allowed_tool_allows() -> None:
     assert decision.call_state == "callable"
 
 
+@pytest.mark.parametrize("tool_name", ["", "   "])
+def test_evaluate_profile_tool_decision_rejects_blank_tool_name(
+    tool_name: str,
+) -> None:
+    profile = MCPProfile(id="reader", name="Reader")
+
+    with pytest.raises(ValueError, match="tool_name cannot be blank"):
+        evaluate_profile_tool_decision(profile, tool_name)
+
+
+def test_evaluate_profile_tool_decision_ignores_unrelated_invalid_command_rules() -> None:
+    profile = MCPProfile(
+        id="reader",
+        name="Reader",
+        policy_document=ProfilePolicy.model_validate(
+            {
+                "allowed_tools": ["fs.read"],
+                "command_rules": [{"pattern": "git status", "outcome": "allow"}],
+            }
+        ),
+    )
+
+    decision = evaluate_profile_tool_decision(profile, "fs.read")
+
+    assert decision.outcome == "allow"
+    assert decision.reason_code == "tool_allowed"
+
+
+def test_evaluate_profile_tool_decision_ignores_unrelated_invalid_mcp_rules() -> None:
+    profile = MCPProfile(
+        id="reader",
+        name="Reader",
+        policy_document=ProfilePolicy.model_validate(
+            {
+                "allowed_tools": ["fs.read"],
+                "mcp_rules": [{"outcome": "deny"}],
+            }
+        ),
+    )
+
+    decision = evaluate_profile_tool_decision(profile, "fs.read")
+
+    assert decision.outcome == "allow"
+    assert decision.reason_code == "tool_allowed"
+
+
+def test_evaluate_profile_tool_decision_requires_exact_tool_rule_pattern() -> None:
+    profile = MCPProfile(
+        id="wildcard-like",
+        name="Wildcard Like",
+        policy_document=ProfilePolicy.model_validate(
+            {"tool_rules": [{"pattern": "fs.*", "outcome": "allow"}]}
+        ),
+    )
+
+    decision = evaluate_profile_tool_decision(profile, "fs.read")
+
+    assert decision.outcome == "deny"
+    assert decision.reason_code == "tool_not_allowed"
+
+
 def test_evaluate_profile_tool_decision_allowed_capability_allows() -> None:
     profile = MCPProfile(
         id="capability-reader",

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_profile_policy_decisions.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_profile_policy_decisions.py
@@ -11,6 +11,7 @@ from mcp_unified.profiles.decisions import (
     PolicyMatchedRule,
     compile_profile_policy_rules,
     evaluate_profile_tool_decision,
+    explain_profile_tool_decision,
     merge_policy_decisions,
 )
 from mcp_unified.profiles.models import MCPProfile, ProfilePolicy
@@ -144,9 +145,7 @@ def test_evaluate_profile_tool_decision_requires_exact_tool_rule_pattern() -> No
     profile = MCPProfile(
         id="wildcard-like",
         name="Wildcard Like",
-        policy_document=ProfilePolicy.model_validate(
-            {"tool_rules": [{"pattern": "fs.*", "outcome": "allow"}]}
-        ),
+        policy_document=ProfilePolicy.model_validate({"tool_rules": [{"pattern": "fs.*", "outcome": "allow"}]}),
     )
 
     decision = evaluate_profile_tool_decision(profile, "fs.read")
@@ -213,15 +212,53 @@ def test_evaluate_profile_tool_decision_structured_ask_rule_requires_approval() 
     profile = MCPProfile(
         id="default-ask",
         name="Default Ask",
-        policy_document=ProfilePolicy.model_validate(
-            {"tool_rules": [{"pattern": "fs.patch", "outcome": "ask"}]}
-        ),
+        policy_document=ProfilePolicy.model_validate({"tool_rules": [{"pattern": "fs.patch", "outcome": "ask"}]}),
     )
 
     decision = evaluate_profile_tool_decision(profile, "fs.patch")
 
     assert decision.outcome == "ask"
     assert decision.call_state == "approval_required"
+
+
+def test_explain_profile_tool_decision_returns_redacted_payload() -> None:
+    profile = MCPProfile(
+        id="qa",
+        name="QA",
+        policy_document=ProfilePolicy(denied_tools=["fs.write"]),
+    )
+
+    explanation = explain_profile_tool_decision(profile, "fs.write")
+
+    assert explanation.final_outcome == "deny"
+    assert explanation.reason_code == "tool_denied"
+    assert explanation.profile_id == "qa"
+    assert explanation.subject.normalized == "fs.write"
+    assert explanation.visibility == "hidden"
+    assert explanation.call_state == "blocked"
+    assert explanation.requires_approval is False
+    assert explanation.redacted is True
+    assert explanation.hook_results == []
+    assert explanation.sandbox == {}
+    assert explanation.matches[0].source == "policy_document.denied_tools"
+
+
+def test_explain_profile_tool_decision_includes_permission_mode() -> None:
+    profile = MCPProfile(
+        id="planner",
+        name="Planner",
+        policy_document=ProfilePolicy.model_validate(
+            {
+                "allowed_tools": ["fs.read"],
+                "permission_mode": "plan/read-only",
+            }
+        ),
+    )
+
+    explanation = explain_profile_tool_decision(profile, "fs.read")
+
+    assert explanation.final_outcome == "allow"
+    assert explanation.permission_mode == "plan/read-only"
 
 
 def test_merge_policy_decisions_uses_deny_over_ask_over_allow() -> None:

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_profile_policy_decisions.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_profile_policy_decisions.py
@@ -127,6 +127,19 @@ def test_evaluate_profile_tool_decision_ignores_unrelated_invalid_mcp_rules() ->
     assert decision.reason_code == "tool_allowed"
 
 
+def test_evaluate_profile_tool_decision_ignores_unrelated_invalid_legacy_bash_pattern() -> None:
+    profile = MCPProfile(
+        id="reader",
+        name="Reader",
+        policy_document=ProfilePolicy(allowed_tools=["fs.read", "Bash(*)"]),
+    )
+
+    decision = evaluate_profile_tool_decision(profile, "fs.read")
+
+    assert decision.outcome == "allow"
+    assert decision.reason_code == "tool_allowed"
+
+
 def test_evaluate_profile_tool_decision_requires_exact_tool_rule_pattern() -> None:
     profile = MCPProfile(
         id="wildcard-like",

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_profile_policy_decisions.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_profile_policy_decisions.py
@@ -1,0 +1,32 @@
+"""Tests for MCP profile policy decision primitives."""
+
+from __future__ import annotations
+
+from mcp_unified.profiles.decisions import (
+    PolicyDecision,
+    PolicyDecisionSubject,
+)
+
+
+def test_policy_decision_defaults_for_ask() -> None:
+    decision = PolicyDecision(
+        outcome="ask",
+        reason_code="approval_required",
+        subject=PolicyDecisionSubject(type="tool", normalized="fs.patch"),
+    )
+
+    assert decision.visibility == "direct"
+    assert decision.call_state == "approval_required"
+    assert decision.requires_approval is True
+
+
+def test_policy_decision_defaults_for_deny() -> None:
+    decision = PolicyDecision(
+        outcome="deny",
+        reason_code="tool_denied",
+        subject=PolicyDecisionSubject(type="tool", normalized="fs.write"),
+    )
+
+    assert decision.visibility == "hidden"
+    assert decision.call_state == "blocked"
+    assert decision.requires_approval is False

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_profile_policy_decisions.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_profile_policy_decisions.py
@@ -81,6 +81,60 @@ def test_evaluate_profile_tool_decision_allowed_tool_allows() -> None:
     assert decision.call_state == "callable"
 
 
+def test_evaluate_profile_tool_decision_allowed_capability_allows() -> None:
+    profile = MCPProfile(
+        id="capability-reader",
+        name="Capability Reader",
+        policy_document=ProfilePolicy(capabilities=["fs.read"]),
+    )
+
+    decision = evaluate_profile_tool_decision(
+        profile,
+        "fs.read",
+        capability="fs.read",
+    )
+
+    assert decision.outcome == "allow"
+    assert decision.reason_code == "capability_allowed"
+
+
+def test_evaluate_profile_tool_decision_missing_capability_denies() -> None:
+    profile = MCPProfile(
+        id="empty",
+        name="Empty",
+        policy_document=ProfilePolicy(capabilities=[]),
+    )
+
+    decision = evaluate_profile_tool_decision(
+        profile,
+        "fs.read",
+        capability="fs.read",
+    )
+
+    assert decision.outcome == "deny"
+    assert decision.reason_code == "tool_not_allowed"
+
+
+def test_evaluate_profile_tool_decision_denied_capability_does_not_allow() -> None:
+    profile = MCPProfile(
+        id="denied-capability",
+        name="Denied Capability",
+        policy_document=ProfilePolicy(
+            capabilities=["fs.write"],
+            denied_capabilities=["fs.write"],
+        ),
+    )
+
+    decision = evaluate_profile_tool_decision(
+        profile,
+        "fs.write",
+        capability="fs.write",
+    )
+
+    assert decision.outcome == "deny"
+    assert decision.reason_code == "tool_not_allowed"
+
+
 def test_evaluate_profile_tool_decision_structured_ask_rule_requires_approval() -> None:
     profile = MCPProfile(
         id="default-ask",

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_profile_policy_decisions.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_profile_policy_decisions.py
@@ -2,10 +2,16 @@
 
 from __future__ import annotations
 
+import pytest
+
 from mcp_unified.profiles.decisions import (
     PolicyDecision,
     PolicyDecisionSubject,
+    PolicyMatchedRule,
+    compile_profile_policy_rules,
+    merge_policy_decisions,
 )
+from mcp_unified.profiles.models import ProfilePolicy
 
 
 def test_policy_decision_defaults_for_ask() -> None:
@@ -30,3 +36,121 @@ def test_policy_decision_defaults_for_deny() -> None:
     assert decision.visibility == "hidden"
     assert decision.call_state == "blocked"
     assert decision.requires_approval is False
+
+
+def test_policy_decision_defaults_for_allow() -> None:
+    decision = PolicyDecision(
+        outcome="allow",
+        reason_code="allowed",
+        subject=PolicyDecisionSubject(type="tool", normalized="fs.read"),
+    )
+
+    assert decision.visibility == "direct"
+    assert decision.call_state == "callable"
+    assert decision.requires_approval is False
+
+
+def test_merge_policy_decisions_uses_deny_over_ask_over_allow() -> None:
+    subject = PolicyDecisionSubject(type="tool", normalized="fs.write")
+    merged = merge_policy_decisions(
+        [
+            PolicyDecision(
+                outcome="allow",
+                reason_code="allowed",
+                subject=subject,
+                matched_rules=[
+                    PolicyMatchedRule(
+                        source="allowed_tools",
+                        rule_type="tool",
+                        pattern="fs.*",
+                        outcome="allow",
+                    )
+                ],
+            ),
+            PolicyDecision(
+                outcome="ask",
+                reason_code="approval_required",
+                subject=subject,
+                matched_rules=[
+                    PolicyMatchedRule(
+                        source="tool_rules",
+                        rule_type="tool",
+                        pattern="fs.write",
+                        outcome="ask",
+                    )
+                ],
+            ),
+            PolicyDecision(
+                outcome="deny",
+                reason_code="tool_denied",
+                subject=subject,
+                matched_rules=[
+                    PolicyMatchedRule(
+                        source="denied_tools",
+                        rule_type="tool",
+                        pattern="fs.write",
+                        outcome="deny",
+                    )
+                ],
+            ),
+        ],
+        subject=subject,
+    )
+
+    assert merged.outcome == "deny"
+    assert merged.reason_code == "tool_denied"
+    assert merged.call_state == "blocked"
+    assert [rule.outcome for rule in merged.matched_rules] == ["allow", "ask", "deny"]
+
+
+def test_merge_policy_decisions_defaults_to_deny_without_matches() -> None:
+    subject = PolicyDecisionSubject(type="tool", normalized="fs.write")
+    merged = merge_policy_decisions([], subject=subject)
+
+    assert merged.outcome == "deny"
+    assert merged.reason_code == "no_matching_rule"
+    assert merged.call_state == "blocked"
+
+
+def test_compile_profile_policy_rules_preserves_legacy_tool_fields() -> None:
+    rules = compile_profile_policy_rules(
+        ProfilePolicy(
+            allowed_tools=["fs.read"],
+            denied_tools=["fs.write"],
+        )
+    )
+
+    assert [(rule.rule_type, rule.pattern, rule.outcome) for rule in rules] == [
+        ("tool", "fs.write", "deny"),
+        ("tool", "fs.read", "allow"),
+    ]
+
+
+def test_compile_profile_policy_rules_converts_legacy_bash_pattern_to_argv_rule() -> None:
+    rules = compile_profile_policy_rules(ProfilePolicy(allowed_tools=["Bash(git *)"]))
+
+    command_rule = rules[0]
+    assert command_rule.rule_type == "command"
+    assert command_rule.argv == ("git", "*")
+    assert command_rule.outcome == "allow"
+
+
+def test_compile_profile_policy_rules_rejects_broad_bash_pattern() -> None:
+    with pytest.raises(ValueError, match="broad bash patterns are not allowed"):
+        compile_profile_policy_rules(ProfilePolicy(allowed_tools=["Bash(*)"]))
+
+
+def test_compile_profile_policy_rules_includes_structured_extra_rules() -> None:
+    rules = compile_profile_policy_rules(
+        {
+            "tool_rules": [{"pattern": "fs.patch", "outcome": "ask"}],
+            "command_rules": [{"argv": ["git", "status"], "outcome": "allow"}],
+            "mcp_rules": [{"pattern": "mcp__github__*", "outcome": "deny"}],
+        }
+    )
+
+    assert [(rule.rule_type, rule.pattern, rule.argv, rule.outcome) for rule in rules] == [
+        ("tool", "fs.patch", None, "ask"),
+        ("command", None, ("git", "status"), "allow"),
+        ("mcp", "mcp__github__*", None, "deny"),
+    ]

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_profile_policy_decisions.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_profile_policy_decisions.py
@@ -6,6 +6,7 @@ import pytest
 
 from mcp_unified.profiles.decisions import (
     PolicyDecision,
+    PolicyDecisionRule,
     PolicyDecisionSubject,
     PolicyMatchedRule,
     compile_profile_policy_rules,
@@ -193,6 +194,15 @@ def test_compile_profile_policy_rules_includes_structured_extra_rules() -> None:
     ]
 
 
+def test_compile_profile_policy_rules_accepts_structured_command_tuple_argv() -> None:
+    rules = compile_profile_policy_rules({"command_rules": [{"argv": ("git", "status"), "outcome": "allow"}]})
+
+    command_rule = rules[0]
+    assert command_rule.rule_type == "command"
+    assert command_rule.argv == ("git", "status")
+    assert command_rule.outcome == "allow"
+
+
 def test_compile_profile_policy_rules_rejects_structured_command_string_argv() -> None:
     with pytest.raises(ValueError, match="command policy rule argv must be a sequence"):
         compile_profile_policy_rules({"command_rules": [{"argv": "git status", "outcome": "allow"}]})
@@ -217,3 +227,43 @@ def test_compile_profile_policy_rules_rejects_structured_wildcard_executables(
 ) -> None:
     with pytest.raises(ValueError, match="command executable must be fixed"):
         compile_profile_policy_rules({"command_rules": [{"argv": argv, "outcome": "allow"}]})
+
+
+def test_policy_decision_rule_rejects_command_wildcard_executable() -> None:
+    with pytest.raises(ValueError, match="command executable must be fixed"):
+        PolicyDecisionRule(
+            rule_type="command",
+            outcome="allow",
+            source="precompiled",
+            argv=("*", "--version"),
+        )
+
+
+@pytest.mark.parametrize("argv", [None, (), ("git", "")])
+def test_policy_decision_rule_rejects_invalid_command_argv(
+    argv: tuple[str, ...] | None,
+) -> None:
+    with pytest.raises(ValueError, match="command policy rule argv"):
+        PolicyDecisionRule(
+            rule_type="command",
+            outcome="allow",
+            source="precompiled",
+            argv=argv,
+        )
+
+
+def test_compile_profile_policy_rules_revalidates_precompiled_command_rules() -> None:
+    invalid_rule = PolicyDecisionRule.model_construct(
+        rule_type="command",
+        outcome="allow",
+        source="precompiled",
+        argv=("*", "--version"),
+    )
+
+    with pytest.raises(ValueError, match="command executable must be fixed"):
+        compile_profile_policy_rules({"command_rules": [invalid_rule]})
+
+
+def test_compile_profile_policy_rules_rejects_structured_bash_pattern_wildcard_executable() -> None:
+    with pytest.raises(ValueError, match="command executable must be fixed"):
+        compile_profile_policy_rules({"command_rules": [{"pattern": "Bash(* --version)", "outcome": "allow"}]})

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_profile_presets.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_profile_presets.py
@@ -194,14 +194,22 @@ def test_preset_direct_categories_do_not_exceed_max_direct_tools() -> None:
 
 
 def test_filesystem_read_presets_include_helper_tools() -> None:
-    expected = {"fs.stat", "fs.glob", "fs.grep"}
+    expected = {"fs.read", "fs.stat", "fs.glob", "fs.grep"}
     for preset in presets.list_builtin_presets():
         tooling = preset.profile.metadata.get("tooling")
         if not isinstance(tooling, dict):
             continue
         enabled_tools = set(tooling.get("enabled_tools") or [])
-        if {"fs.list", "fs.read_text"} <= enabled_tools:
+        if {"fs.list", "fs.read"} <= enabled_tools:
             assert expected <= enabled_tools
+
+
+def test_filesystem_tool_buckets_prefer_canonical_safe_tools() -> None:
+    assert presets._FILES_READ_TOOLS == ["fs.list", "fs.read", "fs.stat", "fs.glob", "fs.grep"]  # nosec B101
+    assert presets._FILES_EDIT_TOOLS == [*presets._FILES_READ_TOOLS, "fs.patch"]  # nosec B101
+    assert presets._FILES_WRITE_TOOLS == [*presets._FILES_EDIT_TOOLS, "fs.write"]  # nosec B101
+    assert presets._LEGACY_FILES_READ_TOOLS == ["fs.read_text"]  # nosec B101
+    assert presets._LEGACY_FILES_WRITE_TOOLS == ["fs.write_text"]  # nosec B101
 
 
 def test_web_search_is_recommended_unavailable_not_enabled() -> None:

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_profile_structured_resolution.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_profile_structured_resolution.py
@@ -135,6 +135,7 @@ def test_effective_policy_requires_workspace_scope_for_write_capable_profiles() 
     assert result.status == "denied"
     assert result.reason_code == "workspace_scope_required"
     assert result.policy is None
+    assert result.decision is None
     assert result.provenance["profile_id"] == "backend-engineer"
 
 
@@ -194,6 +195,7 @@ def test_effective_policy_rejects_unrelated_assignment_binding() -> None:
     assert result.status == "denied"
     assert result.reason_code == "workspace_scope_required"
     assert result.policy is None
+    assert result.decision is None
 
 
 def test_effective_policy_rejects_empty_assignment_binding_value() -> None:
@@ -214,6 +216,7 @@ def test_effective_policy_rejects_empty_assignment_binding_value() -> None:
     assert result.status == "denied"
     assert result.reason_code == "workspace_scope_required"
     assert result.policy is None
+    assert result.decision is None
 
 
 def test_effective_policy_allows_write_profile_with_assignment_path_scopes() -> None:
@@ -254,6 +257,8 @@ def test_effective_policy_denied_tool_overrides_allowed_tool() -> None:
     assert result.status == "denied"
     assert result.reason_code == "tool_denied"
     assert result.policy is None
+    assert result.decision is not None
+    assert result.decision.outcome == "deny"
 
 
 def test_effective_policy_requires_tool_or_capability_allow_for_tool_execution() -> None:
@@ -273,6 +278,8 @@ def test_effective_policy_requires_tool_or_capability_allow_for_tool_execution()
     assert result.status == "denied"
     assert result.reason_code == "tool_not_allowed"
     assert result.policy is None
+    assert result.decision is not None
+    assert result.decision.outcome == "deny"
 
 
 def test_effective_policy_rejects_missing_profile() -> None:
@@ -346,6 +353,76 @@ def test_effective_policy_allows_tool_execution_with_allowed_capability_mapping(
     assert result.status == "resolved"
     assert result.reason_code == "resolved"
     assert result.policy is not None
+    assert result.decision is not None
+    assert result.decision.outcome == "allow"
+
+
+def test_effective_policy_allows_tool_execution_with_explicit_allowed_tool() -> None:
+    profile = MCPProfile(
+        id="tool-mapped",
+        name="Tool Mapped",
+        policy_document=ProfilePolicy(
+            allowed_tools=["filesystem.read"],
+        ),
+    )
+
+    result = profile_resolution.build_effective_policy_result(
+        profile,
+        tool_name="filesystem.read",
+    )
+
+    assert result.status == "resolved"
+    assert result.reason_code == "resolved"
+    assert result.policy is not None
+    assert result.decision is not None
+    assert result.decision.outcome == "allow"
+
+
+def test_effective_policy_preserves_capability_denial_after_allowed_tool_decision() -> None:
+    profile = MCPProfile(
+        id="capability-denied",
+        name="Capability Denied",
+        policy_document=ProfilePolicy(
+            allowed_tools=["filesystem.write"],
+            capabilities=["filesystem.write"],
+            denied_capabilities=["filesystem.write"],
+        ),
+    )
+
+    result = profile_resolution.build_effective_policy_result(
+        profile,
+        assignment_binding={"workspace_id": "workspace-1"},
+        tool_name="filesystem.write",
+        capability="filesystem.write",
+    )
+
+    assert result.status == "denied"
+    assert result.reason_code == "capability_denied"
+    assert result.policy is None
+    assert result.decision is not None
+    assert result.decision.outcome == "allow"
+
+
+def test_effective_policy_preserves_capability_not_allowed_after_allowed_tool_decision() -> None:
+    profile = MCPProfile(
+        id="capability-missing",
+        name="Capability Missing",
+        policy_document=ProfilePolicy(
+            allowed_tools=["filesystem.write"],
+        ),
+    )
+
+    result = profile_resolution.build_effective_policy_result(
+        profile,
+        tool_name="filesystem.write",
+        capability="filesystem.write",
+    )
+
+    assert result.status == "denied"
+    assert result.reason_code == "capability_not_allowed"
+    assert result.policy is None
+    assert result.decision is not None
+    assert result.decision.outcome == "allow"
 
 
 def test_effective_policy_defaults_to_deny_for_unlisted_tool_execution() -> None:
@@ -362,3 +439,26 @@ def test_effective_policy_defaults_to_deny_for_unlisted_tool_execution() -> None
     assert result.status == "denied"
     assert result.reason_code == "tool_not_allowed"
     assert result.policy is None
+    assert result.decision is not None
+    assert result.decision.outcome == "deny"
+
+
+def test_effective_policy_requires_approval_for_structured_tool_ask_rule() -> None:
+    profile = MCPProfile(
+        id="approval",
+        name="Approval",
+        policy_document=ProfilePolicy.model_validate(
+            {"tool_rules": [{"pattern": "filesystem.patch", "outcome": "ask"}]}
+        ),
+    )
+
+    result = profile_resolution.build_effective_policy_result(
+        profile,
+        tool_name="filesystem.patch",
+    )
+
+    assert result.status == "approval_required"
+    assert result.reason_code == "approval_required"
+    assert result.policy is None
+    assert result.decision is not None
+    assert result.decision.outcome == "ask"

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_profile_structured_resolution.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_profile_structured_resolution.py
@@ -378,6 +378,52 @@ def test_effective_policy_allows_tool_execution_with_explicit_allowed_tool() -> 
     assert result.decision.outcome == "allow"
 
 
+def test_effective_policy_ignores_unrelated_invalid_legacy_bash_pattern_for_tool_resolution() -> None:
+    profile = MCPProfile(
+        id="tool-mapped",
+        name="Tool Mapped",
+        policy_document=ProfilePolicy(
+            allowed_tools=["filesystem.read", "Bash(*)"],
+        ),
+    )
+
+    result = profile_resolution.build_effective_policy_result(
+        profile,
+        tool_name="filesystem.read",
+    )
+
+    assert result.status == "resolved"
+    assert result.reason_code == "resolved"
+    assert result.policy is not None
+    assert result.decision is not None
+    assert result.decision.outcome == "allow"
+
+
+def test_effective_policy_ignores_unrelated_invalid_structured_rules_for_tool_resolution() -> None:
+    profile = MCPProfile(
+        id="tool-mapped",
+        name="Tool Mapped",
+        policy_document=ProfilePolicy.model_validate(
+            {
+                "allowed_tools": ["filesystem.read"],
+                "command_rules": [{"pattern": "git status", "outcome": "allow"}],
+                "mcp_rules": [{"outcome": "deny"}],
+            }
+        ),
+    )
+
+    result = profile_resolution.build_effective_policy_result(
+        profile,
+        tool_name="filesystem.read",
+    )
+
+    assert result.status == "resolved"
+    assert result.reason_code == "resolved"
+    assert result.policy is not None
+    assert result.decision is not None
+    assert result.decision.outcome == "allow"
+
+
 def test_effective_policy_preserves_capability_denial_after_allowed_tool_decision() -> None:
     profile = MCPProfile(
         id="capability-denied",

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_profile_structured_resolution.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_profile_structured_resolution.py
@@ -548,3 +548,29 @@ def test_effective_policy_requires_approval_for_structured_tool_ask_rule() -> No
     assert result.policy is None
     assert result.decision is not None
     assert result.decision.outcome == "ask"
+
+
+def test_effective_policy_denied_capability_overrides_structured_tool_ask_rule() -> None:
+    profile = MCPProfile(
+        id="approval-with-deny",
+        name="Approval With Deny",
+        policy_document=ProfilePolicy.model_validate(
+            {
+                "capabilities": ["filesystem.patch"],
+                "denied_capabilities": ["filesystem.patch"],
+                "tool_rules": [{"pattern": "filesystem.patch", "outcome": "ask"}],
+            }
+        ),
+    )
+
+    result = profile_resolution.build_effective_policy_result(
+        profile,
+        tool_name="filesystem.patch",
+        capability="filesystem.patch",
+    )
+
+    assert result.status == "denied"
+    assert result.reason_code == "capability_denied"
+    assert result.policy is None
+    assert result.decision is not None
+    assert result.decision.outcome == "ask"

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_profile_structured_resolution.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_profile_structured_resolution.py
@@ -87,9 +87,7 @@ async def test_profile_result_preserves_explicit_empty_profile_id() -> None:
 async def test_profile_result_reports_store_unavailable_with_reason_code() -> None:
     class UnavailableStore:
         async def get_profile(self, profile_id: str) -> MCPProfile | None:
-            raise ProfileStoreUnavailableError(
-                f"profile store unavailable: {profile_id}"
-            )
+            raise ProfileStoreUnavailableError(f"profile store unavailable: {profile_id}")
 
         async def list_profiles(self) -> list[MCPProfile]:
             raise ProfileStoreUnavailableError("profile store unavailable")
@@ -98,9 +96,7 @@ async def test_profile_result_reports_store_unavailable_with_reason_code() -> No
             raise ProfileStoreUnavailableError("profile store unavailable")
 
         async def delete_profile(self, profile_id: str) -> bool:
-            raise ProfileStoreUnavailableError(
-                f"profile store unavailable: {profile_id}"
-            )
+            raise ProfileStoreUnavailableError(f"profile store unavailable: {profile_id}")
 
     resolver = StoreBackedProfileResolver(UnavailableStore(), default_profile_id="default")
 

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_profile_structured_resolution.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_profile_structured_resolution.py
@@ -425,6 +425,50 @@ def test_effective_policy_preserves_capability_not_allowed_after_allowed_tool_de
     assert result.decision.outcome == "allow"
 
 
+def test_effective_policy_capability_only_missing_grant_attaches_deny_decision() -> None:
+    profile = MCPProfile(
+        id="capability-only-missing",
+        name="Capability Only Missing",
+        policy_document=ProfilePolicy(),
+    )
+
+    result = profile_resolution.build_effective_policy_result(
+        profile,
+        tool_name="filesystem.write",
+        capability="filesystem.write",
+    )
+
+    assert result.status == "denied"
+    assert result.reason_code == "capability_not_allowed"
+    assert result.policy is None
+    assert result.decision is not None
+    assert result.decision.outcome == "deny"
+
+
+def test_effective_policy_capability_only_denied_grant_attaches_deny_decision() -> None:
+    profile = MCPProfile(
+        id="capability-only-denied",
+        name="Capability Only Denied",
+        policy_document=ProfilePolicy(
+            capabilities=["filesystem.write"],
+            denied_capabilities=["filesystem.write"],
+        ),
+    )
+
+    result = profile_resolution.build_effective_policy_result(
+        profile,
+        assignment_binding={"workspace_id": "workspace-1"},
+        tool_name="filesystem.write",
+        capability="filesystem.write",
+    )
+
+    assert result.status == "denied"
+    assert result.reason_code == "capability_denied"
+    assert result.policy is None
+    assert result.decision is not None
+    assert result.decision.outcome == "deny"
+
+
 def test_effective_policy_defaults_to_deny_for_unlisted_tool_execution() -> None:
     profile = MCPProfile(
         id="empty",

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_protocol_path_scope_candidates.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_protocol_path_scope_candidates.py
@@ -1,0 +1,227 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from mcp_unified.interfaces.path_scope import PathScopeCandidate
+from tldw_Server_API.app.core.MCP_unified.modules.base import (
+    BaseModule,
+    ModuleConfig,
+    create_tool_definition,
+)
+from tldw_Server_API.app.core.MCP_unified.protocol import MCPProtocol, RequestContext
+
+
+_PATCH_TEXT = """--- a/src/app.py
++++ b/src/app.py
+@@ -1 +1 @@
+-old
++new
+"""
+
+
+class _AllowAllRbac:
+    async def check_permission(self, *_args: Any, **_kwargs: Any) -> bool:
+        return True
+
+
+class _RegistryStub:
+    def __init__(self, module: BaseModule) -> None:
+        self.module = module
+
+    async def find_module_for_tool(self, tool_name: str) -> BaseModule | None:
+        return self.module if tool_name == "fs.patch" else None
+
+    def get_module_id_for_tool(self, tool_name: str) -> str | None:
+        return "filesystem" if tool_name == "fs.patch" else None
+
+
+class _RecordingPathEnforcer:
+    def __init__(self) -> None:
+        self.received_candidates: list[PathScopeCandidate] | None = None
+
+    async def evaluate_tool_call(
+        self,
+        *,
+        effective_policy: dict[str, Any] | None,
+        context: RequestContext,
+        tool_name: str,
+        tool_args: Any,
+        tool_def: dict[str, Any] | None,
+        path_scope_candidates: list[PathScopeCandidate] | None = None,
+    ) -> dict[str, Any]:
+        del effective_policy, context, tool_name, tool_args, tool_def
+        self.received_candidates = path_scope_candidates
+        return {
+            "enabled": True,
+            "within_scope": True,
+            "reason": None,
+            "force_approval": False,
+            "normalized_paths": [candidate.path for candidate in path_scope_candidates or []],
+            "scope_payload": {"path_decisions": []},
+        }
+
+
+class _OldShapePathEnforcer:
+    async def evaluate_tool_call(
+        self,
+        *,
+        effective_policy: dict[str, Any] | None,
+        context: RequestContext,
+        tool_name: str,
+        tool_args: Any,
+        tool_def: dict[str, Any] | None,
+    ) -> dict[str, Any]:
+        del effective_policy, context, tool_name, tool_args, tool_def
+        return {
+            "enabled": True,
+            "within_scope": True,
+            "reason": None,
+            "force_approval": False,
+            "normalized_paths": [],
+            "scope_payload": None,
+        }
+
+
+class _PatchModule(BaseModule):
+    def __init__(
+        self,
+        *,
+        candidates: list[PathScopeCandidate] | None = None,
+        include_candidate_hook: bool = True,
+    ) -> None:
+        super().__init__(ModuleConfig(name="filesystem"))
+        self._candidates = candidates
+        self._include_candidate_hook = include_candidate_hook
+
+    async def on_initialize(self) -> None:
+        return None
+
+    async def on_shutdown(self) -> None:
+        return None
+
+    async def check_health(self) -> dict[str, bool]:
+        return {"ready": True}
+
+    async def get_tools(self) -> list[dict[str, Any]]:
+        return [
+            create_tool_definition(
+                name="fs.patch",
+                description="Patch files.",
+                parameters={
+                    "properties": {"diff": {"type": "string"}},
+                    "required": ["diff"],
+                },
+                metadata={
+                    "category": "management",
+                    "write_capable": True,
+                    "path_scope_candidate_source": "module",
+                },
+            )
+        ]
+
+    def validate_tool_arguments(self, tool_name: str, arguments: dict[str, Any]) -> None:
+        if tool_name == "fs.patch" and not str(arguments.get("diff") or ""):
+            raise ValueError("diff is required")
+
+    def sanitize_input(self, input_data: Any, _depth: int = 0) -> Any:
+        del _depth
+        return input_data
+
+    async def extract_path_scope_candidates(
+        self,
+        tool_name: str,
+        arguments: dict[str, Any],
+        context: Any = None,
+    ) -> list[PathScopeCandidate]:
+        del tool_name, arguments, context
+        if not self._include_candidate_hook:
+            return await super().extract_path_scope_candidates("fs.patch", {}, None)
+        return list(self._candidates or [])
+
+    async def execute_tool(self, tool_name: str, arguments: dict[str, Any], context: Any = None) -> Any:
+        del tool_name, arguments, context
+        return {"ok": True}
+
+
+def _build_protocol(module: BaseModule, path_scope_enforcer: Any) -> MCPProtocol:
+    protocol = MCPProtocol()
+    protocol.module_registry = _RegistryStub(module)  # type: ignore[assignment]
+    protocol.rbac_policy = _AllowAllRbac()
+    protocol.dependencies.path_scope_enforcer = path_scope_enforcer
+
+    async def _effective_policy(_context: RequestContext) -> dict[str, Any]:
+        return {
+            "enabled": True,
+            "allowed_tools": ["fs.patch"],
+            "denied_tools": [],
+            "capabilities": [],
+            "policy_document": {"path_scope_mode": "workspace_root"},
+            "sources": [],
+        }
+
+    async def _approval_allow(**_kwargs: Any) -> dict[str, Any]:
+        return {"status": "allow", "reason": "test"}
+
+    async def _governance_noop(**_kwargs: Any) -> None:
+        return None
+
+    protocol._resolve_effective_tool_policy = _effective_policy  # type: ignore[method-assign]
+    protocol._evaluate_runtime_approval = _approval_allow  # type: ignore[method-assign]
+    protocol._run_governance_preflight = _governance_noop  # type: ignore[method-assign]
+    return protocol
+
+
+def _context() -> RequestContext:
+    return RequestContext(
+        request_id="candidate-test",
+        user_id="1",
+        client_id="pytest",
+        metadata={"mcp_policy_context_enabled": True},
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_protocol_passes_module_path_candidates_to_enforcer() -> None:
+    candidates = [PathScopeCandidate(path="src/app.py", action="edit", source="module")]
+    module = _PatchModule(candidates=candidates)
+    enforcer = _RecordingPathEnforcer()
+    protocol = _build_protocol(module, enforcer)
+
+    prepared = await protocol.prepare_tool_call(
+        params={"name": "fs.patch", "arguments": {"diff": _PATCH_TEXT}},
+        context=_context(),
+    )
+
+    assert prepared.tool_name == "fs.patch"
+    assert enforcer.received_candidates == candidates
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_protocol_fails_closed_when_module_candidates_unavailable() -> None:
+    module = _PatchModule(include_candidate_hook=False)
+    protocol = _build_protocol(module, _RecordingPathEnforcer())
+
+    with pytest.raises(PermissionError, match="path_scope_candidates_unavailable"):
+        await protocol.prepare_tool_call(
+            params={"name": "fs.patch", "arguments": {"diff": _PATCH_TEXT}},
+            context=_context(),
+        )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_protocol_fails_closed_when_enforcer_cannot_accept_required_candidates() -> None:
+    module = _PatchModule(
+        candidates=[PathScopeCandidate(path="src/app.py", action="edit", source="module")]
+    )
+    protocol = _build_protocol(module, _OldShapePathEnforcer())
+
+    with pytest.raises(PermissionError, match="path_scope_candidates_unsupported"):
+        await protocol.prepare_tool_call(
+            params={"name": "fs.patch", "arguments": {"diff": _PATCH_TEXT}},
+            context=_context(),
+        )

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_protocol_path_scope_candidates.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_protocol_path_scope_candidates.py
@@ -4,7 +4,7 @@ from typing import Any
 
 import pytest
 
-from mcp_unified.interfaces.path_scope import PathScopeCandidate
+from mcp_unified.interfaces.path_scope import PathScopeCandidate, normalize_path_scope_candidate
 from tldw_Server_API.app.core.MCP_unified.modules.base import (
     BaseModule,
     ModuleConfig,
@@ -148,7 +148,13 @@ class _PatchModule(BaseModule):
         return {"ok": True}
 
 
-def _build_protocol(module: BaseModule, path_scope_enforcer: Any) -> MCPProtocol:
+def _build_protocol(
+    module: BaseModule,
+    path_scope_enforcer: Any,
+    *,
+    effective_policy_enabled: bool = True,
+    path_scope_mode: str = "workspace_root",
+) -> MCPProtocol:
     protocol = MCPProtocol()
     protocol.module_registry = _RegistryStub(module)  # type: ignore[assignment]
     protocol.rbac_policy = _AllowAllRbac()
@@ -156,11 +162,11 @@ def _build_protocol(module: BaseModule, path_scope_enforcer: Any) -> MCPProtocol
 
     async def _effective_policy(_context: RequestContext) -> dict[str, Any]:
         return {
-            "enabled": True,
+            "enabled": effective_policy_enabled,
             "allowed_tools": ["fs.patch"],
             "denied_tools": [],
             "capabilities": [],
-            "policy_document": {"path_scope_mode": "workspace_root"},
+            "policy_document": {"path_scope_mode": path_scope_mode},
             "sources": [],
         }
 
@@ -218,9 +224,7 @@ async def test_protocol_fails_closed_when_module_candidates_unavailable() -> Non
 @pytest.mark.unit
 @pytest.mark.asyncio
 async def test_protocol_fails_closed_when_enforcer_cannot_accept_required_candidates() -> None:
-    module = _PatchModule(
-        candidates=[PathScopeCandidate(path="src/app.py", action="edit", source="module")]
-    )
+    module = _PatchModule(candidates=[PathScopeCandidate(path="src/app.py", action="edit", source="module")])
     protocol = _build_protocol(module, _OldShapePathEnforcer())
 
     with pytest.raises(PermissionError, match="path_scope_candidates_unsupported"):
@@ -250,3 +254,60 @@ async def test_protocol_uses_real_filesystem_patch_candidates() -> None:
             requires_existing_file=True,
         )
     ]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("effective_policy_enabled", "path_scope_mode"),
+    [
+        (False, "workspace_root"),
+        (True, "none"),
+    ],
+)
+async def test_protocol_skips_candidate_extraction_when_path_scope_inactive(
+    effective_policy_enabled: bool,
+    path_scope_mode: str,
+) -> None:
+    module = _PatchModule(include_candidate_hook=False)
+    protocol = _build_protocol(
+        module,
+        _RecordingPathEnforcer(),
+        effective_policy_enabled=effective_policy_enabled,
+        path_scope_mode=path_scope_mode,
+    )
+
+    prepared = await protocol.prepare_tool_call(
+        params={"name": "fs.patch", "arguments": {"diff": _PATCH_TEXT}},
+        context=_context(),
+    )
+
+    assert prepared.tool_name == "fs.patch"
+
+
+@pytest.mark.unit
+def test_path_scope_candidate_string_false_flags_remain_false() -> None:
+    candidate = normalize_path_scope_candidate(
+        {
+            "path": "src/app.py",
+            "action": "edit",
+            "source": "test",
+            "requires_existing_file": "false",
+            "creates_file": "0",
+        }
+    )
+
+    assert candidate.requires_existing_file is False
+    assert candidate.creates_file is False
+
+
+@pytest.mark.unit
+def test_path_scope_candidate_rejects_non_boolean_flags() -> None:
+    with pytest.raises(ValueError, match="requires_existing_file must be a boolean"):
+        normalize_path_scope_candidate(
+            {
+                "path": "src/app.py",
+                "action": "edit",
+                "requires_existing_file": "sometimes",
+            }
+        )

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_protocol_path_scope_candidates.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_protocol_path_scope_candidates.py
@@ -10,6 +10,9 @@ from tldw_Server_API.app.core.MCP_unified.modules.base import (
     ModuleConfig,
     create_tool_definition,
 )
+from tldw_Server_API.app.core.MCP_unified.modules.implementations.filesystem_module import (
+    FilesystemModule,
+)
 from tldw_Server_API.app.core.MCP_unified.protocol import MCPProtocol, RequestContext
 
 
@@ -225,3 +228,25 @@ async def test_protocol_fails_closed_when_enforcer_cannot_accept_required_candid
             params={"name": "fs.patch", "arguments": {"diff": _PATCH_TEXT}},
             context=_context(),
         )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_protocol_uses_real_filesystem_patch_candidates() -> None:
+    module = FilesystemModule(ModuleConfig(name="filesystem"))
+    enforcer = _RecordingPathEnforcer()
+    protocol = _build_protocol(module, enforcer)
+
+    await protocol.prepare_tool_call(
+        params={"name": "fs.patch", "arguments": {"diff": _PATCH_TEXT}},
+        context=_context(),
+    )
+
+    assert enforcer.received_candidates == [  # nosec B101
+        PathScopeCandidate(
+            path="src/app.py",
+            action="edit",
+            source="filesystem_diff",
+            requires_existing_file=True,
+        )
+    ]

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_tool_use_reporting_protocol.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_tool_use_reporting_protocol.py
@@ -133,6 +133,56 @@ class _ToolModule:
         return await func(*args, **kwargs)
 
 
+class _FilesystemPayloadModule(_ToolModule):
+    name = "filesystem"
+
+    def __init__(self) -> None:
+        super().__init__(write=True)
+
+    async def get_tools(self) -> list[dict[str, Any]]:
+        return [self._tool_def("fs.patch")]
+
+    def _tool_def(self, tool_name: str) -> dict[str, Any]:
+        return {
+            "name": tool_name,
+            "description": "",
+            "inputSchema": {"type": "object", "properties": {"diff": {"type": "string"}}},
+            "metadata": {
+                "category": "management",
+                "eval": {
+                    "tool_prompt_id": "mcp.fs.patch.v1",
+                    "tool_prompt_version": "2026.06.04",
+                    "task_families": ["filesystem_edit"],
+                    "expected_result_kind": "structured_filesystem_edit",
+                    "prompt_variant": "builtin",
+                },
+            },
+        }
+
+    async def execute_tool(
+        self,
+        tool_name: str,
+        arguments: dict[str, Any],
+        context: RequestContext | None = None,
+    ) -> dict[str, Any]:
+        del tool_name, arguments, context
+        return {
+            "path": "/Users/me/private/story.txt",
+            "content": "SECRET FILE CONTENT",
+            "read_receipt": "receipt-token-secret",
+            "diff": "--- a/private/story.txt\n+++ b/private/story.txt\n",
+            "eval": {
+                "tool_name": "fs.patch",
+                "tool_prompt_id": "mcp.fs.patch.v1",
+                "tool_prompt_version": "2026.06.04",
+                "action_family": "filesystem_edit",
+                "result_kind": "structured_filesystem_edit",
+                "path_filter_used": True,
+                "truncated": False,
+            },
+        }
+
+
 class _Registry:
     def __init__(self, module: _ToolModule) -> None:
         self.module = module
@@ -193,6 +243,36 @@ async def test_protocol_records_successful_tool_use_event() -> None:
     assert event.model_id == "gpt-4.1"
     assert event.tool_prompt_id == "mcp.test.read.v1"
     assert event.status == "success"
+
+
+@pytest.mark.asyncio
+async def test_protocol_records_filesystem_eval_metadata_without_sensitive_payload() -> None:
+    protocol, recorder = _protocol(module=_FilesystemPayloadModule())
+
+    response = await protocol._handle_tools_call(
+        {
+            "name": "fs.patch",
+            "arguments": {
+                "diff": "--- a/private/story.txt\n+++ b/private/story.txt\n",
+                "read_receipt_by_path": {"private/story.txt": "receipt-token-secret"},
+            },
+        },
+        _request_context(metadata={"profile_id": "backend-engineer"}),
+    )
+
+    assert response["content"][0]["json"]["content"] == "SECRET FILE CONTENT"
+    event = recorder.events[-1]
+    dumped = event.model_dump_json()
+    assert event.requested_tool_name == "fs.patch"
+    assert event.action_family == "filesystem_edit"
+    assert event.result_kind == "structured_filesystem_edit"
+    assert event.path_filter_used is True
+    assert event.truncated is False
+    assert event.profile_id == "backend-engineer"
+    assert "SECRET FILE CONTENT" not in dumped
+    assert "receipt-token-secret" not in dumped
+    assert "/Users/me" not in dumped
+    assert "--- a/private" not in dumped
 
 
 @pytest.mark.asyncio

--- a/tldw_Server_API/app/services/mcp_hub_path_enforcement_service.py
+++ b/tldw_Server_API/app/services/mcp_hub_path_enforcement_service.py
@@ -65,6 +65,28 @@ def _unique(values: list[str]) -> list[str]:
     return out
 
 
+def _unique_paths_with_actions(
+    raw_paths: list[str],
+    candidate_actions: list[str],
+    *,
+    default_action: str,
+) -> tuple[list[str], list[str]]:
+    """De-duplicate candidate paths while keeping their action indexes aligned."""
+
+    out_paths: list[str] = []
+    out_actions: list[str] = []
+    seen: set[str] = set()
+    for index, raw_path in enumerate(raw_paths):
+        cleaned = str(raw_path or "").strip()
+        if not cleaned or cleaned in seen:
+            continue
+        seen.add(cleaned)
+        out_paths.append(cleaned)
+        action = candidate_actions[index] if index < len(candidate_actions) else default_action
+        out_actions.append(action if action in _PATH_GRANT_ACTIONS else default_action)
+    return out_paths, out_actions
+
+
 def _is_within(root: Path, candidate: Path) -> bool:
     return candidate == root or root in candidate.parents
 
@@ -121,8 +143,10 @@ def _policy_allowlist_prefixes(effective_policy: dict[str, Any] | None) -> list[
     return sorted(out)
 
 
-def _policy_path_grants(effective_policy: dict[str, Any] | None) -> list[dict[str, Any]]:
+def _policy_path_grants(effective_policy: dict[str, Any] | None) -> list[dict[str, Any]] | None:
     policy_document = _as_dict((effective_policy or {}).get("policy_document"))
+    if "path_grants" not in policy_document:
+        return None
     raw_grants = policy_document.get("path_grants")
     if not isinstance(raw_grants, Iterable) or isinstance(raw_grants, (str, bytes, bytearray, dict)):
         return []
@@ -364,8 +388,13 @@ class McpHubPathEnforcementService:
         if is_multi_root_candidate:
             if self._multi_root_path_service is None:
                 raise RuntimeError("McpHubPathEnforcementService requires an explicit multi_root_path_service for multi-root evaluation")
+            bundle_raw_paths, bundle_candidate_actions = _unique_paths_with_actions(
+                raw_paths,
+                candidate_actions,
+                default_action=inferred_action,
+            )
             multi_root_result = await self._multi_root_path_service.resolve_path_bundle(
-                raw_paths=raw_paths,
+                raw_paths=bundle_raw_paths,
                 active_workspace_id=active_workspace_id,
                 active_workspace_root=str(scope.get("workspace_root") or "").strip() or None,
                 active_base_path=str(scope.get("cwd") or workspace_root),
@@ -393,8 +422,7 @@ class McpHubPathEnforcementService:
             resolved_workspace_roots_by_id = dict(
                 multi_root_result.get("resolved_workspace_roots_by_id") or {}
             )
-            for normalized_text in normalized_paths:
-                path_index = normalized_paths.index(normalized_text)
+            for path_index, normalized_text in enumerate(normalized_paths):
                 matched_workspace_id = str(path_workspace_map.get(normalized_text) or "").strip()
                 matched_root_text = str(resolved_workspace_roots_by_id.get(matched_workspace_id) or "").strip()
                 if not matched_root_text:
@@ -437,7 +465,7 @@ class McpHubPathEnforcementService:
                         workspace_bundle_roots=list(multi_root_result.get("workspace_bundle_roots") or []),
                         path_workspace_map=path_workspace_map,
                     )
-                if path_grants:
+                if path_grants is not None:
                     relative_path = _relative_path_for_decision(matched_root, normalized)
                     if relative_path is None:
                         return self._blocked_result(
@@ -450,7 +478,11 @@ class McpHubPathEnforcementService:
                             workspace_bundle_roots=list(multi_root_result.get("workspace_bundle_roots") or []),
                             path_workspace_map=path_workspace_map,
                         )
-                    action = candidate_actions[path_index] if path_index < len(candidate_actions) else inferred_action
+                    action = (
+                        bundle_candidate_actions[path_index]
+                        if path_index < len(bundle_candidate_actions)
+                        else inferred_action
+                    )
                     decision = _path_grant_decision(
                         relative_path=relative_path,
                         action=action,
@@ -463,7 +495,7 @@ class McpHubPathEnforcementService:
                             path_decisions=[decision],
                         )
             result["normalized_paths"] = normalized_paths
-            if path_grants:
+            if path_grants is not None:
                 path_decisions = []
                 for path_index, normalized_text in enumerate(normalized_paths):
                     matched_workspace_id = str(path_workspace_map.get(normalized_text) or "").strip()
@@ -472,7 +504,11 @@ class McpHubPathEnforcementService:
                     relative_path = _relative_path_for_decision(matched_root, Path(normalized_text).expanduser().resolve(strict=False))
                     if relative_path is None:
                         continue
-                    action = candidate_actions[path_index] if path_index < len(candidate_actions) else inferred_action
+                    action = (
+                        bundle_candidate_actions[path_index]
+                        if path_index < len(bundle_candidate_actions)
+                        else inferred_action
+                    )
                     path_decisions.append(
                         _path_grant_decision(
                             relative_path=relative_path,
@@ -516,7 +552,7 @@ class McpHubPathEnforcementService:
                     normalized_paths=normalized_paths,
                     path_allowlist_prefixes=path_allowlist_prefixes,
                 )
-            if path_grants:
+            if path_grants is not None:
                 relative_path = _relative_path_for_decision(workspace_root, normalized)
                 if relative_path is None:
                     return self._blocked_result(

--- a/tldw_Server_API/app/services/mcp_hub_path_enforcement_service.py
+++ b/tldw_Server_API/app/services/mcp_hub_path_enforcement_service.py
@@ -258,7 +258,8 @@ def _path_grant_decision(
     path_grants: list[dict[str, Any]],
 ) -> dict[str, Any]:
     matches = [
-        grant for grant in path_grants
+        grant
+        for grant in path_grants
         if action in set(grant.get("actions") or [])
         and _grant_prefix_matches(relative_path, str(grant.get("prefix") or ""))
     ]
@@ -341,9 +342,7 @@ class McpHubPathEnforcementService:
                 )
             return self._blocked_result(scope=scope, reason=reason)
 
-        allowed_workspace_ids = _unique(
-            _as_str_list((effective_policy or {}).get("selected_assignment_workspace_ids"))
-        )
+        allowed_workspace_ids = _unique(_as_str_list((effective_policy or {}).get("selected_assignment_workspace_ids")))
         active_workspace_id = str(scope.get("workspace_id") or "").strip()
         if allowed_workspace_ids and active_workspace_id not in allowed_workspace_ids:
             return self._blocked_result(
@@ -381,13 +380,14 @@ class McpHubPathEnforcementService:
         path_allowlist_prefixes = _policy_allowlist_prefixes(effective_policy)
         path_grants = _policy_path_grants(effective_policy)
         is_multi_root_candidate = (
-            str(scope.get("path_scope_mode") or "").strip() == "workspace_root"
-            and len(allowed_workspace_ids) > 1
+            str(scope.get("path_scope_mode") or "").strip() == "workspace_root" and len(allowed_workspace_ids) > 1
         )
 
         if is_multi_root_candidate:
             if self._multi_root_path_service is None:
-                raise RuntimeError("McpHubPathEnforcementService requires an explicit multi_root_path_service for multi-root evaluation")
+                raise RuntimeError(
+                    "McpHubPathEnforcementService requires an explicit multi_root_path_service for multi-root evaluation"
+                )
             bundle_raw_paths, bundle_candidate_actions = _unique_paths_with_actions(
                 raw_paths,
                 candidate_actions,
@@ -419,9 +419,7 @@ class McpHubPathEnforcementService:
 
             normalized_paths = list(multi_root_result.get("normalized_paths") or [])
             path_workspace_map = dict(multi_root_result.get("path_workspace_map") or {})
-            resolved_workspace_roots_by_id = dict(
-                multi_root_result.get("resolved_workspace_roots_by_id") or {}
-            )
+            resolved_workspace_roots_by_id = dict(multi_root_result.get("resolved_workspace_roots_by_id") or {})
             for path_index, normalized_text in enumerate(normalized_paths):
                 matched_workspace_id = str(path_workspace_map.get(normalized_text) or "").strip()
                 matched_root_text = str(resolved_workspace_roots_by_id.get(matched_workspace_id) or "").strip()
@@ -454,7 +452,11 @@ class McpHubPathEnforcementService:
                         workspace_bundle_roots=list(multi_root_result.get("workspace_bundle_roots") or []),
                         path_workspace_map=path_workspace_map,
                     )
-                if allowlist_roots and not any(_is_within(root, normalized) for root in allowlist_roots):
+                if (
+                    path_grants is None
+                    and allowlist_roots
+                    and not any(_is_within(root, normalized) for root in allowlist_roots)
+                ):
                     return self._blocked_result(
                         scope=scope,
                         reason="path_outside_allowlist_scope",
@@ -495,13 +497,15 @@ class McpHubPathEnforcementService:
                             path_decisions=[decision],
                         )
             result["normalized_paths"] = normalized_paths
+            path_decisions: list[dict[str, Any]] = []
             if path_grants is not None:
-                path_decisions = []
                 for path_index, normalized_text in enumerate(normalized_paths):
                     matched_workspace_id = str(path_workspace_map.get(normalized_text) or "").strip()
                     matched_root_text = str(resolved_workspace_roots_by_id.get(matched_workspace_id) or "").strip()
                     matched_root = Path(matched_root_text).expanduser().resolve(strict=False)
-                    relative_path = _relative_path_for_decision(matched_root, Path(normalized_text).expanduser().resolve(strict=False))
+                    relative_path = _relative_path_for_decision(
+                        matched_root, Path(normalized_text).expanduser().resolve(strict=False)
+                    )
                     if relative_path is None:
                         continue
                     action = (
@@ -521,6 +525,7 @@ class McpHubPathEnforcementService:
                 scope=scope,
                 normalized_paths=normalized_paths,
                 path_allowlist_prefixes=path_allowlist_prefixes,
+                path_decisions=path_decisions,
                 allowed_workspace_ids=allowed_workspace_ids,
                 workspace_bundle_ids=list(multi_root_result.get("workspace_bundle_ids") or []),
                 workspace_bundle_roots=list(multi_root_result.get("workspace_bundle_roots") or []),

--- a/tldw_Server_API/app/services/mcp_hub_path_enforcement_service.py
+++ b/tldw_Server_API/app/services/mcp_hub_path_enforcement_service.py
@@ -5,6 +5,8 @@ from pathlib import Path
 import re
 from typing import Any
 
+from mcp_unified.interfaces.path_scope import PathScopeCandidate
+
 from tldw_Server_API.app.core.AuthNZ.database import get_db_pool
 from tldw_Server_API.app.core.AuthNZ.repos.mcp_hub_repo import McpHubRepo
 from tldw_Server_API.app.services.mcp_hub_multi_root_path_service import (
@@ -14,6 +16,8 @@ from tldw_Server_API.app.services.mcp_hub_path_scope_service import McpHubPathSc
 from tldw_Server_API.app.services.mcp_hub_workspace_root_resolver import McpHubWorkspaceRootResolver
 
 _FILESYSTEM_CAPABILITIES = frozenset({"filesystem.read", "filesystem.write", "filesystem.delete"})
+_PATH_GRANT_ACTIONS = frozenset({"read", "edit", "write"})
+_PATH_GRANT_EFFECTS = frozenset({"allow", "deny"})
 _SUPPORTED_PATH_ARGUMENT_HINTS = frozenset(
     {"path", "file_path", "target_path", "cwd", "paths", "file_paths", "files[].path"}
 )
@@ -117,6 +121,33 @@ def _policy_allowlist_prefixes(effective_policy: dict[str, Any] | None) -> list[
     return sorted(out)
 
 
+def _policy_path_grants(effective_policy: dict[str, Any] | None) -> list[dict[str, Any]]:
+    policy_document = _as_dict((effective_policy or {}).get("policy_document"))
+    raw_grants = policy_document.get("path_grants")
+    if not isinstance(raw_grants, Iterable) or isinstance(raw_grants, (str, bytes, bytearray, dict)):
+        return []
+    grants: list[dict[str, Any]] = []
+    seen: set[tuple[str, tuple[str, ...], str]] = set()
+    for raw_grant in raw_grants:
+        if not isinstance(raw_grant, Mapping):
+            continue
+        prefix = _normalize_allowlist_prefix(raw_grant.get("prefix", raw_grant.get("path")))
+        if not prefix:
+            continue
+        actions = sorted({action for action in _as_str_list(raw_grant.get("actions")) if action in _PATH_GRANT_ACTIONS})
+        if not actions:
+            continue
+        effect = str(raw_grant.get("effect") or "allow").strip().lower()
+        if effect not in _PATH_GRANT_EFFECTS:
+            continue
+        key = (prefix, tuple(actions), effect)
+        if key in seen:
+            continue
+        seen.add(key)
+        grants.append({"prefix": prefix, "actions": actions, "effect": effect})
+    return sorted(grants, key=lambda grant: (str(grant["prefix"]), str(grant["effect"])))
+
+
 def _allowlist_roots(*, workspace_root: Path, allowlist_prefixes: list[str]) -> list[Path]:
     return [(workspace_root / prefix).resolve(strict=False) for prefix in allowlist_prefixes]
 
@@ -173,6 +204,66 @@ def _extract_candidate_paths(tool_args: Any, hints: list[str]) -> list[str]:
     return _unique(out)
 
 
+def _path_scope_action(metadata: dict[str, Any]) -> str:
+    action = str(metadata.get("path_scope_action") or "").strip().lower()
+    if action in _PATH_GRANT_ACTIONS:
+        return action
+    for flag_name in ("write_capable", "is_write", "mutates_state"):
+        if _as_bool(metadata.get(flag_name)) is True:
+            return "write"
+    return "read"
+
+
+def _relative_path_for_decision(root: Path, candidate: Path) -> str | None:
+    try:
+        relative = candidate.relative_to(root)
+    except ValueError:
+        return None
+    text = relative.as_posix()
+    return text if text not in {"", "."} else "."
+
+
+def _grant_prefix_matches(relative_path: str, prefix: str) -> bool:
+    return relative_path == prefix or relative_path.startswith(f"{prefix}/")
+
+
+def _path_grant_decision(
+    *,
+    relative_path: str,
+    action: str,
+    path_grants: list[dict[str, Any]],
+) -> dict[str, Any]:
+    matches = [
+        grant for grant in path_grants
+        if action in set(grant.get("actions") or [])
+        and _grant_prefix_matches(relative_path, str(grant.get("prefix") or ""))
+    ]
+    deny_matches = [grant for grant in matches if grant.get("effect") == "deny"]
+    allow_matches = [grant for grant in matches if grant.get("effect") == "allow"]
+    selected: dict[str, Any] | None = None
+    outcome = "not_granted"
+    reason_code: str | None = "path_action_not_granted"
+    if deny_matches:
+        selected = max(deny_matches, key=lambda grant: len(str(grant.get("prefix") or "")))
+        outcome = "denied"
+        reason_code = "path_action_denied"
+    elif allow_matches:
+        selected = max(allow_matches, key=lambda grant: len(str(grant.get("prefix") or "")))
+        outcome = "allowed"
+        reason_code = None
+
+    return {
+        "requested_action": action,
+        "normalized_path": relative_path,
+        "grant_outcome": outcome,
+        "grant_source": "path_grants",
+        "matched_grant_prefix": str((selected or {}).get("prefix") or "") or None,
+        "matched_grant_effect": str((selected or {}).get("effect") or "") or None,
+        "reason_code": reason_code,
+        "redacted": True,
+    }
+
+
 class McpHubPathEnforcementService:
     """Evaluate path-scoped MCP Hub policy for a concrete tool call."""
 
@@ -192,6 +283,7 @@ class McpHubPathEnforcementService:
         tool_name: str,
         tool_args: Any,
         tool_def: dict[str, Any] | None,
+        path_scope_candidates: list[PathScopeCandidate] | None = None,
     ) -> dict[str, Any]:
         if self._path_scope_service is None:
             raise RuntimeError("McpHubPathEnforcementService requires an explicit path_scope_service")
@@ -244,8 +336,15 @@ class McpHubPathEnforcementService:
         if not _path_boundable(metadata):
             return self._blocked_result(scope=scope, reason="tool_not_path_boundable")
 
-        hints = _path_argument_hints(metadata)
-        raw_paths = _extract_candidate_paths(tool_args, hints)
+        inferred_action = _path_scope_action(metadata)
+        candidate_actions: list[str] = []
+        if path_scope_candidates:
+            raw_paths = [candidate.path for candidate in path_scope_candidates]
+            candidate_actions = [candidate.action for candidate in path_scope_candidates]
+        else:
+            hints = _path_argument_hints(metadata)
+            raw_paths = _extract_candidate_paths(tool_args, hints)
+            candidate_actions = [inferred_action for _raw_path in raw_paths]
         if not raw_paths:
             return self._blocked_result(scope=scope, reason="path_unresolvable")
 
@@ -256,6 +355,7 @@ class McpHubPathEnforcementService:
         workspace_root = Path(workspace_root_text).expanduser().resolve(strict=False)
         base_path = Path(str(scope.get("cwd") or workspace_root)).expanduser().resolve(strict=False)
         path_allowlist_prefixes = _policy_allowlist_prefixes(effective_policy)
+        path_grants = _policy_path_grants(effective_policy)
         is_multi_root_candidate = (
             str(scope.get("path_scope_mode") or "").strip() == "workspace_root"
             and len(allowed_workspace_ids) > 1
@@ -294,6 +394,7 @@ class McpHubPathEnforcementService:
                 multi_root_result.get("resolved_workspace_roots_by_id") or {}
             )
             for normalized_text in normalized_paths:
+                path_index = normalized_paths.index(normalized_text)
                 matched_workspace_id = str(path_workspace_map.get(normalized_text) or "").strip()
                 matched_root_text = str(resolved_workspace_roots_by_id.get(matched_workspace_id) or "").strip()
                 if not matched_root_text:
@@ -336,7 +437,50 @@ class McpHubPathEnforcementService:
                         workspace_bundle_roots=list(multi_root_result.get("workspace_bundle_roots") or []),
                         path_workspace_map=path_workspace_map,
                     )
+                if path_grants:
+                    relative_path = _relative_path_for_decision(matched_root, normalized)
+                    if relative_path is None:
+                        return self._blocked_result(
+                            scope=scope,
+                            reason="path_outside_workspace_scope",
+                            normalized_paths=normalized_paths,
+                            path_allowlist_prefixes=path_allowlist_prefixes,
+                            allowed_workspace_ids=allowed_workspace_ids,
+                            workspace_bundle_ids=list(multi_root_result.get("workspace_bundle_ids") or []),
+                            workspace_bundle_roots=list(multi_root_result.get("workspace_bundle_roots") or []),
+                            path_workspace_map=path_workspace_map,
+                        )
+                    action = candidate_actions[path_index] if path_index < len(candidate_actions) else inferred_action
+                    decision = _path_grant_decision(
+                        relative_path=relative_path,
+                        action=action,
+                        path_grants=path_grants,
+                    )
+                    if decision["grant_outcome"] != "allowed":
+                        return self._grant_blocked_result(
+                            scope=scope,
+                            reason=str(decision.get("reason_code") or "path_action_not_granted"),
+                            path_decisions=[decision],
+                        )
             result["normalized_paths"] = normalized_paths
+            if path_grants:
+                path_decisions = []
+                for path_index, normalized_text in enumerate(normalized_paths):
+                    matched_workspace_id = str(path_workspace_map.get(normalized_text) or "").strip()
+                    matched_root_text = str(resolved_workspace_roots_by_id.get(matched_workspace_id) or "").strip()
+                    matched_root = Path(matched_root_text).expanduser().resolve(strict=False)
+                    relative_path = _relative_path_for_decision(matched_root, Path(normalized_text).expanduser().resolve(strict=False))
+                    if relative_path is None:
+                        continue
+                    action = candidate_actions[path_index] if path_index < len(candidate_actions) else inferred_action
+                    path_decisions.append(
+                        _path_grant_decision(
+                            relative_path=relative_path,
+                            action=action,
+                            path_grants=path_grants,
+                        )
+                    )
+                result["path_decisions"] = path_decisions
             result["scope_payload"] = self._scope_payload(
                 scope=scope,
                 normalized_paths=normalized_paths,
@@ -354,7 +498,9 @@ class McpHubPathEnforcementService:
         )
 
         normalized_paths: list[str] = []
+        path_decisions: list[dict[str, Any]] = []
         for raw_path in raw_paths:
+            path_index = len(normalized_paths)
             normalized = _normalize_candidate_path(raw_path, base_path=base_path)
             normalized_paths.append(str(normalized))
             if not _is_within(workspace_root, normalized):
@@ -370,6 +516,28 @@ class McpHubPathEnforcementService:
                     normalized_paths=normalized_paths,
                     path_allowlist_prefixes=path_allowlist_prefixes,
                 )
+            if path_grants:
+                relative_path = _relative_path_for_decision(workspace_root, normalized)
+                if relative_path is None:
+                    return self._blocked_result(
+                        scope=scope,
+                        reason="path_outside_workspace_scope",
+                        normalized_paths=normalized_paths,
+                    )
+                action = candidate_actions[path_index] if path_index < len(candidate_actions) else inferred_action
+                decision = _path_grant_decision(
+                    relative_path=relative_path,
+                    action=action,
+                    path_grants=path_grants,
+                )
+                path_decisions.append(decision)
+                if decision["grant_outcome"] != "allowed":
+                    return self._grant_blocked_result(
+                        scope=scope,
+                        reason=str(decision.get("reason_code") or "path_action_not_granted"),
+                        path_decisions=list(path_decisions),
+                    )
+                continue
             if allowlist_roots and not any(_is_within(root, normalized) for root in allowlist_roots):
                 return self._blocked_result(
                     scope=scope,
@@ -379,10 +547,13 @@ class McpHubPathEnforcementService:
                 )
 
         result["normalized_paths"] = normalized_paths
+        if path_decisions:
+            result["path_decisions"] = list(path_decisions)
         result["scope_payload"] = self._scope_payload(
             scope=scope,
             normalized_paths=normalized_paths,
             path_allowlist_prefixes=path_allowlist_prefixes,
+            path_decisions=path_decisions,
         )
         return result
 
@@ -393,6 +564,7 @@ class McpHubPathEnforcementService:
         normalized_paths: list[str] | None = None,
         reason: str | None = None,
         path_allowlist_prefixes: list[str] | None = None,
+        path_decisions: list[dict[str, Any]] | None = None,
         allowed_workspace_ids: list[str] | None = None,
         workspace_bundle_ids: list[str] | None = None,
         workspace_bundle_roots: list[str] | None = None,
@@ -412,6 +584,8 @@ class McpHubPathEnforcementService:
             payload["normalized_paths"] = list(normalized_paths)
         if path_allowlist_prefixes:
             payload["path_allowlist_prefixes"] = list(path_allowlist_prefixes)
+        if path_decisions:
+            payload["path_decisions"] = [dict(decision) for decision in path_decisions]
         if allowed_workspace_ids:
             payload["allowed_workspace_ids"] = list(allowed_workspace_ids)
         if workspace_bundle_ids:
@@ -426,6 +600,21 @@ class McpHubPathEnforcementService:
             }
         if reason:
             payload["reason"] = reason
+        return {key: value for key, value in payload.items() if value not in (None, "", [])}
+
+    @staticmethod
+    def _safe_grant_scope_payload(
+        *,
+        scope: dict[str, Any],
+        reason: str,
+        path_decisions: list[dict[str, Any]],
+    ) -> dict[str, Any]:
+        payload = {
+            "path_scope_mode": str(scope.get("path_scope_mode") or "none").strip() or "none",
+            "workspace_id": str(scope.get("workspace_id") or "").strip() or None,
+            "reason": reason,
+            "path_decisions": [dict(decision) for decision in path_decisions],
+        }
         return {key: value for key, value in payload.items() if value not in (None, "", [])}
 
     def _blocked_result(
@@ -456,6 +645,28 @@ class McpHubPathEnforcementService:
                 workspace_bundle_ids=workspace_bundle_ids,
                 workspace_bundle_roots=workspace_bundle_roots,
                 path_workspace_map=path_workspace_map,
+            ),
+        }
+
+    def _grant_blocked_result(
+        self,
+        *,
+        scope: dict[str, Any],
+        reason: str,
+        path_decisions: list[dict[str, Any]],
+        force_approval: bool = True,
+    ) -> dict[str, Any]:
+        return {
+            "enabled": bool(scope.get("enabled")),
+            "within_scope": False,
+            "reason": reason,
+            "force_approval": force_approval,
+            "normalized_paths": [],
+            "path_decisions": [dict(decision) for decision in path_decisions],
+            "scope_payload": self._safe_grant_scope_payload(
+                scope=scope,
+                reason=reason,
+                path_decisions=path_decisions,
             ),
         }
 

--- a/tldw_Server_API/tests/MCP_unified/test_mcp_hub_path_enforcement_service.py
+++ b/tldw_Server_API/tests/MCP_unified/test_mcp_hub_path_enforcement_service.py
@@ -507,6 +507,7 @@ async def test_multi_root_path_grants_keep_deduped_paths_and_actions_aligned() -
             "selected_assignment_workspace_ids": ["ws-1", "ws-2"],
             "policy_document": {
                 "path_scope_mode": "workspace_root",
+                "path_allowlist_prefixes": ["legacy-only"],
                 "path_grants": [
                     {"prefix": "documents", "actions": ["read"]},
                     {"prefix": "downloads", "actions": ["write"]},
@@ -528,3 +529,63 @@ async def test_multi_root_path_grants_keep_deduped_paths_and_actions_aligned() -
     assert result["within_scope"] is True
     assert result["reason"] is None
     assert [decision["requested_action"] for decision in result["path_decisions"]] == ["read", "write"]
+    assert result["scope_payload"]["path_decisions"] == result["path_decisions"]
+    assert "/tmp/mcp-hub-path-enforcer" not in repr(result["path_decisions"])
+
+
+@pytest.mark.asyncio
+async def test_multi_root_path_grants_deny_override_blocks_matching_bundle_path() -> None:
+    from tldw_Server_API.app.services.mcp_hub_path_enforcement_service import (
+        McpHubPathEnforcementService,
+    )
+
+    workspace_root = "/tmp/mcp-hub-path-enforcer/project"
+    scope = {
+        **_workspace_scope(),
+        "workspace_id": "ws-1",
+        "selected_workspace_trust_source": "sandbox_workspace_lookup",
+    }
+    multi_root = _FakeMultiRootPathService(workspace_root=workspace_root)
+    svc = McpHubPathEnforcementService(
+        path_scope_service=_FakePathScopeService(scope),
+        multi_root_path_service=multi_root,
+    )
+
+    result = await svc.evaluate_tool_call(
+        effective_policy={
+            "enabled": True,
+            "selected_assignment_workspace_ids": ["ws-1", "ws-2"],
+            "policy_document": {
+                "path_scope_mode": "workspace_root",
+                "path_allowlist_prefixes": ["legacy-only"],
+                "path_grants": [
+                    {"prefix": "documents", "actions": ["read", "edit", "write"]},
+                    {"prefix": "documents/private", "actions": ["edit", "write"], "effect": "deny"},
+                ],
+            },
+        },
+        context=SimpleNamespace(user_id="1", metadata={}),
+        tool_name="fs.patch",
+        tool_args={"diff": "not-inspected-here"},
+        tool_def=_filesystem_tool_def(action="edit"),
+        path_scope_candidates=[
+            PathScopeCandidate(path="documents/private/secret.md", action="edit", source="module"),
+        ],
+    )
+
+    assert result["within_scope"] is False
+    assert result["reason"] == "path_action_denied"
+    assert result["path_decisions"] == [
+        {
+            "requested_action": "edit",
+            "normalized_path": "documents/private/secret.md",
+            "grant_outcome": "denied",
+            "grant_source": "path_grants",
+            "matched_grant_prefix": "documents/private",
+            "matched_grant_effect": "deny",
+            "reason_code": "path_action_denied",
+            "redacted": True,
+        }
+    ]
+    assert result["scope_payload"]["path_decisions"] == result["path_decisions"]
+    assert "/tmp/mcp-hub-path-enforcer" not in repr(result)

--- a/tldw_Server_API/tests/MCP_unified/test_mcp_hub_path_enforcement_service.py
+++ b/tldw_Server_API/tests/MCP_unified/test_mcp_hub_path_enforcement_service.py
@@ -5,6 +5,8 @@ from types import SimpleNamespace
 
 import pytest
 
+from mcp_unified.interfaces.path_scope import PathScopeCandidate
+
 
 class _FakePathScopeService:
     def __init__(self, result: dict) -> None:
@@ -12,6 +14,29 @@ class _FakePathScopeService:
 
     async def resolve_for_context(self, *, effective_policy, context):  # noqa: ANN001
         return dict(self.result)
+
+
+def _workspace_scope() -> dict:
+    return {
+        "enabled": True,
+        "path_scope_mode": "workspace_root",
+        "path_scope_enforcement": "approval_required_when_unenforceable",
+        "workspace_root": "/tmp/mcp-hub-path-enforcer/project",
+        "cwd": "/tmp/mcp-hub-path-enforcer/project",
+        "reason": None,
+    }
+
+
+def _filesystem_tool_def(*, action: str = "read") -> dict:
+    return {
+        "name": f"fs.{action}",
+        "metadata": {
+            "uses_filesystem": True,
+            "path_boundable": True,
+            "path_argument_hints": ["path"],
+            "path_scope_action": action,
+        },
+    }
 
 
 @pytest.mark.asyncio
@@ -283,3 +308,124 @@ async def test_path_enforcement_allows_candidate_within_scope_and_allowlist_root
         "normalized_paths": [expected_path],
         "path_allowlist_prefixes": ["src"],
     }
+
+
+@pytest.mark.asyncio
+async def test_path_grants_allow_candidate_action_and_report_safe_decision() -> None:
+    from tldw_Server_API.app.services.mcp_hub_path_enforcement_service import (
+        McpHubPathEnforcementService,
+    )
+
+    svc = McpHubPathEnforcementService(path_scope_service=_FakePathScopeService(_workspace_scope()))
+
+    result = await svc.evaluate_tool_call(
+        effective_policy={
+            "enabled": True,
+            "policy_document": {
+                "path_scope_mode": "workspace_root",
+                "path_grants": [
+                    {"prefix": "documents", "actions": ["read", "edit", "write"]},
+                ],
+            },
+        },
+        context=SimpleNamespace(metadata={}),
+        tool_name="fs.write",
+        tool_args={"path": "ignored-by-derived-candidates.md"},
+        tool_def=_filesystem_tool_def(action="write"),
+        path_scope_candidates=[
+            PathScopeCandidate(path="documents/story.md", action="write", source="module"),
+        ],
+    )
+
+    assert result["within_scope"] is True
+    assert result["reason"] is None
+    assert result["path_decisions"] == [
+        {
+            "requested_action": "write",
+            "normalized_path": "documents/story.md",
+            "grant_outcome": "allowed",
+            "grant_source": "path_grants",
+            "matched_grant_prefix": "documents",
+            "matched_grant_effect": "allow",
+            "reason_code": None,
+            "redacted": True,
+        }
+    ]
+    assert "/tmp/mcp-hub-path-enforcer" not in repr(result["path_decisions"])
+
+
+@pytest.mark.asyncio
+async def test_path_grants_deny_overrides_broader_allow_grant() -> None:
+    from tldw_Server_API.app.services.mcp_hub_path_enforcement_service import (
+        McpHubPathEnforcementService,
+    )
+
+    svc = McpHubPathEnforcementService(path_scope_service=_FakePathScopeService(_workspace_scope()))
+
+    result = await svc.evaluate_tool_call(
+        effective_policy={
+            "enabled": True,
+            "policy_document": {
+                "path_scope_mode": "workspace_root",
+                "path_grants": [
+                    {"prefix": "documents", "actions": ["read", "edit", "write"]},
+                    {"prefix": "documents/private", "actions": ["edit", "write"], "effect": "deny"},
+                ],
+            },
+        },
+        context=SimpleNamespace(metadata={}),
+        tool_name="fs.patch",
+        tool_args={"diff": "not-inspected-here"},
+        tool_def=_filesystem_tool_def(action="edit"),
+        path_scope_candidates=[
+            PathScopeCandidate(path="documents/private/secret.md", action="edit", source="module"),
+        ],
+    )
+
+    assert result["within_scope"] is False
+    assert result["reason"] == "path_action_denied"
+    assert result["force_approval"] is True
+    assert result["path_decisions"] == [
+        {
+            "requested_action": "edit",
+            "normalized_path": "documents/private/secret.md",
+            "grant_outcome": "denied",
+            "grant_source": "path_grants",
+            "matched_grant_prefix": "documents/private",
+            "matched_grant_effect": "deny",
+            "reason_code": "path_action_denied",
+            "redacted": True,
+        }
+    ]
+    assert "/tmp/mcp-hub-path-enforcer" not in repr(result)
+
+
+@pytest.mark.asyncio
+async def test_path_grants_are_authoritative_when_legacy_allowlist_also_present() -> None:
+    from tldw_Server_API.app.services.mcp_hub_path_enforcement_service import (
+        McpHubPathEnforcementService,
+    )
+
+    svc = McpHubPathEnforcementService(path_scope_service=_FakePathScopeService(_workspace_scope()))
+
+    result = await svc.evaluate_tool_call(
+        effective_policy={
+            "enabled": True,
+            "policy_document": {
+                "path_scope_mode": "workspace_root",
+                "path_allowlist_prefixes": ["documents"],
+                "path_grants": [
+                    {"prefix": "downloads", "actions": ["read"]},
+                ],
+            },
+        },
+        context=SimpleNamespace(metadata={}),
+        tool_name="fs.write",
+        tool_args={"path": "documents/story.md"},
+        tool_def=_filesystem_tool_def(action="write"),
+    )
+
+    assert result["within_scope"] is False
+    assert result["reason"] == "path_action_not_granted"
+    assert result["path_decisions"][0]["normalized_path"] == "documents/story.md"
+    assert result["path_decisions"][0]["grant_source"] == "path_grants"

--- a/tldw_Server_API/tests/MCP_unified/test_mcp_hub_path_enforcement_service.py
+++ b/tldw_Server_API/tests/MCP_unified/test_mcp_hub_path_enforcement_service.py
@@ -16,6 +16,28 @@ class _FakePathScopeService:
         return dict(self.result)
 
 
+class _FakeMultiRootPathService:
+    def __init__(self, workspace_root: str, workspace_id: str = "ws-1") -> None:
+        self.workspace_root = workspace_root
+        self.workspace_id = workspace_id
+        self.calls: list[dict] = []
+
+    async def resolve_path_bundle(self, **kwargs):  # noqa: ANN001
+        self.calls.append(dict(kwargs))
+        normalized_paths = [
+            str((Path(self.workspace_root) / raw_path).resolve()) for raw_path in kwargs.get("raw_paths", [])
+        ]
+        return {
+            "ok": True,
+            "reason": None,
+            "normalized_paths": normalized_paths,
+            "workspace_bundle_ids": [self.workspace_id],
+            "workspace_bundle_roots": [self.workspace_root],
+            "path_workspace_map": {normalized_path: self.workspace_id for normalized_path in normalized_paths},
+            "resolved_workspace_roots_by_id": {self.workspace_id: self.workspace_root},
+        }
+
+
 def _workspace_scope() -> dict:
     return {
         "enabled": True,
@@ -429,3 +451,80 @@ async def test_path_grants_are_authoritative_when_legacy_allowlist_also_present(
     assert result["reason"] == "path_action_not_granted"
     assert result["path_decisions"][0]["normalized_path"] == "documents/story.md"
     assert result["path_decisions"][0]["grant_source"] == "path_grants"
+
+
+@pytest.mark.asyncio
+async def test_empty_path_grants_fail_closed_even_with_legacy_allowlist() -> None:
+    from tldw_Server_API.app.services.mcp_hub_path_enforcement_service import (
+        McpHubPathEnforcementService,
+    )
+
+    svc = McpHubPathEnforcementService(path_scope_service=_FakePathScopeService(_workspace_scope()))
+
+    result = await svc.evaluate_tool_call(
+        effective_policy={
+            "enabled": True,
+            "policy_document": {
+                "path_scope_mode": "workspace_root",
+                "path_allowlist_prefixes": ["documents"],
+                "path_grants": [],
+            },
+        },
+        context=SimpleNamespace(metadata={}),
+        tool_name="fs.read",
+        tool_args={"path": "documents/story.md"},
+        tool_def=_filesystem_tool_def(action="read"),
+    )
+
+    assert result["within_scope"] is False
+    assert result["reason"] == "path_action_not_granted"
+    assert result["path_decisions"][0]["grant_outcome"] == "not_granted"
+
+
+@pytest.mark.asyncio
+async def test_multi_root_path_grants_keep_deduped_paths_and_actions_aligned() -> None:
+    from tldw_Server_API.app.services.mcp_hub_path_enforcement_service import (
+        McpHubPathEnforcementService,
+    )
+
+    workspace_root = "/tmp/mcp-hub-path-enforcer/project"
+    scope = {
+        **_workspace_scope(),
+        "workspace_id": "ws-1",
+        "selected_workspace_trust_source": "sandbox_workspace_lookup",
+        "selected_workspace_scope_type": "user",
+        "selected_workspace_scope_id": 7,
+    }
+    multi_root = _FakeMultiRootPathService(workspace_root=workspace_root)
+    svc = McpHubPathEnforcementService(
+        path_scope_service=_FakePathScopeService(scope),
+        multi_root_path_service=multi_root,
+    )
+
+    result = await svc.evaluate_tool_call(
+        effective_policy={
+            "enabled": True,
+            "selected_assignment_workspace_ids": ["ws-1", "ws-2"],
+            "policy_document": {
+                "path_scope_mode": "workspace_root",
+                "path_grants": [
+                    {"prefix": "documents", "actions": ["read"]},
+                    {"prefix": "downloads", "actions": ["write"]},
+                ],
+            },
+        },
+        context=SimpleNamespace(user_id="1", metadata={}),
+        tool_name="fs.patch",
+        tool_args={"diff": "not-inspected-here"},
+        tool_def=_filesystem_tool_def(action="edit"),
+        path_scope_candidates=[
+            PathScopeCandidate(path="documents/story.md", action="read", source="module"),
+            PathScopeCandidate(path="documents/story.md", action="read", source="module"),
+            PathScopeCandidate(path="downloads/export.md", action="write", source="module"),
+        ],
+    )
+
+    assert multi_root.calls[0]["raw_paths"] == ["documents/story.md", "downloads/export.md"]
+    assert result["within_scope"] is True
+    assert result["reason"] is None
+    assert [decision["requested_action"] for decision in result["path_decisions"]] == ["read", "write"]


### PR DESCRIPTION
## Summary
- Add package-owned MCP profile policy decision primitives for deny/ask/allow outcomes, matched-rule metadata, safe rule compilation, and redacted explanations.
- Attach optional decision metadata to effective profile policy resolution while preserving existing runtime allow/deny behavior.
- Export the decision API from `mcp_unified.profiles` and close `TASK-2308`.

## Test Plan
- [x] `source ../../.venv/bin/activate && python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_profile_policy_decisions.py tldw_Server_API/app/core/MCP_unified/tests/test_profile_structured_resolution.py tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py::test_gateway_profile_runtime_filters_and_allows_default_profile_tools tldw_Server_API/app/core/MCP_unified/tests/test_protocol_allowed_tools.py::test_protocol_tools_call_blocks_tool_denied_by_effective_policy -q` -> 77 passed, 5 warnings
- [x] `source ../../.venv/bin/activate && python -m black --check mcp_unified/profiles/decisions.py mcp_unified/profiles/resolution.py mcp_unified/profiles/__init__.py tldw_Server_API/app/core/MCP_unified/tests/test_profile_policy_decisions.py tldw_Server_API/app/core/MCP_unified/tests/test_profile_structured_resolution.py`
- [x] `source ../../.venv/bin/activate && python -m bandit -r mcp_unified/profiles/decisions.py mcp_unified/profiles/resolution.py mcp_unified/profiles/__init__.py -f json -o /tmp/bandit_mcp_policy_decision_core.json`
- [x] `git diff --check`

## Change Summary
Human-authored change summary required before merge per repository policy.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a package-owned MCP policy decision core (deny/ask/allow) with redacted explanations and optional decision metadata on effective policy. Introduces action-aware path-scope enforcement and safe filesystem tools (`fs.read`, `fs.patch`, `fs.write`) with read receipts and preimage checks; presets now prefer these; closes TASK-2308.

- New Features
  - Decision API in `mcp_unified.profiles.decisions`: compile/evaluate/explain/merge decisions with matched-rule metadata; requires granted capabilities; skips legacy bash rules; hardens command-rule compilation (precompiled/ordered argv) and isolates tool-rule compilation.
  - Effective policy can carry a `decision`. `mcp_unified.interfaces.policy.evaluate_tool_call` accepts `path_scope_candidates`. New `mcp_unified.interfaces.path_scope` defines `PathScopeCandidate` and normalizers; protocol normalizes module-derived candidates.
  - Path enforcer evaluates action-aware `path_grants` (read/edit/write) with legacy allowlist fallback, dedupes multi-root path/action candidates, and enforces strict empty `path_grants` handling.
  - Filesystem: `fs.read` (SHA-256 and short-lived read receipts), `fs.patch` (in-memory unified-diff parser/apply with conflict detection), `fs.write` (create/replace with preimage checks). Added `BaseModule.extract_path_scope_candidates`; presets prefer safe tools; user guide updated. Tests cover decision logic, path-scope enforcement, diff parser, filesystem tools, and protocol wiring.

- Migration
  - Prefer `fs.read`, `fs.patch`, and `fs.write`; legacy `fs.read_text`/`fs.write_text` remain.
  - No behavior change to runtime allow/deny; `decision` is additive metadata.
  - For file-touching tools, set `metadata.path_scope_action` and implement `extract_path_scope_candidates` in modules.

<sup>Written for commit 2efd97b4f30934dfc0b880e1406d1ef82fb358b6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2300?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

