### PR TITLE
Add MCP permission-change governance hooks

### DIFF
--- a/Docs/superpowers/plans/2026-06-08-mcp-permission-change-governance-hooks-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-06-08-mcp-permission-change-governance-hooks-implementation-plan.md
@@ -1,0 +1,183 @@
+# MCP Permission Change Governance Hooks Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [x]`) syntax for tracking.
+
+**Goal:** Add a minimal governance seam for MCP profile permission mutations so profile and path-grant changes can be allowed, denied, or routed to future approval before persistence.
+
+**Architecture:** Keep the executable profile store unchanged and add a small gateway-level governance contract used by `GatewayProfileManager` before permission-changing mutations. The default governor allows existing behavior; injected governors can return `deny` or `ask`, which blocks the mutation and emits redacted audit metadata.
+
+**Tech Stack:** Python, Pydantic profile models, async gateway manager methods, pytest.
+
+---
+
+### Task 1: Governance Contract And Manager Injection
+
+**Files:**
+- Create: `mcp_unified/gateway/profile_governance.py`
+- Modify: `mcp_unified/gateway/profiles.py`
+- Modify: `mcp_unified/gateway/__init__.py`
+- Test: `tldw_Server_API/app/core/MCP_unified/tests/test_gateway_profile_management.py`
+
+- [x] **Step 1: Write the failing contract/injection tests**
+
+Add test doubles in `test_gateway_profile_management.py`:
+
+```python
+class RecordingPermissionGovernor:
+    def __init__(self, outcome: str = "allow") -> None:
+        self.outcome = outcome
+        self.requests = []
+
+    async def evaluate_permission_change(self, request):
+        self.requests.append(request)
+        return PermissionChangeDecision(outcome=self.outcome, reason_code=f"{self.outcome}_for_test")
+```
+
+Add tests that instantiate `_manager(..., permission_governor=governor)` and verify `create_profile()` calls the governor with action `profile.create`, profile id, changed fields, and redacted risk metadata.
+
+- [x] **Step 2: Run the focused test to verify it fails**
+
+Run: `source .venv/bin/activate && python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_gateway_profile_management.py::test_create_profile_calls_permission_governor_with_redacted_summary -q`
+
+Expected: FAIL because `permission_governor` and governance models do not exist yet.
+
+- [x] **Step 3: Add minimal governance models**
+
+Create `profile_governance.py` with:
+
+```python
+PermissionChangeOutcome = Literal["deny", "ask", "allow"]
+
+@dataclass(frozen=True, slots=True)
+class PermissionChangeRequest:
+    action: str
+    profile_id: str | None
+    target_type: str
+    target_id: str
+    changed_fields: tuple[str, ...] = ()
+    policy_fields: tuple[str, ...] = ()
+    risk_flags: tuple[str, ...] = ()
+
+@dataclass(frozen=True, slots=True)
+class PermissionChangeDecision:
+    outcome: PermissionChangeOutcome
+    reason_code: str = "allowed"
+    message: str | None = None
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+```
+
+Add `AllowPermissionChangeGovernor` and `PermissionChangeGovernor` protocol with async `evaluate_permission_change()`.
+
+- [x] **Step 4: Inject the default governor**
+
+Add `permission_governor` to `GatewayProfileManager.__init__`, defaulting to `AllowPermissionChangeGovernor()`, and export the new types from `mcp_unified/gateway/__init__.py`.
+
+- [x] **Step 5: Run the focused test to verify it passes**
+
+Run: `source .venv/bin/activate && python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_gateway_profile_management.py::test_create_profile_calls_permission_governor_with_redacted_summary -q`
+
+Expected: PASS.
+
+### Task 2: Enforcement, Audit Metadata, And Path-Grant Patch Support
+
+**Files:**
+- Modify: `mcp_unified/gateway/profiles.py`
+- Test: `tldw_Server_API/app/core/MCP_unified/tests/test_gateway_profile_management.py`
+
+- [x] **Step 1: Write failing enforcement tests**
+
+Add tests for:
+- `deny` decision blocks `patch_profile()` before persistence with reason `permission_change_denied`.
+- `ask` decision blocks with reason `permission_change_requires_approval`.
+- Denial audit payloads include action, profile id, changed fields, policy fields, risk flags, and decision reason, but not raw `policy_document`, path prefixes, or tool patterns.
+- `policy_document.path_grants` is accepted by semantic patch validation and included in governance `policy_fields`.
+
+- [x] **Step 2: Run the new focused tests to verify they fail**
+
+Run: `source .venv/bin/activate && python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_gateway_profile_management.py -k "permission_governor or path_grants" -q`
+
+Expected: FAIL because enforcement and `path_grants` patch support are missing.
+
+- [x] **Step 3: Add permission-change request summarization**
+
+In `GatewayProfileManager`, add helpers that produce redacted request summaries:
+- `profile.create`
+- `profile.duplicate_from_preset`
+- `profile.patch`
+- `profile.delete`
+- `profile.default_change`
+
+Risk flags should be conservative and content-free, for example:
+- `profile_enabled`
+- `default_profile_change`
+- `policy_allowed_tools_changed`
+- `policy_tool_patterns_changed`
+- `path_grants_changed`
+- `path_grants_write_or_edit`
+- `wildcard_tool_policy`
+
+- [x] **Step 4: Enforce governance decisions before persistence**
+
+Before mutating stores, call the governor. If the outcome is:
+- `allow`: proceed and add redacted governance metadata to success audit payloads.
+- `ask`: audit a blocked permission change and raise `GatewayProfileManagementError(reason_code="permission_change_requires_approval")`.
+- `deny`: audit a blocked permission change and raise `GatewayProfileManagementError(reason_code="permission_change_denied")`.
+
+- [x] **Step 5: Allow path-grant policy patch fields**
+
+Extend `_POLICY_PATCH_FIELDS` to include `path_grants` plus authored path-grant keys already recognized by `mcp_unified.profiles.path_grants`.
+
+- [x] **Step 6: Run focused tests**
+
+Run: `source .venv/bin/activate && python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_gateway_profile_management.py -k "permission_governor or path_grants" -q`
+
+Expected: PASS.
+
+### Task 3: HTTP Mapping, Backlog Notes, And Verification
+
+**Files:**
+- Modify: `mcp_unified/gateway/fastapi.py`
+- Modify: `backlog/tasks/task-2304 - Add-MCP-permission-change-governance-hooks.md`
+- Test: `tldw_Server_API/app/core/MCP_unified/tests/test_gateway_profile_management.py`
+- Test: `tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py` if status mapping coverage already exists nearby.
+
+- [x] **Step 1: Add failing HTTP status expectations if feasible**
+
+If existing FastAPI route tests have a compact profile-management error mapping fixture, add coverage that `permission_change_denied` maps to 403 and `permission_change_requires_approval` maps to 409.
+
+- [x] **Step 2: Add status-code mapping**
+
+In `mcp_unified/gateway/fastapi.py`, add:
+- `permission_change_denied: 403`
+- `permission_change_requires_approval: 409`
+
+- [x] **Step 3: Update Backlog task**
+
+Record acceptance criteria, plan path, touched files, and verification commands in `TASK-2304`.
+
+- [x] **Step 4: Run focused verification**
+
+Run: `source .venv/bin/activate && python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_gateway_profile_management.py -q`
+
+Expected: PASS.
+
+- [x] **Step 5: Run security verification on touched Python scope**
+
+Run: `source .venv/bin/activate && python -m bandit -r mcp_unified/gateway/profiles.py mcp_unified/gateway/profile_governance.py mcp_unified/gateway/fastapi.py -f json -o /tmp/bandit_mcp_permission_governance.json`
+
+Expected: exit 0 or only pre-existing/non-touched findings documented.
+
+- [x] **Step 6: Commit**
+
+Run:
+
+```bash
+git add Docs/superpowers/plans/2026-06-08-mcp-permission-change-governance-hooks-implementation-plan.md \
+  "backlog/tasks/task-2304 - Add-MCP-permission-change-governance-hooks.md" \
+  mcp_unified/gateway/profile_governance.py \
+  mcp_unified/gateway/profiles.py \
+  mcp_unified/gateway/__init__.py \
+  mcp_unified/gateway/fastapi.py \
+  tldw_Server_API/app/core/MCP_unified/tests/test_gateway_profile_management.py
+git commit -m "feat: add MCP permission governance hooks"
+```

