### PR TITLE
Add exact MCP fs.edit primitive

### DIFF
--- a/Docs/superpowers/plans/2026-06-08-mcp-exact-fs-edit-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-06-08-mcp-exact-fs-edit-implementation-plan.md
@@ -1,0 +1,119 @@
+# MCP Exact fs.edit Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a Claude-style exact `fs.edit` MCP filesystem primitive for bounded string replacement.
+
+**Architecture:** Extend the existing `FilesystemModule` rather than creating a parallel editor. `fs.edit` will reuse current workspace path resolution, UTF-8/binary guards, read-receipt/hash preimage authorization, atomic writes, eval metadata, and action-aware path-scope metadata.
+
+**Tech Stack:** Python 3.11, pytest, MCP Unified filesystem module, existing read receipts and path-grant enforcement.
+
+---
+
+### Task 1: Tool Contract And Validation
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_module.py`
+- Test: `tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_module.py`
+
+- [x] **Step 1: Write failing metadata/schema tests**
+
+Add assertions that `fs.edit` appears in `get_tools()` with `path_scope_action == "edit"`, `file_policy_action == "edit"`, `write_capable is True`, strict `additionalProperties is False`, and eval metadata matching `filesystem_edit`.
+
+- [x] **Step 2: Run the focused metadata test**
+
+Run: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_module.py::test_filesystem_tools_include_path_scope_metadata -q`
+
+Expected: FAIL because `fs.edit` is not registered.
+
+- [x] **Step 3: Add the `fs.edit` tool definition and argument validation**
+
+Schema fields: `path`, `old_string`, `new_string`, `expected_sha256`, `read_receipt`, `replace_all`, and `dry_run`. Require `path`, `old_string`, and `new_string`. Reject empty `old_string`, non-string content fields, non-string preimage fields, non-boolean flags, and unknown arguments.
+
+- [x] **Step 4: Rerun metadata test**
+
+Expected: PASS.
+
+### Task 2: Exact Edit Semantics
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_module.py`
+- Test: `tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_module.py`
+
+- [x] **Step 1: Write failing behavior tests**
+
+Cover:
+- exact single replacement with `expected_sha256`
+- rejection when no preimage is supplied
+- rejection when `old_string` is absent
+- rejection when `old_string` appears multiple times and `replace_all` is false
+- `replace_all=true` replaces every occurrence
+- `dry_run=true` reports planned output metadata without writing
+
+- [x] **Step 2: Run the new behavior tests**
+
+Run the new test names individually first.
+
+Expected: FAIL because `fs.edit` dispatch/helper does not exist.
+
+- [x] **Step 3: Implement `_edit_file()` and dispatch**
+
+Use `_resolve_workspace_path_no_follow`, UTF-8 read guards, `hashlib.sha256`, `_authorize_edit_preimage()`, `_assert_preimage_unchanged()`, and `_atomic_write_text_file()`. Count exact literal occurrences with `str.count()`. Use `str.replace(old, new, 1)` unless `replace_all` is true. Do not return raw file content.
+
+- [x] **Step 4: Rerun behavior tests**
+
+Expected: PASS.
+
+### Task 3: Read Receipts, Errors, And Policy Integration
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_module.py`
+- Test: `tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_module.py`
+- Test: `tldw_Server_API/tests/MCP_unified/test_mcp_hub_path_enforcement_service.py`
+
+- [x] **Step 1: Write failing receipt and policy tests**
+
+Cover:
+- successful edit with a current `fs.read` receipt
+- receipt mismatch across session/workspace fails with `edit_read_receipt_mismatch`
+- binary/non-UTF-8 content is rejected with an `fs.edit`-specific error
+- path enforcer treats `fs.edit` as an `edit` action in path grants
+
+- [x] **Step 2: Run the focused tests**
+
+Expected: FAIL until receipt validation and path metadata are wired.
+
+- [x] **Step 3: Implement receipt validation and error metadata**
+
+Mirror patch/write receipt validation with `edit_*` reason codes. Build `eval` metadata using `tool_name="fs.edit"`, prompt id `mcp.fs.edit.v1`, action family `filesystem_edit`, and result kind `structured_filesystem_edit`.
+
+- [x] **Step 4: Rerun focused tests**
+
+Expected: PASS.
+
+### Task 4: Documentation, Verification, And Commit
+
+**Files:**
+- Modify: `mcp_unified/USER_GUIDE.md`
+- Modify: `backlog/tasks/task-2279 - Add-Claude-style-exact-fs.edit-primitive.md`
+
+- [x] **Step 1: Document `fs.edit` as the exact-string edit primitive**
+
+Mention that `fs.patch` remains preferred for diff-first edits and `fs.edit` is for small exact replacements.
+
+- [x] **Step 2: Run validation**
+
+Run:
+- focused filesystem/path-enforcement tests
+- `ruff check` on touched Python files
+- `py_compile` on touched production Python files
+- `bandit` on touched production Python files
+- `git diff --check`
+
+- [x] **Step 3: Update Backlog task final summary**
+
+Record what changed, what was verified, and any skipped checks.
+
+- [x] **Step 4: Commit**
+
+Commit message: `feat: add exact mcp fs edit primitive`

--- a/backlog/tasks/task-2279 - Add-Claude-style-exact-fs.edit-primitive.md
+++ b/backlog/tasks/task-2279 - Add-Claude-style-exact-fs.edit-primitive.md
@@ -41,6 +41,8 @@ Use the existing filesystem module/read-receipt/preimage helpers. Add tests firs
 - Added `fs.edit` tool definition, argument validation, async dispatch, exact replacement helper, edit-specific preimage/read-receipt validation, and structured eval metadata.
 - Added regression coverage for metadata, exact replacement, required preimage, missing/non-unique old strings, `replace_all`, dry-run, read receipts, receipt context mismatch, binary rejection, and path-grant enforcement.
 - Updated `mcp_unified/USER_GUIDE.md` to document `fs.edit` as the small exact-replacement primitive while keeping `fs.patch` preferred for diff-first edits.
+- Addressed PR review feedback by preserving raw exact-match strings, enforcing expected-SHA precedence over receipts, rejecting overlapping matches, using no-follow descriptor reads for edit preimages, adding post-read size enforcement, and adding docstrings for the new helpers.
+- Skipped the `_atomic_write_text_file` AttributeError finding as invalid: the helper is a `@staticmethod` on `FilesystemModule`, not a module-level function, and the edit path now calls it through the class explicitly.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary
@@ -49,6 +51,7 @@ Use the existing filesystem module/read-receipt/preimage helpers. Add tests firs
 - Implemented the Claude-style exact `fs.edit` primitive as a bounded `edit` action in the existing filesystem module.
 - Verification run before commit: focused filesystem/path-enforcement pytest suite, ruff on touched Python, py_compile on the production module, Bandit on the production module, and `git diff --check`.
 - Draft PR: https://github.com/rmusser01/tldw_server/pull/2321
