### PR TITLE
Expand MCP file policy action taxonomy

### DIFF
--- a/Docs/superpowers/plans/2026-06-08-mcp-file-policy-action-taxonomy-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-06-08-mcp-file-policy-action-taxonomy-implementation-plan.md
@@ -1,0 +1,154 @@
+# MCP File Policy Action Taxonomy Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [x]`) syntax for tracking.
+
+**Goal:** Expand MCP file-policy actions beyond the first read/edit/write slice while keeping destructive file operations reserved until dedicated tools land.
+
+**Architecture:** Add a package-owned file-policy action taxonomy and route existing path-grant, path-scope, preview, and filesystem descriptor code through it. This keeps the executable behavior unchanged for `fs.read`, `fs.patch`, and `fs.write`, but lets policy authors and preview tooling express future delete, move, share/export, admin, and lock permissions without collapsing them into generic write authority.
+
+**Tech Stack:** Python 3.11, Pydantic-compatible package models, pytest, existing MCP Unified filesystem/path-enforcement services.
+
+---
+
+### Task 1: Add Shared File Policy Action Metadata
+
+**Files:**
+- Create: `mcp_unified/interfaces/file_policy_actions.py`
+- Modify: `mcp_unified/interfaces/__init__.py`
+- Test: `tldw_Server_API/app/core/MCP_unified/tests/test_file_policy_actions.py`
+
+- [x] **Step 1: Write failing action metadata tests**
+
+Add tests that assert:
+- `FILE_POLICY_ACTIONS` equals `read`, `edit`, `write`, `delete`, `rename`, `move`, `share`, `export`, `chmod`, `admin`, and `lock`.
+- `FILE_POLICY_EXISTING_TOOL_ACTIONS` equals `read`, `edit`, `write`.
+- `FILE_POLICY_EXFILTRATION_ACTIONS` includes `share` and `export`.
+- `get_file_policy_action_metadata("share")` returns a redacted/operator-safe metadata payload with family `exfiltration` and `implemented` set to false.
+- Unknown action lookup fails clearly without falling back to write.
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_file_policy_actions.py -q
+```
+
+Expected: fail because the module does not exist yet.
+
+- [x] **Step 2: Implement minimal taxonomy module**
+
+Create a frozen dataclass for action metadata plus constants and helpers:
+- `FilePolicyAction`
+- `FilePolicyActionMetadata`
+- `FILE_POLICY_ACTIONS`
+- `FILE_POLICY_EXISTING_TOOL_ACTIONS`
+- `FILE_POLICY_DESTRUCTIVE_ACTIONS`
+- `FILE_POLICY_EXFILTRATION_ACTIONS`
+- `FILE_POLICY_ADMIN_ACTIONS`
+- `FILE_POLICY_LOCK_ACTIONS`
+- `normalize_file_policy_action()`
+- `get_file_policy_action_metadata()`
+- `format_file_policy_action_list()`
+
+Do not add executable tools for reserved actions.
+
+- [x] **Step 3: Verify green**
+
+Run the focused metadata test command and confirm it passes.
+
+### Task 2: Wire Taxonomy Into Path Grants And Path Scope Candidates
+
+**Files:**
+- Modify: `mcp_unified/profiles/path_grants.py`
+- Modify: `mcp_unified/interfaces/path_scope.py`
+- Test: `tldw_Server_API/app/core/MCP_unified/tests/test_path_grant_authoring.py`
+
+- [x] **Step 1: Write failing validation tests**
+
+Add tests proving:
+- Flat and authored path grants accept `delete`, `rename`, `move`, `share`, `export`, `chmod`, `admin`, and `lock`.
+- Invalid action diagnostics list the expanded valid action set.
+- `normalize_path_scope_candidate()` accepts a reserved action such as `lock`.
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_path_grant_authoring.py -q
+```
+
+Expected: fail because reserved actions are currently invalid.
+
+- [x] **Step 2: Replace local action sets with shared constants**
+
+Import the shared constants from `mcp_unified.interfaces.file_policy_actions`. Keep existing effect semantics: only `allow` and `deny`.
+
+- [x] **Step 3: Verify green**
+
+Run the same test file and confirm it passes.
+
+### Task 3: Wire Taxonomy Into Enforcement Preview And Filesystem Metadata
+
+**Files:**
+- Modify: `tldw_Server_API/app/services/mcp_hub_path_enforcement_service.py`
+- Modify: `tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_module.py`
+- Test: `tldw_Server_API/tests/MCP_unified/test_mcp_hub_path_enforcement_service.py`
+- Test: `tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_module.py`
+
+- [x] **Step 1: Write failing enforcement and descriptor tests**
+
+Add tests proving:
+- `preview_effective_path_permission()` can explain an allowed `share` action when a path grant explicitly allows `share`.
+- A reserved action without a matching grant is denied as `path_action_not_granted`, not `invalid_path_action`.
+- Filesystem tool descriptors include action-family metadata for `fs.read`, `fs.patch`, and `fs.write`.
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/MCP_unified/test_mcp_hub_path_enforcement_service.py tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_module.py::test_filesystem_tools_include_path_scope_metadata -q
+```
+
+Expected: fail because the enforcer still rejects reserved actions and descriptors lack action-family metadata.
+
+- [x] **Step 2: Import taxonomy in the enforcer**
+
+Replace `_PATH_GRANT_ACTIONS` with the shared action set. Keep path-boundable behavior, path normalization, deny precedence, and allowlist fallback unchanged.
+
+- [x] **Step 3: Add non-behavioral filesystem descriptor metadata**
+
+Add metadata keys such as:
+- `file_policy_action`: `read`, `edit`, or `write`
+- `file_policy_action_family`: `read`, `bounded_edit`, or `whole_write`
+
+Do not add new executable filesystem operation tools in this slice.
+
+- [x] **Step 4: Verify green**
+
+Run the enforcement and descriptor tests and confirm they pass.
+
+### Task 4: Document And Validate
+
+**Files:**
+- Modify: `mcp_unified/USER_GUIDE.md`
+- Modify: `backlog/tasks/task-2305 - Expand-MCP-file-policy-action-taxonomy-and-operation-tools.md`
+
+- [x] **Step 1: Update user guide**
+
+Add a concise section after the safe file tools path grants explaining:
+- Current executable actions: `read`, `edit`, `write`.
+- Reserved actions: `delete`, `rename`, `move`, `share`, `export`, `chmod`, `admin`, `lock`.
+- `share` and `export` are exfiltration-sensitive and must not be treated as write.
+- Reserved actions can be authored and previewed in policy now, but require future dedicated tools before execution.
+
+- [x] **Step 2: Run focused and security validation**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_file_policy_actions.py tldw_Server_API/app/core/MCP_unified/tests/test_path_grant_authoring.py tldw_Server_API/tests/MCP_unified/test_mcp_hub_path_enforcement_service.py tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_module.py::test_filesystem_tools_include_path_scope_metadata -q
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m ruff check mcp_unified/interfaces/file_policy_actions.py mcp_unified/interfaces/path_scope.py mcp_unified/profiles/path_grants.py tldw_Server_API/app/services/mcp_hub_path_enforcement_service.py tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_module.py tldw_Server_API/app/core/MCP_unified/tests/test_file_policy_actions.py tldw_Server_API/app/core/MCP_unified/tests/test_path_grant_authoring.py tldw_Server_API/tests/MCP_unified/test_mcp_hub_path_enforcement_service.py tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_module.py
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r mcp_unified/interfaces/file_policy_actions.py mcp_unified/interfaces/path_scope.py mcp_unified/profiles/path_grants.py tldw_Server_API/app/services/mcp_hub_path_enforcement_service.py tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_module.py -f json -o /tmp/bandit_mcp_file_policy_action_taxonomy.json
+git diff --check
+```
+
+- [x] **Step 3: Finalize Backlog task**
+
+Record touched files, verification results, final summary, and mark the Definition of Done complete.