--- a/backlog/tasks/task-2304 - Add-MCP-permission-change-governance-hooks.md
+++ b/backlog/tasks/task-2304 - Add-MCP-permission-change-governance-hooks.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-2304
 title: Add MCP permission-change governance hooks
-status: To Do
+status: In Progress
 labels:
 - mcp
 - policy
@@ -21,26 +21,48 @@ Add hooks and audit records for MCP profile/path-grant changes. Permission chang
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
+- [x] Add an injectable MCP profile permission-change governor with deny/ask/allow outcomes and an allow-by-default implementation.
+- [x] Gate profile create, duplicate-from-preset, patch, delete, and default-profile change mutations before persistence.
+- [x] Block denied permission changes with `permission_change_denied` and approval-required changes with `permission_change_requires_approval`.
+- [x] Emit redacted audit metadata for allowed and blocked permission changes without raw policy documents, path prefixes, or secret-like payloads.
+- [x] Allow profile semantic patches for flat/authored path-grant policy fields so path-grant changes can be governed.
+- [x] Map new profile-management reason codes to stable HTTP statuses.
+- [x] Add focused regression tests and run touched-scope security verification.
 <!-- AC:END -->
 
 ## Implementation Notes
 
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Plan: `Docs/superpowers/plans/2026-06-08-mcp-permission-change-governance-hooks-implementation-plan.md`
 
+Touched files:
+- `mcp_unified/gateway/profile_governance.py`
+- `mcp_unified/gateway/profiles.py`
+- `mcp_unified/gateway/fastapi.py`
+- `mcp_unified/gateway/__init__.py`
+- `tldw_Server_API/app/core/MCP_unified/tests/test_gateway_profile_management.py`
+- `tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py`
+
+Verification:
+- Red check: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_gateway_profile_management.py::test_create_profile_calls_permission_governor_with_redacted_summary -q` failed before implementation with missing `mcp_unified.gateway.profile_governance`.
+- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_gateway_profile_management.py tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py::test_gateway_profile_management_error_status_mapping -q` passed.
+- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m ruff check mcp_unified/gateway/profile_governance.py mcp_unified/gateway/profiles.py mcp_unified/gateway/fastapi.py tldw_Server_API/app/core/MCP_unified/tests/test_gateway_profile_management.py tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py` passed.
+- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m py_compile mcp_unified/gateway/profile_governance.py mcp_unified/gateway/profiles.py mcp_unified/gateway/fastapi.py tldw_Server_API/app/core/MCP_unified/tests/test_gateway_profile_management.py tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py` passed.
+- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r mcp_unified/gateway/profile_governance.py mcp_unified/gateway/profiles.py mcp_unified/gateway/fastapi.py -f json -o /tmp/bandit_mcp_permission_governance.json` passed with 0 findings.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-
+Implemented an allow-by-default MCP profile permission-change governance seam. Profile create, duplicate, patch, delete, and default assignment changes now call the injected governor before persistence; deny and ask decisions block mutations with stable reason codes and redacted audit events. Path-grant policy patch fields are accepted and validated for governance, and FastAPI maps the new reason codes to 403/409.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->

--- a/backlog/tasks/task-2304 - Add-MCP-permission-change-governance-hooks.md
+++ b/backlog/tasks/task-2304 - Add-MCP-permission-change-governance-hooks.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-2304
 title: Add MCP permission-change governance hooks
-status: In Progress
+status: Done
 labels:
 - mcp
 - policy
@@ -44,11 +44,19 @@ Touched files:
 - `tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py`
 
 Verification:
-- Red check: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_gateway_profile_management.py::test_create_profile_calls_permission_governor_with_redacted_summary -q` failed before implementation with missing `mcp_unified.gateway.profile_governance`.
-- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_gateway_profile_management.py tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py::test_gateway_profile_management_error_status_mapping -q` passed.
-- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m ruff check mcp_unified/gateway/profile_governance.py mcp_unified/gateway/profiles.py mcp_unified/gateway/fastapi.py tldw_Server_API/app/core/MCP_unified/tests/test_gateway_profile_management.py tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py` passed.
-- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m py_compile mcp_unified/gateway/profile_governance.py mcp_unified/gateway/profiles.py mcp_unified/gateway/fastapi.py tldw_Server_API/app/core/MCP_unified/tests/test_gateway_profile_management.py tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py` passed.
-- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r mcp_unified/gateway/profile_governance.py mcp_unified/gateway/profiles.py mcp_unified/gateway/fastapi.py -f json -o /tmp/bandit_mcp_permission_governance.json` passed with 0 findings.
+- Red check: `python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_gateway_profile_management.py::test_create_profile_calls_permission_governor_with_redacted_summary -q` failed before implementation with missing `mcp_unified.gateway.profile_governance`.
+- `python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_gateway_profile_management.py tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py::test_gateway_profile_management_error_status_mapping -q` passed.
+- `python -m ruff check mcp_unified/gateway/profile_governance.py mcp_unified/gateway/profiles.py mcp_unified/gateway/fastapi.py tldw_Server_API/app/core/MCP_unified/tests/test_gateway_profile_management.py tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py` passed.
+- `python -m py_compile mcp_unified/gateway/profile_governance.py mcp_unified/gateway/profiles.py mcp_unified/gateway/fastapi.py tldw_Server_API/app/core/MCP_unified/tests/test_gateway_profile_management.py tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py` passed.
+- `python -m bandit -r mcp_unified/gateway/profile_governance.py mcp_unified/gateway/profiles.py mcp_unified/gateway/fastapi.py -f json -o /tmp/bandit_mcp_permission_governance.json` passed with 0 findings.
+
+Review follow-up:
+- Rebasing on `origin/dev` reported the branch was already up to date.
+- Added create-time and patch-time path-grant validation regressions for malformed `path_grants`.
+- Normalized default `PermissionChangeDecision.reason_code` values so blocked outcomes cannot emit `allowed`.
+- Hardened policy summary helpers for Pydantic v1-style `.dict()` payloads, empty collections, and tuple/set wildcard policy values.
+- Re-ran `python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_gateway_profile_management.py tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py::test_gateway_profile_management_error_status_mapping -q`; 78 passed.
+- Re-ran the ruff, py_compile, and Bandit commands above; all passed and Bandit reported 0 findings.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary

--- a/mcp_unified/gateway/__init__.py
+++ b/mcp_unified/gateway/__init__.py
@@ -29,6 +29,12 @@ from .credential_grants import (
 )
 from .lifecycle import GatewayExternalRuntimeLifecycleConfig
 from .profile_runtime import ProfileAwareGatewayRuntime
+from .profile_governance import (
+    AllowPermissionChangeGovernor,
+    PermissionChangeDecision,
+    PermissionChangeGovernor,
+    PermissionChangeRequest,
+)
 from .profiles import (
     GatewayProfileManagementError,
     GatewayProfileManager,
@@ -60,6 +66,7 @@ __all__ = [
     "GatewayExternalRuntimeError",
     "GatewayExternalRuntimeManager",
     "ExternalRuntimeGatewayRuntime",
+    "AllowPermissionChangeGovernor",
     "GatewayProfileBootstrap",
     "GatewayProfileBootstrapConfig",
     "GatewayProfileManagementError",
@@ -73,6 +80,9 @@ __all__ = [
     "GatewayToolUseReportingConfig",
     "GatewayToolUseReportingStoreConfig",
     "GatewayToolUseReportingStoreKind",
+    "PermissionChangeDecision",
+    "PermissionChangeGovernor",
+    "PermissionChangeRequest",
     "ToolUseReportingGatewayRuntime",
     "ProfileAwareGatewayRuntime",
     "bootstrap_profile_gateway",

--- a/mcp_unified/gateway/fastapi.py
+++ b/mcp_unified/gateway/fastapi.py
@@ -82,6 +82,8 @@ _PROFILE_MANAGEMENT_STATUS_CODES = {
     "profile_already_exists": 409,
     "invalid_profile_request": 422,
     "invalid_profile_patch": 422,
+    "permission_change_denied": 403,
+    "permission_change_requires_approval": 409,
     "profile_store_unavailable": 503,
     "assignment_store_unavailable": 503,
     "unexpected_delete_result": 500,
@@ -123,6 +125,8 @@ _CREDENTIAL_GRANT_STATUS_CODES = {
 }
 _EXTERNAL_SERVER_RESERVED_IDS = frozenset({"runtime", "refresh", "reconcile"})
 _PROFILE_MANAGEMENT_PUBLIC_ERRORS = {
+    "permission_change_denied": "Permission change denied",
+    "permission_change_requires_approval": "Permission change requires approval",
     "profile_store_unavailable": "Profile store unavailable",
     "assignment_store_unavailable": "Profile assignment store unavailable",
 }

--- a/mcp_unified/gateway/profile_governance.py
+++ b/mcp_unified/gateway/profile_governance.py
@@ -1,0 +1,63 @@
+"""Permission-change governance primitives for gateway profile mutations."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from typing import Any, Literal, Protocol
+
+PermissionChangeOutcome = Literal["deny", "ask", "allow"]
+_VALID_PERMISSION_CHANGE_OUTCOMES = frozenset({"deny", "ask", "allow"})
+
+
+@dataclass(frozen=True, slots=True)
+class PermissionChangeRequest:
+    """Redacted permission-change summary passed to governance hooks."""
+
+    action: str
+    profile_id: str | None
+    target_type: str
+    target_id: str
+    changed_fields: tuple[str, ...] = ()
+    policy_fields: tuple[str, ...] = ()
+    risk_flags: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True, slots=True)
+class PermissionChangeDecision:
+    """Governance result for one permission-changing profile mutation."""
+
+    outcome: PermissionChangeOutcome
+    reason_code: str = "allowed"
+    message: str | None = None
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        """Validate the decision shape at the trust boundary."""
+        if self.outcome not in _VALID_PERMISSION_CHANGE_OUTCOMES:
+            raise ValueError("permission change outcome must be deny, ask, or allow")
+        if not isinstance(self.reason_code, str) or not self.reason_code.strip():
+            object.__setattr__(self, "reason_code", self.outcome)
+        if not isinstance(self.metadata, Mapping):
+            object.__setattr__(self, "metadata", {})
+
+
+class PermissionChangeGovernor(Protocol):
+    """Async governance hook for profile permission-surface mutations."""
+
+    async def evaluate_permission_change(
+        self,
+        request: PermissionChangeRequest,
+    ) -> PermissionChangeDecision:
+        """Return the governance decision for a profile permission change."""
+
+
+class AllowPermissionChangeGovernor:
+    """Default governor that preserves existing profile-management behavior."""
+
+    async def evaluate_permission_change(
+        self,
+        request: PermissionChangeRequest,
+    ) -> PermissionChangeDecision:
+        """Allow the permission change without requiring approval."""
+        return PermissionChangeDecision(outcome="allow", reason_code="allowed")

--- a/mcp_unified/gateway/profile_governance.py
+++ b/mcp_unified/gateway/profile_governance.py
@@ -28,7 +28,7 @@ class PermissionChangeDecision:
     """Governance result for one permission-changing profile mutation."""
 
     outcome: PermissionChangeOutcome
-    reason_code: str = "allowed"
+    reason_code: str | None = None
     message: str | None = None
     metadata: Mapping[str, Any] = field(default_factory=dict)
 
@@ -36,8 +36,23 @@ class PermissionChangeDecision:
         """Validate the decision shape at the trust boundary."""
         if self.outcome not in _VALID_PERMISSION_CHANGE_OUTCOMES:
             raise ValueError("permission change outcome must be deny, ask, or allow")
-        if not isinstance(self.reason_code, str) or not self.reason_code.strip():
+        normalized_reason_code = (
+            self.reason_code.strip() if isinstance(self.reason_code, str) else ""
+        )
+        if (
+            not normalized_reason_code
+            or (
+                normalized_reason_code == "allowed"
+                and self.outcome != "allow"
+            )
+            or (
+                normalized_reason_code in _VALID_PERMISSION_CHANGE_OUTCOMES
+                and normalized_reason_code != self.outcome
+            )
+        ):
             object.__setattr__(self, "reason_code", self.outcome)
+        elif normalized_reason_code != self.reason_code:
+            object.__setattr__(self, "reason_code", normalized_reason_code)
         if not isinstance(self.metadata, Mapping):
             object.__setattr__(self, "metadata", {})
 

--- a/mcp_unified/gateway/profiles.py
+++ b/mcp_unified/gateway/profiles.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Mapping
+from collections.abc import Collection, Mapping
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from typing import Any, Literal
@@ -55,6 +55,7 @@ _POLICY_PATCH_FIELDS = frozenset(
         *PATH_GRANT_AUTHORING_KEYS,
     }
 )
+_PATH_GRANT_POLICY_FIELDS = frozenset({"path_grants", *PATH_GRANT_AUTHORING_KEYS})
 
 
 @dataclass(frozen=True, slots=True)
@@ -285,6 +286,10 @@ class GatewayProfileManager:
 
         now = datetime.now(timezone.utc)
         profile = profile.model_copy(update={"updated_at": now}, deep=True)
+        self._validate_path_grant_policy_payload(
+            self._policy_payload(profile.policy_document),
+            reason_code="invalid_profile_request",
+        )
         governance_request = self._permission_request_for_profile(
             "profile.create",
             profile,
@@ -1037,9 +1042,20 @@ class GatewayProfileManager:
             sorted(
                 str(key)
                 for key, value in policy_payload.items()
-                if value not in (None, [], {}, "")
+                if GatewayProfileManager._has_non_empty_policy_value(value)
             )
         )
+
+    @staticmethod
+    def _has_non_empty_policy_value(value: Any) -> bool:
+        if value is None or value == "":
+            return False
+        if isinstance(value, Collection) and not isinstance(
+            value,
+            (str, bytes, bytearray),
+        ):
+            return len(value) > 0
+        return True
 
     @staticmethod
     def _policy_payload(policy_document: object | None) -> dict[str, Any]:
@@ -1048,6 +1064,10 @@ class GatewayProfileManager:
         model_dump = getattr(policy_document, "model_dump", None)
         if callable(model_dump):
             payload = model_dump(mode="json")
+            return payload if isinstance(payload, dict) else {}
+        dict_method = getattr(policy_document, "dict", None)
+        if callable(dict_method):
+            payload = dict_method()
             return payload if isinstance(payload, dict) else {}
         if isinstance(policy_document, Mapping):
             return dict(policy_document)
@@ -1059,11 +1079,31 @@ class GatewayProfileManager:
             values = policy_payload.get(field)
             if isinstance(values, str):
                 values = [values]
-            if not isinstance(values, list):
+            if not isinstance(values, (list, tuple, set)):
                 continue
             if any(isinstance(value, str) and "*" in value for value in values):
                 return True
         return False
+
+    def _validate_path_grant_policy_payload(
+        self,
+        policy_payload: Mapping[str, Any],
+        *,
+        reason_code: str,
+    ) -> None:
+        if not any(field in policy_payload for field in _PATH_GRANT_POLICY_FIELDS):
+            return
+
+        raw_path_grants = policy_payload.get("path_grants")
+        if "path_grants" in policy_payload and (
+            not isinstance(raw_path_grants, list)
+            or any(not isinstance(item, Mapping) for item in raw_path_grants)
+        ):
+            raise self._error("Invalid profile request", reason_code=reason_code)
+
+        compiled_path_grants = compile_policy_path_grants(policy_payload)
+        if compiled_path_grants.has_errors:
+            raise self._error("Invalid profile request", reason_code=reason_code)
 
     async def _get_profile(self, profile_id: str) -> MCPProfile | None:
         try:
@@ -1159,13 +1199,10 @@ class GatewayProfileManager:
                     "Invalid profile patch",
                     reason_code="invalid_profile_patch",
                 )
-            if any(field in policy_patch for field in {"path_grants", *PATH_GRANT_AUTHORING_KEYS}):
-                compiled_path_grants = compile_policy_path_grants(policy_patch)
-                if compiled_path_grants.has_errors:
-                    raise self._error(
-                        "Invalid profile patch",
-                        reason_code="invalid_profile_patch",
-                    )
+            self._validate_path_grant_policy_payload(
+                policy_patch,
+                reason_code="invalid_profile_patch",
+            )
             if not policy_patch and set(normalized) == {"policy_document"}:
                 raise self._error(
                     "Invalid profile patch",

--- a/mcp_unified/gateway/profiles.py
+++ b/mcp_unified/gateway/profiles.py
@@ -10,6 +10,12 @@ from uuid import uuid4
 
 from loguru import logger
 
+from mcp_unified.gateway.profile_governance import (
+    AllowPermissionChangeGovernor,
+    PermissionChangeDecision,
+    PermissionChangeGovernor,
+    PermissionChangeRequest,
+)
 from mcp_unified.interfaces.storage import (
     AuditStore,
     ProfileAssignmentStore,
@@ -20,6 +26,10 @@ from mcp_unified.profiles.defaults import (
     load_gateway_default_assignment,
 )
 from mcp_unified.profiles.models import MCPProfile
+from mcp_unified.profiles.path_grants import (
+    PATH_GRANT_AUTHORING_KEYS,
+    compile_policy_path_grants,
+)
 from mcp_unified.profiles.presets import duplicate_builtin_preset, get_builtin_preset
 from mcp_unified.profiles.store import (
     ProfileAlreadyExistsError,
@@ -41,6 +51,8 @@ _POLICY_PATCH_FIELDS = frozenset(
         "module_patterns",
         "risk_classes",
         "resource_constraints",
+        "path_grants",
+        *PATH_GRANT_AUTHORING_KEYS,
     }
 )
 
@@ -98,12 +110,14 @@ class GatewayProfileManager:
         store_metadata: GatewayProfileStoreMetadata,
         audit_store: AuditStore | None = None,
         fallback_default_profile_id: str | None = None,
+        permission_governor: PermissionChangeGovernor | None = None,
     ) -> None:
         self.profile_store = profile_store
         self.assignment_store = assignment_store
         self.store_metadata = store_metadata
         self.audit_store = audit_store
         self.fallback_default_profile_id = fallback_default_profile_id
+        self.permission_governor = permission_governor or AllowPermissionChangeGovernor()
 
     async def list_profiles(self) -> dict[str, Any]:
         """List all profiles with store metadata."""
@@ -195,6 +209,12 @@ class GatewayProfileManager:
             profile_id=target_profile_id,
             name=normalized_name,
         )
+        governance_request = self._permission_request_for_profile(
+            "profile.duplicate_from_preset",
+            profile,
+            changed_fields=("policy_document", "profile"),
+        )
+        governance_decision = await self._enforce_permission_change(governance_request)
         try:
             stored = await self.profile_store.upsert_profile(profile)
         except ProfileStoreUnavailableError as exc:
@@ -212,6 +232,10 @@ class GatewayProfileManager:
                 "profile_id": stored.id,
                 "preset_id": stored.preset_id,
                 "preset_version": stored.preset_version,
+                "governance": self._governance_audit_payload(
+                    governance_request,
+                    governance_decision,
+                ),
             },
         )
         return {
@@ -261,6 +285,12 @@ class GatewayProfileManager:
 
         now = datetime.now(timezone.utc)
         profile = profile.model_copy(update={"updated_at": now}, deep=True)
+        governance_request = self._permission_request_for_profile(
+            "profile.create",
+            profile,
+            changed_fields=self._profile_create_fields(profile),
+        )
+        governance_decision = await self._enforce_permission_change(governance_request)
         try:
             stored = await self.profile_store.create_profile(profile)
         except ProfileAlreadyExistsError as exc:
@@ -288,7 +318,13 @@ class GatewayProfileManager:
             profile_id=stored.id,
             target_type="profile",
             target_id=stored.id,
-            payload={"profile_id": stored.id},
+            payload={
+                "profile_id": stored.id,
+                "governance": self._governance_audit_payload(
+                    governance_request,
+                    governance_decision,
+                ),
+            },
         )
         profile_payload = self._dump_profile(stored)
         profile_payload["created_at"] = stored.created_at.isoformat()
@@ -362,6 +398,13 @@ class GatewayProfileManager:
             )
             raise
 
+        governance_request = self._permission_request_for_profile(
+            "profile.patch",
+            updated,
+            changed_fields=changed_fields,
+            policy_fields=self._patch_policy_fields(patch),
+        )
+        governance_decision = await self._enforce_permission_change(governance_request)
         updated = updated.model_copy(
             update={"updated_at": datetime.now(timezone.utc)},
             deep=True,
@@ -380,7 +423,14 @@ class GatewayProfileManager:
             profile_id=stored.id,
             target_type="profile",
             target_id=stored.id,
-            payload={"profile_id": stored.id, "changed_fields": list(changed_fields)},
+            payload={
+                "profile_id": stored.id,
+                "changed_fields": list(changed_fields),
+                "governance": self._governance_audit_payload(
+                    governance_request,
+                    governance_decision,
+                ),
+            },
         )
         profile_payload = self._dump_profile(stored)
         profile_payload["created_at"] = stored.created_at.isoformat()
@@ -409,6 +459,50 @@ class GatewayProfileManager:
                 profile_id=normalized_profile_id,
             )
 
+        profile = await self._get_profile(normalized_profile_id)
+        if profile is None:
+            await self._audit_expected_failure(
+                "profile.delete_failed",
+                reason_code="profile_not_found",
+                profile_id=normalized_profile_id,
+                target_type="profile",
+                target_id=normalized_profile_id,
+            )
+            raise self._error(
+                f"Profile not found: {normalized_profile_id}",
+                reason_code="profile_not_found",
+                profile_id=normalized_profile_id,
+            )
+
+        try:
+            assignments = await self.assignment_store.list_assignments(
+                profile_id=normalized_profile_id,
+            )
+        except ProfileAssignmentStoreUnavailableError as exc:
+            raise self._error(
+                "Profile assignment store unavailable",
+                reason_code="assignment_store_unavailable",
+            ) from exc
+        if assignments:
+            await self._audit_expected_failure(
+                "profile.delete_failed",
+                reason_code="profile_has_assignments",
+                profile_id=normalized_profile_id,
+                target_type="profile",
+                target_id=normalized_profile_id,
+            )
+            raise self._error(
+                f"Profile has assignments: {normalized_profile_id}",
+                reason_code="profile_has_assignments",
+                profile_id=normalized_profile_id,
+            )
+
+        governance_request = self._permission_request_for_profile(
+            "profile.delete",
+            profile,
+            changed_fields=("profile",),
+        )
+        governance_decision = await self._enforce_permission_change(governance_request)
         guarded_delete = getattr(
             self.profile_store,
             "delete_profile_if_unassigned",
@@ -468,7 +562,13 @@ class GatewayProfileManager:
                 profile_id=normalized_profile_id,
                 target_type="profile",
                 target_id=normalized_profile_id,
-                payload={"profile_id": normalized_profile_id},
+                payload={
+                    "profile_id": normalized_profile_id,
+                    "governance": self._governance_audit_payload(
+                        governance_request,
+                        governance_decision,
+                    ),
+                },
             )
             return {
                 "ok": True,
@@ -625,6 +725,15 @@ class GatewayProfileManager:
         now = datetime.now(timezone.utc)
         if current_default is not None and current_default.updated_at >= now:
             now = current_default.updated_at + timedelta(microseconds=1)
+        governance_request = self._permission_request_for_profile(
+            "profile.default_change",
+            profile,
+            changed_fields=("default_profile",),
+            target_type="profile_assignment",
+            target_id=GATEWAY_DEFAULT_ASSIGNMENT_ID,
+            extra_risk_flags=("default_profile_change",),
+        )
+        governance_decision = await self._enforce_permission_change(governance_request)
         assignment = ProfileAssignment(
             id=GATEWAY_DEFAULT_ASSIGNMENT_ID,
             profile_id=normalized_profile_id,
@@ -654,6 +763,10 @@ class GatewayProfileManager:
                 "profile_id": normalized_profile_id,
                 "assignment_id": stored_assignment.id,
                 "previous_profile_id": existing.profile_id if existing is not None else None,
+                "governance": self._governance_audit_payload(
+                    governance_request,
+                    governance_decision,
+                ),
             },
         )
         return {
@@ -728,6 +841,229 @@ class GatewayProfileManager:
             target_id=target_id,
             payload=payload,
         )
+
+    async def _enforce_permission_change(
+        self,
+        request: PermissionChangeRequest,
+    ) -> PermissionChangeDecision:
+        """Evaluate and enforce a profile permission-change governance request."""
+        try:
+            decision = await self.permission_governor.evaluate_permission_change(request)
+            if not isinstance(decision, PermissionChangeDecision):
+                raise TypeError("permission governor returned an invalid decision")
+        except Exception as exc:  # noqa: BLE001
+            logger.opt(exception=True).warning(
+                "Gateway profile permission governor failed closed for {action}",
+                action=request.action,
+                target_type=request.target_type,
+                target_id=request.target_id,
+            )
+            decision = PermissionChangeDecision(
+                outcome="deny",
+                reason_code="permission_change_governor_error",
+            )
+            await self._audit_blocked_permission_change(
+                request,
+                decision,
+                reason_code="permission_change_denied",
+            )
+            raise self._error(
+                "Permission change denied",
+                reason_code="permission_change_denied",
+                profile_id=request.profile_id,
+            ) from exc
+
+        if decision.outcome == "allow":
+            return decision
+
+        reason_code = (
+            "permission_change_requires_approval"
+            if decision.outcome == "ask"
+            else "permission_change_denied"
+        )
+        await self._audit_blocked_permission_change(
+            request,
+            decision,
+            reason_code=reason_code,
+        )
+        message = (
+            "Permission change requires approval"
+            if decision.outcome == "ask"
+            else "Permission change denied"
+        )
+        raise self._error(
+            message,
+            reason_code=reason_code,
+            profile_id=request.profile_id,
+        )
+
+    async def _audit_blocked_permission_change(
+        self,
+        request: PermissionChangeRequest,
+        decision: PermissionChangeDecision,
+        *,
+        reason_code: str,
+    ) -> None:
+        payload = self._governance_audit_payload(request, decision)
+        payload["reason_code"] = reason_code
+        await self._append_audit_event(
+            "profile.permission_change_blocked",
+            profile_id=request.profile_id,
+            target_type=request.target_type,
+            target_id=request.target_id,
+            payload=payload,
+        )
+
+    def _permission_request_for_profile(
+        self,
+        action: str,
+        profile: MCPProfile,
+        *,
+        changed_fields: tuple[str, ...],
+        policy_fields: tuple[str, ...] | None = None,
+        target_type: str = "profile",
+        target_id: str | None = None,
+        extra_risk_flags: tuple[str, ...] = (),
+    ) -> PermissionChangeRequest:
+        policy_payload = self._policy_payload(profile.policy_document)
+        effective_policy_fields = (
+            tuple(sorted(policy_fields))
+            if policy_fields is not None
+            else self._non_empty_policy_fields(policy_payload)
+        )
+        risk_flags = self._permission_change_risk_flags(
+            action=action,
+            profile=profile,
+            policy_payload=policy_payload,
+            policy_fields=effective_policy_fields,
+            extra_risk_flags=extra_risk_flags,
+        )
+        return PermissionChangeRequest(
+            action=action,
+            profile_id=profile.id,
+            target_type=target_type,
+            target_id=target_id or profile.id,
+            changed_fields=tuple(sorted(set(changed_fields))),
+            policy_fields=effective_policy_fields,
+            risk_flags=risk_flags,
+        )
+
+    def _permission_change_risk_flags(
+        self,
+        *,
+        action: str,
+        profile: MCPProfile,
+        policy_payload: Mapping[str, Any],
+        policy_fields: tuple[str, ...],
+        extra_risk_flags: tuple[str, ...],
+    ) -> tuple[str, ...]:
+        flags = set(extra_risk_flags)
+        if profile.enabled and action in {
+            "profile.create",
+            "profile.duplicate_from_preset",
+        }:
+            flags.add("profile_enabled")
+        if policy_fields:
+            flags.add("policy_changed")
+        if any(field in policy_fields for field in {"allowed_tools", "tool_patterns", "module_patterns"}):
+            flags.add("tool_policy_changed")
+        if any(field in policy_fields for field in {"path_grants", *PATH_GRANT_AUTHORING_KEYS}):
+            flags.add("path_grants_changed")
+            compiled = compile_policy_path_grants(policy_payload)
+            if any(
+                grant.get("effect") == "allow"
+                and any(action in {"edit", "write"} for action in grant.get("actions", ()))
+                for grant in compiled.path_grants
+            ):
+                flags.add("path_grants_write_or_edit")
+        if self._has_wildcard_tool_policy(policy_payload):
+            flags.add("wildcard_tool_policy")
+        return tuple(sorted(flags))
+
+    def _governance_audit_payload(
+        self,
+        request: PermissionChangeRequest,
+        decision: PermissionChangeDecision,
+    ) -> dict[str, Any]:
+        decision_payload: dict[str, Any] = {
+            "outcome": decision.outcome,
+            "reason_code": decision.reason_code,
+        }
+        if decision.metadata:
+            decision_payload["metadata_keys"] = sorted(str(key) for key in decision.metadata)
+        payload: dict[str, Any] = {
+            "action": request.action,
+            "target_type": request.target_type,
+            "target_id": request.target_id,
+            "changed_fields": self._audit_changed_fields(request.changed_fields),
+            "policy_fields": list(request.policy_fields),
+            "risk_flags": list(request.risk_flags),
+            "decision": decision_payload,
+        }
+        if request.profile_id is not None:
+            payload["profile_id"] = request.profile_id
+        return payload
+
+    @staticmethod
+    def _audit_changed_fields(changed_fields: tuple[str, ...]) -> list[str]:
+        return [
+            "policy" if field == "policy_document" else field
+            for field in changed_fields
+        ]
+
+    @classmethod
+    def _profile_create_fields(cls, profile: MCPProfile) -> tuple[str, ...]:
+        fields = {"name"}
+        if profile.description:
+            fields.add("description")
+        if profile.enabled:
+            fields.add("enabled")
+        if profile.metadata:
+            fields.add("metadata")
+        if cls._non_empty_policy_fields(cls._policy_payload(profile.policy_document)):
+            fields.add("policy_document")
+        return tuple(sorted(fields))
+
+    @staticmethod
+    def _patch_policy_fields(patch: Mapping[str, Any]) -> tuple[str, ...]:
+        policy_patch = patch.get("policy_document")
+        if not isinstance(policy_patch, Mapping):
+            return ()
+        return tuple(sorted(str(key) for key in policy_patch))
+
+    @staticmethod
+    def _non_empty_policy_fields(policy_payload: Mapping[str, Any]) -> tuple[str, ...]:
+        return tuple(
+            sorted(
+                str(key)
+                for key, value in policy_payload.items()
+                if value not in (None, [], {}, "")
+            )
+        )
+
+    @staticmethod
+    def _policy_payload(policy_document: object | None) -> dict[str, Any]:
+        if policy_document is None:
+            return {}
+        model_dump = getattr(policy_document, "model_dump", None)
+        if callable(model_dump):
+            payload = model_dump(mode="json")
+            return payload if isinstance(payload, dict) else {}
+        if isinstance(policy_document, Mapping):
+            return dict(policy_document)
+        return {}
+
+    @staticmethod
+    def _has_wildcard_tool_policy(policy_payload: Mapping[str, Any]) -> bool:
+        for field in ("allowed_tools", "tool_patterns", "module_patterns"):
+            values = policy_payload.get(field)
+            if isinstance(values, str):
+                values = [values]
+            if not isinstance(values, list):
+                continue
+            if any(isinstance(value, str) and "*" in value for value in values):
+                return True
+        return False
 
     async def _get_profile(self, profile_id: str) -> MCPProfile | None:
         try:
@@ -823,6 +1159,13 @@ class GatewayProfileManager:
                     "Invalid profile patch",
                     reason_code="invalid_profile_patch",
                 )
+            if any(field in policy_patch for field in {"path_grants", *PATH_GRANT_AUTHORING_KEYS}):
+                compiled_path_grants = compile_policy_path_grants(policy_patch)
+                if compiled_path_grants.has_errors:
+                    raise self._error(
+                        "Invalid profile patch",
+                        reason_code="invalid_profile_patch",
+                    )
             if not policy_patch and set(normalized) == {"policy_document"}:
                 raise self._error(
                     "Invalid profile patch",

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py
@@ -1287,6 +1287,22 @@ def test_gateway_profile_management_routes_have_pydantic_response_models() -> No
             422,
         ),
         (
+            "PATCH",
+            "/mcp/profiles/reviewer",
+            {"name": "Reviewer"},
+            "patch_profile",
+            "permission_change_denied",
+            403,
+        ),
+        (
+            "PATCH",
+            "/mcp/profiles/reviewer",
+            {"name": "Reviewer"},
+            "patch_profile",
+            "permission_change_requires_approval",
+            409,
+        ),
+        (
             "DELETE",
             "/mcp/profiles/reviewer",
             None,
@@ -3620,7 +3636,6 @@ def test_gateway_config_bootstrap_custom_factory_ignores_config_process_policy(
         GatewayProfileStoreConfig,
         bootstrap_profile_gateway_from_config,
     )
-    from mcp_unified.storage.models import ExternalServerDefinition
 
     def factory(server: ExternalServerDefinition) -> Any:
         return server.id

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_profile_management.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_profile_management.py
@@ -92,6 +92,18 @@ class RecordingPermissionGovernor:
         )
 
 
+class LegacyPolicyModel:
+    """Small Pydantic-v1-like policy object for payload helper coverage."""
+
+    def dict(self) -> dict[str, object]:
+        """Return a mapping using the Pydantic v1 method name."""
+        return {
+            "allowed_tools": ("fs.*",),
+            "resource_constraints": (),
+            "tool_patterns": set(),
+        }
+
+
 class ConflictingCreateProfileStore(InMemoryProfileStore):
     """Profile store double that reports an atomic create conflict."""
 
@@ -348,6 +360,34 @@ async def test_create_profile_calls_permission_governor_with_redacted_summary() 
     assert "policy_document" not in serialized_payload
     assert "docs/private" not in serialized_payload
     assert "fs.write" not in serialized_payload
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "policy_document",
+    [
+        {"path_grants": {"prefix": "docs", "actions": ["read"]}},
+        {"path_grants": ["oops"]},
+        {"path_grants": [{"prefix": "/absolute", "actions": ["read"]}]},
+    ],
+)
+async def test_create_profile_rejects_invalid_path_grant_policy_without_persisting(
+    policy_document: dict[str, object],
+) -> None:
+    store = InMemoryProfileStore()
+    manager = _manager(store)
+
+    with pytest.raises(GatewayProfileManagementError) as exc_info:
+        await manager.create_profile(
+            {
+                "id": "bad-grants",
+                "name": "Bad Grants",
+                "policy_document": policy_document,
+            }
+        )
+
+    assert exc_info.value.reason_code == "invalid_profile_request"
+    assert await store.get_profile("bad-grants") is None
 
 
 @pytest.mark.asyncio
@@ -911,6 +951,46 @@ async def test_patch_profile_accepts_path_grants_and_reports_governance_risk() -
     assert request.changed_fields == ("policy_document",)
     assert request.policy_fields == ("path_grants",)
     assert "path_grants_write_or_edit" in request.risk_flags
+
+
+@pytest.mark.asyncio
+async def test_patch_profile_rejects_non_mapping_path_grant_entries() -> None:
+    store = InMemoryProfileStore([MCPProfile(id="writer", name="Writer")])
+    manager = _manager(store)
+
+    with pytest.raises(GatewayProfileManagementError) as exc_info:
+        await manager.patch_profile(
+            "writer",
+            {"policy_document": {"path_grants": ["oops"]}},
+        )
+
+    assert exc_info.value.reason_code == "invalid_profile_patch"
+    stored = await store.get_profile("writer")
+    assert stored is not None
+    assert "path_grants" not in stored.policy_document.model_dump(mode="json")
+
+
+def test_permission_change_decision_defaults_reason_code_to_outcome() -> None:
+    denied = PermissionChangeDecision(outcome="deny")
+    contradictory = PermissionChangeDecision(outcome="ask", reason_code="allowed")
+
+    assert denied.reason_code == "deny"
+    assert contradictory.reason_code == "ask"
+
+
+def test_permission_summary_helpers_handle_legacy_policy_and_empty_collections() -> None:
+    payload = GatewayProfileManager._policy_payload(LegacyPolicyModel())
+
+    assert payload["allowed_tools"] == ("fs.*",)
+    assert GatewayProfileManager._non_empty_policy_fields(
+        {
+            "empty_tuple": (),
+            "empty_set": set(),
+            "empty_list": [],
+            "filled_tuple": ("x",),
+        }
+    ) == ("filled_tuple",)
+    assert GatewayProfileManager._has_wildcard_tool_policy(payload) is True
 
 
 @pytest.mark.asyncio

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_profile_management.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_profile_management.py
@@ -7,12 +7,17 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 import pytest
+from mcp_unified.gateway.profile_governance import (
+    PermissionChangeDecision,
+    PermissionChangeRequest,
+)
 from mcp_unified.gateway.profiles import (
     GatewayProfileManagementError,
     GatewayProfileManager,
     GatewayProfileStoreMetadata,
 )
 from mcp_unified.profiles.models import MCPProfile
+from mcp_unified.profiles.presets import PRESET_VERSION
 from mcp_unified.profiles.store import (
     InMemoryProfileAssignmentStore,
     InMemoryProfileStore,
@@ -63,6 +68,30 @@ class FailingAuditStore(InMemoryAuditStore):
         raise RuntimeError(f"audit unavailable for {event.event_type}")
 
 
+class RecordingPermissionGovernor:
+    """Permission-change governor double that records redacted requests."""
+
+    def __init__(
+        self,
+        *,
+        outcome: str = "allow",
+        reason_code: str | None = None,
+    ) -> None:
+        self.outcome = outcome
+        self.reason_code = reason_code or f"{outcome}_for_test"
+        self.requests: list[PermissionChangeRequest] = []
+
+    async def evaluate_permission_change(
+        self,
+        request: PermissionChangeRequest,
+    ) -> PermissionChangeDecision:
+        self.requests.append(request)
+        return PermissionChangeDecision(
+            outcome=self.outcome,
+            reason_code=self.reason_code,
+        )
+
+
 class ConflictingCreateProfileStore(InMemoryProfileStore):
     """Profile store double that reports an atomic create conflict."""
 
@@ -100,6 +129,7 @@ def _manager(
     *,
     audit_store: InMemoryAuditStore | None = None,
     fallback_default_profile_id: str | None = None,
+    permission_governor: RecordingPermissionGovernor | None = None,
 ) -> GatewayProfileManager:
     return GatewayProfileManager(
         profile_store=profile_store,
@@ -107,6 +137,7 @@ def _manager(
         audit_store=audit_store,
         store_metadata=GatewayProfileStoreMetadata(kind="memory", persistent=False),
         fallback_default_profile_id=fallback_default_profile_id,
+        permission_governor=permission_governor,
     )
 
 
@@ -192,7 +223,7 @@ async def test_duplicate_preset_uses_preset_id_as_default_stored_id() -> None:
     assert payload["profile"]["id"] == "project-researcher"
     assert payload["profile"]["name"] == "Project Researcher"
     assert payload["profile"]["preset_id"] == "project-researcher"
-    assert payload["profile"]["preset_version"] == "2026.05.27"
+    assert payload["profile"]["preset_version"] == PRESET_VERSION
     assert payload["profile"]["provenance"]["duplicated"] is True
     assert payload["store"] == {"kind": "memory", "persistent": False}
 
@@ -270,6 +301,53 @@ async def test_create_profile_persists_valid_profile_and_audits_success() -> Non
     assert stored.updated_at.isoformat() == payload["profile"]["updated_at"]
     assert stored.enabled is True
     assert [event.event_type for event in audit_store.events] == ["profile.created"]
+
+
+@pytest.mark.asyncio
+async def test_create_profile_calls_permission_governor_with_redacted_summary() -> None:
+    audit_store = InMemoryAuditStore()
+    governor = RecordingPermissionGovernor()
+    manager = _manager(
+        InMemoryProfileStore(),
+        audit_store=audit_store,
+        permission_governor=governor,
+    )
+
+    await manager.create_profile(
+        {
+            "id": "custom-writer",
+            "name": "Custom Writer",
+            "policy_document": {
+                "allowed_tools": ["fs.write"],
+                "path_grants": [
+                    {"prefix": "docs/private", "actions": ["write"], "effect": "allow"}
+                ],
+            },
+        }
+    )
+
+    assert len(governor.requests) == 1
+    request = governor.requests[0]
+    assert request.action == "profile.create"
+    assert request.profile_id == "custom-writer"
+    assert request.target_type == "profile"
+    assert request.target_id == "custom-writer"
+    assert "policy_document" in request.changed_fields
+    assert request.policy_fields == ("allowed_tools", "path_grants")
+    assert "path_grants_changed" in request.risk_flags
+    assert "path_grants_write_or_edit" in request.risk_flags
+
+    assert [event.event_type for event in audit_store.events] == ["profile.created"]
+    governance_payload = audit_store.events[0].payload["governance"]
+    assert governance_payload["action"] == "profile.create"
+    assert governance_payload["decision"] == {
+        "outcome": "allow",
+        "reason_code": "allow_for_test",
+    }
+    serialized_payload = json.dumps(audit_store.events[0].payload, sort_keys=True)
+    assert "policy_document" not in serialized_payload
+    assert "docs/private" not in serialized_payload
+    assert "fs.write" not in serialized_payload
 
 
 @pytest.mark.asyncio
@@ -800,6 +878,128 @@ async def test_patch_profile_policy_document_handles_missing_stored_policy() -> 
     stored = await store.get_profile("reviewer")
     assert stored is not None
     assert stored.policy_document.allowed_tools == ["review.run"]
+
+
+@pytest.mark.asyncio
+async def test_patch_profile_accepts_path_grants_and_reports_governance_risk() -> None:
+    governor = RecordingPermissionGovernor()
+    store = InMemoryProfileStore([MCPProfile(id="writer", name="Writer")])
+    manager = _manager(store, permission_governor=governor)
+
+    payload = await manager.patch_profile(
+        "writer",
+        {
+            "policy_document": {
+                "path_grants": [
+                    {"prefix": "docs", "actions": ["read", "edit"], "effect": "allow"}
+                ],
+            }
+        },
+    )
+
+    assert payload["profile"]["policy_document"]["path_grants"] == [
+        {"actions": ["read", "edit"], "effect": "allow", "prefix": "docs"}
+    ]
+    stored = await store.get_profile("writer")
+    assert stored is not None
+    assert stored.policy_document.model_dump(mode="json")["path_grants"] == [
+        {"actions": ["read", "edit"], "effect": "allow", "prefix": "docs"}
+    ]
+    assert len(governor.requests) == 1
+    request = governor.requests[0]
+    assert request.action == "profile.patch"
+    assert request.changed_fields == ("policy_document",)
+    assert request.policy_fields == ("path_grants",)
+    assert "path_grants_write_or_edit" in request.risk_flags
+
+
+@pytest.mark.asyncio
+async def test_patch_profile_denied_permission_change_does_not_persist_and_redacts_audit() -> None:
+    audit_store = InMemoryAuditStore()
+    governor = RecordingPermissionGovernor(
+        outcome="deny",
+        reason_code="write_grants_blocked",
+    )
+    store = InMemoryProfileStore([MCPProfile(id="writer", name="Writer")])
+    manager = _manager(
+        store,
+        audit_store=audit_store,
+        permission_governor=governor,
+    )
+    before = await store.get_profile("writer")
+    assert before is not None
+    before_dump = before.model_dump(mode="json")
+
+    with pytest.raises(GatewayProfileManagementError) as exc_info:
+        await manager.patch_profile(
+            "writer",
+            {
+                "policy_document": {
+                    "allowed_tools": ["mcp__filesystem__write_file"],
+                    "path_grants": [
+                        {
+                            "prefix": "docs/private",
+                            "actions": ["write"],
+                            "effect": "allow",
+                        }
+                    ],
+                }
+            },
+        )
+
+    assert exc_info.value.reason_code == "permission_change_denied"
+    after = await store.get_profile("writer")
+    assert after is not None
+    assert after.model_dump(mode="json") == before_dump
+    assert [event.event_type for event in audit_store.events] == [
+        "profile.permission_change_blocked"
+    ]
+    event = audit_store.events[0]
+    assert event.target_type == "profile"
+    assert event.target_id == "writer"
+    assert event.payload["reason_code"] == "permission_change_denied"
+    assert event.payload["decision"] == {
+        "outcome": "deny",
+        "reason_code": "write_grants_blocked",
+    }
+    assert event.payload["policy_fields"] == ["allowed_tools", "path_grants"]
+    serialized_payload = json.dumps(event.payload, sort_keys=True)
+    assert "policy_document" not in serialized_payload
+    assert "docs/private" not in serialized_payload
+    assert "mcp__filesystem__write_file" not in serialized_payload
+
+
+@pytest.mark.asyncio
+async def test_default_profile_ask_governance_decision_blocks_assignment_change() -> None:
+    audit_store = InMemoryAuditStore()
+    governor = RecordingPermissionGovernor(
+        outcome="ask",
+        reason_code="approval_required_for_default_change",
+    )
+    store = InMemoryProfileStore([MCPProfile(id="reviewer", name="Reviewer")])
+    assignment_store = InMemoryProfileAssignmentStore()
+    manager = _manager(
+        store,
+        assignment_store,
+        audit_store=audit_store,
+        permission_governor=governor,
+    )
+
+    with pytest.raises(GatewayProfileManagementError) as exc_info:
+        await manager.set_default_profile("reviewer")
+
+    assert exc_info.value.reason_code == "permission_change_requires_approval"
+    assert await assignment_store.get_assignment("gateway-default") is None
+    assert len(governor.requests) == 1
+    request = governor.requests[0]
+    assert request.action == "profile.default_change"
+    assert "default_profile_change" in request.risk_flags
+    assert [event.event_type for event in audit_store.events] == [
+        "profile.permission_change_blocked"
+    ]
+    assert audit_store.events[0].payload["reason_code"] == (
+        "permission_change_requires_approval"
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Add an injectable MCP profile permission-change governance contract with deny / ask / allow outcomes and an allow-by-default implementation.
- Gate profile create, duplicate-from-preset, patch, delete, and default-profile mutations before persistence, with redacted audit payloads for allowed and blocked changes.
- Allow and validate path-grant policy patch fields for governance, and map the new profile-management reason codes to stable FastAPI statuses.

## Verification
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_gateway_profile_management.py tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py::test_gateway_profile_management_error_status_mapping -q`
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m ruff check mcp_unified/gateway/profile_governance.py mcp_unified/gateway/profiles.py mcp_unified/gateway/fastapi.py tldw_Server_API/app/core/MCP_unified/tests/test_gateway_profile_management.py tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py`
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m py_compile mcp_unified/gateway/profile_governance.py mcp_unified/gateway/profiles.py mcp_unified/gateway/fastapi.py tldw_Server_API/app/core/MCP_unified/tests/test_gateway_profile_management.py tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py`
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r mcp_unified/gateway/profile_governance.py mcp_unified/gateway/profiles.py mcp_unified/gateway/fastapi.py -f json -o /tmp/bandit_mcp_permission_governance.json`

## Merge note
Draft until the human requester adds the required human-written Change summary for the AI-generated PR merge gate.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds injectable permission-change governance for MCP profile mutations with allow/ask/deny enforcement before persistence and redacted, decision-aware audit events. Also validates and governs `path_grants` on create/patch and maps new errors to 403/409.

- **New Features**
  - Introduced PermissionChangeGovernor (default allow) and applied to create, duplicate-from-preset, patch, delete, and default-profile changes; denied → 403, approval-required → 409.
  - Redacted audit payloads for allowed and blocked changes include the governance decision and risk flags; no raw policy_document, path prefixes, or tool patterns.
  - Accepts and validates `path_grants` (and authored keys) on create and patch, and adds risk flags for write/edit path grants and wildcard tool policy.

- **Bug Fixes**
  - Normalized decision reason codes so blocked outcomes cannot emit “allowed”; fail-closed on governor errors with blocked audits.
  - Hardened policy summaries for Pydantic v1 `.dict()`, empty collections, and tuple/set wildcard values.
  - Reject invalid `path_grants` without persisting changes.

<sup>Written for commit c2f3fe31e899cd902c33865a6b5e16c31fbfbac1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2310?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

