### PR TITLE
Implement Workspace cross-resource membership foundation

### DIFF
--- a/Docs/superpowers/plans/2026-06-07-workspace-cross-resource-membership-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-06-07-workspace-cross-resource-membership-implementation-plan.md
@@ -1,0 +1,784 @@
+# Workspace Cross-Resource Membership Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement the first server-backed Workspace cross-resource membership slice for `workspace_note`, `media`, `workspace_source`, `workspace_artifact`, and `chat`.
+
+**Architecture:** Add durable membership persistence to ChaChaNotes, then put a Workspace Core service and fail-closed resource adapter registry above it. Expose workspace-scoped membership routes under `/api/v1/workspaces/{workspace_id}/memberships` and a reverse lookup route under `/api/v1/workspace-memberships/resources/{resource_type}/{resource_id}`. Keep Research Workspace source selection, Project Workspace roots, MCP trust/path policy, ACP, and Sandbox runtime semantics separate.
+
+**Tech Stack:** FastAPI, Pydantic, ChaChaNotes SQLite/PostgreSQL backend abstraction, Media DB read API, pytest, Bandit.
+
+---
+
+## Source Documents
+
+- Spec: `Docs/superpowers/specs/2026-06-07-workspace-cross-resource-membership-design.md`
+- Backlog task: `backlog/tasks/task-2315 - Design-Workspace-cross-resource-membership-foundation.md`
+- Existing Workspace endpoint: `tldw_Server_API/app/api/v1/endpoints/workspaces.py`
+- Existing Workspace schemas: `tldw_Server_API/app/api/v1/schemas/workspace_schemas.py`
+- Existing Workspace Core helpers: `tldw_Server_API/app/core/Workspaces/`
+- Existing Workspace DB methods: `tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py`
+
+## Scope
+
+Implement:
+
+- `workspace_resource_memberships` persistence in ChaChaNotes.
+- Fail-closed adapters for `workspace_note`, `media`, `workspace_source`, `workspace_artifact`, and `chat`.
+- Membership service with link, unlink, get, list-by-workspace, list-by-resource, summary resolution, archived workspace write rejection, restore-after-soft-delete, deterministic ordering, and cursor pagination.
+- API schemas and endpoints.
+- Explicit idempotent backfill helper for existing Workspace sub-resource rows.
+- Compact membership summary in Workspace context.
+
+Do not implement:
+
+- UI adoption.
+- Global `note` adapter.
+- Prompt/workflow/watchlist/ACP/Sandbox/project-file adapters.
+- Automatic startup backfill.
+- MCP trust/path admission changes.
+
+## File Structure
+
+Create:
+
+- `tldw_Server_API/app/core/Workspaces/membership_models.py`
+  Typed dataclasses, constants, cursor helpers, and response payload helpers used by the membership service and tests.
+- `tldw_Server_API/app/core/Workspaces/membership_adapters.py`
+  Adapter protocol, adapter registry, and pilot resource adapters.
+- `tldw_Server_API/app/core/Workspaces/membership_service.py`
+  Workspace-level orchestration for validate/link/unlink/list/resolve/backfill.
+- `tldw_Server_API/app/api/v1/endpoints/workspace_memberships.py`
+  Reverse resource lookup endpoint mounted at `/api/v1/workspace-memberships`.
+- `tldw_Server_API/tests/ChaChaNotesDB/test_workspace_resource_memberships_db.py`
+- `tldw_Server_API/tests/Workspaces/test_workspace_membership_adapters.py`
+- `tldw_Server_API/tests/Workspaces/test_workspace_memberships_api.py`
+- `tldw_Server_API/tests/Workspaces/test_workspace_context_membership_summary.py`
+
+Modify:
+
+- `tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py`
+  Schema ensure path and membership persistence methods.
+- `tldw_Server_API/app/api/v1/schemas/workspace_schemas.py`
+  Membership request/response/list schemas and compact summary schema.
+- `tldw_Server_API/app/api/v1/endpoints/workspaces.py`
+  Workspace-scoped membership routes and context summary integration.
+- `tldw_Server_API/app/api/v1/router_groups/content.py`
+  Register the reverse-lookup router.
+- `tldw_Server_API/app/api/v1/router_groups/minimal.py`
+  Add route key if the minimal route group gates content endpoints by key.
+- `tldw_Server_API/app/core/Workspaces/README.md`
+  Document membership boundaries and extension checklist.
+- `backlog/tasks/task-2315 - Design-Workspace-cross-resource-membership-foundation.md`
+  Track implementation plan path and verification.
+
+## Task 1: Persistence And DB Contract
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py`
+- Test: `tldw_Server_API/tests/ChaChaNotesDB/test_workspace_resource_memberships_db.py`
+
+- [ ] **Step 1: Write failing DB tests**
+
+Create `tldw_Server_API/tests/ChaChaNotesDB/test_workspace_resource_memberships_db.py`.
+
+Cover:
+
+```python
+def test_add_workspace_resource_membership_creates_row(db):
+    row = db.add_workspace_resource_membership("ws-1", {
+        "resource_type": "media",
+        "resource_id": "42",
+        "role": "source",
+        "label": "Paper",
+        "transfer_policy": "link",
+        "provenance": {"source_surface": "library"},
+    }, user_id="1")
+    assert row["workspace_id"] == "ws-1"
+    assert row["resource_type"] == "media"
+    assert row["resource_id"] == "42"
+    assert row["deleted"] in (False, 0)
+```
+
+Also cover:
+
+- duplicate create with identical fields returns existing row.
+- duplicate active row with different role or transfer policy raises `ConflictError`.
+- delete soft-deletes and default list hides it.
+- re-add after soft-delete restores the row after updating role/label/provenance.
+- list order is `updated_at DESC`, `resource_type ASC`, `resource_id ASC`.
+- list-by-resource returns all active workspace memberships for one resource.
+- `delete_workspace` soft-deletes the workspace and does not erase membership history.
+- `hard_delete_workspace`, if covered, removes membership rows through the FK cascade/schema cleanup path.
+- PostgreSQL-like backend errors are wrapped into `CharactersRAGDBError` or `ConflictError` consistently where the existing backend abstraction surfaces `BackendDatabaseError`.
+
+- [ ] **Step 2: Run the DB tests and verify they fail for missing methods**
+
+Run:
+
+```bash
+source .venv/bin/activate
+python -m pytest tldw_Server_API/tests/ChaChaNotesDB/test_workspace_resource_memberships_db.py -q
+```
+
+Expected: fail with missing `add_workspace_resource_membership` or missing table.
+
+- [ ] **Step 3: Add the membership table to SQLite and PostgreSQL ensure paths**
+
+In `CharactersRAGDB._ensure_workspace_subresource_schema_sqlite`, create:
+
+```sql
+CREATE TABLE IF NOT EXISTS workspace_resource_memberships (
+    workspace_id TEXT NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
+    resource_type TEXT NOT NULL,
+    resource_id TEXT NOT NULL,
+    role TEXT NOT NULL DEFAULT 'member',
+    label TEXT,
+    transfer_policy TEXT NOT NULL DEFAULT 'link',
+    provenance_json TEXT NOT NULL DEFAULT '{}',
+    metadata_json TEXT NOT NULL DEFAULT '{}',
+    created_by_user_id TEXT,
+    updated_by_user_id TEXT,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    deleted BOOLEAN NOT NULL DEFAULT 0,
+    client_id TEXT NOT NULL DEFAULT 'unknown',
+    version INTEGER NOT NULL DEFAULT 1,
+    PRIMARY KEY (workspace_id, resource_type, resource_id)
+)
+```
+
+Add indexes:
+
+```sql
+CREATE INDEX IF NOT EXISTS idx_ws_resource_memberships_workspace
+ON workspace_resource_memberships(workspace_id, deleted, resource_type, role);
+
+CREATE INDEX IF NOT EXISTS idx_ws_resource_memberships_resource
+ON workspace_resource_memberships(resource_type, resource_id, deleted);
+
+CREATE INDEX IF NOT EXISTS idx_ws_resource_memberships_updated
+ON workspace_resource_memberships(workspace_id, updated_at);
+```
+
+Mirror these statements in `_ensure_workspace_subresource_schema_postgres` with PostgreSQL boolean/timestamp defaults.
+
+- [ ] **Step 4: Add normalization helpers and public getters for scoped resources**
+
+Add or expose:
+
+```python
+def get_workspace_source(self, workspace_id: str, source_id: str) -> dict[str, Any] | None: ...
+def get_workspace_note(self, workspace_id: str, note_id: int) -> dict[str, Any] | None: ...
+def get_conversation_for_workspace_membership(self, conversation_id: str) -> dict[str, Any] | None: ...
+```
+
+`get_conversation_for_workspace_membership` should return non-deleted conversations and include `id`, `title` if present, `workspace_id`, `scope_type`, `last_modified`, and `version`.
+
+- [ ] **Step 5: Add membership persistence methods**
+
+Add:
+
+```python
+def add_workspace_resource_membership(
+    self,
+    workspace_id: str,
+    data: dict[str, Any],
+    *,
+    user_id: str | None = None,
+) -> dict[str, Any]: ...
+
+def get_workspace_resource_membership(
+    self,
+    workspace_id: str,
+    resource_type: str,
+    resource_id: str,
+    *,
+    include_deleted: bool = False,
+) -> dict[str, Any] | None: ...
+
+def list_workspace_resource_memberships(
+    self,
+    workspace_id: str,
+    *,
+    resource_type: str | None = None,
+    role: str | None = None,
+    include_deleted: bool = False,
+    limit: int = 100,
+    cursor: tuple[str, str, str] | None = None,
+) -> list[dict[str, Any]]: ...
+
+def list_resource_workspace_memberships(
+    self,
+    resource_type: str,
+    resource_id: str,
+    *,
+    include_deleted: bool = False,
+    limit: int = 100,
+    cursor: tuple[str, str] | None = None,
+) -> list[dict[str, Any]]: ...
+
+def delete_workspace_resource_membership(
+    self,
+    workspace_id: str,
+    resource_type: str,
+    resource_id: str,
+    *,
+    user_id: str | None = None,
+) -> dict[str, Any] | None: ...
+```
+
+Implementation rules:
+
+- Normalize `resource_type`, `resource_id`, `role`, and `transfer_policy`.
+- Serialize `provenance` to `provenance_json` and `metadata` to `metadata_json`.
+- Duplicate active rows with matching meaningful fields return existing.
+- Duplicate active rows with conflicts raise `ConflictError(entity="workspace_resource_memberships")`.
+- Duplicate deleted rows restore after the service has already validated resource access. DB method should restore when `data["restore_deleted"]` is true.
+- For workspace-scoped pagination, fetch `limit + 1` rows and apply the cursor predicate matching `ORDER BY updated_at DESC, resource_type ASC, resource_id ASC`:
+  `updated_at < cursor.updated_at OR (updated_at = cursor.updated_at AND resource_type > cursor.resource_type) OR (updated_at = cursor.updated_at AND resource_type = cursor.resource_type AND resource_id > cursor.resource_id)`.
+- For reverse resource pagination, use a deterministic order such as `updated_at DESC, workspace_id ASC` and encode a separate cursor shape rather than reusing the workspace-list cursor.
+- Catch `sqlite3.IntegrityError` and `BackendDatabaseError`. Treat uniqueness/constraint messages as conflict/duplicate paths; wrap unrelated backend errors in `CharactersRAGDBError`.
+
+- [ ] **Step 6: Run DB tests**
+
+Run:
+
+```bash
+source .venv/bin/activate
+python -m pytest tldw_Server_API/tests/ChaChaNotesDB/test_workspace_resource_memberships_db.py -q
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 7: Commit Task 1**
+
+```bash
+git add tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py \
+  tldw_Server_API/tests/ChaChaNotesDB/test_workspace_resource_memberships_db.py
+git commit -m "feat: add workspace resource membership persistence"
+```
+
+## Task 2: Membership Models, Cursors, And API Schemas
+
+**Files:**
+- Create: `tldw_Server_API/app/core/Workspaces/membership_models.py`
+- Modify: `tldw_Server_API/app/api/v1/schemas/workspace_schemas.py`
+- Test: `tldw_Server_API/tests/Workspaces/test_workspace_membership_adapters.py`
+
+- [ ] **Step 1: Write failing model/schema tests**
+
+In `test_workspace_membership_adapters.py`, add small tests for:
+
+- valid cursor round-trip.
+- invalid cursor rejected.
+- request schema rejects unsupported role/transfer policy.
+- bounded provenance/metadata JSON sizes.
+
+- [ ] **Step 2: Run schema tests and verify failure**
+
+```bash
+source .venv/bin/activate
+python -m pytest tldw_Server_API/tests/Workspaces/test_workspace_membership_adapters.py -q
+```
+
+Expected: fail because modules/schemas do not exist.
+
+- [ ] **Step 3: Create `membership_models.py`**
+
+Include constants:
+
+```python
+WORKSPACE_MEMBERSHIP_RESOURCE_TYPES = frozenset({
+    "workspace_note", "media", "workspace_source", "workspace_artifact", "chat",
+})
+WORKSPACE_MEMBERSHIP_FUTURE_RESOURCE_TYPES = frozenset({
+    "note", "prompt", "workflow", "watchlist", "acp_session",
+    "sandbox_session", "project_file", "study_deck", "quiz", "study_pack",
+})
+WORKSPACE_MEMBERSHIP_ROLES = frozenset({
+    "member", "source", "artifact", "conversation", "runtime", "reference",
+})
+WORKSPACE_MEMBERSHIP_TRANSFER_POLICIES = frozenset({"link", "copy", "promote", "import"})
+```
+
+Add dataclasses:
+
+```python
+@dataclass(frozen=True)
+class WorkspaceMembershipCursor:
+    updated_at: str
+    resource_type: str
+    resource_id: str
+
+@dataclass(frozen=True)
+class WorkspaceResourceMembershipCursor:
+    updated_at: str
+    workspace_id: str
+
+@dataclass(frozen=True)
+class WorkspaceResourceRef:
+    resource_type: str
+    resource_id: str
+    title: str | None = None
+    subtitle: str | None = None
+    href: str | None = None
+    updated_at: str | None = None
+    state: str = "available"
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+```
+
+Add `encode_membership_cursor` and `decode_membership_cursor` using base64-url JSON. Invalid cursors should raise `ValueError`.
+Add `encode_resource_membership_cursor` and `decode_resource_membership_cursor` for reverse resource lookup pagination. Do not reuse the workspace-list cursor shape for the reverse route.
+
+- [ ] **Step 4: Add Pydantic schemas**
+
+In `workspace_schemas.py`, add:
+
+```python
+WorkspaceMembershipResourceType = Literal[
+    "workspace_note", "media", "workspace_source", "workspace_artifact", "chat",
+]
+WorkspaceMembershipRole = Literal["member", "source", "artifact", "conversation", "runtime", "reference"]
+WorkspaceMembershipTransferPolicy = Literal["link", "copy", "promote", "import"]
+
+class WorkspaceMembershipCreateRequest(BaseModel): ...
+class WorkspaceMembershipSummaryResponse(BaseModel): ...
+class WorkspaceMembershipResponse(BaseModel): ...
+class WorkspaceMembershipListSummary(BaseModel): ...
+class WorkspaceMembershipListResponse(BaseModel): ...
+class WorkspaceContextMembershipSummary(BaseModel): ...
+```
+
+Add JSON size validation using the existing `_validate_json_size` helper pattern. Use conservative limits:
+
+- provenance: 16 KiB.
+- metadata: 16 KiB.
+
+- [ ] **Step 5: Run schema/model tests**
+
+```bash
+source .venv/bin/activate
+python -m pytest tldw_Server_API/tests/Workspaces/test_workspace_membership_adapters.py -q
+```
+
+Expected: model/schema tests pass. Adapter tests may still be skipped or xfailed until Task 3 if grouped in the same file.
+
+- [ ] **Step 6: Commit Task 2**
+
+```bash
+git add tldw_Server_API/app/core/Workspaces/membership_models.py \
+  tldw_Server_API/app/api/v1/schemas/workspace_schemas.py \
+  tldw_Server_API/tests/Workspaces/test_workspace_membership_adapters.py
+git commit -m "feat: add workspace membership schemas"
+```
+
+## Task 3: Adapter Registry And Membership Service
+
+**Files:**
+- Create: `tldw_Server_API/app/core/Workspaces/membership_adapters.py`
+- Create: `tldw_Server_API/app/core/Workspaces/membership_service.py`
+- Modify: `tldw_Server_API/app/core/Workspaces/__init__.py` if needed
+- Test: `tldw_Server_API/tests/Workspaces/test_workspace_membership_adapters.py`
+
+- [ ] **Step 1: Write failing adapter/service tests**
+
+Cover:
+
+- unsupported resource type fails closed.
+- `workspace_note` validates a scoped note in the same workspace.
+- `workspace_source` validates a source in the same workspace.
+- `workspace_artifact` validates an artifact in the same workspace.
+- `media` validates through `media_db_api.get_media_by_id`.
+- `chat` allows a global conversation or a conversation already scoped to the same workspace, and rejects a conversation scoped to another workspace.
+- archived workspace rejects `link_membership` with code `workspace_archived`.
+- `resolve=false` list returns rows without adapter summaries.
+- adapter read failure during list returns `summary.state = "unresolved"` without failing the whole list.
+
+- [ ] **Step 2: Run adapter tests and verify failure**
+
+```bash
+source .venv/bin/activate
+python -m pytest tldw_Server_API/tests/Workspaces/test_workspace_membership_adapters.py -q
+```
+
+Expected: fail because adapters/service do not exist.
+
+- [ ] **Step 3: Implement adapter protocol and registry**
+
+In `membership_adapters.py`, define:
+
+```python
+class WorkspaceMembershipAdapter(Protocol):
+    resource_type: str
+
+    def validate_access(self, resource_id: str, context: WorkspaceMembershipContext) -> WorkspaceResourceRef: ...
+    def summarize(self, resource_id: str, context: WorkspaceMembershipContext) -> WorkspaceResourceRef: ...
+    def on_link(self, membership: Mapping[str, Any], context: WorkspaceMembershipContext) -> None: ...
+    def on_unlink(self, membership: Mapping[str, Any], context: WorkspaceMembershipContext) -> None: ...
+```
+
+Implement:
+
+- `WorkspaceNoteMembershipAdapter`
+- `WorkspaceSourceMembershipAdapter`
+- `WorkspaceArtifactMembershipAdapter`
+- `MediaMembershipAdapter`
+- `ChatMembershipAdapter`
+
+Add:
+
+```python
+def default_workspace_membership_adapters() -> dict[str, WorkspaceMembershipAdapter]: ...
+def get_workspace_membership_adapter(resource_type: str, adapters: Mapping[str, WorkspaceMembershipAdapter] | None = None) -> WorkspaceMembershipAdapter: ...
+```
+
+- [ ] **Step 4: Implement service errors and service**
+
+In `membership_service.py`, define a local service error similar to `WorkspaceRootServiceError`:
+
+```python
+class WorkspaceMembershipServiceError(Exception):
+    def __init__(self, code: str, message: str, *, status_code: int = 409): ...
+```
+
+Implement:
+
+```python
+class WorkspaceMembershipService:
+    def link_membership(...): ...
+    def get_membership(...): ...
+    def list_workspace_memberships(...): ...
+    def list_resource_memberships(...): ...
+    def unlink_membership(...): ...
+    def backfill_workspace_memberships(...): ...
+    def workspace_membership_summary(...): ...
+```
+
+Service rules:
+
+- `_require_workspace` loads `db.get_workspace(workspace_id)`.
+- If missing, raise `workspace_not_found` with 404.
+- If archived and write operation, raise `workspace_archived` with 409.
+- Link validates adapter before DB insert/restore.
+- Delete calls adapter `on_unlink` after soft-delete.
+- List supports `resolve=false`.
+- Resolved list failures are bounded and do not fail the entire list.
+- Reverse lookup validates adapter support and canonicalizes resource ID before listing.
+
+- [ ] **Step 5: Run adapter/service tests**
+
+```bash
+source .venv/bin/activate
+python -m pytest tldw_Server_API/tests/Workspaces/test_workspace_membership_adapters.py -q
+```
+
+Expected: all adapter/service tests pass.
+
+- [ ] **Step 6: Commit Task 3**
+
+```bash
+git add tldw_Server_API/app/core/Workspaces/membership_adapters.py \
+  tldw_Server_API/app/core/Workspaces/membership_service.py \
+  tldw_Server_API/app/core/Workspaces/__init__.py \
+  tldw_Server_API/tests/Workspaces/test_workspace_membership_adapters.py
+git commit -m "feat: add workspace membership adapters"
+```
+
+## Task 4: Membership API Routes
+
+**Files:**
+- Modify: `tldw_Server_API/app/api/v1/endpoints/workspaces.py`
+- Create: `tldw_Server_API/app/api/v1/endpoints/workspace_memberships.py`
+- Modify: `tldw_Server_API/app/api/v1/router_groups/content.py`
+- Modify: `tldw_Server_API/app/api/v1/router_groups/minimal.py` if route keys require it
+- Test: `tldw_Server_API/tests/Workspaces/test_workspace_memberships_api.py`
+
+- [ ] **Step 1: Write failing API tests**
+
+Create `test_workspace_memberships_api.py` with a local FastAPI app that includes:
+
+```python
+app.include_router(workspaces_endpoint.router, prefix="/api/v1/workspaces")
+app.include_router(workspace_memberships_endpoint.router, prefix="/api/v1/workspace-memberships")
+```
+
+Cover:
+
+- `POST /api/v1/workspaces/{workspace_id}/memberships` creates a membership.
+- duplicate same request returns existing row.
+- duplicate conflicting request returns 409.
+- archived workspace write returns 409 with `workspace_archived`.
+- `GET /api/v1/workspaces/{workspace_id}/memberships` filters by type/role.
+- `DELETE /api/v1/workspaces/{workspace_id}/memberships/{resource_type}/{resource_id}` soft-deletes.
+- re-link after delete restores.
+- `GET /api/v1/workspace-memberships/resources/{resource_type}/{resource_id}` returns current user's workspace memberships.
+- unsupported type returns stable error.
+- missing media DB during `media` link returns service unavailable.
+
+- [ ] **Step 2: Run API tests and verify failure**
+
+```bash
+source .venv/bin/activate
+python -m pytest tldw_Server_API/tests/Workspaces/test_workspace_memberships_api.py -q
+```
+
+Expected: fail because routes do not exist.
+
+- [ ] **Step 3: Add workspace-scoped routes to `workspaces.py`**
+
+Add imports for schemas and `WorkspaceMembershipService`.
+
+Add routes:
+
+```python
+@router.get("/{workspace_id}/memberships", response_model=WorkspaceMembershipListResponse)
+async def list_workspace_memberships(...): ...
+
+@router.post("/{workspace_id}/memberships", response_model=WorkspaceMembershipResponse, status_code=201)
+async def add_workspace_membership(...): ...
+
+@router.get("/{workspace_id}/memberships/{resource_type}/{resource_id}", response_model=WorkspaceMembershipResponse)
+async def get_workspace_membership(...): ...
+
+@router.delete("/{workspace_id}/memberships/{resource_type}/{resource_id}", status_code=204)
+async def delete_workspace_membership(...): ...
+```
+
+Use existing `WORKSPACES_READ_RATE_LIMIT`, `WORKSPACES_WRITE_RATE_LIMIT`, and `WORKSPACES_DELETE_RATE_LIMIT`.
+
+- [ ] **Step 4: Add reverse lookup router**
+
+Create `workspace_memberships.py` with:
+
+```python
+router = APIRouter()
+
+@router.get("/resources/{resource_type}/{resource_id}", response_model=WorkspaceMembershipListResponse)
+async def list_resource_workspace_memberships(...): ...
+```
+
+Use `get_chacha_db_for_user`, `try_get_media_db_for_user`, and `get_request_user`.
+
+- [ ] **Step 5: Register reverse lookup router**
+
+In `router_groups/content.py`, add a route entry:
+
+```python
+RouterSpec(
+    import_path="tldw_Server_API.app.api.v1.endpoints.workspace_memberships",
+    log_name="workspace_memberships",
+    prefix=f"{API_V1_PREFIX}/workspace-memberships",
+    tags=("workspaces",),
+    route_key="workspaces",
+)
+```
+
+Update `minimal.py` only if the current route group requires explicit route-key listings for this endpoint.
+
+- [ ] **Step 6: Run API tests**
+
+```bash
+source .venv/bin/activate
+python -m pytest tldw_Server_API/tests/Workspaces/test_workspace_memberships_api.py -q
+```
+
+Expected: all API tests pass.
+
+- [ ] **Step 7: Commit Task 4**
+
+```bash
+git add tldw_Server_API/app/api/v1/endpoints/workspaces.py \
+  tldw_Server_API/app/api/v1/endpoints/workspace_memberships.py \
+  tldw_Server_API/app/api/v1/router_groups/content.py \
+  tldw_Server_API/app/api/v1/router_groups/minimal.py \
+  tldw_Server_API/tests/Workspaces/test_workspace_memberships_api.py
+git commit -m "feat: expose workspace membership api"
+```
+
+## Task 5: Backfill Helper And Context Summary
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/Workspaces/membership_service.py`
+- Modify: `tldw_Server_API/app/api/v1/schemas/workspace_schemas.py`
+- Modify: `tldw_Server_API/app/api/v1/endpoints/workspaces.py`
+- Test: `tldw_Server_API/tests/Workspaces/test_workspace_context_membership_summary.py`
+
+- [ ] **Step 1: Write failing backfill/context tests**
+
+Cover:
+
+- backfill creates `workspace_source`, `media`, `workspace_artifact`, `workspace_note`, and `chat` memberships from existing rows.
+- backfill is idempotent.
+- unresolved rows produce bounded diagnostics but do not delete or rewrite existing sub-resources.
+- `GET /api/v1/workspaces/{workspace_id}/context` returns compact membership totals without full list.
+- MCP permission/trust fields are not derived from generic membership summary.
+
+- [ ] **Step 2: Run tests and verify failure**
+
+```bash
+source .venv/bin/activate
+python -m pytest tldw_Server_API/tests/Workspaces/test_workspace_context_membership_summary.py -q
+```
+
+Expected: fail because helper/summary do not exist.
+
+- [ ] **Step 3: Implement explicit backfill helper**
+
+In `WorkspaceMembershipService.backfill_workspace_memberships`, read:
+
+- `db.list_workspace_sources(workspace_id)`
+- `db.list_workspace_artifacts(workspace_id)`
+- `db.list_workspace_notes(workspace_id)`
+- workspace-scoped conversations through a new or existing DB helper.
+
+Create memberships:
+
+- `workspace_source` role `source`
+- optional `media` role `source` when `media_id > 0`
+- `workspace_artifact` role `artifact`
+- `workspace_note` role `reference`
+- `chat` role `conversation`
+
+Do not run this automatically on startup or schema ensure.
+
+- [ ] **Step 4: Add compact context summary**
+
+Add `WorkspaceContextMembershipSummary` to `workspace_schemas.py`.
+
+Add `memberships: WorkspaceContextMembershipSummary = Field(default_factory=WorkspaceContextMembershipSummary)` to `WorkspaceContextResponse`.
+
+In `get_workspace_context`, call the service summary method and include:
+
+```json
+{
+  "total": 14,
+  "by_resource_type": {"media": 6, "workspace_note": 4},
+  "by_role": {"source": 6, "reference": 4}
+}
+```
+
+If summary resolution fails, add a partial error with `scope="memberships"` and return empty summary.
+
+- [ ] **Step 5: Run context summary tests**
+
+```bash
+source .venv/bin/activate
+python -m pytest tldw_Server_API/tests/Workspaces/test_workspace_context_membership_summary.py -q
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 6: Commit Task 5**
+
+```bash
+git add tldw_Server_API/app/core/Workspaces/membership_service.py \
+  tldw_Server_API/app/api/v1/schemas/workspace_schemas.py \
+  tldw_Server_API/app/api/v1/endpoints/workspaces.py \
+  tldw_Server_API/tests/Workspaces/test_workspace_context_membership_summary.py
+git commit -m "feat: add workspace membership backfill summary"
+```
+
+## Task 6: Documentation, Regression Suite, And Security
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/Workspaces/README.md`
+- Modify: `backlog/tasks/task-2315 - Design-Workspace-cross-resource-membership-foundation.md`
+
+- [ ] **Step 1: Update Workspaces README**
+
+Add a Membership section that states:
+
+- `workspace_resource_memberships` is association, not ownership transfer.
+- `workspace_sources` remains Research Workspace source selection/readiness.
+- MCP effective permission preview/path admission uses MCP policy/root bindings, not generic membership.
+- Future adapters must validate access through domain adapters.
+
+- [ ] **Step 2: Run focused Python tests**
+
+```bash
+source .venv/bin/activate
+python -m pytest \
+  tldw_Server_API/tests/ChaChaNotesDB/test_workspace_resource_memberships_db.py \
+  tldw_Server_API/tests/Workspaces/test_workspace_membership_adapters.py \
+  tldw_Server_API/tests/Workspaces/test_workspace_memberships_api.py \
+  tldw_Server_API/tests/Workspaces/test_workspace_context_membership_summary.py \
+  tldw_Server_API/tests/Workspaces/test_workspaces_api.py \
+  tldw_Server_API/tests/Workspaces/test_workspace_sub_resources_api.py \
+  tldw_Server_API/tests/MCP_unified/test_mcp_hub_path_enforcement_service.py \
+  -q
+```
+
+Expected: all selected tests pass.
+
+- [ ] **Step 3: Run broader Workspace regression if time allows**
+
+```bash
+source .venv/bin/activate
+python -m pytest tldw_Server_API/tests/Workspaces -q
+```
+
+Expected: pass, or document unrelated failures with exact test names and errors.
+
+- [ ] **Step 4: Run Bandit on touched Python paths**
+
+```bash
+source .venv/bin/activate
+python -m bandit -r \
+  tldw_Server_API/app/core/Workspaces/membership_models.py \
+  tldw_Server_API/app/core/Workspaces/membership_adapters.py \
+  tldw_Server_API/app/core/Workspaces/membership_service.py \
+  tldw_Server_API/app/api/v1/endpoints/workspaces.py \
+  tldw_Server_API/app/api/v1/endpoints/workspace_memberships.py \
+  tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py \
+  -f json -o /tmp/bandit_workspace_memberships.json
+```
+
+Expected: no new findings in touched implementation paths. If Bandit reports existing baseline findings outside the changed membership code, document them and do not silently ignore new findings.
+
+- [ ] **Step 5: Run diff checks**
+
+```bash
+git diff --check
+git status --short --branch
+```
+
+Expected: no whitespace errors; only intended files modified.
+
+- [ ] **Step 6: Update Backlog final summary**
+
+Record:
+
+- implemented DB/API/service/adapters.
+- tests run and results.
+- Bandit result.
+- known skips or blockers.
+
+- [ ] **Step 7: Commit Task 6**
+
+```bash
+git add tldw_Server_API/app/core/Workspaces/README.md \
+  "backlog/tasks/task-2315 - Design-Workspace-cross-resource-membership-foundation.md"
+git commit -m "docs: document workspace membership service"
+```
+
+## Parallelization Notes
+
+After Task 1 lands, Tasks 2 and adapter test scaffolding can be done in parallel. After Task 2 lands, Task 3 adapters can be split by resource type with disjoint ownership:
+
+- Worker A: `workspace_note`, `workspace_source`, `workspace_artifact`.
+- Worker B: `media`, `chat`, adapter registry.
+- Worker C: API tests and schema fixtures.
+
+Do not parallelize edits to `ChaChaNotes_DB.py` unless the DB method surface has already landed. It is large and conflict-prone.
+
+## Implementation Guardrails
+
+- Do not use generic membership to filter global Library/Notes/search.
+- Do not make membership a permission source for MCP tool execution.
+- Do not auto-run backfill during startup.
+- Do not implement global `note` until the adapter can prove access cleanly.
+- Keep `absolute_root`, sandbox mount paths, prompts, model outputs, and file contents out of membership provenance and summaries.
+- Treat unsupported resource types as fail-closed errors.
+- Use `apply_patch` for manual edits.
+- Use TDD: write the failing test first for each task, then implement the narrowest passing change.

--- a/Docs/superpowers/specs/2026-06-07-workspace-cross-resource-membership-design.md
+++ b/Docs/superpowers/specs/2026-06-07-workspace-cross-resource-membership-design.md
@@ -10,7 +10,7 @@ Epic alignment: GitHub issue #1990, Workspace Phase 2 cross-resource membership 
 
 Workspace needs one canonical way to say "this resource belongs in this workspace" without turning `/workspaces` into a global browse/search filter and without collapsing Research Workspace, Project Workspace, MCP trusted roots, ACP execution sessions, and Sandbox roots into the same persistence concept.
 
-This design adds a generic Workspace membership layer over existing domain storage. It lets a workspace gather notes, media/sources, artifacts, chats, prompts, workflows, watchlists, ACP sessions, Sandbox sessions, and future resource types through validated links. The first implementation slice should support existing Workspace notes, global notes where the adapter can verify access, media/sources, artifacts, and chats, then expose adapter contracts for the remaining domains.
+This design adds a generic Workspace membership layer over existing domain storage. It lets a workspace gather notes, media/sources, artifacts, chats, prompts, workflows, watchlists, ACP sessions, Sandbox sessions, and future resource types through validated links. The first implementation slice should support existing Workspace notes, media/sources, artifacts, and chats, then expose adapter contracts for reusable global notes and the remaining domains.
 
 ## Verified Current State
 
@@ -26,6 +26,7 @@ This design adds a generic Workspace membership layer over existing domain stora
 - Root state, source status, service capability, and file inventory are projected on read through `tldw_Server_API/app/core/Workspaces/`.
 - `tldw_Server_API/app/core/Workspaces/README.md` explicitly says source status is a projection, `workspace_id` is canonical identity, and file inventory is metadata-only.
 - `GET /api/v1/workspaces/{workspace_id}/context` is the current read envelope for Workspace UI shell state.
+- Current `origin/dev` includes MCP Hub effective permission preview for path-scope decisions. That preview consumes MCP policy/root bindings and should remain separate from generic Workspace resource membership.
 
 ## Concepts To Keep Separate
 
@@ -87,7 +88,6 @@ Use stable snake-case string resource types. The registry should fail closed for
 
 Initial supported adapters:
 
-- `note`
 - `workspace_note`
 - `media`
 - `workspace_source`
@@ -96,6 +96,7 @@ Initial supported adapters:
 
 Documented adapter contracts for later slices:
 
+- `note`
 - `prompt`
 - `workflow`
 - `watchlist`
@@ -108,7 +109,21 @@ Documented adapter contracts for later slices:
 
 `workspace_source` is included separately from `media` because a source has Research Workspace-specific selection, position, and source readiness. `media` membership means "this Library item is associated with the workspace"; `workspace_source` means "this source row participates in the Research Workspace source set."
 
-`workspace_note` is included separately from `note` because current `workspace_notes` are scoped Workspace sub-resources, not rows in the global `notes` table. `note` membership should point to reusable global notes. The implementation should not map one to the other unless a domain flow explicitly creates a copied or promoted note.
+`workspace_note` is the first note adapter because current `workspace_notes` are scoped Workspace sub-resources, not rows in the global `notes` table. A future `note` adapter should point to reusable global notes after access validation is stable. The implementation should not map one to the other unless a domain flow explicitly creates a copied or promoted note.
+
+### Lifecycle
+
+Membership rows are soft-deleted by default so link history and future audit trails remain recoverable.
+
+`DELETE /memberships/{resource_type}/{resource_id}` should set `deleted=1`, update `updated_at`, update `updated_by_user_id`, and bump `version`. It should be idempotent for an already-deleted row.
+
+`POST /memberships` should handle matching rows as follows:
+
+- Active row with matching meaningful fields: return the existing row.
+- Active row with conflicting role, transfer policy, label, or canonical resource ID: return `409`.
+- Deleted row: validate the backing resource again, restore the same row with `deleted=0`, apply the new request fields, update actor/provenance metadata, and bump `version`.
+
+If the backing resource cannot be validated during restore, the restore must fail with the same not-found, forbidden, or service-unavailable error that a fresh link would return.
 
 ### Roles
 
@@ -244,6 +259,8 @@ List response should support:
 
 Return grouped totals by `resource_type` and `role` for manager and UI badges.
 
+Default list ordering must be deterministic: `updated_at DESC`, then `resource_type ASC`, then `resource_id ASC`. Cursor pagination should encode that ordering tuple, not just an offset, so concurrent inserts do not produce duplicate or skipped records in normal use.
+
 ### Error Contract
 
 Use stable machine-readable errors:
@@ -255,6 +272,7 @@ Use stable machine-readable errors:
 - `workspace_membership_backing_service_unavailable`
 - `workspace_membership_conflict`
 - `workspace_membership_version_mismatch`
+- `workspace_archived`
 
 Duplicate create should be idempotent when all meaningful fields match. If the existing membership has conflicting role, transfer policy, or label, return `409` unless the request explicitly opts into update semantics.
 
@@ -268,13 +286,15 @@ The membership list should be a dedicated read model, not a replacement for `/co
 {
   "memberships": {
     "total": 14,
-    "by_resource_type": {"media": 6, "note": 4, "chat": 2, "workspace_artifact": 2},
+    "by_resource_type": {"media": 6, "workspace_note": 4, "chat": 2, "workspace_artifact": 2},
     "by_role": {"source": 6, "reference": 4, "conversation": 2, "artifact": 2}
   }
 }
 ```
 
 Do not include the full membership list in `/context` by default. That would make the page shell too heavy for power users with many resources.
+
+Membership summaries may help the UI explain what belongs to a Workspace, but they must not drive MCP path-permission decisions. MCP effective permission preview and runtime tool admission should continue to use MCP policy assignments, Workspace Sets, trusted-root bindings, and path-scope enforcement. Generic membership can link an MCP- or runtime-related record for discoverability only after the MCP/ACP/Sandbox adapter exposes a safe summary.
 
 ## Relationship To Existing Workspace Tables
 
@@ -311,6 +331,8 @@ Rules:
 - Public membership summaries must not expose absolute local paths, sandbox internal mount paths, secrets, or hidden runtime payloads.
 - Project file membership should use project-root-relative paths only, once implemented.
 
+Archived Workspaces remain readable for recovery and review. Membership write operations for archived Workspaces should fail with `workspace_archived` unless the request is part of an explicit unarchive/restore flow.
+
 ## Audit And Activity
 
 Membership writes should emit an audit/activity event with:
@@ -337,6 +359,7 @@ Schema migration:
 Operational behavior:
 
 - Unknown resource type fails closed.
+- Archived workspaces reject membership writes with `workspace_archived`.
 - Missing backing DB returns `503` or mapped service-unavailable error only when validation requires it.
 - Partial list resolution should not fail the whole list. Return the membership row with `summary.state='unresolved'` and a bounded reason when one adapter fails during read.
 - Link/write validation must fail if the adapter cannot prove access.
@@ -353,7 +376,7 @@ Deliverables:
 - DB schema for SQLite/PostgreSQL.
 - DB methods with idempotent create, update, soft-delete, list-by-workspace, list-by-resource.
 - Pydantic schemas for request/response/list filters.
-- Unit tests for duplicate create, conflict create, soft-delete, restore, and list indexes.
+- Unit tests for duplicate create, conflict create, soft-delete, restore, archived workspace write rejection, and list indexes.
 
 Parallelizable: DB tests and schema model tests can be written independently.
 
@@ -365,7 +388,7 @@ Deliverables:
 
 - Registry with fail-closed lookup.
 - Pilot adapters for `workspace_note`, `media`, `workspace_source`, `workspace_artifact`, and `chat`.
-- A global `note` adapter if existing global note lookup is stable enough in the first slice; otherwise defer global note membership behind the documented adapter contract while still supporting scoped `workspace_note`.
+- Defer global `note` membership behind the documented adapter contract unless implementation confirms stable global-note access validation without broadening the first slice.
 - Adapter tests for missing/deleted/cross-owner cases.
 
 Parallelizable: Adapter implementation can be split by resource type.
@@ -425,6 +448,8 @@ Behavior to cover:
 - Reject cross-owner/cross-user resource where adapter can detect it.
 - Duplicate same create is idempotent.
 - Duplicate with conflicting role/policy returns `409`.
+- Re-linking a soft-deleted membership restores the row after re-validating the backing resource.
+- Archived workspaces reject membership writes with `workspace_archived`.
 - List by workspace returns grouped counts and stable ordering.
 - List by resource returns all memberships for that resource in the current user's scope.
 - Soft-delete hides memberships by default.
@@ -447,10 +472,11 @@ Security validation:
 | Multi-user ownership gets bolted on later | Require `user_id` in service context and forbid client-supplied owner fields from day one. |
 | Runtime records expose unsafe metadata | ACP/Sandbox adapters are contract-only until safe summaries exist. |
 | Project file membership leaks local paths | Use root-relative IDs and redacted path hints only. |
+| MCP trust becomes confused with membership | Keep MCP permission preview and path admission on MCP policy/root bindings; use membership only for discoverability. |
 
 ## Open Decisions For Implementation Plan
 
-1. Whether global `note` joins the first runtime adapter batch or follows immediately after scoped `workspace_note`.
+1. Whether global `note` follows immediately after scoped `workspace_note` or waits for broader Notes ownership/access cleanup.
 2. Whether membership update should be `PATCH /memberships/{type}/{id}` in Stage 3 or deferred until create/delete/list are stable.
 3. Whether backfill runs automatically during schema ensure or as an explicit maintenance endpoint/job. Recommended: explicit helper/job first to avoid surprising startup work.
 

--- a/Docs/superpowers/specs/2026-06-07-workspace-cross-resource-membership-design.md
+++ b/Docs/superpowers/specs/2026-06-07-workspace-cross-resource-membership-design.md
@@ -1,0 +1,459 @@
+# Workspace Cross-Resource Membership Design
+
+Date: 2026-06-07
+
+Task: `TASK-2315`
+
+Epic alignment: GitHub issue #1990, Workspace Phase 2 cross-resource membership service.
+
+## Purpose
+
+Workspace needs one canonical way to say "this resource belongs in this workspace" without turning `/workspaces` into a global browse/search filter and without collapsing Research Workspace, Project Workspace, MCP trusted roots, ACP execution sessions, and Sandbox roots into the same persistence concept.
+
+This design adds a generic Workspace membership layer over existing domain storage. It lets a workspace gather notes, media/sources, artifacts, chats, prompts, workflows, watchlists, ACP sessions, Sandbox sessions, and future resource types through validated links. The first implementation slice should support existing Workspace notes, global notes where the adapter can verify access, media/sources, artifacts, and chats, then expose adapter contracts for the remaining domains.
+
+## Verified Current State
+
+- Canonical Workspace identity already lives in `workspaces` in `tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py`.
+- Workspace profile is persisted as `workspace_profile` with current values `research` and `project`.
+- Current Research Workspace sub-resources are scoped tables:
+  - `workspace_sources`
+  - `workspace_artifacts`
+  - `workspace_artifact_versions`
+  - `workspace_notes`
+- Conversations already have `scope_type` and `workspace_id`; workspace-scoped chat is not the same thing as generic membership.
+- Project Workspace roots live in `workspace_project_roots`, with `host_local` and `sandbox_volume` backends.
+- Root state, source status, service capability, and file inventory are projected on read through `tldw_Server_API/app/core/Workspaces/`.
+- `tldw_Server_API/app/core/Workspaces/README.md` explicitly says source status is a projection, `workspace_id` is canonical identity, and file inventory is metadata-only.
+- `GET /api/v1/workspaces/{workspace_id}/context` is the current read envelope for Workspace UI shell state.
+
+## Concepts To Keep Separate
+
+| Concept | Owns | Does not own |
+| --- | --- | --- |
+| Workspace identity | `workspace_id`, name, profile, lifecycle, owner scope | Domain-specific content internals |
+| Generic workspace membership | Cross-resource links, roles, labels, provenance, transfer policy | Source ingestion/indexing state, runtime execution state |
+| Research Workspace sources | Selected source set, source ordering, source readiness, grounded research context | Global Library visibility or all media ownership |
+| Project Workspace root | One primary local/sandbox root, file inventory metadata, Git/root health | Arbitrary workspace membership for every file by default |
+| MCP trusted root binding | Tool trust and root exposure for MCP | Canonical workspace identity |
+| ACP/Sandbox runtime session | Execution lineage, runtime state, generated outputs | Workspace membership unless explicitly linked/promoted |
+
+The practical rule: membership is association, not relocation. Adding a note or media item to a workspace must not hide it from global Notes/Library surfaces.
+
+## Recommended Architecture
+
+Use a server-backed generic membership table plus a typed resource adapter registry.
+
+The membership service should live in Workspace Core and use domain adapters to validate each resource before writing a membership row. The database should store only stable association metadata; the richer title/status/preview for each resource should be resolved through adapters at read time or cached as bounded labels for list performance.
+
+This is preferable to adding `workspace_id` columns to every domain table because most workspace relationships are many-to-many over time: a source can appear in multiple research projects, a note can be reused, and an accepted artifact can be copied or linked across projects. It is also simpler than an event/projection-first model for the first slice.
+
+## Data Model
+
+Add `workspace_resource_memberships` to ChaChaNotes.
+
+```sql
+CREATE TABLE IF NOT EXISTS workspace_resource_memberships (
+    workspace_id TEXT NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
+    resource_type TEXT NOT NULL,
+    resource_id TEXT NOT NULL,
+    role TEXT NOT NULL DEFAULT 'member',
+    label TEXT,
+    transfer_policy TEXT NOT NULL DEFAULT 'link',
+    provenance_json TEXT NOT NULL DEFAULT '{}',
+    metadata_json TEXT NOT NULL DEFAULT '{}',
+    created_by_user_id TEXT,
+    updated_by_user_id TEXT,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    deleted BOOLEAN NOT NULL DEFAULT 0,
+    client_id TEXT NOT NULL DEFAULT 'unknown',
+    version INTEGER NOT NULL DEFAULT 1,
+    PRIMARY KEY (workspace_id, resource_type, resource_id)
+);
+```
+
+Recommended indexes:
+
+- `(workspace_id, deleted, resource_type, role)`
+- `(resource_type, resource_id, deleted)`
+- `(workspace_id, updated_at)`
+
+PostgreSQL should use the same shape with `BOOLEAN` defaults and `TIMESTAMP`.
+
+### Resource Types
+
+Use stable snake-case string resource types. The registry should fail closed for unknown types.
+
+Initial supported adapters:
+
+- `note`
+- `workspace_note`
+- `media`
+- `workspace_source`
+- `workspace_artifact`
+- `chat`
+
+Documented adapter contracts for later slices:
+
+- `prompt`
+- `workflow`
+- `watchlist`
+- `acp_session`
+- `sandbox_session`
+- `project_file`
+- `study_deck`
+- `quiz`
+- `study_pack`
+
+`workspace_source` is included separately from `media` because a source has Research Workspace-specific selection, position, and source readiness. `media` membership means "this Library item is associated with the workspace"; `workspace_source` means "this source row participates in the Research Workspace source set."
+
+`workspace_note` is included separately from `note` because current `workspace_notes` are scoped Workspace sub-resources, not rows in the global `notes` table. `note` membership should point to reusable global notes. The implementation should not map one to the other unless a domain flow explicitly creates a copied or promoted note.
+
+### Roles
+
+Use a small generic role set first:
+
+- `member`: Default association.
+- `source`: Resource is evidence or context for research.
+- `artifact`: Resource is a generated or accepted work product.
+- `conversation`: Resource is a chat/session associated with the workspace.
+- `runtime`: Resource is an ACP/Sandbox/MCP runtime record associated with the workspace.
+- `reference`: Resource is related but not part of the active research/query context.
+
+Adapters can expose display grouping independent of role. Do not introduce domain-specific roles like `primary_research_pdf` in the first schema; put that in metadata if needed.
+
+### Transfer Policy
+
+Use explicit policy values:
+
+- `link`: Membership points to an existing resource. Global record remains intact.
+- `copy`: Membership references a workspace-owned copy created by a domain flow.
+- `promote`: Runtime/generated output has been promoted into a workspace-owned resource.
+- `import`: Resource came from migration or external import.
+
+The membership API should not perform copy/import/promotion itself in the first slice. It should record the policy used by the calling domain flow.
+
+### Provenance
+
+`provenance_json` is bounded and safe to expose. It may include:
+
+- `created_by`
+- `source_surface`
+- `source_event_id`
+- `origin_workspace_id`
+- `operation_id`
+- `job_id`
+- `migration_id`
+- `adapter_version`
+
+Do not store file contents, prompt transcripts, model outputs, secrets, absolute root paths, request headers, API keys, or unbounded diagnostics in membership provenance.
+
+## Adapter Contract
+
+Create a Workspace membership adapter interface in `tldw_Server_API/app/core/Workspaces/membership_adapters.py`.
+
+Each adapter should provide:
+
+- `resource_type`: stable string.
+- `validate_access(resource_id, context) -> ResourceRef`: proves existence, owner/user scope, non-deleted state, and visibility.
+- `summarize(resource_id, context) -> ResourceSummary`: label, href, subtype, updated_at, deleted/archived state if available.
+- `on_link(...)`: optional hook for domain side effects after a membership row is created.
+- `on_unlink(...)`: optional hook for domain side effects after a membership row is soft-deleted.
+
+The service context should include:
+
+- `workspace_id`
+- `user_id`
+- `chacha_db`
+- `media_db` when available
+- request metadata for audit/provenance
+
+Adapters own resource ID canonicalization. The membership service should store the canonical `resource_id` returned by the adapter, so clients can pass compatible integer or string IDs without creating duplicate rows for the same resource.
+
+The service must reject:
+
+- Unsupported `resource_type`.
+- Missing or deleted resource.
+- Cross-user/cross-owner resource.
+- Resource types whose backing service is unavailable when validation is required.
+- Attempts to link hidden runtime records before the runtime adapter marks them linkable.
+
+## API Design
+
+Add membership routes under the existing Workspaces API:
+
+```text
+GET    /api/v1/workspaces/{workspace_id}/memberships
+POST   /api/v1/workspaces/{workspace_id}/memberships
+GET    /api/v1/workspaces/{workspace_id}/memberships/{resource_type}/{resource_id}
+DELETE /api/v1/workspaces/{workspace_id}/memberships/{resource_type}/{resource_id}
+GET    /api/v1/workspace-memberships/resources/{resource_type}/{resource_id}
+```
+
+### Request And Response Shape
+
+`POST /workspaces/{workspace_id}/memberships`:
+
+```json
+{
+  "resource_type": "media",
+  "resource_id": "123",
+  "role": "source",
+  "label": "Optional user-facing label",
+  "transfer_policy": "link",
+  "provenance": {
+    "source_surface": "library",
+    "operation_id": "optional"
+  }
+}
+```
+
+Response:
+
+```json
+{
+  "workspace_id": "ws-123",
+  "resource_type": "media",
+  "resource_id": "123",
+  "role": "source",
+  "label": "Paper title",
+  "transfer_policy": "link",
+  "provenance": {},
+  "summary": {
+    "title": "Paper title",
+    "subtitle": "PDF",
+    "href": "/media/123",
+    "updated_at": "2026-06-07T12:00:00Z",
+    "state": "available"
+  },
+  "created_at": "2026-06-07T12:00:00Z",
+  "updated_at": "2026-06-07T12:00:00Z",
+  "version": 1
+}
+```
+
+List response should support:
+
+- `resource_type`
+- `role`
+- `include_deleted=false`
+- `resolve=true`
+- `limit`
+- `cursor`
+
+Return grouped totals by `resource_type` and `role` for manager and UI badges.
+
+### Error Contract
+
+Use stable machine-readable errors:
+
+- `workspace_not_found`
+- `workspace_membership_resource_type_unsupported`
+- `workspace_membership_resource_not_found`
+- `workspace_membership_resource_forbidden`
+- `workspace_membership_backing_service_unavailable`
+- `workspace_membership_conflict`
+- `workspace_membership_version_mismatch`
+
+Duplicate create should be idempotent when all meaningful fields match. If the existing membership has conflicting role, transfer policy, or label, return `409` unless the request explicitly opts into update semantics.
+
+## Read Model
+
+The membership list should be a dedicated read model, not a replacement for `/context`.
+
+`GET /api/v1/workspaces/{workspace_id}/context` may later include a compact membership summary:
+
+```json
+{
+  "memberships": {
+    "total": 14,
+    "by_resource_type": {"media": 6, "note": 4, "chat": 2, "workspace_artifact": 2},
+    "by_role": {"source": 6, "reference": 4, "conversation": 2, "artifact": 2}
+  }
+}
+```
+
+Do not include the full membership list in `/context` by default. That would make the page shell too heavy for power users with many resources.
+
+## Relationship To Existing Workspace Tables
+
+Existing scoped tables stay in place.
+
+- `workspace_sources`: continues to represent Research Workspace source set, ordering, selected state, and ingestion/indexing status projection.
+- `workspace_artifacts`: continues to represent workspace-owned traceable work products and versions.
+- `workspace_notes`: continues to represent workspace-scoped notes created inside the workspace.
+- `conversations.workspace_id`: continues to represent workspace-scoped conversations.
+
+Membership rows can point to these records, but they do not replace them in the first implementation slice.
+
+Recommended initial backfill behavior:
+
+- For each `workspace_sources` row, create a `workspace_source` membership with role `source`.
+- Optionally also create a `media` membership with role `source` when `media_id > 0`, marked with provenance `{"source_surface":"workspace_sources_backfill"}`.
+- For each `workspace_artifacts` row, create a `workspace_artifact` membership with role `artifact`.
+- For each `workspace_notes` row, create a `workspace_note` membership with role `reference`. Do not pretend scoped notes are global notes.
+- For each `conversations` row with `scope_type='workspace'`, create a `chat` membership with role `conversation`.
+
+Backfill must be non-destructive and idempotent. If a resource cannot be resolved, record a bounded diagnostic and skip it; do not rewrite ownership or delete existing rows.
+
+## Ownership And Privacy
+
+In current single-user mode, the per-user database boundary is the main owner boundary. The membership service should still accept `user_id` and treat it as required context so multi-user support does not need an API redesign.
+
+Rules:
+
+- Workspace reads/writes use the existing `get_chacha_db_for_user` and `get_request_user` dependencies.
+- Media validation must use the current user's Media DB.
+- The API never accepts `owner_id` from clients.
+- Membership ownership is derived from the Workspace and adapter-validated backing resource, not from client-supplied membership fields.
+- `created_by_user_id` and `updated_by_user_id` are actor/audit fields; they are not authorization boundaries.
+- Public membership summaries must not expose absolute local paths, sandbox internal mount paths, secrets, or hidden runtime payloads.
+- Project file membership should use project-root-relative paths only, once implemented.
+
+## Audit And Activity
+
+Membership writes should emit an audit/activity event with:
+
+- `workspace_id`
+- `resource_type`
+- `resource_id`
+- `action`: `link`, `unlink`, `restore`, `update`
+- `role`
+- `transfer_policy`
+- `user_id`
+- bounded provenance
+
+If a general audit/activity table is not ready, the first implementation can add a Workspace-local hook interface and log events through existing sync/log primitives. The important part is to keep the service boundary ready for team workspace governance.
+
+## Migration And Failure States
+
+Schema migration:
+
+- Add SQLite and PostgreSQL table creation in the workspace schema ensure path.
+- Add DB methods for create, get, list-by-workspace, list-by-resource, soft-delete, restore/update.
+- Catch SQLite `IntegrityError` and backend `BackendDatabaseError` consistently for duplicate races.
+
+Operational behavior:
+
+- Unknown resource type fails closed.
+- Missing backing DB returns `503` or mapped service-unavailable error only when validation requires it.
+- Partial list resolution should not fail the whole list. Return the membership row with `summary.state='unresolved'` and a bounded reason when one adapter fails during read.
+- Link/write validation must fail if the adapter cannot prove access.
+- Soft-deleted resources should remain as membership rows with `summary.state='deleted'` when `resolve=true`; default list should hide deleted memberships unless requested.
+
+## Implementation Roadmap
+
+### Stage 1: Persistence And Schemas
+
+Goal: Add generic membership persistence and response schemas.
+
+Deliverables:
+
+- DB schema for SQLite/PostgreSQL.
+- DB methods with idempotent create, update, soft-delete, list-by-workspace, list-by-resource.
+- Pydantic schemas for request/response/list filters.
+- Unit tests for duplicate create, conflict create, soft-delete, restore, and list indexes.
+
+Parallelizable: DB tests and schema model tests can be written independently.
+
+### Stage 2: Adapter Registry And Pilot Adapters
+
+Goal: Validate resources through domain adapters before membership writes.
+
+Deliverables:
+
+- Registry with fail-closed lookup.
+- Pilot adapters for `workspace_note`, `media`, `workspace_source`, `workspace_artifact`, and `chat`.
+- A global `note` adapter if existing global note lookup is stable enough in the first slice; otherwise defer global note membership behind the documented adapter contract while still supporting scoped `workspace_note`.
+- Adapter tests for missing/deleted/cross-owner cases.
+
+Parallelizable: Adapter implementation can be split by resource type.
+
+### Stage 3: API Routes
+
+Goal: Expose membership management through Workspaces API.
+
+Deliverables:
+
+- `GET/POST/GET/DELETE /workspaces/{workspace_id}/memberships...`
+- `GET /workspace-memberships/resources/{resource_type}/{resource_id}`
+- Stable error mapping.
+- Integration tests for supported type, unsupported type, idempotent duplicate, conflict duplicate, list grouping, and list-by-resource.
+
+Parallelizable: Endpoint tests can be prepared while adapters are implemented.
+
+### Stage 4: Backfill And Read Summary
+
+Goal: Seed memberships from existing Workspace sub-resource data without destructive reassignment.
+
+Deliverables:
+
+- Idempotent backfill helper for existing scoped Workspace data.
+- Bounded diagnostics for skipped/unresolved rows.
+- Compact membership summary for Workspace context, if needed by UI.
+- Tests proving global browse/search is unaffected.
+
+Parallelizable: Backfill tests and context-summary tests can run independently after Stage 1.
+
+### Stage 5: Future Resource Adapter Contracts
+
+Goal: Make later ACP/Sandbox/MCP/project-file support predictable.
+
+Deliverables:
+
+- Document adapter contracts for `prompt`, `workflow`, `watchlist`, `acp_session`, `sandbox_session`, and `project_file`.
+- Define project-file ID format as `{root_id}:{relative_path_hash}` or equivalent stable root-relative identifier; do not use absolute paths.
+- Define runtime-link policy: ACP/Sandbox sessions are membership-linkable only after their runtime service exposes safe summaries.
+
+Parallelizable: Documentation and future adapter stubs can happen after the registry exists.
+
+## Tests
+
+Focused tests:
+
+- `tldw_Server_API/tests/ChaChaNotesDB/test_workspace_resource_memberships_db.py`
+- `tldw_Server_API/tests/Workspaces/test_workspace_membership_adapters.py`
+- `tldw_Server_API/tests/Workspaces/test_workspace_memberships_api.py`
+- `tldw_Server_API/tests/Workspaces/test_workspace_context_membership_summary.py`
+
+Behavior to cover:
+
+- Create membership for supported resources.
+- Reject unsupported resource type.
+- Reject missing/deleted resource.
+- Reject cross-owner/cross-user resource where adapter can detect it.
+- Duplicate same create is idempotent.
+- Duplicate with conflicting role/policy returns `409`.
+- List by workspace returns grouped counts and stable ordering.
+- List by resource returns all memberships for that resource in the current user's scope.
+- Soft-delete hides memberships by default.
+- Backfill is idempotent and non-destructive.
+- Existing `/workspaces/{workspace_id}/sources`, `/artifacts`, `/notes`, `/context`, and global browse/search tests still pass.
+
+Security validation:
+
+- Run Bandit on touched Python implementation paths once runtime code exists.
+- For this docs-only design slice, Bandit is not applicable.
+
+## Design Risks And Mitigations
+
+| Risk | Mitigation |
+| --- | --- |
+| Membership table becomes a dumping ground | Keep resource adapters strict and fail closed; document supported types. |
+| UI treats workspace membership as global filtering | API copy and tests must state membership does not hide global records. |
+| `workspace_sources` and `media` membership duplicate meaning | Keep both types explicit and document their difference. |
+| Adapter reads make list endpoints slow | Support `resolve=false`, pagination, compact labels, and grouped counts. |
+| Multi-user ownership gets bolted on later | Require `user_id` in service context and forbid client-supplied owner fields from day one. |
+| Runtime records expose unsafe metadata | ACP/Sandbox adapters are contract-only until safe summaries exist. |
+| Project file membership leaks local paths | Use root-relative IDs and redacted path hints only. |
+
+## Open Decisions For Implementation Plan
+
+1. Whether global `note` joins the first runtime adapter batch or follows immediately after scoped `workspace_note`.
+2. Whether membership update should be `PATCH /memberships/{type}/{id}` in Stage 3 or deferred until create/delete/list are stable.
+3. Whether backfill runs automatically during schema ensure or as an explicit maintenance endpoint/job. Recommended: explicit helper/job first to avoid surprising startup work.
+
+## Recommendation
+
+Proceed with the generic membership registry plus adapters. It gives Workspaces a single reusable association model, keeps existing Research Workspace and Project Workspace behavior intact, and leaves enough structure for future MCP/ACP/Sandbox/team governance without overbuilding the first slice.

--- a/backlog/tasks/task-2315 - Design-Workspace-cross-resource-membership-foundation.md
+++ b/backlog/tasks/task-2315 - Design-Workspace-cross-resource-membership-foundation.md
@@ -15,8 +15,10 @@ references:
 - Docs/superpowers/specs/2026-06-04-canonical-workspaces-manager-project-creation-design.md
 documentation:
 - Docs/superpowers/specs/2026-06-07-workspace-cross-resource-membership-design.md
+- Docs/superpowers/plans/2026-06-07-workspace-cross-resource-membership-implementation-plan.md
 modified_files:
 - Docs/superpowers/specs/2026-06-07-workspace-cross-resource-membership-design.md
+- Docs/superpowers/plans/2026-06-07-workspace-cross-resource-membership-implementation-plan.md
 - backlog/tasks/task-2315 - Design-Workspace-cross-resource-membership-foundation.md
 ---
 
@@ -35,6 +37,12 @@ Create a focused design/spec for GitHub issue #1990 cross-resource Workspace mem
 - [ ] #5 Design verification is recorded; Bandit applicability is documented for docs-only scope.
 <!-- AC:END -->
 
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Docs/superpowers/plans/2026-06-07-workspace-cross-resource-membership-implementation-plan.md
+<!-- SECTION:PLAN:END -->
+
 ## Implementation Notes
 
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
@@ -44,7 +52,7 @@ Create a focused design/spec for GitHub issue #1990 cross-resource Workspace mem
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Drafted and reviewed the Workspace cross-resource membership design for GitHub issue #1990. The design recommends a generic server-backed membership table plus fail-closed resource adapters, keeps Research Workspace source selection and Project Workspace root/runtime bindings separate, defines API/read-model/backfill behavior, distinguishes scoped workspace_note from future global note membership, and records a sequential implementation roadmap with parallelizable slices. Follow-up review refinements clarified soft-delete restore semantics, archived workspace write rejection, deterministic cursor ordering, and the boundary between generic membership and MCP effective permission preview/path admission. Verification: git diff --check passed. Bandit is not applicable because this task only changes Markdown design/tracking files.
+Drafted, reviewed, and refined the Workspace cross-resource membership design and implementation plan for GitHub issue #1990. The design recommends a generic server-backed membership table plus fail-closed resource adapters, keeps Research Workspace source selection and Project Workspace root/runtime bindings separate, defines API/read-model/backfill behavior, distinguishes scoped workspace_note from future global note membership, and records a sequential implementation plan with TDD checkpoints and parallelizable slices. Follow-up review refinements clarified soft-delete restore semantics, archived workspace write rejection, deterministic cursor ordering, distinct reverse-lookup cursor shape, and the boundary between generic membership and MCP effective permission preview/path admission. Verification: git diff --check passed for the committed design baseline; final plan verification is recorded in the current planning commit. Bandit is not applicable because this task only changes Markdown design/tracking files.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-2315 - Design-Workspace-cross-resource-membership-foundation.md
+++ b/backlog/tasks/task-2315 - Design-Workspace-cross-resource-membership-foundation.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-2315
 title: Design Workspace cross-resource membership foundation
-status: In Progress
+status: Done
 labels:
 - workspaces
 - project-workspace
@@ -30,11 +30,11 @@ Create a focused design/spec for GitHub issue #1990 cross-resource Workspace mem
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Design defines a canonical membership model covering resource types, owner/user scoping, membership roles, provenance, soft-delete/archive behavior, and global visibility guardrails.
-- [ ] #2 Design distinguishes server-backed membership from Research Workspace source selection, MCP trusted root bindings, ACP execution workspaces, and Sandbox project roots.
-- [ ] #3 Design proposes API/read-model slices and migration/backfill behavior without destructive reassignment of existing resources.
-- [ ] #4 Design includes a sequential implementation roadmap with parallelizable tasks, tests, validation, and failure states.
-- [ ] #5 Design verification is recorded; Bandit applicability is documented for docs-only scope.
+- [x] #1 Design defines a canonical membership model covering resource types, owner/user scoping, membership roles, provenance, soft-delete/archive behavior, and global visibility guardrails.
+- [x] #2 Design distinguishes server-backed membership from Research Workspace source selection, MCP trusted root bindings, ACP execution workspaces, and Sandbox project roots.
+- [x] #3 Design proposes API/read-model slices and migration/backfill behavior without destructive reassignment of existing resources.
+- [x] #4 Design includes a sequential implementation roadmap with parallelizable tasks, tests, validation, and failure states.
+- [x] #5 Design verification is recorded; Bandit applicability is documented for docs-only scope.
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -46,21 +46,22 @@ Docs/superpowers/plans/2026-06-07-workspace-cross-resource-membership-implementa
 ## Implementation Notes
 
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
-
+Design authority lives in `Docs/superpowers/specs/2026-06-07-workspace-cross-resource-membership-design.md`, with the sequential implementation roadmap in `Docs/superpowers/plans/2026-06-07-workspace-cross-resource-membership-implementation-plan.md`. Runtime implementation and verification were intentionally tracked under TASK-2316, not this design task.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
 Drafted, reviewed, and refined the Workspace cross-resource membership design and implementation plan for GitHub issue #1990. The design recommends a generic server-backed membership table plus fail-closed resource adapters, keeps Research Workspace source selection and Project Workspace root/runtime bindings separate, defines API/read-model/backfill behavior, distinguishes scoped workspace_note from future global note membership, and records a sequential implementation plan with TDD checkpoints and parallelizable slices. Follow-up review refinements clarified soft-delete restore semantics, archived workspace write rejection, deterministic cursor ordering, distinct reverse-lookup cursor shape, and the boundary between generic membership and MCP effective permission preview/path admission. Verification: git diff --check passed for the committed design baseline; final plan verification is recorded in the current planning commit. Bandit is not applicable because this task only changes Markdown design/tracking files.
+Implementation proceeded under TASK-2316 after the design artifacts were established; TASK-2315 remains the authoritative design record for that implementation.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->

--- a/backlog/tasks/task-2315 - Design-Workspace-cross-resource-membership-foundation.md
+++ b/backlog/tasks/task-2315 - Design-Workspace-cross-resource-membership-foundation.md
@@ -44,7 +44,7 @@ Create a focused design/spec for GitHub issue #1990 cross-resource Workspace mem
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Drafted the Workspace cross-resource membership design for GitHub issue #1990. The design recommends a generic server-backed membership table plus fail-closed resource adapters, keeps Research Workspace source selection and Project Workspace root/runtime bindings separate, defines API/read-model/backfill behavior, distinguishes scoped workspace_note from global note membership, and records a sequential implementation roadmap with parallelizable slices. Verification: git diff --check passed. Bandit is not applicable because this task only changes Markdown design/tracking files.
+Drafted and reviewed the Workspace cross-resource membership design for GitHub issue #1990. The design recommends a generic server-backed membership table plus fail-closed resource adapters, keeps Research Workspace source selection and Project Workspace root/runtime bindings separate, defines API/read-model/backfill behavior, distinguishes scoped workspace_note from future global note membership, and records a sequential implementation roadmap with parallelizable slices. Follow-up review refinements clarified soft-delete restore semantics, archived workspace write rejection, deterministic cursor ordering, and the boundary between generic membership and MCP effective permission preview/path admission. Verification: git diff --check passed. Bandit is not applicable because this task only changes Markdown design/tracking files.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-2315 - Design-Workspace-cross-resource-membership-foundation.md
+++ b/backlog/tasks/task-2315 - Design-Workspace-cross-resource-membership-foundation.md
@@ -1,0 +1,58 @@
+---
+id: TASK-2315
+title: Design Workspace cross-resource membership foundation
+status: In Progress
+labels:
+- workspaces
+- project-workspace
+- design
+- membership
+priority: high
+references:
+- https://github.com/rmusser01/tldw_server/issues/1990
+- https://github.com/rmusser01/tldw_server/issues/1984
+- Docs/superpowers/specs/2026-06-03-canonical-workspace-core-project-model-design.md
+- Docs/superpowers/specs/2026-06-04-canonical-workspaces-manager-project-creation-design.md
+documentation:
+- Docs/superpowers/specs/2026-06-07-workspace-cross-resource-membership-design.md
+modified_files:
+- Docs/superpowers/specs/2026-06-07-workspace-cross-resource-membership-design.md
+- backlog/tasks/task-2315 - Design-Workspace-cross-resource-membership-foundation.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Create a focused design/spec for GitHub issue #1990 cross-resource Workspace membership. Scope is to define how canonical Workspace identity associates notes, media/sources, artifacts, chats, prompts, files, and future agent/sandbox outputs without making /workspaces a global filter that hides existing records. Produce an implementation-ready design and task roadmap; do not implement runtime code in this task.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Design defines a canonical membership model covering resource types, owner/user scoping, membership roles, provenance, soft-delete/archive behavior, and global visibility guardrails.
+- [ ] #2 Design distinguishes server-backed membership from Research Workspace source selection, MCP trusted root bindings, ACP execution workspaces, and Sandbox project roots.
+- [ ] #3 Design proposes API/read-model slices and migration/backfill behavior without destructive reassignment of existing resources.
+- [ ] #4 Design includes a sequential implementation roadmap with parallelizable tasks, tests, validation, and failure states.
+- [ ] #5 Design verification is recorded; Bandit applicability is documented for docs-only scope.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Drafted the Workspace cross-resource membership design for GitHub issue #1990. The design recommends a generic server-backed membership table plus fail-closed resource adapters, keeps Research Workspace source selection and Project Workspace root/runtime bindings separate, defines API/read-model/backfill behavior, distinguishes scoped workspace_note from global note membership, and records a sequential implementation roadmap with parallelizable slices. Verification: git diff --check passed. Bandit is not applicable because this task only changes Markdown design/tracking files.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-2315 - Design-Workspace-cross-resource-membership-foundation.md
+++ b/backlog/tasks/task-2315 - Design-Workspace-cross-resource-membership-foundation.md
@@ -46,14 +46,14 @@ Docs/superpowers/plans/2026-06-07-workspace-cross-resource-membership-implementa
 ## Implementation Notes
 
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
-Design authority lives in `Docs/superpowers/specs/2026-06-07-workspace-cross-resource-membership-design.md`, with the sequential implementation roadmap in `Docs/superpowers/plans/2026-06-07-workspace-cross-resource-membership-implementation-plan.md`. Runtime implementation and verification were intentionally tracked under TASK-2316, not this design task.
+Design authority lives in `Docs/superpowers/specs/2026-06-07-workspace-cross-resource-membership-design.md`, with the sequential implementation roadmap in `Docs/superpowers/plans/2026-06-07-workspace-cross-resource-membership-implementation-plan.md`. Runtime implementation and verification were intentionally tracked under TASK-2317, not this design task.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
 Drafted, reviewed, and refined the Workspace cross-resource membership design and implementation plan for GitHub issue #1990. The design recommends a generic server-backed membership table plus fail-closed resource adapters, keeps Research Workspace source selection and Project Workspace root/runtime bindings separate, defines API/read-model/backfill behavior, distinguishes scoped workspace_note from future global note membership, and records a sequential implementation plan with TDD checkpoints and parallelizable slices. Follow-up review refinements clarified soft-delete restore semantics, archived workspace write rejection, deterministic cursor ordering, distinct reverse-lookup cursor shape, and the boundary between generic membership and MCP effective permission preview/path admission. Verification: git diff --check passed for the committed design baseline; final plan verification is recorded in the current planning commit. Bandit is not applicable because this task only changes Markdown design/tracking files.
-Implementation proceeded under TASK-2316 after the design artifacts were established; TASK-2315 remains the authoritative design record for that implementation.
+Implementation proceeded under TASK-2317 after the design artifacts were established; TASK-2315 remains the authoritative design record for that implementation.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-2316 - Implement-Workspace-cross-resource-membership-foundation.md
+++ b/backlog/tasks/task-2316 - Implement-Workspace-cross-resource-membership-foundation.md
@@ -131,6 +131,9 @@ Task 4 spec-review fix:
 - Verification: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Workspaces/test_workspace_membership_adapters.py tldw_Server_API/tests/Workspaces/test_workspace_memberships_api.py -q` passed with `66 passed, 6 warnings`.
 - Verification: `git diff --check` passed.
 - Bandit touched-scope scan reported zero findings for `workspace_schemas.py` (`/tmp/bandit_workspace_membership_schema_review_fix.json`).
+Task 4 reviews after follow-up:
+- Spec compliance re-review approved the API routes after the unsupported POST resource-type fix; required prefixes, filters, `resolve=false`, soft-delete/relink, reverse lookup, archived write, and missing media DB behavior remain compliant.
+- Code quality review approved the endpoint implementation and focused tests; no route registration, dependency usage, response model, or error mapping issues were found.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-2316 - Implement-Workspace-cross-resource-membership-foundation.md
+++ b/backlog/tasks/task-2316 - Implement-Workspace-cross-resource-membership-foundation.md
@@ -28,6 +28,7 @@ modified_files:
 - tldw_Server_API/app/api/v1/router_groups/content.py
 - tldw_Server_API/app/api/v1/router_groups/minimal.py
 - tldw_Server_API/tests/Workspaces/test_workspace_memberships_api.py
+- tldw_Server_API/tests/Workspaces/test_workspace_context_membership_summary.py
 ---
 
 ## Description
@@ -40,9 +41,9 @@ Implement the approved first server-backed Workspace cross-resource membership s
 <!-- AC:BEGIN -->
 - [x] #1 ChaChaNotes persists `workspace_resource_memberships` with SQLite/PostgreSQL schema support, idempotent create, conflict handling, soft-delete, restore, deterministic workspace listing, and reverse resource lookup.
 - [x] #2 Workspace membership models, schemas, adapters, service, and API endpoints implement the approved first slice for `workspace_note`, `media`, `workspace_source`, `workspace_artifact`, and `chat`.
-- [ ] #3 Backfill helper is explicit and idempotent; Workspace context exposes compact membership totals without making membership a global Library/Notes/search filter.
-- [ ] #4 MCP permission preview/path admission remains driven by MCP policy/root bindings, not generic membership.
-- [ ] #5 Focused tests and Bandit verification are recorded; known skips or unrelated failures are documented.
+- [x] #3 Backfill helper is explicit and idempotent; Workspace context exposes compact membership totals without making membership a global Library/Notes/search filter.
+- [x] #4 MCP permission preview/path admission remains driven by MCP policy/root bindings, not generic membership.
+- [x] #5 Focused tests and Bandit verification are recorded; known skips or unrelated failures are documented.
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -134,6 +135,18 @@ Task 4 spec-review fix:
 Task 4 reviews after follow-up:
 - Spec compliance re-review approved the API routes after the unsupported POST resource-type fix; required prefixes, filters, `resolve=false`, soft-delete/relink, reverse lookup, archived write, and missing media DB behavior remain compliant.
 - Code quality review approved the endpoint implementation and focused tests; no route registration, dependency usage, response model, or error mapping issues were found.
+
+Task 5 completed by Codex:
+- Added explicit `WorkspaceMembershipService.backfill_workspace_memberships(...)` that reads workspace sources, artifacts, notes, and workspace-scoped conversations through existing helpers, then links candidates via `link_membership(resolve=False)` with stable `workspace_backfill` provenance.
+- Backfill creates `workspace_source`, optional `media`, `workspace_artifact`, `workspace_note`, and `chat` memberships; repeated runs count active duplicates as existing and do not create duplicate rows.
+- Backfill records bounded diagnostics capped at 25 entries with only `resource_type`, `resource_id`, `code`, and safe `message`, continuing without deleting or rewriting sub-resources.
+- Added compact `memberships` totals to `WorkspaceContextResponse` and `GET /api/v1/workspaces/{workspace_id}/context`; membership summary failures return an empty summary plus `partial_errors[{scope: "memberships", code: "membership_summary_unavailable"}]`.
+- Added focused tests for backfill creation, idempotency, bounded unresolved diagnostics, compact context totals without item lists, context summary fallback, and MCP capability/trust separation.
+- TDD red run: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Workspaces/test_workspace_context_membership_summary.py -q` failed with 6 expected failures because backfill returned `not_implemented` and context lacked `memberships`.
+- Verification: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Workspaces/test_workspace_context_membership_summary.py -q` passed with `6 passed, 6 warnings`.
+- Verification: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Workspaces/test_workspace_context_membership_summary.py tldw_Server_API/tests/Workspaces/test_workspace_membership_adapters.py tldw_Server_API/tests/Workspaces/test_workspace_memberships_api.py -q` passed with `72 passed, 6 warnings`.
+- Verification: `git diff --check` passed.
+- Bandit touched runtime scan reported zero findings in `/tmp/bandit_workspace_membership_task5.json`.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-2316 - Implement-Workspace-cross-resource-membership-foundation.md
+++ b/backlog/tasks/task-2316 - Implement-Workspace-cross-resource-membership-foundation.md
@@ -93,6 +93,12 @@ Task 3 spec-review coverage follow-up:
 - Added unlink coverage for successful soft-delete hook invocation and missing/already-deleted no-op behavior.
 - Added reverse lookup fail-closed coverage for unsupported resource types.
 - Verification: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Workspaces/test_workspace_membership_adapters.py -q` passed with `52 passed, 6 warnings`.
+Task 3 code-quality follow-up:
+- Prevented duplicate `on_link` adapter hooks on idempotent active-row retries while preserving create/restore hooks.
+- Made generic summary adapter failures return a safe unresolved message instead of raw exception text.
+- Changed direct `get_membership` to read existing memberships before resource resolution so unavailable backing services produce unresolved summaries instead of hard failures.
+- Verification: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Workspaces/test_workspace_membership_adapters.py -q` passed with `55 passed, 6 warnings`.
+- Bandit touched-scope scan reported zero findings for `membership_service.py`.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-2316 - Implement-Workspace-cross-resource-membership-foundation.md
+++ b/backlog/tasks/task-2316 - Implement-Workspace-cross-resource-membership-foundation.md
@@ -1,0 +1,61 @@
+---
+id: TASK-2316
+title: Implement Workspace cross-resource membership foundation
+status: In Progress
+labels:
+- workspaces
+- project-workspace
+- membership
+- implementation
+priority: high
+references:
+- https://github.com/rmusser01/tldw_server/issues/1990
+- https://github.com/rmusser01/tldw_server/issues/1984
+- Docs/superpowers/specs/2026-06-07-workspace-cross-resource-membership-design.md
+documentation:
+- Docs/superpowers/specs/2026-06-07-workspace-cross-resource-membership-design.md
+- Docs/superpowers/plans/2026-06-07-workspace-cross-resource-membership-implementation-plan.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement the approved first server-backed Workspace cross-resource membership slice. Scope includes ChaChaNotes persistence, fail-closed resource adapters, Workspace Core service, API schemas/endpoints, explicit backfill helper, context summary, tests, docs, and verification. Preserve the boundary that generic membership is association, not ownership transfer, global filtering, or MCP permission/path trust.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 ChaChaNotes persists `workspace_resource_memberships` with SQLite/PostgreSQL schema support, idempotent create, conflict handling, soft-delete, restore, deterministic workspace listing, and reverse resource lookup.
+- [ ] #2 Workspace membership models, schemas, adapters, service, and API endpoints implement the approved first slice for `workspace_note`, `media`, `workspace_source`, `workspace_artifact`, and `chat`.
+- [ ] #3 Backfill helper is explicit and idempotent; Workspace context exposes compact membership totals without making membership a global Library/Notes/search filter.
+- [ ] #4 MCP permission preview/path admission remains driven by MCP policy/root bindings, not generic membership.
+- [ ] #5 Focused tests and Bandit verification are recorded; known skips or unrelated failures are documented.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Docs/superpowers/plans/2026-06-07-workspace-cross-resource-membership-implementation-plan.md
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Execution started with subagent-driven Task 1: persistence and DB contract.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-2316 - Implement-Workspace-cross-resource-membership-foundation.md
+++ b/backlog/tasks/task-2316 - Implement-Workspace-cross-resource-membership-foundation.md
@@ -18,6 +18,9 @@ documentation:
 modified_files:
 - tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py
 - tldw_Server_API/tests/ChaChaNotesDB/test_workspace_resource_memberships_db.py
+- tldw_Server_API/app/core/Workspaces/membership_models.py
+- tldw_Server_API/app/api/v1/schemas/workspace_schemas.py
+- tldw_Server_API/tests/Workspaces/test_workspace_membership_adapters.py
 ---
 
 ## Description
@@ -55,6 +58,7 @@ Task 1 completed and reviewed:
 - Verification: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/ChaChaNotesDB/test_workspace_resource_memberships_db.py -q` passed with `21 passed, 6 warnings`.
 - Verification: `git diff --check 243e0b63c9..924aafeb0a66919201b60b4c19414a399f2b81bf` passed.
 - Worker Bandit touched-scope scan reported zero findings for `ChaChaNotes_DB.py`.
+
 Task 2 completed by Worker 2:
 - Added `membership_models.py` constants, dataclasses, and base64-url JSON cursor helpers for workspace and reverse resource membership pagination.
 - Added Workspace membership request/response/list/context summary schemas with Literal validation and 16 KiB provenance/metadata JSON bounds.
@@ -72,6 +76,8 @@ Task 2 follow-up review fixes:
 Task 2 follow-up self-review update:
 - Added an oversized-cursor regression that monkeypatches base64 decode, proving the length guard runs before decode.
 - Final focused verification after that addition: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Workspaces/test_workspace_membership_adapters.py -q` passed with `34 passed, 6 warnings`.
+- Spec compliance review approved Task 2 after checking constants, dataclasses, cursor helpers, schema literals, bounded JSON validation, response/list/context summaries, and no endpoint/service wiring.
+- Code quality review approved Task 2 after the hardening follow-up and found no remaining model/schema issues.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-2316 - Implement-Workspace-cross-resource-membership-foundation.md
+++ b/backlog/tasks/task-2316 - Implement-Workspace-cross-resource-membership-foundation.md
@@ -155,6 +155,9 @@ Task 5 code-quality follow-up:
 - Verification: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Workspaces/test_workspace_context_membership_summary.py tldw_Server_API/tests/Workspaces/test_workspace_membership_adapters.py tldw_Server_API/tests/Workspaces/test_workspace_memberships_api.py -q` passed with `73 passed, 6 warnings`.
 - Verification: `git diff --check` passed.
 - Bandit touched runtime scan reported zero findings in `/tmp/bandit_workspace_membership_task5_restore_fix.json`.
+Task 5 reviews after follow-up:
+- Spec compliance review approved explicit backfill, compact context totals, partial-error fallback, and the MCP/trust separation boundary.
+- Code quality review approved after the restored-membership accounting fix and focused regression coverage.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-2316 - Implement-Workspace-cross-resource-membership-foundation.md
+++ b/backlog/tasks/task-2316 - Implement-Workspace-cross-resource-membership-foundation.md
@@ -23,6 +23,11 @@ modified_files:
 - tldw_Server_API/app/core/Workspaces/membership_adapters.py
 - tldw_Server_API/app/core/Workspaces/membership_service.py
 - tldw_Server_API/tests/Workspaces/test_workspace_membership_adapters.py
+- tldw_Server_API/app/api/v1/endpoints/workspaces.py
+- tldw_Server_API/app/api/v1/endpoints/workspace_memberships.py
+- tldw_Server_API/app/api/v1/router_groups/content.py
+- tldw_Server_API/app/api/v1/router_groups/minimal.py
+- tldw_Server_API/tests/Workspaces/test_workspace_memberships_api.py
 ---
 
 ## Description
@@ -34,7 +39,7 @@ Implement the approved first server-backed Workspace cross-resource membership s
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
 - [x] #1 ChaChaNotes persists `workspace_resource_memberships` with SQLite/PostgreSQL schema support, idempotent create, conflict handling, soft-delete, restore, deterministic workspace listing, and reverse resource lookup.
-- [ ] #2 Workspace membership models, schemas, adapters, service, and API endpoints implement the approved first slice for `workspace_note`, `media`, `workspace_source`, `workspace_artifact`, and `chat`.
+- [x] #2 Workspace membership models, schemas, adapters, service, and API endpoints implement the approved first slice for `workspace_note`, `media`, `workspace_source`, `workspace_artifact`, and `chat`.
 - [ ] #3 Backfill helper is explicit and idempotent; Workspace context exposes compact membership totals without making membership a global Library/Notes/search filter.
 - [ ] #4 MCP permission preview/path admission remains driven by MCP policy/root bindings, not generic membership.
 - [ ] #5 Focused tests and Bandit verification are recorded; known skips or unrelated failures are documented.
@@ -106,6 +111,17 @@ Task 3 on-link race follow-up:
 - Bandit touched-scope scan reported zero findings for `membership_adapters.py` and `membership_service.py`.
 - Spec compliance review approved Task 3 after coverage follow-up.
 - Code quality review approved Task 3 after the reserved `on_link` correction and found no remaining adapter/service issues.
+
+Task 4 completed by Worker 4:
+- Added Workspace membership API routes under `/api/v1/workspaces/{workspace_id}/memberships` for list, create, get, and soft-delete.
+- Added reverse resource lookup router under `/api/v1/workspace-memberships/resources/{resource_type}/{resource_id}` with the resource-scoped response shape.
+- Registered the reverse router in the content and minimal router groups using the Workspace route gate.
+- Added focused FastAPI endpoint tests for create, idempotent duplicate, conflicting duplicate, archived write rejection, filtered list with `resolve=false`, get/missing get, soft-delete hiding, relink restore, reverse lookup, unsupported resource type, and missing media DB.
+- TDD red run: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Workspaces/test_workspace_memberships_api.py -q --tb=short` failed during collection before `workspace_memberships.py` existed.
+- Verification: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Workspaces/test_workspace_memberships_api.py -q --tb=short` passed with `11 passed, 6 warnings`.
+- Verification: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Workspaces/test_workspace_membership_adapters.py tldw_Server_API/tests/Workspaces/test_workspace_memberships_api.py -q` passed with `66 passed, 6 warnings`.
+- Verification: `git diff --check` passed.
+- Bandit touched-scope scan reported zero findings for `workspaces.py`, `workspace_memberships.py`, and `workspace_schemas.py` (`/tmp/bandit_workspace_memberships_api.json`).
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-2316 - Implement-Workspace-cross-resource-membership-foundation.md
+++ b/backlog/tasks/task-2316 - Implement-Workspace-cross-resource-membership-foundation.md
@@ -55,6 +55,13 @@ Task 1 completed and reviewed:
 - Verification: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/ChaChaNotesDB/test_workspace_resource_memberships_db.py -q` passed with `21 passed, 6 warnings`.
 - Verification: `git diff --check 243e0b63c9..924aafeb0a66919201b60b4c19414a399f2b81bf` passed.
 - Worker Bandit touched-scope scan reported zero findings for `ChaChaNotes_DB.py`.
+Task 2 completed by Worker 2:
+- Added `membership_models.py` constants, dataclasses, and base64-url JSON cursor helpers for workspace and reverse resource membership pagination.
+- Added Workspace membership request/response/list/context summary schemas with Literal validation and 16 KiB provenance/metadata JSON bounds.
+- Added focused model/schema tests in `tldw_Server_API/tests/Workspaces/test_workspace_membership_adapters.py`.
+- Verification: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Workspaces/test_workspace_membership_adapters.py -q` passed with `21 passed, 6 warnings`.
+- Verification: `git diff --check` passed.
+- Bandit touched-scope scan reported zero findings for `membership_models.py` and `workspace_schemas.py`.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-2316 - Implement-Workspace-cross-resource-membership-foundation.md
+++ b/backlog/tasks/task-2316 - Implement-Workspace-cross-resource-membership-foundation.md
@@ -94,7 +94,7 @@ Task 3 spec-review coverage follow-up:
 - Added reverse lookup fail-closed coverage for unsupported resource types.
 - Verification: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Workspaces/test_workspace_membership_adapters.py -q` passed with `52 passed, 6 warnings`.
 Task 3 code-quality follow-up:
-- Prevented duplicate `on_link` adapter hooks on idempotent active-row retries while preserving create/restore hooks.
+- First attempted to gate `on_link` by active-row retries, then replaced that with the final reserved-hook design below after code-quality re-review exposed race and retry ambiguity.
 - Made generic summary adapter failures return a safe unresolved message instead of raw exception text.
 - Changed direct `get_membership` to read existing memberships before resource resolution so unavailable backing services produce unresolved summaries instead of hard failures.
 - Verification: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Workspaces/test_workspace_membership_adapters.py -q` passed with `55 passed, 6 warnings`.
@@ -104,6 +104,8 @@ Task 3 on-link race follow-up:
 - This avoids duplicate side effects under insert/restore races and avoids non-retryable post-commit hook failures until the DB contract or an outbox can report durable transitions.
 - Verification: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Workspaces/test_workspace_membership_adapters.py -q` passed with `55 passed, 6 warnings`.
 - Bandit touched-scope scan reported zero findings for `membership_adapters.py` and `membership_service.py`.
+- Spec compliance review approved Task 3 after coverage follow-up.
+- Code quality review approved Task 3 after the reserved `on_link` correction and found no remaining adapter/service issues.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-2316 - Implement-Workspace-cross-resource-membership-foundation.md
+++ b/backlog/tasks/task-2316 - Implement-Workspace-cross-resource-membership-foundation.md
@@ -28,7 +28,7 @@ Implement the approved first server-backed Workspace cross-resource membership s
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 ChaChaNotes persists `workspace_resource_memberships` with SQLite/PostgreSQL schema support, idempotent create, conflict handling, soft-delete, restore, deterministic workspace listing, and reverse resource lookup.
+- [x] #1 ChaChaNotes persists `workspace_resource_memberships` with SQLite/PostgreSQL schema support, idempotent create, conflict handling, soft-delete, restore, deterministic workspace listing, and reverse resource lookup.
 - [ ] #2 Workspace membership models, schemas, adapters, service, and API endpoints implement the approved first slice for `workspace_note`, `media`, `workspace_source`, `workspace_artifact`, and `chat`.
 - [ ] #3 Backfill helper is explicit and idempotent; Workspace context exposes compact membership totals without making membership a global Library/Notes/search filter.
 - [ ] #4 MCP permission preview/path admission remains driven by MCP policy/root bindings, not generic membership.
@@ -45,6 +45,16 @@ Docs/superpowers/plans/2026-06-07-workspace-cross-resource-membership-implementa
 
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
 Execution started with subagent-driven Task 1: persistence and DB contract.
+
+Task 1 completed and reviewed:
+- `f215366949` added `workspace_resource_memberships` persistence and focused DB tests.
+- `227a54fa83` fixed `limit + 1` pagination behavior and added missing delete/backend-error coverage.
+- `924aafeb0a` made restore/delete state transitions race-idempotent with state-predicated updates and rowcount handling.
+- Spec compliance review approved the DB contract after follow-up.
+- Code quality review approved the concurrency fix and found no remaining Task 1 issues.
+- Verification: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/ChaChaNotesDB/test_workspace_resource_memberships_db.py -q` passed with `21 passed, 6 warnings`.
+- Verification: `git diff --check 243e0b63c9..924aafeb0a66919201b60b4c19414a399f2b81bf` passed.
+- Worker Bandit touched-scope scan reported zero findings for `ChaChaNotes_DB.py`.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-2316 - Implement-Workspace-cross-resource-membership-foundation.md
+++ b/backlog/tasks/task-2316 - Implement-Workspace-cross-resource-membership-foundation.md
@@ -147,6 +147,14 @@ Task 5 completed by Codex:
 - Verification: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Workspaces/test_workspace_context_membership_summary.py tldw_Server_API/tests/Workspaces/test_workspace_membership_adapters.py tldw_Server_API/tests/Workspaces/test_workspace_memberships_api.py -q` passed with `72 passed, 6 warnings`.
 - Verification: `git diff --check` passed.
 - Bandit touched runtime scan reported zero findings in `/tmp/bandit_workspace_membership_task5.json`.
+Task 5 code-quality follow-up:
+- Fixed backfill accounting for soft-deleted membership restores by reading pre-link rows with `include_deleted=True`, classifying active existing rows separately from deleted rows, and returning a distinct `restored` count.
+- Updated the focused fake DB to model restore behavior and added regression coverage proving restored rows are not reported as newly created.
+- TDD red run: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Workspaces/test_workspace_context_membership_summary.py -q` failed with expected missing `restored` keys and `created == 5` instead of `4` for a restored row.
+- Verification: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Workspaces/test_workspace_context_membership_summary.py -q` passed with `7 passed, 6 warnings`.
+- Verification: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Workspaces/test_workspace_context_membership_summary.py tldw_Server_API/tests/Workspaces/test_workspace_membership_adapters.py tldw_Server_API/tests/Workspaces/test_workspace_memberships_api.py -q` passed with `73 passed, 6 warnings`.
+- Verification: `git diff --check` passed.
+- Bandit touched runtime scan reported zero findings in `/tmp/bandit_workspace_membership_task5_restore_fix.json`.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-2316 - Implement-Workspace-cross-resource-membership-foundation.md
+++ b/backlog/tasks/task-2316 - Implement-Workspace-cross-resource-membership-foundation.md
@@ -88,6 +88,11 @@ Task 3 completed by Worker 3:
 - Verification: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Workspaces/test_workspace_membership_adapters.py -q` passed with `48 passed, 6 warnings`.
 - Verification: `git diff --check` passed.
 - Bandit touched-scope scan reported zero findings for `membership_adapters.py` and `membership_service.py`.
+Task 3 spec-review coverage follow-up:
+- Added missing-workspace service coverage for `workspace_not_found` / 404.
+- Added unlink coverage for successful soft-delete hook invocation and missing/already-deleted no-op behavior.
+- Added reverse lookup fail-closed coverage for unsupported resource types.
+- Verification: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Workspaces/test_workspace_membership_adapters.py -q` passed with `52 passed, 6 warnings`.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-2316 - Implement-Workspace-cross-resource-membership-foundation.md
+++ b/backlog/tasks/task-2316 - Implement-Workspace-cross-resource-membership-foundation.md
@@ -117,11 +117,11 @@ Task 4 completed by Worker 4:
 - Added reverse resource lookup router under `/api/v1/workspace-memberships/resources/{resource_type}/{resource_id}` with the resource-scoped response shape.
 - Registered the reverse router in the content and minimal router groups using the Workspace route gate.
 - Added focused FastAPI endpoint tests for create, idempotent duplicate, conflicting duplicate, archived write rejection, filtered list with `resolve=false`, get/missing get, soft-delete hiding, relink restore, reverse lookup, unsupported resource type, and missing media DB.
-- TDD red run: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Workspaces/test_workspace_memberships_api.py -q --tb=short` failed during collection before `workspace_memberships.py` existed.
-- Verification: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Workspaces/test_workspace_memberships_api.py -q --tb=short` passed with `11 passed, 6 warnings`.
-- Verification: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Workspaces/test_workspace_membership_adapters.py tldw_Server_API/tests/Workspaces/test_workspace_memberships_api.py -q` passed with `66 passed, 6 warnings`.
+- TDD red run: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Workspaces/test_workspace_memberships_api.py -q` failed with `11 failed` because the membership routes returned `404`.
+- Verification: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Workspaces/test_workspace_memberships_api.py -q` passed with `11 passed, 6 warnings`.
+- Verification: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Workspaces/test_workspace_membership_adapters.py -q` passed with `55 passed, 6 warnings`.
 - Verification: `git diff --check` passed.
-- Bandit touched-scope scan reported zero findings for `workspaces.py`, `workspace_memberships.py`, and `workspace_schemas.py` (`/tmp/bandit_workspace_memberships_api.json`).
+- Bandit touched-scope scan reported zero findings for `workspaces.py`, `workspace_memberships.py`, and `workspace_schemas.py` (`/tmp/bandit_workspace_membership_api_task2316.json`).
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-2316 - Implement-Workspace-cross-resource-membership-foundation.md
+++ b/backlog/tasks/task-2316 - Implement-Workspace-cross-resource-membership-foundation.md
@@ -99,6 +99,11 @@ Task 3 code-quality follow-up:
 - Changed direct `get_membership` to read existing memberships before resource resolution so unavailable backing services produce unresolved summaries instead of hard failures.
 - Verification: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Workspaces/test_workspace_membership_adapters.py -q` passed with `55 passed, 6 warnings`.
 - Bandit touched-scope scan reported zero findings for `membership_service.py`.
+Task 3 on-link race follow-up:
+- Reserved `on_link` as a future transition-aware adapter hook and stopped invoking it from first-slice `link_membership`.
+- This avoids duplicate side effects under insert/restore races and avoids non-retryable post-commit hook failures until the DB contract or an outbox can report durable transitions.
+- Verification: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Workspaces/test_workspace_membership_adapters.py -q` passed with `55 passed, 6 warnings`.
+- Bandit touched-scope scan reported zero findings for `membership_adapters.py` and `membership_service.py`.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-2316 - Implement-Workspace-cross-resource-membership-foundation.md
+++ b/backlog/tasks/task-2316 - Implement-Workspace-cross-resource-membership-foundation.md
@@ -15,6 +15,9 @@ references:
 documentation:
 - Docs/superpowers/specs/2026-06-07-workspace-cross-resource-membership-design.md
 - Docs/superpowers/plans/2026-06-07-workspace-cross-resource-membership-implementation-plan.md
+modified_files:
+- tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py
+- tldw_Server_API/tests/ChaChaNotesDB/test_workspace_resource_memberships_db.py
 ---
 
 ## Description

--- a/backlog/tasks/task-2316 - Implement-Workspace-cross-resource-membership-foundation.md
+++ b/backlog/tasks/task-2316 - Implement-Workspace-cross-resource-membership-foundation.md
@@ -20,6 +20,8 @@ modified_files:
 - tldw_Server_API/tests/ChaChaNotesDB/test_workspace_resource_memberships_db.py
 - tldw_Server_API/app/core/Workspaces/membership_models.py
 - tldw_Server_API/app/api/v1/schemas/workspace_schemas.py
+- tldw_Server_API/app/core/Workspaces/membership_adapters.py
+- tldw_Server_API/app/core/Workspaces/membership_service.py
 - tldw_Server_API/tests/Workspaces/test_workspace_membership_adapters.py
 ---
 
@@ -78,6 +80,14 @@ Task 2 follow-up self-review update:
 - Final focused verification after that addition: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Workspaces/test_workspace_membership_adapters.py -q` passed with `34 passed, 6 warnings`.
 - Spec compliance review approved Task 2 after checking constants, dataclasses, cursor helpers, schema literals, bounded JSON validation, response/list/context summaries, and no endpoint/service wiring.
 - Code quality review approved Task 2 after the hardening follow-up and found no remaining model/schema issues.
+
+Task 3 completed by Worker 3:
+- Added fail-closed Workspace membership adapters for `workspace_note`, `workspace_source`, `workspace_artifact`, `media`, and `chat`.
+- Added `WorkspaceMembershipService` with link/get/list/reverse-list/unlink/summary orchestration, archived write rejection, restore-after-soft-delete, cursor payloads, and unresolved per-row summaries for adapter read failures.
+- Added focused adapter/service tests to `tldw_Server_API/tests/Workspaces/test_workspace_membership_adapters.py`.
+- Verification: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Workspaces/test_workspace_membership_adapters.py -q` passed with `48 passed, 6 warnings`.
+- Verification: `git diff --check` passed.
+- Bandit touched-scope scan reported zero findings for `membership_adapters.py` and `membership_service.py`.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-2316 - Implement-Workspace-cross-resource-membership-foundation.md
+++ b/backlog/tasks/task-2316 - Implement-Workspace-cross-resource-membership-foundation.md
@@ -62,6 +62,16 @@ Task 2 completed by Worker 2:
 - Verification: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Workspaces/test_workspace_membership_adapters.py -q` passed with `21 passed, 6 warnings`.
 - Verification: `git diff --check` passed.
 - Bandit touched-scope scan reported zero findings for `membership_models.py` and `workspace_schemas.py`.
+Task 2 follow-up review fixes:
+- Rejected non-finite floats in membership provenance/metadata by making schema JSON sizing use strict JSON serialization (`allow_nan=False`).
+- Added a 2048-character encoded cursor cap before base64 decode and exact integer cursor-version validation for both cursor shapes.
+- Added regression coverage for NaN/Infinity metadata/provenance, oversized cursors, and boolean/float cursor versions.
+- Verification: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Workspaces/test_workspace_membership_adapters.py -q` passed with `33 passed, 6 warnings`.
+- Verification: `git diff --check` passed.
+- Bandit touched-scope scan reported zero findings for `membership_models.py` and `workspace_schemas.py`.
+Task 2 follow-up self-review update:
+- Added an oversized-cursor regression that monkeypatches base64 decode, proving the length guard runs before decode.
+- Final focused verification after that addition: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Workspaces/test_workspace_membership_adapters.py -q` passed with `34 passed, 6 warnings`.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-2316 - Implement-Workspace-cross-resource-membership-foundation.md
+++ b/backlog/tasks/task-2316 - Implement-Workspace-cross-resource-membership-foundation.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-2316
 title: Implement Workspace cross-resource membership foundation
-status: In Progress
+status: Done
 labels:
 - workspaces
 - project-workspace
@@ -29,6 +29,9 @@ modified_files:
 - tldw_Server_API/app/api/v1/router_groups/minimal.py
 - tldw_Server_API/tests/Workspaces/test_workspace_memberships_api.py
 - tldw_Server_API/tests/Workspaces/test_workspace_context_membership_summary.py
+- tldw_Server_API/app/core/Workspaces/README.md
+- backlog/tasks/task-2315 - Design-Workspace-cross-resource-membership-foundation.md
+- backlog/tasks/task-2316 - Implement-Workspace-cross-resource-membership-foundation.md
 ---
 
 ## Description
@@ -163,15 +166,26 @@ Task 5 reviews after follow-up:
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Implemented the first server-backed Workspace cross-resource membership foundation under the design in TASK-2315. The implementation added ChaChaNotes `workspace_resource_memberships` persistence, typed membership/cursor models, fail-closed adapters for `workspace_note`, `media`, `workspace_source`, `workspace_artifact`, and `chat`, Workspace membership service orchestration, workspace-scoped and reverse resource lookup API routes, explicit idempotent backfill, and compact Workspace context membership totals while preserving the boundary that membership is association rather than ownership transfer, global filtering, or MCP trust/path admission.
 
+Task 6 documented the membership boundary in `tldw_Server_API/app/core/Workspaces/README.md`, including `workspace_sources` as Research Workspace source selection/readiness, MCP permission/path admission as MCP policy/root binding-owned, future adapter validation through domain adapters, and explicit non-automatic backfill.
+
+Final verification on 2026-06-07:
+- Focused selected suite: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/ChaChaNotesDB/test_workspace_resource_memberships_db.py tldw_Server_API/tests/Workspaces/test_workspace_membership_adapters.py tldw_Server_API/tests/Workspaces/test_workspace_memberships_api.py tldw_Server_API/tests/Workspaces/test_workspace_context_membership_summary.py tldw_Server_API/tests/Workspaces/test_workspaces_api.py tldw_Server_API/tests/Workspaces/test_workspace_sub_resources_api.py tldw_Server_API/tests/MCP_unified/test_mcp_hub_path_enforcement_service.py -q` passed with `194 passed, 6 warnings`.
+- Broader Workspace regression: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Workspaces -q` passed with `370 passed, 8 warnings`.
+- Bandit touched Python paths: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/core/Workspaces/membership_models.py tldw_Server_API/app/core/Workspaces/membership_adapters.py tldw_Server_API/app/core/Workspaces/membership_service.py tldw_Server_API/app/api/v1/endpoints/workspaces.py tldw_Server_API/app/api/v1/endpoints/workspace_memberships.py tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py -f json -o /tmp/bandit_workspace_memberships.json` exited 0 with zero findings. The JSON summary reported `results: 0` and `skipped_tests: 76` from existing `# nosec` suppressions in scanned files.
+- `git diff --check` passed.
+- `git status --short --branch` before Backlog finalization showed only the intended README edit; final status is recorded in the closing commit.
+
+Known skips/blockers: none. The broader Workspace regression was run and passed, so there are no unrelated Workspace failures to record for this task.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->

--- a/backlog/tasks/task-2316 - Implement-Workspace-cross-resource-membership-foundation.md
+++ b/backlog/tasks/task-2316 - Implement-Workspace-cross-resource-membership-foundation.md
@@ -122,6 +122,15 @@ Task 4 completed by Worker 4:
 - Verification: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Workspaces/test_workspace_membership_adapters.py -q` passed with `55 passed, 6 warnings`.
 - Verification: `git diff --check` passed.
 - Bandit touched-scope scan reported zero findings for `workspaces.py`, `workspace_memberships.py`, and `workspace_schemas.py` (`/tmp/bandit_workspace_membership_api_task2316.json`).
+Task 4 spec-review fix:
+- Fixed unsupported POST resource types reaching FastAPI/Pydantic literal validation before the service by changing `WorkspaceMembershipCreateRequest.resource_type` to a raw non-empty string while keeping response schemas typed.
+- Added POST regression coverage for `resource_type="note"` returning `400` with `detail.code == "unsupported_resource_type"`.
+- Updated the older schema unit expectation so role/transfer-policy literals remain schema-owned while create `resource_type` validation is service-owned.
+- TDD red run: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Workspaces/test_workspace_memberships_api.py::test_post_unsupported_resource_type_returns_stable_400_code -q --tb=short` failed with `assert 422 == 400`.
+- Verification: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Workspaces/test_workspace_memberships_api.py -q` passed with `12 passed, 6 warnings`.
+- Verification: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Workspaces/test_workspace_membership_adapters.py tldw_Server_API/tests/Workspaces/test_workspace_memberships_api.py -q` passed with `66 passed, 6 warnings`.
+- Verification: `git diff --check` passed.
+- Bandit touched-scope scan reported zero findings for `workspace_schemas.py` (`/tmp/bandit_workspace_membership_schema_review_fix.json`).
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-2317 - Implement-Workspace-cross-resource-membership-foundation.md
+++ b/backlog/tasks/task-2317 - Implement-Workspace-cross-resource-membership-foundation.md
@@ -17,11 +17,14 @@ documentation:
 - Docs/superpowers/plans/2026-06-07-workspace-cross-resource-membership-implementation-plan.md
 modified_files:
 - tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py
+- tldw_Server_API/app/core/DB_Management/backends/pg_rls_policies.py
 - tldw_Server_API/tests/ChaChaNotesDB/test_workspace_resource_memberships_db.py
+- tldw_Server_API/tests/DB_Management/test_pg_rls_policies_contract.py
 - tldw_Server_API/app/core/Workspaces/membership_models.py
 - tldw_Server_API/app/api/v1/schemas/workspace_schemas.py
 - tldw_Server_API/app/core/Workspaces/membership_adapters.py
 - tldw_Server_API/app/core/Workspaces/membership_service.py
+- tldw_Server_API/app/core/exceptions.py
 - tldw_Server_API/tests/Workspaces/test_workspace_membership_adapters.py
 - tldw_Server_API/app/api/v1/endpoints/workspaces.py
 - tldw_Server_API/app/api/v1/endpoints/workspace_memberships.py
@@ -166,17 +169,7 @@ Task 5 reviews after follow-up:
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Implemented the first server-backed Workspace cross-resource membership foundation under the design in TASK-2315 and remediated the pre-merge review feedback on PR #2312. The PR branch was rebased onto current origin/dev, removing the stale Knowledge QA/RAG trust files from the comparison. The implementation task was renumbered from the colliding TASK-2316 to TASK-2317 so dev's existing PR #2309 task remains canonical.
-
-Review remediation added shared strict membership JSON normalization in `membership_models.py` and routed membership provenance/metadata validation through it from API schemas, WorkspaceMembershipService, and ChaChaNotes DB writes. Direct service and DB callers now reject non-finite JSON values and 16 KiB-plus provenance/metadata before adapter validation or durable writes. Existing linked resources that later become deleted/trash/archived now summarize truthfully through deleted-inclusive adapter summary reads while `validate_access` remains active-record-only and fail-closed for new links.
-
-Final verification on 2026-06-07:
-- Focused regression: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Workspaces/test_workspace_membership_adapters.py tldw_Server_API/tests/ChaChaNotesDB/test_workspace_resource_memberships_db.py -q` passed with `96 passed, 6 warnings`.
-- Broader Workspace regression: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Workspaces tldw_Server_API/tests/ChaChaNotesDB/test_workspace_resource_memberships_db.py -q` passed with `412 passed, 8 warnings`.
-- Bandit touched Python paths: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/core/Workspaces/membership_models.py tldw_Server_API/app/core/Workspaces/membership_adapters.py tldw_Server_API/app/core/Workspaces/membership_service.py tldw_Server_API/app/api/v1/schemas/workspace_schemas.py tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py tldw_Server_API/app/api/v1/endpoints/workspaces.py tldw_Server_API/app/api/v1/endpoints/workspace_memberships.py -f json -o /tmp/bandit_workspace_membership_pr_review.json` exited 0 with `results: 0`.
-- `git diff --check` passed.
-
-Known skips/blockers: none in the exercised Workspace membership scope.
+Implemented PR #2312 review remediation after confirming the branch was already rebased onto current origin/dev (a9c0f9d228b481e7ed2e871aa466bd6aa18d378f). Changes moved Workspace membership service/adapter errors into core.exceptions, added docstrings for membership cursor/model helpers, changed list endpoints to default resolve=false while leaving create/get resolved, made workspace context membership summaries use a DB aggregate instead of paged row scans, made backfill fail fast for archived workspaces before candidate collection, made cursor tuple handling fail closed for unsupported cursor objects and malformed cursor parts, redacted malformed membership JSON logs, made chat membership deleted predicates backend-aware, added best-effort unlink hook handling after soft-delete, and added ChaCha Postgres RLS coverage/policy for workspace_resource_memberships. Verification on 2026-06-07: focused suite passed with 137 passed, 6 warnings; broader Workspace/DB/RLS suite passed with 434 passed, 8 warnings; git diff --check passed; Bandit touched Python scope exited 0 with results length 0 in /tmp/bandit_workspace_membership_pr2312_review2.json. Known blockers: none in the exercised Workspace membership scope.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-2317 - Implement-Workspace-cross-resource-membership-foundation.md
+++ b/backlog/tasks/task-2317 - Implement-Workspace-cross-resource-membership-foundation.md
@@ -1,5 +1,5 @@
 ---
-id: TASK-2316
+id: TASK-2317
 title: Implement Workspace cross-resource membership foundation
 status: Done
 labels:
@@ -31,7 +31,7 @@ modified_files:
 - tldw_Server_API/tests/Workspaces/test_workspace_context_membership_summary.py
 - tldw_Server_API/app/core/Workspaces/README.md
 - backlog/tasks/task-2315 - Design-Workspace-cross-resource-membership-foundation.md
-- backlog/tasks/task-2316 - Implement-Workspace-cross-resource-membership-foundation.md
+- backlog/tasks/task-2317 - Implement-Workspace-cross-resource-membership-foundation.md
 ---
 
 ## Description
@@ -125,7 +125,7 @@ Task 4 completed by Worker 4:
 - Verification: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Workspaces/test_workspace_memberships_api.py -q` passed with `11 passed, 6 warnings`.
 - Verification: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Workspaces/test_workspace_membership_adapters.py -q` passed with `55 passed, 6 warnings`.
 - Verification: `git diff --check` passed.
-- Bandit touched-scope scan reported zero findings for `workspaces.py`, `workspace_memberships.py`, and `workspace_schemas.py` (`/tmp/bandit_workspace_membership_api_task2316.json`).
+- Bandit touched-scope scan reported zero findings for `workspaces.py`, `workspace_memberships.py`, and `workspace_schemas.py` (`/tmp/bandit_workspace_membership_api_task2317.json`).
 Task 4 spec-review fix:
 - Fixed unsupported POST resource types reaching FastAPI/Pydantic literal validation before the service by changing `WorkspaceMembershipCreateRequest.resource_type` to a raw non-empty string while keeping response schemas typed.
 - Added POST regression coverage for `resource_type="note"` returning `400` with `detail.code == "unsupported_resource_type"`.
@@ -166,18 +166,17 @@ Task 5 reviews after follow-up:
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Implemented the first server-backed Workspace cross-resource membership foundation under the design in TASK-2315. The implementation added ChaChaNotes `workspace_resource_memberships` persistence, typed membership/cursor models, fail-closed adapters for `workspace_note`, `media`, `workspace_source`, `workspace_artifact`, and `chat`, Workspace membership service orchestration, workspace-scoped and reverse resource lookup API routes, explicit idempotent backfill, and compact Workspace context membership totals while preserving the boundary that membership is association rather than ownership transfer, global filtering, or MCP trust/path admission.
+Implemented the first server-backed Workspace cross-resource membership foundation under the design in TASK-2315 and remediated the pre-merge review feedback on PR #2312. The PR branch was rebased onto current origin/dev, removing the stale Knowledge QA/RAG trust files from the comparison. The implementation task was renumbered from the colliding TASK-2316 to TASK-2317 so dev's existing PR #2309 task remains canonical.
 
-Task 6 documented the membership boundary in `tldw_Server_API/app/core/Workspaces/README.md`, including `workspace_sources` as Research Workspace source selection/readiness, MCP permission/path admission as MCP policy/root binding-owned, future adapter validation through domain adapters, and explicit non-automatic backfill.
+Review remediation added shared strict membership JSON normalization in `membership_models.py` and routed membership provenance/metadata validation through it from API schemas, WorkspaceMembershipService, and ChaChaNotes DB writes. Direct service and DB callers now reject non-finite JSON values and 16 KiB-plus provenance/metadata before adapter validation or durable writes. Existing linked resources that later become deleted/trash/archived now summarize truthfully through deleted-inclusive adapter summary reads while `validate_access` remains active-record-only and fail-closed for new links.
 
 Final verification on 2026-06-07:
-- Focused selected suite: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/ChaChaNotesDB/test_workspace_resource_memberships_db.py tldw_Server_API/tests/Workspaces/test_workspace_membership_adapters.py tldw_Server_API/tests/Workspaces/test_workspace_memberships_api.py tldw_Server_API/tests/Workspaces/test_workspace_context_membership_summary.py tldw_Server_API/tests/Workspaces/test_workspaces_api.py tldw_Server_API/tests/Workspaces/test_workspace_sub_resources_api.py tldw_Server_API/tests/MCP_unified/test_mcp_hub_path_enforcement_service.py -q` passed with `194 passed, 6 warnings`.
-- Broader Workspace regression: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Workspaces -q` passed with `370 passed, 8 warnings`.
-- Bandit touched Python paths: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/core/Workspaces/membership_models.py tldw_Server_API/app/core/Workspaces/membership_adapters.py tldw_Server_API/app/core/Workspaces/membership_service.py tldw_Server_API/app/api/v1/endpoints/workspaces.py tldw_Server_API/app/api/v1/endpoints/workspace_memberships.py tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py -f json -o /tmp/bandit_workspace_memberships.json` exited 0 with zero findings. The JSON summary reported `results: 0` and `skipped_tests: 76` from existing `# nosec` suppressions in scanned files.
+- Focused regression: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Workspaces/test_workspace_membership_adapters.py tldw_Server_API/tests/ChaChaNotesDB/test_workspace_resource_memberships_db.py -q` passed with `96 passed, 6 warnings`.
+- Broader Workspace regression: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Workspaces tldw_Server_API/tests/ChaChaNotesDB/test_workspace_resource_memberships_db.py -q` passed with `412 passed, 8 warnings`.
+- Bandit touched Python paths: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/core/Workspaces/membership_models.py tldw_Server_API/app/core/Workspaces/membership_adapters.py tldw_Server_API/app/core/Workspaces/membership_service.py tldw_Server_API/app/api/v1/schemas/workspace_schemas.py tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py tldw_Server_API/app/api/v1/endpoints/workspaces.py tldw_Server_API/app/api/v1/endpoints/workspace_memberships.py -f json -o /tmp/bandit_workspace_membership_pr_review.json` exited 0 with `results: 0`.
 - `git diff --check` passed.
-- `git status --short --branch` before Backlog finalization showed only the intended README edit; final status is recorded in the closing commit.
 
-Known skips/blockers: none. The broader Workspace regression was run and passed, so there are no unrelated Workspace failures to record for this task.
+Known skips/blockers: none in the exercised Workspace membership scope.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/tldw_Server_API/app/api/v1/endpoints/workspace_memberships.py
+++ b/tldw_Server_API/app/api/v1/endpoints/workspace_memberships.py
@@ -54,7 +54,7 @@ async def list_resource_workspace_memberships(
     resource_type: str,
     resource_id: str,
     include_deleted: bool = Query(default=False),
-    resolve: bool = Query(default=True),
+    resolve: bool = Query(default=False),
     limit: int = Query(default=100, ge=1, le=1000),
     cursor: str | None = Query(default=None),
     db: CharactersRAGDB = Depends(get_chacha_db_for_user),

--- a/tldw_Server_API/app/api/v1/endpoints/workspace_memberships.py
+++ b/tldw_Server_API/app/api/v1/endpoints/workspace_memberships.py
@@ -1,0 +1,80 @@
+"""Workspace membership reverse lookup endpoints."""
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import User, get_request_user
+from tldw_Server_API.app.api.v1.API_Deps.ChaCha_Notes_DB_Deps import get_chacha_db_for_user
+from tldw_Server_API.app.api.v1.API_Deps.DB_Deps import try_get_media_db_for_user
+from tldw_Server_API.app.api.v1.endpoints.workspaces_rate_limit_policy import WORKSPACES_READ_RATE_LIMIT
+from tldw_Server_API.app.api.v1.schemas.workspace_schemas import WorkspaceResourceMembershipListResponse
+from tldw_Server_API.app.api.v1.utils.http_errors import map_db_error_to_http
+from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import (
+    CharactersRAGDB,
+    CharactersRAGDBError,
+    ConflictError,
+    InputError,
+)
+from tldw_Server_API.app.core.Workspaces.membership_service import (
+    WorkspaceMembershipService,
+    WorkspaceMembershipServiceError,
+)
+
+router = APIRouter()
+
+
+def _request_user_id(user: User) -> str:
+    return str(getattr(user, "id", ""))
+
+
+def _membership_service(db: CharactersRAGDB) -> WorkspaceMembershipService:
+    return WorkspaceMembershipService(db)
+
+
+def _membership_service_error_to_http(exc: WorkspaceMembershipServiceError) -> HTTPException:
+    return HTTPException(
+        status_code=exc.status_code,
+        detail={
+            "code": exc.code,
+            "message": exc.message,
+            "details": exc.details,
+        },
+    )
+
+
+@router.get(
+    "/resources/{resource_type}/{resource_id}",
+    response_model=WorkspaceResourceMembershipListResponse,
+    dependencies=[Depends(WORKSPACES_READ_RATE_LIMIT)],
+    summary="List workspace memberships for a resource",
+)
+async def list_resource_workspace_memberships(
+    resource_type: str,
+    resource_id: str,
+    include_deleted: bool = Query(default=False),
+    resolve: bool = Query(default=True),
+    limit: int = Query(default=100, ge=1, le=1000),
+    cursor: str | None = Query(default=None),
+    db: CharactersRAGDB = Depends(get_chacha_db_for_user),
+    media_db: Any | None = Depends(try_get_media_db_for_user),
+    current_user: User = Depends(get_request_user),
+) -> WorkspaceResourceMembershipListResponse:
+    """List memberships that connect the current user's workspaces to one resource."""
+    try:
+        payload = _membership_service(db).list_resource_memberships(
+            resource_type,
+            resource_id,
+            include_deleted=include_deleted,
+            resolve=resolve,
+            limit=limit,
+            cursor=cursor,
+            media_db=media_db,
+            user_id=_request_user_id(current_user),
+        )
+    except WorkspaceMembershipServiceError as exc:
+        raise _membership_service_error_to_http(exc) from exc
+    except (ConflictError, InputError, CharactersRAGDBError) as exc:
+        raise map_db_error_to_http(exc, default_detail="Failed to fetch resource workspace memberships") from exc
+    return WorkspaceResourceMembershipListResponse(**payload)

--- a/tldw_Server_API/app/api/v1/endpoints/workspaces.py
+++ b/tldw_Server_API/app/api/v1/endpoints/workspaces.py
@@ -33,6 +33,9 @@ from tldw_Server_API.app.api.v1.schemas.workspace_schemas import (
     WorkspaceFileInventoryScanRequest,
     WorkspaceFileInventoryStatusResponse,
     WorkspaceListResponse,
+    WorkspaceMembershipCreateRequest,
+    WorkspaceMembershipListResponse,
+    WorkspaceMembershipResponse,
     WorkspaceNoteCreateRequest,
     WorkspaceNoteResponse,
     WorkspaceNoteUpdateRequest,
@@ -71,6 +74,10 @@ from tldw_Server_API.app.core.Workspaces.file_inventory_jobs import (
     enqueue_workspace_file_inventory_scan_job,
 )
 from tldw_Server_API.app.core.Workspaces.context import build_workspace_core_context
+from tldw_Server_API.app.core.Workspaces.membership_service import (
+    WorkspaceMembershipService,
+    WorkspaceMembershipServiceError,
+)
 from tldw_Server_API.app.core.Workspaces.source_jobs import (
     WORKSPACE_SOURCE_JOB_DOMAIN,
     WORKSPACE_SOURCE_JOB_QUEUE,
@@ -462,6 +469,39 @@ def _require_workspace(db: CharactersRAGDB, workspace_id: str) -> dict:
     if not ws:
         raise HTTPException(status_code=404, detail="Workspace not found")
     return ws
+
+
+def _membership_service(db: CharactersRAGDB) -> WorkspaceMembershipService:
+    return WorkspaceMembershipService(db)
+
+
+def _request_user_id(current_user: User) -> str:
+    return str(current_user.id)
+
+
+def _membership_service_error_to_http(exc: WorkspaceMembershipServiceError) -> HTTPException:
+    return HTTPException(
+        status_code=exc.status_code,
+        detail={
+            "code": exc.code,
+            "message": exc.message,
+            "details": exc.details,
+        },
+    )
+
+
+def _workspace_membership_not_found(resource_type: str, resource_id: str) -> HTTPException:
+    return HTTPException(
+        status_code=status.HTTP_404_NOT_FOUND,
+        detail={
+            "code": "workspace_membership_not_found",
+            "message": "Workspace membership was not found.",
+            "details": {
+                "resource_type": resource_type,
+                "resource_id": resource_id,
+            },
+        },
+    )
 
 
 def _workspace_with_primary_root(
@@ -983,6 +1023,140 @@ async def delete_workspace(
         db.delete_workspace(workspace_id, ws["version"])
     except (ConflictError, InputError, CharactersRAGDBError) as exc:
         raise map_db_error_to_http(exc, default_detail="Failed to delete workspace") from exc
+
+
+# ── Memberships ─────────────────────────────────────────────────
+
+@router.get(
+    "/{workspace_id}/memberships",
+    response_model=WorkspaceMembershipListResponse,
+    dependencies=[Depends(WORKSPACES_READ_RATE_LIMIT)],
+    summary="List workspace resource memberships",
+)
+async def list_workspace_memberships(
+    workspace_id: str,
+    resource_type: str | None = Query(default=None),
+    role: str | None = Query(default=None),
+    include_deleted: bool = Query(default=False),
+    resolve: bool = Query(default=True),
+    limit: int = Query(default=100, ge=1, le=1000),
+    cursor: str | None = Query(default=None),
+    db: CharactersRAGDB = Depends(get_chacha_db_for_user),
+    media_db: Any | None = Depends(try_get_media_db_for_user),
+    current_user: User = Depends(get_request_user),
+) -> WorkspaceMembershipListResponse:
+    """List memberships for one workspace."""
+    try:
+        payload = _membership_service(db).list_workspace_memberships(
+            workspace_id,
+            resource_type=resource_type,
+            role=role,
+            include_deleted=include_deleted,
+            resolve=resolve,
+            limit=limit,
+            cursor=cursor,
+            media_db=media_db,
+            user_id=_request_user_id(current_user),
+        )
+    except WorkspaceMembershipServiceError as exc:
+        raise _membership_service_error_to_http(exc) from exc
+    except (ConflictError, InputError, CharactersRAGDBError) as exc:
+        raise map_db_error_to_http(exc, default_detail="Failed to fetch workspace memberships") from exc
+    return WorkspaceMembershipListResponse(**payload)
+
+
+@router.post(
+    "/{workspace_id}/memberships",
+    response_model=WorkspaceMembershipResponse,
+    status_code=status.HTTP_201_CREATED,
+    dependencies=[Depends(WORKSPACES_WRITE_RATE_LIMIT)],
+    summary="Create workspace resource membership",
+)
+async def create_workspace_membership(
+    workspace_id: str,
+    body: WorkspaceMembershipCreateRequest,
+    db: CharactersRAGDB = Depends(get_chacha_db_for_user),
+    media_db: Any | None = Depends(try_get_media_db_for_user),
+    current_user: User = Depends(get_request_user),
+) -> WorkspaceMembershipResponse:
+    """Link a resource to a workspace, idempotently for matching active rows."""
+    try:
+        payload = _membership_service(db).link_membership(
+            workspace_id,
+            body,
+            media_db=media_db,
+            user_id=_request_user_id(current_user),
+            resolve=True,
+        )
+    except WorkspaceMembershipServiceError as exc:
+        raise _membership_service_error_to_http(exc) from exc
+    except (ConflictError, InputError, CharactersRAGDBError) as exc:
+        raise map_db_error_to_http(exc, default_detail="Failed to create workspace membership") from exc
+    return WorkspaceMembershipResponse(**payload)
+
+
+@router.get(
+    "/{workspace_id}/memberships/{resource_type}/{resource_id}",
+    response_model=WorkspaceMembershipResponse,
+    dependencies=[Depends(WORKSPACES_READ_RATE_LIMIT)],
+    summary="Get workspace resource membership",
+)
+async def get_workspace_membership(
+    workspace_id: str,
+    resource_type: str,
+    resource_id: str,
+    resolve: bool = Query(default=True),
+    db: CharactersRAGDB = Depends(get_chacha_db_for_user),
+    media_db: Any | None = Depends(try_get_media_db_for_user),
+    current_user: User = Depends(get_request_user),
+) -> WorkspaceMembershipResponse:
+    """Fetch one active workspace membership by resource."""
+    try:
+        payload = _membership_service(db).get_membership(
+            workspace_id,
+            resource_type,
+            resource_id,
+            media_db=media_db,
+            user_id=_request_user_id(current_user),
+            resolve=resolve,
+        )
+    except WorkspaceMembershipServiceError as exc:
+        raise _membership_service_error_to_http(exc) from exc
+    except (ConflictError, InputError, CharactersRAGDBError) as exc:
+        raise map_db_error_to_http(exc, default_detail="Failed to fetch workspace membership") from exc
+    if payload is None:
+        raise _workspace_membership_not_found(resource_type, resource_id)
+    return WorkspaceMembershipResponse(**payload)
+
+
+@router.delete(
+    "/{workspace_id}/memberships/{resource_type}/{resource_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    dependencies=[Depends(WORKSPACES_DELETE_RATE_LIMIT)],
+    summary="Delete workspace resource membership",
+)
+async def delete_workspace_membership(
+    workspace_id: str,
+    resource_type: str,
+    resource_id: str,
+    db: CharactersRAGDB = Depends(get_chacha_db_for_user),
+    media_db: Any | None = Depends(try_get_media_db_for_user),
+    current_user: User = Depends(get_request_user),
+) -> Response:
+    """Soft-delete a workspace membership; missing rows are idempotent no-ops."""
+    try:
+        _membership_service(db).unlink_membership(
+            workspace_id,
+            resource_type,
+            resource_id,
+            media_db=media_db,
+            user_id=_request_user_id(current_user),
+        )
+    except WorkspaceMembershipServiceError as exc:
+        raise _membership_service_error_to_http(exc) from exc
+    except (ConflictError, InputError, CharactersRAGDBError) as exc:
+        raise map_db_error_to_http(exc, default_detail="Failed to delete workspace membership") from exc
+    return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
 # ── Sources ─────────────────────────────────────────────────────

--- a/tldw_Server_API/app/api/v1/endpoints/workspaces.py
+++ b/tldw_Server_API/app/api/v1/endpoints/workspaces.py
@@ -1319,6 +1319,18 @@ async def get_workspace_context(
                 "message": "Jobs service is unavailable; in-flight ingestion progress may be incomplete.",
             }
         )
+    membership_summary = {"total": 0, "by_resource_type": {}, "by_role": {}}
+    try:
+        membership_summary = WorkspaceMembershipService(db).workspace_membership_summary(workspace_id)
+    except Exception:
+        logger.warning("Workspace membership summary unavailable for workspace {}", workspace_id)
+        partial_errors.append(
+            {
+                "scope": "memberships",
+                "code": "membership_summary_unavailable",
+                "message": "Workspace membership summary is unavailable.",
+            }
+        )
 
     context_sources = [
         _context_source_payload(
@@ -1351,6 +1363,7 @@ async def get_workspace_context(
         allowed_actions=capability_payload.get("allowed_actions") or {},
         active_jobs=active_jobs,
         active_operations=core_context_payload.get("active_operations") or [],
+        memberships=membership_summary,
         partial_errors=partial_errors,
     )
 

--- a/tldw_Server_API/app/api/v1/endpoints/workspaces.py
+++ b/tldw_Server_API/app/api/v1/endpoints/workspaces.py
@@ -1038,7 +1038,7 @@ async def list_workspace_memberships(
     resource_type: str | None = Query(default=None),
     role: str | None = Query(default=None),
     include_deleted: bool = Query(default=False),
-    resolve: bool = Query(default=True),
+    resolve: bool = Query(default=False),
     limit: int = Query(default=100, ge=1, le=1000),
     cursor: str | None = Query(default=None),
     db: CharactersRAGDB = Depends(get_chacha_db_for_user),

--- a/tldw_Server_API/app/api/v1/router_groups/content.py
+++ b/tldw_Server_API/app/api/v1/router_groups/content.py
@@ -390,6 +390,13 @@ def iter_content_router_specs() -> Iterable[RouterSpec]:
             route_key="workspaces",
         ),
         ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.workspace_memberships",
+            log_name="workspace_memberships",
+            prefix=f"{API_V1_PREFIX}/workspace-memberships",
+            tags=("workspaces",),
+            route_key="workspaces",
+        ),
+        ImportedRouterSpec(
             import_path="tldw_Server_API.app.api.v1.endpoints.character_chat_sessions",
             log_name="character_chat_sessions",
             prefix=f"{API_V1_PREFIX}/chats",

--- a/tldw_Server_API/app/api/v1/router_groups/minimal.py
+++ b/tldw_Server_API/app/api/v1/router_groups/minimal.py
@@ -46,6 +46,7 @@ MINIMAL_REQUIRED_ROUTER_NAMES = (
     "character_messages",
     "workspace_migrations",
     "workspaces",
+    "workspace_memberships",
 )
 MINIMAL_REQUIRED_ROUTER_OVERRIDES = {
     name: RouterSpecOverride(skip_exceptions=REQUIRED_ROUTER_SKIP_EXCEPTIONS)

--- a/tldw_Server_API/app/api/v1/schemas/workspace_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/workspace_schemas.py
@@ -71,7 +71,15 @@ WorkspaceMembershipTransferPolicy = Literal["link", "copy", "promote", "import"]
 
 
 def _json_size_bytes(value: Any) -> int:
-    return len(json.dumps(value, ensure_ascii=True, separators=(",", ":"), sort_keys=True).encode("utf-8"))
+    return len(
+        json.dumps(
+            value,
+            ensure_ascii=True,
+            allow_nan=False,
+            separators=(",", ":"),
+            sort_keys=True,
+        ).encode("utf-8")
+    )
 
 
 def _validate_sha256(value: str) -> str:

--- a/tldw_Server_API/app/api/v1/schemas/workspace_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/workspace_schemas.py
@@ -290,6 +290,15 @@ class WorkspaceMembershipListResponse(BaseModel):
     summary: WorkspaceMembershipListSummary = Field(default_factory=WorkspaceMembershipListSummary)
 
 
+class WorkspaceResourceMembershipListResponse(BaseModel):
+    resource_type: WorkspaceMembershipResourceType
+    resource_id: str
+    items: list[WorkspaceMembershipResponse]
+    total: int
+    next_cursor: str | None = None
+    summary: WorkspaceMembershipListSummary = Field(default_factory=WorkspaceMembershipListSummary)
+
+
 class WorkspaceContextMembershipSummary(BaseModel):
     total: int = 0
     by_resource_type: dict[str, int] = Field(default_factory=dict)

--- a/tldw_Server_API/app/api/v1/schemas/workspace_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/workspace_schemas.py
@@ -691,6 +691,7 @@ class WorkspaceContextResponse(BaseModel):
     allowed_actions: dict[str, WorkspaceAllowedAction]
     active_jobs: list[WorkspaceSourceJobStatus] = Field(default_factory=list)
     active_operations: list[WorkspaceOperationResponse] = Field(default_factory=list)
+    memberships: WorkspaceContextMembershipSummary = Field(default_factory=WorkspaceContextMembershipSummary)
     partial_errors: list[WorkspaceContextPartialError] = Field(default_factory=list)
 
 

--- a/tldw_Server_API/app/api/v1/schemas/workspace_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/workspace_schemas.py
@@ -224,7 +224,7 @@ class WorkspaceListResponse(BaseModel):
 class WorkspaceMembershipCreateRequest(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    resource_type: WorkspaceMembershipResourceType
+    resource_type: str = Field(..., min_length=1)
     resource_id: str = Field(..., min_length=1)
     role: WorkspaceMembershipRole = "member"
     label: str | None = Field(default=None, max_length=512)

--- a/tldw_Server_API/app/api/v1/schemas/workspace_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/workspace_schemas.py
@@ -7,14 +7,17 @@ from typing import Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field, StrictBool, ValidationInfo, field_validator, model_validator
 
+from tldw_Server_API.app.core.Workspaces.membership_models import (
+    WORKSPACE_MEMBERSHIP_MAX_METADATA_BYTES,
+    WORKSPACE_MEMBERSHIP_MAX_PROVENANCE_BYTES,
+    normalize_membership_json_object,
+)
 
 WORKSPACE_MIGRATION_MAX_MANIFEST_BYTES = 256 * 1024
 WORKSPACE_MIGRATION_MAX_DIAGNOSTICS_BYTES = 64 * 1024
 WORKSPACE_MIGRATION_MAX_CHUNK_METADATA_BYTES = 64 * 1024
 WORKSPACE_MIGRATION_MAX_CHUNK_BYTES = 2 * 1024 * 1024
 WORKSPACE_MIGRATION_MAX_DECLARED_CHUNKS = 512
-WORKSPACE_MEMBERSHIP_MAX_PROVENANCE_BYTES = 16 * 1024
-WORKSPACE_MEMBERSHIP_MAX_METADATA_BYTES = 16 * 1024
 _SHA256_RE = re.compile(r"^[a-fA-F0-9]{64}$")
 
 WorkspaceProfile = Literal["research", "project"]
@@ -235,20 +238,26 @@ class WorkspaceMembershipCreateRequest(BaseModel):
     @field_validator("provenance")
     @classmethod
     def _validate_provenance_size(cls, value: dict[str, Any]) -> dict[str, Any]:
-        return _validate_json_size(
-            value,
-            field_name="provenance",
-            max_bytes=WORKSPACE_MEMBERSHIP_MAX_PROVENANCE_BYTES,
-        )
+        try:
+            return normalize_membership_json_object(
+                value,
+                field_name="provenance",
+                max_bytes=WORKSPACE_MEMBERSHIP_MAX_PROVENANCE_BYTES,
+            )
+        except ValueError as exc:
+            raise ValueError(str(exc)) from exc
 
     @field_validator("metadata")
     @classmethod
     def _validate_membership_metadata_size(cls, value: dict[str, Any]) -> dict[str, Any]:
-        return _validate_json_size(
-            value,
-            field_name="metadata",
-            max_bytes=WORKSPACE_MEMBERSHIP_MAX_METADATA_BYTES,
-        )
+        try:
+            return normalize_membership_json_object(
+                value,
+                field_name="metadata",
+                max_bytes=WORKSPACE_MEMBERSHIP_MAX_METADATA_BYTES,
+            )
+        except ValueError as exc:
+            raise ValueError(str(exc)) from exc
 
 
 class WorkspaceMembershipSummaryResponse(BaseModel):

--- a/tldw_Server_API/app/api/v1/schemas/workspace_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/workspace_schemas.py
@@ -13,6 +13,8 @@ WORKSPACE_MIGRATION_MAX_DIAGNOSTICS_BYTES = 64 * 1024
 WORKSPACE_MIGRATION_MAX_CHUNK_METADATA_BYTES = 64 * 1024
 WORKSPACE_MIGRATION_MAX_CHUNK_BYTES = 2 * 1024 * 1024
 WORKSPACE_MIGRATION_MAX_DECLARED_CHUNKS = 512
+WORKSPACE_MEMBERSHIP_MAX_PROVENANCE_BYTES = 16 * 1024
+WORKSPACE_MEMBERSHIP_MAX_METADATA_BYTES = 16 * 1024
 _SHA256_RE = re.compile(r"^[a-fA-F0-9]{64}$")
 
 WorkspaceProfile = Literal["research", "project"]
@@ -50,6 +52,22 @@ WorkspaceProjectRootState = Literal[
     "cleanup_pending",
     "archived",
 ]
+WorkspaceMembershipResourceType = Literal[
+    "workspace_note",
+    "media",
+    "workspace_source",
+    "workspace_artifact",
+    "chat",
+]
+WorkspaceMembershipRole = Literal[
+    "member",
+    "source",
+    "artifact",
+    "conversation",
+    "runtime",
+    "reference",
+]
+WorkspaceMembershipTransferPolicy = Literal["link", "copy", "promote", "import"]
 
 
 def _json_size_bytes(value: Any) -> int:
@@ -191,6 +209,83 @@ class WorkspaceResponse(BaseModel):
 class WorkspaceListResponse(BaseModel):
     items: list[WorkspaceResponse]
     total: int
+
+
+# --- Membership schemas ---
+
+class WorkspaceMembershipCreateRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    resource_type: WorkspaceMembershipResourceType
+    resource_id: str = Field(..., min_length=1)
+    role: WorkspaceMembershipRole = "member"
+    label: str | None = Field(default=None, max_length=512)
+    transfer_policy: WorkspaceMembershipTransferPolicy = "link"
+    provenance: dict[str, Any] = Field(default_factory=dict)
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+    @field_validator("provenance")
+    @classmethod
+    def _validate_provenance_size(cls, value: dict[str, Any]) -> dict[str, Any]:
+        return _validate_json_size(
+            value,
+            field_name="provenance",
+            max_bytes=WORKSPACE_MEMBERSHIP_MAX_PROVENANCE_BYTES,
+        )
+
+    @field_validator("metadata")
+    @classmethod
+    def _validate_membership_metadata_size(cls, value: dict[str, Any]) -> dict[str, Any]:
+        return _validate_json_size(
+            value,
+            field_name="metadata",
+            max_bytes=WORKSPACE_MEMBERSHIP_MAX_METADATA_BYTES,
+        )
+
+
+class WorkspaceMembershipSummaryResponse(BaseModel):
+    title: str | None = None
+    subtitle: str | None = None
+    href: str | None = None
+    updated_at: str | None = None
+    state: str = "available"
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+
+class WorkspaceMembershipResponse(BaseModel):
+    workspace_id: str
+    resource_type: WorkspaceMembershipResourceType
+    resource_id: str
+    role: WorkspaceMembershipRole
+    label: str | None = None
+    transfer_policy: WorkspaceMembershipTransferPolicy = "link"
+    provenance: dict[str, Any] = Field(default_factory=dict)
+    metadata: dict[str, Any] = Field(default_factory=dict)
+    summary: WorkspaceMembershipSummaryResponse | None = None
+    created_at: str
+    updated_at: str
+    version: int
+    deleted: bool = False
+
+
+class WorkspaceMembershipListSummary(BaseModel):
+    total: int = 0
+    by_resource_type: dict[str, int] = Field(default_factory=dict)
+    by_role: dict[str, int] = Field(default_factory=dict)
+
+
+class WorkspaceMembershipListResponse(BaseModel):
+    workspace_id: str
+    items: list[WorkspaceMembershipResponse]
+    total: int
+    next_cursor: str | None = None
+    summary: WorkspaceMembershipListSummary = Field(default_factory=WorkspaceMembershipListSummary)
+
+
+class WorkspaceContextMembershipSummary(BaseModel):
+    total: int = 0
+    by_resource_type: dict[str, int] = Field(default_factory=dict)
+    by_role: dict[str, int] = Field(default_factory=dict)
 
 
 # --- Source schemas ---

--- a/tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py
+++ b/tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py
@@ -123,6 +123,11 @@ from tldw_Server_API.app.core.Workspaces.file_inventory_models import (  # noqa:
     normalize_inventory_counts,
     sort_inventory_relative_paths,
 )
+from tldw_Server_API.app.core.Workspaces.membership_models import (  # noqa: E402
+    WORKSPACE_MEMBERSHIP_MAX_METADATA_BYTES,
+    WORKSPACE_MEMBERSHIP_MAX_PROVENANCE_BYTES,
+    dump_membership_json_object,
+)
 from tldw_Server_API.app.core.Workspaces.operations import (  # noqa: E402
     WORKSPACE_OPERATION_ACTIVE_STATUSES,
     WORKSPACE_OPERATION_STATUSES,
@@ -18111,7 +18116,13 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
                 ) from exc
         return self._get_workspace_source(workspace_id, source_id)  # type: ignore[return-value]
 
-    def _get_workspace_source(self, workspace_id: str, source_id: str) -> dict[str, Any] | None:
+    def _get_workspace_source(
+        self,
+        workspace_id: str,
+        source_id: str,
+        *,
+        include_deleted: bool = False,
+    ) -> dict[str, Any] | None:
         cursor = self.execute_query(
             "SELECT * FROM workspace_sources WHERE workspace_id = ? AND id = ?",
             (workspace_id, source_id),
@@ -18119,9 +18130,15 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
         row = cursor.fetchone()
         return dict(row) if row else None
 
-    def get_workspace_source(self, workspace_id: str, source_id: str) -> dict[str, Any] | None:
+    def get_workspace_source(
+        self,
+        workspace_id: str,
+        source_id: str,
+        *,
+        include_deleted: bool = False,
+    ) -> dict[str, Any] | None:
         """Fetch a workspace source by id."""
-        return self._get_workspace_source(workspace_id, source_id)
+        return self._get_workspace_source(workspace_id, source_id, include_deleted=include_deleted)
 
     def list_workspace_sources(self, workspace_id: str) -> list[dict[str, Any]]:
         """List all sources for a workspace ordered by position."""
@@ -18227,29 +18244,15 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
 
     @classmethod
     def _normalize_workspace_membership_json_object(cls, value: Any, field_name: str) -> tuple[dict[str, Any], str]:
-        if value is None:
-            normalized: dict[str, Any] = {}
-        elif isinstance(value, str):
-            if not value.strip():
-                normalized = {}
-            else:
-                try:
-                    parsed = json.loads(value)
-                except json.JSONDecodeError as exc:
-                    raise InputError(f"{field_name} must be valid JSON.") from exc  # noqa: TRY003
-                if not isinstance(parsed, dict):
-                    raise InputError(f"{field_name} must be a JSON object.")  # noqa: TRY003
-                normalized = parsed
-        elif isinstance(value, Mapping):
-            normalized = dict(value)
-        else:
-            raise InputError(f"{field_name} must be a JSON object.")  # noqa: TRY003
-
+        max_bytes = (
+            WORKSPACE_MEMBERSHIP_MAX_PROVENANCE_BYTES
+            if field_name == "provenance"
+            else WORKSPACE_MEMBERSHIP_MAX_METADATA_BYTES
+        )
         try:
-            dumped = json.dumps(normalized, ensure_ascii=True, sort_keys=True)
-        except TypeError as exc:
-            raise InputError(f"{field_name} must be JSON-serializable.") from exc  # noqa: TRY003
-        return normalized, dumped
+            return dump_membership_json_object(value, field_name=field_name, max_bytes=max_bytes)
+        except ValueError as exc:
+            raise InputError(str(exc)) from exc  # noqa: TRY003
 
     @classmethod
     def _load_workspace_membership_json_object(cls, value: Any, *, field_name: str) -> dict[str, Any]:
@@ -18805,15 +18808,21 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
         except (sqlite3.IntegrityError, BackendDatabaseError) as exc:
             raise self._workspace_membership_write_error(exc) from exc
 
-    def get_conversation_for_workspace_membership(self, conversation_id: str) -> dict[str, Any] | None:
+    def get_conversation_for_workspace_membership(
+        self,
+        conversation_id: str,
+        *,
+        include_deleted: bool = False,
+    ) -> dict[str, Any] | None:
         """Fetch the compact conversation row needed by Workspace membership adapters."""
         normalized_conversation_id = self._normalize_workspace_membership_required_string(
             conversation_id,
             "conversation_id",
         )
+        deleted_clause = "" if include_deleted else " AND deleted = 0"
         cursor = self.execute_query(
-            "SELECT id, title, workspace_id, scope_type, last_modified, version "
-            "FROM conversations WHERE id = ? AND deleted = 0",
+            "SELECT id, title, workspace_id, scope_type, last_modified, deleted, version "
+            f"FROM conversations WHERE id = ?{deleted_clause}",  # nosec B608
             (normalized_conversation_id,),
         )
         row = cursor.fetchone()
@@ -19032,7 +19041,13 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
             )
         return self._get_workspace_artifact(workspace_id, artifact_id)  # type: ignore[return-value]
 
-    def _get_workspace_artifact(self, workspace_id: str, artifact_id: str) -> dict[str, Any] | None:
+    def _get_workspace_artifact(
+        self,
+        workspace_id: str,
+        artifact_id: str,
+        *,
+        include_deleted: bool = False,
+    ) -> dict[str, Any] | None:
         cursor = self.execute_query(
             "SELECT * FROM workspace_artifacts WHERE workspace_id = ? AND id = ?",
             (workspace_id, artifact_id),
@@ -19040,9 +19055,15 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
         row = cursor.fetchone()
         return self._normalize_workspace_artifact_row(row)
 
-    def get_workspace_artifact(self, workspace_id: str, artifact_id: str) -> dict[str, Any] | None:
+    def get_workspace_artifact(
+        self,
+        workspace_id: str,
+        artifact_id: str,
+        *,
+        include_deleted: bool = False,
+    ) -> dict[str, Any] | None:
         """Fetch a workspace artifact by id."""
-        return self._get_workspace_artifact(workspace_id, artifact_id)
+        return self._get_workspace_artifact(workspace_id, artifact_id, include_deleted=include_deleted)
 
     def list_workspace_artifacts(self, workspace_id: str) -> list[dict[str, Any]]:
         """List all artifacts for a workspace."""
@@ -19336,17 +19357,30 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
             note_id = cursor.lastrowid
         return self._get_workspace_note(workspace_id, note_id)  # type: ignore[return-value]
 
-    def _get_workspace_note(self, workspace_id: str, note_id: int) -> dict[str, Any] | None:
+    def _get_workspace_note(
+        self,
+        workspace_id: str,
+        note_id: int,
+        *,
+        include_deleted: bool = False,
+    ) -> dict[str, Any] | None:
+        deleted_clause = "" if include_deleted else " AND deleted = 0"
         cursor = self.execute_query(
-            "SELECT * FROM workspace_notes WHERE workspace_id = ? AND id = ? AND deleted = 0",
+            f"SELECT * FROM workspace_notes WHERE workspace_id = ? AND id = ?{deleted_clause}",  # nosec B608
             (workspace_id, note_id),
         )
         row = cursor.fetchone()
         return dict(row) if row else None
 
-    def get_workspace_note(self, workspace_id: str, note_id: int) -> dict[str, Any] | None:
-        """Fetch a non-deleted workspace note by id."""
-        return self._get_workspace_note(workspace_id, note_id)
+    def get_workspace_note(
+        self,
+        workspace_id: str,
+        note_id: int,
+        *,
+        include_deleted: bool = False,
+    ) -> dict[str, Any] | None:
+        """Fetch a workspace note by id."""
+        return self._get_workspace_note(workspace_id, note_id, include_deleted=include_deleted)
 
     def list_workspace_notes(self, workspace_id: str) -> list[dict[str, Any]]:
         """List all non-deleted notes for a workspace."""

--- a/tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py
+++ b/tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py
@@ -18266,12 +18266,10 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
             try:
                 parsed = json.loads(value)
             except json.JSONDecodeError:
-                preview = value[:120].replace("\n", "\\n")
                 logger.warning(
-                    "Failed to decode workspace resource membership JSON field {} ({} chars): {}",
+                    "Failed to decode workspace resource membership JSON field {} ({} chars)",
                     field_name,
                     len(value),
-                    preview,
                 )
                 return {}
             return parsed if isinstance(parsed, dict) else {}
@@ -18723,6 +18721,75 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
             if (normalized := self._normalize_workspace_membership_row(row)) is not None
         ]
 
+    def workspace_resource_membership_summary(self, workspace_id: str) -> dict[str, Any]:
+        """Return compact active membership counts for one Workspace."""
+        normalized_workspace_id = self._normalize_workspace_membership_required_string(
+            workspace_id,
+            "workspace_id",
+        )
+        active_deleted_value = self._workspace_active_deleted_value()
+
+        def _row_value(row: Any, key: str, index: int, default: Any = 0) -> Any:
+            if row is None:
+                return default
+            try:
+                return row[key]
+            except (KeyError, IndexError, TypeError):
+                try:
+                    return row[index]
+                except (IndexError, TypeError):
+                    return default
+
+        try:
+            total_cursor = self.execute_query(
+                """
+                SELECT COUNT(*) AS total
+                  FROM workspace_resource_memberships
+                 WHERE workspace_id = ? AND deleted = ?
+                """,
+                (normalized_workspace_id, active_deleted_value),
+            )
+            total_row = total_cursor.fetchone()
+            resource_cursor = self.execute_query(
+                """
+                SELECT resource_type, COUNT(*) AS count
+                  FROM workspace_resource_memberships
+                 WHERE workspace_id = ? AND deleted = ?
+                 GROUP BY resource_type
+                 ORDER BY resource_type ASC
+                """,
+                (normalized_workspace_id, active_deleted_value),
+            )
+            role_cursor = self.execute_query(
+                """
+                SELECT role, COUNT(*) AS count
+                  FROM workspace_resource_memberships
+                 WHERE workspace_id = ? AND deleted = ?
+                 GROUP BY role
+                 ORDER BY role ASC
+                """,
+                (normalized_workspace_id, active_deleted_value),
+            )
+            by_resource_type = {
+                str(_row_value(row, "resource_type", 0)): int(_row_value(row, "count", 1))
+                for row in resource_cursor.fetchall()
+                if _row_value(row, "resource_type", 0, None) is not None
+            }
+            by_role = {
+                str(_row_value(row, "role", 0)): int(_row_value(row, "count", 1))
+                for row in role_cursor.fetchall()
+                if _row_value(row, "role", 0, None) is not None
+            }
+            return {
+                "total": int(_row_value(total_row, "total", 0)),
+                "by_resource_type": by_resource_type,
+                "by_role": by_role,
+            }
+        except BackendDatabaseError as exc:
+            raise CharactersRAGDBError(
+                f"Failed summarizing workspace resource memberships: {exc}"
+            ) from exc  # noqa: TRY003
+
     def delete_workspace_resource_membership(
         self,
         workspace_id: str,
@@ -18819,11 +18886,15 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
             conversation_id,
             "conversation_id",
         )
-        deleted_clause = "" if include_deleted else " AND deleted = 0"
+        deleted_clause = ""
+        params: list[Any] = [normalized_conversation_id]
+        if not include_deleted:
+            deleted_clause = " AND deleted = ?"
+            params.append(self._workspace_active_deleted_value())
         cursor = self.execute_query(
             "SELECT id, title, workspace_id, scope_type, last_modified, deleted, version "
             f"FROM conversations WHERE id = ?{deleted_clause}",  # nosec B608
-            (normalized_conversation_id,),
+            tuple(params),
         )
         row = cursor.fetchone()
         return dict(row) if row else None

--- a/tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py
+++ b/tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py
@@ -18643,7 +18643,7 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
                     cursor_resource_id,
                 ]
             )
-        params.append(normalized_limit)
+        params.append(normalized_limit + 1)
         cursor_obj = self.execute_query(
             f"SELECT * FROM workspace_resource_memberships WHERE {' AND '.join(clauses)} "  # nosec B608
             "ORDER BY updated_at DESC, resource_type ASC, resource_id ASC LIMIT ?",
@@ -18687,7 +18687,7 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
                 "(updated_at < ? OR (updated_at = ? AND workspace_id > ?))"
             )
             params.extend([cursor_updated_at, cursor_updated_at, cursor_workspace_id])
-        params.append(normalized_limit)
+        params.append(normalized_limit + 1)
         cursor_obj = self.execute_query(
             f"SELECT * FROM workspace_resource_memberships WHERE {' AND '.join(clauses)} "  # nosec B608
             "ORDER BY updated_at DESC, workspace_id ASC LIMIT ?",

--- a/tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py
+++ b/tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py
@@ -9108,6 +9108,39 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
             conn.execute(
                 "CREATE INDEX IF NOT EXISTS idx_ws_notes_workspace ON workspace_notes(workspace_id)"
             )
+
+            conn.execute("""
+                CREATE TABLE IF NOT EXISTS workspace_resource_memberships (
+                    workspace_id        TEXT NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
+                    resource_type       TEXT NOT NULL,
+                    resource_id         TEXT NOT NULL,
+                    role                TEXT NOT NULL DEFAULT 'member',
+                    label               TEXT,
+                    transfer_policy     TEXT NOT NULL DEFAULT 'link',
+                    provenance_json     TEXT NOT NULL DEFAULT '{}',
+                    metadata_json       TEXT NOT NULL DEFAULT '{}',
+                    created_by_user_id  TEXT,
+                    updated_by_user_id  TEXT,
+                    created_at          DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                    updated_at          DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                    deleted             BOOLEAN NOT NULL DEFAULT 0,
+                    client_id           TEXT NOT NULL DEFAULT 'unknown',
+                    version             INTEGER NOT NULL DEFAULT 1,
+                    PRIMARY KEY (workspace_id, resource_type, resource_id)
+                )
+            """)
+            conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_ws_resource_memberships_workspace "
+                "ON workspace_resource_memberships(workspace_id, deleted, resource_type, role)"
+            )
+            conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_ws_resource_memberships_resource "
+                "ON workspace_resource_memberships(resource_type, resource_id, deleted)"
+            )
+            conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_ws_resource_memberships_updated "
+                "ON workspace_resource_memberships(workspace_id, updated_at)"
+            )
         except sqlite3.Error as exc:
             raise SchemaError(f"Failed ensuring SQLite workspace sub-resource schema: {exc}") from exc  # noqa: TRY003
 
@@ -9289,6 +9322,32 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
             )
             """,
             "CREATE INDEX IF NOT EXISTS idx_ws_notes_workspace ON workspace_notes(workspace_id)",
+            """
+            CREATE TABLE IF NOT EXISTS workspace_resource_memberships (
+                workspace_id        TEXT NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
+                resource_type       TEXT NOT NULL,
+                resource_id         TEXT NOT NULL,
+                role                TEXT NOT NULL DEFAULT 'member',
+                label               TEXT,
+                transfer_policy     TEXT NOT NULL DEFAULT 'link',
+                provenance_json     TEXT NOT NULL DEFAULT '{}',
+                metadata_json       TEXT NOT NULL DEFAULT '{}',
+                created_by_user_id  TEXT,
+                updated_by_user_id  TEXT,
+                created_at          TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                updated_at          TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                deleted             BOOLEAN NOT NULL DEFAULT false,
+                client_id           TEXT NOT NULL DEFAULT 'unknown',
+                version             INTEGER NOT NULL DEFAULT 1,
+                PRIMARY KEY (workspace_id, resource_type, resource_id)
+            )
+            """,
+            "CREATE INDEX IF NOT EXISTS idx_ws_resource_memberships_workspace "
+            "ON workspace_resource_memberships(workspace_id, deleted, resource_type, role)",
+            "CREATE INDEX IF NOT EXISTS idx_ws_resource_memberships_resource "
+            "ON workspace_resource_memberships(resource_type, resource_id, deleted)",
+            "CREATE INDEX IF NOT EXISTS idx_ws_resource_memberships_updated "
+            "ON workspace_resource_memberships(workspace_id, updated_at)",
         ]
         for statement in statements:
             self.backend.execute(statement, connection=conn)
@@ -16096,6 +16155,7 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
             conversation_id = conversation["id"] if isinstance(conversation, dict) else conversation[0]
             self.hard_delete_conversation(str(conversation_id))
         with self.transaction() as conn:
+            conn.execute("DELETE FROM workspace_resource_memberships WHERE workspace_id = ?", (workspace_id,))
             conn.execute("DELETE FROM workspace_project_roots WHERE workspace_id = ?", (workspace_id,))
             conn.execute("DELETE FROM workspaces WHERE id = ?", (workspace_id,))
 
@@ -18059,6 +18119,10 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
         row = cursor.fetchone()
         return dict(row) if row else None
 
+    def get_workspace_source(self, workspace_id: str, source_id: str) -> dict[str, Any] | None:
+        """Fetch a workspace source by id."""
+        return self._get_workspace_source(workspace_id, source_id)
+
     def list_workspace_sources(self, workspace_id: str) -> list[dict[str, Any]]:
         """List all sources for a workspace ordered by position."""
         cursor = self.execute_query(
@@ -18144,6 +18208,580 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
                     "UPDATE workspace_sources SET position = ?, version = version + 1 WHERE workspace_id = ? AND id = ?",
                     (idx, workspace_id, source_id),
                 )
+
+    # --- Workspace Resource Membership Methods ---
+
+    @staticmethod
+    def _normalize_workspace_membership_required_string(value: Any, field_name: str) -> str:
+        normalized = str(value if value is not None else "").strip()
+        if not normalized:
+            raise InputError(f"{field_name} is required.")  # noqa: TRY003
+        return normalized
+
+    @staticmethod
+    def _normalize_workspace_membership_optional_string(value: Any) -> str | None:
+        if value is None:
+            return None
+        normalized = str(value).strip()
+        return normalized or None
+
+    @classmethod
+    def _normalize_workspace_membership_json_object(cls, value: Any, field_name: str) -> tuple[dict[str, Any], str]:
+        if value is None:
+            normalized: dict[str, Any] = {}
+        elif isinstance(value, str):
+            if not value.strip():
+                normalized = {}
+            else:
+                try:
+                    parsed = json.loads(value)
+                except json.JSONDecodeError as exc:
+                    raise InputError(f"{field_name} must be valid JSON.") from exc  # noqa: TRY003
+                if not isinstance(parsed, dict):
+                    raise InputError(f"{field_name} must be a JSON object.")  # noqa: TRY003
+                normalized = parsed
+        elif isinstance(value, Mapping):
+            normalized = dict(value)
+        else:
+            raise InputError(f"{field_name} must be a JSON object.")  # noqa: TRY003
+
+        try:
+            dumped = json.dumps(normalized, ensure_ascii=True, sort_keys=True)
+        except TypeError as exc:
+            raise InputError(f"{field_name} must be JSON-serializable.") from exc  # noqa: TRY003
+        return normalized, dumped
+
+    @classmethod
+    def _load_workspace_membership_json_object(cls, value: Any, *, field_name: str) -> dict[str, Any]:
+        if value is None:
+            return {}
+        if isinstance(value, Mapping):
+            return dict(value)
+        if isinstance(value, str):
+            if not value.strip():
+                return {}
+            try:
+                parsed = json.loads(value)
+            except json.JSONDecodeError:
+                preview = value[:120].replace("\n", "\\n")
+                logger.warning(
+                    "Failed to decode workspace resource membership JSON field {} ({} chars): {}",
+                    field_name,
+                    len(value),
+                    preview,
+                )
+                return {}
+            return parsed if isinstance(parsed, dict) else {}
+        return {}
+
+    def _normalize_workspace_membership_input(self, data: Mapping[str, Any]) -> dict[str, Any]:
+        resource_type = self._normalize_workspace_membership_required_string(
+            data.get("resource_type"),
+            "resource_type",
+        )
+        resource_id = self._normalize_workspace_membership_required_string(
+            data.get("resource_id"),
+            "resource_id",
+        )
+        role = self._normalize_workspace_membership_optional_string(data.get("role")) or "member"
+        transfer_policy = (
+            self._normalize_workspace_membership_optional_string(data.get("transfer_policy"))
+            or "link"
+        )
+        label = self._normalize_workspace_membership_optional_string(data.get("label"))
+        provenance, provenance_json = self._normalize_workspace_membership_json_object(
+            data.get("provenance", data.get("provenance_json")),
+            "provenance",
+        )
+        metadata, metadata_json = self._normalize_workspace_membership_json_object(
+            data.get("metadata", data.get("metadata_json")),
+            "metadata",
+        )
+        return {
+            "resource_type": resource_type,
+            "resource_id": resource_id,
+            "role": role,
+            "label": label,
+            "transfer_policy": transfer_policy,
+            "provenance": provenance,
+            "provenance_json": provenance_json,
+            "metadata": metadata,
+            "metadata_json": metadata_json,
+        }
+
+    def _normalize_workspace_membership_actor(self, user_id: str | None) -> str | None:
+        if user_id is None:
+            return None
+        normalized = str(user_id).strip()
+        return normalized or None
+
+    def _normalize_workspace_membership_row(self, row: Mapping[str, Any] | None) -> dict[str, Any] | None:
+        if not row:
+            return None
+        item = dict(row)
+        item["provenance"] = self._load_workspace_membership_json_object(
+            item.get("provenance_json"),
+            field_name="provenance_json",
+        )
+        item["metadata"] = self._load_workspace_membership_json_object(
+            item.get("metadata_json"),
+            field_name="metadata_json",
+        )
+        item["version"] = int(item.get("version") or 1)
+        return item
+
+    @staticmethod
+    def _workspace_membership_fields_match(
+        existing: Mapping[str, Any],
+        requested: Mapping[str, Any],
+    ) -> bool:
+        return (
+            existing.get("role") == requested.get("role")
+            and existing.get("label") == requested.get("label")
+            and existing.get("transfer_policy") == requested.get("transfer_policy")
+            and existing.get("provenance") == requested.get("provenance")
+            and existing.get("metadata") == requested.get("metadata")
+        )
+
+    @staticmethod
+    def _workspace_membership_is_constraint_error(exc: Exception) -> bool:
+        message = str(exc).lower()
+        return any(
+            token in message
+            for token in (
+                "unique",
+                "duplicate",
+                "constraint",
+                "foreign key",
+            )
+        )
+
+    def _workspace_membership_write_error(self, exc: Exception) -> CharactersRAGDBError:
+        if self._workspace_membership_is_constraint_error(exc):
+            return ConflictError(
+                f"Workspace resource membership write conflicted: {exc}",
+                entity="workspace_resource_memberships",
+            )
+        return CharactersRAGDBError(f"Workspace resource membership write failed: {exc}")  # noqa: TRY003
+
+    def _get_workspace_resource_membership_with_conn(
+        self,
+        conn: sqlite3.Connection | BackendConnectionWrapper,
+        workspace_id: str,
+        resource_type: str,
+        resource_id: str,
+        *,
+        include_deleted: bool,
+    ) -> dict[str, Any] | None:
+        clauses = [
+            "workspace_id = ?",
+            "resource_type = ?",
+            "resource_id = ?",
+        ]
+        params: list[Any] = [workspace_id, resource_type, resource_id]
+        if not include_deleted:
+            clauses.append("deleted = ?")
+            params.append(self._workspace_active_deleted_value())
+        row = conn.execute(
+            f"SELECT * FROM workspace_resource_memberships WHERE {' AND '.join(clauses)}",  # nosec B608
+            tuple(params),
+        ).fetchone()
+        return self._normalize_workspace_membership_row(row)
+
+    def add_workspace_resource_membership(
+        self,
+        workspace_id: str,
+        data: dict[str, Any],
+        *,
+        user_id: str | None = None,
+    ) -> dict[str, Any]:
+        """Create or restore a Workspace resource membership."""
+        normalized_workspace_id = self._normalize_workspace_membership_required_string(
+            workspace_id,
+            "workspace_id",
+        )
+        values = self._normalize_workspace_membership_input(data)
+        actor = self._normalize_workspace_membership_actor(user_id)
+        restore_deleted = bool(data.get("restore_deleted") is True)
+        now = self._get_current_utc_timestamp_iso()
+        active_deleted_value = self._workspace_active_deleted_value()
+
+        try:
+            with self.transaction() as conn:
+                existing = self._get_workspace_resource_membership_with_conn(
+                    conn,
+                    normalized_workspace_id,
+                    values["resource_type"],
+                    values["resource_id"],
+                    include_deleted=True,
+                )
+                if existing is not None:
+                    if existing.get("deleted") in (True, 1):
+                        if not restore_deleted:
+                            raise ConflictError(
+                                "Workspace resource membership exists but is deleted.",
+                                entity="workspace_resource_memberships",
+                                entity_id=values["resource_id"],
+                            )
+                        conn.execute(
+                            """
+                            UPDATE workspace_resource_memberships
+                               SET role = ?,
+                                   label = ?,
+                                   transfer_policy = ?,
+                                   provenance_json = ?,
+                                   metadata_json = ?,
+                                   updated_by_user_id = ?,
+                                   updated_at = ?,
+                                   deleted = ?,
+                                   client_id = ?,
+                                   version = version + 1
+                             WHERE workspace_id = ?
+                               AND resource_type = ?
+                               AND resource_id = ?
+                            """,
+                            (
+                                values["role"],
+                                values["label"],
+                                values["transfer_policy"],
+                                values["provenance_json"],
+                                values["metadata_json"],
+                                actor,
+                                now,
+                                active_deleted_value,
+                                self.client_id or "unknown",
+                                normalized_workspace_id,
+                                values["resource_type"],
+                                values["resource_id"],
+                            ),
+                        )
+                        restored = self._get_workspace_resource_membership_with_conn(
+                            conn,
+                            normalized_workspace_id,
+                            values["resource_type"],
+                            values["resource_id"],
+                            include_deleted=False,
+                        )
+                        if restored is None:
+                            raise CharactersRAGDBError("Restored membership row could not be reloaded.")  # noqa: TRY003
+                        return restored
+
+                    if self._workspace_membership_fields_match(existing, values):
+                        return existing
+                    raise ConflictError(
+                        "Workspace resource membership already exists with different fields.",
+                        entity="workspace_resource_memberships",
+                        entity_id=values["resource_id"],
+                    )
+
+                conn.execute(
+                    """
+                    INSERT INTO workspace_resource_memberships (
+                        workspace_id,
+                        resource_type,
+                        resource_id,
+                        role,
+                        label,
+                        transfer_policy,
+                        provenance_json,
+                        metadata_json,
+                        created_by_user_id,
+                        updated_by_user_id,
+                        created_at,
+                        updated_at,
+                        deleted,
+                        client_id,
+                        version
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 1)
+                    """,
+                    (
+                        normalized_workspace_id,
+                        values["resource_type"],
+                        values["resource_id"],
+                        values["role"],
+                        values["label"],
+                        values["transfer_policy"],
+                        values["provenance_json"],
+                        values["metadata_json"],
+                        actor,
+                        actor,
+                        now,
+                        now,
+                        active_deleted_value,
+                        self.client_id or "unknown",
+                    ),
+                )
+                created = self._get_workspace_resource_membership_with_conn(
+                    conn,
+                    normalized_workspace_id,
+                    values["resource_type"],
+                    values["resource_id"],
+                    include_deleted=False,
+                )
+                if created is None:
+                    raise CharactersRAGDBError("Created membership row could not be reloaded.")  # noqa: TRY003
+                return created
+        except ConflictError:
+            raise
+        except (sqlite3.IntegrityError, BackendDatabaseError) as exc:
+            existing = self.get_workspace_resource_membership(
+                normalized_workspace_id,
+                values["resource_type"],
+                values["resource_id"],
+                include_deleted=True,
+            )
+            if existing is not None and not existing.get("deleted") and self._workspace_membership_fields_match(
+                existing,
+                values,
+            ):
+                return existing
+            raise self._workspace_membership_write_error(exc) from exc
+
+    def get_workspace_resource_membership(
+        self,
+        workspace_id: str,
+        resource_type: str,
+        resource_id: str,
+        *,
+        include_deleted: bool = False,
+    ) -> dict[str, Any] | None:
+        """Fetch one Workspace resource membership by composite id."""
+        normalized_workspace_id = self._normalize_workspace_membership_required_string(
+            workspace_id,
+            "workspace_id",
+        )
+        normalized_resource_type = self._normalize_workspace_membership_required_string(
+            resource_type,
+            "resource_type",
+        )
+        normalized_resource_id = self._normalize_workspace_membership_required_string(
+            resource_id,
+            "resource_id",
+        )
+        try:
+            if include_deleted:
+                cursor = self.execute_query(
+                    "SELECT * FROM workspace_resource_memberships "
+                    "WHERE workspace_id = ? AND resource_type = ? AND resource_id = ?",
+                    (
+                        normalized_workspace_id,
+                        normalized_resource_type,
+                        normalized_resource_id,
+                    ),
+                )
+                return self._normalize_workspace_membership_row(cursor.fetchone())
+            cursor = self.execute_query(
+                "SELECT * FROM workspace_resource_memberships "
+                "WHERE workspace_id = ? AND resource_type = ? AND resource_id = ? AND deleted = ?",
+                (
+                    normalized_workspace_id,
+                    normalized_resource_type,
+                    normalized_resource_id,
+                    self._workspace_active_deleted_value(),
+                ),
+            )
+            return self._normalize_workspace_membership_row(cursor.fetchone())
+        except BackendDatabaseError as exc:
+            raise CharactersRAGDBError(f"Failed fetching workspace resource membership: {exc}") from exc  # noqa: TRY003
+
+    @staticmethod
+    def _normalize_membership_limit(limit: int) -> int:
+        if isinstance(limit, bool) or not isinstance(limit, int):
+            raise InputError("limit must be an integer.")  # noqa: TRY003
+        if limit < 1 or limit > 1000:
+            raise InputError("limit must be between 1 and 1000.")  # noqa: TRY003
+        return limit
+
+    def list_workspace_resource_memberships(
+        self,
+        workspace_id: str,
+        *,
+        resource_type: str | None = None,
+        role: str | None = None,
+        include_deleted: bool = False,
+        limit: int = 100,
+        cursor: tuple[str, str, str] | None = None,
+    ) -> list[dict[str, Any]]:
+        """List resource memberships for a workspace in deterministic order."""
+        normalized_workspace_id = self._normalize_workspace_membership_required_string(
+            workspace_id,
+            "workspace_id",
+        )
+        normalized_limit = self._normalize_membership_limit(limit)
+        clauses = ["workspace_id = ?"]
+        params: list[Any] = [normalized_workspace_id]
+        if resource_type is not None:
+            clauses.append("resource_type = ?")
+            params.append(
+                self._normalize_workspace_membership_required_string(
+                    resource_type,
+                    "resource_type",
+                )
+            )
+        if role is not None:
+            clauses.append("role = ?")
+            params.append(self._normalize_workspace_membership_required_string(role, "role"))
+        if not include_deleted:
+            clauses.append("deleted = ?")
+            params.append(self._workspace_active_deleted_value())
+        if cursor is not None:
+            if len(cursor) != 3:
+                raise InputError("cursor must be a tuple of (updated_at, resource_type, resource_id).")  # noqa: TRY003
+            cursor_updated_at, cursor_resource_type, cursor_resource_id = cursor
+            clauses.append(
+                "(updated_at < ? "
+                "OR (updated_at = ? AND resource_type > ?) "
+                "OR (updated_at = ? AND resource_type = ? AND resource_id > ?))"
+            )
+            params.extend(
+                [
+                    cursor_updated_at,
+                    cursor_updated_at,
+                    cursor_resource_type,
+                    cursor_updated_at,
+                    cursor_resource_type,
+                    cursor_resource_id,
+                ]
+            )
+        params.append(normalized_limit)
+        cursor_obj = self.execute_query(
+            f"SELECT * FROM workspace_resource_memberships WHERE {' AND '.join(clauses)} "  # nosec B608
+            "ORDER BY updated_at DESC, resource_type ASC, resource_id ASC LIMIT ?",
+            tuple(params),
+        )
+        return [
+            normalized
+            for row in cursor_obj.fetchall()
+            if (normalized := self._normalize_workspace_membership_row(row)) is not None
+        ]
+
+    def list_resource_workspace_memberships(
+        self,
+        resource_type: str,
+        resource_id: str,
+        *,
+        include_deleted: bool = False,
+        limit: int = 100,
+        cursor: tuple[str, str] | None = None,
+    ) -> list[dict[str, Any]]:
+        """List all workspace memberships for one resource."""
+        normalized_resource_type = self._normalize_workspace_membership_required_string(
+            resource_type,
+            "resource_type",
+        )
+        normalized_resource_id = self._normalize_workspace_membership_required_string(
+            resource_id,
+            "resource_id",
+        )
+        normalized_limit = self._normalize_membership_limit(limit)
+        clauses = ["resource_type = ?", "resource_id = ?"]
+        params: list[Any] = [normalized_resource_type, normalized_resource_id]
+        if not include_deleted:
+            clauses.append("deleted = ?")
+            params.append(self._workspace_active_deleted_value())
+        if cursor is not None:
+            if len(cursor) != 2:
+                raise InputError("cursor must be a tuple of (updated_at, workspace_id).")  # noqa: TRY003
+            cursor_updated_at, cursor_workspace_id = cursor
+            clauses.append(
+                "(updated_at < ? OR (updated_at = ? AND workspace_id > ?))"
+            )
+            params.extend([cursor_updated_at, cursor_updated_at, cursor_workspace_id])
+        params.append(normalized_limit)
+        cursor_obj = self.execute_query(
+            f"SELECT * FROM workspace_resource_memberships WHERE {' AND '.join(clauses)} "  # nosec B608
+            "ORDER BY updated_at DESC, workspace_id ASC LIMIT ?",
+            tuple(params),
+        )
+        return [
+            normalized
+            for row in cursor_obj.fetchall()
+            if (normalized := self._normalize_workspace_membership_row(row)) is not None
+        ]
+
+    def delete_workspace_resource_membership(
+        self,
+        workspace_id: str,
+        resource_type: str,
+        resource_id: str,
+        *,
+        user_id: str | None = None,
+    ) -> dict[str, Any] | None:
+        """Soft-delete one Workspace resource membership.
+
+        Missing rows and already deleted rows are idempotent no-ops.
+        """
+        normalized_workspace_id = self._normalize_workspace_membership_required_string(
+            workspace_id,
+            "workspace_id",
+        )
+        normalized_resource_type = self._normalize_workspace_membership_required_string(
+            resource_type,
+            "resource_type",
+        )
+        normalized_resource_id = self._normalize_workspace_membership_required_string(
+            resource_id,
+            "resource_id",
+        )
+        actor = self._normalize_workspace_membership_actor(user_id)
+        now = self._get_current_utc_timestamp_iso()
+        try:
+            with self.transaction() as conn:
+                existing = self._get_workspace_resource_membership_with_conn(
+                    conn,
+                    normalized_workspace_id,
+                    normalized_resource_type,
+                    normalized_resource_id,
+                    include_deleted=True,
+                )
+                if existing is None or existing.get("deleted") in (True, 1):
+                    return None
+                deleted_value = True if self.backend_type == BackendType.POSTGRESQL else 1
+                conn.execute(
+                    """
+                    UPDATE workspace_resource_memberships
+                       SET deleted = ?,
+                           updated_at = ?,
+                           updated_by_user_id = ?,
+                           client_id = ?,
+                           version = version + 1
+                     WHERE workspace_id = ?
+                       AND resource_type = ?
+                       AND resource_id = ?
+                    """,
+                    (
+                        deleted_value,
+                        now,
+                        actor,
+                        self.client_id or "unknown",
+                        normalized_workspace_id,
+                        normalized_resource_type,
+                        normalized_resource_id,
+                    ),
+                )
+                return self._get_workspace_resource_membership_with_conn(
+                    conn,
+                    normalized_workspace_id,
+                    normalized_resource_type,
+                    normalized_resource_id,
+                    include_deleted=True,
+                )
+        except (sqlite3.IntegrityError, BackendDatabaseError) as exc:
+            raise self._workspace_membership_write_error(exc) from exc
+
+    def get_conversation_for_workspace_membership(self, conversation_id: str) -> dict[str, Any] | None:
+        """Fetch the compact conversation row needed by Workspace membership adapters."""
+        normalized_conversation_id = self._normalize_workspace_membership_required_string(
+            conversation_id,
+            "conversation_id",
+        )
+        cursor = self.execute_query(
+            "SELECT id, title, workspace_id, scope_type, last_modified, version "
+            "FROM conversations WHERE id = ? AND deleted = 0",
+            (normalized_conversation_id,),
+        )
+        row = cursor.fetchone()
+        return dict(row) if row else None
 
     # --- Workspace Artifact Methods ---
 
@@ -18669,6 +19307,10 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
         )
         row = cursor.fetchone()
         return dict(row) if row else None
+
+    def get_workspace_note(self, workspace_id: str, note_id: int) -> dict[str, Any] | None:
+        """Fetch a non-deleted workspace note by id."""
+        return self._get_workspace_note(workspace_id, note_id)
 
     def list_workspace_notes(self, workspace_id: str) -> list[dict[str, Any]]:
         """List all non-deleted notes for a workspace."""

--- a/tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py
+++ b/tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py
@@ -18423,7 +18423,8 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
                                 entity="workspace_resource_memberships",
                                 entity_id=values["resource_id"],
                             )
-                        conn.execute(
+                        deleted_value = True if self.backend_type == BackendType.POSTGRESQL else 1
+                        cursor = conn.execute(
                             """
                             UPDATE workspace_resource_memberships
                                SET role = ?,
@@ -18439,6 +18440,7 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
                              WHERE workspace_id = ?
                                AND resource_type = ?
                                AND resource_id = ?
+                               AND deleted = ?
                             """,
                             (
                                 values["role"],
@@ -18453,18 +18455,37 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
                                 normalized_workspace_id,
                                 values["resource_type"],
                                 values["resource_id"],
+                                deleted_value,
                             ),
                         )
-                        restored = self._get_workspace_resource_membership_with_conn(
+                        if cursor.rowcount == 1:
+                            restored = self._get_workspace_resource_membership_with_conn(
+                                conn,
+                                normalized_workspace_id,
+                                values["resource_type"],
+                                values["resource_id"],
+                                include_deleted=False,
+                            )
+                            if restored is None:
+                                raise CharactersRAGDBError("Restored membership row could not be reloaded.")  # noqa: TRY003
+                            return restored
+
+                        raced = self._get_workspace_resource_membership_with_conn(
                             conn,
                             normalized_workspace_id,
                             values["resource_type"],
                             values["resource_id"],
-                            include_deleted=False,
+                            include_deleted=True,
                         )
-                        if restored is None:
-                            raise CharactersRAGDBError("Restored membership row could not be reloaded.")  # noqa: TRY003
-                        return restored
+                        if raced is None or raced.get("deleted") in (True, 1):
+                            raise CharactersRAGDBError("Restore race left membership unavailable.")  # noqa: TRY003
+                        if self._workspace_membership_fields_match(raced, values):
+                            return raced
+                        raise ConflictError(
+                            "Workspace resource membership already restored with different fields.",
+                            entity="workspace_resource_memberships",
+                            entity_id=values["resource_id"],
+                        )
 
                     if self._workspace_membership_fields_match(existing, values):
                         return existing
@@ -18737,7 +18758,8 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
                 if existing is None or existing.get("deleted") in (True, 1):
                     return None
                 deleted_value = True if self.backend_type == BackendType.POSTGRESQL else 1
-                conn.execute(
+                active_deleted_value = self._workspace_active_deleted_value()
+                cursor = conn.execute(
                     """
                     UPDATE workspace_resource_memberships
                        SET deleted = ?,
@@ -18748,6 +18770,7 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
                      WHERE workspace_id = ?
                        AND resource_type = ?
                        AND resource_id = ?
+                       AND deleted = ?
                     """,
                     (
                         deleted_value,
@@ -18757,15 +18780,28 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
                         normalized_workspace_id,
                         normalized_resource_type,
                         normalized_resource_id,
+                        active_deleted_value,
                     ),
                 )
-                return self._get_workspace_resource_membership_with_conn(
+                if cursor.rowcount == 1:
+                    return self._get_workspace_resource_membership_with_conn(
+                        conn,
+                        normalized_workspace_id,
+                        normalized_resource_type,
+                        normalized_resource_id,
+                        include_deleted=True,
+                    )
+
+                raced = self._get_workspace_resource_membership_with_conn(
                     conn,
                     normalized_workspace_id,
                     normalized_resource_type,
                     normalized_resource_id,
                     include_deleted=True,
                 )
+                if raced is None or raced.get("deleted") in (True, 1):
+                    return None
+                raise CharactersRAGDBError("Delete race left membership active.")  # noqa: TRY003
         except (sqlite3.IntegrityError, BackendDatabaseError) as exc:
             raise self._workspace_membership_write_error(exc) from exc
 

--- a/tldw_Server_API/app/core/DB_Management/backends/pg_rls_policies.py
+++ b/tldw_Server_API/app/core/DB_Management/backends/pg_rls_policies.py
@@ -209,6 +209,17 @@ def build_chacha_rls_sql() -> list[str]:
           USING (client_id = current_setting('app.current_user_id', true));
         """
     )
+
+    # Workspace resource memberships
+    add("ALTER TABLE IF EXISTS workspace_resource_memberships ENABLE ROW LEVEL SECURITY;")
+    add("ALTER TABLE IF EXISTS workspace_resource_memberships FORCE ROW LEVEL SECURITY;")
+    add("DROP POLICY IF EXISTS workspace_resource_memberships_tenant_isolation ON workspace_resource_memberships;")
+    add(
+        """
+        CREATE POLICY workspace_resource_memberships_tenant_isolation ON workspace_resource_memberships
+          USING (client_id = current_setting('app.current_user_id', true));
+        """
+    )
     return stmts
 
 

--- a/tldw_Server_API/app/core/Workspaces/README.md
+++ b/tldw_Server_API/app/core/Workspaces/README.md
@@ -42,6 +42,33 @@ holds focused core helpers used by those flows.
   and Jobs enqueue helpers for project-root file inventory.
 - `workspace_artifact_exports.py` - artifact export helpers and traceability checks.
 
+## Membership
+
+`workspace_resource_memberships` stores Workspace-to-resource associations. It
+does not transfer ownership, hide or move global records, or make `/workspaces`
+the global filter for Library, Notes, Chat, or search surfaces. The first slice
+supports explicit links for `workspace_note`, `media`, `workspace_source`,
+`workspace_artifact`, and `chat`.
+
+`workspace_sources` remains the Research Workspace source-selection and
+readiness table. A `workspace_source` membership can associate that source row
+with the generic membership read model, but it does not replace source
+selection, source ordering, ingest readiness, or status projection behavior.
+
+The explicit backfill helper links existing Workspace-scoped source, artifact,
+note, and chat rows into `workspace_resource_memberships` on demand. Backfill is
+idempotent and intentionally not automatic at startup; callers must opt in when
+they want existing rows represented in the generic membership table.
+
+MCP effective permission preview and path admission continue to use MCP policy
+and root bindings. Generic Workspace membership is not a trust source for MCP
+tool execution, file access, ACP execution, or Sandbox path admission.
+
+Future membership adapters must validate access through the owning domain
+adapter before linking or resolving a resource. Unsupported resource types must
+fail closed, and summaries/provenance should avoid exposing secrets, absolute
+paths, sandbox mount paths, prompts, model output contents, or file contents.
+
 ## How It Connects
 
 - `app/api/v1/endpoints/workspaces.py` exposes workspace CRUD, sources, status, preview, sub-resource routes, and read-only Workspace Core contract surfaces.
@@ -115,6 +142,9 @@ holds focused core helpers used by those flows.
 - Artifact export requires an accepted review state and preserves traceability
   through `root_artifact_id`, `artifact_version_id`, `source_lineage`, and
   embedded metadata.
+- Generic membership rows are a read-model association layer over domain-owned
+  resources. Domain tables and adapters remain responsible for ownership,
+  visibility, and access validation.
 
 ### Follow-Up Slices
 
@@ -138,6 +168,9 @@ holds focused core helpers used by those flows.
   idempotency tests.
 - New artifact export format: update `workspace_artifact_exports.py`, schema
   allowlists, and artifact promotion/export contract tests.
+- New membership resource type: add a fail-closed domain adapter, validate
+  resource access through the owning domain API, update schemas/tests, and keep
+  MCP/root/path trust decisions outside generic membership.
 
 ## Extension Points
 
@@ -158,6 +191,9 @@ holds focused core helpers used by those flows.
 - `tests/Workspaces/test_workspace_source_status_api.py`
 - `tests/Workspaces/test_workspace_source_preview_context_api.py`
 - `tests/Workspaces/test_workspace_sub_resources_api.py`
+- `tests/Workspaces/test_workspace_membership_adapters.py`
+- `tests/Workspaces/test_workspace_memberships_api.py`
+- `tests/Workspaces/test_workspace_context_membership_summary.py`
 - `tests/Workspaces/test_workspace_migration_api.py`
 - `tests/Workspaces/test_workspace_rate_limit_contract.py`
 - `tests/Agent_Orchestration/test_artifact_promotion_contract.py`

--- a/tldw_Server_API/app/core/Workspaces/membership_adapters.py
+++ b/tldw_Server_API/app/core/Workspaces/membership_adapters.py
@@ -1,0 +1,327 @@
+"""Workspace resource membership adapter registry and pilot adapters."""
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from typing import Any, Protocol
+
+from tldw_Server_API.app.core.DB_Management.media_db import api as media_db_api
+from tldw_Server_API.app.core.Workspaces.membership_models import WorkspaceResourceRef
+
+
+@dataclass(frozen=True)
+class WorkspaceMembershipContext:
+    """Context shared with resource adapters during membership operations."""
+
+    workspace_id: str
+    user_id: str | None
+    chacha_db: Any
+    media_db: Any | None = None
+    request_metadata: Mapping[str, Any] = field(default_factory=dict)
+
+
+class WorkspaceMembershipAdapterError(Exception):
+    """Fail-closed adapter error that the service maps onto API-facing errors."""
+
+    def __init__(
+        self,
+        code: str,
+        message: str,
+        *,
+        status_code: int = 404,
+        details: Mapping[str, Any] | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.code = code
+        self.message = message
+        self.status_code = status_code
+        self.details = dict(details or {})
+
+
+class WorkspaceMembershipAdapter(Protocol):
+    resource_type: str
+
+    def validate_access(self, resource_id: str, context: WorkspaceMembershipContext) -> WorkspaceResourceRef:
+        """Validate access to a resource and return its canonical reference."""
+
+    def summarize(self, resource_id: str, context: WorkspaceMembershipContext) -> WorkspaceResourceRef:
+        """Return a display summary for a resource."""
+
+    def on_link(self, membership: Mapping[str, Any], context: WorkspaceMembershipContext) -> None:
+        """Optional hook after a membership row is created or restored."""
+
+    def on_unlink(self, membership: Mapping[str, Any], context: WorkspaceMembershipContext) -> None:
+        """Optional hook after a membership row is soft-deleted."""
+
+
+class WorkspaceNoteMembershipAdapter:
+    resource_type = "workspace_note"
+
+    def validate_access(self, resource_id: str, context: WorkspaceMembershipContext) -> WorkspaceResourceRef:
+        note_id = _parse_int_resource_id(resource_id, resource_type=self.resource_type)
+        row = context.chacha_db.get_workspace_note(context.workspace_id, note_id)
+        if not row or _is_deleted(row) or _row_workspace_mismatch(row, context.workspace_id):
+            raise _resource_not_found(self.resource_type, str(note_id))
+        title = _first_non_empty(row, "title") or f"Workspace note {note_id}"
+        return WorkspaceResourceRef(
+            resource_type=self.resource_type,
+            resource_id=str(row.get("id") or note_id),
+            title=title,
+            updated_at=_first_non_empty(row, "last_modified", "updated_at", "created_at"),
+        )
+
+    def summarize(self, resource_id: str, context: WorkspaceMembershipContext) -> WorkspaceResourceRef:
+        return self.validate_access(resource_id, context)
+
+    def on_link(self, membership: Mapping[str, Any], context: WorkspaceMembershipContext) -> None:
+        return None
+
+    def on_unlink(self, membership: Mapping[str, Any], context: WorkspaceMembershipContext) -> None:
+        return None
+
+
+class WorkspaceSourceMembershipAdapter:
+    resource_type = "workspace_source"
+
+    def validate_access(self, resource_id: str, context: WorkspaceMembershipContext) -> WorkspaceResourceRef:
+        canonical_id = _require_resource_id(resource_id)
+        row = context.chacha_db.get_workspace_source(context.workspace_id, canonical_id)
+        if not row or _is_deleted(row) or _row_workspace_mismatch(row, context.workspace_id):
+            raise _resource_not_found(self.resource_type, canonical_id)
+        source_type = _first_non_empty(row, "source_type")
+        metadata = _compact_metadata(row, "source_type", "media_id")
+        return WorkspaceResourceRef(
+            resource_type=self.resource_type,
+            resource_id=str(row.get("id") or canonical_id),
+            title=_first_non_empty(row, "title") or f"Workspace source {canonical_id}",
+            subtitle=source_type,
+            updated_at=_first_non_empty(row, "last_modified", "updated_at", "added_at", "created_at"),
+            metadata=metadata,
+        )
+
+    def summarize(self, resource_id: str, context: WorkspaceMembershipContext) -> WorkspaceResourceRef:
+        return self.validate_access(resource_id, context)
+
+    def on_link(self, membership: Mapping[str, Any], context: WorkspaceMembershipContext) -> None:
+        return None
+
+    def on_unlink(self, membership: Mapping[str, Any], context: WorkspaceMembershipContext) -> None:
+        return None
+
+
+class WorkspaceArtifactMembershipAdapter:
+    resource_type = "workspace_artifact"
+
+    def validate_access(self, resource_id: str, context: WorkspaceMembershipContext) -> WorkspaceResourceRef:
+        canonical_id = _require_resource_id(resource_id)
+        row = context.chacha_db.get_workspace_artifact(context.workspace_id, canonical_id)
+        if not row or _is_deleted(row) or _row_workspace_mismatch(row, context.workspace_id):
+            raise _resource_not_found(self.resource_type, canonical_id)
+        artifact_type = _first_non_empty(row, "artifact_type")
+        metadata = _compact_metadata(row, "artifact_type", "review_state", "status")
+        return WorkspaceResourceRef(
+            resource_type=self.resource_type,
+            resource_id=str(row.get("id") or canonical_id),
+            title=_first_non_empty(row, "title") or f"Workspace artifact {canonical_id}",
+            subtitle=artifact_type,
+            updated_at=_first_non_empty(row, "last_modified", "updated_at", "completed_at", "created_at"),
+            metadata=metadata,
+        )
+
+    def summarize(self, resource_id: str, context: WorkspaceMembershipContext) -> WorkspaceResourceRef:
+        return self.validate_access(resource_id, context)
+
+    def on_link(self, membership: Mapping[str, Any], context: WorkspaceMembershipContext) -> None:
+        return None
+
+    def on_unlink(self, membership: Mapping[str, Any], context: WorkspaceMembershipContext) -> None:
+        return None
+
+
+class MediaMembershipAdapter:
+    resource_type = "media"
+
+    def validate_access(self, resource_id: str, context: WorkspaceMembershipContext) -> WorkspaceResourceRef:
+        media_id = _parse_int_resource_id(resource_id, resource_type=self.resource_type)
+        if context.media_db is None:
+            raise WorkspaceMembershipAdapterError(
+                "media_db_unavailable",
+                "Media DB is required to validate media workspace membership.",
+                status_code=503,
+            )
+        try:
+            row = media_db_api.get_media_by_id(
+                context.media_db,
+                media_id,
+                include_deleted=False,
+                include_trash=False,
+            )
+        except Exception as exc:  # pragma: no cover - defensive adapter boundary.
+            raise WorkspaceMembershipAdapterError(
+                "media_lookup_failed",
+                "Media lookup failed while validating workspace membership.",
+                status_code=503,
+            ) from exc
+        if not row:
+            raise _resource_not_found(self.resource_type, str(media_id))
+        canonical_id = str(row.get("id") or media_id)
+        subtitle = _first_non_empty(row, "media_type", "type", "content_type")
+        metadata = _compact_metadata(row, "media_type", "type", "content_type", "url")
+        return WorkspaceResourceRef(
+            resource_type=self.resource_type,
+            resource_id=canonical_id,
+            title=_first_non_empty(row, "title", "name", "url") or f"Media {canonical_id}",
+            subtitle=subtitle,
+            href=_media_href(canonical_id),
+            updated_at=_first_non_empty(row, "last_modified", "updated_at", "created_at"),
+            metadata=metadata,
+        )
+
+    def summarize(self, resource_id: str, context: WorkspaceMembershipContext) -> WorkspaceResourceRef:
+        return self.validate_access(resource_id, context)
+
+    def on_link(self, membership: Mapping[str, Any], context: WorkspaceMembershipContext) -> None:
+        return None
+
+    def on_unlink(self, membership: Mapping[str, Any], context: WorkspaceMembershipContext) -> None:
+        return None
+
+
+class ChatMembershipAdapter:
+    resource_type = "chat"
+
+    def validate_access(self, resource_id: str, context: WorkspaceMembershipContext) -> WorkspaceResourceRef:
+        canonical_id = _require_resource_id(resource_id)
+        row = context.chacha_db.get_conversation_for_workspace_membership(canonical_id)
+        if not row or _is_deleted(row):
+            raise _resource_not_found(self.resource_type, canonical_id)
+
+        scope_type = str(row.get("scope_type") or "").strip().lower()
+        row_workspace_id = row.get("workspace_id")
+        if scope_type == "workspace" and str(row_workspace_id or "") != context.workspace_id:
+            raise _resource_not_found(self.resource_type, canonical_id)
+        if scope_type not in ("", "global", "workspace"):
+            raise _resource_not_found(self.resource_type, canonical_id)
+
+        normalized_scope = scope_type or "global"
+        metadata: dict[str, Any] = {"scope_type": normalized_scope}
+        if row_workspace_id:
+            metadata["workspace_id"] = row_workspace_id
+        return WorkspaceResourceRef(
+            resource_type=self.resource_type,
+            resource_id=str(row.get("id") or canonical_id),
+            title=_first_non_empty(row, "title") or f"Chat {canonical_id}",
+            subtitle="chat",
+            updated_at=_first_non_empty(row, "last_modified", "updated_at", "created_at"),
+            metadata=metadata,
+        )
+
+    def summarize(self, resource_id: str, context: WorkspaceMembershipContext) -> WorkspaceResourceRef:
+        return self.validate_access(resource_id, context)
+
+    def on_link(self, membership: Mapping[str, Any], context: WorkspaceMembershipContext) -> None:
+        return None
+
+    def on_unlink(self, membership: Mapping[str, Any], context: WorkspaceMembershipContext) -> None:
+        return None
+
+
+def default_workspace_membership_adapters() -> dict[str, WorkspaceMembershipAdapter]:
+    adapters: tuple[WorkspaceMembershipAdapter, ...] = (
+        WorkspaceNoteMembershipAdapter(),
+        MediaMembershipAdapter(),
+        WorkspaceSourceMembershipAdapter(),
+        WorkspaceArtifactMembershipAdapter(),
+        ChatMembershipAdapter(),
+    )
+    return {adapter.resource_type: adapter for adapter in adapters}
+
+
+def get_workspace_membership_adapter(
+    resource_type: str,
+    adapters: Mapping[str, WorkspaceMembershipAdapter] | None = None,
+) -> WorkspaceMembershipAdapter:
+    normalized = _require_resource_id(resource_type)
+    registry = adapters if adapters is not None else default_workspace_membership_adapters()
+    adapter = registry.get(normalized)
+    if adapter is None:
+        raise WorkspaceMembershipAdapterError(
+            "unsupported_resource_type",
+            f"Workspace resource type '{normalized}' is not supported.",
+            status_code=400,
+            details={"resource_type": normalized},
+        )
+    return adapter
+
+
+def _require_resource_id(value: Any) -> str:
+    if value is None:
+        raise WorkspaceMembershipAdapterError(
+            "invalid_resource_id",
+            "Workspace membership resource_id is required.",
+            status_code=400,
+        )
+    normalized = str(value).strip()
+    if not normalized:
+        raise WorkspaceMembershipAdapterError(
+            "invalid_resource_id",
+            "Workspace membership resource_id is required.",
+            status_code=400,
+        )
+    return normalized
+
+
+def _parse_int_resource_id(value: Any, *, resource_type: str) -> int:
+    raw = _require_resource_id(value)
+    try:
+        parsed = int(raw)
+    except (TypeError, ValueError) as exc:
+        raise WorkspaceMembershipAdapterError(
+            "invalid_resource_id",
+            f"Workspace membership resource_id for '{resource_type}' must be an integer.",
+            status_code=400,
+        ) from exc
+    if parsed < 0:
+        raise WorkspaceMembershipAdapterError(
+            "invalid_resource_id",
+            f"Workspace membership resource_id for '{resource_type}' must be non-negative.",
+            status_code=400,
+        )
+    return parsed
+
+
+def _resource_not_found(resource_type: str, resource_id: str) -> WorkspaceMembershipAdapterError:
+    return WorkspaceMembershipAdapterError(
+        "resource_not_found",
+        f"Workspace resource '{resource_type}:{resource_id}' was not found or is not visible.",
+        status_code=404,
+        details={"resource_type": resource_type, "resource_id": resource_id},
+    )
+
+
+def _is_deleted(row: Mapping[str, Any]) -> bool:
+    return row.get("deleted") in (True, 1, "1", "true", "True")
+
+
+def _row_workspace_mismatch(row: Mapping[str, Any], workspace_id: str) -> bool:
+    row_workspace_id = row.get("workspace_id")
+    return row_workspace_id is not None and str(row_workspace_id) != workspace_id
+
+
+def _first_non_empty(row: Mapping[str, Any], *keys: str) -> str | None:
+    for key in keys:
+        value = row.get(key)
+        if value is None:
+            continue
+        text = str(value).strip()
+        if text:
+            return text
+    return None
+
+
+def _compact_metadata(row: Mapping[str, Any], *keys: str) -> dict[str, Any]:
+    return {key: row[key] for key in keys if row.get(key) is not None}
+
+
+def _media_href(media_id: str) -> str:
+    return f"/media/{media_id}"

--- a/tldw_Server_API/app/core/Workspaces/membership_adapters.py
+++ b/tldw_Server_API/app/core/Workspaces/membership_adapters.py
@@ -1,6 +1,7 @@
 """Workspace resource membership adapter registry and pilot adapters."""
 from __future__ import annotations
 
+import inspect
 from collections.abc import Mapping
 from dataclasses import dataclass, field
 from typing import Any, Protocol
@@ -66,16 +67,29 @@ class WorkspaceNoteMembershipAdapter:
         row = context.chacha_db.get_workspace_note(context.workspace_id, note_id)
         if not row or _is_deleted(row) or _row_workspace_mismatch(row, context.workspace_id):
             raise _resource_not_found(self.resource_type, str(note_id))
+        return self._ref(row, note_id)
+
+    def summarize(self, resource_id: str, context: WorkspaceMembershipContext) -> WorkspaceResourceRef:
+        note_id = _parse_int_resource_id(resource_id, resource_type=self.resource_type)
+        row = _call_with_optional_include_deleted(
+            context.chacha_db.get_workspace_note,
+            context.workspace_id,
+            note_id,
+            include_deleted=True,
+        )
+        if not row or _row_workspace_mismatch(row, context.workspace_id):
+            raise _resource_not_found(self.resource_type, str(note_id))
+        return self._ref(row, note_id, state=_resource_state(row))
+
+    def _ref(self, row: Mapping[str, Any], note_id: int, *, state: str = "available") -> WorkspaceResourceRef:
         title = _first_non_empty(row, "title") or f"Workspace note {note_id}"
         return WorkspaceResourceRef(
             resource_type=self.resource_type,
             resource_id=str(row.get("id") or note_id),
             title=title,
             updated_at=_first_non_empty(row, "last_modified", "updated_at", "created_at"),
+            state=state,
         )
-
-    def summarize(self, resource_id: str, context: WorkspaceMembershipContext) -> WorkspaceResourceRef:
-        return self.validate_access(resource_id, context)
 
     def on_link(self, membership: Mapping[str, Any], context: WorkspaceMembershipContext) -> None:
         return None
@@ -92,6 +106,21 @@ class WorkspaceSourceMembershipAdapter:
         row = context.chacha_db.get_workspace_source(context.workspace_id, canonical_id)
         if not row or _is_deleted(row) or _row_workspace_mismatch(row, context.workspace_id):
             raise _resource_not_found(self.resource_type, canonical_id)
+        return self._ref(row, canonical_id)
+
+    def summarize(self, resource_id: str, context: WorkspaceMembershipContext) -> WorkspaceResourceRef:
+        canonical_id = _require_resource_id(resource_id)
+        row = _call_with_optional_include_deleted(
+            context.chacha_db.get_workspace_source,
+            context.workspace_id,
+            canonical_id,
+            include_deleted=True,
+        )
+        if not row or _row_workspace_mismatch(row, context.workspace_id):
+            raise _resource_not_found(self.resource_type, canonical_id)
+        return self._ref(row, canonical_id, state=_resource_state(row))
+
+    def _ref(self, row: Mapping[str, Any], canonical_id: str, *, state: str = "available") -> WorkspaceResourceRef:
         source_type = _first_non_empty(row, "source_type")
         metadata = _compact_metadata(row, "source_type", "media_id")
         return WorkspaceResourceRef(
@@ -101,10 +130,8 @@ class WorkspaceSourceMembershipAdapter:
             subtitle=source_type,
             updated_at=_first_non_empty(row, "last_modified", "updated_at", "added_at", "created_at"),
             metadata=metadata,
+            state=state,
         )
-
-    def summarize(self, resource_id: str, context: WorkspaceMembershipContext) -> WorkspaceResourceRef:
-        return self.validate_access(resource_id, context)
 
     def on_link(self, membership: Mapping[str, Any], context: WorkspaceMembershipContext) -> None:
         return None
@@ -121,6 +148,21 @@ class WorkspaceArtifactMembershipAdapter:
         row = context.chacha_db.get_workspace_artifact(context.workspace_id, canonical_id)
         if not row or _is_deleted(row) or _row_workspace_mismatch(row, context.workspace_id):
             raise _resource_not_found(self.resource_type, canonical_id)
+        return self._ref(row, canonical_id)
+
+    def summarize(self, resource_id: str, context: WorkspaceMembershipContext) -> WorkspaceResourceRef:
+        canonical_id = _require_resource_id(resource_id)
+        row = _call_with_optional_include_deleted(
+            context.chacha_db.get_workspace_artifact,
+            context.workspace_id,
+            canonical_id,
+            include_deleted=True,
+        )
+        if not row or _row_workspace_mismatch(row, context.workspace_id):
+            raise _resource_not_found(self.resource_type, canonical_id)
+        return self._ref(row, canonical_id, state=_resource_state(row))
+
+    def _ref(self, row: Mapping[str, Any], canonical_id: str, *, state: str = "available") -> WorkspaceResourceRef:
         artifact_type = _first_non_empty(row, "artifact_type")
         metadata = _compact_metadata(row, "artifact_type", "review_state", "status")
         return WorkspaceResourceRef(
@@ -130,10 +172,8 @@ class WorkspaceArtifactMembershipAdapter:
             subtitle=artifact_type,
             updated_at=_first_non_empty(row, "last_modified", "updated_at", "completed_at", "created_at"),
             metadata=metadata,
+            state=state,
         )
-
-    def summarize(self, resource_id: str, context: WorkspaceMembershipContext) -> WorkspaceResourceRef:
-        return self.validate_access(resource_id, context)
 
     def on_link(self, membership: Mapping[str, Any], context: WorkspaceMembershipContext) -> None:
         return None
@@ -168,6 +208,34 @@ class MediaMembershipAdapter:
             ) from exc
         if not row:
             raise _resource_not_found(self.resource_type, str(media_id))
+        return self._ref(row, media_id)
+
+    def summarize(self, resource_id: str, context: WorkspaceMembershipContext) -> WorkspaceResourceRef:
+        media_id = _parse_int_resource_id(resource_id, resource_type=self.resource_type)
+        if context.media_db is None:
+            raise WorkspaceMembershipAdapterError(
+                "media_db_unavailable",
+                "Media DB is required to summarize media workspace membership.",
+                status_code=503,
+            )
+        try:
+            row = media_db_api.get_media_by_id(
+                context.media_db,
+                media_id,
+                include_deleted=True,
+                include_trash=True,
+            )
+        except Exception as exc:  # pragma: no cover - defensive adapter boundary.
+            raise WorkspaceMembershipAdapterError(
+                "media_lookup_failed",
+                "Media lookup failed while summarizing workspace membership.",
+                status_code=503,
+            ) from exc
+        if not row:
+            raise _resource_not_found(self.resource_type, str(media_id))
+        return self._ref(row, media_id, state=_resource_state(row))
+
+    def _ref(self, row: Mapping[str, Any], media_id: int, *, state: str = "available") -> WorkspaceResourceRef:
         canonical_id = str(row.get("id") or media_id)
         subtitle = _first_non_empty(row, "media_type", "type", "content_type")
         metadata = _compact_metadata(row, "media_type", "type", "content_type", "url")
@@ -179,10 +247,8 @@ class MediaMembershipAdapter:
             href=_media_href(canonical_id),
             updated_at=_first_non_empty(row, "last_modified", "updated_at", "created_at"),
             metadata=metadata,
+            state=state,
         )
-
-    def summarize(self, resource_id: str, context: WorkspaceMembershipContext) -> WorkspaceResourceRef:
-        return self.validate_access(resource_id, context)
 
     def on_link(self, membership: Mapping[str, Any], context: WorkspaceMembershipContext) -> None:
         return None
@@ -199,7 +265,27 @@ class ChatMembershipAdapter:
         row = context.chacha_db.get_conversation_for_workspace_membership(canonical_id)
         if not row or _is_deleted(row):
             raise _resource_not_found(self.resource_type, canonical_id)
+        return self._ref(row, canonical_id, context)
 
+    def summarize(self, resource_id: str, context: WorkspaceMembershipContext) -> WorkspaceResourceRef:
+        canonical_id = _require_resource_id(resource_id)
+        row = _call_with_optional_include_deleted(
+            context.chacha_db.get_conversation_for_workspace_membership,
+            canonical_id,
+            include_deleted=True,
+        )
+        if not row:
+            raise _resource_not_found(self.resource_type, canonical_id)
+        return self._ref(row, canonical_id, context, state=_resource_state(row))
+
+    def _ref(
+        self,
+        row: Mapping[str, Any],
+        canonical_id: str,
+        context: WorkspaceMembershipContext,
+        *,
+        state: str = "available",
+    ) -> WorkspaceResourceRef:
         scope_type = str(row.get("scope_type") or "").strip().lower()
         row_workspace_id = row.get("workspace_id")
         if scope_type == "workspace" and str(row_workspace_id or "") != context.workspace_id:
@@ -218,10 +304,8 @@ class ChatMembershipAdapter:
             subtitle="chat",
             updated_at=_first_non_empty(row, "last_modified", "updated_at", "created_at"),
             metadata=metadata,
+            state=state,
         )
-
-    def summarize(self, resource_id: str, context: WorkspaceMembershipContext) -> WorkspaceResourceRef:
-        return self.validate_access(resource_id, context)
 
     def on_link(self, membership: Mapping[str, Any], context: WorkspaceMembershipContext) -> None:
         return None
@@ -310,6 +394,35 @@ def _is_deleted(row: Mapping[str, Any]) -> bool:
 def _row_workspace_mismatch(row: Mapping[str, Any], workspace_id: str) -> bool:
     row_workspace_id = row.get("workspace_id")
     return row_workspace_id is not None and str(row_workspace_id) != workspace_id
+
+
+def _is_archived(row: Mapping[str, Any]) -> bool:
+    return row.get("archived") in (True, 1, "1", "true", "True")
+
+
+def _is_trash(row: Mapping[str, Any]) -> bool:
+    return row.get("is_trash") in (True, 1, "1", "true", "True")
+
+
+def _resource_state(row: Mapping[str, Any]) -> str:
+    if _is_deleted(row) or _is_trash(row):
+        return "deleted"
+    if _is_archived(row):
+        return "archived"
+    return "available"
+
+
+def _call_with_optional_include_deleted(func: Any, *args: Any, include_deleted: bool) -> Any:
+    try:
+        parameters = inspect.signature(func).parameters
+    except (TypeError, ValueError):
+        try:
+            return func(*args, include_deleted=include_deleted)
+        except TypeError:
+            return func(*args)
+    if "include_deleted" in parameters:
+        return func(*args, include_deleted=include_deleted)
+    return func(*args)
 
 
 def _first_non_empty(row: Mapping[str, Any], *keys: str) -> str | None:

--- a/tldw_Server_API/app/core/Workspaces/membership_adapters.py
+++ b/tldw_Server_API/app/core/Workspaces/membership_adapters.py
@@ -8,6 +8,7 @@ from typing import Any, Protocol
 
 from tldw_Server_API.app.core.DB_Management.media_db import api as media_db_api
 from tldw_Server_API.app.core.Workspaces.membership_models import WorkspaceResourceRef
+from tldw_Server_API.app.core.exceptions import WorkspaceMembershipAdapterError
 
 
 @dataclass(frozen=True)
@@ -19,24 +20,6 @@ class WorkspaceMembershipContext:
     chacha_db: Any
     media_db: Any | None = None
     request_metadata: Mapping[str, Any] = field(default_factory=dict)
-
-
-class WorkspaceMembershipAdapterError(Exception):
-    """Fail-closed adapter error that the service maps onto API-facing errors."""
-
-    def __init__(
-        self,
-        code: str,
-        message: str,
-        *,
-        status_code: int = 404,
-        details: Mapping[str, Any] | None = None,
-    ) -> None:
-        super().__init__(message)
-        self.code = code
-        self.message = message
-        self.status_code = status_code
-        self.details = dict(details or {})
 
 
 class WorkspaceMembershipAdapter(Protocol):

--- a/tldw_Server_API/app/core/Workspaces/membership_adapters.py
+++ b/tldw_Server_API/app/core/Workspaces/membership_adapters.py
@@ -48,7 +48,11 @@ class WorkspaceMembershipAdapter(Protocol):
         """Return a display summary for a resource."""
 
     def on_link(self, membership: Mapping[str, Any], context: WorkspaceMembershipContext) -> None:
-        """Optional hook after a membership row is created or restored."""
+        """Reserved hook for future transition-aware link side effects.
+
+        The first-slice service does not invoke this until membership writes can
+        report insert/restore transitions or use an outbox.
+        """
 
     def on_unlink(self, membership: Mapping[str, Any], context: WorkspaceMembershipContext) -> None:
         """Optional hook after a membership row is soft-deleted."""

--- a/tldw_Server_API/app/core/Workspaces/membership_models.py
+++ b/tldw_Server_API/app/core/Workspaces/membership_models.py
@@ -29,6 +29,7 @@ WORKSPACE_MEMBERSHIP_ROLES = frozenset(
     {"member", "source", "artifact", "conversation", "runtime", "reference"}
 )
 WORKSPACE_MEMBERSHIP_TRANSFER_POLICIES = frozenset({"link", "copy", "promote", "import"})
+WORKSPACE_MEMBERSHIP_CURSOR_MAX_BYTES = 2048
 
 _CURSOR_VERSION = 1
 _MEMBERSHIP_CURSOR_KEYS = frozenset({"v", "updated_at", "resource_type", "resource_id"})
@@ -77,7 +78,7 @@ def encode_membership_cursor(cursor: WorkspaceMembershipCursor) -> str:
 
 def decode_membership_cursor(value: str) -> WorkspaceMembershipCursor:
     payload = _decode_cursor_payload(value)
-    if set(payload) != _MEMBERSHIP_CURSOR_KEYS or payload.get("v") != _CURSOR_VERSION:
+    if set(payload) != _MEMBERSHIP_CURSOR_KEYS or not _cursor_version_is_valid(payload.get("v")):
         raise ValueError("Workspace membership cursor is invalid.")
 
     updated_at = _require_non_empty_string(payload.get("updated_at"), "updated_at")
@@ -106,7 +107,7 @@ def encode_resource_membership_cursor(cursor: WorkspaceResourceMembershipCursor)
 
 def decode_resource_membership_cursor(value: str) -> WorkspaceResourceMembershipCursor:
     payload = _decode_cursor_payload(value)
-    if set(payload) != _RESOURCE_MEMBERSHIP_CURSOR_KEYS or payload.get("v") != _CURSOR_VERSION:
+    if set(payload) != _RESOURCE_MEMBERSHIP_CURSOR_KEYS or not _cursor_version_is_valid(payload.get("v")):
         raise ValueError("Workspace resource membership cursor is invalid.")
 
     return WorkspaceResourceMembershipCursor(
@@ -125,6 +126,8 @@ def _encode_cursor_payload(payload: Mapping[str, Any]) -> str:
 
 def _decode_cursor_payload(value: str) -> Mapping[str, Any]:
     raw = _require_non_empty_string(value, "cursor")
+    if len(raw.encode("utf-8")) > WORKSPACE_MEMBERSHIP_CURSOR_MAX_BYTES:
+        raise ValueError("Workspace membership cursor is invalid.")
     padded = raw + ("=" * (-len(raw) % 4))
     try:
         decoded = base64.b64decode(padded, altchars=b"-_", validate=True)
@@ -140,3 +143,7 @@ def _require_non_empty_string(value: Any, field_name: str) -> str:
     if not isinstance(value, str) or not value:
         raise ValueError(f"Workspace membership cursor requires string {field_name}.")
     return value
+
+
+def _cursor_version_is_valid(value: Any) -> bool:
+    return type(value) is int and value == _CURSOR_VERSION

--- a/tldw_Server_API/app/core/Workspaces/membership_models.py
+++ b/tldw_Server_API/app/core/Workspaces/membership_models.py
@@ -30,6 +30,8 @@ WORKSPACE_MEMBERSHIP_ROLES = frozenset(
 )
 WORKSPACE_MEMBERSHIP_TRANSFER_POLICIES = frozenset({"link", "copy", "promote", "import"})
 WORKSPACE_MEMBERSHIP_CURSOR_MAX_BYTES = 2048
+WORKSPACE_MEMBERSHIP_MAX_PROVENANCE_BYTES = 16 * 1024
+WORKSPACE_MEMBERSHIP_MAX_METADATA_BYTES = 16 * 1024
 
 _CURSOR_VERSION = 1
 _MEMBERSHIP_CURSOR_KEYS = frozenset({"v", "updated_at", "resource_type", "resource_id"})
@@ -114,6 +116,53 @@ def decode_resource_membership_cursor(value: str) -> WorkspaceResourceMembership
         updated_at=_require_non_empty_string(payload.get("updated_at"), "updated_at"),
         workspace_id=_require_non_empty_string(payload.get("workspace_id"), "workspace_id"),
     )
+
+
+def normalize_membership_json_object(value: Any, *, field_name: str, max_bytes: int) -> dict[str, Any]:
+    """Normalize and strictly bound membership provenance/metadata JSON objects."""
+    if value is None:
+        normalized: dict[str, Any] = {}
+    elif isinstance(value, str):
+        if not value.strip():
+            normalized = {}
+        else:
+            try:
+                parsed = json.loads(value)
+            except json.JSONDecodeError as exc:
+                raise ValueError(f"{field_name} must be valid JSON") from exc
+            if not isinstance(parsed, Mapping):
+                raise ValueError(f"{field_name} must be a JSON object")
+            normalized = dict(parsed)
+    elif isinstance(value, Mapping):
+        normalized = dict(value)
+    else:
+        raise ValueError(f"{field_name} must be a JSON object")
+
+    _dump_membership_json_object(normalized, field_name=field_name, max_bytes=max_bytes)
+    return normalized
+
+
+def dump_membership_json_object(value: Any, *, field_name: str, max_bytes: int) -> tuple[dict[str, Any], str]:
+    """Normalize and dump a bounded membership JSON object for durable storage."""
+    normalized = normalize_membership_json_object(value, field_name=field_name, max_bytes=max_bytes)
+    dumped = _dump_membership_json_object(normalized, field_name=field_name, max_bytes=max_bytes)
+    return normalized, dumped
+
+
+def _dump_membership_json_object(value: Mapping[str, Any], *, field_name: str, max_bytes: int) -> str:
+    try:
+        dumped = json.dumps(
+            value,
+            ensure_ascii=True,
+            allow_nan=False,
+            separators=(",", ":"),
+            sort_keys=True,
+        )
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{field_name} must be JSON serializable") from exc
+    if len(dumped.encode("utf-8")) > max_bytes:
+        raise ValueError(f"{field_name} exceeds {max_bytes} bytes")
+    return dumped
 
 
 def _encode_cursor_payload(payload: Mapping[str, Any]) -> str:

--- a/tldw_Server_API/app/core/Workspaces/membership_models.py
+++ b/tldw_Server_API/app/core/Workspaces/membership_models.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+import base64
+import binascii
+import json
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from typing import Any
+
+
+WORKSPACE_MEMBERSHIP_RESOURCE_TYPES = frozenset(
+    {"workspace_note", "media", "workspace_source", "workspace_artifact", "chat"}
+)
+WORKSPACE_MEMBERSHIP_FUTURE_RESOURCE_TYPES = frozenset(
+    {
+        "note",
+        "prompt",
+        "workflow",
+        "watchlist",
+        "acp_session",
+        "sandbox_session",
+        "project_file",
+        "study_deck",
+        "quiz",
+        "study_pack",
+    }
+)
+WORKSPACE_MEMBERSHIP_ROLES = frozenset(
+    {"member", "source", "artifact", "conversation", "runtime", "reference"}
+)
+WORKSPACE_MEMBERSHIP_TRANSFER_POLICIES = frozenset({"link", "copy", "promote", "import"})
+
+_CURSOR_VERSION = 1
+_MEMBERSHIP_CURSOR_KEYS = frozenset({"v", "updated_at", "resource_type", "resource_id"})
+_RESOURCE_MEMBERSHIP_CURSOR_KEYS = frozenset({"v", "updated_at", "workspace_id"})
+
+
+@dataclass(frozen=True)
+class WorkspaceMembershipCursor:
+    updated_at: str
+    resource_type: str
+    resource_id: str
+
+
+@dataclass(frozen=True)
+class WorkspaceResourceMembershipCursor:
+    updated_at: str
+    workspace_id: str
+
+
+@dataclass(frozen=True)
+class WorkspaceResourceRef:
+    resource_type: str
+    resource_id: str
+    title: str | None = None
+    subtitle: str | None = None
+    href: str | None = None
+    updated_at: str | None = None
+    state: str = "available"
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+
+def encode_membership_cursor(cursor: WorkspaceMembershipCursor) -> str:
+    if cursor.resource_type not in WORKSPACE_MEMBERSHIP_RESOURCE_TYPES:
+        raise ValueError("Workspace membership cursor resource_type is invalid.")
+    _require_non_empty_string(cursor.updated_at, "updated_at")
+    _require_non_empty_string(cursor.resource_id, "resource_id")
+    return _encode_cursor_payload(
+        {
+            "v": _CURSOR_VERSION,
+            "updated_at": cursor.updated_at,
+            "resource_type": cursor.resource_type,
+            "resource_id": cursor.resource_id,
+        }
+    )
+
+
+def decode_membership_cursor(value: str) -> WorkspaceMembershipCursor:
+    payload = _decode_cursor_payload(value)
+    if set(payload) != _MEMBERSHIP_CURSOR_KEYS or payload.get("v") != _CURSOR_VERSION:
+        raise ValueError("Workspace membership cursor is invalid.")
+
+    updated_at = _require_non_empty_string(payload.get("updated_at"), "updated_at")
+    resource_type = _require_non_empty_string(payload.get("resource_type"), "resource_type")
+    resource_id = _require_non_empty_string(payload.get("resource_id"), "resource_id")
+    if resource_type not in WORKSPACE_MEMBERSHIP_RESOURCE_TYPES:
+        raise ValueError("Workspace membership cursor resource_type is invalid.")
+    return WorkspaceMembershipCursor(
+        updated_at=updated_at,
+        resource_type=resource_type,
+        resource_id=resource_id,
+    )
+
+
+def encode_resource_membership_cursor(cursor: WorkspaceResourceMembershipCursor) -> str:
+    _require_non_empty_string(cursor.updated_at, "updated_at")
+    _require_non_empty_string(cursor.workspace_id, "workspace_id")
+    return _encode_cursor_payload(
+        {
+            "v": _CURSOR_VERSION,
+            "updated_at": cursor.updated_at,
+            "workspace_id": cursor.workspace_id,
+        }
+    )
+
+
+def decode_resource_membership_cursor(value: str) -> WorkspaceResourceMembershipCursor:
+    payload = _decode_cursor_payload(value)
+    if set(payload) != _RESOURCE_MEMBERSHIP_CURSOR_KEYS or payload.get("v") != _CURSOR_VERSION:
+        raise ValueError("Workspace resource membership cursor is invalid.")
+
+    return WorkspaceResourceMembershipCursor(
+        updated_at=_require_non_empty_string(payload.get("updated_at"), "updated_at"),
+        workspace_id=_require_non_empty_string(payload.get("workspace_id"), "workspace_id"),
+    )
+
+
+def _encode_cursor_payload(payload: Mapping[str, Any]) -> str:
+    try:
+        raw = json.dumps(payload, separators=(",", ":"), sort_keys=True).encode("utf-8")
+    except (TypeError, ValueError) as exc:
+        raise ValueError("Workspace membership cursor is invalid.") from exc
+    return base64.urlsafe_b64encode(raw).decode("ascii").rstrip("=")
+
+
+def _decode_cursor_payload(value: str) -> Mapping[str, Any]:
+    raw = _require_non_empty_string(value, "cursor")
+    padded = raw + ("=" * (-len(raw) % 4))
+    try:
+        decoded = base64.b64decode(padded, altchars=b"-_", validate=True)
+        payload = json.loads(decoded.decode("utf-8"))
+    except (binascii.Error, json.JSONDecodeError, UnicodeDecodeError) as exc:
+        raise ValueError("Workspace membership cursor is invalid.") from exc
+    if not isinstance(payload, Mapping):
+        raise ValueError("Workspace membership cursor is invalid.")
+    return payload
+
+
+def _require_non_empty_string(value: Any, field_name: str) -> str:
+    if not isinstance(value, str) or not value:
+        raise ValueError(f"Workspace membership cursor requires string {field_name}.")
+    return value

--- a/tldw_Server_API/app/core/Workspaces/membership_models.py
+++ b/tldw_Server_API/app/core/Workspaces/membership_models.py
@@ -1,3 +1,4 @@
+"""Shared models and validation helpers for Workspace resource memberships."""
 from __future__ import annotations
 
 import base64
@@ -40,6 +41,8 @@ _RESOURCE_MEMBERSHIP_CURSOR_KEYS = frozenset({"v", "updated_at", "workspace_id"}
 
 @dataclass(frozen=True)
 class WorkspaceMembershipCursor:
+    """Opaque pagination cursor for memberships listed within one Workspace."""
+
     updated_at: str
     resource_type: str
     resource_id: str
@@ -47,12 +50,16 @@ class WorkspaceMembershipCursor:
 
 @dataclass(frozen=True)
 class WorkspaceResourceMembershipCursor:
+    """Opaque pagination cursor for reverse resource-to-Workspace membership lists."""
+
     updated_at: str
     workspace_id: str
 
 
 @dataclass(frozen=True)
 class WorkspaceResourceRef:
+    """Canonical resource reference and compact display summary returned by adapters."""
+
     resource_type: str
     resource_id: str
     title: str | None = None
@@ -64,6 +71,7 @@ class WorkspaceResourceRef:
 
 
 def encode_membership_cursor(cursor: WorkspaceMembershipCursor) -> str:
+    """Encode a Workspace membership page cursor as URL-safe opaque text."""
     if cursor.resource_type not in WORKSPACE_MEMBERSHIP_RESOURCE_TYPES:
         raise ValueError("Workspace membership cursor resource_type is invalid.")
     _require_non_empty_string(cursor.updated_at, "updated_at")
@@ -79,6 +87,7 @@ def encode_membership_cursor(cursor: WorkspaceMembershipCursor) -> str:
 
 
 def decode_membership_cursor(value: str) -> WorkspaceMembershipCursor:
+    """Decode and validate an opaque Workspace membership page cursor."""
     payload = _decode_cursor_payload(value)
     if set(payload) != _MEMBERSHIP_CURSOR_KEYS or not _cursor_version_is_valid(payload.get("v")):
         raise ValueError("Workspace membership cursor is invalid.")
@@ -96,6 +105,7 @@ def decode_membership_cursor(value: str) -> WorkspaceMembershipCursor:
 
 
 def encode_resource_membership_cursor(cursor: WorkspaceResourceMembershipCursor) -> str:
+    """Encode a reverse resource membership page cursor as URL-safe opaque text."""
     _require_non_empty_string(cursor.updated_at, "updated_at")
     _require_non_empty_string(cursor.workspace_id, "workspace_id")
     return _encode_cursor_payload(
@@ -108,6 +118,7 @@ def encode_resource_membership_cursor(cursor: WorkspaceResourceMembershipCursor)
 
 
 def decode_resource_membership_cursor(value: str) -> WorkspaceResourceMembershipCursor:
+    """Decode and validate an opaque reverse resource membership page cursor."""
     payload = _decode_cursor_payload(value)
     if set(payload) != _RESOURCE_MEMBERSHIP_CURSOR_KEYS or not _cursor_version_is_valid(payload.get("v")):
         raise ValueError("Workspace resource membership cursor is invalid.")

--- a/tldw_Server_API/app/core/Workspaces/membership_service.py
+++ b/tldw_Server_API/app/core/Workspaces/membership_service.py
@@ -302,6 +302,7 @@ class WorkspaceMembershipService:
         self._require_workspace(workspace_id)
         created = 0
         existing = 0
+        restored = 0
         skipped = 0
         errors: list[dict[str, str]] = []
 
@@ -310,8 +311,9 @@ class WorkspaceMembershipService:
                 workspace_id,
                 candidate["resource_type"],
                 candidate["resource_id"],
-                include_deleted=False,
+                include_deleted=True,
             )
+            was_deleted = before is not None and self._row_is_deleted(before)
             try:
                 self.link_membership(
                     workspace_id,
@@ -341,6 +343,8 @@ class WorkspaceMembershipService:
                 continue
             if before is None:
                 created += 1
+            elif was_deleted:
+                restored += 1
             else:
                 existing += 1
 
@@ -350,6 +354,7 @@ class WorkspaceMembershipService:
             "status": status,
             "created": created,
             "existing": existing,
+            "restored": restored,
             "skipped": skipped,
             "errors": errors,
             "summary": summary,

--- a/tldw_Server_API/app/core/Workspaces/membership_service.py
+++ b/tldw_Server_API/app/core/Workspaces/membership_service.py
@@ -87,7 +87,6 @@ class WorkspaceMembershipService:
             include_deleted=True,
         )
         restore_deleted = existing is not None and self._row_is_deleted(existing)
-        should_call_on_link = existing is None or restore_deleted
         row = self.chacha_db.add_workspace_resource_membership(
             workspace_id,
             {
@@ -102,8 +101,6 @@ class WorkspaceMembershipService:
             },
             user_id=user_id,
         )
-        if should_call_on_link:
-            adapter.on_link(row, context)
         return self._serialize_membership(row, context=context, summary_ref=ref if resolve else None, resolve=resolve)
 
     def get_membership(

--- a/tldw_Server_API/app/core/Workspaces/membership_service.py
+++ b/tldw_Server_API/app/core/Workspaces/membership_service.py
@@ -1,0 +1,620 @@
+"""Workspace resource membership service orchestration."""
+from __future__ import annotations
+
+from collections import Counter
+from collections.abc import Mapping
+from typing import Any
+
+from tldw_Server_API.app.core.Workspaces.membership_adapters import (
+    WorkspaceMembershipAdapter,
+    WorkspaceMembershipAdapterError,
+    WorkspaceMembershipContext,
+    default_workspace_membership_adapters,
+    get_workspace_membership_adapter,
+)
+from tldw_Server_API.app.core.Workspaces.membership_models import (
+    WORKSPACE_MEMBERSHIP_ROLES,
+    WORKSPACE_MEMBERSHIP_TRANSFER_POLICIES,
+    WorkspaceMembershipCursor,
+    WorkspaceResourceMembershipCursor,
+    WorkspaceResourceRef,
+    decode_membership_cursor,
+    decode_resource_membership_cursor,
+    encode_membership_cursor,
+    encode_resource_membership_cursor,
+)
+
+
+class WorkspaceMembershipServiceError(Exception):
+    """Service-level Workspace membership error."""
+
+    def __init__(
+        self,
+        code: str,
+        message: str,
+        *,
+        status_code: int = 409,
+        details: Mapping[str, Any] | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.code = code
+        self.message = message
+        self.status_code = status_code
+        self.details = dict(details or {})
+
+
+class WorkspaceMembershipService:
+    """Validate and persist Workspace cross-resource memberships."""
+
+    def __init__(
+        self,
+        chacha_db: Any,
+        *,
+        adapters: Mapping[str, WorkspaceMembershipAdapter] | None = None,
+    ) -> None:
+        self.chacha_db = chacha_db
+        self.adapters = dict(adapters) if adapters is not None else default_workspace_membership_adapters()
+
+    def link_membership(
+        self,
+        workspace_id: str,
+        request: Any,
+        *,
+        user_id: str | None = None,
+        media_db: Any | None = None,
+        request_metadata: Mapping[str, Any] | None = None,
+        resolve: bool = True,
+    ) -> dict[str, Any]:
+        """Validate a resource and create or restore its Workspace membership."""
+        workspace = self._require_workspace(workspace_id)
+        self._require_writable_workspace(workspace)
+        data = self._membership_request_data(request)
+        adapter = self._get_adapter(data["resource_type"])
+        context = self._context(
+            workspace_id,
+            user_id=user_id,
+            media_db=media_db,
+            request_metadata=request_metadata,
+        )
+        ref = self._validate_access(adapter, data["resource_id"], context)
+        existing = self.chacha_db.get_workspace_resource_membership(
+            workspace_id,
+            ref.resource_type,
+            ref.resource_id,
+            include_deleted=True,
+        )
+        row = self.chacha_db.add_workspace_resource_membership(
+            workspace_id,
+            {
+                "resource_type": ref.resource_type,
+                "resource_id": ref.resource_id,
+                "role": data["role"],
+                "label": data.get("label"),
+                "transfer_policy": data["transfer_policy"],
+                "provenance": data["provenance"],
+                "metadata": data["metadata"],
+                "restore_deleted": existing is not None and self._row_is_deleted(existing),
+            },
+            user_id=user_id,
+        )
+        adapter.on_link(row, context)
+        return self._serialize_membership(row, context=context, summary_ref=ref if resolve else None, resolve=resolve)
+
+    def get_membership(
+        self,
+        workspace_id: str,
+        resource_type: str,
+        resource_id: str,
+        *,
+        user_id: str | None = None,
+        media_db: Any | None = None,
+        resolve: bool = True,
+    ) -> dict[str, Any] | None:
+        """Fetch one active membership row for a Workspace."""
+        self._require_workspace(workspace_id)
+        adapter = self._get_adapter(resource_type)
+        canonical_resource_type = adapter.resource_type
+        canonical_resource_id = self._canonical_resource_id(
+            adapter,
+            canonical_resource_type,
+            resource_id,
+            workspace_id=workspace_id,
+            user_id=user_id,
+            media_db=media_db,
+            request_metadata=None,
+            validate=resolve,
+        )
+        row = self.chacha_db.get_workspace_resource_membership(
+            workspace_id,
+            canonical_resource_type,
+            canonical_resource_id,
+            include_deleted=False,
+        )
+        if row is None:
+            return None
+        context = self._context(workspace_id, user_id=user_id, media_db=media_db)
+        return self._serialize_membership(row, context=context, resolve=resolve)
+
+    def list_workspace_memberships(
+        self,
+        workspace_id: str,
+        *,
+        resource_type: str | None = None,
+        role: str | None = None,
+        include_deleted: bool = False,
+        limit: int = 100,
+        cursor: str | WorkspaceMembershipCursor | tuple[str, str, str] | None = None,
+        user_id: str | None = None,
+        media_db: Any | None = None,
+        resolve: bool = True,
+    ) -> dict[str, Any]:
+        """List memberships for one Workspace."""
+        self._require_workspace(workspace_id)
+        canonical_resource_type = None
+        if resource_type is not None:
+            canonical_resource_type = self._get_adapter(resource_type).resource_type
+        normalized_limit = self._normalize_limit(limit)
+        normalized_cursor = self._workspace_cursor_tuple(cursor)
+        rows = self.chacha_db.list_workspace_resource_memberships(
+            workspace_id,
+            resource_type=canonical_resource_type,
+            role=role,
+            include_deleted=include_deleted,
+            limit=normalized_limit,
+            cursor=normalized_cursor,
+        )
+        page_rows, next_cursor = self._trim_workspace_page(rows, normalized_limit)
+        context = self._context(workspace_id, user_id=user_id, media_db=media_db)
+        items = [self._serialize_membership(row, context=context, resolve=resolve) for row in page_rows]
+        return {
+            "workspace_id": workspace_id,
+            "items": items,
+            "total": len(items),
+            "next_cursor": next_cursor,
+            "summary": self._summary_from_rows(page_rows),
+        }
+
+    def list_resource_memberships(
+        self,
+        resource_type: str,
+        resource_id: str,
+        *,
+        include_deleted: bool = False,
+        limit: int = 100,
+        cursor: str | WorkspaceResourceMembershipCursor | tuple[str, str] | None = None,
+        user_id: str | None = None,
+        media_db: Any | None = None,
+        resolve: bool = True,
+    ) -> dict[str, Any]:
+        """List Workspace memberships for one canonical resource."""
+        adapter = self._get_adapter(resource_type)
+        canonical_resource_type = adapter.resource_type
+        canonical_resource_id = self._canonical_resource_id(
+            adapter,
+            canonical_resource_type,
+            resource_id,
+            workspace_id="",
+            user_id=user_id,
+            media_db=media_db,
+            request_metadata=None,
+            validate=canonical_resource_type == "media",
+        )
+        normalized_limit = self._normalize_limit(limit)
+        normalized_cursor = self._resource_cursor_tuple(cursor)
+        rows = self.chacha_db.list_resource_workspace_memberships(
+            canonical_resource_type,
+            canonical_resource_id,
+            include_deleted=include_deleted,
+            limit=normalized_limit,
+            cursor=normalized_cursor,
+        )
+        page_rows, next_cursor = self._trim_resource_page(rows, normalized_limit)
+        items = [
+            self._serialize_membership(
+                row,
+                context=self._context(str(row.get("workspace_id") or ""), user_id=user_id, media_db=media_db),
+                resolve=resolve,
+            )
+            for row in page_rows
+        ]
+        return {
+            "resource_type": canonical_resource_type,
+            "resource_id": canonical_resource_id,
+            "items": items,
+            "total": len(items),
+            "next_cursor": next_cursor,
+            "summary": self._summary_from_rows(page_rows),
+        }
+
+    def unlink_membership(
+        self,
+        workspace_id: str,
+        resource_type: str,
+        resource_id: str,
+        *,
+        user_id: str | None = None,
+        media_db: Any | None = None,
+    ) -> dict[str, Any] | None:
+        """Soft-delete one Workspace membership."""
+        workspace = self._require_workspace(workspace_id)
+        self._require_writable_workspace(workspace)
+        adapter = self._get_adapter(resource_type)
+        context = self._context(workspace_id, user_id=user_id, media_db=media_db)
+        canonical_resource_id = self._canonical_resource_id(
+            adapter,
+            adapter.resource_type,
+            resource_id,
+            workspace_id=workspace_id,
+            user_id=user_id,
+            media_db=media_db,
+            request_metadata=None,
+            validate=False,
+        )
+        row = self.chacha_db.delete_workspace_resource_membership(
+            workspace_id,
+            adapter.resource_type,
+            canonical_resource_id,
+            user_id=user_id,
+        )
+        if row is None:
+            return None
+        adapter.on_unlink(row, context)
+        return self._serialize_membership(row, context=context, resolve=False)
+
+    def workspace_membership_summary(self, workspace_id: str) -> dict[str, Any]:
+        """Return compact active membership totals for Workspace context."""
+        self._require_workspace(workspace_id)
+        rows: list[Mapping[str, Any]] = []
+        cursor: tuple[str, str, str] | None = None
+        page_size = 1000
+        while True:
+            page = self.chacha_db.list_workspace_resource_memberships(
+                workspace_id,
+                include_deleted=False,
+                limit=page_size,
+                cursor=cursor,
+            )
+            active_page = page[:page_size]
+            rows.extend(active_page)
+            if len(page) <= page_size or not active_page:
+                break
+            last = active_page[-1]
+            cursor = (
+                str(last.get("updated_at") or ""),
+                str(last.get("resource_type") or ""),
+                str(last.get("resource_id") or ""),
+            )
+        return self._summary_from_rows(rows)
+
+    def backfill_workspace_memberships(self, *args: Any, **kwargs: Any) -> dict[str, Any]:
+        """Task 5 owns broad backfill; this slice only exposes an explicit stub."""
+        return {
+            "status": "not_implemented",
+            "message": "Workspace membership backfill is owned by Task 5.",
+        }
+
+    def _require_workspace(self, workspace_id: str) -> Mapping[str, Any]:
+        workspace = self.chacha_db.get_workspace(workspace_id)
+        if workspace is None:
+            raise WorkspaceMembershipServiceError(
+                "workspace_not_found",
+                f"Workspace '{workspace_id}' was not found.",
+                status_code=404,
+            )
+        return workspace
+
+    def _require_writable_workspace(self, workspace: Mapping[str, Any]) -> None:
+        if workspace.get("archived") in (True, 1, "1", "true", "True"):
+            raise WorkspaceMembershipServiceError(
+                "workspace_archived",
+                "Archived workspaces cannot be modified.",
+                status_code=409,
+            )
+
+    def _context(
+        self,
+        workspace_id: str,
+        *,
+        user_id: str | None,
+        media_db: Any | None,
+        request_metadata: Mapping[str, Any] | None = None,
+    ) -> WorkspaceMembershipContext:
+        return WorkspaceMembershipContext(
+            workspace_id=workspace_id,
+            user_id=user_id,
+            chacha_db=self.chacha_db,
+            media_db=media_db,
+            request_metadata=dict(request_metadata or {}),
+        )
+
+    def _get_adapter(self, resource_type: str) -> WorkspaceMembershipAdapter:
+        try:
+            return get_workspace_membership_adapter(resource_type, self.adapters)
+        except WorkspaceMembershipAdapterError as exc:
+            raise self._service_error_from_adapter_error(exc) from exc
+
+    def _validate_access(
+        self,
+        adapter: WorkspaceMembershipAdapter,
+        resource_id: str,
+        context: WorkspaceMembershipContext,
+    ) -> WorkspaceResourceRef:
+        try:
+            return adapter.validate_access(resource_id, context)
+        except WorkspaceMembershipAdapterError as exc:
+            raise self._service_error_from_adapter_error(exc) from exc
+
+    def _canonical_resource_id(
+        self,
+        adapter: WorkspaceMembershipAdapter,
+        resource_type: str,
+        resource_id: str,
+        *,
+        workspace_id: str,
+        user_id: str | None,
+        media_db: Any | None,
+        request_metadata: Mapping[str, Any] | None,
+        validate: bool,
+    ) -> str:
+        if validate:
+            context = self._context(
+                workspace_id,
+                user_id=user_id,
+                media_db=media_db,
+                request_metadata=request_metadata,
+            )
+            return self._validate_access(adapter, resource_id, context).resource_id
+        normalized_resource_id = self._non_empty_string(resource_id, "resource_id")
+        if resource_type in {"media", "workspace_note"}:
+            try:
+                parsed = int(normalized_resource_id)
+            except (TypeError, ValueError) as exc:
+                raise WorkspaceMembershipServiceError(
+                    "invalid_resource_id",
+                    f"Workspace membership resource_id for '{resource_type}' must be an integer.",
+                    status_code=400,
+                ) from exc
+            if parsed < 0:
+                raise WorkspaceMembershipServiceError(
+                    "invalid_resource_id",
+                    f"Workspace membership resource_id for '{resource_type}' must be non-negative.",
+                    status_code=400,
+                )
+            return str(parsed)
+        return normalized_resource_id
+
+    def _serialize_membership(
+        self,
+        row: Mapping[str, Any],
+        *,
+        context: WorkspaceMembershipContext,
+        summary_ref: WorkspaceResourceRef | None = None,
+        resolve: bool = True,
+    ) -> dict[str, Any]:
+        item = {
+            "workspace_id": str(row.get("workspace_id") or context.workspace_id),
+            "resource_type": str(row.get("resource_type") or ""),
+            "resource_id": str(row.get("resource_id") or ""),
+            "role": str(row.get("role") or "member"),
+            "label": row.get("label"),
+            "transfer_policy": str(row.get("transfer_policy") or "link"),
+            "provenance": self._mapping_value(row.get("provenance")),
+            "metadata": self._mapping_value(row.get("metadata")),
+            "summary": None,
+            "created_at": str(row.get("created_at") or ""),
+            "updated_at": str(row.get("updated_at") or ""),
+            "version": int(row.get("version") or 1),
+            "deleted": self._row_is_deleted(row),
+        }
+        if resolve:
+            if summary_ref is None:
+                summary_ref = self._resolve_summary(row, context)
+            item["summary"] = self._summary_to_dict(summary_ref)
+        return item
+
+    def _resolve_summary(
+        self,
+        row: Mapping[str, Any],
+        context: WorkspaceMembershipContext,
+    ) -> WorkspaceResourceRef:
+        resource_type = str(row.get("resource_type") or "")
+        resource_id = str(row.get("resource_id") or "")
+        try:
+            adapter = get_workspace_membership_adapter(resource_type, self.adapters)
+            return adapter.summarize(resource_id, context)
+        except WorkspaceMembershipAdapterError as exc:
+            return self._unresolved_summary(resource_type, resource_id, exc.code, exc.message)
+        except Exception as exc:  # pragma: no cover - protects list calls from adapter bugs.
+            return self._unresolved_summary(resource_type, resource_id, "summary_unavailable", str(exc))
+
+    @staticmethod
+    def _service_error_from_adapter_error(exc: WorkspaceMembershipAdapterError) -> WorkspaceMembershipServiceError:
+        return WorkspaceMembershipServiceError(
+            exc.code,
+            exc.message,
+            status_code=exc.status_code,
+            details=exc.details,
+        )
+
+    @staticmethod
+    def _summary_to_dict(ref: WorkspaceResourceRef) -> dict[str, Any]:
+        return {
+            "title": ref.title,
+            "subtitle": ref.subtitle,
+            "href": ref.href,
+            "updated_at": ref.updated_at,
+            "state": ref.state,
+            "metadata": dict(ref.metadata),
+        }
+
+    @staticmethod
+    def _unresolved_summary(
+        resource_type: str,
+        resource_id: str,
+        code: str,
+        message: str,
+    ) -> WorkspaceResourceRef:
+        bounded_message = message[:240]
+        return WorkspaceResourceRef(
+            resource_type=resource_type,
+            resource_id=resource_id,
+            state="unresolved",
+            metadata={"code": code, "message": bounded_message},
+        )
+
+    @staticmethod
+    def _row_is_deleted(row: Mapping[str, Any]) -> bool:
+        return row.get("deleted") in (True, 1, "1", "true", "True")
+
+    @staticmethod
+    def _mapping_value(value: Any) -> dict[str, Any]:
+        return dict(value) if isinstance(value, Mapping) else {}
+
+    def _membership_request_data(self, request: Any) -> dict[str, Any]:
+        if hasattr(request, "model_dump"):
+            raw = request.model_dump()
+        elif isinstance(request, Mapping):
+            raw = dict(request)
+        else:
+            raise WorkspaceMembershipServiceError(
+                "invalid_membership_request",
+                "Workspace membership request must be a mapping.",
+                status_code=400,
+            )
+        data = {
+            "resource_type": self._non_empty_string(raw.get("resource_type"), "resource_type"),
+            "resource_id": self._non_empty_string(raw.get("resource_id"), "resource_id"),
+            "role": str(raw.get("role") or "member"),
+            "label": raw.get("label"),
+            "transfer_policy": str(raw.get("transfer_policy") or "link"),
+            "provenance": self._mapping_value(raw.get("provenance")),
+            "metadata": self._mapping_value(raw.get("metadata")),
+        }
+        if data["role"] not in WORKSPACE_MEMBERSHIP_ROLES:
+            raise WorkspaceMembershipServiceError(
+                "unsupported_membership_role",
+                f"Workspace membership role '{data['role']}' is not supported.",
+                status_code=400,
+            )
+        if data["transfer_policy"] not in WORKSPACE_MEMBERSHIP_TRANSFER_POLICIES:
+            raise WorkspaceMembershipServiceError(
+                "unsupported_transfer_policy",
+                f"Workspace membership transfer policy '{data['transfer_policy']}' is not supported.",
+                status_code=400,
+            )
+        if data["label"] is not None:
+            data["label"] = str(data["label"])
+        return data
+
+    @staticmethod
+    def _non_empty_string(value: Any, field_name: str) -> str:
+        if value is None:
+            raise WorkspaceMembershipServiceError(
+                "invalid_membership_request",
+                f"Workspace membership {field_name} is required.",
+                status_code=400,
+            )
+        normalized = str(value).strip()
+        if not normalized:
+            raise WorkspaceMembershipServiceError(
+                "invalid_membership_request",
+                f"Workspace membership {field_name} is required.",
+                status_code=400,
+            )
+        return normalized
+
+    @staticmethod
+    def _normalize_limit(limit: int) -> int:
+        if isinstance(limit, bool) or not isinstance(limit, int):
+            raise WorkspaceMembershipServiceError("invalid_limit", "limit must be an integer.", status_code=400)
+        if limit < 1 or limit > 1000:
+            raise WorkspaceMembershipServiceError("invalid_limit", "limit must be between 1 and 1000.", status_code=400)
+        return limit
+
+    @staticmethod
+    def _workspace_cursor_tuple(
+        cursor: str | WorkspaceMembershipCursor | tuple[str, str, str] | None,
+    ) -> tuple[str, str, str] | None:
+        if cursor is None:
+            return None
+        if isinstance(cursor, WorkspaceMembershipCursor):
+            return (cursor.updated_at, cursor.resource_type, cursor.resource_id)
+        if isinstance(cursor, str):
+            try:
+                decoded = decode_membership_cursor(cursor)
+            except ValueError as exc:
+                raise WorkspaceMembershipServiceError(
+                    "invalid_cursor",
+                    "Workspace membership cursor is invalid.",
+                    status_code=400,
+                ) from exc
+            return (decoded.updated_at, decoded.resource_type, decoded.resource_id)
+        if len(cursor) != 3:
+            raise WorkspaceMembershipServiceError("invalid_cursor", "Workspace membership cursor is invalid.", status_code=400)
+        return cursor
+
+    @staticmethod
+    def _resource_cursor_tuple(
+        cursor: str | WorkspaceResourceMembershipCursor | tuple[str, str] | None,
+    ) -> tuple[str, str] | None:
+        if cursor is None:
+            return None
+        if isinstance(cursor, WorkspaceResourceMembershipCursor):
+            return (cursor.updated_at, cursor.workspace_id)
+        if isinstance(cursor, str):
+            try:
+                decoded = decode_resource_membership_cursor(cursor)
+            except ValueError as exc:
+                raise WorkspaceMembershipServiceError(
+                    "invalid_cursor",
+                    "Workspace resource membership cursor is invalid.",
+                    status_code=400,
+                ) from exc
+            return (decoded.updated_at, decoded.workspace_id)
+        if len(cursor) != 2:
+            raise WorkspaceMembershipServiceError("invalid_cursor", "Workspace resource membership cursor is invalid.", status_code=400)
+        return cursor
+
+    @staticmethod
+    def _trim_workspace_page(rows: list[Mapping[str, Any]], limit: int) -> tuple[list[Mapping[str, Any]], str | None]:
+        page_rows = rows[:limit]
+        if len(rows) <= limit or not page_rows:
+            return page_rows, None
+        last = page_rows[-1]
+        return page_rows, encode_membership_cursor(
+            WorkspaceMembershipCursor(
+                updated_at=str(last.get("updated_at") or ""),
+                resource_type=str(last.get("resource_type") or ""),
+                resource_id=str(last.get("resource_id") or ""),
+            )
+        )
+
+    @staticmethod
+    def _trim_resource_page(rows: list[Mapping[str, Any]], limit: int) -> tuple[list[Mapping[str, Any]], str | None]:
+        page_rows = rows[:limit]
+        if len(rows) <= limit or not page_rows:
+            return page_rows, None
+        last = page_rows[-1]
+        return page_rows, encode_resource_membership_cursor(
+            WorkspaceResourceMembershipCursor(
+                updated_at=str(last.get("updated_at") or ""),
+                workspace_id=str(last.get("workspace_id") or ""),
+            )
+        )
+
+    @staticmethod
+    def _summary_from_rows(rows: list[Mapping[str, Any]]) -> dict[str, Any]:
+        active_rows = [
+            row
+            for row in rows
+            if row.get("deleted") not in (True, 1, "1", "true", "True")
+        ]
+        by_resource_type = Counter(str(row.get("resource_type") or "") for row in active_rows)
+        by_role = Counter(str(row.get("role") or "member") for row in active_rows)
+        by_resource_type.pop("", None)
+        by_role.pop("", None)
+        return {
+            "total": len(active_rows),
+            "by_resource_type": dict(sorted(by_resource_type.items())),
+            "by_role": dict(sorted(by_role.items())),
+        }

--- a/tldw_Server_API/app/core/Workspaces/membership_service.py
+++ b/tldw_Server_API/app/core/Workspaces/membership_service.py
@@ -25,6 +25,9 @@ from tldw_Server_API.app.core.Workspaces.membership_models import (
 )
 
 
+_SUMMARY_UNAVAILABLE_MESSAGE = "Workspace resource summary is unavailable."
+
+
 class WorkspaceMembershipServiceError(Exception):
     """Service-level Workspace membership error."""
 
@@ -83,6 +86,8 @@ class WorkspaceMembershipService:
             ref.resource_id,
             include_deleted=True,
         )
+        restore_deleted = existing is not None and self._row_is_deleted(existing)
+        should_call_on_link = existing is None or restore_deleted
         row = self.chacha_db.add_workspace_resource_membership(
             workspace_id,
             {
@@ -93,11 +98,12 @@ class WorkspaceMembershipService:
                 "transfer_policy": data["transfer_policy"],
                 "provenance": data["provenance"],
                 "metadata": data["metadata"],
-                "restore_deleted": existing is not None and self._row_is_deleted(existing),
+                "restore_deleted": restore_deleted,
             },
             user_id=user_id,
         )
-        adapter.on_link(row, context)
+        if should_call_on_link:
+            adapter.on_link(row, context)
         return self._serialize_membership(row, context=context, summary_ref=ref if resolve else None, resolve=resolve)
 
     def get_membership(
@@ -122,7 +128,7 @@ class WorkspaceMembershipService:
             user_id=user_id,
             media_db=media_db,
             request_metadata=None,
-            validate=resolve,
+            validate=False,
         )
         row = self.chacha_db.get_workspace_resource_membership(
             workspace_id,
@@ -424,8 +430,13 @@ class WorkspaceMembershipService:
             return adapter.summarize(resource_id, context)
         except WorkspaceMembershipAdapterError as exc:
             return self._unresolved_summary(resource_type, resource_id, exc.code, exc.message)
-        except Exception as exc:  # pragma: no cover - protects list calls from adapter bugs.
-            return self._unresolved_summary(resource_type, resource_id, "summary_unavailable", str(exc))
+        except Exception:  # pragma: no cover - protects list calls from adapter bugs.
+            return self._unresolved_summary(
+                resource_type,
+                resource_id,
+                "summary_unavailable",
+                _SUMMARY_UNAVAILABLE_MESSAGE,
+            )
 
     @staticmethod
     def _service_error_from_adapter_error(exc: WorkspaceMembershipAdapterError) -> WorkspaceMembershipServiceError:

--- a/tldw_Server_API/app/core/Workspaces/membership_service.py
+++ b/tldw_Server_API/app/core/Workspaces/membership_service.py
@@ -13,6 +13,8 @@ from tldw_Server_API.app.core.Workspaces.membership_adapters import (
     get_workspace_membership_adapter,
 )
 from tldw_Server_API.app.core.Workspaces.membership_models import (
+    WORKSPACE_MEMBERSHIP_MAX_METADATA_BYTES,
+    WORKSPACE_MEMBERSHIP_MAX_PROVENANCE_BYTES,
     WORKSPACE_MEMBERSHIP_ROLES,
     WORKSPACE_MEMBERSHIP_TRANSFER_POLICIES,
     WorkspaceMembershipCursor,
@@ -22,6 +24,7 @@ from tldw_Server_API.app.core.Workspaces.membership_models import (
     decode_resource_membership_cursor,
     encode_membership_cursor,
     encode_resource_membership_cursor,
+    normalize_membership_json_object,
 )
 
 
@@ -764,8 +767,16 @@ class WorkspaceMembershipService:
             "role": str(raw.get("role") or "member"),
             "label": raw.get("label"),
             "transfer_policy": str(raw.get("transfer_policy") or "link"),
-            "provenance": self._mapping_value(raw.get("provenance")),
-            "metadata": self._mapping_value(raw.get("metadata")),
+            "provenance": self._membership_json_value(
+                raw.get("provenance"),
+                field_name="provenance",
+                max_bytes=WORKSPACE_MEMBERSHIP_MAX_PROVENANCE_BYTES,
+            ),
+            "metadata": self._membership_json_value(
+                raw.get("metadata"),
+                field_name="metadata",
+                max_bytes=WORKSPACE_MEMBERSHIP_MAX_METADATA_BYTES,
+            ),
         }
         if data["role"] not in WORKSPACE_MEMBERSHIP_ROLES:
             raise WorkspaceMembershipServiceError(
@@ -782,6 +793,17 @@ class WorkspaceMembershipService:
         if data["label"] is not None:
             data["label"] = str(data["label"])
         return data
+
+    @staticmethod
+    def _membership_json_value(value: Any, *, field_name: str, max_bytes: int) -> dict[str, Any]:
+        try:
+            return normalize_membership_json_object(value, field_name=field_name, max_bytes=max_bytes)
+        except ValueError as exc:
+            raise WorkspaceMembershipServiceError(
+                "invalid_membership_request",
+                str(exc),
+                status_code=400,
+            ) from exc
 
     @staticmethod
     def _non_empty_string(value: Any, field_name: str) -> str:

--- a/tldw_Server_API/app/core/Workspaces/membership_service.py
+++ b/tldw_Server_API/app/core/Workspaces/membership_service.py
@@ -5,9 +5,10 @@ from collections import Counter
 from collections.abc import Mapping
 from typing import Any
 
+from loguru import logger
+
 from tldw_Server_API.app.core.Workspaces.membership_adapters import (
     WorkspaceMembershipAdapter,
-    WorkspaceMembershipAdapterError,
     WorkspaceMembershipContext,
     default_workspace_membership_adapters,
     get_workspace_membership_adapter,
@@ -26,29 +27,15 @@ from tldw_Server_API.app.core.Workspaces.membership_models import (
     encode_resource_membership_cursor,
     normalize_membership_json_object,
 )
+from tldw_Server_API.app.core.exceptions import (
+    WorkspaceMembershipAdapterError,
+    WorkspaceMembershipServiceError,
+)
 
 
 _SUMMARY_UNAVAILABLE_MESSAGE = "Workspace resource summary is unavailable."
 _BACKFILL_ERROR_LIMIT = 25
 _BACKFILL_SAFE_ERROR_MESSAGE = "Workspace membership backfill could not link this resource."
-
-
-class WorkspaceMembershipServiceError(Exception):
-    """Service-level Workspace membership error."""
-
-    def __init__(
-        self,
-        code: str,
-        message: str,
-        *,
-        status_code: int = 409,
-        details: Mapping[str, Any] | None = None,
-    ) -> None:
-        super().__init__(message)
-        self.code = code
-        self.message = message
-        self.status_code = status_code
-        self.details = dict(details or {})
 
 
 class WorkspaceMembershipService:
@@ -266,33 +253,26 @@ class WorkspaceMembershipService:
         )
         if row is None:
             return None
-        adapter.on_unlink(row, context)
+        try:
+            adapter.on_unlink(row, context)
+        except Exception:  # noqa: BLE001 - unlink hooks are post-delete best-effort cleanup.
+            logger.opt(exception=True).warning(
+                "Workspace membership unlink hook failed for workspace={} resource_type={} resource_id={}",
+                workspace_id,
+                adapter.resource_type,
+                canonical_resource_id,
+            )
         return self._serialize_membership(row, context=context, resolve=False)
 
     def workspace_membership_summary(self, workspace_id: str) -> dict[str, Any]:
         """Return compact active membership totals for Workspace context."""
         self._require_workspace(workspace_id)
-        rows: list[Mapping[str, Any]] = []
-        cursor: tuple[str, str, str] | None = None
-        page_size = 1000
-        while True:
-            page = self.chacha_db.list_workspace_resource_memberships(
-                workspace_id,
-                include_deleted=False,
-                limit=page_size,
-                cursor=cursor,
-            )
-            active_page = page[:page_size]
-            rows.extend(active_page)
-            if len(page) <= page_size or not active_page:
-                break
-            last = active_page[-1]
-            cursor = (
-                str(last.get("updated_at") or ""),
-                str(last.get("resource_type") or ""),
-                str(last.get("resource_id") or ""),
-            )
-        return self._summary_from_rows(rows)
+        summary = self.chacha_db.workspace_resource_membership_summary(workspace_id)
+        return {
+            "total": int(summary.get("total") or 0),
+            "by_resource_type": dict(summary.get("by_resource_type") or {}),
+            "by_role": dict(summary.get("by_role") or {}),
+        }
 
     def backfill_workspace_memberships(
         self,
@@ -302,7 +282,8 @@ class WorkspaceMembershipService:
         media_db: Any | None = None,
     ) -> dict[str, Any]:
         """Explicitly link existing Workspace-scoped rows into generic memberships."""
-        self._require_workspace(workspace_id)
+        workspace = self._require_workspace(workspace_id)
+        self._require_writable_workspace(workspace)
         created = 0
         existing = 0
         restored = 0
@@ -848,9 +829,13 @@ class WorkspaceMembershipService:
                     status_code=400,
                 ) from exc
             return (decoded.updated_at, decoded.resource_type, decoded.resource_id)
-        if len(cursor) != 3:
+        if (
+            not isinstance(cursor, (tuple, list))
+            or len(cursor) != 3
+            or not all(isinstance(part, str) and part for part in cursor)
+        ):
             raise WorkspaceMembershipServiceError("invalid_cursor", "Workspace membership cursor is invalid.", status_code=400)
-        return cursor
+        return (cursor[0], cursor[1], cursor[2])
 
     @staticmethod
     def _resource_cursor_tuple(
@@ -870,9 +855,13 @@ class WorkspaceMembershipService:
                     status_code=400,
                 ) from exc
             return (decoded.updated_at, decoded.workspace_id)
-        if len(cursor) != 2:
+        if (
+            not isinstance(cursor, (tuple, list))
+            or len(cursor) != 2
+            or not all(isinstance(part, str) and part for part in cursor)
+        ):
             raise WorkspaceMembershipServiceError("invalid_cursor", "Workspace resource membership cursor is invalid.", status_code=400)
-        return cursor
+        return (cursor[0], cursor[1])
 
     @staticmethod
     def _trim_workspace_page(rows: list[Mapping[str, Any]], limit: int) -> tuple[list[Mapping[str, Any]], str | None]:

--- a/tldw_Server_API/app/core/Workspaces/membership_service.py
+++ b/tldw_Server_API/app/core/Workspaces/membership_service.py
@@ -26,6 +26,8 @@ from tldw_Server_API.app.core.Workspaces.membership_models import (
 
 
 _SUMMARY_UNAVAILABLE_MESSAGE = "Workspace resource summary is unavailable."
+_BACKFILL_ERROR_LIMIT = 25
+_BACKFILL_SAFE_ERROR_MESSAGE = "Workspace membership backfill could not link this resource."
 
 
 class WorkspaceMembershipServiceError(Exception):
@@ -289,11 +291,68 @@ class WorkspaceMembershipService:
             )
         return self._summary_from_rows(rows)
 
-    def backfill_workspace_memberships(self, *args: Any, **kwargs: Any) -> dict[str, Any]:
-        """Task 5 owns broad backfill; this slice only exposes an explicit stub."""
+    def backfill_workspace_memberships(
+        self,
+        workspace_id: str,
+        *,
+        user_id: str | None = None,
+        media_db: Any | None = None,
+    ) -> dict[str, Any]:
+        """Explicitly link existing Workspace-scoped rows into generic memberships."""
+        self._require_workspace(workspace_id)
+        created = 0
+        existing = 0
+        skipped = 0
+        errors: list[dict[str, str]] = []
+
+        for candidate in self._workspace_backfill_candidates(workspace_id, errors):
+            before = self.chacha_db.get_workspace_resource_membership(
+                workspace_id,
+                candidate["resource_type"],
+                candidate["resource_id"],
+                include_deleted=False,
+            )
+            try:
+                self.link_membership(
+                    workspace_id,
+                    {
+                        "resource_type": candidate["resource_type"],
+                        "resource_id": candidate["resource_id"],
+                        "role": candidate["role"],
+                        "label": candidate.get("label"),
+                        "transfer_policy": "link",
+                        "provenance": {
+                            "source_surface": "workspace_backfill",
+                            "source_table": candidate["source_table"],
+                        },
+                        "metadata": {},
+                    },
+                    user_id=user_id,
+                    media_db=media_db,
+                    resolve=False,
+                )
+            except Exception as exc:  # noqa: BLE001 - explicit backfill records bounded diagnostics and continues.
+                self._append_backfill_error(
+                    errors,
+                    resource_type=candidate["resource_type"],
+                    resource_id=candidate["resource_id"],
+                    exc=exc,
+                )
+                continue
+            if before is None:
+                created += 1
+            else:
+                existing += 1
+
+        summary = self.workspace_membership_summary(workspace_id)
+        status = "partial" if errors or skipped else "complete"
         return {
-            "status": "not_implemented",
-            "message": "Workspace membership backfill is owned by Task 5.",
+            "status": status,
+            "created": created,
+            "existing": existing,
+            "skipped": skipped,
+            "errors": errors,
+            "summary": summary,
         }
 
     def _require_workspace(self, workspace_id: str) -> Mapping[str, Any]:
@@ -329,6 +388,211 @@ class WorkspaceMembershipService:
             media_db=media_db,
             request_metadata=dict(request_metadata or {}),
         )
+
+    def _workspace_backfill_candidates(
+        self,
+        workspace_id: str,
+        errors: list[dict[str, str]],
+    ) -> list[dict[str, str | None]]:
+        candidates: list[dict[str, str | None]] = []
+        for source in self._safe_backfill_rows(
+            "workspace_source",
+            "",
+            errors,
+            self.chacha_db.list_workspace_sources,
+            workspace_id,
+        ):
+            source_id = self._backfill_row_id(source)
+            if source_id is not None:
+                candidates.append(
+                    {
+                        "resource_type": "workspace_source",
+                        "resource_id": source_id,
+                        "role": "source",
+                        "label": self._backfill_label(source),
+                        "source_table": "workspace_sources",
+                    }
+                )
+            media_id = self._positive_backfill_int(source.get("media_id"))
+            if media_id is not None:
+                candidates.append(
+                    {
+                        "resource_type": "media",
+                        "resource_id": str(media_id),
+                        "role": "source",
+                        "label": self._backfill_label(source),
+                        "source_table": "workspace_sources",
+                    }
+                )
+
+        for artifact in self._safe_backfill_rows(
+            "workspace_artifact",
+            "",
+            errors,
+            self.chacha_db.list_workspace_artifacts,
+            workspace_id,
+        ):
+            artifact_id = self._backfill_row_id(artifact)
+            if artifact_id is not None:
+                candidates.append(
+                    {
+                        "resource_type": "workspace_artifact",
+                        "resource_id": artifact_id,
+                        "role": "artifact",
+                        "label": self._backfill_label(artifact),
+                        "source_table": "workspace_artifacts",
+                    }
+                )
+
+        for note in self._safe_backfill_rows(
+            "workspace_note",
+            "",
+            errors,
+            self.chacha_db.list_workspace_notes,
+            workspace_id,
+        ):
+            note_id = self._backfill_row_id(note)
+            if note_id is not None:
+                candidates.append(
+                    {
+                        "resource_type": "workspace_note",
+                        "resource_id": note_id,
+                        "role": "reference",
+                        "label": self._backfill_label(note),
+                        "source_table": "workspace_notes",
+                    }
+                )
+
+        for conversation in self._workspace_backfill_conversations(workspace_id, errors):
+            conversation_id = self._backfill_row_id(conversation)
+            if conversation_id is not None:
+                candidates.append(
+                    {
+                        "resource_type": "chat",
+                        "resource_id": conversation_id,
+                        "role": "conversation",
+                        "label": self._backfill_label(conversation),
+                        "source_table": "conversations",
+                    }
+                )
+        return candidates
+
+    def _workspace_backfill_conversations(
+        self,
+        workspace_id: str,
+        errors: list[dict[str, str]],
+    ) -> list[Mapping[str, Any]]:
+        list_workspace_conversations = getattr(self.chacha_db, "list_workspace_conversations", None)
+        if callable(list_workspace_conversations):
+            return self._safe_backfill_rows("chat", "", errors, list_workspace_conversations, workspace_id)
+        search_conversations = getattr(self.chacha_db, "search_conversations", None)
+        if callable(search_conversations):
+            return self._safe_backfill_rows(
+                "chat",
+                "",
+                errors,
+                search_conversations,
+                None,
+                scope_type="workspace",
+                workspace_id=workspace_id,
+            )
+        self._append_backfill_error(
+            errors,
+            resource_type="chat",
+            resource_id="",
+            code="chat_listing_unavailable",
+            message="Workspace-scoped chat listing is unavailable.",
+        )
+        return []
+
+    def _safe_backfill_rows(
+        self,
+        resource_type: str,
+        resource_id: str,
+        errors: list[dict[str, str]],
+        func: Any,
+        *args: Any,
+        **kwargs: Any,
+    ) -> list[Mapping[str, Any]]:
+        try:
+            rows = func(*args, **kwargs)
+        except Exception as exc:  # noqa: BLE001 - bounded diagnostics are the backfill contract.
+            self._append_backfill_error(
+                errors,
+                resource_type=resource_type,
+                resource_id=resource_id,
+                exc=exc,
+            )
+            return []
+        if not isinstance(rows, list):
+            self._append_backfill_error(
+                errors,
+                resource_type=resource_type,
+                resource_id=resource_id,
+                code="invalid_backfill_rows",
+                message="Workspace backfill row listing returned an invalid payload.",
+            )
+            return []
+        return [row for row in rows if isinstance(row, Mapping)]
+
+    @staticmethod
+    def _backfill_row_id(row: Mapping[str, Any]) -> str | None:
+        raw_id = row.get("id")
+        if raw_id is None:
+            return None
+        normalized = str(raw_id).strip()
+        return normalized or None
+
+    @staticmethod
+    def _backfill_label(row: Mapping[str, Any]) -> str | None:
+        for key in ("title", "name"):
+            raw = row.get(key)
+            if raw is not None and str(raw).strip():
+                return str(raw).strip()[:512]
+        return None
+
+    @staticmethod
+    def _positive_backfill_int(value: Any) -> int | None:
+        try:
+            parsed = int(value)
+        except (TypeError, ValueError):
+            return None
+        return parsed if parsed > 0 else None
+
+    @classmethod
+    def _append_backfill_error(
+        cls,
+        errors: list[dict[str, str]],
+        *,
+        resource_type: str,
+        resource_id: str,
+        exc: Exception | None = None,
+        code: str | None = None,
+        message: str | None = None,
+    ) -> None:
+        if len(errors) >= _BACKFILL_ERROR_LIMIT:
+            return
+        if isinstance(exc, WorkspaceMembershipServiceError):
+            code = exc.code
+            message = exc.message
+        elif exc is not None:
+            code = code or "backfill_link_failed"
+            message = message or _BACKFILL_SAFE_ERROR_MESSAGE
+        errors.append(
+            {
+                "resource_type": resource_type,
+                "resource_id": resource_id,
+                "code": code or "backfill_link_failed",
+                "message": cls._safe_backfill_message(message),
+            }
+        )
+
+    @staticmethod
+    def _safe_backfill_message(message: str | None) -> str:
+        raw_message = str(message or _BACKFILL_SAFE_ERROR_MESSAGE).replace("\n", " ").strip()
+        if "/" in raw_message or "\\" in raw_message:
+            return _BACKFILL_SAFE_ERROR_MESSAGE
+        return raw_message[:240]
 
     def _get_adapter(self, resource_type: str) -> WorkspaceMembershipAdapter:
         try:

--- a/tldw_Server_API/app/core/exceptions.py
+++ b/tldw_Server_API/app/core/exceptions.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Mapping
 from typing import Any
 
 from fastapi import FastAPI, HTTPException, Request, status
@@ -236,6 +237,42 @@ class StorageUnavailableError(StoragePathValidationError):
 
 class WorkspaceArtifactExportStateError(ValueError):
     """Raised when a workspace artifact version is not eligible for export."""
+
+
+class WorkspaceMembershipAdapterError(Exception):
+    """Fail-closed adapter error for Workspace cross-resource memberships."""
+
+    def __init__(
+        self,
+        code: str,
+        message: str,
+        *,
+        status_code: int = 404,
+        details: Mapping[str, Any] | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.code = code
+        self.message = message
+        self.status_code = status_code
+        self.details = dict(details or {})
+
+
+class WorkspaceMembershipServiceError(Exception):
+    """API-facing service error for Workspace cross-resource memberships."""
+
+    def __init__(
+        self,
+        code: str,
+        message: str,
+        *,
+        status_code: int = 409,
+        details: Mapping[str, Any] | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.code = code
+        self.message = message
+        self.status_code = status_code
+        self.details = dict(details or {})
 
 
 class InvalidStorageUserIdError(StoragePathValidationError):

--- a/tldw_Server_API/tests/ChaChaNotesDB/test_workspace_resource_memberships_db.py
+++ b/tldw_Server_API/tests/ChaChaNotesDB/test_workspace_resource_memberships_db.py
@@ -7,6 +7,7 @@ from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import (
     CharactersRAGDB,
     CharactersRAGDBError,
     ConflictError,
+    InputError,
 )
 
 
@@ -143,6 +144,33 @@ def test_duplicate_workspace_resource_membership_conflict_raises(db, updates):
         )
 
     assert exc_info.value.entity == "workspace_resource_memberships"
+
+
+@pytest.mark.parametrize("field_name", ["provenance", "metadata"])
+@pytest.mark.parametrize("value", [float("nan"), float("inf"), -float("inf")])
+def test_workspace_resource_membership_rejects_non_finite_json_values(db, field_name, value):
+    with pytest.raises(InputError, match=f"{field_name} must be JSON serializable"):
+        db.add_workspace_resource_membership(
+            "ws-1",
+            {
+                "resource_type": "media",
+                "resource_id": "42",
+                field_name: {"value": value},
+            },
+        )
+
+
+@pytest.mark.parametrize("field_name", ["provenance", "metadata"])
+def test_workspace_resource_membership_rejects_oversized_json_values(db, field_name):
+    with pytest.raises(InputError, match=f"{field_name} exceeds"):
+        db.add_workspace_resource_membership(
+            "ws-1",
+            {
+                "resource_type": "media",
+                "resource_id": "42",
+                field_name: {"value": "x" * (16 * 1024 + 1)},
+            },
+        )
 
 
 def test_delete_workspace_resource_membership_soft_deletes_and_default_reads_hide(db):

--- a/tldw_Server_API/tests/ChaChaNotesDB/test_workspace_resource_memberships_db.py
+++ b/tldw_Server_API/tests/ChaChaNotesDB/test_workspace_resource_memberships_db.py
@@ -431,6 +431,115 @@ def test_workspace_membership_backend_constraint_error_maps_to_conflict(db, monk
     assert exc_info.value.entity == "workspace_resource_memberships"
 
 
+class _RowcountCursor:
+    def __init__(self, rowcount: int):
+        self.rowcount = rowcount
+
+
+class _RowcountZeroConnection:
+    def __init__(self):
+        self.statements: list[tuple[str, tuple[object, ...]]] = []
+
+    def execute(self, statement: str, params: tuple[object, ...]):
+        self.statements.append((statement, params))
+        return _RowcountCursor(0)
+
+
+class _RowcountZeroTransaction:
+    def __init__(self, conn: _RowcountZeroConnection):
+        self.conn = conn
+
+    def __enter__(self):
+        return self.conn
+
+    def __exit__(self, exc_type, exc, traceback):
+        return False
+
+
+def _membership_row(**updates: object) -> dict[str, object]:
+    row: dict[str, object] = {
+        "workspace_id": "ws-1",
+        "resource_type": "media",
+        "resource_id": "42",
+        "role": "member",
+        "label": "Restored",
+        "transfer_policy": "link",
+        "provenance": {"source_surface": "restore"},
+        "provenance_json": '{"source_surface": "restore"}',
+        "metadata": {"reason": "manual"},
+        "metadata_json": '{"reason": "manual"}',
+        "created_by_user_id": "user-1",
+        "updated_by_user_id": "user-2",
+        "created_at": "2026-06-07T12:00:00.000Z",
+        "updated_at": "2026-06-07T12:01:00.000Z",
+        "deleted": 0,
+        "client_id": "test-client",
+        "version": 3,
+    }
+    row.update(updates)
+    return row
+
+
+def test_restore_deleted_membership_race_returns_already_restored_row(db, monkeypatch):
+    fake_conn = _RowcountZeroConnection()
+    calls: list[bool] = []
+    deleted_row = _membership_row(deleted=1, version=2)
+    active_row = _membership_row(deleted=0, version=3)
+
+    def fake_getter(conn, workspace_id, resource_type, resource_id, *, include_deleted):
+        calls.append(include_deleted)
+        if len(calls) == 1:
+            return deleted_row
+        return active_row if include_deleted else None
+
+    monkeypatch.setattr(db, "transaction", lambda: _RowcountZeroTransaction(fake_conn))
+    monkeypatch.setattr(db, "_get_workspace_resource_membership_with_conn", fake_getter)
+
+    restored = db.add_workspace_resource_membership(
+        "ws-1",
+        {
+            "resource_type": "media",
+            "resource_id": "42",
+            "role": "member",
+            "label": "Restored",
+            "transfer_policy": "link",
+            "provenance": {"source_surface": "restore"},
+            "metadata": {"reason": "manual"},
+            "restore_deleted": True,
+        },
+        user_id="user-2",
+    )
+
+    assert restored == active_row
+    assert calls == [True, True]
+    assert "AND deleted = ?" in fake_conn.statements[0][0]
+
+
+def test_delete_membership_race_returns_none_for_already_deleted_row(db, monkeypatch):
+    fake_conn = _RowcountZeroConnection()
+    calls: list[bool] = []
+    active_row = _membership_row(deleted=0, version=2)
+    deleted_row = _membership_row(deleted=1, version=3)
+
+    def fake_getter(conn, workspace_id, resource_type, resource_id, *, include_deleted):
+        calls.append(include_deleted)
+        return active_row if len(calls) == 1 else deleted_row
+
+    monkeypatch.setattr(db, "transaction", lambda: _RowcountZeroTransaction(fake_conn))
+    monkeypatch.setattr(db, "_get_workspace_resource_membership_with_conn", fake_getter)
+
+    deleted = db.delete_workspace_resource_membership(
+        "ws-1",
+        "media",
+        "42",
+        user_id="user-2",
+    )
+
+    assert deleted is None
+    assert calls == [True, True]
+    assert "AND deleted = ?" in fake_conn.statements[0][0]
+
+
 def test_workspace_subresource_public_getters_return_existing_scoped_rows(db):
     source = db.add_workspace_source(
         "ws-1",

--- a/tldw_Server_API/tests/ChaChaNotesDB/test_workspace_resource_memberships_db.py
+++ b/tldw_Server_API/tests/ChaChaNotesDB/test_workspace_resource_memberships_db.py
@@ -1,0 +1,343 @@
+"""Tests for Workspace cross-resource membership persistence."""
+
+import pytest
+
+from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import (
+    CharactersRAGDB,
+    ConflictError,
+)
+
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture
+def db(tmp_path):
+    database = CharactersRAGDB(
+        db_path=str(tmp_path / "workspace_memberships.sqlite"),
+        client_id="test-client",
+    )
+    database.upsert_workspace("ws-1", "Workspace One")
+    database.upsert_workspace("ws-2", "Workspace Two")
+    database.upsert_workspace("ws-3", "Workspace Three")
+    return database
+
+
+def _set_membership_updated_at(
+    db: CharactersRAGDB,
+    workspace_id: str,
+    resource_type: str,
+    resource_id: str,
+    updated_at: str,
+) -> None:
+    db.execute_query(
+        "UPDATE workspace_resource_memberships "
+        "SET updated_at = ? "
+        "WHERE workspace_id = ? AND resource_type = ? AND resource_id = ?",
+        (updated_at, workspace_id, resource_type, resource_id),
+        commit=True,
+    )
+
+
+def test_add_workspace_resource_membership_creates_normalized_row(db):
+    row = db.add_workspace_resource_membership(
+        "ws-1",
+        {
+            "resource_type": " media ",
+            "resource_id": " 42 ",
+            "role": " source ",
+            "label": "Paper",
+            "transfer_policy": " link ",
+            "provenance": {"source_surface": "library"},
+            "metadata": {"priority": "high"},
+        },
+        user_id="user-1",
+    )
+
+    assert row["workspace_id"] == "ws-1"
+    assert row["resource_type"] == "media"
+    assert row["resource_id"] == "42"
+    assert row["role"] == "source"
+    assert row["transfer_policy"] == "link"
+    assert row["label"] == "Paper"
+    assert row["provenance"] == {"source_surface": "library"}
+    assert row["metadata"] == {"priority": "high"}
+    assert row["created_by_user_id"] == "user-1"
+    assert row["updated_by_user_id"] == "user-1"
+    assert row["client_id"] == "test-client"
+    assert row["version"] == 1
+    assert row["deleted"] in (False, 0)
+
+
+def test_duplicate_workspace_resource_membership_same_request_returns_existing(db):
+    first = db.add_workspace_resource_membership(
+        "ws-1",
+        {
+            "resource_type": "media",
+            "resource_id": "42",
+            "role": "source",
+            "label": "Paper",
+            "transfer_policy": "link",
+            "provenance": {"source_surface": "library"},
+            "metadata": {"priority": "high"},
+        },
+        user_id="user-1",
+    )
+
+    duplicate = db.add_workspace_resource_membership(
+        "ws-1",
+        {
+            "resource_type": " media ",
+            "resource_id": " 42 ",
+            "role": " source ",
+            "label": "Paper",
+            "transfer_policy": " link ",
+            "provenance": {"source_surface": "library"},
+            "metadata": {"priority": "high"},
+        },
+        user_id="user-2",
+    )
+
+    assert duplicate == first
+
+
+@pytest.mark.parametrize(
+    "updates",
+    [
+        {"role": "member"},
+        {"transfer_policy": "copy"},
+        {"label": "Other label"},
+        {"provenance": {"source_surface": "backfill"}},
+        {"metadata": {"priority": "low"}},
+    ],
+)
+def test_duplicate_workspace_resource_membership_conflict_raises(db, updates):
+    db.add_workspace_resource_membership(
+        "ws-1",
+        {
+            "resource_type": "media",
+            "resource_id": "42",
+            "role": "source",
+            "label": "Paper",
+            "transfer_policy": "link",
+            "provenance": {"source_surface": "library"},
+            "metadata": {"priority": "high"},
+        },
+    )
+
+    with pytest.raises(ConflictError) as exc_info:
+        db.add_workspace_resource_membership(
+            "ws-1",
+            {
+                "resource_type": "media",
+                "resource_id": "42",
+                "role": "source",
+                "label": "Paper",
+                "transfer_policy": "link",
+                "provenance": {"source_surface": "library"},
+                "metadata": {"priority": "high"},
+                **updates,
+            },
+        )
+
+    assert exc_info.value.entity == "workspace_resource_memberships"
+
+
+def test_delete_workspace_resource_membership_soft_deletes_and_default_reads_hide(db):
+    db.add_workspace_resource_membership(
+        "ws-1",
+        {"resource_type": "media", "resource_id": "42", "role": "source"},
+        user_id="user-1",
+    )
+
+    deleted = db.delete_workspace_resource_membership(
+        "ws-1",
+        "media",
+        "42",
+        user_id="user-2",
+    )
+
+    assert deleted is not None
+    assert deleted["deleted"] in (True, 1)
+    assert deleted["updated_by_user_id"] == "user-2"
+    assert deleted["version"] == 2
+    assert db.get_workspace_resource_membership("ws-1", "media", "42") is None
+    assert db.list_workspace_resource_memberships("ws-1") == []
+
+    include_deleted = db.get_workspace_resource_membership(
+        "ws-1",
+        "media",
+        "42",
+        include_deleted=True,
+    )
+    assert include_deleted is not None
+    assert include_deleted["deleted"] in (True, 1)
+    assert db.delete_workspace_resource_membership("ws-1", "media", "42") is None
+
+
+def test_add_workspace_resource_membership_restores_deleted_row(db):
+    created = db.add_workspace_resource_membership(
+        "ws-1",
+        {
+            "resource_type": "media",
+            "resource_id": "42",
+            "role": "source",
+            "label": "Original",
+            "provenance": {"source_surface": "library"},
+        },
+        user_id="user-1",
+    )
+    deleted = db.delete_workspace_resource_membership(
+        "ws-1",
+        "media",
+        "42",
+        user_id="user-2",
+    )
+    assert deleted is not None
+
+    restored = db.add_workspace_resource_membership(
+        "ws-1",
+        {
+            "resource_type": "media",
+            "resource_id": "42",
+            "role": "member",
+            "label": "Restored",
+            "transfer_policy": "link",
+            "provenance": {"source_surface": "restore"},
+            "metadata": {"reason": "manual"},
+            "restore_deleted": True,
+        },
+        user_id="user-3",
+    )
+
+    assert restored["deleted"] in (False, 0)
+    assert restored["role"] == "member"
+    assert restored["label"] == "Restored"
+    assert restored["provenance"] == {"source_surface": "restore"}
+    assert restored["metadata"] == {"reason": "manual"}
+    assert restored["created_at"] == created["created_at"]
+    assert restored["created_by_user_id"] == "user-1"
+    assert restored["updated_by_user_id"] == "user-3"
+    assert restored["version"] == deleted["version"] + 1
+
+
+def test_list_workspace_resource_memberships_order_is_deterministic(db):
+    db.add_workspace_resource_membership(
+        "ws-1",
+        {"resource_type": "workspace_source", "resource_id": "src-b"},
+    )
+    db.add_workspace_resource_membership(
+        "ws-1",
+        {"resource_type": "media", "resource_id": "99"},
+    )
+    db.add_workspace_resource_membership(
+        "ws-1",
+        {"resource_type": "media", "resource_id": "42"},
+    )
+    db.add_workspace_resource_membership(
+        "ws-1",
+        {"resource_type": "chat", "resource_id": "conv-1"},
+    )
+    _set_membership_updated_at(
+        db,
+        "ws-1",
+        "workspace_source",
+        "src-b",
+        "2026-06-07T12:00:00.000Z",
+    )
+    _set_membership_updated_at(
+        db,
+        "ws-1",
+        "media",
+        "99",
+        "2026-06-07T12:00:00.000Z",
+    )
+    _set_membership_updated_at(
+        db,
+        "ws-1",
+        "media",
+        "42",
+        "2026-06-07T12:00:00.000Z",
+    )
+    _set_membership_updated_at(
+        db,
+        "ws-1",
+        "chat",
+        "conv-1",
+        "2026-06-07T11:00:00.000Z",
+    )
+
+    rows = db.list_workspace_resource_memberships("ws-1")
+
+    assert [(row["resource_type"], row["resource_id"]) for row in rows] == [
+        ("media", "42"),
+        ("media", "99"),
+        ("workspace_source", "src-b"),
+        ("chat", "conv-1"),
+    ]
+
+
+def test_list_resource_workspace_memberships_returns_all_active_workspaces(db):
+    db.add_workspace_resource_membership(
+        "ws-2",
+        {"resource_type": "media", "resource_id": "42", "role": "source"},
+    )
+    db.add_workspace_resource_membership(
+        "ws-1",
+        {"resource_type": "media", "resource_id": "42", "role": "source"},
+    )
+    db.add_workspace_resource_membership(
+        "ws-3",
+        {"resource_type": "media", "resource_id": "42", "role": "source"},
+    )
+    db.delete_workspace_resource_membership("ws-3", "media", "42")
+    _set_membership_updated_at(db, "ws-1", "media", "42", "2026-06-07T12:00:00.000Z")
+    _set_membership_updated_at(db, "ws-2", "media", "42", "2026-06-07T12:00:00.000Z")
+
+    rows = db.list_resource_workspace_memberships("media", "42")
+
+    assert [row["workspace_id"] for row in rows] == ["ws-1", "ws-2"]
+
+
+def test_workspace_subresource_public_getters_return_existing_scoped_rows(db):
+    source = db.add_workspace_source(
+        "ws-1",
+        {
+            "id": "src-1",
+            "media_id": 42,
+            "title": "Research Source",
+            "source_type": "video",
+        },
+    )
+    note = db.add_workspace_note(
+        "ws-1",
+        {
+            "title": "Workspace Note",
+            "content": "Evidence notes",
+        },
+    )
+
+    assert db.get_workspace_source("ws-1", "src-1") == source
+    assert db.get_workspace_note("ws-1", note["id"]) == note
+
+
+def test_get_conversation_for_workspace_membership_returns_workspace_conversation(db):
+    db.add_character_card({"name": "Workspace Character"})
+    conversation_id = db.add_conversation(
+        {
+            "character_id": 1,
+            "title": "Workspace Chat",
+            "scope_type": "workspace",
+            "workspace_id": "ws-1",
+        }
+    )
+
+    row = db.get_conversation_for_workspace_membership(conversation_id)
+
+    assert row is not None
+    assert row["id"] == conversation_id
+    assert row["title"] == "Workspace Chat"
+    assert row["scope_type"] == "workspace"
+    assert row["workspace_id"] == "ws-1"
+    assert row["last_modified"] is not None
+    assert row["version"] == 1

--- a/tldw_Server_API/tests/ChaChaNotesDB/test_workspace_resource_memberships_db.py
+++ b/tldw_Server_API/tests/ChaChaNotesDB/test_workspace_resource_memberships_db.py
@@ -3,7 +3,9 @@
 import pytest
 
 from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import (
+    BackendDatabaseError,
     CharactersRAGDB,
+    CharactersRAGDBError,
     ConflictError,
 )
 
@@ -277,6 +279,33 @@ def test_list_workspace_resource_memberships_order_is_deterministic(db):
     ]
 
 
+def test_list_workspace_resource_memberships_returns_limit_plus_one_for_pagination(db):
+    for resource_type, resource_id in (
+        ("media", "42"),
+        ("media", "99"),
+        ("workspace_source", "src-b"),
+    ):
+        db.add_workspace_resource_membership(
+            "ws-1",
+            {"resource_type": resource_type, "resource_id": resource_id},
+        )
+        _set_membership_updated_at(
+            db,
+            "ws-1",
+            resource_type,
+            resource_id,
+            "2026-06-07T12:00:00.000Z",
+        )
+
+    rows = db.list_workspace_resource_memberships("ws-1", limit=2)
+
+    assert [(row["resource_type"], row["resource_id"]) for row in rows] == [
+        ("media", "42"),
+        ("media", "99"),
+        ("workspace_source", "src-b"),
+    ]
+
+
 def test_list_resource_workspace_memberships_returns_all_active_workspaces(db):
     db.add_workspace_resource_membership(
         "ws-2",
@@ -297,6 +326,109 @@ def test_list_resource_workspace_memberships_returns_all_active_workspaces(db):
     rows = db.list_resource_workspace_memberships("media", "42")
 
     assert [row["workspace_id"] for row in rows] == ["ws-1", "ws-2"]
+
+
+def test_list_resource_workspace_memberships_returns_limit_plus_one_for_pagination(db):
+    for workspace_id in ("ws-2", "ws-1", "ws-3"):
+        db.add_workspace_resource_membership(
+            workspace_id,
+            {"resource_type": "media", "resource_id": "42", "role": "source"},
+        )
+        _set_membership_updated_at(
+            db,
+            workspace_id,
+            "media",
+            "42",
+            "2026-06-07T12:00:00.000Z",
+        )
+
+    rows = db.list_resource_workspace_memberships("media", "42", limit=2)
+
+    assert [row["workspace_id"] for row in rows] == ["ws-1", "ws-2", "ws-3"]
+
+
+def test_delete_workspace_preserves_membership_history(db):
+    created = db.add_workspace_resource_membership(
+        "ws-1",
+        {"resource_type": "media", "resource_id": "42", "role": "source"},
+    )
+    workspace = db.get_workspace("ws-1")
+    assert workspace is not None
+
+    assert db.delete_workspace("ws-1", expected_version=workspace["version"]) is True
+
+    assert db.get_workspace("ws-1") is None
+    preserved = db.get_workspace_resource_membership(
+        "ws-1",
+        "media",
+        "42",
+        include_deleted=True,
+    )
+    assert preserved is not None
+    assert preserved["deleted"] in (False, 0)
+    assert preserved["created_at"] == created["created_at"]
+
+
+def test_hard_delete_workspace_removes_membership_rows(db):
+    db.add_workspace_resource_membership(
+        "ws-1",
+        {"resource_type": "media", "resource_id": "42", "role": "source"},
+    )
+
+    db.hard_delete_workspace("ws-1")
+
+    assert (
+        db.get_workspace_resource_membership(
+            "ws-1",
+            "media",
+            "42",
+            include_deleted=True,
+        )
+        is None
+    )
+
+
+class _BackendErrorTransaction:
+    def __init__(self, error: BackendDatabaseError):
+        self.error = error
+
+    def __enter__(self):
+        raise self.error
+
+    def __exit__(self, exc_type, exc, traceback):
+        return False
+
+
+def test_workspace_membership_backend_error_wraps_unrelated_errors(db, monkeypatch):
+    monkeypatch.setattr(
+        db,
+        "transaction",
+        lambda: _BackendErrorTransaction(BackendDatabaseError("pg down")),
+    )
+
+    with pytest.raises(CharactersRAGDBError, match="pg down"):
+        db.add_workspace_resource_membership(
+            "ws-1",
+            {"resource_type": "media", "resource_id": "42"},
+        )
+
+
+def test_workspace_membership_backend_constraint_error_maps_to_conflict(db, monkeypatch):
+    monkeypatch.setattr(
+        db,
+        "transaction",
+        lambda: _BackendErrorTransaction(
+            BackendDatabaseError("duplicate key value violates unique constraint")
+        ),
+    )
+
+    with pytest.raises(ConflictError) as exc_info:
+        db.add_workspace_resource_membership(
+            "ws-1",
+            {"resource_type": "media", "resource_id": "42"},
+        )
+
+    assert exc_info.value.entity == "workspace_resource_memberships"
 
 
 def test_workspace_subresource_public_getters_return_existing_scoped_rows(db):

--- a/tldw_Server_API/tests/ChaChaNotesDB/test_workspace_resource_memberships_db.py
+++ b/tldw_Server_API/tests/ChaChaNotesDB/test_workspace_resource_memberships_db.py
@@ -375,6 +375,34 @@ def test_list_resource_workspace_memberships_returns_limit_plus_one_for_paginati
     assert [row["workspace_id"] for row in rows] == ["ws-1", "ws-2", "ws-3"]
 
 
+def test_workspace_resource_membership_summary_counts_active_rows(db):
+    db.add_workspace_resource_membership(
+        "ws-1",
+        {"resource_type": "media", "resource_id": "42", "role": "source"},
+    )
+    db.add_workspace_resource_membership(
+        "ws-1",
+        {"resource_type": "chat", "resource_id": "chat-1", "role": "conversation"},
+    )
+    db.add_workspace_resource_membership(
+        "ws-1",
+        {"resource_type": "media", "resource_id": "99", "role": "source"},
+    )
+    db.add_workspace_resource_membership(
+        "ws-2",
+        {"resource_type": "media", "resource_id": "42", "role": "source"},
+    )
+    db.delete_workspace_resource_membership("ws-1", "media", "99")
+
+    summary = db.workspace_resource_membership_summary("ws-1")
+
+    assert summary == {
+        "total": 2,
+        "by_resource_type": {"chat": 1, "media": 1},
+        "by_role": {"conversation": 1, "source": 1},
+    }
+
+
 def test_delete_workspace_preserves_membership_history(db):
     created = db.add_workspace_resource_membership(
         "ws-1",
@@ -610,3 +638,52 @@ def test_get_conversation_for_workspace_membership_returns_workspace_conversatio
     assert row["workspace_id"] == "ws-1"
     assert row["last_modified"] is not None
     assert row["version"] == 1
+
+
+class _SingleRowCursor:
+    def __init__(self, row: dict[str, object] | None = None) -> None:
+        self.row = row
+
+    def fetchone(self) -> dict[str, object] | None:
+        return self.row
+
+
+def test_get_conversation_for_workspace_membership_uses_backend_active_deleted_value(db, monkeypatch):
+    captured: list[tuple[str, tuple[object, ...]]] = []
+
+    def fake_execute(query: str, params: tuple[object, ...], *, commit: bool = False):
+        assert commit is False
+        captured.append((query, params))
+        return _SingleRowCursor()
+
+    monkeypatch.setattr(db, "_workspace_active_deleted_value", lambda: "ACTIVE")
+    monkeypatch.setattr(db, "execute_query", fake_execute)
+
+    assert db.get_conversation_for_workspace_membership("chat-1") is None
+
+    assert captured
+    query, params = captured[0]
+    assert "deleted = ?" in query
+    assert params == ("chat-1", "ACTIVE")
+
+
+def test_malformed_workspace_membership_json_warning_redacts_payload(db, monkeypatch):
+    captured: list[tuple[str, tuple[object, ...], dict[str, object]]] = []
+
+    def fake_warning(message: str, *args: object, **kwargs: object) -> None:
+        captured.append((message, args, kwargs))
+
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB.logger.warning",
+        fake_warning,
+    )
+    secret_payload = '{"api_key": "sk-secret", "path": "/tmp/private"'
+
+    loaded = db._load_workspace_membership_json_object(secret_payload, field_name="metadata_json")
+
+    assert loaded == {}
+    assert captured
+    rendered = repr(captured)
+    assert "sk-secret" not in rendered
+    assert "/tmp/private" not in rendered
+    assert captured[0][1] == ("metadata_json", len(secret_payload))

--- a/tldw_Server_API/tests/DB_Management/test_pg_rls_policies_contract.py
+++ b/tldw_Server_API/tests/DB_Management/test_pg_rls_policies_contract.py
@@ -5,6 +5,7 @@ import pytest
 
 from tldw_Server_API.app.core.DB_Management.backends.base import DatabaseError
 from tldw_Server_API.app.core.DB_Management.backends.pg_rls_policies import (
+    build_chacha_rls_sql,
     ensure_prompt_studio_rls,
 )
 
@@ -71,6 +72,17 @@ def test_ensure_prompt_studio_rls_raises_on_partial_failure():
         pytest.fail("transaction should not commit after a partial failure")
     if conn.rolled_back is not True:
         pytest.fail("transaction should roll back after a partial failure")
+
+
+def test_chacha_rls_includes_workspace_resource_memberships_tenant_policy():
+    sql = "\n".join(build_chacha_rls_sql())
+
+    assert "ALTER TABLE IF EXISTS workspace_resource_memberships ENABLE ROW LEVEL SECURITY" in sql
+    assert "ALTER TABLE IF EXISTS workspace_resource_memberships FORCE ROW LEVEL SECURITY" in sql
+    assert "DROP POLICY IF EXISTS workspace_resource_memberships_tenant_isolation" in sql
+    assert "CREATE POLICY workspace_resource_memberships_tenant_isolation" in sql
+    assert "ON workspace_resource_memberships" in sql
+    assert "client_id = current_setting('app.current_user_id', true)" in sql
 
 
 def test_run_pg_rls_auto_ensure_logs_success_only_after_both_installers_pass(monkeypatch):

--- a/tldw_Server_API/tests/Workspaces/test_workspace_context_membership_summary.py
+++ b/tldw_Server_API/tests/Workspaces/test_workspace_context_membership_summary.py
@@ -1,0 +1,473 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from tldw_Server_API.app.api.v1.API_Deps.ChaCha_Notes_DB_Deps import get_chacha_db_for_user
+from tldw_Server_API.app.api.v1.API_Deps.DB_Deps import try_get_media_db_for_user
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import get_request_user
+from tldw_Server_API.app.api.v1.endpoints import workspaces as workspaces_endpoint
+from tldw_Server_API.app.api.v1.endpoints.workspaces_rate_limit_policy import WORKSPACES_READ_RATE_LIMIT
+from tldw_Server_API.app.core.Workspaces import membership_adapters
+from tldw_Server_API.app.core.Workspaces.membership_service import WorkspaceMembershipService
+
+
+class BackfillFakeDB:
+    def __init__(self) -> None:
+        self.workspaces = {"workspace-1": _workspace_row("workspace-1")}
+        self.sources = [
+            {
+                "id": "source-1",
+                "workspace_id": "workspace-1",
+                "media_id": 42,
+                "title": "Source title",
+                "source_type": "pdf",
+                "added_at": "2026-06-07T12:01:00Z",
+            }
+        ]
+        self.artifacts = [
+            {
+                "id": "artifact-1",
+                "workspace_id": "workspace-1",
+                "title": "Artifact title",
+                "artifact_type": "report",
+                "review_state": "accepted",
+                "created_at": "2026-06-07T12:02:00Z",
+            }
+        ]
+        self.notes = [
+            {
+                "id": 7,
+                "workspace_id": "workspace-1",
+                "title": "Note title",
+                "last_modified": "2026-06-07T12:03:00Z",
+                "deleted": 0,
+            }
+        ]
+        self.conversations = [
+            {
+                "id": "chat-1",
+                "workspace_id": "workspace-1",
+                "scope_type": "workspace",
+                "title": "Workspace chat",
+                "last_modified": "2026-06-07T12:04:00Z",
+                "deleted": 0,
+                "version": 1,
+            }
+        ]
+        self.memberships: dict[tuple[str, str, str], dict[str, object]] = {}
+        self._clock = 0
+
+    def _timestamp(self) -> str:
+        self._clock += 1
+        return f"2026-06-07T12:30:{self._clock:02d}Z"
+
+    def get_workspace(self, workspace_id: str) -> dict[str, object] | None:
+        return self.workspaces.get(workspace_id)
+
+    def list_workspace_sources(self, workspace_id: str) -> list[dict[str, object]]:
+        return [dict(row) for row in self.sources if row["workspace_id"] == workspace_id]
+
+    def get_workspace_source(self, workspace_id: str, source_id: str) -> dict[str, object] | None:
+        return next(
+            (
+                dict(row)
+                for row in self.sources
+                if row["workspace_id"] == workspace_id and str(row["id"]) == source_id
+            ),
+            None,
+        )
+
+    def list_workspace_artifacts(self, workspace_id: str) -> list[dict[str, object]]:
+        return [dict(row) for row in self.artifacts if row["workspace_id"] == workspace_id]
+
+    def get_workspace_artifact(self, workspace_id: str, artifact_id: str) -> dict[str, object] | None:
+        return next(
+            (
+                dict(row)
+                for row in self.artifacts
+                if row["workspace_id"] == workspace_id and str(row["id"]) == artifact_id
+            ),
+            None,
+        )
+
+    def list_workspace_notes(self, workspace_id: str) -> list[dict[str, object]]:
+        return [dict(row) for row in self.notes if row["workspace_id"] == workspace_id and not row.get("deleted")]
+
+    def get_workspace_note(self, workspace_id: str, note_id: int) -> dict[str, object] | None:
+        return next(
+            (
+                dict(row)
+                for row in self.notes
+                if row["workspace_id"] == workspace_id and int(row["id"]) == note_id and not row.get("deleted")
+            ),
+            None,
+        )
+
+    def search_conversations(
+        self,
+        query: str | None,
+        *,
+        scope_type: str | None = None,
+        workspace_id: str | None = None,
+    ) -> list[dict[str, object]]:
+        assert query is None
+        return [
+            dict(row)
+            for row in self.conversations
+            if row.get("scope_type") == scope_type
+            and row.get("workspace_id") == workspace_id
+            and not row.get("deleted")
+        ]
+
+    def get_conversation_for_workspace_membership(self, conversation_id: str) -> dict[str, object] | None:
+        return next(
+            (
+                dict(row)
+                for row in self.conversations
+                if str(row["id"]) == conversation_id and not row.get("deleted")
+            ),
+            None,
+        )
+
+    def add_workspace_resource_membership(
+        self,
+        workspace_id: str,
+        data: dict[str, object],
+        *,
+        user_id: str | None = None,
+    ) -> dict[str, object]:
+        key = (workspace_id, str(data["resource_type"]), str(data["resource_id"]))
+        existing = self.memberships.get(key)
+        if existing is not None:
+            return dict(existing)
+        now = self._timestamp()
+        row = {
+            "workspace_id": workspace_id,
+            "resource_type": str(data["resource_type"]),
+            "resource_id": str(data["resource_id"]),
+            "role": data.get("role", "member"),
+            "label": data.get("label"),
+            "transfer_policy": data.get("transfer_policy", "link"),
+            "provenance": data.get("provenance", {}),
+            "metadata": data.get("metadata", {}),
+            "created_at": now,
+            "updated_at": now,
+            "version": 1,
+            "deleted": False,
+            "created_by_user_id": user_id,
+            "updated_by_user_id": user_id,
+        }
+        self.memberships[key] = row
+        return dict(row)
+
+    def get_workspace_resource_membership(
+        self,
+        workspace_id: str,
+        resource_type: str,
+        resource_id: str,
+        *,
+        include_deleted: bool = False,
+    ) -> dict[str, object] | None:
+        row = self.memberships.get((workspace_id, resource_type, resource_id))
+        if row is None or (row.get("deleted") and not include_deleted):
+            return None
+        return dict(row)
+
+    def list_workspace_resource_memberships(
+        self,
+        workspace_id: str,
+        *,
+        resource_type: str | None = None,
+        role: str | None = None,
+        include_deleted: bool = False,
+        limit: int = 100,
+        cursor: tuple[str, str, str] | None = None,
+    ) -> list[dict[str, object]]:
+        _ = cursor
+        rows = [
+            row
+            for (row_workspace_id, _, _), row in self.memberships.items()
+            if row_workspace_id == workspace_id
+            and (resource_type is None or row["resource_type"] == resource_type)
+            and (role is None or row["role"] == role)
+            and (include_deleted or not row.get("deleted"))
+        ]
+        rows.sort(
+            key=lambda row: (
+                str(row["updated_at"]),
+                str(row["resource_type"]),
+                str(row["resource_id"]),
+            ),
+            reverse=True,
+        )
+        return [dict(row) for row in rows[:limit]]
+
+
+class ContextFakeDB(BackfillFakeDB):
+    def __init__(self) -> None:
+        super().__init__()
+        self.sources = []
+        self.artifacts = []
+        self.notes = []
+        self.conversations = []
+
+    def get_workspace_primary_root(self, workspace_id: str) -> None:
+        _ = workspace_id
+        return None
+
+    def list_active_workspace_operations(self, workspace_id: str) -> list[dict[str, object]]:
+        _ = workspace_id
+        return []
+
+
+def _workspace_row(workspace_id: str) -> dict[str, object]:
+    return {
+        "id": workspace_id,
+        "name": "Workspace",
+        "archived": False,
+        "study_materials_policy": "general",
+        "workspace_profile": "research",
+        "deleted": False,
+        "created_at": "2026-06-07T12:00:00Z",
+        "last_modified": "2026-06-07T12:00:00Z",
+        "version": 1,
+    }
+
+
+def _membership_row(
+    workspace_id: str,
+    resource_type: str,
+    resource_id: str,
+    role: str,
+) -> dict[str, object]:
+    return {
+        "workspace_id": workspace_id,
+        "resource_type": resource_type,
+        "resource_id": resource_id,
+        "role": role,
+        "label": None,
+        "transfer_policy": "link",
+        "provenance": {"source_surface": "test"},
+        "metadata": {},
+        "created_at": "2026-06-07T12:00:00Z",
+        "updated_at": "2026-06-07T12:00:00Z",
+        "version": 1,
+        "deleted": False,
+    }
+
+
+@pytest.fixture
+def media_db(monkeypatch: pytest.MonkeyPatch) -> object:
+    media_db_instance = object()
+
+    def fake_get_media_by_id(
+        passed_db: object,
+        media_id: int,
+        *,
+        include_deleted: bool = False,
+        include_trash: bool = False,
+    ) -> dict[str, object]:
+        _ = include_deleted, include_trash
+        assert passed_db is media_db_instance
+        if media_id == 42:
+            return {
+                "id": 42,
+                "title": "Media title",
+                "type": "pdf",
+                "last_modified": "2026-06-07T12:05:00Z",
+            }
+        raise RuntimeError("media missing")
+
+    monkeypatch.setattr(membership_adapters.media_db_api, "get_media_by_id", fake_get_media_by_id)
+    return media_db_instance
+
+
+def test_backfill_creates_memberships_from_existing_workspace_rows(media_db: object) -> None:
+    db = BackfillFakeDB()
+    service = WorkspaceMembershipService(db)
+
+    result = service.backfill_workspace_memberships("workspace-1", user_id="user-1", media_db=media_db)
+
+    assert result["status"] == "complete"
+    assert result["created"] == 5
+    assert result["existing"] == 0
+    assert result["skipped"] == 0
+    assert result["errors"] == []
+    assert set(db.memberships) == {
+        ("workspace-1", "workspace_source", "source-1"),
+        ("workspace-1", "media", "42"),
+        ("workspace-1", "workspace_artifact", "artifact-1"),
+        ("workspace-1", "workspace_note", "7"),
+        ("workspace-1", "chat", "chat-1"),
+    }
+    assert db.memberships[("workspace-1", "workspace_source", "source-1")]["role"] == "source"
+    assert db.memberships[("workspace-1", "media", "42")]["role"] == "source"
+    assert db.memberships[("workspace-1", "workspace_artifact", "artifact-1")]["role"] == "artifact"
+    assert db.memberships[("workspace-1", "workspace_note", "7")]["role"] == "reference"
+    assert db.memberships[("workspace-1", "chat", "chat-1")]["role"] == "conversation"
+    assert result["summary"]["by_resource_type"] == {
+        "chat": 1,
+        "media": 1,
+        "workspace_artifact": 1,
+        "workspace_note": 1,
+        "workspace_source": 1,
+    }
+
+
+def test_backfill_is_idempotent(media_db: object) -> None:
+    db = BackfillFakeDB()
+    service = WorkspaceMembershipService(db)
+
+    first = service.backfill_workspace_memberships("workspace-1", user_id="user-1", media_db=media_db)
+    second = service.backfill_workspace_memberships("workspace-1", user_id="user-1", media_db=media_db)
+
+    assert first["created"] == 5
+    assert second["created"] == 0
+    assert second["existing"] == 5
+    assert len(db.memberships) == 5
+
+
+def test_backfill_reports_bounded_unresolved_rows_without_rewriting_resources(media_db: object) -> None:
+    db = BackfillFakeDB()
+    db.sources = [
+        {
+            "id": "source-missing-media",
+            "workspace_id": "workspace-1",
+            "media_id": 999,
+            "title": "Source with missing media",
+            "source_type": "pdf",
+        }
+    ]
+    db.notes = [
+        {
+            "id": f"bad-note-{index}",
+            "workspace_id": "workspace-1",
+            "title": f"Bad note {index}",
+            "deleted": 0,
+        }
+        for index in range(30)
+    ]
+    original_sources = [dict(row) for row in db.sources]
+    original_notes = [dict(row) for row in db.notes]
+    service = WorkspaceMembershipService(db)
+
+    result = service.backfill_workspace_memberships("workspace-1", user_id="user-1", media_db=media_db)
+
+    assert result["status"] == "partial"
+    assert result["created"] == 3
+    assert len(result["errors"]) == 25
+    assert result["errors"][0].keys() == {"resource_type", "resource_id", "code", "message"}
+    assert all("/" not in error["message"] for error in result["errors"])
+    assert db.sources == original_sources
+    assert db.notes == original_notes
+    assert ("workspace-1", "workspace_source", "source-missing-media") in db.memberships
+    assert ("workspace-1", "media", "999") not in db.memberships
+
+
+def test_context_returns_compact_membership_totals_without_membership_list(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db = ContextFakeDB()
+    db.memberships[("workspace-1", "media", "42")] = _membership_row("workspace-1", "media", "42", "source")
+    db.memberships[("workspace-1", "workspace_note", "7")] = _membership_row(
+        "workspace-1",
+        "workspace_note",
+        "7",
+        "reference",
+    )
+    app = _context_app(db, monkeypatch)
+
+    with TestClient(app, raise_server_exceptions=False) as client:
+        response = client.get("/api/v1/workspaces/workspace-1/context")
+
+    assert response.status_code == 200, response.text
+    memberships = response.json()["memberships"]
+    assert memberships == {
+        "total": 2,
+        "by_resource_type": {"media": 1, "workspace_note": 1},
+        "by_role": {"reference": 1, "source": 1},
+    }
+    assert "items" not in memberships
+
+
+def test_context_membership_summary_failure_returns_partial_error_and_empty_summary(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db = ContextFakeDB()
+    app = _context_app(db, monkeypatch)
+
+    def fail_summary(self: WorkspaceMembershipService, workspace_id: str) -> dict[str, object]:
+        _ = self, workspace_id
+        raise RuntimeError("summary backend unavailable at /tmp/secret")
+
+    monkeypatch.setattr(WorkspaceMembershipService, "workspace_membership_summary", fail_summary)
+
+    with TestClient(app, raise_server_exceptions=False) as client:
+        response = client.get("/api/v1/workspaces/workspace-1/context")
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["memberships"] == {"total": 0, "by_resource_type": {}, "by_role": {}}
+    assert {
+        "scope": "memberships",
+        "code": "membership_summary_unavailable",
+        "message": "Workspace membership summary is unavailable.",
+    } in body["partial_errors"]
+
+
+def test_context_mcp_permissions_are_not_derived_from_membership_summary(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db = ContextFakeDB()
+    for index in range(10):
+        db.memberships[("workspace-1", "chat", f"chat-{index}")] = _membership_row(
+            "workspace-1",
+            "chat",
+            f"chat-{index}",
+            "conversation",
+        )
+    app = _context_app(db, monkeypatch)
+
+    with TestClient(app, raise_server_exceptions=False) as client:
+        response = client.get("/api/v1/workspaces/workspace-1/context")
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["memberships"]["total"] == 10
+    assert body["allowed_actions"]["run_mcp_tools"] == {
+        "allowed": False,
+        "reason_code": "mcp_not_configured",
+    }
+    assert body["services"]["mcp"] == {
+        "state": "not_configured",
+        "reason_code": "no_workspace_mcp_binding",
+        "management_surface": "mcp_hub",
+    }
+
+
+def _context_app(db: ContextFakeDB, monkeypatch: pytest.MonkeyPatch) -> FastAPI:
+    app = FastAPI()
+    app.include_router(workspaces_endpoint.router, prefix="/api/v1/workspaces")
+
+    async def allow_rate_limit() -> None:
+        return None
+
+    async def fake_capabilities(*, workspace_id: str, user_id: str | int | None) -> dict[str, object]:
+        _ = workspace_id, user_id
+        return {
+            "workspace_services": {},
+            "allowed_actions": {},
+        }
+
+    monkeypatch.setattr(workspaces_endpoint, "collect_workspace_service_capabilities", fake_capabilities)
+    app.dependency_overrides[get_request_user] = lambda: SimpleNamespace(id="user-1")
+    app.dependency_overrides[get_chacha_db_for_user] = lambda: db
+    app.dependency_overrides[try_get_media_db_for_user] = lambda: None
+    app.dependency_overrides[workspaces_endpoint.try_get_workspace_job_manager] = lambda: None
+    app.dependency_overrides[WORKSPACES_READ_RATE_LIMIT] = allow_rate_limit
+    return app

--- a/tldw_Server_API/tests/Workspaces/test_workspace_context_membership_summary.py
+++ b/tldw_Server_API/tests/Workspaces/test_workspace_context_membership_summary.py
@@ -13,7 +13,10 @@ from tldw_Server_API.app.api.v1.API_Deps.auth_deps import get_request_user
 from tldw_Server_API.app.api.v1.endpoints import workspaces as workspaces_endpoint
 from tldw_Server_API.app.api.v1.endpoints.workspaces_rate_limit_policy import WORKSPACES_READ_RATE_LIMIT
 from tldw_Server_API.app.core.Workspaces import membership_adapters
-from tldw_Server_API.app.core.Workspaces.membership_service import WorkspaceMembershipService
+from tldw_Server_API.app.core.Workspaces.membership_service import (
+    WorkspaceMembershipService,
+    WorkspaceMembershipServiceError,
+)
 
 
 class BackfillFakeDB:
@@ -60,6 +63,7 @@ class BackfillFakeDB:
             }
         ]
         self.memberships: dict[tuple[str, str, str], dict[str, object]] = {}
+        self.backfill_list_calls = 0
         self._clock = 0
 
     def _timestamp(self) -> str:
@@ -70,6 +74,7 @@ class BackfillFakeDB:
         return self.workspaces.get(workspace_id)
 
     def list_workspace_sources(self, workspace_id: str) -> list[dict[str, object]]:
+        self.backfill_list_calls += 1
         return [dict(row) for row in self.sources if row["workspace_id"] == workspace_id]
 
     def get_workspace_source(self, workspace_id: str, source_id: str) -> dict[str, object] | None:
@@ -83,6 +88,7 @@ class BackfillFakeDB:
         )
 
     def list_workspace_artifacts(self, workspace_id: str) -> list[dict[str, object]]:
+        self.backfill_list_calls += 1
         return [dict(row) for row in self.artifacts if row["workspace_id"] == workspace_id]
 
     def get_workspace_artifact(self, workspace_id: str, artifact_id: str) -> dict[str, object] | None:
@@ -96,6 +102,7 @@ class BackfillFakeDB:
         )
 
     def list_workspace_notes(self, workspace_id: str) -> list[dict[str, object]]:
+        self.backfill_list_calls += 1
         return [dict(row) for row in self.notes if row["workspace_id"] == workspace_id and not row.get("deleted")]
 
     def get_workspace_note(self, workspace_id: str, note_id: int) -> dict[str, object] | None:
@@ -116,6 +123,7 @@ class BackfillFakeDB:
         workspace_id: str | None = None,
     ) -> list[dict[str, object]]:
         assert query is None
+        self.backfill_list_calls += 1
         return [
             dict(row)
             for row in self.conversations
@@ -220,6 +228,23 @@ class BackfillFakeDB:
             reverse=True,
         )
         return [dict(row) for row in rows[:limit]]
+
+    def workspace_resource_membership_summary(self, workspace_id: str) -> dict[str, object]:
+        rows = [
+            row
+            for (row_workspace_id, _, _), row in self.memberships.items()
+            if row_workspace_id == workspace_id and not row.get("deleted")
+        ]
+        by_resource_type: dict[str, int] = {}
+        by_role: dict[str, int] = {}
+        for row in rows:
+            by_resource_type[str(row["resource_type"])] = by_resource_type.get(str(row["resource_type"]), 0) + 1
+            by_role[str(row["role"])] = by_role.get(str(row["role"]), 0) + 1
+        return {
+            "total": len(rows),
+            "by_resource_type": dict(sorted(by_resource_type.items())),
+            "by_role": dict(sorted(by_role.items())),
+        }
 
 
 class ContextFakeDB(BackfillFakeDB):
@@ -375,6 +400,19 @@ def test_backfill_restores_soft_deleted_membership_without_reporting_created(med
     restored = db.memberships[("workspace-1", "workspace_source", "source-1")]
     assert restored["deleted"] is False
     assert restored["version"] == 3
+
+
+def test_backfill_rejects_archived_workspace_before_listing_rows(media_db: object) -> None:
+    db = BackfillFakeDB()
+    db.workspaces["workspace-1"] = {**db.workspaces["workspace-1"], "archived": True}
+    service = WorkspaceMembershipService(db)
+
+    with pytest.raises(WorkspaceMembershipServiceError) as exc_info:
+        service.backfill_workspace_memberships("workspace-1", user_id="user-1", media_db=media_db)
+
+    assert exc_info.value.code == "workspace_archived"
+    assert db.backfill_list_calls == 0
+    assert db.memberships == {}
 
 
 def test_backfill_reports_bounded_unresolved_rows_without_rewriting_resources(media_db: object) -> None:

--- a/tldw_Server_API/tests/Workspaces/test_workspace_context_membership_summary.py
+++ b/tldw_Server_API/tests/Workspaces/test_workspace_context_membership_summary.py
@@ -144,6 +144,20 @@ class BackfillFakeDB:
         key = (workspace_id, str(data["resource_type"]), str(data["resource_id"]))
         existing = self.memberships.get(key)
         if existing is not None:
+            if existing.get("deleted") and data.get("restore_deleted") is True:
+                existing.update(
+                    {
+                        "role": data.get("role", "member"),
+                        "label": data.get("label"),
+                        "transfer_policy": data.get("transfer_policy", "link"),
+                        "provenance": data.get("provenance", {}),
+                        "metadata": data.get("metadata", {}),
+                        "updated_at": self._timestamp(),
+                        "updated_by_user_id": user_id,
+                        "version": int(existing.get("version", 1)) + 1,
+                        "deleted": False,
+                    }
+                )
             return dict(existing)
         now = self._timestamp()
         row = {
@@ -296,6 +310,7 @@ def test_backfill_creates_memberships_from_existing_workspace_rows(media_db: obj
     assert result["status"] == "complete"
     assert result["created"] == 5
     assert result["existing"] == 0
+    assert result["restored"] == 0
     assert result["skipped"] == 0
     assert result["errors"] == []
     assert set(db.memberships) == {
@@ -327,9 +342,39 @@ def test_backfill_is_idempotent(media_db: object) -> None:
     second = service.backfill_workspace_memberships("workspace-1", user_id="user-1", media_db=media_db)
 
     assert first["created"] == 5
+    assert first["restored"] == 0
     assert second["created"] == 0
     assert second["existing"] == 5
+    assert second["restored"] == 0
     assert len(db.memberships) == 5
+
+
+def test_backfill_restores_soft_deleted_membership_without_reporting_created(media_db: object) -> None:
+    db = BackfillFakeDB()
+    db.memberships[("workspace-1", "workspace_source", "source-1")] = {
+        "workspace_id": "workspace-1",
+        "resource_type": "workspace_source",
+        "resource_id": "source-1",
+        "role": "source",
+        "label": "Old source label",
+        "transfer_policy": "link",
+        "provenance": {"source_surface": "previous"},
+        "metadata": {},
+        "created_at": "2026-06-07T11:00:00Z",
+        "updated_at": "2026-06-07T11:30:00Z",
+        "version": 2,
+        "deleted": True,
+    }
+    service = WorkspaceMembershipService(db)
+
+    result = service.backfill_workspace_memberships("workspace-1", user_id="user-1", media_db=media_db)
+
+    assert result["created"] == 4
+    assert result["existing"] == 0
+    assert result["restored"] == 1
+    restored = db.memberships[("workspace-1", "workspace_source", "source-1")]
+    assert restored["deleted"] is False
+    assert restored["version"] == 3
 
 
 def test_backfill_reports_bounded_unresolved_rows_without_rewriting_resources(media_db: object) -> None:
@@ -360,6 +405,7 @@ def test_backfill_reports_bounded_unresolved_rows_without_rewriting_resources(me
 
     assert result["status"] == "partial"
     assert result["created"] == 3
+    assert result["restored"] == 0
     assert len(result["errors"]) == 25
     assert result["errors"][0].keys() == {"resource_type", "resource_id", "code", "message"}
     assert all("/" not in error["message"] for error in result["errors"])

--- a/tldw_Server_API/tests/Workspaces/test_workspace_membership_adapters.py
+++ b/tldw_Server_API/tests/Workspaces/test_workspace_membership_adapters.py
@@ -14,15 +14,31 @@ from tldw_Server_API.app.api.v1.schemas.workspace_schemas import (
     WorkspaceMembershipResponse,
     WorkspaceMembershipSummaryResponse,
 )
+from tldw_Server_API.app.core.Workspaces import membership_adapters
+from tldw_Server_API.app.core.Workspaces.membership_adapters import (
+    ChatMembershipAdapter,
+    MediaMembershipAdapter,
+    WorkspaceArtifactMembershipAdapter,
+    WorkspaceMembershipAdapterError,
+    WorkspaceMembershipContext,
+    WorkspaceNoteMembershipAdapter,
+    WorkspaceSourceMembershipAdapter,
+    get_workspace_membership_adapter,
+)
 from tldw_Server_API.app.core.Workspaces import membership_models
 from tldw_Server_API.app.core.Workspaces.membership_models import (
     WORKSPACE_MEMBERSHIP_CURSOR_MAX_BYTES,
     WorkspaceMembershipCursor,
+    WorkspaceResourceRef,
     WorkspaceResourceMembershipCursor,
     decode_membership_cursor,
     decode_resource_membership_cursor,
     encode_membership_cursor,
     encode_resource_membership_cursor,
+)
+from tldw_Server_API.app.core.Workspaces.membership_service import (
+    WorkspaceMembershipService,
+    WorkspaceMembershipServiceError,
 )
 
 
@@ -292,3 +308,483 @@ def test_workspace_context_membership_summary_constructs_grouped_totals() -> Non
     assert summary.total == 3
     assert summary.by_resource_type["media"] == 2
     assert summary.by_role["conversation"] == 1
+
+
+class FakeChaChaDB:
+    def __init__(self) -> None:
+        self.workspaces = {
+            "workspace-1": {"id": "workspace-1", "archived": False},
+            "workspace-archived": {"id": "workspace-archived", "archived": True},
+        }
+        self.notes: dict[tuple[str, int], dict[str, object]] = {}
+        self.sources: dict[tuple[str, str], dict[str, object]] = {}
+        self.artifacts: dict[tuple[str, str], dict[str, object]] = {}
+        self.conversations: dict[str, dict[str, object]] = {}
+        self.memberships: dict[tuple[str, str, str], dict[str, object]] = {}
+        self.last_add_data: dict[str, object] | None = None
+        self.last_list_resource_key: tuple[str, str] | None = None
+        self._clock = 0
+
+    def _timestamp(self) -> str:
+        self._clock += 1
+        return f"2026-06-07T12:00:{self._clock:02d}Z"
+
+    def get_workspace(self, workspace_id: str) -> dict[str, object] | None:
+        return self.workspaces.get(workspace_id)
+
+    def get_workspace_note(self, workspace_id: str, note_id: int) -> dict[str, object] | None:
+        return self.notes.get((workspace_id, note_id))
+
+    def get_workspace_source(self, workspace_id: str, source_id: str) -> dict[str, object] | None:
+        return self.sources.get((workspace_id, source_id))
+
+    def get_workspace_artifact(self, workspace_id: str, artifact_id: str) -> dict[str, object] | None:
+        return self.artifacts.get((workspace_id, artifact_id))
+
+    def get_conversation_for_workspace_membership(self, conversation_id: str) -> dict[str, object] | None:
+        return self.conversations.get(conversation_id)
+
+    def add_workspace_resource_membership(
+        self,
+        workspace_id: str,
+        data: dict[str, object],
+        *,
+        user_id: str | None = None,
+    ) -> dict[str, object]:
+        self.last_add_data = dict(data)
+        key = (workspace_id, str(data["resource_type"]), str(data["resource_id"]))
+        existing = self.memberships.get(key)
+        if existing is not None:
+            if existing.get("deleted") and data.get("restore_deleted") is True:
+                existing.update(
+                    {
+                        "role": data.get("role", "member"),
+                        "label": data.get("label"),
+                        "transfer_policy": data.get("transfer_policy", "link"),
+                        "provenance": data.get("provenance", {}),
+                        "metadata": data.get("metadata", {}),
+                        "deleted": False,
+                        "updated_at": self._timestamp(),
+                        "version": int(existing.get("version", 1)) + 1,
+                    }
+                )
+            return dict(existing)
+
+        now = self._timestamp()
+        row = {
+            "workspace_id": workspace_id,
+            "resource_type": str(data["resource_type"]),
+            "resource_id": str(data["resource_id"]),
+            "role": data.get("role", "member"),
+            "label": data.get("label"),
+            "transfer_policy": data.get("transfer_policy", "link"),
+            "provenance": data.get("provenance", {}),
+            "metadata": data.get("metadata", {}),
+            "summary": None,
+            "created_at": now,
+            "updated_at": now,
+            "version": 1,
+            "deleted": False,
+            "created_by_user_id": user_id,
+            "updated_by_user_id": user_id,
+        }
+        self.memberships[key] = row
+        return dict(row)
+
+    def get_workspace_resource_membership(
+        self,
+        workspace_id: str,
+        resource_type: str,
+        resource_id: str,
+        *,
+        include_deleted: bool = False,
+    ) -> dict[str, object] | None:
+        row = self.memberships.get((workspace_id, resource_type, resource_id))
+        if row is None or (row.get("deleted") and not include_deleted):
+            return None
+        return dict(row)
+
+    def list_workspace_resource_memberships(
+        self,
+        workspace_id: str,
+        *,
+        resource_type: str | None = None,
+        role: str | None = None,
+        include_deleted: bool = False,
+        limit: int = 100,
+        cursor: tuple[str, str, str] | None = None,
+    ) -> list[dict[str, object]]:
+        rows = [
+            row
+            for (row_workspace_id, _, _), row in self.memberships.items()
+            if row_workspace_id == workspace_id
+            and (resource_type is None or row["resource_type"] == resource_type)
+            and (role is None or row["role"] == role)
+            and (include_deleted or not row.get("deleted"))
+        ]
+        rows.sort(
+            key=lambda row: (str(row["updated_at"]), str(row["resource_type"]), str(row["resource_id"])),
+            reverse=True,
+        )
+        return [dict(row) for row in rows[:limit]]
+
+    def list_resource_workspace_memberships(
+        self,
+        resource_type: str,
+        resource_id: str,
+        *,
+        include_deleted: bool = False,
+        limit: int = 100,
+        cursor: tuple[str, str] | None = None,
+    ) -> list[dict[str, object]]:
+        self.last_list_resource_key = (resource_type, resource_id)
+        rows = [
+            row
+            for (_, row_resource_type, row_resource_id), row in self.memberships.items()
+            if row_resource_type == resource_type
+            and row_resource_id == resource_id
+            and (include_deleted or not row.get("deleted"))
+        ]
+        rows.sort(key=lambda row: (str(row["updated_at"]), str(row["workspace_id"])), reverse=True)
+        return [dict(row) for row in rows[:limit]]
+
+    def delete_workspace_resource_membership(
+        self,
+        workspace_id: str,
+        resource_type: str,
+        resource_id: str,
+        *,
+        user_id: str | None = None,
+    ) -> dict[str, object] | None:
+        row = self.memberships.get((workspace_id, resource_type, resource_id))
+        if row is None or row.get("deleted"):
+            return None
+        row["deleted"] = True
+        row["updated_by_user_id"] = user_id
+        row["updated_at"] = self._timestamp()
+        row["version"] = int(row.get("version", 1)) + 1
+        return dict(row)
+
+
+def _membership_row(
+    workspace_id: str = "workspace-1",
+    resource_type: str = "media",
+    resource_id: str = "42",
+    role: str = "source",
+    *,
+    deleted: bool = False,
+) -> dict[str, object]:
+    return {
+        "workspace_id": workspace_id,
+        "resource_type": resource_type,
+        "resource_id": resource_id,
+        "role": role,
+        "label": "Stored label",
+        "transfer_policy": "link",
+        "provenance": {"source_surface": "test"},
+        "metadata": {"rank": 1},
+        "created_at": "2026-06-07T12:00:00Z",
+        "updated_at": "2026-06-07T12:30:00Z",
+        "version": 1,
+        "deleted": deleted,
+    }
+
+
+def _context(db: FakeChaChaDB, *, media_db: object | None = None) -> WorkspaceMembershipContext:
+    return WorkspaceMembershipContext(
+        workspace_id="workspace-1",
+        user_id="user-1",
+        chacha_db=db,
+        media_db=media_db,
+    )
+
+
+def test_unsupported_resource_type_fails_closed() -> None:
+    service = WorkspaceMembershipService(FakeChaChaDB())
+
+    with pytest.raises(WorkspaceMembershipServiceError) as exc_info:
+        service.link_membership(
+            "workspace-1",
+            {"resource_type": "note", "resource_id": "1"},
+            user_id="user-1",
+        )
+
+    assert exc_info.value.code == "unsupported_resource_type"
+    assert exc_info.value.status_code == 400
+    with pytest.raises(WorkspaceMembershipAdapterError):
+        get_workspace_membership_adapter("note")
+
+
+def test_workspace_note_adapter_validates_same_workspace_note() -> None:
+    db = FakeChaChaDB()
+    db.notes[("workspace-1", 7)] = {
+        "id": 7,
+        "workspace_id": "workspace-1",
+        "title": "Research note",
+        "last_modified": "2026-06-07T12:05:00Z",
+        "deleted": 0,
+    }
+
+    ref = WorkspaceNoteMembershipAdapter().validate_access("7", _context(db))
+
+    assert ref.resource_type == "workspace_note"
+    assert ref.resource_id == "7"
+    assert ref.title == "Research note"
+    assert ref.updated_at == "2026-06-07T12:05:00Z"
+
+
+def test_workspace_source_adapter_validates_same_workspace_source() -> None:
+    db = FakeChaChaDB()
+    db.sources[("workspace-1", "source-1")] = {
+        "id": "source-1",
+        "workspace_id": "workspace-1",
+        "title": "Source title",
+        "source_type": "pdf",
+        "media_id": 42,
+        "added_at": "2026-06-07T12:05:00Z",
+    }
+
+    ref = WorkspaceSourceMembershipAdapter().validate_access("source-1", _context(db))
+
+    assert ref.resource_type == "workspace_source"
+    assert ref.resource_id == "source-1"
+    assert ref.title == "Source title"
+    assert ref.subtitle == "pdf"
+    assert ref.metadata["media_id"] == 42
+
+
+def test_workspace_artifact_adapter_validates_same_workspace_artifact() -> None:
+    db = FakeChaChaDB()
+    db.artifacts[("workspace-1", "artifact-1")] = {
+        "id": "artifact-1",
+        "workspace_id": "workspace-1",
+        "title": "Draft report",
+        "artifact_type": "report",
+        "review_state": "approved",
+        "created_at": "2026-06-07T12:05:00Z",
+    }
+
+    ref = WorkspaceArtifactMembershipAdapter().validate_access("artifact-1", _context(db))
+
+    assert ref.resource_type == "workspace_artifact"
+    assert ref.resource_id == "artifact-1"
+    assert ref.title == "Draft report"
+    assert ref.subtitle == "report"
+    assert ref.metadata["review_state"] == "approved"
+
+
+def test_media_adapter_validates_via_media_db_api_and_canonicalizes_id(monkeypatch: pytest.MonkeyPatch) -> None:
+    db = FakeChaChaDB()
+    media_db = object()
+    calls: list[tuple[object, int, bool, bool]] = []
+
+    def fake_get_media_by_id(
+        passed_db: object,
+        media_id: int,
+        *,
+        include_deleted: bool = False,
+        include_trash: bool = False,
+    ) -> dict[str, object]:
+        calls.append((passed_db, media_id, include_deleted, include_trash))
+        return {
+            "id": media_id,
+            "title": "Library item",
+            "type": "video",
+            "url": "https://example.test/item",
+            "last_modified": "2026-06-07T12:05:00Z",
+        }
+
+    monkeypatch.setattr(membership_adapters.media_db_api, "get_media_by_id", fake_get_media_by_id)
+
+    ref = MediaMembershipAdapter().validate_access("0042", _context(db, media_db=media_db))
+
+    assert calls == [(media_db, 42, False, False)]
+    assert ref.resource_type == "media"
+    assert ref.resource_id == "42"
+    assert ref.title == "Library item"
+
+
+def test_media_service_requires_media_db_for_validation() -> None:
+    service = WorkspaceMembershipService(FakeChaChaDB())
+
+    with pytest.raises(WorkspaceMembershipServiceError) as exc_info:
+        service.link_membership(
+            "workspace-1",
+            {"resource_type": "media", "resource_id": "42", "role": "source"},
+            user_id="user-1",
+        )
+
+    assert exc_info.value.code == "media_db_unavailable"
+    assert exc_info.value.status_code == 503
+
+
+def test_chat_adapter_allows_global_and_same_workspace_conversations() -> None:
+    db = FakeChaChaDB()
+    db.conversations["chat-global"] = {
+        "id": "chat-global",
+        "title": "Global chat",
+        "scope_type": "global",
+        "workspace_id": None,
+        "last_modified": "2026-06-07T12:05:00Z",
+    }
+    db.conversations["chat-workspace"] = {
+        "id": "chat-workspace",
+        "title": "Workspace chat",
+        "scope_type": "workspace",
+        "workspace_id": "workspace-1",
+        "last_modified": "2026-06-07T12:06:00Z",
+    }
+
+    global_ref = ChatMembershipAdapter().validate_access("chat-global", _context(db))
+    workspace_ref = ChatMembershipAdapter().validate_access("chat-workspace", _context(db))
+
+    assert global_ref.resource_id == "chat-global"
+    assert global_ref.title == "Global chat"
+    assert workspace_ref.resource_id == "chat-workspace"
+    assert workspace_ref.title == "Workspace chat"
+
+
+def test_chat_adapter_rejects_other_workspace_conversation() -> None:
+    db = FakeChaChaDB()
+    db.conversations["chat-other"] = {
+        "id": "chat-other",
+        "title": "Other workspace chat",
+        "scope_type": "workspace",
+        "workspace_id": "workspace-2",
+        "last_modified": "2026-06-07T12:06:00Z",
+    }
+
+    with pytest.raises(WorkspaceMembershipAdapterError) as exc_info:
+        ChatMembershipAdapter().validate_access("chat-other", _context(db))
+
+    assert exc_info.value.code == "resource_not_found"
+
+
+def test_archived_workspace_rejects_link_membership() -> None:
+    service = WorkspaceMembershipService(FakeChaChaDB())
+
+    with pytest.raises(WorkspaceMembershipServiceError) as exc_info:
+        service.link_membership(
+            "workspace-archived",
+            {"resource_type": "chat", "resource_id": "chat-1"},
+            user_id="user-1",
+        )
+
+    assert exc_info.value.code == "workspace_archived"
+    assert exc_info.value.status_code == 409
+
+
+def test_list_workspace_memberships_resolve_false_omits_adapter_summary() -> None:
+    db = FakeChaChaDB()
+    db.memberships[("workspace-1", "media", "42")] = _membership_row()
+    service = WorkspaceMembershipService(db)
+
+    payload = service.list_workspace_memberships("workspace-1", resolve=False)
+
+    assert payload["workspace_id"] == "workspace-1"
+    assert payload["items"][0]["summary"] is None
+    assert payload["summary"]["by_resource_type"] == {"media": 1}
+
+
+class FailingSummaryAdapter:
+    resource_type = "media"
+
+    def validate_access(self, resource_id: str, context: WorkspaceMembershipContext) -> WorkspaceResourceRef:
+        return WorkspaceResourceRef(resource_type=self.resource_type, resource_id=str(int(resource_id)))
+
+    def summarize(self, resource_id: str, context: WorkspaceMembershipContext) -> WorkspaceResourceRef:
+        raise RuntimeError("summary backend unavailable")
+
+    def on_link(self, membership: dict[str, object], context: WorkspaceMembershipContext) -> None:
+        return None
+
+    def on_unlink(self, membership: dict[str, object], context: WorkspaceMembershipContext) -> None:
+        return None
+
+
+def test_adapter_summarize_failure_during_list_marks_item_unresolved() -> None:
+    db = FakeChaChaDB()
+    db.memberships[("workspace-1", "media", "42")] = _membership_row()
+    service = WorkspaceMembershipService(db, adapters={"media": FailingSummaryAdapter()})
+
+    payload = service.list_workspace_memberships("workspace-1", media_db=object())
+
+    summary = payload["items"][0]["summary"]
+    assert summary["state"] == "unresolved"
+    assert summary["metadata"]["code"] == "summary_unavailable"
+
+
+class RecordingAdapter:
+    resource_type = "media"
+
+    def __init__(self) -> None:
+        self.validated: list[str] = []
+        self.linked: list[dict[str, object]] = []
+
+    def validate_access(self, resource_id: str, context: WorkspaceMembershipContext) -> WorkspaceResourceRef:
+        self.validated.append(resource_id)
+        return WorkspaceResourceRef(resource_type=self.resource_type, resource_id=str(int(resource_id)), title="Restored")
+
+    def summarize(self, resource_id: str, context: WorkspaceMembershipContext) -> WorkspaceResourceRef:
+        return WorkspaceResourceRef(resource_type=self.resource_type, resource_id=str(int(resource_id)), title="Restored")
+
+    def on_link(self, membership: dict[str, object], context: WorkspaceMembershipContext) -> None:
+        self.linked.append(dict(membership))
+
+    def on_unlink(self, membership: dict[str, object], context: WorkspaceMembershipContext) -> None:
+        return None
+
+
+def test_link_membership_restores_deleted_row_after_adapter_validation() -> None:
+    db = FakeChaChaDB()
+    db.memberships[("workspace-1", "media", "42")] = _membership_row(deleted=True)
+    adapter = RecordingAdapter()
+    service = WorkspaceMembershipService(db, adapters={"media": adapter})
+
+    payload = service.link_membership(
+        "workspace-1",
+        {"resource_type": "media", "resource_id": "0042", "role": "source"},
+        user_id="user-1",
+        media_db=object(),
+    )
+
+    assert adapter.validated == ["0042"]
+    assert db.last_add_data is not None
+    assert db.last_add_data["resource_id"] == "42"
+    assert db.last_add_data["restore_deleted"] is True
+    assert payload["resource_id"] == "42"
+    assert payload["deleted"] is False
+    assert adapter.linked
+
+
+def test_list_resource_memberships_canonicalizes_resource_id_before_listing() -> None:
+    db = FakeChaChaDB()
+    db.memberships[("workspace-1", "media", "42")] = _membership_row()
+    service = WorkspaceMembershipService(db, adapters={"media": RecordingAdapter()})
+
+    payload = service.list_resource_memberships("media", "0042", media_db=object())
+
+    assert db.last_list_resource_key == ("media", "42")
+    assert payload["resource_type"] == "media"
+    assert payload["resource_id"] == "42"
+    assert payload["items"][0]["resource_id"] == "42"
+
+
+def test_workspace_membership_summary_returns_active_compact_totals() -> None:
+    db = FakeChaChaDB()
+    db.memberships[("workspace-1", "media", "42")] = _membership_row(role="source")
+    db.memberships[("workspace-1", "chat", "chat-1")] = _membership_row(
+        resource_type="chat",
+        resource_id="chat-1",
+        role="conversation",
+    )
+    db.memberships[("workspace-1", "media", "43")] = _membership_row(resource_id="43", deleted=True)
+    service = WorkspaceMembershipService(db)
+
+    summary = service.workspace_membership_summary("workspace-1")
+
+    assert summary == {
+        "total": 2,
+        "by_resource_type": {"chat": 1, "media": 1},
+        "by_role": {"conversation": 1, "source": 1},
+    }

--- a/tldw_Server_API/tests/Workspaces/test_workspace_membership_adapters.py
+++ b/tldw_Server_API/tests/Workspaces/test_workspace_membership_adapters.py
@@ -778,10 +778,10 @@ def test_link_membership_restores_deleted_row_after_adapter_validation() -> None
     assert db.last_add_data["restore_deleted"] is True
     assert payload["resource_id"] == "42"
     assert payload["deleted"] is False
-    assert adapter.linked
+    assert adapter.linked == []
 
 
-def test_link_membership_idempotent_retry_does_not_duplicate_on_link_hook() -> None:
+def test_link_membership_idempotent_retry_does_not_invoke_reserved_on_link_hook() -> None:
     db = FakeChaChaDB()
     adapter = RecordingAdapter()
     service = WorkspaceMembershipService(db, adapters={"media": adapter})
@@ -801,7 +801,7 @@ def test_link_membership_idempotent_retry_does_not_duplicate_on_link_hook() -> N
 
     assert first_payload["resource_id"] == "42"
     assert retry_payload["resource_id"] == "42"
-    assert len(adapter.linked) == 1
+    assert adapter.linked == []
 
 
 def test_get_membership_returns_unresolved_summary_when_media_db_is_unavailable() -> None:

--- a/tldw_Server_API/tests/Workspaces/test_workspace_membership_adapters.py
+++ b/tldw_Server_API/tests/Workspaces/test_workspace_membership_adapters.py
@@ -197,7 +197,6 @@ def test_workspace_membership_create_request_accepts_valid_payload() -> None:
 @pytest.mark.parametrize(
     "field_name,value",
     [
-        ("resource_type", "note"),
         ("role", "owner"),
         ("transfer_policy", "move"),
     ],

--- a/tldw_Server_API/tests/Workspaces/test_workspace_membership_adapters.py
+++ b/tldw_Server_API/tests/Workspaces/test_workspace_membership_adapters.py
@@ -368,6 +368,8 @@ class FakeChaChaDB:
         self.memberships: dict[tuple[str, str, str], dict[str, object]] = {}
         self.last_add_data: dict[str, object] | None = None
         self.last_list_resource_key: tuple[str, str] | None = None
+        self.list_workspace_calls = 0
+        self.summary_calls = 0
         self._clock = 0
 
     def _timestamp(self) -> str:
@@ -482,6 +484,7 @@ class FakeChaChaDB:
         limit: int = 100,
         cursor: tuple[str, str, str] | None = None,
     ) -> list[dict[str, object]]:
+        self.list_workspace_calls += 1
         rows = [
             row
             for (row_workspace_id, _, _), row in self.memberships.items()
@@ -495,6 +498,24 @@ class FakeChaChaDB:
             reverse=True,
         )
         return [dict(row) for row in rows[:limit]]
+
+    def workspace_resource_membership_summary(self, workspace_id: str) -> dict[str, object]:
+        self.summary_calls += 1
+        rows = [
+            row
+            for (row_workspace_id, _, _), row in self.memberships.items()
+            if row_workspace_id == workspace_id and not row.get("deleted")
+        ]
+        by_resource_type: dict[str, int] = {}
+        by_role: dict[str, int] = {}
+        for row in rows:
+            by_resource_type[str(row["resource_type"])] = by_resource_type.get(str(row["resource_type"]), 0) + 1
+            by_role[str(row["role"])] = by_role.get(str(row["role"]), 0) + 1
+        return {
+            "total": len(rows),
+            "by_resource_type": dict(sorted(by_resource_type.items())),
+            "by_role": dict(sorted(by_role.items())),
+        }
 
     def list_resource_workspace_memberships(
         self,
@@ -762,6 +783,34 @@ def test_list_workspace_memberships_resolve_false_omits_adapter_summary() -> Non
     assert payload["workspace_id"] == "workspace-1"
     assert payload["items"][0]["summary"] is None
     assert payload["summary"]["by_resource_type"] == {"media": 1}
+
+
+@pytest.mark.parametrize(
+    "cursor",
+    [123, object(), ("only-updated-at", "media"), ("", "media", "42"), ("2026-06-07T12:00:00Z", "media", 42)],
+)
+def test_list_workspace_memberships_rejects_invalid_cursor_types(cursor: object) -> None:
+    service = WorkspaceMembershipService(FakeChaChaDB())
+
+    with pytest.raises(WorkspaceMembershipServiceError) as exc_info:
+        service.list_workspace_memberships("workspace-1", cursor=cursor)
+
+    assert exc_info.value.code == "invalid_cursor"
+    assert exc_info.value.status_code == 400
+
+
+@pytest.mark.parametrize(
+    "cursor",
+    [123, object(), ("only-updated-at",), ("", "workspace-1"), ("2026-06-07T12:00:00Z", 7)],
+)
+def test_list_resource_memberships_rejects_invalid_cursor_types(cursor: object) -> None:
+    service = WorkspaceMembershipService(FakeChaChaDB(), adapters={"media": RecordingAdapter()})
+
+    with pytest.raises(WorkspaceMembershipServiceError) as exc_info:
+        service.list_resource_memberships("media", "42", cursor=cursor, media_db=object())
+
+    assert exc_info.value.code == "invalid_cursor"
+    assert exc_info.value.status_code == 400
 
 
 class FailingSummaryAdapter:
@@ -1050,7 +1099,24 @@ def test_unlink_membership_noops_without_adapter_hook_for_missing_or_deleted_mem
     assert adapter.unlinked == []
 
 
-def test_workspace_membership_summary_returns_active_compact_totals() -> None:
+class FailingUnlinkAdapter(RecordingAdapter):
+    def on_unlink(self, membership: dict[str, object], context: WorkspaceMembershipContext) -> None:
+        raise RuntimeError("external cleanup failed")
+
+
+def test_unlink_membership_returns_deleted_row_when_adapter_hook_fails() -> None:
+    db = FakeChaChaDB()
+    db.memberships[("workspace-1", "media", "42")] = _membership_row()
+    service = WorkspaceMembershipService(db, adapters={"media": FailingUnlinkAdapter()})
+
+    payload = service.unlink_membership("workspace-1", "media", "0042", user_id="user-1", media_db=object())
+
+    assert payload is not None
+    assert payload["deleted"] is True
+    assert db.memberships[("workspace-1", "media", "42")]["deleted"] is True
+
+
+def test_workspace_membership_summary_uses_db_aggregate_for_active_compact_totals() -> None:
     db = FakeChaChaDB()
     db.memberships[("workspace-1", "media", "42")] = _membership_row(role="source")
     db.memberships[("workspace-1", "chat", "chat-1")] = _membership_row(
@@ -1068,3 +1134,5 @@ def test_workspace_membership_summary_returns_active_compact_totals() -> None:
         "by_resource_type": {"chat": 1, "media": 1},
         "by_role": {"conversation": 1, "source": 1},
     }
+    assert db.summary_calls == 1
+    assert db.list_workspace_calls == 0

--- a/tldw_Server_API/tests/Workspaces/test_workspace_membership_adapters.py
+++ b/tldw_Server_API/tests/Workspaces/test_workspace_membership_adapters.py
@@ -703,7 +703,7 @@ class FailingSummaryAdapter:
         return WorkspaceResourceRef(resource_type=self.resource_type, resource_id=str(int(resource_id)))
 
     def summarize(self, resource_id: str, context: WorkspaceMembershipContext) -> WorkspaceResourceRef:
-        raise RuntimeError("summary backend unavailable")
+        raise RuntimeError("summary backend unavailable at /tmp/secret-token api_key=sk-test")
 
     def on_link(self, membership: dict[str, object], context: WorkspaceMembershipContext) -> None:
         return None
@@ -722,6 +722,19 @@ def test_adapter_summarize_failure_during_list_marks_item_unresolved() -> None:
     summary = payload["items"][0]["summary"]
     assert summary["state"] == "unresolved"
     assert summary["metadata"]["code"] == "summary_unavailable"
+
+
+def test_generic_summarize_failure_uses_safe_unresolved_message() -> None:
+    db = FakeChaChaDB()
+    db.memberships[("workspace-1", "media", "42")] = _membership_row()
+    service = WorkspaceMembershipService(db, adapters={"media": FailingSummaryAdapter()})
+
+    payload = service.list_workspace_memberships("workspace-1", media_db=object())
+
+    message = payload["items"][0]["summary"]["metadata"]["message"]
+    assert message == "Workspace resource summary is unavailable."
+    assert "/tmp/secret-token" not in message
+    assert "sk-test" not in message
 
 
 class RecordingAdapter:
@@ -766,6 +779,42 @@ def test_link_membership_restores_deleted_row_after_adapter_validation() -> None
     assert payload["resource_id"] == "42"
     assert payload["deleted"] is False
     assert adapter.linked
+
+
+def test_link_membership_idempotent_retry_does_not_duplicate_on_link_hook() -> None:
+    db = FakeChaChaDB()
+    adapter = RecordingAdapter()
+    service = WorkspaceMembershipService(db, adapters={"media": adapter})
+
+    first_payload = service.link_membership(
+        "workspace-1",
+        {"resource_type": "media", "resource_id": "0042", "role": "source"},
+        user_id="user-1",
+        media_db=object(),
+    )
+    retry_payload = service.link_membership(
+        "workspace-1",
+        {"resource_type": "media", "resource_id": "0042", "role": "source"},
+        user_id="user-1",
+        media_db=object(),
+    )
+
+    assert first_payload["resource_id"] == "42"
+    assert retry_payload["resource_id"] == "42"
+    assert len(adapter.linked) == 1
+
+
+def test_get_membership_returns_unresolved_summary_when_media_db_is_unavailable() -> None:
+    db = FakeChaChaDB()
+    db.memberships[("workspace-1", "media", "42")] = _membership_row()
+    service = WorkspaceMembershipService(db)
+
+    payload = service.get_membership("workspace-1", "media", "0042")
+
+    assert payload is not None
+    assert payload["resource_id"] == "42"
+    assert payload["summary"]["state"] == "unresolved"
+    assert payload["summary"]["metadata"]["code"] == "media_db_unavailable"
 
 
 def test_list_resource_memberships_canonicalizes_resource_id_before_listing() -> None:

--- a/tldw_Server_API/tests/Workspaces/test_workspace_membership_adapters.py
+++ b/tldw_Server_API/tests/Workspaces/test_workspace_membership_adapters.py
@@ -14,7 +14,9 @@ from tldw_Server_API.app.api.v1.schemas.workspace_schemas import (
     WorkspaceMembershipResponse,
     WorkspaceMembershipSummaryResponse,
 )
+from tldw_Server_API.app.core.Workspaces import membership_models
 from tldw_Server_API.app.core.Workspaces.membership_models import (
+    WORKSPACE_MEMBERSHIP_CURSOR_MAX_BYTES,
     WorkspaceMembershipCursor,
     WorkspaceResourceMembershipCursor,
     decode_membership_cursor,
@@ -74,6 +76,35 @@ def test_workspace_membership_cursor_rejects_invalid_values(payload: str) -> Non
         decode_membership_cursor(payload)
 
 
+@pytest.mark.parametrize("version", [True, 1.0])
+def test_workspace_membership_cursor_rejects_non_integer_versions(version: object) -> None:
+    payload = _encoded_json(
+        {
+            "v": version,
+            "updated_at": "2026-06-07T12:30:00Z",
+            "resource_type": "media",
+            "resource_id": "42",
+        }
+    )
+
+    with pytest.raises(ValueError):
+        decode_membership_cursor(payload)
+
+
+def test_workspace_membership_cursor_rejects_oversized_values() -> None:
+    payload = _encoded_json(
+        {
+            "v": 1,
+            "updated_at": "2026-06-07T12:30:00Z" + ("x" * 5000),
+            "resource_type": "media",
+            "resource_id": "42",
+        }
+    )
+
+    with pytest.raises(ValueError):
+        decode_membership_cursor(payload)
+
+
 @pytest.mark.parametrize(
     "payload",
     [
@@ -84,6 +115,46 @@ def test_workspace_membership_cursor_rejects_invalid_values(payload: str) -> Non
     ],
 )
 def test_workspace_resource_membership_cursor_rejects_invalid_values(payload: str) -> None:
+    with pytest.raises(ValueError):
+        decode_resource_membership_cursor(payload)
+
+
+@pytest.mark.parametrize("version", [True, 1.0])
+def test_workspace_resource_membership_cursor_rejects_non_integer_versions(version: object) -> None:
+    payload = _encoded_json(
+        {
+            "v": version,
+            "updated_at": "2026-06-07T12:30:00Z",
+            "workspace_id": "workspace-1",
+        }
+    )
+
+    with pytest.raises(ValueError):
+        decode_resource_membership_cursor(payload)
+
+
+def test_workspace_resource_membership_cursor_rejects_oversized_values() -> None:
+    payload = _encoded_json(
+        {
+            "v": 1,
+            "updated_at": "2026-06-07T12:30:00Z" + ("x" * 5000),
+            "workspace_id": "workspace-1",
+        }
+    )
+
+    with pytest.raises(ValueError):
+        decode_resource_membership_cursor(payload)
+
+
+def test_workspace_membership_cursors_reject_oversized_values_before_decode(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fail_decode(*_args: object, **_kwargs: object) -> bytes:
+        raise AssertionError("base64 decode should not run for oversized cursors")
+
+    monkeypatch.setattr(membership_models.base64, "b64decode", fail_decode)
+    payload = "A" * (WORKSPACE_MEMBERSHIP_CURSOR_MAX_BYTES + 1)
+
+    with pytest.raises(ValueError):
+        decode_membership_cursor(payload)
     with pytest.raises(ValueError):
         decode_resource_membership_cursor(payload)
 
@@ -150,6 +221,21 @@ def test_workspace_membership_create_request_rejects_non_json_serializable_value
         "role": "source",
         "transfer_policy": "link",
         field_name: {"bad": object()},
+    }
+
+    with pytest.raises(ValidationError, match=f"{field_name} must be JSON serializable"):
+        WorkspaceMembershipCreateRequest(**payload)
+
+
+@pytest.mark.parametrize("field_name", ["provenance", "metadata"])
+@pytest.mark.parametrize("value", [float("nan"), float("inf"), -float("inf")])
+def test_workspace_membership_create_request_rejects_non_finite_json_values(field_name: str, value: float) -> None:
+    payload = {
+        "resource_type": "media",
+        "resource_id": "42",
+        "role": "source",
+        "transfer_policy": "link",
+        field_name: {"value": value},
     }
 
     with pytest.raises(ValidationError, match=f"{field_name} must be JSON serializable"):

--- a/tldw_Server_API/tests/Workspaces/test_workspace_membership_adapters.py
+++ b/tldw_Server_API/tests/Workspaces/test_workspace_membership_adapters.py
@@ -674,6 +674,16 @@ def test_archived_workspace_rejects_link_membership() -> None:
     assert exc_info.value.status_code == 409
 
 
+def test_missing_workspace_rejects_membership_read_path() -> None:
+    service = WorkspaceMembershipService(FakeChaChaDB())
+
+    with pytest.raises(WorkspaceMembershipServiceError) as exc_info:
+        service.list_workspace_memberships("workspace-missing")
+
+    assert exc_info.value.code == "workspace_not_found"
+    assert exc_info.value.status_code == 404
+
+
 def test_list_workspace_memberships_resolve_false_omits_adapter_summary() -> None:
     db = FakeChaChaDB()
     db.memberships[("workspace-1", "media", "42")] = _membership_row()
@@ -720,6 +730,7 @@ class RecordingAdapter:
     def __init__(self) -> None:
         self.validated: list[str] = []
         self.linked: list[dict[str, object]] = []
+        self.unlinked: list[dict[str, object]] = []
 
     def validate_access(self, resource_id: str, context: WorkspaceMembershipContext) -> WorkspaceResourceRef:
         self.validated.append(resource_id)
@@ -732,7 +743,7 @@ class RecordingAdapter:
         self.linked.append(dict(membership))
 
     def on_unlink(self, membership: dict[str, object], context: WorkspaceMembershipContext) -> None:
-        return None
+        self.unlinked.append(dict(membership))
 
 
 def test_link_membership_restores_deleted_row_after_adapter_validation() -> None:
@@ -768,6 +779,44 @@ def test_list_resource_memberships_canonicalizes_resource_id_before_listing() ->
     assert payload["resource_type"] == "media"
     assert payload["resource_id"] == "42"
     assert payload["items"][0]["resource_id"] == "42"
+
+
+def test_list_resource_memberships_unsupported_type_fails_closed() -> None:
+    service = WorkspaceMembershipService(FakeChaChaDB())
+
+    with pytest.raises(WorkspaceMembershipServiceError) as exc_info:
+        service.list_resource_memberships("note", "1")
+
+    assert exc_info.value.code == "unsupported_resource_type"
+    assert exc_info.value.status_code == 400
+
+
+def test_unlink_membership_soft_deletes_active_membership_and_calls_adapter_hook() -> None:
+    db = FakeChaChaDB()
+    db.memberships[("workspace-1", "media", "42")] = _membership_row()
+    adapter = RecordingAdapter()
+    service = WorkspaceMembershipService(db, adapters={"media": adapter})
+
+    payload = service.unlink_membership("workspace-1", "media", "0042", user_id="user-1", media_db=object())
+
+    assert payload is not None
+    assert payload["deleted"] is True
+    assert db.memberships[("workspace-1", "media", "42")]["deleted"] is True
+    assert adapter.unlinked == [db.memberships[("workspace-1", "media", "42")]]
+
+
+def test_unlink_membership_noops_without_adapter_hook_for_missing_or_deleted_membership() -> None:
+    db = FakeChaChaDB()
+    db.memberships[("workspace-1", "media", "42")] = _membership_row(deleted=True)
+    adapter = RecordingAdapter()
+    service = WorkspaceMembershipService(db, adapters={"media": adapter})
+
+    missing_payload = service.unlink_membership("workspace-1", "media", "43", user_id="user-1", media_db=object())
+    deleted_payload = service.unlink_membership("workspace-1", "media", "42", user_id="user-1", media_db=object())
+
+    assert missing_payload is None
+    assert deleted_payload is None
+    assert adapter.unlinked == []
 
 
 def test_workspace_membership_summary_returns_active_compact_totals() -> None:

--- a/tldw_Server_API/tests/Workspaces/test_workspace_membership_adapters.py
+++ b/tldw_Server_API/tests/Workspaces/test_workspace_membership_adapters.py
@@ -257,6 +257,52 @@ def test_workspace_membership_create_request_rejects_non_finite_json_values(fiel
         WorkspaceMembershipCreateRequest(**payload)
 
 
+@pytest.mark.parametrize("field_name", ["provenance", "metadata"])
+@pytest.mark.parametrize("value", [float("nan"), float("inf"), -float("inf")])
+def test_membership_service_rejects_non_finite_json_values(field_name: str, value: float) -> None:
+    db = FakeChaChaDB()
+    adapter = RecordingAdapter()
+    service = WorkspaceMembershipService(db, adapters={"media": adapter})
+
+    with pytest.raises(WorkspaceMembershipServiceError) as exc_info:
+        service.link_membership(
+            "workspace-1",
+            {
+                "resource_type": "media",
+                "resource_id": "42",
+                "role": "source",
+                field_name: {"value": value},
+            },
+            media_db=object(),
+        )
+
+    assert exc_info.value.code == "invalid_membership_request"
+    assert exc_info.value.status_code == 400
+    assert adapter.validated == []
+    assert db.last_add_data is None
+
+
+@pytest.mark.parametrize("field_name", ["provenance", "metadata"])
+def test_membership_service_rejects_oversized_json_values(field_name: str) -> None:
+    db = FakeChaChaDB()
+    service = WorkspaceMembershipService(db, adapters={"media": RecordingAdapter()})
+
+    with pytest.raises(WorkspaceMembershipServiceError) as exc_info:
+        service.link_membership(
+            "workspace-1",
+            {
+                "resource_type": "media",
+                "resource_id": "42",
+                "role": "source",
+                field_name: {"value": "x" * (16 * 1024 + 1)},
+            },
+            media_db=object(),
+        )
+
+    assert exc_info.value.code == "invalid_membership_request"
+    assert db.last_add_data is None
+
+
 def test_workspace_membership_list_response_constructs_grouped_totals() -> None:
     item = WorkspaceMembershipResponse(
         workspace_id="workspace-1",
@@ -331,16 +377,39 @@ class FakeChaChaDB:
     def get_workspace(self, workspace_id: str) -> dict[str, object] | None:
         return self.workspaces.get(workspace_id)
 
-    def get_workspace_note(self, workspace_id: str, note_id: int) -> dict[str, object] | None:
+    def get_workspace_note(
+        self,
+        workspace_id: str,
+        note_id: int,
+        *,
+        include_deleted: bool = False,
+    ) -> dict[str, object] | None:
         return self.notes.get((workspace_id, note_id))
 
-    def get_workspace_source(self, workspace_id: str, source_id: str) -> dict[str, object] | None:
+    def get_workspace_source(
+        self,
+        workspace_id: str,
+        source_id: str,
+        *,
+        include_deleted: bool = False,
+    ) -> dict[str, object] | None:
         return self.sources.get((workspace_id, source_id))
 
-    def get_workspace_artifact(self, workspace_id: str, artifact_id: str) -> dict[str, object] | None:
+    def get_workspace_artifact(
+        self,
+        workspace_id: str,
+        artifact_id: str,
+        *,
+        include_deleted: bool = False,
+    ) -> dict[str, object] | None:
         return self.artifacts.get((workspace_id, artifact_id))
 
-    def get_conversation_for_workspace_membership(self, conversation_id: str) -> dict[str, object] | None:
+    def get_conversation_for_workspace_membership(
+        self,
+        conversation_id: str,
+        *,
+        include_deleted: bool = False,
+    ) -> dict[str, object] | None:
         return self.conversations.get(conversation_id)
 
     def add_workspace_resource_membership(
@@ -734,6 +803,120 @@ def test_generic_summarize_failure_uses_safe_unresolved_message() -> None:
     assert message == "Workspace resource summary is unavailable."
     assert "/tmp/secret-token" not in message
     assert "sk-test" not in message
+
+
+@pytest.mark.parametrize(
+    "resource_type,resource_id,store_key,row",
+    [
+        (
+            "workspace_note",
+            "7",
+            ("workspace-1", 7),
+            {"id": 7, "workspace_id": "workspace-1", "title": "Deleted note", "deleted": 1},
+        ),
+        (
+            "workspace_source",
+            "source-1",
+            ("workspace-1", "source-1"),
+            {
+                "id": "source-1",
+                "workspace_id": "workspace-1",
+                "title": "Deleted source",
+                "source_type": "pdf",
+                "deleted": 1,
+            },
+        ),
+        (
+            "workspace_artifact",
+            "artifact-1",
+            ("workspace-1", "artifact-1"),
+            {
+                "id": "artifact-1",
+                "workspace_id": "workspace-1",
+                "title": "Deleted artifact",
+                "artifact_type": "report",
+                "deleted": 1,
+            },
+        ),
+    ],
+)
+def test_deleted_workspace_subresource_summary_reports_deleted_state(
+    resource_type: str,
+    resource_id: str,
+    store_key: tuple[object, ...],
+    row: dict[str, object],
+) -> None:
+    db = FakeChaChaDB()
+    if resource_type == "workspace_note":
+        db.notes[store_key] = row
+    elif resource_type == "workspace_source":
+        db.sources[store_key] = row
+    else:
+        db.artifacts[store_key] = row
+    db.memberships[("workspace-1", resource_type, resource_id)] = _membership_row(
+        resource_type=resource_type,
+        resource_id=resource_id,
+    )
+    service = WorkspaceMembershipService(db)
+
+    payload = service.list_workspace_memberships("workspace-1")
+
+    summary = payload["items"][0]["summary"]
+    assert summary["state"] == "deleted"
+    assert summary["title"] == row["title"]
+
+
+def test_deleted_chat_summary_reports_deleted_state() -> None:
+    db = FakeChaChaDB()
+    db.conversations["chat-1"] = {
+        "id": "chat-1",
+        "title": "Deleted chat",
+        "scope_type": "workspace",
+        "workspace_id": "workspace-1",
+        "deleted": 1,
+    }
+    db.memberships[("workspace-1", "chat", "chat-1")] = _membership_row(
+        resource_type="chat",
+        resource_id="chat-1",
+        role="conversation",
+    )
+    service = WorkspaceMembershipService(db)
+
+    payload = service.list_workspace_memberships("workspace-1")
+
+    summary = payload["items"][0]["summary"]
+    assert summary["state"] == "deleted"
+    assert summary["title"] == "Deleted chat"
+
+
+def test_deleted_media_summary_reports_deleted_state(monkeypatch: pytest.MonkeyPatch) -> None:
+    db = FakeChaChaDB()
+    db.memberships[("workspace-1", "media", "42")] = _membership_row()
+    media_db = object()
+    calls: list[tuple[int, bool, bool]] = []
+
+    def fake_get_media_by_id(
+        passed_db: object,
+        media_id: int,
+        *,
+        include_deleted: bool = False,
+        include_trash: bool = False,
+    ) -> dict[str, object] | None:
+        assert passed_db is media_db
+        calls.append((media_id, include_deleted, include_trash))
+        if include_deleted and include_trash:
+            return {"id": media_id, "title": "Deleted media", "deleted": 1}
+        return None
+
+    monkeypatch.setattr(membership_adapters.media_db_api, "get_media_by_id", fake_get_media_by_id)
+    service = WorkspaceMembershipService(db)
+
+    payload = service.list_workspace_memberships("workspace-1", media_db=media_db)
+
+    summary = payload["items"][0]["summary"]
+    assert summary["state"] == "deleted"
+    assert summary["title"] == "Deleted media"
+    assert calls == [(42, True, True)]
 
 
 class RecordingAdapter:

--- a/tldw_Server_API/tests/Workspaces/test_workspace_membership_adapters.py
+++ b/tldw_Server_API/tests/Workspaces/test_workspace_membership_adapters.py
@@ -1,0 +1,208 @@
+from __future__ import annotations
+
+import base64
+import json
+
+import pytest
+from pydantic import ValidationError
+
+from tldw_Server_API.app.api.v1.schemas.workspace_schemas import (
+    WorkspaceContextMembershipSummary,
+    WorkspaceMembershipCreateRequest,
+    WorkspaceMembershipListResponse,
+    WorkspaceMembershipListSummary,
+    WorkspaceMembershipResponse,
+    WorkspaceMembershipSummaryResponse,
+)
+from tldw_Server_API.app.core.Workspaces.membership_models import (
+    WorkspaceMembershipCursor,
+    WorkspaceResourceMembershipCursor,
+    decode_membership_cursor,
+    decode_resource_membership_cursor,
+    encode_membership_cursor,
+    encode_resource_membership_cursor,
+)
+
+
+def _encoded_json(payload: object) -> str:
+    return base64.urlsafe_b64encode(json.dumps(payload).encode("utf-8")).decode("ascii").rstrip("=")
+
+
+def test_workspace_membership_cursor_round_trips() -> None:
+    cursor = WorkspaceMembershipCursor(
+        updated_at="2026-06-07T12:30:00Z",
+        resource_type="media",
+        resource_id="42",
+    )
+
+    encoded = encode_membership_cursor(cursor)
+
+    assert encoded != cursor.updated_at
+    assert decode_membership_cursor(encoded) == cursor
+
+
+def test_workspace_resource_membership_cursor_round_trips() -> None:
+    cursor = WorkspaceResourceMembershipCursor(
+        updated_at="2026-06-07T12:30:00Z",
+        workspace_id="workspace-1",
+    )
+
+    encoded = encode_resource_membership_cursor(cursor)
+
+    assert encoded != cursor.updated_at
+    assert decode_resource_membership_cursor(encoded) == cursor
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        "not-base64",
+        _encoded_json(["not", "an", "object"]),
+        _encoded_json({"updated_at": "2026-06-07T12:30:00Z", "resource_type": "media"}),
+        _encoded_json({"updated_at": "2026-06-07T12:30:00Z", "resource_type": "media", "resource_id": 42}),
+        _encoded_json(
+            {
+                "updated_at": "2026-06-07T12:30:00Z",
+                "resource_type": "future_resource",
+                "resource_id": "42",
+            }
+        ),
+    ],
+)
+def test_workspace_membership_cursor_rejects_invalid_values(payload: str) -> None:
+    with pytest.raises(ValueError):
+        decode_membership_cursor(payload)
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        "not-base64",
+        _encoded_json({"updated_at": "2026-06-07T12:30:00Z", "resource_type": "media", "resource_id": "42"}),
+        _encoded_json({"updated_at": "2026-06-07T12:30:00Z"}),
+        _encoded_json({"updated_at": "2026-06-07T12:30:00Z", "workspace_id": 7}),
+    ],
+)
+def test_workspace_resource_membership_cursor_rejects_invalid_values(payload: str) -> None:
+    with pytest.raises(ValueError):
+        decode_resource_membership_cursor(payload)
+
+
+def test_workspace_membership_create_request_accepts_valid_payload() -> None:
+    request = WorkspaceMembershipCreateRequest(
+        resource_type="media",
+        resource_id="42",
+        role="source",
+        label="Research paper",
+        transfer_policy="link",
+        provenance={"source_surface": "library", "operation_id": "op-1"},
+        metadata={"rank": 1},
+    )
+
+    assert request.resource_type == "media"
+    assert request.resource_id == "42"
+    assert request.role == "source"
+    assert request.transfer_policy == "link"
+    assert request.provenance["source_surface"] == "library"
+    assert request.metadata["rank"] == 1
+
+
+@pytest.mark.parametrize(
+    "field_name,value",
+    [
+        ("resource_type", "note"),
+        ("role", "owner"),
+        ("transfer_policy", "move"),
+    ],
+)
+def test_workspace_membership_create_request_rejects_unsupported_literals(field_name: str, value: str) -> None:
+    payload = {
+        "resource_type": "media",
+        "resource_id": "42",
+        "role": "source",
+        "transfer_policy": "link",
+    }
+    payload[field_name] = value
+
+    with pytest.raises(ValidationError):
+        WorkspaceMembershipCreateRequest(**payload)
+
+
+@pytest.mark.parametrize("field_name", ["provenance", "metadata"])
+def test_workspace_membership_create_request_rejects_oversized_json(field_name: str) -> None:
+    payload = {
+        "resource_type": "media",
+        "resource_id": "42",
+        "role": "source",
+        "transfer_policy": "link",
+        field_name: {"value": "x" * (16 * 1024 + 1)},
+    }
+
+    with pytest.raises(ValidationError, match=f"{field_name} exceeds"):
+        WorkspaceMembershipCreateRequest(**payload)
+
+
+@pytest.mark.parametrize("field_name", ["provenance", "metadata"])
+def test_workspace_membership_create_request_rejects_non_json_serializable_values(field_name: str) -> None:
+    payload = {
+        "resource_type": "media",
+        "resource_id": "42",
+        "role": "source",
+        "transfer_policy": "link",
+        field_name: {"bad": object()},
+    }
+
+    with pytest.raises(ValidationError, match=f"{field_name} must be JSON serializable"):
+        WorkspaceMembershipCreateRequest(**payload)
+
+
+def test_workspace_membership_list_response_constructs_grouped_totals() -> None:
+    item = WorkspaceMembershipResponse(
+        workspace_id="workspace-1",
+        resource_type="media",
+        resource_id="42",
+        role="source",
+        label="Research paper",
+        transfer_policy="link",
+        provenance={"source_surface": "library"},
+        metadata={"rank": 1},
+        summary=WorkspaceMembershipSummaryResponse(
+            title="Research paper",
+            subtitle="PDF",
+            href="/media/42",
+            updated_at="2026-06-07T12:30:00Z",
+            state="available",
+        ),
+        created_at="2026-06-07T12:00:00Z",
+        updated_at="2026-06-07T12:30:00Z",
+        version=2,
+        deleted=False,
+    )
+
+    response = WorkspaceMembershipListResponse(
+        workspace_id="workspace-1",
+        items=[item],
+        total=1,
+        next_cursor=None,
+        summary=WorkspaceMembershipListSummary(
+            total=1,
+            by_resource_type={"media": 1},
+            by_role={"source": 1},
+        ),
+    )
+
+    assert response.items[0].summary is not None
+    assert response.summary.by_resource_type == {"media": 1}
+    assert response.summary.by_role == {"source": 1}
+
+
+def test_workspace_context_membership_summary_constructs_grouped_totals() -> None:
+    summary = WorkspaceContextMembershipSummary(
+        total=3,
+        by_resource_type={"media": 2, "chat": 1},
+        by_role={"source": 2, "conversation": 1},
+    )
+
+    assert summary.total == 3
+    assert summary.by_resource_type["media"] == 2
+    assert summary.by_role["conversation"] == 1

--- a/tldw_Server_API/tests/Workspaces/test_workspace_memberships_api.py
+++ b/tldw_Server_API/tests/Workspaces/test_workspace_memberships_api.py
@@ -300,6 +300,17 @@ def test_workspace_list_filters_and_resolve_false(client: TestClient, db: FakeMe
     assert body["summary"]["by_role"] == {"conversation": 1}
 
 
+def test_workspace_list_default_omits_resolved_summaries(client: TestClient) -> None:
+    client.post("/api/v1/workspaces/workspace-1/memberships", json=_membership_payload())
+
+    response = client.get("/api/v1/workspaces/workspace-1/memberships")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["total"] == 1
+    assert body["items"][0]["summary"] is None
+
+
 def test_get_one_membership_and_missing_returns_stable_404(client: TestClient) -> None:
     client.post("/api/v1/workspaces/workspace-1/memberships", json=_membership_payload())
 
@@ -353,6 +364,17 @@ def test_reverse_resource_route_returns_resource_memberships(client: TestClient)
     assert body["total"] == 2
     assert {item["workspace_id"] for item in body["items"]} == {"workspace-1", "workspace-2"}
     assert all(item["summary"] is None for item in body["items"])
+
+
+def test_reverse_resource_route_default_omits_resolved_summaries(client: TestClient) -> None:
+    client.post("/api/v1/workspaces/workspace-1/memberships", json=_membership_payload())
+
+    response = client.get("/api/v1/workspace-memberships/resources/chat/chat-1")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["total"] == 1
+    assert body["items"][0]["summary"] is None
 
 
 def test_unsupported_resource_type_returns_stable_400_code(client: TestClient) -> None:

--- a/tldw_Server_API/tests/Workspaces/test_workspace_memberships_api.py
+++ b/tldw_Server_API/tests/Workspaces/test_workspace_memberships_api.py
@@ -362,6 +362,16 @@ def test_unsupported_resource_type_returns_stable_400_code(client: TestClient) -
     assert response.json()["detail"]["code"] == "unsupported_resource_type"
 
 
+def test_post_unsupported_resource_type_returns_stable_400_code(client: TestClient) -> None:
+    response = client.post(
+        "/api/v1/workspaces/workspace-1/memberships",
+        json=_membership_payload(resource_type="note", resource_id="1"),
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"]["code"] == "unsupported_resource_type"
+
+
 def test_missing_media_db_on_media_link_returns_503_code(membership_app: FastAPI) -> None:
     membership_app.dependency_overrides[try_get_media_db_for_user] = lambda: None
     with TestClient(membership_app, raise_server_exceptions=False) as test_client:

--- a/tldw_Server_API/tests/Workspaces/test_workspace_memberships_api.py
+++ b/tldw_Server_API/tests/Workspaces/test_workspace_memberships_api.py
@@ -1,0 +1,374 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from tldw_Server_API.app.api.v1.API_Deps.ChaCha_Notes_DB_Deps import get_chacha_db_for_user
+from tldw_Server_API.app.api.v1.API_Deps.DB_Deps import try_get_media_db_for_user
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import get_request_user
+from tldw_Server_API.app.api.v1.endpoints import workspace_memberships as workspace_memberships_endpoint
+from tldw_Server_API.app.api.v1.endpoints import workspaces as workspaces_endpoint
+from tldw_Server_API.app.api.v1.endpoints.workspaces_rate_limit_policy import (
+    WORKSPACES_DELETE_RATE_LIMIT,
+    WORKSPACES_READ_RATE_LIMIT,
+    WORKSPACES_WRITE_RATE_LIMIT,
+)
+from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import ConflictError
+
+
+class FakeMembershipDB:
+    def __init__(self) -> None:
+        self.workspaces: dict[str, dict[str, object]] = {
+            "workspace-1": {"id": "workspace-1", "archived": False},
+            "workspace-2": {"id": "workspace-2", "archived": False},
+            "workspace-archived": {"id": "workspace-archived", "archived": True},
+        }
+        self.conversations: dict[str, dict[str, object]] = {
+            "chat-1": {
+                "id": "chat-1",
+                "title": "Research chat",
+                "scope_type": "global",
+                "workspace_id": None,
+                "last_modified": "2026-06-07T12:00:00Z",
+                "version": 1,
+            }
+        }
+        self.memberships: dict[tuple[str, str, str], dict[str, object]] = {}
+        self._clock = 0
+
+    def _timestamp(self) -> str:
+        self._clock += 1
+        return f"2026-06-07T12:00:{self._clock:02d}Z"
+
+    def get_workspace(self, workspace_id: str) -> dict[str, object] | None:
+        return self.workspaces.get(workspace_id)
+
+    def get_conversation_for_workspace_membership(self, conversation_id: str) -> dict[str, object] | None:
+        return self.conversations.get(conversation_id)
+
+    def add_workspace_resource_membership(
+        self,
+        workspace_id: str,
+        data: dict[str, object],
+        *,
+        user_id: str | None = None,
+    ) -> dict[str, object]:
+        key = (workspace_id, str(data["resource_type"]), str(data["resource_id"]))
+        existing = self.memberships.get(key)
+        if existing is not None:
+            if existing.get("deleted"):
+                if data.get("restore_deleted") is not True:
+                    return dict(existing)
+                existing.update(
+                    {
+                        "role": data.get("role", "member"),
+                        "label": data.get("label"),
+                        "transfer_policy": data.get("transfer_policy", "link"),
+                        "provenance": data.get("provenance", {}),
+                        "metadata": data.get("metadata", {}),
+                        "updated_by_user_id": user_id,
+                        "updated_at": self._timestamp(),
+                        "version": int(existing.get("version", 1)) + 1,
+                        "deleted": False,
+                    }
+                )
+                return dict(existing)
+            if (
+                existing.get("role") != data.get("role", "member")
+                or existing.get("label") != data.get("label")
+                or existing.get("transfer_policy") != data.get("transfer_policy", "link")
+            ):
+                raise ConflictError(entity="workspace_resource_memberships")
+            return dict(existing)
+
+        now = self._timestamp()
+        row = {
+            "workspace_id": workspace_id,
+            "resource_type": str(data["resource_type"]),
+            "resource_id": str(data["resource_id"]),
+            "role": data.get("role", "member"),
+            "label": data.get("label"),
+            "transfer_policy": data.get("transfer_policy", "link"),
+            "provenance": data.get("provenance", {}),
+            "metadata": data.get("metadata", {}),
+            "created_at": now,
+            "updated_at": now,
+            "version": 1,
+            "deleted": False,
+            "created_by_user_id": user_id,
+            "updated_by_user_id": user_id,
+        }
+        self.memberships[key] = row
+        return dict(row)
+
+    def get_workspace_resource_membership(
+        self,
+        workspace_id: str,
+        resource_type: str,
+        resource_id: str,
+        *,
+        include_deleted: bool = False,
+    ) -> dict[str, object] | None:
+        row = self.memberships.get((workspace_id, resource_type, resource_id))
+        if row is None or (row.get("deleted") and not include_deleted):
+            return None
+        return dict(row)
+
+    def list_workspace_resource_memberships(
+        self,
+        workspace_id: str,
+        *,
+        resource_type: str | None = None,
+        role: str | None = None,
+        include_deleted: bool = False,
+        limit: int = 100,
+        cursor: tuple[str, str, str] | None = None,
+    ) -> list[dict[str, object]]:
+        _ = cursor
+        rows = [
+            row
+            for (row_workspace_id, _, _), row in self.memberships.items()
+            if row_workspace_id == workspace_id
+            and (resource_type is None or row["resource_type"] == resource_type)
+            and (role is None or row["role"] == role)
+            and (include_deleted or not row.get("deleted"))
+        ]
+        rows.sort(
+            key=lambda row: (
+                str(row["updated_at"]),
+                str(row["resource_type"]),
+                str(row["resource_id"]),
+            ),
+            reverse=True,
+        )
+        return [dict(row) for row in rows[:limit]]
+
+    def list_resource_workspace_memberships(
+        self,
+        resource_type: str,
+        resource_id: str,
+        *,
+        include_deleted: bool = False,
+        limit: int = 100,
+        cursor: tuple[str, str] | None = None,
+    ) -> list[dict[str, object]]:
+        _ = cursor
+        rows = [
+            row
+            for (_, row_resource_type, row_resource_id), row in self.memberships.items()
+            if row_resource_type == resource_type
+            and row_resource_id == resource_id
+            and (include_deleted or not row.get("deleted"))
+        ]
+        rows.sort(key=lambda row: (str(row["updated_at"]), str(row["workspace_id"])), reverse=True)
+        return [dict(row) for row in rows[:limit]]
+
+    def delete_workspace_resource_membership(
+        self,
+        workspace_id: str,
+        resource_type: str,
+        resource_id: str,
+        *,
+        user_id: str | None = None,
+    ) -> dict[str, object] | None:
+        row = self.memberships.get((workspace_id, resource_type, resource_id))
+        if row is None or row.get("deleted"):
+            return None
+        row["deleted"] = True
+        row["updated_by_user_id"] = user_id
+        row["updated_at"] = self._timestamp()
+        row["version"] = int(row.get("version", 1)) + 1
+        return dict(row)
+
+
+@pytest.fixture
+def db() -> FakeMembershipDB:
+    return FakeMembershipDB()
+
+
+@pytest.fixture
+def membership_app(db: FakeMembershipDB) -> FastAPI:
+    app = FastAPI()
+    app.include_router(workspaces_endpoint.router, prefix="/api/v1/workspaces")
+    app.include_router(workspace_memberships_endpoint.router, prefix="/api/v1/workspace-memberships")
+
+    async def _allow_rate_limit() -> None:
+        return None
+
+    app.dependency_overrides[get_request_user] = lambda: SimpleNamespace(id="user-1")
+    app.dependency_overrides[get_chacha_db_for_user] = lambda: db
+    app.dependency_overrides[try_get_media_db_for_user] = lambda: object()
+    app.dependency_overrides[WORKSPACES_READ_RATE_LIMIT] = _allow_rate_limit
+    app.dependency_overrides[WORKSPACES_WRITE_RATE_LIMIT] = _allow_rate_limit
+    app.dependency_overrides[WORKSPACES_DELETE_RATE_LIMIT] = _allow_rate_limit
+    return app
+
+
+@pytest.fixture
+def client(membership_app: FastAPI) -> TestClient:
+    with TestClient(membership_app, raise_server_exceptions=False) as test_client:
+        yield test_client
+
+
+def _membership_payload(**overrides: Any) -> dict[str, Any]:
+    payload = {
+        "resource_type": "chat",
+        "resource_id": "chat-1",
+        "role": "conversation",
+        "label": "Research chat",
+        "transfer_policy": "link",
+        "provenance": {"source_surface": "test"},
+    }
+    payload.update(overrides)
+    return payload
+
+
+def test_post_creates_membership(client: TestClient) -> None:
+    response = client.post("/api/v1/workspaces/workspace-1/memberships", json=_membership_payload())
+
+    assert response.status_code == 201
+    body = response.json()
+    assert body["workspace_id"] == "workspace-1"
+    assert body["resource_type"] == "chat"
+    assert body["resource_id"] == "chat-1"
+    assert body["role"] == "conversation"
+    assert body["summary"]["title"] == "Research chat"
+
+
+def test_duplicate_same_request_is_idempotent(client: TestClient, db: FakeMembershipDB) -> None:
+    first = client.post("/api/v1/workspaces/workspace-1/memberships", json=_membership_payload())
+    second = client.post("/api/v1/workspaces/workspace-1/memberships", json=_membership_payload())
+
+    assert first.status_code == 201
+    assert second.status_code == 201
+    assert second.json()["version"] == first.json()["version"]
+    assert second.json()["created_at"] == first.json()["created_at"]
+    assert len(db.memberships) == 1
+
+
+def test_duplicate_conflicting_request_returns_409(client: TestClient) -> None:
+    created = client.post("/api/v1/workspaces/workspace-1/memberships", json=_membership_payload())
+
+    response = client.post(
+        "/api/v1/workspaces/workspace-1/memberships",
+        json=_membership_payload(role="reference"),
+    )
+
+    assert created.status_code == 201
+    assert response.status_code == 409
+
+
+def test_archived_workspace_write_returns_stable_error_code(client: TestClient) -> None:
+    response = client.post(
+        "/api/v1/workspaces/workspace-archived/memberships",
+        json=_membership_payload(),
+    )
+
+    assert response.status_code == 409
+    assert response.json()["detail"]["code"] == "workspace_archived"
+
+
+def test_workspace_list_filters_and_resolve_false(client: TestClient, db: FakeMembershipDB) -> None:
+    db.conversations["chat-2"] = {
+        "id": "chat-2",
+        "title": "Reference chat",
+        "scope_type": "global",
+        "workspace_id": None,
+        "last_modified": "2026-06-07T12:01:00Z",
+    }
+    client.post("/api/v1/workspaces/workspace-1/memberships", json=_membership_payload())
+    client.post(
+        "/api/v1/workspaces/workspace-1/memberships",
+        json=_membership_payload(resource_id="chat-2", role="reference", label="Reference chat"),
+    )
+
+    response = client.get(
+        "/api/v1/workspaces/workspace-1/memberships",
+        params={"resource_type": "chat", "role": "conversation", "resolve": "false"},
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["workspace_id"] == "workspace-1"
+    assert body["total"] == 1
+    assert body["items"][0]["resource_id"] == "chat-1"
+    assert body["items"][0]["summary"] is None
+    assert body["summary"]["by_role"] == {"conversation": 1}
+
+
+def test_get_one_membership_and_missing_returns_stable_404(client: TestClient) -> None:
+    client.post("/api/v1/workspaces/workspace-1/memberships", json=_membership_payload())
+
+    found = client.get("/api/v1/workspaces/workspace-1/memberships/chat/chat-1")
+    missing = client.get("/api/v1/workspaces/workspace-1/memberships/chat/missing-chat")
+
+    assert found.status_code == 200
+    assert found.json()["resource_id"] == "chat-1"
+    assert missing.status_code == 404
+    assert missing.json()["detail"]["code"] == "workspace_membership_not_found"
+
+
+def test_delete_soft_deletes_and_default_list_hides_membership(client: TestClient) -> None:
+    client.post("/api/v1/workspaces/workspace-1/memberships", json=_membership_payload())
+
+    delete_response = client.delete("/api/v1/workspaces/workspace-1/memberships/chat/chat-1")
+    list_response = client.get("/api/v1/workspaces/workspace-1/memberships")
+
+    assert delete_response.status_code == 204
+    assert list_response.status_code == 200
+    assert list_response.json()["items"] == []
+
+
+def test_relink_after_delete_restores_membership(client: TestClient) -> None:
+    client.post("/api/v1/workspaces/workspace-1/memberships", json=_membership_payload())
+    client.delete("/api/v1/workspaces/workspace-1/memberships/chat/chat-1")
+
+    response = client.post(
+        "/api/v1/workspaces/workspace-1/memberships",
+        json=_membership_payload(role="reference"),
+    )
+
+    assert response.status_code == 201
+    body = response.json()
+    assert body["role"] == "reference"
+    assert body["deleted"] is False
+    assert body["version"] == 3
+
+
+def test_reverse_resource_route_returns_resource_memberships(client: TestClient) -> None:
+    client.post("/api/v1/workspaces/workspace-1/memberships", json=_membership_payload())
+    client.post("/api/v1/workspaces/workspace-2/memberships", json=_membership_payload())
+
+    response = client.get("/api/v1/workspace-memberships/resources/chat/chat-1", params={"resolve": "false"})
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["resource_type"] == "chat"
+    assert body["resource_id"] == "chat-1"
+    assert "workspace_id" not in body
+    assert body["total"] == 2
+    assert {item["workspace_id"] for item in body["items"]} == {"workspace-1", "workspace-2"}
+    assert all(item["summary"] is None for item in body["items"])
+
+
+def test_unsupported_resource_type_returns_stable_400_code(client: TestClient) -> None:
+    response = client.get("/api/v1/workspace-memberships/resources/note/1")
+
+    assert response.status_code == 400
+    assert response.json()["detail"]["code"] == "unsupported_resource_type"
+
+
+def test_missing_media_db_on_media_link_returns_503_code(membership_app: FastAPI) -> None:
+    membership_app.dependency_overrides[try_get_media_db_for_user] = lambda: None
+    with TestClient(membership_app, raise_server_exceptions=False) as test_client:
+        response = test_client.post(
+            "/api/v1/workspaces/workspace-1/memberships",
+            json=_membership_payload(resource_type="media", resource_id="42", role="source"),
+        )
+
+    assert response.status_code == 503
+    assert response.json()["detail"]["code"] == "media_db_unavailable"


### PR DESCRIPTION
## Summary
- Add server-backed `workspace_resource_memberships` persistence, membership models/cursors, fail-closed adapters, and Workspace membership service orchestration.
- Expose workspace-scoped membership APIs plus reverse resource lookup, explicit idempotent backfill, and compact membership totals in Workspace context.
- Document boundaries: membership is association, not ownership transfer/global filtering/MCP trust or path admission.

## Verification
- `python -m pytest tldw_Server_API/tests/ChaChaNotesDB/test_workspace_resource_memberships_db.py tldw_Server_API/tests/Workspaces/test_workspace_membership_adapters.py tldw_Server_API/tests/Workspaces/test_workspace_memberships_api.py tldw_Server_API/tests/Workspaces/test_workspace_context_membership_summary.py tldw_Server_API/tests/Workspaces/test_workspaces_api.py tldw_Server_API/tests/Workspaces/test_workspace_sub_resources_api.py tldw_Server_API/tests/MCP_unified/test_mcp_hub_path_enforcement_service.py -q` passed: 194 passed, 6 warnings.
- `python -m pytest tldw_Server_API/tests/Workspaces -q` passed: 370 passed, 8 warnings.
- `python -m bandit -r ... -f json -o /tmp/bandit_workspace_memberships.json` exited 0 with zero findings.
- `git diff --check` passed.

## Change Summary
This PR is AI-authored. Per project policy, a human maintainer should confirm or replace this change summary before merge, explaining in their own words what changed and why these implementation choices were made.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements server-backed cross-resource Workspace memberships with persistence, service/adapters, workspace-scoped and reverse-lookup APIs, and workspace context summaries. Preserves association-only semantics (no ownership transfer or global filtering; MCP trust/path stay separate) and addresses review gaps.

- New Features
  - New `workspace_resource_memberships` table with unique keys, Postgres RLS tenant isolation, and cursor pagination.
  - Membership service with fail-closed adapters for `workspace_note`, `media`, `workspace_source`, `workspace_artifact`, and `chat`; `POST/GET/DELETE /api/v1/workspaces/{workspace_id}/memberships` plus reverse lookup `GET /api/v1/workspace-memberships/resources/{resource_type}/{resource_id}`; routes wired into `content` and `minimal` router groups; workspace context shows compact membership totals; idempotent backfill returns created/restored counts.

- Bug Fixes
  - Tightened pagination with stricter cursor validation and deterministic ordering; safer retries under concurrency; hardened validation with resource-type checks deferred to adapters.
  - Addressed review gaps: enforced tenant RLS, exposed reverse-lookup in minimal bundle, reserved on-link hook for future side effects, and aligned error mapping.

<sup>Written for commit 3bf82352425f570af9075dd39394387d6ba249b2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2312?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

