### PR TITLE
Fix Skills readiness gates on dev

### DIFF
--- a/apps/packages/ui/src/components/Option/Skills/SkillsWorkspace.tsx
+++ b/apps/packages/ui/src/components/Option/Skills/SkillsWorkspace.tsx
@@ -42,6 +42,10 @@ export const SkillsWorkspace: React.FC = () => {
         defaultValue:
           "To use Skills, connect to your tldw server so skill definitions can be stored and executed."
       })}
+      unreachableDescription={t("option:skillsEmpty.unreachableDescription", {
+        defaultValue:
+          "To use Skills, reconnect to your tldw server so skill definitions can be stored and executed."
+      })}
     >
       {capsLoading ? (
         <PageShell>

--- a/apps/packages/ui/src/components/Option/Skills/__tests__/SkillsWorkspace.test.tsx
+++ b/apps/packages/ui/src/components/Option/Skills/__tests__/SkillsWorkspace.test.tsx
@@ -15,6 +15,7 @@ const mocks = vi.hoisted(() => ({
   connectionState: {
     uxState: "connected_ok" as
       | "connected_ok"
+      | "connected_degraded"
       | "testing"
       | "configuring_url"
       | "configuring_auth"
@@ -130,5 +131,37 @@ describe("SkillsWorkspace capability states", () => {
     renderWorkspace()
 
     expect(screen.getByTestId("skills-manager")).toBeInTheDocument()
+  })
+
+  it("keeps Skills usable when the connected server is degraded", () => {
+    mocks.connectionState = {
+      uxState: "connected_degraded",
+      hasCompletedFirstRun: true
+    }
+
+    renderWorkspace()
+
+    expect(screen.getByTestId("skills-manager")).toBeInTheDocument()
+  })
+
+  it("uses Skills-specific recovery guidance when the server is unreachable", () => {
+    mocks.connectionState = {
+      uxState: "error_unreachable",
+      hasCompletedFirstRun: true
+    }
+
+    renderWorkspace()
+
+    expect(
+      screen.getByRole("heading", {
+        name: "Can't reach your tldw server right now."
+      })
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText(
+        "To use Skills, reconnect to your tldw server so skill definitions can be stored and executed."
+      )
+    ).toBeInTheDocument()
+    expect(screen.queryByTestId("skills-manager")).not.toBeInTheDocument()
   })
 })

--- a/apps/tldw-frontend/components/networking/ServerReadinessGate.tsx
+++ b/apps/tldw-frontend/components/networking/ServerReadinessGate.tsx
@@ -1,6 +1,7 @@
 import React from "react"
 
 import { resolvePublicApiOrigin, type DeploymentEnv } from "@web/lib/api-base"
+import { useConnectionStore } from "@tldw/ui/store/connection"
 import {
   StatePanel,
   type StatePanelDiagnostic,
@@ -12,12 +13,6 @@ const _env: DeploymentEnv = {
   NEXT_PUBLIC_API_URL: process.env.NEXT_PUBLIC_API_URL
 }
 
-const _origin =
-  typeof window !== "undefined"
-    ? resolvePublicApiOrigin(_env, window.location.origin)
-    : resolvePublicApiOrigin(_env)
-
-const HEALTH_URL = `${_origin}/api/v1/health`
 const MAX_WAIT_MS = 15_000
 const RETRY_INTERVAL_MS = 2_000
 const OFFLINE_BYPASS_KEYS = ["__tldw_allow_offline", "__tldw_test_bypass"] as const
@@ -47,6 +42,66 @@ const ENTERABLE_HTTP_STATUSES = new Set([200, 206])
 const READY_HEALTH_STATUSES = new Set(["healthy", "ok"])
 const HEALTHY_CHECK_STATUSES = new Set(["healthy", "ok"])
 const SERVER_READINESS_STATE_EVENT = "tldw:server-readiness-state"
+const HEALTH_PATH = "/api/v1/health"
+
+const trimTrailingSlash = (value: string): string => value.replace(/\/+$/, "")
+const buildHealthUrl = (origin: string): string =>
+  origin ? `${trimTrailingSlash(origin)}${HEALTH_PATH}` : HEALTH_PATH
+
+const warnReadinessUrlIssue = (
+  message: string,
+  metadata?: Record<string, string>
+): void => {
+  if (metadata) {
+    console.warn(message, metadata)
+    return
+  }
+  console.warn(message)
+}
+
+export function resolveReadinessHealthUrl({
+  configuredServerUrl,
+  env,
+  pageOrigin
+}: {
+  configuredServerUrl?: string | null
+  env: DeploymentEnv
+  pageOrigin?: string
+}): string {
+  const configured = String(configuredServerUrl || "").trim()
+  if (configured) {
+    try {
+      const configuredUrl = new URL(configured)
+      if (
+        configuredUrl.protocol === "http:" ||
+        configuredUrl.protocol === "https:"
+      ) {
+        return buildHealthUrl(configuredUrl.origin)
+      }
+      warnReadinessUrlIssue(
+        "Ignoring unsupported tldw server URL protocol for readiness health check.",
+        { protocol: configuredUrl.protocol }
+      )
+    } catch {
+      warnReadinessUrlIssue(
+        "Ignoring invalid tldw server URL for readiness health check."
+      )
+    }
+  }
+
+  try {
+    const fallbackOrigin =
+      typeof pageOrigin === "string"
+        ? resolvePublicApiOrigin(env, pageOrigin)
+        : resolvePublicApiOrigin(env)
+    return buildHealthUrl(fallbackOrigin)
+  } catch {
+    warnReadinessUrlIssue(
+      "Falling back to relative readiness health check after API origin resolution failed."
+    )
+    return HEALTH_PATH
+  }
+}
 
 function readStorageFlag(key: string): boolean {
   try {
@@ -84,12 +139,14 @@ function extractHealthStatus(body: unknown): string | undefined {
 
 function buildReadinessDiagnostics({
   state,
+  healthUrl,
   degradedChecks = [],
   httpStatus,
   healthStatus,
   errorMessage
 }: {
   state: "ready" | "degraded" | "blocked"
+  healthUrl: string
   degradedChecks?: string[]
   httpStatus?: number
   healthStatus?: string
@@ -98,7 +155,7 @@ function buildReadinessDiagnostics({
   return {
     state,
     degradedChecks,
-    healthUrl: HEALTH_URL,
+    healthUrl,
     httpStatus,
     healthStatus,
     errorMessage,
@@ -106,9 +163,9 @@ function buildReadinessDiagnostics({
   }
 }
 
-async function checkHealth(): Promise<ReadinessResult> {
+async function checkHealth(healthUrl: string): Promise<ReadinessResult> {
   try {
-    const res = await fetch(HEALTH_URL, {
+    const res = await fetch(healthUrl, {
       method: "GET",
       signal: AbortSignal.timeout(3000)
     })
@@ -124,6 +181,7 @@ async function checkHealth(): Promise<ReadinessResult> {
           state: "blocked",
           diagnostics: buildReadinessDiagnostics({
             state: "blocked",
+            healthUrl,
             httpStatus: res.status,
             errorMessage: err instanceof Error ? err.message : "Could not parse health response."
           })
@@ -135,6 +193,7 @@ async function checkHealth(): Promise<ReadinessResult> {
         state: "blocked",
         diagnostics: buildReadinessDiagnostics({
           state: "blocked",
+          healthUrl,
           httpStatus: res.status,
           healthStatus
         })
@@ -146,6 +205,7 @@ async function checkHealth(): Promise<ReadinessResult> {
         state: "ready",
         diagnostics: buildReadinessDiagnostics({
           state: "ready",
+          healthUrl,
           httpStatus: res.status,
           healthStatus: status
         })
@@ -158,6 +218,7 @@ async function checkHealth(): Promise<ReadinessResult> {
         degradedChecks,
         diagnostics: buildReadinessDiagnostics({
           state: "degraded",
+          healthUrl,
           degradedChecks,
           httpStatus: res.status,
           healthStatus: status
@@ -168,6 +229,7 @@ async function checkHealth(): Promise<ReadinessResult> {
       state: "blocked",
       diagnostics: buildReadinessDiagnostics({
         state: "blocked",
+        healthUrl,
         httpStatus: res.status,
         // Empty status means the health JSON did not include a usable status field.
         healthStatus: status !== "" ? status : undefined
@@ -178,6 +240,7 @@ async function checkHealth(): Promise<ReadinessResult> {
       state: "blocked",
       diagnostics: buildReadinessDiagnostics({
         state: "blocked",
+        healthUrl,
         errorMessage: err instanceof Error ? err.message : "Health request failed."
       })
     }
@@ -200,18 +263,18 @@ function navigateTo(path: string): void {
 }
 
 function ReadinessRecoveryPanel({
-  children,
   diagnostics,
+  healthUrl,
   onRetry,
 }: {
-  children: React.ReactNode
   diagnostics: ServerReadinessPublishedState | null
+  healthUrl: string
   onRetry: () => void
 }) {
   const panelDiagnostics: StatePanelDiagnostic[] = [
     {
       label: "Health endpoint",
-      value: HEALTH_URL,
+      value: healthUrl,
       code: true,
     },
     {
@@ -240,32 +303,29 @@ function ReadinessRecoveryPanel({
   }
 
   return (
-    <>
-      <main className="flex min-h-screen items-center justify-center bg-bg px-4 py-10 text-text">
-        <StatePanel
-          state="unavailable"
-          title="Backend readiness check failed"
-          message="The WebUI could not confirm that the tldw server is ready. You can retry the health check, inspect diagnostics, or update server settings before continuing."
-          diagnostics={panelDiagnostics}
-          primaryAction={{ label: "Retry", onClick: onRetry }}
-          secondaryActions={[
-            {
-              label: "Health & diagnostics",
-              onClick: () => navigateTo("/settings/health"),
-            },
-            {
-              label: "Server settings",
-              onClick: () => navigateTo("/settings/tldw"),
-            },
-          ]}
-          role="alert"
-          aria-live="assertive"
-          className="w-full max-w-3xl"
-          data-testid="server-readiness-recovery"
-        />
-      </main>
-      <div data-testid="server-readiness-route-content">{children}</div>
-    </>
+    <main className="flex min-h-screen items-center justify-center bg-bg px-4 py-10 text-text">
+      <StatePanel
+        state="unavailable"
+        title="Backend readiness check failed"
+        message="The WebUI could not confirm that the tldw server is ready. You can retry the health check, inspect diagnostics, or update server settings before continuing."
+        diagnostics={panelDiagnostics}
+        primaryAction={{ label: "Retry", onClick: onRetry }}
+        secondaryActions={[
+          {
+            label: "Health & diagnostics",
+            onClick: () => navigateTo("/settings/health"),
+          },
+          {
+            label: "Server settings",
+            onClick: () => navigateTo("/settings/tldw"),
+          },
+        ]}
+        role="alert"
+        aria-live="assertive"
+        className="w-full max-w-3xl"
+        data-testid="server-readiness-recovery"
+      />
+    </main>
   )
 }
 
@@ -274,13 +334,28 @@ export const ServerReadinessGate: React.FC<{
   allowDegraded?: boolean
   bypass?: boolean
 }> = ({ children, allowDegraded = false, bypass = false }) => {
+  const configuredServerUrl = useConnectionStore((s) => s.state.serverUrl)
+  const offlineBypassEnabled = shouldBypassReadinessForOffline()
   const [gate, setGate] = React.useState<GateState>(() =>
-    shouldBypassReadinessForOffline() ? "ready" : "checking"
+    offlineBypassEnabled ? "ready" : "checking"
   )
   const [degradedChecks, setDegradedChecks] = React.useState<string[]>([])
   const [lastReadinessState, setLastReadinessState] =
     React.useState<ServerReadinessPublishedState | null>(null)
   const [retryVersion, setRetryVersion] = React.useState(0)
+  const pageOrigin =
+    typeof window !== "undefined" ? window.location.origin : undefined
+  const healthUrl = React.useMemo(
+    () => {
+      if (bypass || offlineBypassEnabled) return HEALTH_PATH
+      return resolveReadinessHealthUrl({
+        configuredServerUrl,
+        env: _env,
+        pageOrigin
+      })
+    },
+    [bypass, configuredServerUrl, offlineBypassEnabled, pageOrigin]
+  )
 
   const retryNow = React.useCallback(() => {
     setRetryVersion((version) => version + 1)
@@ -292,7 +367,7 @@ export const ServerReadinessGate: React.FC<{
       setGate((current) => (current === "ready" ? current : "checking"))
       return
     }
-    if (shouldBypassReadinessForOffline()) {
+    if (offlineBypassEnabled) {
       setGate("ready")
       return
     }
@@ -302,20 +377,28 @@ export const ServerReadinessGate: React.FC<{
     setLastReadinessState(null)
 
     let cancelled = false
-    let retryTimer: number | undefined
+    let retryTimer: ReturnType<typeof setTimeout> | undefined
+    let deadlineTimer: ReturnType<typeof setTimeout> | undefined
     const deadline = Date.now() + MAX_WAIT_MS
+    deadlineTimer = setTimeout(() => {
+      if (!cancelled) {
+        setGate("timeout")
+      }
+    }, MAX_WAIT_MS)
 
     const attempt = async () => {
-      const result = await checkHealth()
+      const result = await checkHealth(healthUrl)
       if (cancelled) return
       setLastReadinessState(result.diagnostics)
 
       if (result.state === "ready") {
+        if (deadlineTimer) clearTimeout(deadlineTimer)
         setGate("ready")
         return
       }
 
       if (result.state === "degraded" && allowDegraded) {
+        if (deadlineTimer) clearTimeout(deadlineTimer)
         setDegradedChecks(result.degradedChecks)
         setGate("degraded")
         return
@@ -327,7 +410,7 @@ export const ServerReadinessGate: React.FC<{
       }
 
       setGate("waiting")
-      retryTimer = window.setTimeout(() => {
+      retryTimer = setTimeout(() => {
         if (!cancelled) void attempt()
       }, RETRY_INTERVAL_MS)
     }
@@ -336,9 +419,10 @@ export const ServerReadinessGate: React.FC<{
 
     return () => {
       cancelled = true
-      if (retryTimer) window.clearTimeout(retryTimer)
+      if (retryTimer) clearTimeout(retryTimer)
+      if (deadlineTimer) clearTimeout(deadlineTimer)
     }
-  }, [allowDegraded, bypass, retryVersion])
+  }, [allowDegraded, bypass, healthUrl, offlineBypassEnabled, retryVersion])
 
   React.useEffect(() => {
     if (typeof window === "undefined" || bypass) return
@@ -363,6 +447,7 @@ export const ServerReadinessGate: React.FC<{
         ...(lastReadinessState ??
           buildReadinessDiagnostics({
             state,
+            healthUrl,
             degradedChecks: emittedDegradedChecks
           })),
         state,
@@ -373,7 +458,7 @@ export const ServerReadinessGate: React.FC<{
     return () => {
       window.clearTimeout(emitTimer)
     }
-  }, [bypass, degradedChecks, gate, lastReadinessState])
+  }, [bypass, degradedChecks, gate, healthUrl, lastReadinessState])
 
   if (bypass || gate === "ready") {
     return <>{children}</>
@@ -397,10 +482,9 @@ export const ServerReadinessGate: React.FC<{
     return (
       <ReadinessRecoveryPanel
         diagnostics={lastReadinessState}
+        healthUrl={healthUrl}
         onRetry={retryNow}
-      >
-        {children}
-      </ReadinessRecoveryPanel>
+      />
     )
   }
 

--- a/apps/tldw-frontend/components/networking/__tests__/ServerReadinessGate.test.tsx
+++ b/apps/tldw-frontend/components/networking/__tests__/ServerReadinessGate.test.tsx
@@ -1,5 +1,19 @@
 import { act, render, screen, waitFor } from "@testing-library/react"
-import { afterEach, describe, expect, it, vi } from "vitest"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+const connectionStoreMock = vi.hoisted(() => ({
+  store: {
+    state: {
+      serverUrl: ""
+    }
+  }
+}))
+
+vi.mock("@tldw/ui/store/connection", () => ({
+  useConnectionStore: (
+    selector: (store: typeof connectionStoreMock.store) => unknown
+  ) => selector(connectionStoreMock.store)
+}))
 
 describe("ServerReadinessGate", () => {
   const expectReadinessStatus = () => {
@@ -7,6 +21,10 @@ describe("ServerReadinessGate", () => {
     expect(status).toHaveTextContent(/Checking server readiness|Retrying server readiness/)
     expect(status).toHaveTextContent(/Loading|Retrying/)
   }
+
+  beforeEach(() => {
+    connectionStoreMock.store.state.serverUrl = ""
+  })
 
   afterEach(() => {
     try {
@@ -20,6 +38,7 @@ describe("ServerReadinessGate", () => {
     vi.restoreAllMocks()
     vi.useRealTimers()
     vi.unstubAllEnvs()
+    vi.resetModules()
   })
 
   it("accepts the backend healthy status envelope", async () => {
@@ -46,6 +65,205 @@ describe("ServerReadinessGate", () => {
       "http://127.0.0.1:8000/api/v1/health",
       expect.objectContaining({ method: "GET" })
     )
+  })
+
+  it("uses the saved server URL over the page and environment origin", async () => {
+    vi.stubEnv("NEXT_PUBLIC_TLDW_DEPLOYMENT_MODE", "advanced")
+    vi.stubEnv("NEXT_PUBLIC_API_URL", "http://127.0.0.1:8000")
+    connectionStoreMock.store.state.serverUrl = " http://10.0.0.5:9000/ "
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ status: "healthy" })
+    } as Response)
+    const { ServerReadinessGate } = await import("../ServerReadinessGate")
+
+    render(
+      <ServerReadinessGate>
+        <div>App ready</div>
+      </ServerReadinessGate>
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText("App ready")).toBeInTheDocument()
+    })
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://10.0.0.5:9000/api/v1/health",
+      expect.objectContaining({ method: "GET" })
+    )
+  })
+
+  it("normalizes the saved server URL to its origin before probing health", async () => {
+    vi.stubEnv("NEXT_PUBLIC_TLDW_DEPLOYMENT_MODE", "advanced")
+    vi.stubEnv("NEXT_PUBLIC_API_URL", "http://127.0.0.1:8000")
+    connectionStoreMock.store.state.serverUrl =
+      " https://user:secret@example.test/base/path?api_key=hidden "
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ status: "healthy" })
+    } as Response)
+    const { ServerReadinessGate } = await import("../ServerReadinessGate")
+
+    render(
+      <ServerReadinessGate>
+        <div>App ready</div>
+      </ServerReadinessGate>
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText("App ready")).toBeInTheDocument()
+    })
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://example.test/api/v1/health",
+      expect.objectContaining({ method: "GET" })
+    )
+  })
+
+  it("falls back to the environment origin for invalid saved server URLs", async () => {
+    vi.stubEnv("NEXT_PUBLIC_TLDW_DEPLOYMENT_MODE", "advanced")
+    vi.stubEnv("NEXT_PUBLIC_API_URL", "http://127.0.0.1:8000")
+    connectionStoreMock.store.state.serverUrl = "not a url"
+    const warnMock = vi.spyOn(console, "warn").mockImplementation(() => undefined)
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ status: "healthy" })
+    } as Response)
+    const { ServerReadinessGate } = await import("../ServerReadinessGate")
+
+    render(
+      <ServerReadinessGate>
+        <div>App ready</div>
+      </ServerReadinessGate>
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText("App ready")).toBeInTheDocument()
+    })
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://127.0.0.1:8000/api/v1/health",
+      expect.objectContaining({ method: "GET" })
+    )
+    expect(warnMock).toHaveBeenCalledWith(
+      "Ignoring invalid tldw server URL for readiness health check."
+    )
+  })
+
+  it("falls back to the environment origin for unsupported saved server URL protocols", async () => {
+    vi.stubEnv("NEXT_PUBLIC_TLDW_DEPLOYMENT_MODE", "advanced")
+    vi.stubEnv("NEXT_PUBLIC_API_URL", "http://127.0.0.1:8000")
+    connectionStoreMock.store.state.serverUrl =
+      "ftp://user:secret@example.test/base/path"
+    const warnMock = vi.spyOn(console, "warn").mockImplementation(() => undefined)
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ status: "healthy" })
+    } as Response)
+    const { ServerReadinessGate } = await import("../ServerReadinessGate")
+
+    render(
+      <ServerReadinessGate>
+        <div>App ready</div>
+      </ServerReadinessGate>
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText("App ready")).toBeInTheDocument()
+    })
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://127.0.0.1:8000/api/v1/health",
+      expect.objectContaining({ method: "GET" })
+    )
+    expect(warnMock).toHaveBeenCalledWith(
+      "Ignoring unsupported tldw server URL protocol for readiness health check.",
+      { protocol: "ftp:" }
+    )
+    expect(warnMock.mock.calls.flat().map(String).join(" ")).not.toContain(
+      "secret"
+    )
+  })
+
+  it("restarts readiness checks when the configured server URL changes", async () => {
+    vi.stubEnv("NEXT_PUBLIC_TLDW_DEPLOYMENT_MODE", "advanced")
+    vi.stubEnv("NEXT_PUBLIC_API_URL", "http://127.0.0.1:8000")
+    connectionStoreMock.store.state.serverUrl = "http://old.example:8000"
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue({
+      ok: false,
+      status: 503,
+      json: async () => ({ status: "unavailable" })
+    } as Response)
+    const { ServerReadinessGate } = await import("../ServerReadinessGate")
+
+    const { rerender } = render(
+      <ServerReadinessGate>
+        <div>App ready</div>
+      </ServerReadinessGate>
+    )
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        "http://old.example:8000/api/v1/health",
+        expect.objectContaining({ method: "GET" })
+      )
+    })
+
+    connectionStoreMock.store.state.serverUrl = "http://new.example:9000"
+    rerender(
+      <ServerReadinessGate>
+        <div>App ready</div>
+      </ServerReadinessGate>
+    )
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        "http://new.example:9000/api/v1/health",
+        expect.objectContaining({ method: "GET" })
+      )
+    })
+  })
+
+  it("falls back before config hydration and restarts after config is available", async () => {
+    vi.stubEnv("NEXT_PUBLIC_TLDW_DEPLOYMENT_MODE", "advanced")
+    vi.stubEnv("NEXT_PUBLIC_API_URL", "http://127.0.0.1:8000")
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue({
+      ok: false,
+      status: 503,
+      json: async () => ({ status: "unavailable" })
+    } as Response)
+    const { ServerReadinessGate } = await import("../ServerReadinessGate")
+
+    const { rerender } = render(
+      <ServerReadinessGate>
+        <div>App ready</div>
+      </ServerReadinessGate>
+    )
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        "http://127.0.0.1:8000/api/v1/health",
+        expect.objectContaining({ method: "GET" })
+      )
+    })
+
+    connectionStoreMock.store.state.serverUrl = "http://configured.local:8123"
+    rerender(
+      <ServerReadinessGate>
+        <div>App ready</div>
+      </ServerReadinessGate>
+    )
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        "http://configured.local:8123/api/v1/health",
+        expect.objectContaining({ method: "GET" })
+      )
+    })
   })
 
   it("accepts degraded health as enterable for partial-content responses when allowed", async () => {
@@ -248,7 +466,7 @@ describe("ServerReadinessGate", () => {
       await vi.advanceTimersByTimeAsync(16_000)
     })
 
-    expect(screen.getByText("App ready")).toBeInTheDocument()
+    expect(screen.queryByText("App ready")).not.toBeInTheDocument()
     await act(async () => {
       await vi.runOnlyPendingTimersAsync()
     })
@@ -295,7 +513,7 @@ describe("ServerReadinessGate", () => {
       await vi.advanceTimersByTimeAsync(16_000)
     })
 
-    expect(screen.getByText("App ready")).toBeInTheDocument()
+    expect(screen.queryByText("App ready")).not.toBeInTheDocument()
     await act(async () => {
       await vi.runOnlyPendingTimersAsync()
     })
@@ -334,7 +552,7 @@ describe("ServerReadinessGate", () => {
       await vi.advanceTimersByTimeAsync(16_000)
     })
 
-    expect(screen.getByText("App ready")).toBeInTheDocument()
+    expect(screen.queryByText("App ready")).not.toBeInTheDocument()
 
     await act(async () => {
       rerender(
@@ -381,7 +599,9 @@ describe("ServerReadinessGate", () => {
       await vi.advanceTimersByTimeAsync(16_000)
     })
 
-    expect(screen.getByTestId("knowledge-main-region")).toBeInTheDocument()
+    expect(screen.queryByTestId("knowledge-main-region")).not.toBeInTheDocument()
+    expect(screen.queryByTestId("server-readiness-route-content")).not.toBeInTheDocument()
+    expect(screen.getAllByRole("main")).toHaveLength(1)
     expect(
       screen.getByRole("heading", { name: /Backend readiness check failed/i })
     ).toBeInTheDocument()
@@ -414,7 +634,9 @@ describe("ServerReadinessGate", () => {
       await vi.advanceTimersByTimeAsync(16_000)
     })
 
-    expect(screen.getByTestId("knowledge-main-region")).toBeInTheDocument()
+    expect(screen.queryByTestId("knowledge-main-region")).not.toBeInTheDocument()
+    expect(screen.queryByTestId("server-readiness-route-content")).not.toBeInTheDocument()
+    expect(screen.getAllByRole("main")).toHaveLength(1)
     expect(
       screen.getByRole("heading", { name: /Backend readiness check failed/i })
     ).toBeInTheDocument()

--- a/apps/tldw-frontend/e2e/ux-audit/knowledge-readiness-recovery.spec.ts
+++ b/apps/tldw-frontend/e2e/ux-audit/knowledge-readiness-recovery.spec.ts
@@ -47,7 +47,8 @@ const expectKnowledgeRecovery = async (page: Page) => {
   await expect(recovery.getByRole("button", { name: "Retry" })).toBeVisible()
   await expect(recovery.getByRole("button", { name: "Health & diagnostics" })).toBeVisible()
   await expect(recovery.getByRole("button", { name: "Server settings" })).toBeVisible()
-  await expect(page.getByTestId("server-readiness-route-content")).toBeAttached()
+  await expect(page.getByTestId("server-readiness-route-content")).toHaveCount(0)
+  await expect(page.locator("main")).toHaveCount(1)
   await expect
     .poll(async () => {
       const text = await recovery.textContent()

--- a/backlog/tasks/task-2318 - Implement-Skills-readiness-and-capability-gates-on-dev.md
+++ b/backlog/tasks/task-2318 - Implement-Skills-readiness-and-capability-gates-on-dev.md
@@ -1,0 +1,52 @@
+---
+id: TASK-2318
+title: Implement Skills readiness and capability gates on dev
+status: Done
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Recreate the Skills readiness/capability fix from a clean dev branch. Scope is limited to the shared readiness gate, Skills workspace capability state, focused tests, and the readiness recovery E2E assertion.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Server readiness health checks use the persisted configured server URL when present instead of a stale module-level origin.
+- [x] #2 Readiness timeout renders one blocking recovery surface without preserving hidden route content.
+- [x] #3 Readiness checks restart when the configured server URL changes after hydration.
+- [x] #4 Skills page remains usable in connected degraded state when Skills capability is available.
+- [x] #5 Skills unreachable state uses Skills-specific recovery copy.
+- [x] #6 Focused unit and E2E coverage verifies the changed behavior.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+- Closed polluted stacked PR #2314 and recreated the change from a clean `origin/dev` worktree.
+- Scope is limited to readiness gate behavior, Skills capability/unreachable state, focused tests, and this Backlog task.
+- PR review follow-up normalized configured readiness URLs to origin-only health endpoints, added non-sensitive warnings for invalid/unsupported configured URLs, removed the redundant config timestamp effect dependency, and used timer return types compatible with the runtime timer APIs.
+- Verification:
+  - `git diff --check`
+  - `apps/tldw-frontend`: `node_modules/.bin/vitest run components/networking/__tests__/ServerReadinessGate.test.tsx` (19 passed)
+  - `apps/packages/ui`: `node_modules/.bin/vitest run src/components/Option/Skills/__tests__/SkillsWorkspace.test.tsx` (6 passed)
+  - `apps/tldw-frontend`: `TLDW_WEB_CMD='bun run dev:webpack -- -p 8080' node_modules/.bin/playwright test e2e/ux-audit/knowledge-readiness-recovery.spec.ts --reporter=line` (2 passed)
+  - `apps/tldw-frontend`: `TLDW_WEB_CMD='bun run dev:webpack -- -p 8080' node_modules/.bin/playwright test e2e/workflows/tier-5-specialized/skills.spec.ts --reporter=line` (3 skipped by backend availability guard)
+- Bandit skipped because touched implementation files are frontend TypeScript/Playwright only.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Implemented clean Skills readiness/capability fixes on top of `dev`: origin-normalized configured server URL readiness probing, one blocking timeout recovery surface, URL-change retry coverage, degraded Skills access, Skills-specific unreachable copy, and review-requested readiness URL/error handling hardening.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## Summary
- Recreated the Skills readiness fix from a clean `dev` branch after closing polluted PR #2314.
- Use the persisted tldw server URL for readiness health probes and restart probes after config changes.
- Render a single blocking readiness recovery surface, including stalled-request timeout recovery, and clarify Skills unreachable/degraded states.

## Scope
This PR is one commit ahead of `dev` and changes only:
- `apps/tldw-frontend/components/networking/ServerReadinessGate.tsx`
- `apps/tldw-frontend/components/networking/__tests__/ServerReadinessGate.test.tsx`
- `apps/tldw-frontend/e2e/ux-audit/knowledge-readiness-recovery.spec.ts`
- `apps/packages/ui/src/components/Option/Skills/SkillsWorkspace.tsx`
- `apps/packages/ui/src/components/Option/Skills/__tests__/SkillsWorkspace.test.tsx`
- `backlog/tasks/task-2318 - Implement-Skills-readiness-and-capability-gates-on-dev.md`

## Test Plan
- [x] `git diff --check`
- [x] `apps/tldw-frontend`: `node_modules/.bin/vitest run components/networking/__tests__/ServerReadinessGate.test.tsx` (16 passed)
- [x] `apps/packages/ui`: `node_modules/.bin/vitest run src/components/Option/Skills/__tests__/SkillsWorkspace.test.tsx` (6 passed)
- [x] `apps/tldw-frontend`: `TLDW_WEB_CMD="bun run dev:webpack -- -p 8080" node_modules/.bin/playwright test e2e/ux-audit/knowledge-readiness-recovery.spec.ts --reporter=line` (2 passed)
- [x] `apps/tldw-frontend`: `TLDW_WEB_CMD="bun run dev:webpack -- -p 8080" node_modules/.bin/playwright test e2e/workflows/tier-5-specialized/skills.spec.ts --reporter=line` (3 skipped by backend availability guard)
- [x] Bandit skipped: frontend TypeScript/Playwright-only change

Backlog: TASK-2318

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Skills readiness on dev by using the saved tldw server URL for health checks (normalized to origin), restarting probes on config changes, and showing a single blocking recovery screen on timeout. Keeps Skills usable in degraded mode and adds Skills-specific unreachable guidance. Addresses TASK-2318.

- **Bug Fixes**
  - Health checks prefer the persisted server URL, normalize it to origin, trim trailing slashes, and fall back to env/page origin or a relative path; invalid/unsupported protocols are ignored with safe warnings.
  - Readiness checks restart when `serverUrl` changes after hydration.
  - Single blocking recovery surface on timeout; no hidden route content remains.
  - Skills stays usable in `connected_degraded`; unreachable state uses Skills-specific recovery text.
  - Added focused unit and E2E tests for URL selection, restart/retry, timeout recovery, and Skills states.

<sup>Written for commit dade031c6fa3a7c09fa473867540d7e880b0dc54. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2315?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