+- Review follow-up verification: review regression tests, full focused filesystem/path-enforcement suite, ruff, py_compile, Bandit on production filesystem module, and `git diff --check`.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-2279 - Add-Claude-style-exact-fs.edit-primitive.md
+++ b/backlog/tasks/task-2279 - Add-Claude-style-exact-fs.edit-primitive.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-2279
 title: Add Claude-style exact fs.edit primitive
-status: To Do
+status: Done
 labels:
 - mcp
 - filesystem
@@ -10,6 +10,7 @@ labels:
 references:
 - https://code.claude.com/docs/en/tools-reference#edit-tool-behavior
 - Docs/superpowers/specs/2026-06-07-mcp-fs-patch-write-safe-edit-tools-design.md
+- https://github.com/rmusser01/tldw_server/pull/2321
 ---
 
 ## Description
@@ -20,26 +21,42 @@ Design and implement a Claude-style fs.edit primitive for exact string replaceme
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
+- [x] `fs.edit` is exposed by the filesystem MCP module with strict schema metadata, `path_scope_action="edit"`, and bounded edit eval metadata.
+- [x] `fs.edit` performs exact literal UTF-8 replacement only, rejects missing matches, and rejects non-unique matches unless `replace_all=true`.
+- [x] Existing-file edits require either `expected_sha256` or a valid `fs.read` receipt and recheck the preimage before writing.
+- [x] Results return structured metadata without raw file content and support `dry_run=true`.
+- [x] Path-policy tests cover `fs.edit` as an `edit` action.
+- [x] User guide documentation describes when to use `fs.edit` versus `fs.patch` and `fs.write`.
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Use the existing filesystem module/read-receipt/preimage helpers. Add tests first for tool metadata, exact edit success, duplicate handling, missing preimage, read-receipt success/mismatch, dry-run, and binary rejection. Then add fs.edit schema/validation/dispatch and a small _edit_file helper that reuses workspace resolution, read receipt validation semantics, _assert_preimage_unchanged, and _atomic_write_text_file.
+<!-- SECTION:PLAN:END -->
 
 ## Implementation Notes
 
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
-
+- Added `fs.edit` tool definition, argument validation, async dispatch, exact replacement helper, edit-specific preimage/read-receipt validation, and structured eval metadata.
+- Added regression coverage for metadata, exact replacement, required preimage, missing/non-unique old strings, `replace_all`, dry-run, read receipts, receipt context mismatch, binary rejection, and path-grant enforcement.
+- Updated `mcp_unified/USER_GUIDE.md` to document `fs.edit` as the small exact-replacement primitive while keeping `fs.patch` preferred for diff-first edits.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-
+- Implemented the Claude-style exact `fs.edit` primitive as a bounded `edit` action in the existing filesystem module.
+- Verification run before commit: focused filesystem/path-enforcement pytest suite, ruff on touched Python, py_compile on the production module, Bandit on the production module, and `git diff --check`.
+- Draft PR: https://github.com/rmusser01/tldw_server/pull/2321
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->

--- a/mcp_unified/USER_GUIDE.md
+++ b/mcp_unified/USER_GUIDE.md
@@ -129,9 +129,13 @@ module has a stable `read_receipt_secret` configured.
 For existing-file edits, prefer `fs.patch` over whole-file replacement. It
 accepts unified diff text, derives affected paths before execution for path
 policy checks, validates context in memory, and only writes after preimage
-checks pass. For whole-file creation or deliberate replacement, use `fs.write`.
-`fs.write` `mode="create"` fails if the file already exists. `mode="replace"`
-requires either `expected_sha256` or a valid `read_receipt` from `fs.read`.
+checks pass. For small literal replacements where a unified diff is unnecessary,
+`fs.edit` replaces one exact UTF-8 string in an existing file. It rejects missing
+or non-unique matches unless `replace_all=true`, and it also requires either
+`expected_sha256` or a valid `read_receipt` from `fs.read`. For whole-file
+creation or deliberate replacement, use `fs.write`. `fs.write` `mode="create"`
+fails if the file already exists. `mode="replace"` requires either
+`expected_sha256` or a valid `read_receipt` from `fs.read`.
 
 This read-before-mutate flow protects against stale edits: if a file changes
 after the model read it, the expected hash or receipt no longer matches and the
@@ -161,7 +165,7 @@ The executable filesystem actions today are:
 
 - `read`: inspect file content, directory listings, search results, and path
   metadata.
-- `edit`: bounded existing-file edits through `fs.patch`.
+- `edit`: bounded existing-file edits through `fs.patch` or `fs.edit`.
 - `write`: deliberate whole-file create or replace through `fs.write`.
 
 The reserved action names are `delete`, `rename`, `move`, `share`, `export`,
@@ -209,7 +213,8 @@ source, and redaction status. They should not include raw file content, read
 receipts, raw diffs, or absolute host paths.
 
 `fs.read_text` and `fs.write_text` remain compatibility tools for older clients.
-New profiles and front-ends should prefer `fs.read`, `fs.patch`, and `fs.write`.
+New profiles and front-ends should prefer `fs.read`, `fs.patch`, `fs.edit`, and
+`fs.write`.
 
 Recommendation catalog patches only change discovery metadata. They do not grant
 execution authority, start external servers, create credential grants, or bypass

--- a/mcp_unified/USER_GUIDE.md
+++ b/mcp_unified/USER_GUIDE.md
@@ -131,11 +131,11 @@ accepts unified diff text, derives affected paths before execution for path
 policy checks, validates context in memory, and only writes after preimage
 checks pass. For small literal replacements where a unified diff is unnecessary,
 `fs.edit` replaces one exact UTF-8 string in an existing file. It rejects missing
-or non-unique matches unless `replace_all=true`, and it also requires either
-`expected_sha256` or a valid `read_receipt` from `fs.read`. For whole-file
-creation or deliberate replacement, use `fs.write`. `fs.write` `mode="create"`
-fails if the file already exists. `mode="replace"` requires either
-`expected_sha256` or a valid `read_receipt` from `fs.read`.
+or non-unique matches unless `replace_all=true`, rejects overlapping matches,
+and it also requires either `expected_sha256` or a valid `read_receipt` from
+`fs.read`. For whole-file creation or deliberate replacement, use `fs.write`.
+`fs.write` `mode="create"` fails if the file already exists. `mode="replace"`
+requires either `expected_sha256` or a valid `read_receipt` from `fs.read`.
 
 This read-before-mutate flow protects against stale edits: if a file changes
 after the model read it, the expected hash or receipt no longer matches and the

--- a/tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_module.py
@@ -3,7 +3,11 @@ Workspace-bounded filesystem MCP module.
 
 Exposes:
 - fs.list
+- fs.edit
+- fs.read
 - fs.read_text
+- fs.patch
+- fs.write
 - fs.write_text
 - fs.stat
 - fs.glob
@@ -159,6 +163,38 @@ class FilesystemModule(BaseModule):
             },
         )
         read_tool["inputSchema"]["additionalProperties"] = False
