### PR TITLE
Add MCP effective permission preview

### DIFF
--- a/backlog/tasks/task-2298 - Add-MCP-effective-permission-preview-surface.md
+++ b/backlog/tasks/task-2298 - Add-MCP-effective-permission-preview-surface.md
@@ -44,7 +44,7 @@ Implemented the MCP Hub effective permission preview surface for path-scoped too
 ## Definition of Done
 <!-- DOD:BEGIN -->
 - [x] #1 Acceptance criteria completed
-- [x] #2 Tests or verification recorded: `python -m pytest tldw_Server_API/tests/MCP_unified/test_mcp_hub_path_enforcement_service.py tldw_Server_API/tests/MCP_unified/test_mcp_hub_policy_api.py` -> 57 passed
+- [x] #2 Tests or verification recorded: `python -m pytest tldw_Server_API/tests/MCP_unified/test_mcp_hub_path_enforcement_service.py tldw_Server_API/tests/MCP_unified/test_mcp_hub_policy_api.py` -> 59 passed
 - [x] #3 Documentation updated when relevant: schema and route tests cover this API-surface slice
 - [x] #4 Bandit run for touched code: `python -m bandit -r <touched production files> -f json -o /tmp/bandit_mcp_effective_permission_preview.json` -> 0 findings
 - [x] #5 Final summary added

--- a/backlog/tasks/task-2298 - Add-MCP-effective-permission-preview-surface.md
+++ b/backlog/tasks/task-2298 - Add-MCP-effective-permission-preview-surface.md
@@ -44,7 +44,7 @@ Implemented the MCP Hub effective permission preview surface for path-scoped too
 ## Definition of Done
 <!-- DOD:BEGIN -->
 - [x] #1 Acceptance criteria completed
-- [x] #2 Tests or verification recorded: `python -m pytest tldw_Server_API/tests/MCP_unified/test_mcp_hub_path_enforcement_service.py tldw_Server_API/tests/MCP_unified/test_mcp_hub_policy_api.py` -> 59 passed
+- [x] #2 Tests or verification recorded: `python -m pytest tldw_Server_API/tests/MCP_unified/test_mcp_hub_path_enforcement_service.py tldw_Server_API/tests/MCP_unified/test_mcp_hub_policy_api.py` -> 60 passed
 - [x] #3 Documentation updated when relevant: schema and route tests cover this API-surface slice
 - [x] #4 Bandit run for touched code: `python -m bandit -r <touched production files> -f json -o /tmp/bandit_mcp_effective_permission_preview.json` -> 0 findings
 - [x] #5 Final summary added

--- a/backlog/tasks/task-2298 - Add-MCP-effective-permission-preview-surface.md
+++ b/backlog/tasks/task-2298 - Add-MCP-effective-permission-preview-surface.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-2298
 title: Add MCP effective permission preview surface
-status: To Do
+status: Done
 labels:
 - mcp
 - policy
@@ -20,26 +20,33 @@ Add an admin/API/CLI surface that explains effective path permissions for a prof
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
+- [x] Resolve the caller's effective MCP Hub policy for persona/group/org/team/workspace context.
+- [x] Reuse the existing `McpHubPathEnforcementService` path-decision contract.
+- [x] Return redacted preview fields for tool, action, workspace-relative path, outcome, reason, selected assignment/profile, grant source/outcome/effect, path-scope mode, workspace id, allowlist prefixes, and path decisions.
+- [x] Avoid exposing absolute filesystem paths or file contents in the preview response.
+- [x] Cover service-level redaction and API route wiring with regression tests.
 <!-- AC:END -->
 
 ## Implementation Notes
 
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Added `EffectivePermissionPreviewRequest` / `EffectivePermissionPreviewResponse`, `POST /mcp/hub/effective-permission-preview`, and `McpHubPathEnforcementService.preview_effective_path_permission()`.
 
+The preview wrapper normalizes workspace-relative paths, invokes the existing enforcer using a synthetic path-boundable filesystem tool definition, and emits only redacted workspace-relative decision metadata. Standalone gateway CLI/admin simulation remains a separate follow-up under `TASK-2303`.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-
+Implemented the MCP Hub effective permission preview surface for path-scoped tool calls. The endpoint resolves the authenticated user's effective policy context, delegates path/action/path evaluation to the existing path enforcer, and returns a redacted operator/debug payload for policy troubleshooting.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded: `python -m pytest tldw_Server_API/tests/MCP_unified/test_mcp_hub_path_enforcement_service.py tldw_Server_API/tests/MCP_unified/test_mcp_hub_policy_api.py` -> 55 passed
+- [x] #3 Documentation updated when relevant: schema and route tests cover this API-surface slice
+- [x] #4 Bandit run for touched code: `python -m bandit -r <touched production files> -f json -o /tmp/bandit_mcp_effective_permission_preview.json` -> 0 findings
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented: standalone gateway CLI/admin simulation remains covered by `TASK-2303`
 <!-- DOD:END -->

--- a/backlog/tasks/task-2298 - Add-MCP-effective-permission-preview-surface.md
+++ b/backlog/tasks/task-2298 - Add-MCP-effective-permission-preview-surface.md
@@ -30,7 +30,7 @@ Add an admin/API/CLI surface that explains effective path permissions for a prof
 ## Implementation Notes
 
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
-Added `EffectivePermissionPreviewRequest` / `EffectivePermissionPreviewResponse`, `POST /mcp/hub/effective-permission-preview`, and `McpHubPathEnforcementService.preview_effective_path_permission()`.
+Added `EffectivePermissionPreviewRequest` / `EffectivePermissionPreviewResponse`, `POST /api/v1/mcp/hub/effective-permission-preview`, and `McpHubPathEnforcementService.preview_effective_path_permission()`.
 
 The preview wrapper normalizes workspace-relative paths, invokes the existing enforcer using a synthetic path-boundable filesystem tool definition, and emits only redacted workspace-relative decision metadata. Standalone gateway CLI/admin simulation remains a separate follow-up under `TASK-2303`.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