--- a/backlog/tasks/task-2305 - Expand-MCP-file-policy-action-taxonomy-and-operation-tools.md
+++ b/backlog/tasks/task-2305 - Expand-MCP-file-policy-action-taxonomy-and-operation-tools.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-2305
 title: Expand MCP file policy action taxonomy and operation tools
-status: To Do
+status: Done
 labels:
 - mcp
 - filesystem
@@ -20,26 +20,54 @@ Implement the reserved file-policy actions beyond the first `read`/`edit`/`write
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
+- [x] Package-level file-policy action constants and metadata cover `read`, `edit`, `write`, `delete`, `rename`, `move`, `share`, `export`, `chmod`, `admin`, and `lock`.
+- [x] Path-grant validation, path-scope candidates, and effective-permission previews accept the expanded action vocabulary while still rejecting malformed actions fail-closed.
+- [x] Existing `fs.read`, `fs.patch`, `fs.write`, `fs.read_text`, and `fs.write_text` behavior remains unchanged.
+- [x] Existing filesystem tool descriptors expose action-family metadata so clients can distinguish read, bounded edit, and whole-write authority.
+- [x] Package/user documentation explains the expanded action taxonomy and makes clear that destructive, exfiltration, admin, and lock actions are reserved until dedicated tools land.
+- [x] Focused regression tests cover action metadata, compiler validation, preview/explanation behavior, filesystem descriptor metadata, and backward compatibility.
 <!-- AC:END -->
 
 ## Implementation Notes
 
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Plan: `Docs/superpowers/plans/2026-06-08-mcp-file-policy-action-taxonomy-implementation-plan.md`
 
+Touched files:
+- `mcp_unified/interfaces/file_policy_actions.py`
+- `mcp_unified/interfaces/__init__.py`
+- `mcp_unified/interfaces/path_scope.py`
+- `mcp_unified/profiles/path_grants.py`
+- `mcp_unified/gateway/profiles.py`
+- `mcp_unified/USER_GUIDE.md`
+- `tldw_Server_API/app/services/mcp_hub_path_enforcement_service.py`
+- `tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_module.py`
+- `tldw_Server_API/app/core/MCP_unified/tests/test_file_policy_actions.py`
+- `tldw_Server_API/app/core/MCP_unified/tests/test_path_grant_authoring.py`
+- `tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_module.py`
+- `tldw_Server_API/app/core/MCP_unified/tests/test_gateway_profile_management.py`
+- `tldw_Server_API/tests/MCP_unified/test_mcp_hub_path_enforcement_service.py`
+
+Verification:
+- `python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_file_policy_actions.py tldw_Server_API/app/core/MCP_unified/tests/test_path_grant_authoring.py tldw_Server_API/tests/MCP_unified/test_mcp_hub_path_enforcement_service.py tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_module.py::test_filesystem_tools_include_path_scope_metadata tldw_Server_API/app/core/MCP_unified/tests/test_gateway_profile_management.py::test_create_profile_permission_governor_flags_reserved_path_grant_risks tldw_Server_API/app/core/MCP_unified/tests/test_gateway_profile_management.py::test_create_profile_calls_permission_governor_with_redacted_summary -q` -> 31 passed.
+- `python -m ruff check <touched Python files>` -> all checks passed.
+- `python -m py_compile <touched Python files>` -> passed.
+- `python -m bandit -r <touched production files> -f json -o /tmp/bandit_mcp_file_policy_action_taxonomy.json` -> 0 findings, 0 errors.
+- `git diff --check` -> clean.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-
+Expanded the MCP file-policy action taxonomy with package-level metadata for `read`, `edit`, `write`, `delete`, `rename`, `move`, `share`, `export`, `chmod`, `admin`, and `lock`. Path grants, path-scope candidates, and effective-permission previews now use the shared vocabulary, while existing filesystem tool behavior remains limited to the current safe read/edit/write tools. Filesystem descriptors include action-family metadata, governance risk flags distinguish destructive/exfiltration/admin/lock grants, and the package user guide documents reserved-action semantics.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented: reserved actions are policy/preview vocabulary only until dedicated safe operation tools land.
 <!-- DOD:END -->

--- a/backlog/tasks/task-2320 - Address-PR-2311-review-comments-for-MCP-file-policy-action-taxonomy.md
+++ b/backlog/tasks/task-2320 - Address-PR-2311-review-comments-for-MCP-file-policy-action-taxonomy.md
@@ -1,0 +1,57 @@
+---
+id: TASK-2320
+title: Address PR 2311 review comments for MCP file-policy action taxonomy
+status: In Progress
+priority: High
+references:
+- https://github.com/rmusser01/tldw_server/pull/2311
+modified_files:
+- mcp_unified/interfaces/file_policy_actions.py
+- tldw_Server_API/app/services/mcp_hub_path_enforcement_service.py
+- tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_module.py
+- tldw_Server_API/app/core/MCP_unified/tests/test_file_policy_actions.py
+- tldw_Server_API/tests/MCP_unified/test_mcp_hub_path_enforcement_service.py
+- tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_module.py
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Verify current PR #2311 review findings after rebasing on latest dev, fix only still-valid issues, and validate the focused touched scope.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 PR branch is rebased on latest origin/dev and pushed safely.
+- [ ] #2 Still-valid review comments are addressed with minimal code/test changes.
+- [ ] #3 Invalid or superseded comments are skipped with a documented reason.
+- [ ] #4 Focused tests, lint/compile, Bandit, and diff checks are run for touched scope.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Review current unresolved threads, patch valid issues in file-policy metadata, path enforcement preview semantics, and fs.patch rollback handling, then validate and push.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Pending commit/push: review comments addressed locally and focused validation passed.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-2320 - Address-PR-2311-review-comments-for-MCP-file-policy-action-taxonomy.md
+++ b/backlog/tasks/task-2320 - Address-PR-2311-review-comments-for-MCP-file-policy-action-taxonomy.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-2320
 title: Address PR 2311 review comments for MCP file-policy action taxonomy
-status: In Progress
+status: Done
 priority: High
 references:
 - https://github.com/rmusser01/tldw_server/pull/2311
@@ -43,7 +43,7 @@ Review current unresolved threads, patch valid issues in file-policy metadata, p
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Pending commit/push: review comments addressed locally and focused validation passed.
+Rebased PR #2311 on origin/dev and pushed codex/mcp-file-policy-action-taxonomy at 92892b7121. Addressed still-valid review findings: metadata lookup now fails with ValueError on action/metadata drift; effective permission preview now returns ask for true force-approval scope blocks while explicit path-grant deny/not_granted remains hard deny; missing nested path_decisions are normalized safely; fs.patch rollback catches/logs unexpected restore failures without masking the original partial-write error. Validation passed: focused review regression pytest set (9 passed), broader touched-scope pytest set (35 passed), ruff touched files, py_compile touched production files, Bandit touched production files, and git diff --check.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/mcp_unified/USER_GUIDE.md
+++ b/mcp_unified/USER_GUIDE.md
@@ -156,6 +156,22 @@ profile with `write` can use `fs.write` and patch-created files when policy also
 allows creation. Deny grants take precedence over broader allow grants, so a
 private subtree can remain read-only or blocked under a writable parent.
 
+The file-policy action vocabulary is broader than the tools currently shipped.
+The executable filesystem actions today are:
+
+- `read`: inspect file content, directory listings, search results, and path
+  metadata.
+- `edit`: bounded existing-file edits through `fs.patch`.
+- `write`: deliberate whole-file create or replace through `fs.write`.
+
+The reserved action names are `delete`, `rename`, `move`, `share`, `export`,
+`chmod`, `admin`, and `lock`. Profiles may author and preview these grants now
+so policy intent is explicit, but they do not become executable until a
+dedicated safe tool for that operation lands. Do not treat these actions as
+aliases for `write`: `share` and `export` are exfiltration-sensitive, `delete`,
+`rename`, and `move` are destructive, `chmod` and `admin` are administrative,
+and `lock` is a concurrency-control action.
+
 Operators that prefer inherited policy authoring can keep the executable
 runtime contract flat by compiling `path_grant_authoring` into `path_grants`.
 The supported authoring levels are `org`, `workspace`, `folders`, and `files`;

--- a/mcp_unified/gateway/profiles.py
+++ b/mcp_unified/gateway/profiles.py
@@ -16,6 +16,12 @@ from mcp_unified.gateway.profile_governance import (
     PermissionChangeGovernor,
     PermissionChangeRequest,
 )
+from mcp_unified.interfaces.file_policy_actions import (
+    FILE_POLICY_ADMIN_ACTIONS,
+    FILE_POLICY_DESTRUCTIVE_ACTIONS,
+    FILE_POLICY_EXFILTRATION_ACTIONS,
+    FILE_POLICY_LOCK_ACTIONS,
+)
 from mcp_unified.interfaces.storage import (
     AuditStore,
     ProfileAssignmentStore,
@@ -975,12 +981,22 @@ class GatewayProfileManager:
         if any(field in policy_fields for field in {"path_grants", *PATH_GRANT_AUTHORING_KEYS}):
             flags.add("path_grants_changed")
             compiled = compile_policy_path_grants(policy_payload)
-            if any(
-                grant.get("effect") == "allow"
-                and any(action in {"edit", "write"} for action in grant.get("actions", ()))
+            allowed_path_grant_actions = {
+                str(action)
                 for grant in compiled.path_grants
-            ):
+                if grant.get("effect") == "allow"
+                for action in grant.get("actions", ())
+            }
+            if allowed_path_grant_actions.intersection({"edit", "write"}):
                 flags.add("path_grants_write_or_edit")
+            if allowed_path_grant_actions.intersection(FILE_POLICY_DESTRUCTIVE_ACTIONS):
+                flags.add("path_grants_destructive")
+            if allowed_path_grant_actions.intersection(FILE_POLICY_EXFILTRATION_ACTIONS):
+                flags.add("path_grants_exfiltration")
+            if allowed_path_grant_actions.intersection(FILE_POLICY_ADMIN_ACTIONS):
+                flags.add("path_grants_admin")
+            if allowed_path_grant_actions.intersection(FILE_POLICY_LOCK_ACTIONS):
+                flags.add("path_grants_lock")
         if self._has_wildcard_tool_policy(policy_payload):
             flags.add("wildcard_tool_policy")
         return tuple(sorted(flags))

--- a/mcp_unified/interfaces/__init__.py
+++ b/mcp_unified/interfaces/__init__.py
@@ -1,5 +1,18 @@
 """Host-neutral MCP Unified interface contracts."""
 
+from .file_policy_actions import (
+    FILE_POLICY_ACTIONS,
+    FILE_POLICY_ADMIN_ACTIONS,
+    FILE_POLICY_DESTRUCTIVE_ACTIONS,
+    FILE_POLICY_EXFILTRATION_ACTIONS,
+    FILE_POLICY_EXISTING_TOOL_ACTIONS,
+    FILE_POLICY_LOCK_ACTIONS,
+    FilePolicyAction,
+    FilePolicyActionMetadata,
+    format_file_policy_action_list,
+    get_file_policy_action_metadata,
+    normalize_file_policy_action,
+)
 from .policy import (
     ApprovalEvaluator,
     EffectivePolicyResolver,
@@ -53,6 +66,14 @@ __all__ = [
     "EnvironmentFlagsProvider",
     "ExternalAccessEvaluator",
     "ExternalRegistryStore",
+    "FILE_POLICY_ACTIONS",
+    "FILE_POLICY_ADMIN_ACTIONS",
+    "FILE_POLICY_DESTRUCTIVE_ACTIONS",
+    "FILE_POLICY_EXISTING_TOOL_ACTIONS",
+    "FILE_POLICY_EXFILTRATION_ACTIONS",
+    "FILE_POLICY_LOCK_ACTIONS",
+    "FilePolicyAction",
+    "FilePolicyActionMetadata",
     "LifecycleGuard",
     "MCPRuntimeDependencies",
     "MetricsCollector",
@@ -74,4 +95,7 @@ __all__ = [
     "WebSocketCloseTarget",
     "WebSocketStream",
     "WebSocketStreamFactory",
+    "format_file_policy_action_list",
+    "get_file_policy_action_metadata",
+    "normalize_file_policy_action",
 ]

--- a/mcp_unified/interfaces/file_policy_actions.py
+++ b/mcp_unified/interfaces/file_policy_actions.py
@@ -159,7 +159,10 @@ def get_file_policy_action_metadata(action: object) -> FilePolicyActionMetadata:
     normalized = normalize_file_policy_action(action)
     if normalized is None:
         raise ValueError("unknown file policy action")
-    return _ACTION_METADATA[normalized]
+    metadata = _ACTION_METADATA.get(normalized)
+    if metadata is None:
+        raise ValueError(f"file policy action metadata is missing for {normalized!r}")
+    return metadata
 
 
 def format_file_policy_action_list(actions: frozenset[str] = FILE_POLICY_ACTIONS) -> str:

--- a/mcp_unified/interfaces/file_policy_actions.py
+++ b/mcp_unified/interfaces/file_policy_actions.py
@@ -1,0 +1,186 @@
+"""Shared MCP file-policy action taxonomy."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+FilePolicyAction = Literal[
+    "read",
+    "edit",
+    "write",
+    "delete",
+    "rename",
+    "move",
+    "share",
+    "export",
+    "chmod",
+    "admin",
+    "lock",
+]
+
+FILE_POLICY_ACTIONS = frozenset(
+    {
+        "read",
+        "edit",
+        "write",
+        "delete",
+        "rename",
+        "move",
+        "share",
+        "export",
+        "chmod",
+        "admin",
+        "lock",
+    }
+)
+FILE_POLICY_EXISTING_TOOL_ACTIONS = frozenset({"read", "edit", "write"})
+FILE_POLICY_DESTRUCTIVE_ACTIONS = frozenset({"delete", "rename", "move"})
+FILE_POLICY_EXFILTRATION_ACTIONS = frozenset({"share", "export"})
+FILE_POLICY_ADMIN_ACTIONS = frozenset({"chmod", "admin"})
+FILE_POLICY_LOCK_ACTIONS = frozenset({"lock"})
+
+
+@dataclass(frozen=True, slots=True)
+class FilePolicyActionMetadata:
+    """Operator-facing metadata for one file-policy action."""
+
+    action: FilePolicyAction
+    family: str
+    description: str
+    implemented: bool
+    risk: str
+
+    def as_dict(self) -> dict[str, str | bool]:
+        """Return a JSON-serializable metadata payload."""
+
+        return {
+            "action": self.action,
+            "family": self.family,
+            "description": self.description,
+            "implemented": self.implemented,
+            "risk": self.risk,
+        }
+
+
+_ACTION_METADATA: dict[str, FilePolicyActionMetadata] = {
+    "read": FilePolicyActionMetadata(
+        action="read",
+        family="read",
+        description="Inspect file or directory content and metadata inside an allowed workspace path.",
+        implemented=True,
+        risk="read",
+    ),
+    "edit": FilePolicyActionMetadata(
+        action="edit",
+        family="bounded_edit",
+        description="Modify existing file content through bounded edit tools with preimage checks.",
+        implemented=True,
+        risk="mutation",
+    ),
+    "write": FilePolicyActionMetadata(
+        action="write",
+        family="whole_write",
+        description="Create or replace complete file content inside an allowed workspace path.",
+        implemented=True,
+        risk="mutation",
+    ),
+    "delete": FilePolicyActionMetadata(
+        action="delete",
+        family="destructive",
+        description="Delete file or directory content inside an allowed workspace path.",
+        implemented=False,
+        risk="destructive",
+    ),
+    "rename": FilePolicyActionMetadata(
+        action="rename",
+        family="destructive",
+        description="Rename a file or directory inside an allowed workspace path.",
+        implemented=False,
+        risk="destructive",
+    ),
+    "move": FilePolicyActionMetadata(
+        action="move",
+        family="destructive",
+        description="Move a file or directory between allowed workspace paths.",
+        implemented=False,
+        risk="destructive",
+    ),
+    "share": FilePolicyActionMetadata(
+        action="share",
+        family="exfiltration",
+        description="Share or publish file content outside the active workspace boundary.",
+        implemented=False,
+        risk="exfiltration",
+    ),
+    "export": FilePolicyActionMetadata(
+        action="export",
+        family="exfiltration",
+        description="Export file content outside the active workspace boundary.",
+        implemented=False,
+        risk="exfiltration",
+    ),
+    "chmod": FilePolicyActionMetadata(
+        action="chmod",
+        family="admin",
+        description="Change filesystem permission bits inside an allowed workspace path.",
+        implemented=False,
+        risk="admin",
+    ),
+    "admin": FilePolicyActionMetadata(
+        action="admin",
+        family="admin",
+        description="Perform administrative filesystem operations inside an allowed workspace path.",
+        implemented=False,
+        risk="admin",
+    ),
+    "lock": FilePolicyActionMetadata(
+        action="lock",
+        family="lock",
+        description="Acquire or release coordination locks for allowed workspace paths.",
+        implemented=False,
+        risk="coordination",
+    ),
+}
+
+
+def normalize_file_policy_action(value: object) -> FilePolicyAction | None:
+    """Normalize an arbitrary value into a known file-policy action."""
+
+    action = str(value or "").strip().lower()
+    if action not in FILE_POLICY_ACTIONS:
+        return None
+    return action  # type: ignore[return-value]
+
+
+def get_file_policy_action_metadata(action: object) -> FilePolicyActionMetadata:
+    """Return metadata for a known file-policy action."""
+
+    normalized = normalize_file_policy_action(action)
+    if normalized is None:
+        raise ValueError("unknown file policy action")
+    return _ACTION_METADATA[normalized]
+
+
+def format_file_policy_action_list(actions: frozenset[str] = FILE_POLICY_ACTIONS) -> str:
+    """Return a human-readable list of file-policy actions."""
+
+    ordered = [action for action in _ACTION_METADATA if action in actions]
+    if len(ordered) <= 1:
+        return "".join(ordered)
+    return ", ".join(ordered[:-1]) + f", or {ordered[-1]}"
+
+
+__all__ = [
+    "FILE_POLICY_ACTIONS",
+    "FILE_POLICY_ADMIN_ACTIONS",
+    "FILE_POLICY_DESTRUCTIVE_ACTIONS",
+    "FILE_POLICY_EXISTING_TOOL_ACTIONS",
+    "FILE_POLICY_EXFILTRATION_ACTIONS",
+    "FILE_POLICY_LOCK_ACTIONS",
+    "FilePolicyAction",
+    "FilePolicyActionMetadata",
+    "format_file_policy_action_list",
+    "get_file_policy_action_metadata",
+    "normalize_file_policy_action",
+]

--- a/mcp_unified/interfaces/path_scope.py
+++ b/mcp_unified/interfaces/path_scope.py
@@ -4,11 +4,11 @@ from __future__ import annotations
 
 from collections.abc import Iterable, Mapping
 from dataclasses import dataclass
-from typing import Any, Literal
+from typing import Any
 
-PathScopeAction = Literal["read", "edit", "write"]
+from .file_policy_actions import FilePolicyAction, normalize_file_policy_action
 
-_VALID_ACTIONS = {"read", "edit", "write"}
+PathScopeAction = FilePolicyAction
 
 
 @dataclass(frozen=True, slots=True)
@@ -61,14 +61,14 @@ def normalize_path_scope_candidate(raw: PathScopeCandidate | Mapping[str, Any]) 
     if path is None:
         raise ValueError("path scope candidate path is required")
 
-    action = _clean_optional_string(raw.get("action"))
-    if action not in _VALID_ACTIONS:
+    action = normalize_file_policy_action(raw.get("action"))
+    if action is None:
         raise ValueError("path scope candidate action is invalid")
 
     source = _clean_optional_string(raw.get("source")) or "module"
     return PathScopeCandidate(
         path=path,
-        action=action,  # type: ignore[arg-type]
+        action=action,
         source=source,
         display_path=_clean_optional_string(raw.get("display_path")),
         requires_existing_file=_coerce_bool_flag(

--- a/mcp_unified/profiles/path_grants.py
+++ b/mcp_unified/profiles/path_grants.py
@@ -7,7 +7,9 @@ from collections.abc import Iterable, Mapping
 from dataclasses import dataclass
 from typing import Any
 
-PATH_GRANT_ACTIONS = frozenset({"read", "edit", "write"})
+from mcp_unified.interfaces.file_policy_actions import FILE_POLICY_ACTIONS, format_file_policy_action_list
+
+PATH_GRANT_ACTIONS = FILE_POLICY_ACTIONS
 PATH_GRANT_EFFECTS = frozenset({"allow", "deny"})
 PATH_GRANT_AUTHORING_KEYS = (
     "path_grant_authoring",
@@ -153,7 +155,13 @@ def _compile_rules(rules: Iterable[tuple[Mapping[str, Any], str, str]]) -> PathG
         invalid_actions = [action for action in actions if action not in PATH_GRANT_ACTIONS]
         actions = [action for action in actions if action in PATH_GRANT_ACTIONS]
         if invalid_actions or not actions:
-            diagnostics.append(_diagnostic("invalid_actions", "path grant actions must be read, edit, or write", source))
+            diagnostics.append(
+                _diagnostic(
+                    "invalid_actions",
+                    f"path grant actions must be {format_file_policy_action_list(PATH_GRANT_ACTIONS)}",
+                    source,
+                )
+            )
             continue
 
         effect = str(rule.get("effect") or "allow").strip().lower()

--- a/tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_module.py
@@ -1449,7 +1449,8 @@ class FilesystemModule(BaseModule):
                             self._atomic_write_text_file(target, str(plan["_text_before"]))
                         else:
                             target.unlink(missing_ok=True)
-                    except OSError:
+                    # Rollback is best effort; preserve the original write failure even if restore fails.
+                    except Exception:  # noqa: BLE001
                         logger.exception("Failed to roll back partial fs.patch write for {}", target.name)
                 raise ValueError("partial_write_rollback_attempted") from exc
 

--- a/tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_module.py
@@ -25,8 +25,9 @@ from pathlib import Path
 from typing import Any
 
 from loguru import logger
-
+from mcp_unified.interfaces.file_policy_actions import get_file_policy_action_metadata
 from mcp_unified.interfaces.path_scope import PathScopeCandidate
+
 from tldw_Server_API.app.services.mcp_hub_workspace_root_resolver import (
     McpHubWorkspaceRootResolver,
 )
@@ -43,6 +44,16 @@ def _first_nonempty(*values: Any) -> str | None:
         if text:
             return text
     return None
+
+
+def _file_policy_metadata(action: str) -> dict[str, str]:
+    """Return non-sensitive descriptor metadata for a file-policy action."""
+
+    metadata = get_file_policy_action_metadata(action)
+    return {
+        "file_policy_action": metadata.action,
+        "file_policy_action_family": metadata.family,
+    }
 
 
 class FilesystemModule(BaseModule):
@@ -92,6 +103,7 @@ class FilesystemModule(BaseModule):
                 "category": "retrieval",
                 "readOnlyHint": True,
                 "capabilities": ["filesystem.read"],
+                **_file_policy_metadata("read"),
                 **shared_path_metadata,
             },
         )
@@ -113,6 +125,7 @@ class FilesystemModule(BaseModule):
                 "path_scope_action": "read",
                 "legacy_tool": True,
                 "replacement_tool": "fs.read",
+                **_file_policy_metadata("read"),
                 **shared_path_metadata,
             },
         )
@@ -137,6 +150,7 @@ class FilesystemModule(BaseModule):
                 "readOnlyHint": True,
                 "capabilities": ["filesystem.read"],
                 "path_scope_action": "read",
+                **_file_policy_metadata("read"),
                 "eval": {
                     "task_families": ["filesystem_read"],
                     "expected_result_kind": "structured_filesystem_read",
@@ -172,6 +186,7 @@ class FilesystemModule(BaseModule):
                 "write_capable": True,
                 "capabilities": ["filesystem.edit", "filesystem.write"],
                 "path_scope_candidate_source": "module",
+                **_file_policy_metadata("edit"),
                 "eval": {
                     "task_families": ["filesystem_edit"],
                     "expected_result_kind": "structured_filesystem_edit",
@@ -202,6 +217,7 @@ class FilesystemModule(BaseModule):
                 "write_capable": True,
                 "capabilities": ["filesystem.write"],
                 "path_scope_action": "write",
+                **_file_policy_metadata("write"),
                 "eval": {
                     "task_families": ["filesystem_write"],
                     "expected_result_kind": "structured_filesystem_write",
@@ -230,6 +246,7 @@ class FilesystemModule(BaseModule):
                 "path_scope_action": "write",
                 "legacy_tool": True,
                 "replacement_tools": ["fs.patch", "fs.write"],
+                **_file_policy_metadata("write"),
                 **shared_path_metadata,
             },
         )
@@ -253,6 +270,7 @@ class FilesystemModule(BaseModule):
                 "category": "retrieval",
                 "readOnlyHint": True,
                 "capabilities": ["filesystem.read"],
+                **_file_policy_metadata("read"),
                 **shared_path_metadata,
             },
         )
@@ -278,6 +296,7 @@ class FilesystemModule(BaseModule):
                 "category": "retrieval",
                 "readOnlyHint": True,
                 "capabilities": ["filesystem.read"],
+                **_file_policy_metadata("read"),
                 **shared_fs_metadata,
                 "path_argument_hints": ["base_path"],
             },
@@ -310,6 +329,7 @@ class FilesystemModule(BaseModule):
                 "category": "retrieval",
                 "readOnlyHint": True,
                 "capabilities": ["filesystem.read"],
+                **_file_policy_metadata("read"),
                 **shared_fs_metadata,
                 "path_argument_hints": ["base_path"],
             },
@@ -1429,7 +1449,7 @@ class FilesystemModule(BaseModule):
                             self._atomic_write_text_file(target, str(plan["_text_before"]))
                         else:
                             target.unlink(missing_ok=True)
-                    except Exception:
+                    except OSError:
                         logger.exception("Failed to roll back partial fs.patch write for {}", target.name)
                 raise ValueError("partial_write_rollback_attempted") from exc
 

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_file_policy_actions.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_file_policy_actions.py
@@ -50,3 +50,14 @@ def test_file_policy_action_metadata_rejects_unknown_actions() -> None:
 
     with pytest.raises(ValueError, match="unknown file policy action"):
         get_file_policy_action_metadata("destroy")
+
+
+def test_file_policy_action_metadata_rejects_missing_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from mcp_unified.interfaces import file_policy_actions
+
+    monkeypatch.delitem(file_policy_actions._ACTION_METADATA, "lock")
+
+    with pytest.raises(ValueError, match="metadata is missing"):
+        file_policy_actions.get_file_policy_action_metadata("lock")

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_file_policy_actions.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_file_policy_actions.py
@@ -1,0 +1,52 @@
+"""Tests for shared MCP file-policy action metadata."""
+
+from __future__ import annotations
+
+import pytest
+
+
+def test_file_policy_action_taxonomy_lists_existing_and_reserved_actions() -> None:
+    from mcp_unified.interfaces.file_policy_actions import (
+        FILE_POLICY_ACTIONS,
+        FILE_POLICY_EXFILTRATION_ACTIONS,
+        FILE_POLICY_EXISTING_TOOL_ACTIONS,
+    )
+
+    assert frozenset(
+        {
+            "read",
+            "edit",
+            "write",
+            "delete",
+            "rename",
+            "move",
+            "share",
+            "export",
+            "chmod",
+            "admin",
+            "lock",
+        }
+    ) == FILE_POLICY_ACTIONS
+    assert frozenset({"read", "edit", "write"}) == FILE_POLICY_EXISTING_TOOL_ACTIONS
+    assert frozenset({"share", "export"}) == FILE_POLICY_EXFILTRATION_ACTIONS
+
+
+def test_file_policy_action_metadata_describes_reserved_actions_without_implementation() -> None:
+    from mcp_unified.interfaces.file_policy_actions import get_file_policy_action_metadata
+
+    metadata = get_file_policy_action_metadata("share")
+
+    assert metadata.as_dict() == {
+        "action": "share",
+        "family": "exfiltration",
+        "description": "Share or publish file content outside the active workspace boundary.",
+        "implemented": False,
+        "risk": "exfiltration",
+    }
+
+
+def test_file_policy_action_metadata_rejects_unknown_actions() -> None:
+    from mcp_unified.interfaces.file_policy_actions import get_file_policy_action_metadata
+
+    with pytest.raises(ValueError, match="unknown file policy action"):
+        get_file_policy_action_metadata("destroy")

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_module.py
@@ -775,6 +775,65 @@ async def test_filesystem_patch_rolls_back_previous_writes_on_partial_failure(
 
 
 @pytest.mark.asyncio
+async def test_filesystem_patch_preserves_original_error_when_rollback_raises_unexpected_error(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace_root = tmp_path / "workspace"
+    docs_dir = workspace_root / "docs"
+    docs_dir.mkdir(parents=True, exist_ok=True)
+    first = docs_dir / "one.txt"
+    second = docs_dir / "two.txt"
+    first_original = "alpha\n"
+    second_original = "beta\n"
+    first.write_text(first_original, encoding="utf-8")
+    second.write_text(second_original, encoding="utf-8")
+    resolver = _FakeWorkspaceRootResolver({"workspace_root": str(workspace_root)})
+    mod = FilesystemModule(ModuleConfig(name="filesystem"), workspace_root_resolver=resolver)
+    context = RequestContext(request_id="req-fs-patch-rollback-unexpected", user_id="1", metadata={})
+    original_atomic_write = FilesystemModule._atomic_write_text_file
+
+    def _fail_second_write_and_first_restore(target: Path, text: str) -> None:
+        if target.name == "two.txt":
+            raise OSError("simulated write failure")
+        if target.name == "one.txt" and text == first_original:
+            raise RuntimeError("simulated rollback failure")
+        original_atomic_write(target, text)
+
+    monkeypatch.setattr(
+        FilesystemModule,
+        "_atomic_write_text_file",
+        staticmethod(_fail_second_write_and_first_restore),
+    )
+
+    with pytest.raises(ValueError, match="partial_write_rollback_attempted"):
+        await mod.execute_tool(
+            "fs.patch",
+            {
+                "diff": """--- a/docs/one.txt
++++ b/docs/one.txt
+@@ -1 +1 @@
+-alpha
++ALPHA
+--- a/docs/two.txt
++++ b/docs/two.txt
+@@ -1 +1 @@
+-beta
++BETA
+""",
+                "expected_sha256_by_path": {
+                    "docs/one.txt": hashlib.sha256(first_original.encode("utf-8")).hexdigest(),
+                    "docs/two.txt": hashlib.sha256(second_original.encode("utf-8")).hexdigest(),
+                },
+            },
+            context=context,
+        )
+
+    assert first.read_text(encoding="utf-8") == "ALPHA\n"  # nosec B101
+    assert second.read_text(encoding="utf-8") == second_original  # nosec B101
+
+
+@pytest.mark.asyncio
 async def test_filesystem_patch_dry_run_does_not_write(tmp_path: Path) -> None:
     workspace_root = tmp_path / "workspace"
     docs_dir = workspace_root / "docs"

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_module.py
@@ -7,8 +7,8 @@ from pathlib import Path
 from typing import Any
 
 import pytest
-
 from mcp_unified.interfaces.path_scope import PathScopeCandidate
+
 from tldw_Server_API.app.core.MCP_unified.modules.base import ModuleConfig
 from tldw_Server_API.app.core.MCP_unified.modules.implementations.filesystem_module import (
     FilesystemModule,
@@ -219,12 +219,16 @@ async def test_filesystem_tools_include_path_scope_metadata() -> None:
     assert read_metadata["path_argument_hints"] == ["path"]  # nosec B101
     assert read_metadata["readOnlyHint"] is True  # nosec B101
     assert read_metadata["path_scope_action"] == "read"  # nosec B101
+    assert read_metadata["file_policy_action"] == "read"  # nosec B101
+    assert read_metadata["file_policy_action_family"] == "read"  # nosec B101
     assert "filesystem.read" in read_metadata["capabilities"]  # nosec B101
     assert read_metadata["eval"]["task_families"] == ["filesystem_read"]  # nosec B101
     assert read_metadata["eval"]["expected_result_kind"] == "structured_filesystem_read"  # nosec B101
     assert by_name["fs.read"]["inputSchema"]["additionalProperties"] is False  # nosec B101
     patch_metadata = by_name["fs.patch"]["metadata"]
     assert patch_metadata["path_scope_candidate_source"] == "module"  # nosec B101
+    assert patch_metadata["file_policy_action"] == "edit"  # nosec B101
+    assert patch_metadata["file_policy_action_family"] == "bounded_edit"  # nosec B101
     assert patch_metadata["write_capable"] is True  # nosec B101
     assert patch_metadata["eval"]["task_families"] == ["filesystem_edit"]  # nosec B101
     assert patch_metadata["eval"]["expected_result_kind"] == "structured_filesystem_edit"  # nosec B101
@@ -232,6 +236,8 @@ async def test_filesystem_tools_include_path_scope_metadata() -> None:
     write_metadata = by_name["fs.write"]["metadata"]
     assert write_metadata["path_argument_hints"] == ["path"]  # nosec B101
     assert write_metadata["path_scope_action"] == "write"  # nosec B101
+    assert write_metadata["file_policy_action"] == "write"  # nosec B101
+    assert write_metadata["file_policy_action_family"] == "whole_write"  # nosec B101
     assert write_metadata["write_capable"] is True  # nosec B101
     assert write_metadata["eval"]["task_families"] == ["filesystem_write"]  # nosec B101
     assert write_metadata["eval"]["expected_result_kind"] == "structured_filesystem_write"  # nosec B101
@@ -558,7 +564,7 @@ async def test_filesystem_read_can_include_line_numbers(tmp_path: Path) -> None:
     assert result["start_line"] == 2  # nosec B101
     assert result["end_line"] == 3  # nosec B101
     assert result["line_count_total"] == 3  # nosec B101
-    assert result["bytes_read"] == len("beta\ngamma\n".encode("utf-8"))  # nosec B101
+    assert result["bytes_read"] == len(b"beta\ngamma\n")  # nosec B101
     assert result["truncated"] is False  # nosec B101
 
 
@@ -794,7 +800,7 @@ async def test_filesystem_patch_dry_run_does_not_write(tmp_path: Path) -> None:
     assert result["applied"] is False  # nosec B101
     assert result["dry_run"] is True  # nosec B101
     assert (
-        result["files"][0]["sha256_after"] == hashlib.sha256("alpha\nBETTA\ngamma\n".encode("utf-8")).hexdigest()
+        result["files"][0]["sha256_after"] == hashlib.sha256(b"alpha\nBETTA\ngamma\n").hexdigest()
     )  # nosec B101
 
 
@@ -969,7 +975,7 @@ async def test_filesystem_write_create_creates_new_text_file(tmp_path: Path) -> 
     assert result["path"] == "docs/new.txt"  # nosec B101
     assert result["written"] is True  # nosec B101
     assert result["created"] is True  # nosec B101
-    assert result["bytes_written"] == len("created\n".encode("utf-8"))  # nosec B101
+    assert result["bytes_written"] == len(b"created\n")  # nosec B101
     assert result["eval"]["action_family"] == "filesystem_write"  # nosec B101
 
     with pytest.raises(ValueError, match="write_target_exists"):
@@ -1033,7 +1039,7 @@ async def test_filesystem_write_replace_with_expected_hash(tmp_path: Path) -> No
     resolver = _FakeWorkspaceRootResolver({"workspace_root": str(workspace_root)})
     mod = FilesystemModule(ModuleConfig(name="filesystem"), workspace_root_resolver=resolver)
     context = RequestContext(request_id="req-fs-write-expected", user_id="1", metadata={})
-    expected_sha = hashlib.sha256("old\n".encode("utf-8")).hexdigest()
+    expected_sha = hashlib.sha256(b"old\n").hexdigest()
 
     result = await mod.execute_tool(
         "fs.write",
@@ -1045,7 +1051,7 @@ async def test_filesystem_write_replace_with_expected_hash(tmp_path: Path) -> No
     assert result["written"] is True  # nosec B101
     assert result["created"] is False  # nosec B101
     assert result["sha256_before"] == expected_sha  # nosec B101
-    assert result["sha256_after"] == hashlib.sha256("new\n".encode("utf-8")).hexdigest()  # nosec B101
+    assert result["sha256_after"] == hashlib.sha256(b"new\n").hexdigest()  # nosec B101
 
 
 @pytest.mark.asyncio
@@ -1187,7 +1193,7 @@ async def test_filesystem_write_rejects_stale_hash_and_dry_run_does_not_write(tm
     resolver = _FakeWorkspaceRootResolver({"workspace_root": str(workspace_root)})
     mod = FilesystemModule(ModuleConfig(name="filesystem"), workspace_root_resolver=resolver)
     context = RequestContext(request_id="req-fs-write-stale", user_id="1", metadata={})
-    expected_sha = hashlib.sha256("old\n".encode("utf-8")).hexdigest()
+    expected_sha = hashlib.sha256(b"old\n").hexdigest()
 
     with pytest.raises(ValueError, match="write_preimage_mismatch"):
         await mod.execute_tool(
@@ -1211,7 +1217,7 @@ async def test_filesystem_write_rejects_stale_hash_and_dry_run_does_not_write(tm
     assert target.read_text(encoding="utf-8") == "old\n"  # nosec B101
     assert result["written"] is False  # nosec B101
     assert result["dry_run"] is True  # nosec B101
-    assert result["sha256_after"] == hashlib.sha256("dry-run\n".encode("utf-8")).hexdigest()  # nosec B101
+    assert result["sha256_after"] == hashlib.sha256(b"dry-run\n").hexdigest()  # nosec B101
 
 
 @pytest.mark.asyncio

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_profile_management.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_profile_management.py
@@ -363,6 +363,38 @@ async def test_create_profile_calls_permission_governor_with_redacted_summary() 
 
 
 @pytest.mark.asyncio
+async def test_create_profile_permission_governor_flags_reserved_path_grant_risks() -> None:
+    governor = RecordingPermissionGovernor()
+    manager = _manager(
+        InMemoryProfileStore(),
+        audit_store=InMemoryAuditStore(),
+        permission_governor=governor,
+    )
+
+    await manager.create_profile(
+        {
+            "id": "custom-exporter",
+            "name": "Custom Exporter",
+            "policy_document": {
+                "path_grants": [
+                    {
+                        "prefix": "docs",
+                        "actions": ["delete", "share", "export", "chmod", "admin", "lock"],
+                    }
+                ],
+            },
+        }
+    )
+
+    request = governor.requests[0]
+    assert "path_grants_changed" in request.risk_flags
+    assert "path_grants_destructive" in request.risk_flags
+    assert "path_grants_exfiltration" in request.risk_flags
+    assert "path_grants_admin" in request.risk_flags
+    assert "path_grants_lock" in request.risk_flags
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "policy_document",
     [

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_path_grant_authoring.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_path_grant_authoring.py
@@ -65,7 +65,7 @@ def test_compile_hierarchical_path_grants_reports_invalid_rules() -> None:
                 {"prefix": "/etc", "actions": ["read"]},
                 {"prefix": "docs/../secrets", "actions": ["read"]},
                 {"prefix": "C:secrets", "actions": ["read"]},
-                {"prefix": "docs", "actions": ["share"]},
+                {"prefix": "docs", "actions": ["destroy"]},
                 {"prefix": "docs", "actions": ["read"], "effect": "prompt"},
             ]
         }
@@ -80,6 +80,51 @@ def test_compile_hierarchical_path_grants_reports_invalid_rules() -> None:
         "invalid_actions",
         "invalid_effect",
     ]
+    assert "share" in result.diagnostics[3]["message"]
+    assert "lock" in result.diagnostics[3]["message"]
+
+
+def test_compile_hierarchical_path_grants_accepts_reserved_file_policy_actions() -> None:
+    from mcp_unified.profiles.path_grants import compile_hierarchical_path_grants
+
+    result = compile_hierarchical_path_grants(
+        {
+            "workspace": [
+                {
+                    "prefix": "documents",
+                    "actions": ["delete", "rename", "move", "share", "export", "chmod", "admin", "lock"],
+                },
+            ],
+            "folders": [
+                {"path": "documents/private", "actions": ["share", "export"], "effect": "deny"},
+            ],
+        }
+    )
+
+    assert result.has_errors is False
+    assert result.path_grants == [
+        {
+            "prefix": "documents",
+            "actions": ["admin", "chmod", "delete", "export", "lock", "move", "rename", "share"],
+            "effect": "allow",
+        },
+        {"prefix": "documents/private", "actions": ["export", "share"], "effect": "deny"},
+    ]
+
+
+def test_path_scope_candidate_accepts_reserved_file_policy_action() -> None:
+    from mcp_unified.interfaces.path_scope import normalize_path_scope_candidate
+
+    candidate = normalize_path_scope_candidate(
+        {
+            "path": "documents/story.md",
+            "action": "lock",
+            "source": "lock_tool",
+        }
+    )
+
+    assert candidate.action == "lock"
+    assert candidate.path == "documents/story.md"
 
 
 def test_compile_policy_path_grants_prefers_explicit_flat_grants() -> None:

--- a/tldw_Server_API/app/services/mcp_hub_path_enforcement_service.py
+++ b/tldw_Server_API/app/services/mcp_hub_path_enforcement_service.py
@@ -304,13 +304,13 @@ def _preview_outcome(enforcement_result: dict[str, Any]) -> str:
 
     if not bool(enforcement_result.get("enabled")):
         return "allow"
-    for decision in _safe_path_decisions(enforcement_result):
-        if decision.get("grant_outcome") in {"denied", "not_granted"}:
-            return "deny"
     if bool(enforcement_result.get("within_scope", True)):
         return "allow"
     if bool(enforcement_result.get("force_approval", False)):
         return "ask"
+    for decision in _safe_path_decisions(enforcement_result):
+        if decision.get("grant_outcome") in {"denied", "not_granted"}:
+            return "deny"
     return "deny"
 
 
@@ -320,7 +320,8 @@ def _safe_path_decisions(enforcement_result: dict[str, Any]) -> list[dict[str, A
     raw_decisions = enforcement_result.get("path_decisions")
     if not isinstance(raw_decisions, list):
         scope_payload = enforcement_result.get("scope_payload")
-        raw_decisions = scope_payload.get("path_decisions") if isinstance(scope_payload, dict) else []
+        scope_decisions = scope_payload.get("path_decisions") if isinstance(scope_payload, dict) else []
+        raw_decisions = scope_decisions if isinstance(scope_decisions, list) else []
     return [dict(decision) for decision in raw_decisions if isinstance(decision, Mapping)]
 
 
@@ -887,7 +888,7 @@ class McpHubPathEnforcementService:
         reason: str,
         path_decisions: list[dict[str, Any]],
         path_grant_diagnostics: list[dict[str, str]] | None = None,
-        force_approval: bool = True,
+        force_approval: bool = False,
     ) -> dict[str, Any]:
         return {
             "enabled": bool(scope.get("enabled")),

--- a/tldw_Server_API/app/services/mcp_hub_path_enforcement_service.py
+++ b/tldw_Server_API/app/services/mcp_hub_path_enforcement_service.py
@@ -5,6 +5,7 @@ from collections.abc import Iterable, Mapping
 from pathlib import Path
 from typing import Any
 
+from mcp_unified.interfaces.file_policy_actions import FILE_POLICY_ACTIONS
 from mcp_unified.interfaces.path_scope import PathScopeCandidate
 from mcp_unified.profiles.path_grants import (
     PathGrantCompilationResult,
@@ -21,7 +22,7 @@ from tldw_Server_API.app.services.mcp_hub_path_scope_service import McpHubPathSc
 from tldw_Server_API.app.services.mcp_hub_workspace_root_resolver import McpHubWorkspaceRootResolver
 
 _FILESYSTEM_CAPABILITIES = frozenset({"filesystem.read", "filesystem.write", "filesystem.delete"})
-_PATH_GRANT_ACTIONS = frozenset({"read", "edit", "write"})
+_PATH_GRANT_ACTIONS = FILE_POLICY_ACTIONS
 _PATH_GRANT_EFFECTS = frozenset({"allow", "deny"})
 _SUPPORTED_PATH_ARGUMENT_HINTS = frozenset(
     {"path", "file_path", "target_path", "cwd", "paths", "file_paths", "files[].path"}
@@ -303,6 +304,9 @@ def _preview_outcome(enforcement_result: dict[str, Any]) -> str:
 
     if not bool(enforcement_result.get("enabled")):
         return "allow"
+    for decision in _safe_path_decisions(enforcement_result):
+        if decision.get("grant_outcome") in {"denied", "not_granted"}:
+            return "deny"
     if bool(enforcement_result.get("within_scope", True)):
         return "allow"
     if bool(enforcement_result.get("force_approval", False)):

--- a/tldw_Server_API/tests/MCP_unified/test_mcp_hub_path_enforcement_service.py
+++ b/tldw_Server_API/tests/MCP_unified/test_mcp_hub_path_enforcement_service.py
@@ -427,6 +427,69 @@ async def test_effective_permission_preview_returns_redacted_path_grant_decision
 
 
 @pytest.mark.asyncio
+async def test_effective_permission_preview_explains_reserved_file_policy_action() -> None:
+    from tldw_Server_API.app.services.mcp_hub_path_enforcement_service import (
+        McpHubPathEnforcementService,
+    )
+
+    svc = McpHubPathEnforcementService(path_scope_service=_FakePathScopeService(_workspace_scope()))
+
+    result = await svc.preview_effective_path_permission(
+        effective_policy={
+            "enabled": True,
+            "policy_document": {
+                "path_scope_mode": "workspace_root",
+                "path_grants": [
+                    {"prefix": "documents", "actions": ["share"]},
+                ],
+            },
+        },
+        context=SimpleNamespace(metadata={}),
+        tool_name="fs.share",
+        action="share",
+        path="documents/story.md",
+    )
+
+    assert result["requested_action"] == "share"
+    assert result["outcome"] == "allow"
+    assert result["grant_outcome"] == "allowed"
+    assert result["matched_grant_prefix"] == "documents"
+    assert result["redacted"] is True
+    assert "/tmp/mcp-hub-path-enforcer" not in repr(result)
+
+
+@pytest.mark.asyncio
+async def test_effective_permission_preview_denies_ungranted_reserved_file_policy_action() -> None:
+    from tldw_Server_API.app.services.mcp_hub_path_enforcement_service import (
+        McpHubPathEnforcementService,
+    )
+
+    svc = McpHubPathEnforcementService(path_scope_service=_FakePathScopeService(_workspace_scope()))
+
+    result = await svc.preview_effective_path_permission(
+        effective_policy={
+            "enabled": True,
+            "policy_document": {
+                "path_scope_mode": "workspace_root",
+                "path_grants": [
+                    {"prefix": "documents", "actions": ["read"]},
+                ],
+            },
+        },
+        context=SimpleNamespace(metadata={}),
+        tool_name="fs.export",
+        action="export",
+        path="documents/story.md",
+    )
+
+    assert result["requested_action"] == "export"
+    assert result["outcome"] == "deny"
+    assert result["reason_code"] == "path_action_not_granted"
+    assert result["grant_outcome"] == "not_granted"
+    assert result["redacted"] is True
+
+
+@pytest.mark.asyncio
 async def test_effective_permission_preview_does_not_guess_profile_for_ambiguous_sources() -> None:
     from tldw_Server_API.app.services.mcp_hub_path_enforcement_service import (
         McpHubPathEnforcementService,

--- a/tldw_Server_API/tests/MCP_unified/test_mcp_hub_path_enforcement_service.py
+++ b/tldw_Server_API/tests/MCP_unified/test_mcp_hub_path_enforcement_service.py
@@ -490,6 +490,33 @@ async def test_effective_permission_preview_denies_ungranted_reserved_file_polic
 
 
 @pytest.mark.asyncio
+async def test_effective_permission_preview_returns_ask_for_force_approval_scope_block() -> None:
+    from tldw_Server_API.app.services.mcp_hub_path_enforcement_service import (
+        McpHubPathEnforcementService,
+    )
+
+    scope = _workspace_scope()
+    scope["workspace_id"] = "ws-1"
+    svc = McpHubPathEnforcementService(path_scope_service=_FakePathScopeService(scope))
+
+    result = await svc.preview_effective_path_permission(
+        effective_policy={
+            "enabled": True,
+            "selected_assignment_workspace_ids": ["ws-2"],
+            "policy_document": {"path_scope_mode": "workspace_root"},
+        },
+        context=SimpleNamespace(metadata={}),
+        tool_name="fs.read",
+        action="read",
+        path="documents/story.md",
+    )
+
+    assert result["outcome"] == "ask"
+    assert result["reason_code"] == "workspace_not_allowed_but_trusted"
+    assert result.get("path_decisions", []) == []
+
+
+@pytest.mark.asyncio
 async def test_effective_permission_preview_does_not_guess_profile_for_ambiguous_sources() -> None:
     from tldw_Server_API.app.services.mcp_hub_path_enforcement_service import (
         McpHubPathEnforcementService,
@@ -581,7 +608,7 @@ async def test_path_grants_deny_overrides_broader_allow_grant() -> None:
 
     assert result["within_scope"] is False
     assert result["reason"] == "path_action_denied"
-    assert result["force_approval"] is True
+    assert result["force_approval"] is False
     assert result["path_decisions"] == [
         {
             "requested_action": "edit",


### PR DESCRIPTION
## Summary
- Add a shared MCP file-policy action taxonomy for read/edit/write plus reserved delete, rename, move, share, export, chmod, admin, and lock actions.
- Wire path grants, path-scope candidates, effective-permission previews, filesystem descriptor metadata, and governance risk flags to the shared action vocabulary.
- Document reserved-action semantics in the package user guide while keeping executable filesystem behavior limited to the current safe read/edit/write tools.

## Test Plan
- [x] `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_file_policy_actions.py tldw_Server_API/app/core/MCP_unified/tests/test_path_grant_authoring.py tldw_Server_API/tests/MCP_unified/test_mcp_hub_path_enforcement_service.py tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_module.py::test_filesystem_tools_include_path_scope_metadata tldw_Server_API/app/core/MCP_unified/tests/test_gateway_profile_management.py::test_create_profile_permission_governor_flags_reserved_path_grant_risks tldw_Server_API/app/core/MCP_unified/tests/test_gateway_profile_management.py::test_create_profile_calls_permission_governor_with_redacted_summary -q`
- [x] `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m ruff check <touched Python files>`
- [x] `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m py_compile <touched Python files>`
- [x] `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r <touched production files> -f json -o /tmp/bandit_mcp_file_policy_action_taxonomy.json`
- [x] `git diff --check`

## Change summary
Human owner should replace or confirm this section before marking the PR merge-ready, per the AI-generated PR policy.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a shared MCP file-policy action taxonomy and routes path grants, path scope, previews, and filesystem tool descriptors through it. Expands policy vocabulary beyond read/edit/write while keeping execution limited to existing safe tools; tightens preview outcomes and preserves original errors during `fs.patch` rollback.

- **New Features**
  - Added `mcp_unified.interfaces.file_policy_actions` with constants and metadata for `read`, `edit`, `write`, `delete`, `rename`, `move`, `share`, `export`, `chmod`, `admin`, `lock` (families, risk, implemented flags).
  - Path grants and path-scope candidates now accept the expanded actions; diagnostics list the allowed set via `format_file_policy_action_list`.
  - Effective-permission preview explains allowed reserved actions and denies ungranted ones as `path_action_not_granted`.
  - Filesystem tool descriptors include `file_policy_action` and `file_policy_action_family` for `fs.read`, `fs.patch`, and `fs.write`.
  - Profile governance flags destructive, exfiltration, admin, and lock grants; docs clarify reserved-action semantics.

- **Bug Fixes**
  - Preview outcome returns deny for denied/not_granted path decisions and ask only for trusted-but-unselected workspaces; blocked grants no longer set `force_approval` by default, and nested `path_decisions` are normalized safely.
  - `fs.patch` rollback now logs unexpected restore failures without masking the original partial-write error.

<sup>Written for commit ebf79e071744427d936ec3cf8fc184b1a2427cad. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2311?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


## Review Fix Validation
- [x] Rebased codex/mcp-file-policy-action-taxonomy on latest origin/dev.
- [x] Addressed Qodo/Gemini review findings for metadata drift handling, preview force-approval semantics, and fs.patch rollback exception safety.
- [x] Focused review regression pytest set: 9 passed.
- [x] Broader touched-scope pytest set: 35 passed.
- [x] Ruff, py_compile, Bandit on touched production files, and git diff --check passed.

## Risk & Rollback
- Risk: Low. Changes are scoped to metadata lookup, path-permission preview classification, and fs.patch rollback error handling with regression coverage.
- Rollback: Revert commits 92892b7121 and ebf79e0717 from this PR branch if unexpected behavior appears.