+
+        edit_tool = create_tool_definition(
+            name="fs.edit",
+            description="Replace exact UTF-8 text inside an existing workspace file after preimage checks.",
+            parameters={
+                "properties": {
+                    "path": {"type": "string", "description": "Workspace-relative or absolute file path"},
+                    "old_string": {"type": "string", "description": "Exact literal text to replace"},
+                    "new_string": {"type": "string", "description": "Replacement literal text"},
+                    "expected_sha256": {"type": "string"},
+                    "read_receipt": {"type": "string"},
+                    "replace_all": {"type": "boolean", "default": False},
+                    "dry_run": {"type": "boolean", "default": False},
+                },
+                "required": ["path", "old_string", "new_string"],
+            },
+            metadata={
+                "category": "management",
+                "readOnlyHint": False,
+                "write_capable": True,
+                "capabilities": ["filesystem.edit"],
+                "path_scope_action": "edit",
+                **_file_policy_metadata("edit"),
+                "eval": {
+                    "task_families": ["filesystem_edit"],
+                    "expected_result_kind": "structured_filesystem_edit",
+                    "success_signals": ["completed_requested_mutation"],
+                },
+                **shared_path_metadata,
+            },
+        )
+        edit_tool["inputSchema"]["additionalProperties"] = False
 
         patch_tool = create_tool_definition(
             name="fs.patch",
@@ -339,6 +375,7 @@ class FilesystemModule(BaseModule):
         return [
             list_tool,
             read_tool,
+            edit_tool,
             read_text_tool,
             patch_tool,
             write_tool,
@@ -417,6 +454,23 @@ class FilesystemModule(BaseModule):
                 truncated=bool(result.get("truncated", False)),
             )
             return result
+
+        if tool_name == "fs.edit":
+            target = self._resolve_workspace_path_no_follow(workspace_root, str(args.get("path")))
+            return await asyncio.to_thread(
+                self._edit_file,
+                workspace_root,
+                target,
+                str(args.get("old_string")),
+                str(args.get("new_string")),
+                args.get("expected_sha256"),
+                args.get("read_receipt"),
+                bool(args.get("replace_all", False)),
+                bool(args.get("dry_run", False)),
+                self._setting_positive_int("edit_preimage_max_bytes", 5_000_000),
+                self._setting_positive_int("edit_write_max_bytes", 5_000_000),
+                context,
+            )
 
         if tool_name == "fs.patch":
             patch_files = self._parse_patch_diff(str(args.get("diff") or ""))
@@ -616,6 +670,38 @@ class FilesystemModule(BaseModule):
             self._validate_positive_int_argument(arguments, "max_bytes")
             self._validate_bool_argument(arguments, "include_line_numbers")
             self._validate_bool_argument(arguments, "include_receipt")
+            return
+
+        if tool_name == "fs.edit":
+            unknown = sorted(
+                set(arguments)
+                - {
+                    "path",
+                    "old_string",
+                    "new_string",
+                    "expected_sha256",
+                    "read_receipt",
+                    "replace_all",
+                    "dry_run",
+                }
+            )
+            if unknown:
+                raise ValueError(f"unknown arguments: {', '.join(unknown)}")
+            path = arguments.get("path")
+            old_string = arguments.get("old_string")
+            new_string = arguments.get("new_string")
+            if not isinstance(path, str) or not path.strip():
+                raise ValueError("path is required")
+            if not isinstance(old_string, str) or old_string == "":
+                raise ValueError("old_string is required")
+            if not isinstance(new_string, str):
+                raise ValueError("new_string must be a string")
+            for key in ("expected_sha256", "read_receipt"):
+                value = arguments.get(key)
+                if value is not None and not isinstance(value, str):
+                    raise ValueError(f"{key} must be a string")
+            self._validate_bool_argument(arguments, "replace_all")
+            self._validate_bool_argument(arguments, "dry_run")
             return
 
         if tool_name == "fs.patch":
@@ -1664,6 +1750,142 @@ class FilesystemModule(BaseModule):
             with suppress(OSError):
                 if tmp_path.exists():
                     tmp_path.unlink()
+
+    def _edit_file(
+        self,
+        workspace_root: Path,
+        target: Path,
+        old_string: str,
+        new_string: str,
+        expected_sha256: Any,
+        read_receipt: Any,
+        replace_all: bool,
+        dry_run: bool,
+        preimage_max_bytes: int,
+        write_max_bytes: int,
+        context: Any | None,
+    ) -> dict[str, Any]:
+        if "\x00" in old_string or "\x00" in new_string:
+            raise ValueError("binary content is not supported by fs.edit")
+
+        rel_path = self._to_workspace_relative_path(workspace_root, target)
+        if target.is_symlink():
+            raise ValueError("file_not_regular")
+        if not target.exists():
+            raise FileNotFoundError(f"path not found: {target}")
+        if not target.is_file():
+            raise ValueError("file_not_regular")
+
+        file_size = target.stat(follow_symlinks=False).st_size
+        if file_size > preimage_max_bytes:
+            raise ValueError("edit_preimage_too_large")
+        payload = target.read_bytes()
+        if b"\x00" in payload:
+            raise ValueError("binary content is not supported by fs.edit")
+        try:
+            text_before = payload.decode("utf-8")
+        except UnicodeDecodeError as exc:
+            raise ValueError("binary content is not supported by fs.edit") from exc
+
+        sha256_before = hashlib.sha256(payload).hexdigest()
+        bytes_before = len(payload)
+        self._authorize_edit_preimage(
+            rel_path,
+            sha256_before,
+            bytes_before,
+            expected_sha256,
+            read_receipt,
+            context,
+        )
+
+        matches = text_before.count(old_string)
+        if matches == 0:
+            raise ValueError("edit_old_string_not_found")
+        if matches > 1 and not replace_all:
+            raise ValueError("edit_old_string_not_unique")
+
+        replacements = matches if replace_all else 1
+        text_after = text_before.replace(old_string, new_string) if replace_all else text_before.replace(
+            old_string,
+            new_string,
+            1,
+        )
+        data_after = text_after.encode("utf-8")
+        if len(data_after) > write_max_bytes:
+            raise ValueError("edit_write_too_large")
+
+        sha256_after = hashlib.sha256(data_after).hexdigest()
+        if not dry_run:
+            self._assert_preimage_unchanged(target, sha256_before, bytes_before)
+            self._atomic_write_text_file(target, text_after)
+
+        result: dict[str, Any] = {
+            "path": rel_path,
+            "edited": not dry_run,
+            "dry_run": dry_run,
+            "replacements": replacements,
+            "bytes_before": bytes_before,
+            "bytes_after": len(data_after),
+            "sha256_before": sha256_before,
+            "sha256_after": sha256_after,
+            "eval": build_execution_eval_metadata(
+                tool_name="fs.edit",
+                tool_prompt_id="mcp.fs.edit.v1",
+                tool_prompt_version="2026.06.08",
+                action_family="filesystem_edit",
+                result_kind="structured_filesystem_edit",
+                path_filter_used=True,
+                truncated=False,
+            ),
+        }
+        if not dry_run:
+            result["bytes_written"] = len(data_after)
+        return result
+
+    def _authorize_edit_preimage(
+        self,
+        rel_path: str,
+        sha256_before: str,
+        bytes_before: int,
+        expected_sha256: Any,
+        read_receipt: Any,
+        context: Any | None,
+    ) -> None:
+        has_expected = isinstance(expected_sha256, str) and bool(expected_sha256)
+        has_receipt = isinstance(read_receipt, str) and bool(read_receipt)
+        if not has_expected and not has_receipt:
+            raise ValueError("edit_preimage_required")
+        if has_expected and str(expected_sha256) == sha256_before:
+            return
+        if has_receipt:
+            self._validate_edit_read_receipt(str(read_receipt), rel_path, sha256_before, bytes_before, context)
+            return
+        raise ValueError("edit_preimage_mismatch")
+
+    def _validate_edit_read_receipt(
+        self,
+        receipt: str,
+        rel_path: str,
+        sha256_before: str,
+        bytes_before: int,
+        context: Any | None,
+    ) -> None:
+        try:
+            payload = self._read_receipts.validate(receipt)
+        except ReadReceiptError as exc:
+            raise ValueError(exc.reason_code) from exc
+        if payload.path != rel_path or payload.sha256 != sha256_before or payload.size != bytes_before:
+            raise ValueError("edit_read_receipt_mismatch")
+
+        context_workspace_id = self._context_metadata_value(context, "workspace_id")
+        if payload.workspace_id and payload.workspace_id != context_workspace_id:
+            raise ValueError("edit_read_receipt_mismatch")
+        context_session_id = _first_nonempty(
+            getattr(context, "session_id", None),
+            self._context_metadata_value(context, "session_id"),
+        )
+        if payload.session_id and payload.session_id != context_session_id:
+            raise ValueError("edit_read_receipt_mismatch")
 
     def _write_file(
         self,

--- a/tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_module.py
@@ -17,6 +17,7 @@ Exposes:
 from __future__ import annotations
 
 import asyncio
+import errno
 import fnmatch
 import hashlib
 import os
@@ -386,7 +387,14 @@ class FilesystemModule(BaseModule):
         ]
 
     async def execute_tool(self, tool_name: str, arguments: dict[str, Any], context: Any | None = None) -> Any:
-        args = self.sanitize_input(arguments or {})
+        raw_args = arguments or {}
+        if tool_name == "fs.edit":
+            args = {
+                key: value if key in {"old_string", "new_string"} else self.sanitize_input(value)
+                for key, value in raw_args.items()
+            }
+        else:
+            args = self.sanitize_input(raw_args)
         self.validate_tool_arguments(tool_name, args)
 
         workspace_root = await self._resolve_workspace_root(context)
@@ -1751,6 +1759,85 @@ class FilesystemModule(BaseModule):
                 if tmp_path.exists():
                     tmp_path.unlink()
 
+    @staticmethod
+    def _read_existing_regular_file_no_follow(target: Path, *, max_bytes: int) -> tuple[bytes, os.stat_result]:
+        """Read a regular file through a descriptor opened without following symlinks when supported.
+
+        The helper performs the size check both before and after reading so a file
+        that grows between `fstat()` and `read()` cannot bypass the configured
+        preimage limit. Platforms without `O_NOFOLLOW` fall back to opening the
+        file and then rejecting paths that still identify as symlinks.
+        """
+
+        flags = os.O_RDONLY | getattr(os, "O_BINARY", 0)
+        if hasattr(os, "O_NOFOLLOW"):
+            flags |= os.O_NOFOLLOW
+
+        try:
+            fd = os.open(target, flags)
+        except OSError as exc:
+            if exc.errno == errno.ELOOP:
+                raise ValueError("file_not_regular") from exc
+            raise
+
+        try:
+            if not hasattr(os, "O_NOFOLLOW") and target.is_symlink():
+                raise ValueError("file_not_regular")
+            file_stat = os.fstat(fd)
+            if not stat_module.S_ISREG(file_stat.st_mode):
+                raise ValueError("file_not_regular")
+            if file_stat.st_size > max_bytes:
+                raise ValueError("edit_preimage_too_large")
+
+            chunks: list[bytes] = []
+            remaining = max_bytes + 1
+            while remaining > 0:
+                chunk = os.read(fd, min(remaining, 1024 * 1024))
+                if not chunk:
+                    break
+                chunks.append(chunk)
+                remaining -= len(chunk)
+            payload = b"".join(chunks)
+            if len(payload) > max_bytes:
+                raise ValueError("edit_preimage_too_large")
+            return payload, file_stat
+        finally:
+            os.close(fd)
+
+    @classmethod
+    def _assert_edit_preimage_unchanged_no_follow(
+        cls,
+        target: Path,
+        expected_sha256: str,
+        expected_size: int,
+        expected_stat: os.stat_result,
+    ) -> None:
+        """Recheck an edit target using no-follow descriptor reads before committing."""
+
+        try:
+            payload, current_stat = cls._read_existing_regular_file_no_follow(target, max_bytes=expected_size)
+        except (OSError, ValueError) as exc:
+            raise ValueError("preimage_changed_during_commit") from exc
+        if (
+            current_stat.st_dev != expected_stat.st_dev
+            or current_stat.st_ino != expected_stat.st_ino
+            or current_stat.st_size != expected_size
+            or len(payload) != expected_size
+            or hashlib.sha256(payload).hexdigest() != expected_sha256
+        ):
+            raise ValueError("preimage_changed_during_commit")
+
+    @staticmethod
+    def _find_overlapping_matches(text: str, old_string: str) -> list[int]:
+        """Return every match start for exact edit uniqueness checks, including overlaps."""
+
+        matches: list[int] = []
+        index = text.find(old_string)
+        while index != -1:
+            matches.append(index)
+            index = text.find(old_string, index + 1)
+        return matches
+
     def _edit_file(
         self,
         workspace_root: Path,
@@ -1765,21 +1852,19 @@ class FilesystemModule(BaseModule):
         write_max_bytes: int,
         context: Any | None,
     ) -> dict[str, Any]:
+        """Apply a bounded exact string replacement to an existing UTF-8 file.
+
+        The operation rejects binary payloads, requires an explicit expected hash
+        or read receipt, rejects ambiguous matches unless `replace_all` is set,
+        and performs a no-follow preimage recheck immediately before the atomic
+        replacement. Returned metadata intentionally excludes raw file content.
+        """
+
         if "\x00" in old_string or "\x00" in new_string:
             raise ValueError("binary content is not supported by fs.edit")
 
         rel_path = self._to_workspace_relative_path(workspace_root, target)
-        if target.is_symlink():
-            raise ValueError("file_not_regular")
-        if not target.exists():
-            raise FileNotFoundError(f"path not found: {target}")
-        if not target.is_file():
-            raise ValueError("file_not_regular")
-
-        file_size = target.stat(follow_symlinks=False).st_size
-        if file_size > preimage_max_bytes:
-            raise ValueError("edit_preimage_too_large")
-        payload = target.read_bytes()
+        payload, file_stat = self._read_existing_regular_file_no_follow(target, max_bytes=preimage_max_bytes)
         if b"\x00" in payload:
             raise ValueError("binary content is not supported by fs.edit")
         try:
@@ -1798,11 +1883,18 @@ class FilesystemModule(BaseModule):
             context,
         )
 