@@ -44,7 +44,7 @@ Implemented the MCP Hub effective permission preview surface for path-scoped too
 ## Definition of Done
 <!-- DOD:BEGIN -->
 - [x] #1 Acceptance criteria completed
-- [x] #2 Tests or verification recorded: `python -m pytest tldw_Server_API/tests/MCP_unified/test_mcp_hub_path_enforcement_service.py tldw_Server_API/tests/MCP_unified/test_mcp_hub_policy_api.py` -> 55 passed
+- [x] #2 Tests or verification recorded: `python -m pytest tldw_Server_API/tests/MCP_unified/test_mcp_hub_path_enforcement_service.py tldw_Server_API/tests/MCP_unified/test_mcp_hub_policy_api.py` -> 57 passed
 - [x] #3 Documentation updated when relevant: schema and route tests cover this API-surface slice
 - [x] #4 Bandit run for touched code: `python -m bandit -r <touched production files> -f json -o /tmp/bandit_mcp_effective_permission_preview.json` -> 0 findings
 - [x] #5 Final summary added

--- a/tldw_Server_API/app/api/v1/endpoints/mcp_hub_management.py
+++ b/tldw_Server_API/app/api/v1/endpoints/mcp_hub_management.py
@@ -5,6 +5,7 @@ from copy import deepcopy
 import json
 import re
 from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
 from typing import Any, Callable
 
 from fastapi import APIRouter, Body, Depends, HTTPException, Query, Request
