### PR TITLE
test(web): preserve media query mock exports

### DIFF
--- a/apps/tldw-frontend/__tests__/components/layout/WebLayout.chat-scroll-contract.test.tsx
+++ b/apps/tldw-frontend/__tests__/components/layout/WebLayout.chat-scroll-contract.test.tsx
@@ -228,9 +228,17 @@ vi.mock('@/hooks/useFeatureFlags', () => ({
   useChatSidebar: () => [featureFlagState.showChatSidebar],
 }));
 
-vi.mock('@/hooks/useMediaQuery', () => ({
-  useMobile: () => false,
-}));
+vi.mock('@/hooks/useMediaQuery', async () => {
+  const actual = await vi.importActual<typeof import('@/hooks/useMediaQuery')>(
+    '@/hooks/useMediaQuery'
+  );
+
+  return {
+    ...actual,
+    useDesktop: () => false,
+    useMobile: () => false,
+  };
+});
 
 vi.mock('@/hooks/useSetting', () => ({
   useSetting: () => [''],
@@ -421,5 +429,12 @@ describe('WebLayout /chat scroll contract', () => {
     );
 
     expect(await screen.findByTestId('tutorial-runner')).toBeInTheDocument();
+  });
+
+  it('preserves non-overridden media query exports in the test mock', async () => {
+    const mediaQueryModule = await import('@/hooks/useMediaQuery');
+
+    expect(mediaQueryModule.useTablet).toEqual(expect.any(Function));
+    expect(mediaQueryModule.useMediaQuery).toEqual(expect.any(Function));
   });
 });

--- a/backlog/tasks/task-530 - Address-PR-2313-media-query-mock-review-feedback.md
+++ b/backlog/tasks/task-530 - Address-PR-2313-media-query-mock-review-feedback.md
@@ -1,0 +1,58 @@
+---
+id: TASK-530
+title: Address PR 2313 media query mock review feedback
+status: Done
+labels:
+- webui
+- extension
+- review
+references:
+- TASK-529
+- https://github.com/rmusser01/tldw_server/pull/2313
+modified_files:
+- apps/tldw-frontend/__tests__/components/layout/WebLayout.chat-scroll-contract.test.tsx
+- backlog/tasks/task-530 - Address-PR-2313-media-query-mock-review-feedback.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Address PR #2313 review feedback by making the WebLayout media-query test mock resilient to additional exports, then rebase the PR branch onto latest dev and complete merge readiness checks.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 WebLayout test uses a partial useMediaQuery module mock that preserves non-overridden exports.
+- [x] #2 Regression guard verifies useTablet and useMediaQuery remain available from the mocked module.
+- [x] #3 PR branch is rebased onto latest origin/dev and reduced to the relevant review-remediation diff.
+- [x] #4 Focused WebLayout and shared ChatSidebar/Layout Vitest suites pass after rebase.
+- [x] #5 Bandit frontend-only/Markdown-only note and final summary are recorded.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Qodo review item verified as technically sound: the prior full module mock reproduced the missing-export failure once a guard checked non-overridden useMediaQuery exports. Replaced it with a partial mock using vi.importActual and overriding only useDesktop/useMobile. Added a regression guard that useTablet and useMediaQuery remain available from the mocked module. Next steps: rebase PR branch onto latest origin/dev, update PR base to dev, rerun focused suites, resolve review threads/comment, then merge if merge gates allow.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Addressed Qodo PR #2313 feedback by replacing the full useMediaQuery module mock with a partial vi.importActual mock that preserves non-overridden exports while forcing useDesktop/useMobile false for this WebLayout test. Added a regression guard that useTablet and useMediaQuery remain available from the mocked module. Rebasing onto latest origin/dev reduced the PR to the single review-remediation commit because latest dev already contains the prior sidebar implementation and TASK-401/TASK-404 closeout via TASK-567/PR #2168. Verification passed after rebase: WebLayout chat scroll contract, 6 tests; shared ChatSidebar/Layout focused suite, 15 tests. Bandit not run because touched code is frontend TypeScript/test-only plus Backlog Markdown.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## Summary
- Rebased PR #2313 onto latest `origin/dev` and changed the PR base to `dev`.
- Dropped stale duplicate sidebar closeout commits because latest `dev` already contains that work via TASK-567 / PR #2168.
- Addressed Qodo feedback by converting the WebLayout `useMediaQuery` mock to a partial mock and adding a guard that non-overridden exports stay available.
- Added TASK-530 to record the PR review remediation and verification.

## Why
The previous WebLayout test replaced the entire `@/hooks/useMediaQuery` module, which made any newly imported export from that module undefined under test. That exact fragility caused the stale `useDesktop` mock failure, so this PR preserves the real module exports and overrides only the viewport hooks needed by the WebLayout contract test. Rebasing onto `dev` avoids reintroducing duplicate sidebar closeout metadata that has already landed via TASK-567 / PR #2168.

## Validation
- [x] `node_modules/.bin/vitest run __tests__/components/layout/WebLayout.chat-scroll-contract.test.tsx` from `apps/tldw-frontend`
- [x] `node_modules/.bin/vitest run src/components/Common/ChatSidebar/__tests__/ChatSidebar.tools-first.test.tsx src/components/Common/ChatSidebar/__tests__/ChatSidebar.lazy-history.test.tsx src/components/Common/__tests__/ChatSidebar.coordinator.test.tsx src/components/Layouts/__tests__/Layout.chat-sidebar-reset-signal.guard.test.ts` from `apps/packages/ui`
- [x] `git diff --check origin/dev..HEAD`
- [x] Qodo review item resolved; no unresolved review threads remain.

## Risk And Rollback
Risk is low: the runtime app is unchanged; this touches one frontend test file and one Backlog Markdown task. If it regresses, revert commit `d215c43106` or restore the previous test mock. Bandit was not run because the touched scope is frontend TypeScript test code plus Backlog Markdown only.

## Change Summary
Human-owned merge summary required by repo policy: pending human owner confirmation before merge.