-        matches = text_before.count(old_string)
+        match_positions = self._find_overlapping_matches(text_before, old_string)
+        matches = len(match_positions)
         if matches == 0:
             raise ValueError("edit_old_string_not_found")
         if matches > 1 and not replace_all:
             raise ValueError("edit_old_string_not_unique")
+        has_overlapping_matches = any(
+            next_position < position + len(old_string)
+            for position, next_position in zip(match_positions, match_positions[1:], strict=False)
+        )
+        if has_overlapping_matches:
+            raise ValueError("edit_old_string_overlaps")
 
         replacements = matches if replace_all else 1
         text_after = text_before.replace(old_string, new_string) if replace_all else text_before.replace(
@@ -1816,8 +1908,8 @@ class FilesystemModule(BaseModule):
 
         sha256_after = hashlib.sha256(data_after).hexdigest()
         if not dry_run:
-            self._assert_preimage_unchanged(target, sha256_before, bytes_before)
-            self._atomic_write_text_file(target, text_after)
+            self._assert_edit_preimage_unchanged_no_follow(target, sha256_before, bytes_before, file_stat)
+            FilesystemModule._atomic_write_text_file(target, text_after)
 
         result: dict[str, Any] = {
             "path": rel_path,
@@ -1851,16 +1943,24 @@ class FilesystemModule(BaseModule):
         read_receipt: Any,
         context: Any | None,
     ) -> None:
+        """Authorize an edit preimage using either an expected hash or a read receipt.
+
+        If the caller supplies `expected_sha256`, it is treated as the stricter
+        assertion and must match the current preimage even when a valid receipt
+        is also supplied.
+        """
+
         has_expected = isinstance(expected_sha256, str) and bool(expected_sha256)
         has_receipt = isinstance(read_receipt, str) and bool(read_receipt)
         if not has_expected and not has_receipt:
             raise ValueError("edit_preimage_required")
-        if has_expected and str(expected_sha256) == sha256_before:
+        if has_expected:
+            if str(expected_sha256) != sha256_before:
+                raise ValueError("edit_preimage_mismatch")
             return
         if has_receipt:
             self._validate_edit_read_receipt(str(read_receipt), rel_path, sha256_before, bytes_before, context)
             return
-        raise ValueError("edit_preimage_mismatch")
 
     def _validate_edit_read_receipt(
         self,
@@ -1870,6 +1970,8 @@ class FilesystemModule(BaseModule):
         bytes_before: int,
         context: Any | None,
     ) -> None:
+        """Validate that a read receipt still describes the current edit preimage."""
+
         try:
             payload = self._read_receipts.validate(receipt)
         except ReadReceiptError as exc:

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_module.py
@@ -38,6 +38,7 @@ class _FilesystemRegistry:
         self.module = module
         self._tool_names = {
             "fs.list",
+            "fs.edit",
             "fs.read",
             "fs.read_text",
             "fs.patch",
@@ -208,9 +209,11 @@ async def test_filesystem_tools_include_path_scope_metadata() -> None:
     tools = await mod.get_tools()
     by_name = {tool["name"]: tool for tool in tools}
 
-    assert {"fs.list", "fs.read", "fs.read_text", "fs.patch", "fs.write", "fs.write_text"} <= set(by_name)  # nosec B101
+    assert {"fs.list", "fs.edit", "fs.read", "fs.read_text", "fs.patch", "fs.write", "fs.write_text"} <= set(  # nosec B101
+        by_name
+    )
 
-    for tool_name in ("fs.list", "fs.read", "fs.read_text", "fs.patch", "fs.write", "fs.write_text"):
+    for tool_name in ("fs.list", "fs.edit", "fs.read", "fs.read_text", "fs.patch", "fs.write", "fs.write_text"):
         metadata = by_name[tool_name]["metadata"]
         assert metadata["uses_filesystem"] is True  # nosec B101
         assert metadata["path_boundable"] is True  # nosec B101
@@ -233,6 +236,15 @@ async def test_filesystem_tools_include_path_scope_metadata() -> None:
     assert patch_metadata["eval"]["task_families"] == ["filesystem_edit"]  # nosec B101
     assert patch_metadata["eval"]["expected_result_kind"] == "structured_filesystem_edit"  # nosec B101
     assert by_name["fs.patch"]["inputSchema"]["additionalProperties"] is False  # nosec B101
+    edit_metadata = by_name["fs.edit"]["metadata"]
+    assert edit_metadata["path_argument_hints"] == ["path"]  # nosec B101
+    assert edit_metadata["path_scope_action"] == "edit"  # nosec B101
+    assert edit_metadata["file_policy_action"] == "edit"  # nosec B101
+    assert edit_metadata["file_policy_action_family"] == "bounded_edit"  # nosec B101
+    assert edit_metadata["write_capable"] is True  # nosec B101
+    assert edit_metadata["eval"]["task_families"] == ["filesystem_edit"]  # nosec B101
+    assert edit_metadata["eval"]["expected_result_kind"] == "structured_filesystem_edit"  # nosec B101
+    assert by_name["fs.edit"]["inputSchema"]["additionalProperties"] is False  # nosec B101
     write_metadata = by_name["fs.write"]["metadata"]
     assert write_metadata["path_argument_hints"] == ["path"]  # nosec B101
     assert write_metadata["path_scope_action"] == "write"  # nosec B101
@@ -637,6 +649,244 @@ async def test_filesystem_read_rejects_binary_payload(tmp_path: Path) -> None:
     with pytest.raises(ValueError, match="binary content is not supported"):
         await mod.execute_tool("fs.read", {"path": "blob.bin"}, context=context)
     assert len(resolver.calls) == 1  # nosec B101
+
+
+@pytest.mark.asyncio
+async def test_filesystem_edit_applies_exact_single_replacement_with_expected_hash(tmp_path: Path) -> None:
+    workspace_root = tmp_path / "workspace"
+    docs_dir = workspace_root / "docs"
+    docs_dir.mkdir(parents=True, exist_ok=True)
+    target = docs_dir / "story.txt"
+    original = "alpha\nbeta\ngamma\n"
+    target.write_text(original, encoding="utf-8")
+    resolver = _FakeWorkspaceRootResolver({"workspace_root": str(workspace_root), "workspace_id": "ws-1"})
+    mod = FilesystemModule(ModuleConfig(name="filesystem"), workspace_root_resolver=resolver)
+    context = RequestContext(request_id="req-fs-edit-expected", user_id="1", metadata={"workspace_id": "ws-1"})
+    expected_sha = hashlib.sha256(original.encode("utf-8")).hexdigest()
+
+    result = await mod.execute_tool(
+        "fs.edit",
+        {
+            "path": "docs/story.txt",
+            "old_string": "beta",
+            "new_string": "BETTA",
+            "expected_sha256": expected_sha,
+        },
+        context=context,
+    )
+
+    assert target.read_text(encoding="utf-8") == "alpha\nBETTA\ngamma\n"  # nosec B101
+    assert result["path"] == "docs/story.txt"  # nosec B101
+    assert result["edited"] is True  # nosec B101
+    assert result["dry_run"] is False  # nosec B101
+    assert result["replacements"] == 1  # nosec B101
+    assert result["sha256_before"] == expected_sha  # nosec B101
+    assert result["sha256_after"] == hashlib.sha256(b"alpha\nBETTA\ngamma\n").hexdigest()  # nosec B101
+    assert result["bytes_written"] == len(b"alpha\nBETTA\ngamma\n")  # nosec B101
+    assert result["eval"]["action_family"] == "filesystem_edit"  # nosec B101
+    assert "alpha" not in str(result)  # nosec B101
+    assert "BETTA" not in str(result)  # nosec B101
+
+
+@pytest.mark.asyncio
+async def test_filesystem_edit_requires_preimage_for_existing_file(tmp_path: Path) -> None:
+    workspace_root = tmp_path / "workspace"
+    workspace_root.mkdir(parents=True, exist_ok=True)
+    (workspace_root / "story.txt").write_text("old\n", encoding="utf-8")
+    resolver = _FakeWorkspaceRootResolver({"workspace_root": str(workspace_root)})
+    mod = FilesystemModule(ModuleConfig(name="filesystem"), workspace_root_resolver=resolver)
+    context = RequestContext(request_id="req-fs-edit-preimage", user_id="1", metadata={})
+
+    with pytest.raises(ValueError, match="edit_preimage_required"):
+        await mod.execute_tool(
+            "fs.edit",
+            {"path": "story.txt", "old_string": "old", "new_string": "new"},
+            context=context,
+        )
+
+
+@pytest.mark.asyncio
+async def test_filesystem_edit_rejects_missing_and_non_unique_old_string(tmp_path: Path) -> None:
+    workspace_root = tmp_path / "workspace"
+    workspace_root.mkdir(parents=True, exist_ok=True)
+    target = workspace_root / "story.txt"
+    original = "one\ntwo\ntwo\n"
+    target.write_text(original, encoding="utf-8")
+    resolver = _FakeWorkspaceRootResolver({"workspace_root": str(workspace_root)})
+    mod = FilesystemModule(ModuleConfig(name="filesystem"), workspace_root_resolver=resolver)
+    context = RequestContext(request_id="req-fs-edit-exact", user_id="1", metadata={})
+    expected_sha = hashlib.sha256(original.encode("utf-8")).hexdigest()
+
+    with pytest.raises(ValueError, match="edit_old_string_not_found"):
+        await mod.execute_tool(
+            "fs.edit",
+            {
+                "path": "story.txt",
+                "old_string": "missing",
+                "new_string": "new",
+                "expected_sha256": expected_sha,
+            },
+            context=context,
+        )
+    with pytest.raises(ValueError, match="edit_old_string_not_unique"):
+        await mod.execute_tool(
+            "fs.edit",
+            {
+                "path": "story.txt",
+                "old_string": "two",
+                "new_string": "TWO",
+                "expected_sha256": expected_sha,
+            },
+            context=context,
+        )
+
+    assert target.read_text(encoding="utf-8") == original  # nosec B101
+
+
+@pytest.mark.asyncio
+async def test_filesystem_edit_replace_all_replaces_every_exact_occurrence(tmp_path: Path) -> None:
+    workspace_root = tmp_path / "workspace"
+    workspace_root.mkdir(parents=True, exist_ok=True)
+    target = workspace_root / "story.txt"
+    original = "two\ntwo\n"
+    target.write_text(original, encoding="utf-8")
+    resolver = _FakeWorkspaceRootResolver({"workspace_root": str(workspace_root)})
+    mod = FilesystemModule(ModuleConfig(name="filesystem"), workspace_root_resolver=resolver)
+    context = RequestContext(request_id="req-fs-edit-replace-all", user_id="1", metadata={})
+    expected_sha = hashlib.sha256(original.encode("utf-8")).hexdigest()
+
+    result = await mod.execute_tool(
+        "fs.edit",
+        {
+            "path": "story.txt",
+            "old_string": "two",
+            "new_string": "TWO",
+            "replace_all": True,
+            "expected_sha256": expected_sha,
+        },
+        context=context,
+    )
+
+    assert target.read_text(encoding="utf-8") == "TWO\nTWO\n"  # nosec B101
+    assert result["replacements"] == 2  # nosec B101
+
+
+@pytest.mark.asyncio
+async def test_filesystem_edit_dry_run_reports_without_writing(tmp_path: Path) -> None:
+    workspace_root = tmp_path / "workspace"
+    workspace_root.mkdir(parents=True, exist_ok=True)
+    target = workspace_root / "story.txt"
+    original = "alpha\nbeta\n"
+    target.write_text(original, encoding="utf-8")
+    resolver = _FakeWorkspaceRootResolver({"workspace_root": str(workspace_root)})
+    mod = FilesystemModule(ModuleConfig(name="filesystem"), workspace_root_resolver=resolver)
+    context = RequestContext(request_id="req-fs-edit-dry-run", user_id="1", metadata={})
+    expected_sha = hashlib.sha256(original.encode("utf-8")).hexdigest()
+
+    result = await mod.execute_tool(
+        "fs.edit",
+        {
+            "path": "story.txt",
+            "old_string": "beta",
+            "new_string": "BETTA",
+            "expected_sha256": expected_sha,
+            "dry_run": True,
+        },
+        context=context,
+    )
+
+    assert target.read_text(encoding="utf-8") == original  # nosec B101
+    assert result["edited"] is False  # nosec B101
+    assert result["dry_run"] is True  # nosec B101
+    assert result["replacements"] == 1  # nosec B101
+    assert "bytes_written" not in result  # nosec B101
+
+
+@pytest.mark.asyncio
+async def test_filesystem_edit_applies_with_read_receipt(tmp_path: Path) -> None:
+    workspace_root = tmp_path / "workspace"
+    workspace_root.mkdir(parents=True, exist_ok=True)
+    target = workspace_root / "story.txt"
+    target.write_text("old\n", encoding="utf-8")
+    resolver = _FakeWorkspaceRootResolver({"workspace_root": str(workspace_root), "workspace_id": "ws-1"})
+    mod = FilesystemModule(
+        ModuleConfig(name="filesystem", settings={"read_receipt_secret": "unit-test-secret"}),  # nosec B105
+        workspace_root_resolver=resolver,
+    )
+    context = RequestContext(request_id="req-fs-edit-receipt", user_id="1", metadata={"workspace_id": "ws-1"})
+    read_result = await mod.execute_tool("fs.read", {"path": "story.txt"}, context=context)
+
+    result = await mod.execute_tool(
+        "fs.edit",
+        {
+            "path": "story.txt",
+            "old_string": "old",
+            "new_string": "new",
+            "read_receipt": read_result["read_receipt"],
+        },
+        context=context,
+    )
+
+    assert target.read_text(encoding="utf-8") == "new\n"  # nosec B101
+    assert result["sha256_before"] == read_result["sha256"]  # nosec B101
+
+
+@pytest.mark.asyncio
+async def test_filesystem_edit_rejects_bound_read_receipt_without_matching_context(tmp_path: Path) -> None:
+    workspace_root = tmp_path / "workspace"
+    workspace_root.mkdir(parents=True, exist_ok=True)
+    target = workspace_root / "story.txt"
+    target.write_text("old\n", encoding="utf-8")
+    resolver = _FakeWorkspaceRootResolver({"workspace_root": str(workspace_root), "workspace_id": "ws-1"})
+    mod = FilesystemModule(
+        ModuleConfig(name="filesystem", settings={"read_receipt_secret": "unit-test-secret"}),  # nosec B105
+        workspace_root_resolver=resolver,
+    )
+    bound_context = RequestContext(
+        request_id="req-fs-edit-receipt-bound",
+        user_id="1",
+        session_id="session-1",
+        metadata={"workspace_id": "ws-1"},
+    )
+    unbound_context = RequestContext(request_id="req-fs-edit-receipt-unbound", user_id="1", metadata={})
+    read_result = await mod.execute_tool("fs.read", {"path": "story.txt"}, context=bound_context)
+
+    with pytest.raises(ValueError, match="edit_read_receipt_mismatch"):
+        await mod.execute_tool(
+            "fs.edit",
+            {
+                "path": "story.txt",
+                "old_string": "old",
+                "new_string": "new",
+                "read_receipt": read_result["read_receipt"],
+            },
+            context=unbound_context,
+        )
+
+    assert target.read_text(encoding="utf-8") == "old\n"  # nosec B101
+
+
+@pytest.mark.asyncio
+async def test_filesystem_edit_rejects_binary_payload(tmp_path: Path) -> None:
+    workspace_root = tmp_path / "workspace"
+    workspace_root.mkdir(parents=True, exist_ok=True)
+    target = workspace_root / "blob.bin"
+    target.write_bytes(b"old\x00data")
+    resolver = _FakeWorkspaceRootResolver({"workspace_root": str(workspace_root)})
+    mod = FilesystemModule(ModuleConfig(name="filesystem"), workspace_root_resolver=resolver)
+    context = RequestContext(request_id="req-fs-edit-binary", user_id="1", metadata={})
+
+    with pytest.raises(ValueError, match="binary content is not supported by fs.edit"):
+        await mod.execute_tool(
+            "fs.edit",
+            {
+                "path": "blob.bin",
+                "old_string": "old",
+                "new_string": "new",
+                "expected_sha256": hashlib.sha256(target.read_bytes()).hexdigest(),
+            },
+            context=context,
+        )
 
 
 @pytest.mark.asyncio

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_module.py
@@ -744,6 +744,71 @@ async def test_filesystem_edit_rejects_missing_and_non_unique_old_string(tmp_pat
 
 
 @pytest.mark.asyncio
+async def test_filesystem_edit_preserves_raw_tab_literals(tmp_path: Path) -> None:
+    workspace_root = tmp_path / "workspace"
+    workspace_root.mkdir(parents=True, exist_ok=True)
+    target = workspace_root / "story.txt"
+    original = "plain old\nprefixed\told\n"
+    target.write_text(original, encoding="utf-8")
+    resolver = _FakeWorkspaceRootResolver({"workspace_root": str(workspace_root)})
+    mod = FilesystemModule(ModuleConfig(name="filesystem"), workspace_root_resolver=resolver)
+    context = RequestContext(request_id="req-fs-edit-raw-tab", user_id="1", metadata={})
+
+    result = await mod.execute_tool(
+        "fs.edit",
+        {
+            "path": "story.txt",
+            "old_string": "\told",
+            "new_string": "\tnew",
+            "expected_sha256": hashlib.sha256(original.encode("utf-8")).hexdigest(),
+        },
+        context=context,
+    )
+
+    assert target.read_text(encoding="utf-8") == "plain old\nprefixed\tnew\n"  # nosec B101
+    assert result["replacements"] == 1  # nosec B101
+
+
+@pytest.mark.asyncio
+async def test_filesystem_edit_rejects_overlapping_old_string_matches(tmp_path: Path) -> None:
+    workspace_root = tmp_path / "workspace"
+    workspace_root.mkdir(parents=True, exist_ok=True)
+    target = workspace_root / "story.txt"
+    original = "ababa\n"
+    target.write_text(original, encoding="utf-8")
+    resolver = _FakeWorkspaceRootResolver({"workspace_root": str(workspace_root)})
+    mod = FilesystemModule(ModuleConfig(name="filesystem"), workspace_root_resolver=resolver)
+    context = RequestContext(request_id="req-fs-edit-overlap", user_id="1", metadata={})
+    expected_sha = hashlib.sha256(original.encode("utf-8")).hexdigest()
+
+    with pytest.raises(ValueError, match="edit_old_string_not_unique"):
+        await mod.execute_tool(
+            "fs.edit",
+            {
+                "path": "story.txt",
+                "old_string": "aba",
+                "new_string": "ABA",
+                "expected_sha256": expected_sha,
+            },
+            context=context,
+        )
+    with pytest.raises(ValueError, match="edit_old_string_overlaps"):
+        await mod.execute_tool(
+            "fs.edit",
+            {
+                "path": "story.txt",
+                "old_string": "aba",
+                "new_string": "ABA",
+                "replace_all": True,
+                "expected_sha256": expected_sha,
+            },
+            context=context,
+        )
+
+    assert target.read_text(encoding="utf-8") == original  # nosec B101
+
+
+@pytest.mark.asyncio
 async def test_filesystem_edit_replace_all_replaces_every_exact_occurrence(tmp_path: Path) -> None:
     workspace_root = tmp_path / "workspace"
     workspace_root.mkdir(parents=True, exist_ok=True)
@@ -832,6 +897,37 @@ async def test_filesystem_edit_applies_with_read_receipt(tmp_path: Path) -> None
 
 
 @pytest.mark.asyncio
+async def test_filesystem_edit_rejects_expected_sha_mismatch_even_with_read_receipt(tmp_path: Path) -> None:
+    workspace_root = tmp_path / "workspace"
+    workspace_root.mkdir(parents=True, exist_ok=True)
+    target = workspace_root / "story.txt"
+    original = "old\n"
+    target.write_text(original, encoding="utf-8")
+    resolver = _FakeWorkspaceRootResolver({"workspace_root": str(workspace_root), "workspace_id": "ws-1"})
+    mod = FilesystemModule(
+        ModuleConfig(name="filesystem", settings={"read_receipt_secret": "unit-test-secret"}),  # nosec B105
+        workspace_root_resolver=resolver,
+    )
+    context = RequestContext(request_id="req-fs-edit-sha-receipt", user_id="1", metadata={"workspace_id": "ws-1"})
+    read_result = await mod.execute_tool("fs.read", {"path": "story.txt"}, context=context)
+
+    with pytest.raises(ValueError, match="edit_preimage_mismatch"):
+        await mod.execute_tool(
+            "fs.edit",
+            {
+                "path": "story.txt",
+                "old_string": "old",
+                "new_string": "new",
+                "expected_sha256": hashlib.sha256(b"different\n").hexdigest(),
+                "read_receipt": read_result["read_receipt"],
+            },
+            context=context,
+        )
+
+    assert target.read_text(encoding="utf-8") == original  # nosec B101
+
+
+@pytest.mark.asyncio
 async def test_filesystem_edit_rejects_bound_read_receipt_without_matching_context(tmp_path: Path) -> None:
     workspace_root = tmp_path / "workspace"
     workspace_root.mkdir(parents=True, exist_ok=True)
@@ -887,6 +983,27 @@ async def test_filesystem_edit_rejects_binary_payload(tmp_path: Path) -> None:
             },
             context=context,
         )
+
+
+def test_filesystem_edit_no_follow_reader_rejects_oversized_payload(tmp_path: Path) -> None:
+    target = tmp_path / "story.txt"
+    target.write_text("abc", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="edit_preimage_too_large"):
+        FilesystemModule._read_existing_regular_file_no_follow(target, max_bytes=2)
+
+
+def test_filesystem_edit_no_follow_reader_rejects_symlink(tmp_path: Path) -> None:
+    target = tmp_path / "story.txt"
+    target.write_text("abc", encoding="utf-8")
+    link_path = tmp_path / "story-link.txt"
+    try:
+        link_path.symlink_to(target)
+    except (OSError, NotImplementedError) as exc:
+        pytest.skip(f"symlink creation unavailable on this platform: {exc}")
+
+    with pytest.raises(ValueError, match="file_not_regular"):
+        FilesystemModule._read_existing_regular_file_no_follow(link_path, max_bytes=10)
 
 
 @pytest.mark.asyncio

--- a/tldw_Server_API/tests/MCP_unified/test_mcp_hub_path_enforcement_service.py
+++ b/tldw_Server_API/tests/MCP_unified/test_mcp_hub_path_enforcement_service.py
@@ -758,6 +758,52 @@ async def test_path_grants_are_authoritative_when_legacy_allowlist_also_present(
 
 
 @pytest.mark.asyncio
+async def test_path_grants_treat_fs_edit_as_edit_action() -> None:
+    from tldw_Server_API.app.services.mcp_hub_path_enforcement_service import (
+        McpHubPathEnforcementService,
+    )
+
+    svc = McpHubPathEnforcementService(path_scope_service=_FakePathScopeService(_workspace_scope()))
+
+    allowed = await svc.evaluate_tool_call(
+        effective_policy={
+            "enabled": True,
+            "policy_document": {
+                "path_scope_mode": "workspace_root",
+                "path_grants": [
+                    {"prefix": "documents", "actions": ["read", "edit"]},
+                ],
+            },
+        },
+        context=SimpleNamespace(metadata={}),
+        tool_name="fs.edit",
+        tool_args={"path": "documents/story.md"},
+        tool_def=_filesystem_tool_def(action="edit"),
+    )
+    denied = await svc.evaluate_tool_call(
+        effective_policy={
+            "enabled": True,
+            "policy_document": {
+                "path_scope_mode": "workspace_root",
+                "path_grants": [
+                    {"prefix": "documents", "actions": ["read"]},
+                ],
+            },
+        },
+        context=SimpleNamespace(metadata={}),
+        tool_name="fs.edit",
+        tool_args={"path": "documents/story.md"},
+        tool_def=_filesystem_tool_def(action="edit"),
+    )
+
+    assert allowed["within_scope"] is True  # nosec B101
+    assert allowed["path_decisions"][0]["requested_action"] == "edit"  # nosec B101
+    assert denied["within_scope"] is False  # nosec B101
+    assert denied["reason"] == "path_action_not_granted"  # nosec B101
+    assert denied["path_decisions"][0]["requested_action"] == "edit"  # nosec B101
+
+
+@pytest.mark.asyncio
 async def test_empty_path_grants_fail_closed_even_with_legacy_allowlist() -> None:
     from tldw_Server_API.app.services.mcp_hub_path_enforcement_service import (
         McpHubPathEnforcementService,


### PR DESCRIPTION
## Summary
- Add `fs.edit` as an exact UTF-8 string replacement primitive for the MCP filesystem module.
- Reuse workspace path resolution, action-aware path grants, read receipts/hash preimage checks, atomic writes, and structured eval metadata.
- Address review feedback by preserving raw exact-match strings, rejecting overlapping matches, enforcing expected-SHA precedence, and using descriptor-based no-follow preimage reads for `fs.edit`.

## Validation
- [x] `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_module.py tldw_Server_API/tests/MCP_unified/test_mcp_hub_path_enforcement_service.py -q`
- [x] `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m ruff check tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_module.py tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_module.py tldw_Server_API/tests/MCP_unified/test_mcp_hub_path_enforcement_service.py`
- [x] `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m py_compile tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_module.py`
- [x] `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -q tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_module.py`
- [x] `git diff --check`
- [x] Docs updated in `mcp_unified/USER_GUIDE.md`.

## Review Resolution
- Fixed: `fs.edit` raw `old_string`/`new_string` preservation.
- Fixed: post-read preimage size enforcement and no-follow descriptor read path for `fs.edit`.
- Fixed: `expected_sha256` mismatch now fails even when a valid read receipt is also present.
- Fixed: overlapping exact matches are rejected; `replace_all` remains deterministic for non-overlapping matches only.
- Fixed: docstrings added for new `fs.edit` helper methods.
- Skipped as invalid: `_atomic_write_text_file` AttributeError claim. The helper is a `@staticmethod` on `FilesystemModule`; the edit path now calls it via the class explicitly.

## Risk & Rollback
- Risk: medium. This adds a new write-capable MCP filesystem primitive, but it is bounded by existing workspace path policy, read-before-edit preimage checks, and no raw content in results.
- Rollback: revert the `fs.edit` commits or remove the tool from the filesystem module registry; existing `fs.patch`, `fs.write`, and compatibility tools are unchanged.

## UX & Accessibility
- [x] Not applicable: backend MCP/tooling change only; no frontend UI or accessibility surface changed.

## Merge Gate
- Human-authored Change summary is still required before merge per project policy.