@@ -27,8 +28,10 @@ from tldw_Server_API.app.api.v1.schemas.mcp_hub_schemas import (
     CapabilityAdapterMappingResponse,
     CapabilityAdapterMappingUpdateRequest,
     CredentialBindingResponse,
-    EffectivePolicyResponse,
     EffectiveExternalAccessResponse,
+    EffectivePermissionPreviewRequest,
+    EffectivePermissionPreviewResponse,
+    EffectivePolicyResponse,
     ExternalSecretSetRequest,
     ExternalSecretSetResponse,
     ExternalServerDiscoveryRefreshRequest,
@@ -120,6 +123,10 @@ from tldw_Server_API.app.services.mcp_hub_governance_pack_distribution_service i
 )
 from tldw_Server_API.app.services.mcp_credential_broker_service import (
     McpCredentialBrokerService,
+)
+from tldw_Server_API.app.services.mcp_hub_path_enforcement_service import (
+    McpHubPathEnforcementService,
+    get_mcp_hub_path_enforcement_service,
 )
 from tldw_Server_API.app.services.mcp_hub_policy_resolver import McpHubPolicyResolver, get_mcp_hub_policy_resolver
 from tldw_Server_API.app.services.mcp_hub_service import (
@@ -215,6 +222,11 @@ async def get_mcp_hub_capability_adapter_service() -> McpHubCapabilityAdapterSer
 async def get_mcp_hub_policy_resolver_dep() -> McpHubPolicyResolver:
     """Resolve MCP Hub policy resolver for effective policy previews."""
     return await get_mcp_hub_policy_resolver()
+
+
+async def get_mcp_hub_path_enforcement_service_dep() -> McpHubPathEnforcementService:
+    """Resolve MCP Hub path enforcement service for effective permission previews."""
+    return await get_mcp_hub_path_enforcement_service()
 
 
 async def get_mcp_hub_tool_registry_dep() -> McpHubToolRegistryService:
@@ -3455,6 +3467,44 @@ async def get_effective_policy(
         user_id=principal.user_id,
         metadata=metadata,
     )
+
+
+@router.post("/effective-permission-preview", response_model=EffectivePermissionPreviewResponse)
+async def preview_effective_permission(
+    payload: EffectivePermissionPreviewRequest,
+    principal: AuthPrincipal = Depends(get_auth_principal),
+    resolver: McpHubPolicyResolver = Depends(get_mcp_hub_policy_resolver_dep),
+    path_enforcer: McpHubPathEnforcementService = Depends(get_mcp_hub_path_enforcement_service_dep),
+) -> EffectivePermissionPreviewResponse:
+    """Explain the effective path permission for a candidate tool call without exposing absolute paths."""
+    if principal.user_id is None:
+        raise HTTPException(status_code=403, detail="Authenticated user required")
+
+    metadata: dict[str, Any] = {"mcp_policy_context_enabled": True}
+    for key in ("persona_id", "group_id", "workspace_id", "cwd"):
+        value = getattr(payload, key)
+        if value:
+            metadata[key] = value
+    if payload.org_id is not None:
+        metadata["org_id"] = payload.org_id
+    if payload.team_id is not None:
+        metadata["team_id"] = payload.team_id
+
+    effective_policy = await resolver.resolve_for_context(
+        user_id=principal.user_id,
+        metadata=metadata,
+    )
+    preview = await path_enforcer.preview_effective_path_permission(
+        effective_policy=effective_policy,
+        context=SimpleNamespace(
+            user_id=principal.user_id,
+            metadata=metadata,
+        ),
+        tool_name=payload.tool_name,
+        action=payload.action,
+        path=payload.path,
+    )
+    return EffectivePermissionPreviewResponse.model_validate(preview)
 
 
 @router.get("/acp-profiles", response_model=list[ACPProfileResponse])

--- a/tldw_Server_API/app/api/v1/schemas/mcp_hub_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/mcp_hub_schemas.py
@@ -535,6 +535,8 @@ class EffectivePolicyResponse(BaseModel):
 
 
 class EffectivePermissionPreviewRequest(BaseModel):
+    """Request a redacted effective permission preview for a path-scoped MCP tool call."""
+
     model_config = ConfigDict(extra="forbid")
 
     tool_name: str = Field(..., min_length=1, max_length=255)
@@ -549,6 +551,8 @@ class EffectivePermissionPreviewRequest(BaseModel):
 
 
 class EffectivePermissionPreviewResponse(BaseModel):
+    """Redacted explanation of the effective path policy decision for an MCP tool call."""
+
     tool_name: str
     requested_action: PathPermissionAction
     requested_path: str

--- a/tldw_Server_API/app/api/v1/schemas/mcp_hub_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/mcp_hub_schemas.py
@@ -32,6 +32,8 @@ ToolRiskClass = Literal["low", "medium", "high", "unclassified"]
 ToolMetadataSource = Literal["explicit", "heuristic", "fallback"]
 PathScopeMode = Literal["none", "workspace_root", "cwd_descendants"]
 PathScopeEnforcement = Literal["approval_required_when_unenforceable"]
+PathPermissionAction = Literal["read", "edit", "write"]
+PathPermissionOutcome = Literal["allow", "ask", "deny"]
 WorkspaceSourceMode = Literal["inline", "named"]
 WorkspaceTrustSource = Literal["user_local", "shared_registry"]
 ExternalAuthTemplateTargetType = Literal["header", "env"]
@@ -530,6 +532,41 @@ class EffectivePolicyResponse(BaseModel):
     selected_assignment_workspace_ids: list[str] = Field(default_factory=list)
     sources: list[EffectivePolicySourceResponse] = Field(default_factory=list)
     provenance: list[EffectivePolicyProvenanceResponse] = Field(default_factory=list)
+
+
+class EffectivePermissionPreviewRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    tool_name: str = Field(..., min_length=1, max_length=255)
+    action: PathPermissionAction
+    path: str = Field(..., min_length=1, max_length=1024)
+    persona_id: str | None = Field(default=None, max_length=200)
+    group_id: str | None = Field(default=None, max_length=200)
+    org_id: int | None = None
+    team_id: int | None = None
+    workspace_id: str | None = Field(default=None, max_length=255)
+    cwd: str | None = Field(default=None, max_length=1024)
+
+
+class EffectivePermissionPreviewResponse(BaseModel):
+    tool_name: str
+    requested_action: PathPermissionAction
+    requested_path: str
+    normalized_path: str | None = None
+    outcome: PathPermissionOutcome
+    within_scope: bool
+    reason_code: str | None = None
+    selected_assignment_id: int | None = None
+    profile_id: int | None = None
+    grant_source: str | None = None
+    grant_outcome: str | None = None
+    matched_grant_prefix: str | None = None
+    matched_grant_effect: str | None = None
+    path_scope_mode: PathScopeMode | None = None
+    workspace_id: str | None = None
+    path_allowlist_prefixes: list[str] = Field(default_factory=list)
+    path_decisions: list[dict[str, Any]] = Field(default_factory=list)
+    redacted: bool = True
 
 
 class ToolRegistryEntryResponse(BaseModel):

--- a/tldw_Server_API/app/services/mcp_hub_path_enforcement_service.py
+++ b/tldw_Server_API/app/services/mcp_hub_path_enforcement_service.py
@@ -136,6 +136,8 @@ def _normalize_allowlist_prefix(raw_value: Any) -> str | None:
 
 
 def _normalize_workspace_relative_path(raw_value: Any) -> tuple[str | None, str | None]:
+    """Normalize a user-supplied path and reject values outside workspace-relative form."""
+
     value = str(raw_value or "").strip().replace("\\", "/")
     while value.startswith("./"):
         value = value[2:]
@@ -267,6 +269,8 @@ def _path_scope_action(metadata: dict[str, Any]) -> str:
 
 
 def _selected_profile_id(effective_policy: dict[str, Any] | None) -> int | None:
+    """Return the profile id for the explicitly selected policy assignment when present."""
+
     policy = dict(effective_policy or {})
     selected_assignment_id = policy.get("selected_assignment_id")
     if selected_assignment_id in (None, ""):
@@ -288,6 +292,8 @@ def _selected_profile_id(effective_policy: dict[str, Any] | None) -> int | None:
 
 
 def _preview_outcome(enforcement_result: dict[str, Any]) -> str:
+    """Map the path-enforcement result shape into the preview allow/ask/deny outcome."""
+
     if not bool(enforcement_result.get("enabled")):
         return "allow"
     if bool(enforcement_result.get("within_scope", True)):
@@ -298,6 +304,8 @@ def _preview_outcome(enforcement_result: dict[str, Any]) -> str:
 
 
 def _safe_path_decisions(enforcement_result: dict[str, Any]) -> list[dict[str, Any]]:
+    """Extract serializable path-decision dictionaries from direct or nested result payloads."""
+
     raw_decisions = enforcement_result.get("path_decisions")
     if not isinstance(raw_decisions, list):
         scope_payload = enforcement_result.get("scope_payload")

--- a/tldw_Server_API/app/services/mcp_hub_path_enforcement_service.py
+++ b/tldw_Server_API/app/services/mcp_hub_path_enforcement_service.py
@@ -21,7 +21,7 @@ _PATH_GRANT_EFFECTS = frozenset({"allow", "deny"})
 _SUPPORTED_PATH_ARGUMENT_HINTS = frozenset(
     {"path", "file_path", "target_path", "cwd", "paths", "file_paths", "files[].path"}
 )
-_WINDOWS_ABSOLUTE_PATH_RE = re.compile(r"^[A-Za-z]:[\\/]")
+_WINDOWS_ABSOLUTE_PATH_RE = re.compile(r"^[A-Za-z]:")
 _PREVIEW_TOOL_METADATA = {
     "uses_filesystem": True,
     "path_boundable": True,

--- a/tldw_Server_API/app/services/mcp_hub_path_enforcement_service.py
+++ b/tldw_Server_API/app/services/mcp_hub_path_enforcement_service.py
@@ -269,27 +269,22 @@ def _path_scope_action(metadata: dict[str, Any]) -> str:
 def _selected_profile_id(effective_policy: dict[str, Any] | None) -> int | None:
     policy = dict(effective_policy or {})
     selected_assignment_id = policy.get("selected_assignment_id")
+    if selected_assignment_id in (None, ""):
+        return None
     sources = policy.get("sources")
     if not isinstance(sources, list):
         return None
-    valid_sources = [dict(source) for source in sources if isinstance(source, Mapping)]
-    selected_source: dict[str, Any] | None = None
-    if selected_assignment_id not in (None, ""):
-        for source in valid_sources:
-            if source.get("assignment_id") == selected_assignment_id:
-                selected_source = source
-                break
-    elif len(valid_sources) == 1:
-        selected_source = valid_sources[0]
-    if selected_source is None and len(valid_sources) == 1:
-        selected_source = valid_sources[0]
-    if selected_source is None:
-        return None
-    try:
-        profile_id = selected_source.get("profile_id")
-        return int(profile_id) if profile_id not in (None, "") else None
-    except (TypeError, ValueError):
-        return None
+    for source in sources:
+        if not isinstance(source, Mapping):
+            continue
+        if source.get("assignment_id") != selected_assignment_id:
+            continue
+        try:
+            profile_id = source.get("profile_id")
+            return int(profile_id) if profile_id not in (None, "") else None
+        except (TypeError, ValueError):
+            return None
+    return None
 
 
 def _preview_outcome(enforcement_result: dict[str, Any]) -> str:

--- a/tldw_Server_API/app/services/mcp_hub_path_enforcement_service.py
+++ b/tldw_Server_API/app/services/mcp_hub_path_enforcement_service.py
@@ -272,14 +272,17 @@ def _selected_profile_id(effective_policy: dict[str, Any] | None) -> int | None:
     sources = policy.get("sources")
     if not isinstance(sources, list):
         return None
+    valid_sources = [dict(source) for source in sources if isinstance(source, Mapping)]
     selected_source: dict[str, Any] | None = None
-    for source in sources:
-        if not isinstance(source, Mapping):
-            continue
-        if selected_assignment_id not in (None, "") and source.get("assignment_id") == selected_assignment_id:
-            selected_source = dict(source)
-            break
-        selected_source = dict(source)
+    if selected_assignment_id not in (None, ""):
+        for source in valid_sources:
+            if source.get("assignment_id") == selected_assignment_id:
+                selected_source = source
+                break
+    elif len(valid_sources) == 1:
+        selected_source = valid_sources[0]
+    if selected_source is None and len(valid_sources) == 1:
+        selected_source = valid_sources[0]
     if selected_source is None:
         return None
     try:
@@ -382,10 +385,11 @@ class McpHubPathEnforcementService:
 
         requested_action = str(action or "").strip().lower()
         normalized_path, path_error = _normalize_workspace_relative_path(path)
+        safe_requested_path = normalized_path if normalized_path is not None else "<redacted>"
         base_payload: dict[str, Any] = {
             "tool_name": str(tool_name or "").strip(),
             "requested_action": requested_action,
-            "requested_path": str(path or "").strip(),
+            "requested_path": safe_requested_path,
             "normalized_path": normalized_path,
             "selected_assignment_id": (effective_policy or {}).get("selected_assignment_id"),
             "profile_id": _selected_profile_id(effective_policy),

--- a/tldw_Server_API/app/services/mcp_hub_path_enforcement_service.py
+++ b/tldw_Server_API/app/services/mcp_hub_path_enforcement_service.py
@@ -22,6 +22,11 @@ _SUPPORTED_PATH_ARGUMENT_HINTS = frozenset(
     {"path", "file_path", "target_path", "cwd", "paths", "file_paths", "files[].path"}
 )
 _WINDOWS_ABSOLUTE_PATH_RE = re.compile(r"^[A-Za-z]:[\\/]")
+_PREVIEW_TOOL_METADATA = {
+    "uses_filesystem": True,
+    "path_boundable": True,
+    "path_argument_hints": ["path"],
+}
 
 
 def _as_bool(value: Any) -> bool | None:
@@ -128,6 +133,29 @@ def _normalize_allowlist_prefix(raw_value: Any) -> str | None:
     if not parts:
         return None
     return "/".join(parts)
+
+
+def _normalize_workspace_relative_path(raw_value: Any) -> tuple[str | None, str | None]:
+    value = str(raw_value or "").strip().replace("\\", "/")
+    while value.startswith("./"):
+        value = value[2:]
+    value = re.sub(r"/+", "/", value)
+    if not value:
+        return None, "path_required"
+    if value.startswith("/") or _WINDOWS_ABSOLUTE_PATH_RE.match(value):
+        return None, "path_must_be_workspace_relative"
+
+    parts: list[str] = []
+    for part in value.split("/"):
+        cleaned = str(part or "").strip()
+        if not cleaned or cleaned == ".":
+            continue
+        if cleaned == "..":
+            return None, "path_traversal_not_allowed"
+        parts.append(cleaned)
+    if not parts:
+        return ".", None
+    return "/".join(parts), None
 
 
 def _policy_allowlist_prefixes(effective_policy: dict[str, Any] | None) -> list[str]:
@@ -238,6 +266,47 @@ def _path_scope_action(metadata: dict[str, Any]) -> str:
     return "read"
 
 
+def _selected_profile_id(effective_policy: dict[str, Any] | None) -> int | None:
+    policy = dict(effective_policy or {})
+    selected_assignment_id = policy.get("selected_assignment_id")
+    sources = policy.get("sources")
+    if not isinstance(sources, list):
+        return None
+    selected_source: dict[str, Any] | None = None
+    for source in sources:
+        if not isinstance(source, Mapping):
+            continue
+        if selected_assignment_id not in (None, "") and source.get("assignment_id") == selected_assignment_id:
+            selected_source = dict(source)
+            break
+        selected_source = dict(source)
+    if selected_source is None:
+        return None
+    try:
+        profile_id = selected_source.get("profile_id")
+        return int(profile_id) if profile_id not in (None, "") else None
+    except (TypeError, ValueError):
+        return None
+
+
+def _preview_outcome(enforcement_result: dict[str, Any]) -> str:
+    if not bool(enforcement_result.get("enabled")):
+        return "allow"
+    if bool(enforcement_result.get("within_scope", True)):
+        return "allow"
+    if bool(enforcement_result.get("force_approval", False)):
+        return "ask"
+    return "deny"
+
+
+def _safe_path_decisions(enforcement_result: dict[str, Any]) -> list[dict[str, Any]]:
+    raw_decisions = enforcement_result.get("path_decisions")
+    if not isinstance(raw_decisions, list):
+        scope_payload = enforcement_result.get("scope_payload")
+        raw_decisions = scope_payload.get("path_decisions") if isinstance(scope_payload, dict) else []
+    return [dict(decision) for decision in raw_decisions if isinstance(decision, Mapping)]
+
+
 def _relative_path_for_decision(root: Path, candidate: Path) -> str | None:
     try:
         relative = candidate.relative_to(root)
@@ -299,6 +368,88 @@ class McpHubPathEnforcementService:
     ) -> None:
         self._path_scope_service = path_scope_service
         self._multi_root_path_service = multi_root_path_service
+
+    async def preview_effective_path_permission(
+        self,
+        *,
+        effective_policy: dict[str, Any] | None,
+        context: Any | None,
+        tool_name: str,
+        action: str,
+        path: str,
+    ) -> dict[str, Any]:
+        """Return a redacted effective path-permission explanation for operators."""
+
+        requested_action = str(action or "").strip().lower()
+        normalized_path, path_error = _normalize_workspace_relative_path(path)
+        base_payload: dict[str, Any] = {
+            "tool_name": str(tool_name or "").strip(),
+            "requested_action": requested_action,
+            "requested_path": str(path or "").strip(),
+            "normalized_path": normalized_path,
+            "selected_assignment_id": (effective_policy or {}).get("selected_assignment_id"),
+            "profile_id": _selected_profile_id(effective_policy),
+            "redacted": True,
+        }
+        if requested_action not in _PATH_GRANT_ACTIONS:
+            return {
+                **base_payload,
+                "outcome": "deny",
+                "within_scope": False,
+                "reason_code": "invalid_path_action",
+                "path_decisions": [],
+            }
+        if path_error or normalized_path is None:
+            return {
+                **base_payload,
+                "outcome": "deny",
+                "within_scope": False,
+                "reason_code": path_error,
+                "path_decisions": [],
+            }
+
+        tool_def = {
+            "name": base_payload["tool_name"],
+            "metadata": {
+                **_PREVIEW_TOOL_METADATA,
+                "path_scope_action": requested_action,
+            },
+        }
+        enforcement_result = await self.evaluate_tool_call(
+            effective_policy=effective_policy,
+            context=context,
+            tool_name=base_payload["tool_name"],
+            tool_args={"path": normalized_path},
+            tool_def=tool_def,
+            path_scope_candidates=[
+                PathScopeCandidate(
+                    path=normalized_path,
+                    action=requested_action,  # type: ignore[arg-type]
+                    source="effective_permission_preview",
+                    display_path=normalized_path,
+                )
+            ],
+        )
+
+        path_decisions = _safe_path_decisions(enforcement_result)
+        selected_decision = path_decisions[0] if path_decisions else {}
+        scope_payload = enforcement_result.get("scope_payload")
+        scope_payload = dict(scope_payload) if isinstance(scope_payload, Mapping) else {}
+        preview = {
+            **base_payload,
+            "outcome": _preview_outcome(enforcement_result),
+            "within_scope": bool(enforcement_result.get("within_scope", True)),
+            "reason_code": str(enforcement_result.get("reason") or "").strip() or None,
+            "grant_source": selected_decision.get("grant_source"),
+            "grant_outcome": selected_decision.get("grant_outcome"),
+            "matched_grant_prefix": selected_decision.get("matched_grant_prefix"),
+            "matched_grant_effect": selected_decision.get("matched_grant_effect"),
+            "path_scope_mode": scope_payload.get("path_scope_mode"),
+            "workspace_id": scope_payload.get("workspace_id"),
+            "path_allowlist_prefixes": list(scope_payload.get("path_allowlist_prefixes") or []),
+            "path_decisions": path_decisions,
+        }
+        return {key: value for key, value in preview.items() if value not in ("", [])}
 
     async def evaluate_tool_call(
         self,

--- a/tldw_Server_API/tests/MCP_unified/test_mcp_hub_path_enforcement_service.py
+++ b/tldw_Server_API/tests/MCP_unified/test_mcp_hub_path_enforcement_service.py
@@ -4,7 +4,6 @@ from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
-
 from mcp_unified.interfaces.path_scope import PathScopeCandidate
 
 
@@ -374,6 +373,57 @@ async def test_path_grants_allow_candidate_action_and_report_safe_decision() -> 
         }
     ]
     assert "/tmp/mcp-hub-path-enforcer" not in repr(result["path_decisions"])
+
+
+@pytest.mark.asyncio
+async def test_effective_permission_preview_returns_redacted_path_grant_decision() -> None:
+    from tldw_Server_API.app.services.mcp_hub_path_enforcement_service import (
+        McpHubPathEnforcementService,
+    )
+
+    svc = McpHubPathEnforcementService(path_scope_service=_FakePathScopeService(_workspace_scope()))
+
+    result = await svc.preview_effective_path_permission(
+        effective_policy={
+            "enabled": True,
+            "selected_assignment_id": 11,
+            "policy_document": {
+                "path_scope_mode": "workspace_root",
+                "path_grants": [
+                    {"prefix": "documents", "actions": ["read", "edit", "write"]},
+                ],
+            },
+            "sources": [
+                {
+                    "assignment_id": 11,
+                    "target_type": "persona",
+                    "target_id": "researcher",
+                    "owner_scope_type": "user",
+                    "owner_scope_id": 7,
+                    "profile_id": 5,
+                }
+            ],
+        },
+        context=SimpleNamespace(metadata={}),
+        tool_name="fs.write",
+        action="write",
+        path="documents/story.md",
+    )
+
+    assert result["tool_name"] == "fs.write"
+    assert result["requested_action"] == "write"
+    assert result["normalized_path"] == "documents/story.md"
+    assert result["outcome"] == "allow"
+    assert result["within_scope"] is True
+    assert result["reason_code"] is None
+    assert result["selected_assignment_id"] == 11
+    assert result["profile_id"] == 5
+    assert result["grant_source"] == "path_grants"
+    assert result["grant_outcome"] == "allowed"
+    assert result["matched_grant_prefix"] == "documents"
+    assert result["matched_grant_effect"] == "allow"
+    assert result["redacted"] is True
+    assert "/tmp/mcp-hub-path-enforcer" not in repr(result)
 
 
 @pytest.mark.asyncio

--- a/tldw_Server_API/tests/MCP_unified/test_mcp_hub_path_enforcement_service.py
+++ b/tldw_Server_API/tests/MCP_unified/test_mcp_hub_path_enforcement_service.py
@@ -459,6 +459,36 @@ async def test_effective_permission_preview_does_not_guess_profile_for_ambiguous
 
 
 @pytest.mark.asyncio
+async def test_effective_permission_preview_does_not_guess_profile_without_selected_assignment() -> None:
+    from tldw_Server_API.app.services.mcp_hub_path_enforcement_service import (
+        McpHubPathEnforcementService,
+    )
+
+    svc = McpHubPathEnforcementService(path_scope_service=_FakePathScopeService(_workspace_scope()))
+
+    result = await svc.preview_effective_path_permission(
+        effective_policy={
+            "enabled": True,
+            "policy_document": {
+                "path_scope_mode": "workspace_root",
+                "path_grants": [
+                    {"prefix": "documents", "actions": ["read"]},
+                ],
+            },
+            "sources": [
+                {"assignment_id": 11, "profile_id": 5},
+            ],
+        },
+        context=SimpleNamespace(metadata={}),
+        tool_name="fs.read",
+        action="read",
+        path="documents/story.md",
+    )
+
+    assert result["profile_id"] is None
+
+
+@pytest.mark.asyncio
 async def test_path_grants_deny_overrides_broader_allow_grant() -> None:
     from tldw_Server_API.app.services.mcp_hub_path_enforcement_service import (
         McpHubPathEnforcementService,

--- a/tldw_Server_API/tests/MCP_unified/test_mcp_hub_path_enforcement_service.py
+++ b/tldw_Server_API/tests/MCP_unified/test_mcp_hub_path_enforcement_service.py
@@ -427,6 +427,38 @@ async def test_effective_permission_preview_returns_redacted_path_grant_decision
 
 
 @pytest.mark.asyncio
+async def test_effective_permission_preview_does_not_guess_profile_for_ambiguous_sources() -> None:
+    from tldw_Server_API.app.services.mcp_hub_path_enforcement_service import (
+        McpHubPathEnforcementService,
+    )
+
+    svc = McpHubPathEnforcementService(path_scope_service=_FakePathScopeService(_workspace_scope()))
+
+    result = await svc.preview_effective_path_permission(
+        effective_policy={
+            "enabled": True,
+            "selected_assignment_id": 99,
+            "policy_document": {
+                "path_scope_mode": "workspace_root",
+                "path_grants": [
+                    {"prefix": "documents", "actions": ["read"]},
+                ],
+            },
+            "sources": [
+                {"assignment_id": 11, "profile_id": 5},
+                {"assignment_id": 12, "profile_id": 6},
+            ],
+        },
+        context=SimpleNamespace(metadata={}),
+        tool_name="fs.read",
+        action="read",
+        path="documents/story.md",
+    )
+
+    assert result["profile_id"] is None
+
+
+@pytest.mark.asyncio
 async def test_path_grants_deny_overrides_broader_allow_grant() -> None:
     from tldw_Server_API.app.services.mcp_hub_path_enforcement_service import (
         McpHubPathEnforcementService,

--- a/tldw_Server_API/tests/MCP_unified/test_mcp_hub_policy_api.py
+++ b/tldw_Server_API/tests/MCP_unified/test_mcp_hub_policy_api.py
@@ -1551,6 +1551,40 @@ def test_preview_effective_permission_returns_redacted_path_decision() -> None:
     assert preview_service.calls[0]["context"].metadata["workspace_id"] == "workspace-alpha"
 
 
+def test_preview_effective_permission_redacts_rejected_absolute_path() -> None:
+    from tldw_Server_API.app.services.mcp_hub_path_enforcement_service import (
+        McpHubPathEnforcementService,
+    )
+
+    app = _build_app(
+        _make_principal(
+            roles=[],
+            permissions=[],
+        ),
+        path_permission_preview=McpHubPathEnforcementService(path_scope_service=object()),
+    )
+
+    with TestClient(app) as client:
+        resp = client.post(
+            "/api/v1/mcp/hub/effective-permission-preview",
+            json={
+                "persona_id": "researcher",
+                "group_id": "team-red",
+                "workspace_id": "workspace-alpha",
+                "tool_name": "fs.read",
+                "action": "read",
+                "path": "/tmp/secrets.txt",
+            },
+        )
+
+    assert resp.status_code == 200
+    payload = resp.json()
+    assert payload["outcome"] == "deny"
+    assert payload["reason_code"] == "path_must_be_workspace_relative"
+    assert payload["requested_path"] == "<redacted>"
+    assert "/tmp/secrets.txt" not in repr(payload)
+
+
 def test_list_policy_assignments_includes_override_summary_fields() -> None:
     app = _build_app(
         _make_principal(

--- a/tldw_Server_API/tests/MCP_unified/test_mcp_hub_policy_api.py
+++ b/tldw_Server_API/tests/MCP_unified/test_mcp_hub_policy_api.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from datetime import datetime, timezone
+from typing import Any
 
 from fastapi import FastAPI, HTTPException
 from fastapi.testclient import TestClient
@@ -729,9 +730,9 @@ class _FakePolicyResolver:
 
 class _FakePathPermissionPreviewService:
     def __init__(self) -> None:
-        self.calls: list[dict] = []
+        self.calls: list[dict[str, Any]] = []
 
-    async def preview_effective_path_permission(self, **kwargs):
+    async def preview_effective_path_permission(self, **kwargs: Any) -> dict[str, Any]:
         self.calls.append(dict(kwargs))
         return {
             "tool_name": kwargs["tool_name"],
@@ -1551,7 +1552,8 @@ def test_preview_effective_permission_returns_redacted_path_decision() -> None:
     assert preview_service.calls[0]["context"].metadata["workspace_id"] == "workspace-alpha"
 
 
-def test_preview_effective_permission_redacts_rejected_absolute_path() -> None:
+@pytest.mark.parametrize("raw_path", ["/tmp/secrets.txt", "C:secrets.txt", "C:/secrets.txt"])
+def test_preview_effective_permission_redacts_rejected_non_workspace_path(raw_path: str) -> None:
     from tldw_Server_API.app.services.mcp_hub_path_enforcement_service import (
         McpHubPathEnforcementService,
     )
@@ -1573,7 +1575,7 @@ def test_preview_effective_permission_redacts_rejected_absolute_path() -> None:
                 "workspace_id": "workspace-alpha",
                 "tool_name": "fs.read",
                 "action": "read",
-                "path": "/tmp/secrets.txt",
+                "path": raw_path,
             },
         )
 
@@ -1582,7 +1584,7 @@ def test_preview_effective_permission_redacts_rejected_absolute_path() -> None:
     assert payload["outcome"] == "deny"
     assert payload["reason_code"] == "path_must_be_workspace_relative"
     assert payload["requested_path"] == "<redacted>"
-    assert "/tmp/secrets.txt" not in repr(payload)
+    assert raw_path not in repr(payload)
 
 
 def test_list_policy_assignments_includes_override_summary_fields() -> None:

--- a/tldw_Server_API/tests/MCP_unified/test_mcp_hub_policy_api.py
+++ b/tldw_Server_API/tests/MCP_unified/test_mcp_hub_policy_api.py
@@ -727,6 +727,44 @@ class _FakePolicyResolver:
         }
 
 
+class _FakePathPermissionPreviewService:
+    def __init__(self) -> None:
+        self.calls: list[dict] = []
+
+    async def preview_effective_path_permission(self, **kwargs):
+        self.calls.append(dict(kwargs))
+        return {
+            "tool_name": kwargs["tool_name"],
+            "requested_action": kwargs["action"],
+            "requested_path": kwargs["path"],
+            "normalized_path": kwargs["path"],
+            "outcome": "allow",
+            "within_scope": True,
+            "reason_code": None,
+            "selected_assignment_id": 11,
+            "profile_id": 5,
+            "grant_source": "path_grants",
+            "grant_outcome": "allowed",
+            "matched_grant_prefix": "documents",
+            "matched_grant_effect": "allow",
+            "path_scope_mode": "workspace_root",
+            "workspace_id": "workspace-alpha",
+            "redacted": True,
+            "path_decisions": [
+                {
+                    "requested_action": kwargs["action"],
+                    "normalized_path": kwargs["path"],
+                    "grant_outcome": "allowed",
+                    "grant_source": "path_grants",
+                    "matched_grant_prefix": "documents",
+                    "matched_grant_effect": "allow",
+                    "reason_code": None,
+                    "redacted": True,
+                }
+            ],
+        }
+
+
 class _StructuredBadRequestError(BadRequestError):
     def __init__(self, detail: dict[str, object]) -> None:
         super().__init__(str(detail.get("message") or detail.get("code") or "invalid request"))
@@ -811,6 +849,7 @@ def _build_app(
     resolver: _FakePolicyResolver | None = None,
     *,
     tool_registry: _FakeToolRegistryService | None = None,
+    path_permission_preview: _FakePathPermissionPreviewService | None = None,
     rate_limit_calls: list[str] | None = None,
 ) -> FastAPI:
     app = FastAPI()
@@ -827,6 +866,13 @@ def _build_app(
     if hasattr(mcp_hub_management, "get_mcp_hub_tool_registry_dep"):
         app.dependency_overrides[mcp_hub_management.get_mcp_hub_tool_registry_dep] = (
             lambda: tool_registry or _FakeToolRegistryService()
+        )
+    if path_permission_preview is not None and hasattr(
+        mcp_hub_management,
+        "get_mcp_hub_path_enforcement_service_dep",
+    ):
+        app.dependency_overrides[mcp_hub_management.get_mcp_hub_path_enforcement_service_dep] = (
+            lambda: path_permission_preview
         )
     if rate_limit_calls is not None:
         async def _fake_check_rate_limit(_request: Request) -> None:
@@ -1466,6 +1512,43 @@ def test_get_effective_policy_returns_resolved_payload() -> None:
     assert payload["policy_document"]["path_scope_enforcement"] == "approval_required_when_unenforceable"
     assert payload["sources"][0]["target_id"] == "researcher"
     assert payload["provenance"][1]["source_kind"] == "assignment_override"
+
+
+def test_preview_effective_permission_returns_redacted_path_decision() -> None:
+    preview_service = _FakePathPermissionPreviewService()
+    app = _build_app(
+        _make_principal(
+            roles=[],
+            permissions=[],
+        ),
+        path_permission_preview=preview_service,
+    )
+
+    with TestClient(app) as client:
+        resp = client.post(
+            "/api/v1/mcp/hub/effective-permission-preview",
+            json={
+                "persona_id": "researcher",
+                "group_id": "team-red",
+                "workspace_id": "workspace-alpha",
+                "tool_name": "fs.write",
+                "action": "write",
+                "path": "documents/story.md",
+            },
+        )
+
+    assert resp.status_code == 200
+    payload = resp.json()
+    assert payload["tool_name"] == "fs.write"
+    assert payload["requested_action"] == "write"
+    assert payload["normalized_path"] == "documents/story.md"
+    assert payload["outcome"] == "allow"
+    assert payload["grant_source"] == "path_grants"
+    assert payload["matched_grant_prefix"] == "documents"
+    assert payload["redacted"] is True
+    assert "/tmp/" not in repr(payload)
+    assert preview_service.calls[0]["effective_policy"]["policy_document"]["path_scope_mode"] == "workspace_root"
+    assert preview_service.calls[0]["context"].metadata["workspace_id"] == "workspace-alpha"
 
 
 def test_list_policy_assignments_includes_override_summary_fields() -> None:


### PR DESCRIPTION
## Summary
- Add `POST /api/v1/mcp/hub/effective-permission-preview` for redacted path permission previews.
- Add a `McpHubPathEnforcementService.preview_effective_path_permission()` wrapper that reuses existing path grant evaluation and avoids returning absolute paths or file content.
- Add regression coverage for source selection, rejected absolute paths, and Windows drive-prefixed paths.
- Complete `TASK-2298`.

## Why
Operators need a safe way to debug why a profile/tool/path combination is allowed, denied, or requires approval without exposing absolute filesystem paths or raw file content. This endpoint gives admin surfaces a redacted effective-permission explanation while keeping enforcement behavior tied to the existing path-enforcer contract.

## Validation Checklist
- [x] Focused tests: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/MCP_unified/test_mcp_hub_path_enforcement_service.py tldw_Server_API/tests/MCP_unified/test_mcp_hub_policy_api.py` -> 60 passed.
- [x] Security scan: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/api/v1/endpoints/mcp_hub_management.py tldw_Server_API/app/api/v1/schemas/mcp_hub_schemas.py tldw_Server_API/app/services/mcp_hub_path_enforcement_service.py -f json -o /tmp/bandit_mcp_effective_permission_preview.json` -> 0 findings.
- [x] Whitespace check: `git diff --check`.
- [x] Qodo review: latest comment reports 0 bugs, 0 rule violations, 0 requirement gaps, and 0 UX issues.
- [ ] GitHub Actions: fresh runs for commit `769a243058e37f8b53e08d5f4d71728fb72701fc` need CI completion; earlier runs were cancelled before steps/logs were produced.
- [ ] Human requester must provide the required human-written Change summary before merge.

## Docs Update Status
- Backlog task `TASK-2298` documents the implemented endpoint, service wrapper, verification, and deferred standalone gateway simulation follow-up.
- No separate user-guide update was added for this narrow admin/debug API slice; route and schema coverage are captured in tests.

## Risk & Rollback
- Risk level: low. The change adds a new admin/debug preview endpoint and helper path; it does not alter enforcement behavior for actual tool calls.
- Primary risk: preview output could misattribute a selected profile or expose unsafe path text. Regression tests cover selected-assignment matching, ambiguous/missing selection, rejected absolute paths, and drive-prefixed paths.
- Rollback plan: revert the PR commits to remove the route, schemas, service preview helper, and tests. Existing MCP Hub enforcement remains intact because the preview wraps the current enforcer instead of replacing it.

## UX, Scale, And Security Notes
- UX impact is limited to admin/API consumers inspecting policy decisions; no frontend UI is included in this slice.
- Scale impact is bounded to one effective-policy resolution plus one synthetic path-enforcement evaluation per preview request.
- Security posture: rejected non-workspace paths are redacted, absolute paths/file contents are not returned, and Bandit found zero issues in the touched production files.

## Merge Gate
Human requester still needs to provide the required Change summary before merge. This PR body documents the implementation and verification, but it is not a substitute for the human-owned merge-gate summary required by project policy.
