### PR TITLE
Bring MCP fs.glob and fs.grep closer to Claude parity

### DIFF
--- a/Docs/superpowers/plans/2026-06-09-mcp-glob-grep-parity-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-06-09-mcp-glob-grep-parity-implementation-plan.md
@@ -1,0 +1,91 @@
+# MCP Glob/Grep Parity Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Bring the existing workspace-bounded `fs.glob` and `fs.grep` tools closer to useful Claude Code Glob/Grep behavior without weakening path scope, no-shell execution, or safe literal-search defaults.
+
+**Architecture:** Extend `FilesystemModule` in place. Keep all filesystem traversal inside the existing workspace resolver and `asyncio.to_thread` execution path. Add narrowly scoped schema, validation, search-filter, and response-shaping support while preserving existing response fields for compatibility.
+
+**Tech Stack:** Python, FastAPI-side MCP module code, pytest, Backlog.md, Bandit.
+
+---
+
+### Task 1: Write Failing Parity Tests
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_module.py`
+
+- [x] **Step 1: Add `fs.glob` mtime sorting coverage**
+  - Create files with controlled mtimes.
+  - Assert default `fs.glob` returns newest-first paths with truncation metadata.
+  - Assert `sort_by="path"` remains available for deterministic path-ordered results.
+
+- [x] **Step 2: Add `fs.grep` output mode and filter coverage**
+  - Assert `output_mode="files_with_matches"` returns only matched file paths and is the default.
+  - Assert `output_mode="content"` preserves existing line records.
+  - Assert `output_mode="count"` returns per-file counts.
+  - Assert `glob` and `type` filters narrow the scan without bypassing workspace scope.
+  - Assert directory grep respects `.gitignore` by default and can disable that filtering.
+  - Assert safe multiline regex works for file/count outputs.
+
+- [x] **Step 3: Add direct-file base path coverage**
+  - Assert `fs.grep` can search a directly named text file via `base_path`.
+  - Assert unsupported direct-file inputs still report bounded skip/error behavior.
+
+- [x] **Step 4: Run targeted tests and confirm RED**
+  - Run: `source .venv/bin/activate && python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_module.py -k "glob or grep" -q`
+  - Expected: fail on the new unsupported arguments/ordering/default-mode assertions.
+
+### Task 2: Implement Bounded Search Parity Additions
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_module.py`
+
+- [x] **Step 1: Extend tool schemas and validation**
+  - Add `fs.glob.sort_by` with values `modified_at` and `path`; default to `modified_at`.
+  - Add `fs.grep.output_mode` with values `files_with_matches`, `content`, and `count`; default to `files_with_matches`.
+  - Add `fs.grep.glob` as a single-pattern convenience filter and `fs.grep.type` for a bounded extension alias map.
+
+- [x] **Step 2: Implement `fs.glob` sorting**
+  - Capture per-match mtime internally.
+  - Sort newest-first when `sort_by="modified_at"`.
+  - Preserve response compatibility by omitting internal sort metadata from records unless already present.
+
+- [x] **Step 3: Implement `fs.grep` result shaping**
+  - Collect matches internally as content records.
+  - Shape output by mode after scanning.
+  - Keep existing `matches`, `truncated`, `remaining_count`, `remaining_count_known`, `truncation_reasons`, and `skipped` fields.
+
+- [x] **Step 4: Implement filters, gitignore handling, multiline, and direct-file search**
+  - Merge `glob` into include filters.
+  - Map common `type` aliases such as `py`, `js`, `ts`, `tsx`, `md`, `json`, `yaml`, `rust`, `go`, and `java` to portable include patterns.
+  - Add root `.gitignore` handling using a declared `pathspec` dependency.
+  - Add safe multiline regex support for `files_with_matches` and `count` output modes.
+  - If `base_path` resolves to a file, search only that file while applying the same binary, decode, size, and budget checks.
+
+- [x] **Step 5: Run targeted tests and confirm GREEN**
+  - Run: `source .venv/bin/activate && python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_module.py -k "glob or grep" -q`
+  - Expected: pass.
+
+### Task 3: Documentation, Backlog, And Verification
+
+**Files:**
+- Modify: `mcp_unified/USER_GUIDE.md`
+- Modify: `backlog/tasks/task-2280 - Bring-fs.glob-and-fs.grep-to-Claude-Code-parity.md`
+
+- [x] **Step 1: Update user guide**
+  - Document mtime-sorted glob results and grep output modes/filters.
+  - State that regex remains opt-in and no host shell is invoked.
+
+- [x] **Step 2: Update Backlog.md task**
+  - Record implementation notes, validation commands, and known follow-ups for gitignore and multiline behavior.
+
+- [x] **Step 3: Run verification**
+  - Run targeted pytest.
+  - Run Bandit on the touched MCP filesystem module.
+  - Run `git diff --check`.
+
+- [x] **Step 4: Commit and open PR**
+  - Commit the plan, tests, code, docs, and backlog task.
+  - Push `codex/mcp-glob-grep-parity`.
+  - Open a draft PR against `dev` with a human-readable change summary placeholder.

--- a/backlog/tasks/task-2280 - Bring-fs.glob-and-fs.grep-to-Claude-Code-parity.md
+++ b/backlog/tasks/task-2280 - Bring-fs.glob-and-fs.grep-to-Claude-Code-parity.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-2280
 title: Bring fs.glob and fs.grep to Claude Code parity
-status: To Do
+status: Done
 labels:
 - mcp
 - filesystem
@@ -10,6 +10,12 @@ labels:
 - agentic-execution
 references:
 - https://code.claude.com/docs/en/tools-reference
+modified_files:
+- pyproject.toml
+- mcp_unified/USER_GUIDE.md
+- tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_module.py
+- tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_module.py
+- Docs/superpowers/plans/2026-06-09-mcp-glob-grep-parity-implementation-plan.md
 ---
 
 ## Description
@@ -20,26 +26,48 @@ Enhance filesystem search tools to match useful Claude Code Glob/Grep behavior. 
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
+- [x] `fs.glob` returns capped results sorted by newest modification time by default and supports `sort_by: "path"` for deterministic path order.
+- [x] `fs.glob` supports opt-in `.gitignore` filtering with `respect_gitignore: true`.
+- [x] `fs.grep` supports `files_with_matches`, `content`, and `count` output modes, defaulting to `files_with_matches`.
+- [x] `fs.grep` supports `glob` and `type` narrowing without broadening existing include/exclude filters.
+- [x] Directory `fs.grep` respects root `.gitignore` by default, while direct-file `base_path` searches can inspect an ignored file when profile/path policy allows it.
+- [x] `fs.grep` supports bounded multiline regex search for `files_with_matches` and `count` modes.
+- [x] `fs.glob` and `fs.grep` responses include redacted scalar eval metadata without file contents or absolute paths.
+- [x] Focused regression tests cover the new behavior and adjacent command-runtime tests remain green.
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Docs/superpowers/plans/2026-06-09-mcp-glob-grep-parity-implementation-plan.md
+<!-- SECTION:PLAN:END -->
 
 ## Implementation Notes
 
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Implemented Claude-style filesystem search parity in the workspace-bounded `FilesystemModule`.
 
+- Added `pathspec>=0.12.1` as an explicit dependency for root `.gitignore` gitwildmatch parsing.
+- Added `fs.glob.sort_by`, defaulting to `modified_at`, and `fs.glob.respect_gitignore`, defaulting to `false`.
+- Added `fs.grep.output_mode`, `glob`, `type`, `respect_gitignore`, and safe `multiline` options. Directory grep defaults to `.gitignore` filtering; direct-file grep intentionally bypasses gitignore filtering while still using workspace path resolution and profile/path policy.
+- Added safe execution eval metadata for `fs.glob` and `fs.grep`; metadata records tool/result/truncation shape only.
+- Kept all traversal and reads under existing workspace containment, file size, total byte, file count, and walk-entry limits.
+- PR review fixes hardened `.gitignore` loading against symlinks, undecodable bytes, and parse failures; added diagnostics for ignored filesystem errors; and short-circuited file-match grep scans.
+- PR review docstring pass added concise docstrings for newly introduced helpers and regression tests.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-
+Verification recorded: python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_module.py -q => 82 passed; python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_run_command_module.py tldw_Server_API/app/core/MCP_unified/tests/test_command_runtime_registry.py -q => 21 passed; git diff --check => clean; bandit filesystem_module.py => 0 findings.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->

--- a/mcp_unified/USER_GUIDE.md
+++ b/mcp_unified/USER_GUIDE.md
@@ -115,8 +115,19 @@ Filesystem-capable presets expose portable workspace-bounded helpers for common
 read workflows: `fs.stat` for metadata, `fs.glob` for cross-platform path
 matching, and `fs.grep` for UTF-8 text search. These helpers do not invoke a
 host shell and remain subject to the active profile policy and workspace path
-scope. `fs.grep` uses literal matching by default; regex matching requires the
-filesystem module `grep_allow_regex` setting. Grep scans are also bounded by
+scope. `fs.glob` returns capped matches sorted by newest modification time by
+default; pass `sort_by: "path"` when deterministic path ordering is more useful.
+Glob does not apply `.gitignore` by default, but callers can pass
+`respect_gitignore: true` when they want ignored paths filtered.
+`fs.grep` defaults to `output_mode: "files_with_matches"` and can also return
+matching line records with `output_mode: "content"` or per-file totals with
+`output_mode: "count"`. Use `glob` or `type` to narrow grep scans by file
+pattern or common language/file extension aliases. Directory grep scans respect
+the workspace root `.gitignore` by default; direct-file grep still works for a
+named ignored file when profile and path policy allow that file. `fs.grep` uses
+literal matching by default; regex matching requires the filesystem module
+`grep_allow_regex` setting. `multiline: true` is available only with regex mode
+and `files_with_matches` or `count` output. Grep scans are also bounded by
 per-file, total-byte, total-file, and walk-entry limits.
 
 ### Safe File Read, Patch, And Write Tools

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,7 @@ dependencies = [
   "openpyxl>=3.1.2",
   "pandas>=2.0.0",
   "passlib>=1.7.0",
+  "pathspec>=0.12.1",
   "prometheus-client",
   "psutil>=5.9.0",
   "pydantic>=2.0.0",

--- a/tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_module.py
@@ -29,6 +29,8 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
+import pathspec
+from pathspec.patterns.gitwildmatch import GitWildMatchPatternError
 from loguru import logger
 from mcp_unified.interfaces.file_policy_actions import get_file_policy_action_metadata
 from mcp_unified.interfaces.path_scope import PathScopeCandidate
@@ -65,6 +67,35 @@ class FilesystemModule(BaseModule):
     """Workspace-scoped text filesystem primitives."""
 
     _DEFAULT_MAX_READ_BYTES = 1_000_000
+    _GREP_TYPE_PATTERNS = {
+        "c": ("**/*.c", "**/*.h"),
+        "cpp": (
+            "**/*.cpp",
+            "**/*.cc",
+            "**/*.cxx",
+            "**/*.hpp",
+            "**/*.hh",
+            "**/*.hxx",
+        ),
+        "cs": ("**/*.cs",),
+        "go": ("**/*.go",),
+        "java": ("**/*.java",),
+        "js": ("**/*.js", "**/*.jsx"),
+        "json": ("**/*.json",),
+        "md": ("**/*.md", "**/*.markdown"),
+        "php": ("**/*.php",),
+        "py": ("**/*.py",),
+        "python": ("**/*.py",),
+        "rb": ("**/*.rb",),
+        "rs": ("**/*.rs",),
+        "rust": ("**/*.rs",),
+        "sh": ("**/*.sh", "**/*.bash", "**/*.zsh"),
+        "ts": ("**/*.ts",),
+        "tsx": ("**/*.tsx",),
+        "txt": ("**/*.txt",),
+        "yaml": ("**/*.yaml", "**/*.yml"),
+        "yml": ("**/*.yml", "**/*.yaml"),
+    }
 
     def __init__(
         self,
@@ -325,6 +356,12 @@ class FilesystemModule(BaseModule):
                     "include_directories": {"type": "boolean", "default": True},
                     "follow_symlinks": {"type": "boolean", "default": False},
                     "case_sensitive": {"type": "boolean", "default": True},
+                    "respect_gitignore": {"type": "boolean", "default": False},
+                    "sort_by": {
+                        "type": "string",
+                        "enum": ["modified_at", "path"],
+                        "default": "modified_at",
+                    },
                     "limit": {"type": "integer", "minimum": 1},
                 },
                 "required": ["pattern"],
@@ -334,6 +371,11 @@ class FilesystemModule(BaseModule):
                 "readOnlyHint": True,
                 "capabilities": ["filesystem.read"],
                 **_file_policy_metadata("read"),
+                "eval": {
+                    "task_families": ["filesystem_search"],
+                    "expected_result_kind": "structured_filesystem_glob",
+                    "success_signals": ["avoided_mutation"],
+                },
                 **shared_fs_metadata,
                 "path_argument_hints": ["base_path"],
             },
@@ -349,6 +391,13 @@ class FilesystemModule(BaseModule):
                     "base_path": {"type": "string", "description": "Workspace-relative base path"},
                     "include": {"type": "array", "items": {"type": "string"}},
                     "exclude": {"type": "array", "items": {"type": "string"}},
+                    "glob": {"type": "string", "description": "Portable file pattern used to narrow results."},
+                    "type": {"type": "string", "description": "Language/file type alias used to narrow results."},
+                    "output_mode": {
+                        "type": "string",
+                        "enum": ["files_with_matches", "content", "count"],
+                        "default": "files_with_matches",
+                    },
                     "regex": {
                         "type": "boolean",
                         "default": False,
@@ -357,6 +406,12 @@ class FilesystemModule(BaseModule):
                     "case_sensitive": {"type": "boolean", "default": True},
                     "include_hidden": {"type": "boolean", "default": False},
                     "follow_symlinks": {"type": "boolean", "default": False},
+                    "respect_gitignore": {"type": "boolean", "default": True},
+                    "multiline": {
+                        "type": "boolean",
+                        "default": False,
+                        "description": "Regex-only multiline search for files_with_matches or count output modes.",
+                    },
                     "limit": {"type": "integer", "minimum": 1},
                     "max_file_bytes": {"type": "integer", "minimum": 1},
                 },
@@ -367,6 +422,11 @@ class FilesystemModule(BaseModule):
                 "readOnlyHint": True,
                 "capabilities": ["filesystem.read"],
                 **_file_policy_metadata("read"),
+                "eval": {
+                    "task_families": ["filesystem_search"],
+                    "expected_result_kind": "structured_filesystem_grep",
+                    "success_signals": ["avoided_mutation"],
+                },
                 **shared_fs_metadata,
                 "path_argument_hints": ["base_path"],
             },
@@ -536,6 +596,7 @@ class FilesystemModule(BaseModule):
             pattern = self._normalize_portable_pattern(str(args.get("pattern")))
             self._reject_unsafe_pattern(pattern)
             limit = self._bounded_positive_int(args.get("limit"), self._setting_positive_int("glob_result_limit", 500))
+            sort_by = str(args.get("sort_by") or "modified_at")
             return await asyncio.to_thread(
                 self._glob_paths,
                 workspace_root,
@@ -546,6 +607,8 @@ class FilesystemModule(BaseModule):
                 bool(args.get("include_directories", True)),
                 bool(args.get("follow_symlinks", False)),
                 bool(args.get("case_sensitive", True)),
+                bool(args.get("respect_gitignore", False)),
+                sort_by,
                 limit,
                 self._setting_positive_int("glob_walk_entry_limit", 50_000),
             )
@@ -556,9 +619,12 @@ class FilesystemModule(BaseModule):
             pattern = str(args.get("pattern") or "")
             regex = bool(args.get("regex", False))
             case_sensitive = bool(args.get("case_sensitive", True))
+            multiline = bool(args.get("multiline", False))
             regex_pattern = None
             if regex:
                 flags = 0 if case_sensitive else re.IGNORECASE
+                if multiline:
+                    flags |= re.DOTALL
                 try:
                     regex_pattern = re.compile(pattern, flags)
                 except re.error as exc:
@@ -571,10 +637,19 @@ class FilesystemModule(BaseModule):
                 self._normalize_portable_pattern(str(item))
                 for item in (args.get("exclude") if args.get("exclude") is not None else [])
             ]
+            glob_filter = None
+            if args.get("glob") is not None:
+                glob_filter = self._normalize_portable_pattern(str(args.get("glob")))
+                self._reject_unsafe_pattern(glob_filter)
+            type_filter = None
+            if args.get("type") is not None:
+                type_filter = self._grep_type_patterns(str(args.get("type")))
             for include_pattern in include:
                 self._reject_unsafe_pattern(include_pattern)
             for exclude_pattern in exclude:
                 self._reject_unsafe_pattern(exclude_pattern)
+            for type_pattern in type_filter or ():
+                self._reject_unsafe_pattern(type_pattern)
             limit = self._bounded_positive_int(args.get("limit"), self._setting_positive_int("grep_result_limit", 200))
             max_file_bytes = self._bounded_positive_int(
                 args.get("max_file_bytes"),
@@ -594,8 +669,13 @@ class FilesystemModule(BaseModule):
                 case_sensitive,
                 include,
                 exclude,
+                glob_filter,
+                type_filter,
+                str(args.get("output_mode") or "files_with_matches"),
                 bool(args.get("include_hidden", False)),
                 bool(args.get("follow_symlinks", False)),
+                bool(args.get("respect_gitignore", True)),
+                multiline,
                 limit,
                 max_file_bytes,
                 max_total_bytes,
@@ -799,6 +879,8 @@ class FilesystemModule(BaseModule):
                     "include_directories",
                     "follow_symlinks",
                     "case_sensitive",
+                    "respect_gitignore",
+                    "sort_by",
                     "limit",
                 }
             )
@@ -816,8 +898,12 @@ class FilesystemModule(BaseModule):
                 "include_directories",
                 "follow_symlinks",
                 "case_sensitive",
+                "respect_gitignore",
             ):
                 self._validate_bool_argument(arguments, key)
+            sort_by = arguments.get("sort_by")
+            if sort_by is not None and sort_by not in {"modified_at", "path"}:
+                raise ValueError("sort_by must be one of: modified_at, path")
             self._validate_positive_int_argument(arguments, "limit")
             return
 
@@ -829,10 +915,15 @@ class FilesystemModule(BaseModule):
                     "base_path",
                     "include",
                     "exclude",
+                    "glob",
+                    "type",
+                    "output_mode",
                     "regex",
                     "case_sensitive",
                     "include_hidden",
                     "follow_symlinks",
+                    "respect_gitignore",
+                    "multiline",
                     "limit",
                     "max_file_bytes",
                 }
@@ -855,8 +946,31 @@ class FilesystemModule(BaseModule):
                 not isinstance(exclude, list) or not all(isinstance(item, str) for item in exclude)
             ):
                 raise ValueError("exclude must be a list of strings")
-            for key in ("regex", "case_sensitive", "include_hidden", "follow_symlinks"):
+            glob_filter = arguments.get("glob")
+            if glob_filter is not None and not isinstance(glob_filter, str):
+                raise ValueError("glob must be a string")
+            type_filter = arguments.get("type")
+            if type_filter is not None and not isinstance(type_filter, str):
+                raise ValueError("type must be a string")
+            if isinstance(type_filter, str) and type_filter.strip().lower() not in self._GREP_TYPE_PATTERNS:
+                raise ValueError(f"unsupported grep type: {type_filter}")
+            output_mode = arguments.get("output_mode")
+            if output_mode is not None and output_mode not in {"files_with_matches", "content", "count"}:
+                raise ValueError("output_mode must be one of: files_with_matches, content, count")
+            for key in (
+                "regex",
+                "case_sensitive",
+                "include_hidden",
+                "follow_symlinks",
+                "respect_gitignore",
+                "multiline",
+            ):
                 self._validate_bool_argument(arguments, key)
+            if arguments.get("multiline") is True:
+                if arguments.get("regex") is not True:
+                    raise ValueError("multiline grep requires regex=true")
+                if arguments.get("output_mode") == "content":
+                    raise ValueError("multiline grep does not support content output_mode")
             self._validate_positive_int_argument(arguments, "limit")
             self._validate_positive_int_argument(arguments, "max_file_bytes")
             if arguments.get("regex") is True:
@@ -1046,6 +1160,54 @@ class FilesystemModule(BaseModule):
         if pattern.count("**/") > 5:
             raise ValueError("unsafe pattern: too many double-star wildcards")
 
+    @classmethod
+    def _grep_type_patterns(cls, raw_type: str) -> list[str]:
+        """Return glob patterns for a supported grep file type alias."""
+        type_name = raw_type.strip().lower()
+        patterns = cls._GREP_TYPE_PATTERNS.get(type_name)
+        if not patterns:
+            raise ValueError(f"unsupported grep type: {raw_type}")
+        return list(patterns)
+
+    @staticmethod
+    def _load_gitignore_spec(workspace_root: Path) -> pathspec.PathSpec | None:
+        """Load the workspace root .gitignore as a best-effort pathspec."""
+        gitignore_path = workspace_root / ".gitignore"
+        try:
+            gitignore_stat = gitignore_path.lstat()
+        except FileNotFoundError:
+            return None
+        except OSError as exc:
+            logger.debug("Unable to stat workspace .gitignore; ignoring it: {}", exc.__class__.__name__)
+            return None
+        if not stat_module.S_ISREG(gitignore_stat.st_mode):
+            if stat_module.S_ISLNK(gitignore_stat.st_mode):
+                logger.debug("Ignoring symlinked workspace .gitignore")
+            return None
+        try:
+            text = gitignore_path.read_bytes().decode("utf-8", errors="replace")
+        except OSError as exc:
+            logger.debug("Unable to read workspace .gitignore; ignoring it: {}", exc.__class__.__name__)
+            return None
+        try:
+            return pathspec.PathSpec.from_lines("gitwildmatch", text.splitlines())
+        except (GitWildMatchPatternError, TypeError, ValueError) as exc:
+            logger.debug("Unable to parse workspace .gitignore; ignoring it: {}", exc.__class__.__name__)
+            return None
+
+    @staticmethod
+    def _is_gitignored(
+        gitignore_spec: pathspec.PathSpec | None,
+        rel_path: str,
+        *,
+        is_directory: bool,
+    ) -> bool:
+        """Return whether a workspace-relative path matches the gitignore spec."""
+        if gitignore_spec is None:
+            return False
+        candidate = f"{rel_path}/" if is_directory and not rel_path.endswith("/") else rel_path
+        return bool(gitignore_spec.match_file(candidate))
+
     @staticmethod
     def _portable_pattern_matches(path: str, pattern: str, *, case_sensitive: bool) -> bool:
         candidate = path if case_sensitive else path.lower()
@@ -1121,6 +1283,8 @@ class FilesystemModule(BaseModule):
         include_directories: bool,
         follow_symlinks: bool,
         case_sensitive: bool,
+        respect_gitignore: bool,
+        sort_by: str,
         limit: int,
         walk_entry_limit: int,
     ) -> dict[str, Any]:
@@ -1129,10 +1293,11 @@ class FilesystemModule(BaseModule):
         if not base.is_dir():
             raise NotADirectoryError(f"path is not a directory: {base}")
 
-        matches: list[dict[str, Any]] = []
+        matches: list[tuple[dict[str, Any], float]] = []
         visited_entries = 0
         walk_truncated = False
         seen_dirs: set[Path] = {base.resolve(strict=False)}
+        gitignore_spec = FilesystemModule._load_gitignore_spec(workspace_root) if respect_gitignore else None
 
         for root, dirnames, filenames in os.walk(base, topdown=True, followlinks=follow_symlinks):
             current_root = Path(root)
@@ -1144,6 +1309,9 @@ class FilesystemModule(BaseModule):
                 dir_path = current_root / dirname
                 rel_path = FilesystemModule._to_workspace_relative_path(workspace_root, dir_path)
                 if not include_hidden and FilesystemModule._is_hidden_relative_path(rel_path):
+                    dirnames.remove(dirname)
+                    continue
+                if FilesystemModule._is_gitignored(gitignore_spec, rel_path, is_directory=True):
                     dirnames.remove(dirname)
                     continue
                 if dir_path.is_symlink():
@@ -1173,6 +1341,12 @@ class FilesystemModule(BaseModule):
                 rel_path = FilesystemModule._to_workspace_relative_path(workspace_root, candidate)
                 if not include_hidden and FilesystemModule._is_hidden_relative_path(rel_path):
                     continue
+                if FilesystemModule._is_gitignored(
+                    gitignore_spec,
+                    rel_path,
+                    is_directory=candidate_kind == "directory",
+                ):
+                    continue
                 is_symlink = candidate.is_symlink()
                 if is_symlink:
                     candidate_type = "symlink"
@@ -1191,26 +1365,51 @@ class FilesystemModule(BaseModule):
                     "path": rel_path,
                     "type": candidate_type,
                 }
+                modified_at = 0.0
                 if candidate_kind == "file":
                     try:
-                        record["size"] = candidate.stat(follow_symlinks=False).st_size
+                        stat_result = candidate.stat(follow_symlinks=False)
+                        record["size"] = stat_result.st_size
+                        modified_at = stat_result.st_mtime
                     except OSError:
                         record["size"] = None
                         record["size_unavailable"] = True
-                matches.append(record)
+                else:
+                    try:
+                        modified_at = candidate.lstat().st_mtime
+                    except OSError as exc:
+                        logger.debug(
+                            "Unable to read fs.glob mtime for workspace path {}; using default sort key: {}",
+                            rel_path,
+                            exc.__class__.__name__,
+                        )
+                matches.append((record, modified_at))
 
             if walk_truncated:
                 break
 
-        matches.sort(key=lambda item: str(item.get("path") or ""))
-        limited_matches = matches[:limit]
+        if sort_by == "path":
+            matches.sort(key=lambda item: str(item[0].get("path") or ""))
+        else:
+            matches.sort(key=lambda item: (-item[1], str(item[0].get("path") or "")))
+        limited_matches = [record for record, _modified_at in matches[:limit]]
         remaining_count = max(0, len(matches) - len(limited_matches))
+        truncated = walk_truncated or remaining_count > 0
         return {
             "base_path": FilesystemModule._to_workspace_relative_path(workspace_root, base),
             "pattern": pattern,
             "matches": limited_matches,
-            "truncated": walk_truncated or remaining_count > 0,
+            "truncated": truncated,
             "remaining_count": remaining_count,
+            "eval": build_execution_eval_metadata(
+                tool_name="fs.glob",
+                tool_prompt_id="mcp.fs.glob.v1",
+                tool_prompt_version="2026.06.04",
+                action_family="filesystem_search",
+                result_kind="structured_filesystem_glob",
+                path_filter_used=True,
+                truncated=truncated,
+            ),
         }
 
     @staticmethod
@@ -1223,8 +1422,13 @@ class FilesystemModule(BaseModule):
         case_sensitive: bool,
         include: list[str],
         exclude: list[str],
+        glob_filter: str | None,
+        type_filter: list[str] | None,
+        output_mode: str,
         include_hidden: bool,
         follow_symlinks: bool,
+        respect_gitignore: bool,
+        multiline: bool,
         limit: int,
         max_file_bytes: int,
         max_total_bytes: int,
@@ -1233,10 +1437,11 @@ class FilesystemModule(BaseModule):
     ) -> dict[str, Any]:
         if not base.exists():
             raise FileNotFoundError(f"path not found: {base}")
-        if not base.is_dir():
-            raise NotADirectoryError(f"path is not a directory: {base}")
+        if not base.is_dir() and not base.is_file():
+            raise NotADirectoryError(f"path is not a directory or file: {base}")
 
-        matches: list[dict[str, Any]] = []
+        content_matches: list[dict[str, Any]] = []
+        matched_file_counts: dict[str, int] = {}
         remaining_count = 0
         skipped = {
             "binary": 0,
@@ -1253,77 +1458,106 @@ class FilesystemModule(BaseModule):
         files_read = 0
         seen_dirs: set[Path] = {base.resolve(strict=False)}
         file_candidates: list[tuple[str, Path]] = []
+        gitignore_spec = (
+            FilesystemModule._load_gitignore_spec(workspace_root) if respect_gitignore and base.is_dir() else None
+        )
 
-        for root, dirnames, filenames in os.walk(base, topdown=True, followlinks=follow_symlinks):
-            current_root = Path(root)
-            dirnames.sort()
-            filenames.sort()
+        def _rel_path_matches_filters(rel_path: str) -> bool:
+            """Return whether a candidate path passes include, glob, type, and exclude filters."""
+            if not any(
+                FilesystemModule._portable_pattern_matches(rel_path, include_pattern, case_sensitive=True)
+                for include_pattern in include
+            ):
+                return False
+            if glob_filter and not FilesystemModule._portable_pattern_matches(
+                rel_path, glob_filter, case_sensitive=True
+            ):
+                return False
+            if type_filter and not any(
+                FilesystemModule._portable_pattern_matches(rel_path, type_pattern, case_sensitive=True)
+                for type_pattern in type_filter
+            ):
+                return False
+            return not any(
+                FilesystemModule._portable_pattern_matches(rel_path, exclude_pattern, case_sensitive=True)
+                for exclude_pattern in exclude
+            )
 
-            for dirname in list(dirnames):
-                dir_path = current_root / dirname
-                rel_path = FilesystemModule._to_workspace_relative_path(workspace_root, dir_path)
-                if not include_hidden and FilesystemModule._is_hidden_relative_path(rel_path):
-                    dirnames.remove(dirname)
-                    continue
-                if dir_path.is_symlink():
-                    resolved_dir = dir_path.resolve(strict=False)
-                    if follow_symlinks:
-                        if resolved_dir != workspace_root and workspace_root not in resolved_dir.parents:
-                            raise PermissionError("path is outside workspace scope")
-                        if resolved_dir in seen_dirs:
-                            dirnames.remove(dirname)
-                            continue
-                        seen_dirs.add(resolved_dir)
-                    else:
+        if base.is_file():
+            rel_path = FilesystemModule._to_workspace_relative_path(workspace_root, base)
+            if (
+                (include_hidden or not FilesystemModule._is_hidden_relative_path(rel_path))
+                and _rel_path_matches_filters(rel_path)
+            ):
+                file_candidates.append((rel_path, base))
+        else:
+            for root, dirnames, filenames in os.walk(base, topdown=True, followlinks=follow_symlinks):
+                current_root = Path(root)
+                dirnames.sort()
+                filenames.sort()
+
+                for dirname in list(dirnames):
+                    dir_path = current_root / dirname
+                    rel_path = FilesystemModule._to_workspace_relative_path(workspace_root, dir_path)
+                    if not include_hidden and FilesystemModule._is_hidden_relative_path(rel_path):
                         dirnames.remove(dirname)
                         continue
-                visited_entries += 1
-                if visited_entries > walk_entry_limit:
-                    walk_truncated = True
-                    dirnames.clear()
+                    if FilesystemModule._is_gitignored(gitignore_spec, rel_path, is_directory=True):
+                        dirnames.remove(dirname)
+                        continue
+                    if dir_path.is_symlink():
+                        resolved_dir = dir_path.resolve(strict=False)
+                        if follow_symlinks:
+                            if resolved_dir != workspace_root and workspace_root not in resolved_dir.parents:
+                                raise PermissionError("path is outside workspace scope")
+                            if resolved_dir in seen_dirs:
+                                dirnames.remove(dirname)
+                                continue
+                            seen_dirs.add(resolved_dir)
+                        else:
+                            dirnames.remove(dirname)
+                            continue
+                    visited_entries += 1
+                    if visited_entries > walk_entry_limit:
+                        walk_truncated = True
+                        dirnames.clear()
+                        break
+
+                if walk_truncated:
                     break
 
-            if walk_truncated:
-                break
+                for filename in filenames:
+                    visited_entries += 1
+                    if visited_entries > walk_entry_limit:
+                        walk_truncated = True
+                        dirnames.clear()
+                        break
 
-            for filename in filenames:
-                visited_entries += 1
-                if visited_entries > walk_entry_limit:
-                    walk_truncated = True
-                    dirnames.clear()
-                    break
-
-                candidate = current_root / filename
-                rel_path = FilesystemModule._to_workspace_relative_path(workspace_root, candidate)
-                if not include_hidden and FilesystemModule._is_hidden_relative_path(rel_path):
-                    continue
-                if candidate.is_symlink():
-                    if not follow_symlinks:
+                    candidate = current_root / filename
+                    rel_path = FilesystemModule._to_workspace_relative_path(workspace_root, candidate)
+                    if not include_hidden and FilesystemModule._is_hidden_relative_path(rel_path):
+                        continue
+                    if FilesystemModule._is_gitignored(gitignore_spec, rel_path, is_directory=False):
+                        continue
+                    if candidate.is_symlink():
+                        if not follow_symlinks:
+                            skipped["unsupported_type"] += 1
+                            continue
+                        resolved_file = candidate.resolve(strict=False)
+                        if resolved_file != workspace_root and workspace_root not in resolved_file.parents:
+                            raise PermissionError("path is outside workspace scope")
+                        read_target = resolved_file
+                    else:
+                        read_target = candidate
+                    if not _rel_path_matches_filters(rel_path):
+                        continue
+                    if not read_target.is_file():
                         skipped["unsupported_type"] += 1
                         continue
-                    resolved_file = candidate.resolve(strict=False)
-                    if resolved_file != workspace_root and workspace_root not in resolved_file.parents:
-                        raise PermissionError("path is outside workspace scope")
-                    read_target = resolved_file
-                else:
-                    read_target = candidate
-                if not any(
-                    FilesystemModule._portable_pattern_matches(rel_path, include_pattern, case_sensitive=True)
-                    for include_pattern in include
-                ):
-                    continue
-                if any(
-                    FilesystemModule._portable_pattern_matches(rel_path, exclude_pattern, case_sensitive=True)
-                    for exclude_pattern in exclude
-                ):
-                    continue
-                if not read_target.is_file():
-                    skipped["unsupported_type"] += 1
-                    continue
-                file_candidates.append((rel_path, read_target))
+                    file_candidates.append((rel_path, read_target))
 
-            if walk_truncated:
-                break
+                if walk_truncated:
+                    break
 
         for rel_path, read_target in sorted(file_candidates, key=lambda item: item[0]):
             try:
@@ -1362,6 +1596,18 @@ class FilesystemModule(BaseModule):
                 skipped["decode_error"] += 1
                 continue
 
+            if multiline:
+                if regex_pattern is None:
+                    continue
+                if output_mode == "files_with_matches":
+                    if regex_pattern.search(text):
+                        matched_file_counts[rel_path] = 1
+                else:
+                    match_count = sum(1 for _match in regex_pattern.finditer(text))
+                    if match_count:
+                        matched_file_counts[rel_path] = matched_file_counts.get(rel_path, 0) + match_count
+                continue
+
             for line_number, line in enumerate(text.splitlines(), start=1):
                 match_text = FilesystemModule._line_match_text(
                     line,
@@ -1372,18 +1618,34 @@ class FilesystemModule(BaseModule):
                 )
                 if match_text is None:
                     continue
-                match_record = {
-                    "path": rel_path,
-                    "line_number": line_number,
-                    "line": line,
-                    "match_text": match_text,
-                }
-                if len(matches) < limit:
-                    matches.append(match_record)
+                if output_mode == "content":
+                    match_record = {
+                        "path": rel_path,
+                        "line_number": line_number,
+                        "line": line,
+                        "match_text": match_text,
+                    }
+                    if len(content_matches) < limit:
+                        content_matches.append(match_record)
+                    else:
+                        remaining_count += 1
                 else:
-                    remaining_count += 1
+                    matched_file_counts[rel_path] = matched_file_counts.get(rel_path, 0) + 1
+                    if output_mode == "files_with_matches":
+                        break
 
-        matches.sort(key=lambda item: (str(item.get("path") or ""), int(item.get("line_number") or 0)))
+        if output_mode == "content":
+            matches = sorted(
+                content_matches,
+                key=lambda item: (str(item.get("path") or ""), int(item.get("line_number") or 0)),
+            )
+        else:
+            all_file_matches = [
+                {"path": rel_path, "count": count} if output_mode == "count" else {"path": rel_path}
+                for rel_path, count in sorted(matched_file_counts.items())
+            ]
+            matches = all_file_matches[:limit]
+            remaining_count = max(0, len(all_file_matches) - len(matches))
         truncation_reasons = []
         if walk_truncated:
             truncation_reasons.append("walk_entry_limit")
@@ -1393,14 +1655,25 @@ class FilesystemModule(BaseModule):
             truncation_reasons.append("file_budget")
         if remaining_count > 0:
             truncation_reasons.append("match_limit")
+        truncated = bool(truncation_reasons)
         return {
             "base_path": FilesystemModule._to_workspace_relative_path(workspace_root, base),
+            "output_mode": output_mode,
             "matches": matches,
-            "truncated": bool(truncation_reasons),
+            "truncated": truncated,
             "remaining_count": remaining_count,
             "remaining_count_known": not (walk_truncated or io_truncated or file_budget_truncated),
             "truncation_reasons": truncation_reasons,
             "skipped": skipped,
+            "eval": build_execution_eval_metadata(
+                tool_name="fs.grep",
+                tool_prompt_id="mcp.fs.grep.v1",
+                tool_prompt_version="2026.06.04",
+                action_family="filesystem_search",
+                result_kind="structured_filesystem_grep",
+                path_filter_used=True,
+                truncated=truncated,
+            ),
         }
 
     @staticmethod

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_module.py
@@ -304,16 +304,27 @@ def test_filesystem_validates_new_filesystem_helper_arguments() -> None:
     )
 
     mod.validate_tool_arguments("fs.stat", {"path": "docs/readme.md"})
-    mod.validate_tool_arguments("fs.glob", {"pattern": "**/*.py", "limit": 10})
+    mod.validate_tool_arguments(
+        "fs.glob",
+        {"pattern": "**/*.py", "limit": 10, "respect_gitignore": True, "sort_by": "path"},
+    )
     mod.validate_tool_arguments(
         "fs.grep",
         {
             "pattern": "TODO",
             "include": ["*.py", "**/*.md"],
             "exclude": ["**/.venv/**"],
+            "glob": "**/*.py",
+            "type": "py",
+            "output_mode": "content",
+            "respect_gitignore": True,
             "limit": 10,
             "max_file_bytes": 1024,
         },
+    )
+    mod.validate_tool_arguments(
+        "fs.grep",
+        {"pattern": "a.*b", "regex": True, "multiline": True, "output_mode": "count"},
     )
 
     invalid_cases = [
@@ -330,6 +341,8 @@ def test_filesystem_validates_new_filesystem_helper_arguments() -> None:
         ("fs.glob", {"pattern": "**/*.py", "include_directories": "yes"}, "include_directories must be a boolean"),
         ("fs.glob", {"pattern": "**/*.py", "follow_symlinks": "yes"}, "follow_symlinks must be a boolean"),
         ("fs.glob", {"pattern": "**/*.py", "case_sensitive": "yes"}, "case_sensitive must be a boolean"),
+        ("fs.glob", {"pattern": "**/*.py", "respect_gitignore": "yes"}, "respect_gitignore must be a boolean"),
+        ("fs.glob", {"pattern": "**/*.py", "sort_by": "ctime"}, "sort_by must be one of"),
         ("fs.glob", {"pattern": "**/*.py", "limit": 0}, "limit must be a positive integer"),
         ("fs.grep", {"pattern": "TODO", "unknown": True}, "unknown arguments"),
         ("fs.grep", {}, "pattern is required"),
@@ -338,10 +351,22 @@ def test_filesystem_validates_new_filesystem_helper_arguments() -> None:
         ("fs.grep", {"pattern": "TODO", "include": "*.py"}, "include must be a list of strings"),
         ("fs.grep", {"pattern": "TODO", "include": [1]}, "include must be a list of strings"),
         ("fs.grep", {"pattern": "TODO", "exclude": "*.py"}, "exclude must be a list of strings"),
+        ("fs.grep", {"pattern": "TODO", "glob": 7}, "glob must be a string"),
+        ("fs.grep", {"pattern": "TODO", "type": 7}, "type must be a string"),
+        ("fs.grep", {"pattern": "TODO", "type": "unknown"}, "unsupported grep type"),
+        ("fs.grep", {"pattern": "TODO", "output_mode": "json"}, "output_mode must be one of"),
         ("fs.grep", {"pattern": "TODO", "regex": "yes"}, "regex must be a boolean"),
         ("fs.grep", {"pattern": "TODO", "case_sensitive": "yes"}, "case_sensitive must be a boolean"),
         ("fs.grep", {"pattern": "TODO", "include_hidden": "yes"}, "include_hidden must be a boolean"),
         ("fs.grep", {"pattern": "TODO", "follow_symlinks": "yes"}, "follow_symlinks must be a boolean"),
+        ("fs.grep", {"pattern": "TODO", "respect_gitignore": "yes"}, "respect_gitignore must be a boolean"),
+        ("fs.grep", {"pattern": "TODO", "multiline": "yes"}, "multiline must be a boolean"),
+        ("fs.grep", {"pattern": "TODO", "multiline": True}, "multiline grep requires regex=true"),
+        (
+            "fs.grep",
+            {"pattern": "TODO.*done", "regex": True, "multiline": True, "output_mode": "content"},
+            "multiline grep does not support content output_mode",
+        ),
         ("fs.grep", {"pattern": "TODO", "limit": 0}, "limit must be a positive integer"),
         ("fs.grep", {"pattern": "TODO", "max_file_bytes": 0}, "max_file_bytes must be a positive integer"),
         (
@@ -1810,14 +1835,96 @@ async def test_filesystem_glob_matches_sorted_paths_and_normalizes_patterns(tmp_
         metadata={"workspace_id": "workspace-1"},
     )
 
-    result = await mod.execute_tool("fs.glob", {"pattern": "**/*.py"}, context=context)
-    backslash_result = await mod.execute_tool("fs.glob", {"pattern": r"**\*.py"}, context=context)
+    result = await mod.execute_tool("fs.glob", {"pattern": "**/*.py", "sort_by": "path"}, context=context)
+    backslash_result = await mod.execute_tool(
+        "fs.glob",
+        {"pattern": r"**\*.py", "sort_by": "path"},
+        context=context,
+    )
 
     assert [match["path"] for match in result["matches"]] == ["app.py", "pkg/app.py"]  # nosec B101
     assert [match["path"] for match in backslash_result["matches"]] == ["app.py", "pkg/app.py"]  # nosec B101
     assert result["base_path"] == "."  # nosec B101
     assert result["pattern"] == "**/*.py"  # nosec B101
     assert result["truncated"] is False  # nosec B101
+
+
+@pytest.mark.asyncio
+async def test_filesystem_glob_defaults_to_mtime_sort_with_path_sort_opt_in(tmp_path: Path) -> None:
+    """Verify fs.glob defaults to mtime sorting and can opt into path sorting."""
+    workspace_root = tmp_path / "workspace"
+    workspace_root.mkdir(parents=True, exist_ok=True)
+    old_file = workspace_root / "a-old.py"
+    new_file = workspace_root / "z-new.py"
+    old_file.write_text("old", encoding="utf-8")
+    new_file.write_text("new", encoding="utf-8")
+    os.utime(old_file, (1_700_000_000, 1_700_000_000))
+    os.utime(new_file, (1_700_000_100, 1_700_000_100))
+
+    resolver = _FakeWorkspaceRootResolver(
+        {
+            "workspace_root": str(workspace_root),
+            "workspace_id": "workspace-1",
+            "source": "sandbox_workspace_lookup",
+            "reason": None,
+        }
+    )
+    mod = FilesystemModule(ModuleConfig(name="filesystem"), workspace_root_resolver=resolver)
+    context = RequestContext(
+        request_id="req-filesystem-glob-mtime-sort",
+        user_id="7",
+        metadata={"workspace_id": "workspace-1"},
+    )
+
+    default_sorted = await mod.execute_tool("fs.glob", {"pattern": "*.py"}, context=context)
+    path_sorted = await mod.execute_tool("fs.glob", {"pattern": "*.py", "sort_by": "path"}, context=context)
+
+    assert [match["path"] for match in default_sorted["matches"]] == ["z-new.py", "a-old.py"]  # nosec B101
+    assert [match["path"] for match in path_sorted["matches"]] == ["a-old.py", "z-new.py"]  # nosec B101
+    assert default_sorted["eval"]["result_kind"] == "structured_filesystem_glob"  # nosec B101
+    assert default_sorted["eval"]["path_filter_used"] is True  # nosec B101
+
+
+@pytest.mark.asyncio
+async def test_filesystem_glob_respects_gitignore_when_requested(tmp_path: Path) -> None:
+    """Verify fs.glob applies root gitignore rules only when requested."""
+    workspace_root = tmp_path / "workspace"
+    workspace_root.mkdir(parents=True, exist_ok=True)
+    (workspace_root / ".gitignore").write_text("ignored.py\nbuild/\n", encoding="utf-8")
+    (workspace_root / "visible.py").write_text("visible", encoding="utf-8")
+    (workspace_root / "ignored.py").write_text("ignored", encoding="utf-8")
+    build_dir = workspace_root / "build"
+    build_dir.mkdir()
+    (build_dir / "generated.py").write_text("generated", encoding="utf-8")
+
+    resolver = _FakeWorkspaceRootResolver(
+        {
+            "workspace_root": str(workspace_root),
+            "workspace_id": "workspace-1",
+            "source": "sandbox_workspace_lookup",
+            "reason": None,
+        }
+    )
+    mod = FilesystemModule(ModuleConfig(name="filesystem"), workspace_root_resolver=resolver)
+    context = RequestContext(
+        request_id="req-filesystem-glob-gitignore",
+        user_id="7",
+        metadata={"workspace_id": "workspace-1"},
+    )
+
+    default_result = await mod.execute_tool("fs.glob", {"pattern": "**/*.py", "sort_by": "path"}, context=context)
+    ignored_result = await mod.execute_tool(
+        "fs.glob",
+        {"pattern": "**/*.py", "respect_gitignore": True, "sort_by": "path"},
+        context=context,
+    )
+
+    assert [match["path"] for match in default_result["matches"]] == [  # nosec B101
+        "build/generated.py",
+        "ignored.py",
+        "visible.py",
+    ]
+    assert [match["path"] for match in ignored_result["matches"]] == ["visible.py"]  # nosec B101
 
 
 @pytest.mark.asyncio
@@ -1916,20 +2023,20 @@ async def test_filesystem_glob_case_hidden_and_limit_behavior(tmp_path: Path) ->
         metadata={"workspace_id": "workspace-1"},
     )
 
-    sensitive = await mod.execute_tool("fs.glob", {"pattern": "**/*.py"}, context=context)
+    sensitive = await mod.execute_tool("fs.glob", {"pattern": "**/*.py", "sort_by": "path"}, context=context)
     insensitive = await mod.execute_tool(
         "fs.glob",
-        {"pattern": "**/*.py", "case_sensitive": False},
+        {"pattern": "**/*.py", "case_sensitive": False, "sort_by": "path"},
         context=context,
     )
     hidden = await mod.execute_tool(
         "fs.glob",
-        {"pattern": "**/*.py", "case_sensitive": False, "include_hidden": True},
+        {"pattern": "**/*.py", "case_sensitive": False, "include_hidden": True, "sort_by": "path"},
         context=context,
     )
     limited = await mod.execute_tool(
         "fs.glob",
-        {"pattern": "**/*.py", "case_sensitive": False, "include_hidden": True, "limit": 2},
+        {"pattern": "**/*.py", "case_sensitive": False, "include_hidden": True, "limit": 2, "sort_by": "path"},
         context=context,
     )
 
@@ -2076,22 +2183,22 @@ async def test_filesystem_grep_literal_regex_case_and_newlines(tmp_path: Path) -
 
     literal = await mod.execute_tool(
         "fs.grep",
-        {"pattern": "TODO", "base_path": "docs", "include": ["**/*.py"]},
+        {"pattern": "TODO", "base_path": "docs", "include": ["**/*.py"], "output_mode": "content"},
         context=context,
     )
     regex = await mod.execute_tool(
         "fs.grep",
-        {"pattern": r"TODO:\s+\w+", "base_path": "docs", "regex": True},
+        {"pattern": r"TODO:\s+\w+", "base_path": "docs", "regex": True, "output_mode": "content"},
         context=context,
     )
     insensitive = await mod.execute_tool(
         "fs.grep",
-        {"pattern": "error", "base_path": "docs", "case_sensitive": False},
+        {"pattern": "error", "base_path": "docs", "case_sensitive": False, "output_mode": "content"},
         context=context,
     )
     newline = await mod.execute_tool(
         "fs.grep",
-        {"pattern": "third", "base_path": "docs"},
+        {"pattern": "third", "base_path": "docs", "output_mode": "content"},
         context=context,
     )
 
@@ -2107,6 +2214,228 @@ async def test_filesystem_grep_literal_regex_case_and_newlines(tmp_path: Path) -
     assert insensitive["matches"][0]["match_text"] == "Error"  # nosec B101
     assert newline["matches"][0]["line_number"] == 3  # nosec B101
     assert newline["matches"][0]["line"] == "third"  # nosec B101
+
+
+@pytest.mark.asyncio
+async def test_filesystem_grep_output_modes_glob_type_and_direct_file_base(tmp_path: Path) -> None:
+    """Verify fs.grep output modes, glob/type filters, and direct-file searches."""
+    workspace_root = tmp_path / "workspace"
+    src_dir = workspace_root / "src"
+    docs_dir = workspace_root / "docs"
+    src_dir.mkdir(parents=True, exist_ok=True)
+    docs_dir.mkdir(parents=True, exist_ok=True)
+    (src_dir / "app.py").write_text("TODO app\nTODO second\n", encoding="utf-8")
+    (src_dir / "app.ts").write_text("TODO ts\n", encoding="utf-8")
+    (src_dir / "notes.md").write_text("TODO notes\n", encoding="utf-8")
+    (docs_dir / "guide.py").write_text("TODO docs\n", encoding="utf-8")
+
+    resolver = _FakeWorkspaceRootResolver(
+        {
+            "workspace_root": str(workspace_root),
+            "workspace_id": "workspace-1",
+            "source": "sandbox_workspace_lookup",
+            "reason": None,
+        }
+    )
+    mod = FilesystemModule(ModuleConfig(name="filesystem"), workspace_root_resolver=resolver)
+    context = RequestContext(
+        request_id="req-filesystem-grep-output-modes",
+        user_id="7",
+        metadata={"workspace_id": "workspace-1"},
+    )
+
+    default_mode = await mod.execute_tool("fs.grep", {"pattern": "TODO", "base_path": "src"}, context=context)
+    content_mode = await mod.execute_tool(
+        "fs.grep",
+        {"pattern": "TODO", "base_path": "src", "output_mode": "content", "glob": "**/*.py"},
+        context=context,
+    )
+    count_mode = await mod.execute_tool(
+        "fs.grep",
+        {"pattern": "TODO", "base_path": "src", "output_mode": "count", "type": "py"},
+        context=context,
+    )
+    direct_file = await mod.execute_tool(
+        "fs.grep",
+        {"pattern": "TODO", "base_path": "src/app.py", "output_mode": "count"},
+        context=context,
+    )
+
+    assert default_mode["output_mode"] == "files_with_matches"  # nosec B101
+    assert default_mode["eval"]["result_kind"] == "structured_filesystem_grep"  # nosec B101
+    assert default_mode["eval"]["path_filter_used"] is True  # nosec B101
+    assert default_mode["matches"] == [  # nosec B101
+        {"path": "src/app.py"},
+        {"path": "src/app.ts"},
+        {"path": "src/notes.md"},
+    ]
+    assert content_mode["output_mode"] == "content"  # nosec B101
+    assert [match["path"] for match in content_mode["matches"]] == ["src/app.py", "src/app.py"]  # nosec B101
+    assert all("line" in match and "line_number" in match for match in content_mode["matches"])  # nosec B101
+    assert count_mode["output_mode"] == "count"  # nosec B101
+    assert count_mode["matches"] == [{"path": "src/app.py", "count": 2}]  # nosec B101
+    assert direct_file["matches"] == [{"path": "src/app.py", "count": 2}]  # nosec B101
+
+
+@pytest.mark.asyncio
+async def test_filesystem_grep_respects_gitignore_but_allows_direct_file_base(tmp_path: Path) -> None:
+    """Verify directory grep respects gitignore while direct-file grep bypasses it."""
+    workspace_root = tmp_path / "workspace"
+    workspace_root.mkdir(parents=True, exist_ok=True)
+    (workspace_root / ".gitignore").write_text("ignored.py\n", encoding="utf-8")
+    (workspace_root / "visible.py").write_text("TODO visible\n", encoding="utf-8")
+    (workspace_root / "ignored.py").write_text("TODO ignored\n", encoding="utf-8")
+
+    resolver = _FakeWorkspaceRootResolver(
+        {
+            "workspace_root": str(workspace_root),
+            "workspace_id": "workspace-1",
+            "source": "sandbox_workspace_lookup",
+            "reason": None,
+        }
+    )
+    mod = FilesystemModule(ModuleConfig(name="filesystem"), workspace_root_resolver=resolver)
+    context = RequestContext(
+        request_id="req-filesystem-grep-gitignore",
+        user_id="7",
+        metadata={"workspace_id": "workspace-1"},
+    )
+
+    default_result = await mod.execute_tool("fs.grep", {"pattern": "TODO"}, context=context)
+    include_ignored = await mod.execute_tool(
+        "fs.grep",
+        {"pattern": "TODO", "respect_gitignore": False},
+        context=context,
+    )
+    direct_ignored = await mod.execute_tool(
+        "fs.grep",
+        {"pattern": "TODO", "base_path": "ignored.py", "output_mode": "count"},
+        context=context,
+    )
+
+    assert default_result["matches"] == [{"path": "visible.py"}]  # nosec B101
+    assert include_ignored["matches"] == [{"path": "ignored.py"}, {"path": "visible.py"}]  # nosec B101
+    assert direct_ignored["matches"] == [{"path": "ignored.py", "count": 1}]  # nosec B101
+
+
+@pytest.mark.asyncio
+async def test_filesystem_grep_handles_malformed_gitignore_and_direct_file_bypass(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verify malformed gitignore content cannot break grep or direct-file search."""
+    workspace_root = tmp_path / "workspace"
+    workspace_root.mkdir(parents=True, exist_ok=True)
+    (workspace_root / ".gitignore").write_bytes(b"\xff\n")
+    (workspace_root / "visible.py").write_text("TODO visible\n", encoding="utf-8")
+
+    resolver = _FakeWorkspaceRootResolver(
+        {
+            "workspace_root": str(workspace_root),
+            "workspace_id": "workspace-1",
+            "source": "sandbox_workspace_lookup",
+            "reason": None,
+        }
+    )
+    mod = FilesystemModule(ModuleConfig(name="filesystem"), workspace_root_resolver=resolver)
+    context = RequestContext(
+        request_id="req-filesystem-grep-malformed-gitignore",
+        user_id="7",
+        metadata={"workspace_id": "workspace-1"},
+    )
+
+    malformed_result = await mod.execute_tool("fs.grep", {"pattern": "TODO"}, context=context)
+
+    def _fail_load_gitignore(_workspace_root: Path) -> None:
+        """Fail if direct-file grep attempts to load workspace gitignore rules."""
+        raise AssertionError("direct-file grep should not load .gitignore")
+
+    monkeypatch.setattr(FilesystemModule, "_load_gitignore_spec", staticmethod(_fail_load_gitignore))
+    direct_file = await mod.execute_tool(
+        "fs.grep",
+        {"pattern": "TODO", "base_path": "visible.py", "output_mode": "count"},
+        context=context,
+    )
+
+    assert malformed_result["matches"] == [{"path": "visible.py"}]  # nosec B101
+    assert direct_file["matches"] == [{"path": "visible.py", "count": 1}]  # nosec B101
+
+
+@pytest.mark.asyncio
+async def test_filesystem_grep_ignores_symlinked_gitignore(tmp_path: Path) -> None:
+    """Verify symlinked workspace gitignore files are ignored for grep."""
+    workspace_root = tmp_path / "workspace"
+    workspace_root.mkdir(parents=True, exist_ok=True)
+    outside_gitignore = tmp_path / "outside.gitignore"
+    outside_gitignore.write_text("visible.py\n", encoding="utf-8")
+    try:
+        (workspace_root / ".gitignore").symlink_to(outside_gitignore)
+    except OSError as exc:
+        pytest.skip(f"symlink creation unavailable on this platform: {exc}")
+    (workspace_root / "visible.py").write_text("TODO visible\n", encoding="utf-8")
+
+    resolver = _FakeWorkspaceRootResolver(
+        {
+            "workspace_root": str(workspace_root),
+            "workspace_id": "workspace-1",
+            "source": "sandbox_workspace_lookup",
+            "reason": None,
+        }
+    )
+    mod = FilesystemModule(ModuleConfig(name="filesystem"), workspace_root_resolver=resolver)
+    context = RequestContext(
+        request_id="req-filesystem-grep-symlink-gitignore",
+        user_id="7",
+        metadata={"workspace_id": "workspace-1"},
+    )
+
+    result = await mod.execute_tool("fs.grep", {"pattern": "TODO"}, context=context)
+
+    assert result["matches"] == [{"path": "visible.py"}]  # nosec B101
+
+
+@pytest.mark.asyncio
+async def test_filesystem_grep_multiline_regex_supports_file_and_count_modes(tmp_path: Path) -> None:
+    """Verify multiline grep regex works for file and count output modes."""
+    workspace_root = tmp_path / "workspace"
+    workspace_root.mkdir(parents=True, exist_ok=True)
+    (workspace_root / "story.txt").write_text("alpha\nmiddle\nomega\n", encoding="utf-8")
+    (workspace_root / "single.txt").write_text("alpha omega\n", encoding="utf-8")
+
+    resolver = _FakeWorkspaceRootResolver(
+        {
+            "workspace_root": str(workspace_root),
+            "workspace_id": "workspace-1",
+            "source": "sandbox_workspace_lookup",
+            "reason": None,
+        }
+    )
+    mod = FilesystemModule(
+        ModuleConfig(name="filesystem", settings={"grep_allow_regex": True}),
+        workspace_root_resolver=resolver,
+    )
+    context = RequestContext(
+        request_id="req-filesystem-grep-multiline",
+        user_id="7",
+        metadata={"workspace_id": "workspace-1"},
+    )
+
+    single_line = await mod.execute_tool(
+        "fs.grep",
+        {"pattern": "alpha.*omega", "regex": True},
+        context=context,
+    )
+    multiline_count = await mod.execute_tool(
+        "fs.grep",
+        {"pattern": "alpha.*omega", "regex": True, "multiline": True, "output_mode": "count"},
+        context=context,
+    )
+
+    assert single_line["matches"] == [{"path": "single.txt"}]  # nosec B101
+    assert multiline_count["matches"] == [  # nosec B101
+        {"path": "single.txt", "count": 1},
+        {"path": "story.txt", "count": 1},
+    ]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
<h3>PR Summary by Qodo</h3>

Align MCP fs.glob/fs.grep behavior with Claude (mtime sort, modes, gitignore)
<code>✨ Enhancement</code> <code>🧪 Tests</code> <code>📝 Documentation</code> <code>⚙️ Configuration changes</code> <code>🕐 40+ Minutes</code>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>Walkthroughs</h3>

<details open>
<summary>User Description</summary>

<br/>

## Summary
- Adds Claude-style `fs.glob` mtime sorting with `sort_by=path` opt-in and optional `.gitignore` filtering.
- Adds `fs.grep` output modes, `glob`/`type` narrowing, root `.gitignore` handling, direct-file ignored-path support, and safe multiline regex support for file/count outputs.
- Adds redacted eval metadata, docs, backlog updates, and regression coverage.

## Verification
- `python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_module.py -q` => 82 passed
- `python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_run_command_module.py tldw_Server_API/app/core/MCP_unified/tests/test_command_runtime_registry.py -q` => 21 passed
- `git diff --check` => clean
- `python -m bandit -r tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_module.py -f json -o /tmp/bandit_mcp_glob_grep_parity.json` => 0 findings

## Change summary
Draft PR placeholder. Per project policy, a human-authored change summary explaining what changed and why is required before this PR is merge-ready.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Brings `fs.glob` and `fs.grep` closer to Claude Code with mtime-sorted glob results, richer grep modes/filters, and `.gitignore` support — all workspace-scoped with safe defaults. Adds redacted result `eval` metadata for both tools.

- **New Features**
  - `fs.glob`: default `sort_by: "modified_at"` (opt-in `sort_by: "path"`), optional `respect_gitignore`; response shape preserved; adds redacted `eval` metadata.
  - `fs.grep`: output modes `files_with_matches` (default), `content`, `count`; filters `glob` and `type` (common aliases); directory scans respect root `.gitignore` by default (toggle via `respect_gitignore`), while direct-file `base_path` searches still work even if ignored; safe `multiline` regex for file/count modes (requires `regex: true`, not allowed with `content`); hardened `.gitignore` handling (symlinked/malformed files safely ignored); adds redacted `eval` metadata. Docs and regression tests updated.

- **Dependencies**
  - Add `pathspec>=0.12.1` for `.gitignore` (gitwildmatch) parsing.

<sup>Written for commit a9fee3771783b17b6cf6e3cf5194e8b45967f873. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2323?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

</details>

<details open>
<summary>AI Description</summary>

<br/>

<pre>
• Add mtime-sorted <b><i>fs.glob</i></b> results with <b><i>sort_by=&quot;path&quot;</i></b> and optional <b><i>.gitignore</i></b> filtering.
• Extend <b><i>fs.grep</i></b> with output modes, <b><i>glob</i></b>/<b><i>type</i></b> narrowing, <b><i>.gitignore</i></b> defaults, and safe
  multiline regex.
• Add redacted execution <b><i>eval</i></b> metadata plus docs, dependency, and regression tests.
</pre>
</details>

<details>
<summary>Diagram</summary>

<br/>

```mermaid
graph TD
  C(["MCP client"]) --> M["FilesystemModule"] --> S["Bounded scan & filters"] --> R["Structured results"]
  S --> W[("Workspace files")]
  S --> P{{"pathspec"}} --> G[".gitignore"]

  subgraph Legend
    direction LR
    _actor(["Caller"]) ~~~ _svc["Module"] ~~~ _fs[("Filesystem")] ~~~ _ext{{"Dependency"}}
  end
```

</details>




<details>
<summary>High-Level Assessment</summary>

<br/>

The following are alternative approaches to this PR:

<details>
<summary><b>1. Implement minimal .gitignore matching in-house</b></summary>

- ➕ Avoids adding a new dependency
- ➕ Could be tailored to existing portable pattern matcher
- ➖ Hard to correctly replicate gitwildmatch semantics (negation, directory rules, edge cases)
- ➖ Higher maintenance burden and risk of parity regressions

</details>

<details>
<summary><b>2. Use a dedicated grep engine (ripgrep via subprocess)</b></summary>

- ➕ Faster scanning and richer matching semantics out of the box
- ➖ Violates/noisy around the project’s “no-shell execution” safety posture
- ➖ Harder to enforce workspace-bounded traversal and read budgets consistently across platforms

</details>

**Recommendation:** The chosen approach (use `pathspec` for gitwildmatch parsing and keep scanning in-process under existing workspace/budget controls) is the best fit for Claude parity while preserving the project’s safety constraints. The main follow-up to watch is ensuring `.gitignore` semantics match expectations (especially negations) and that multiline regex remains bounded under existing byte/file limits.

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>File Changes</h3>

<details>
<summary><strong>Enhancement</strong> (1)</summary>

<blockquote>
<details>
<summary><strong>filesystem_module.py</strong> <code>Extend fs.glob/fs.grep with sorting, modes, gitignore, and eval metadata</code> <code>+310/-82</code></summary>

<br/>

>Extend fs.glob/fs.grep with sorting, modes, gitignore, and eval metadata
>
><pre>
>• Adds &#x27;fs.glob&#x27; support for &#x27;sort_by&#x27; (default mtime desc, optional path order) and opt-in &#x27;.gitignore&#x27; filtering. Extends &#x27;fs.grep&#x27; with output modes (&#x27;files_with_matches&#x27; default, &#x27;content&#x27;, &#x27;count&#x27;), &#x27;glob&#x27; and &#x27;type&#x27; narrowing, root &#x27;.gitignore&#x27; filtering by default for directory scans (toggleable), direct-file base_path support, and bounded multiline regex (regex-only; not allowed for content mode). Both tools now attach redacted scalar &#x27;eval&#x27; metadata describing result kind and truncation without exposing file contents or absolute paths.
></pre>
>
><a href='https://github.com/rmusser01/tldw_server/pull/2323/files#diff-5abf14b3a6df4be9145e0d0aa6a1a1deee94e3c9dd93685c93b743d77feefa1f'>tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_module.py</a>
<hr/>

</details>
</blockquote>

</details>

<details>
<summary><strong>Tests</strong> (1)</summary>

<blockquote>
<details>
<summary><strong>test_filesystem_module.py</strong> <code>Add regression tests for new glob/grep parity behaviors</code> <code>+259/-11</code></summary>

<br/>

>Add regression tests for new glob/grep parity behaviors
>
><pre>
>• Expands argument validation coverage and adds async tests for glob mtime sorting + path sort opt-in, optional gitignore filtering, grep output modes, glob/type narrowing, default gitignore behavior with direct-file override, and multiline regex behavior for file/count modes.
></pre>
>
><a href='https://github.com/rmusser01/tldw_server/pull/2323/files#diff-83b4b2034beff411ec804deb8d900234791729fe1926f1b26cd8c580397014aa'>tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_module.py</a>
<hr/>

</details>
</blockquote>

</details>

<details>
<summary><strong>Documentation</strong> (3)</summary>

<blockquote>
<details>
<summary><strong>2026-06-09-mcp-glob-grep-parity-implementation-plan.md</strong> <code>Add execution plan for glob/grep parity work</code> <code>+91/-0</code></summary>

<br/>

>Add execution plan for glob/grep parity work
>
><pre>
>• Introduces a tracked implementation plan outlining test-first steps, schema changes, gitignore handling, and verification commands for bringing &#x27;fs.glob&#x27;/&#x27;fs.grep&#x27; closer to Claude behavior.
></pre>
>
><a href='https://github.com/rmusser01/tldw_server/pull/2323/files#diff-b7422a94c96412eb633949d7d3b5c27b736ff4aa5ea504b1ca615b68955e5aa9'>Docs/superpowers/plans/2026-06-09-mcp-glob-grep-parity-implementation-plan.md</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>task-2280 - Bring-fs.glob-and-fs.grep-to-Claude-Code-parity.md</strong> <code>Mark parity task complete with notes and verification</code> <code>+34/-8</code></summary>

<br/>

>Mark parity task complete with notes and verification
>
><pre>
>• Sets TASK-2280 to Done and records acceptance criteria, implementation notes (new args, defaults, safety posture), and verification command outputs.
></pre>
>
><a href='https://github.com/rmusser01/tldw_server/pull/2323/files#diff-0492006391a87864d9fd1ce353277f7dd8bfada461076132324be1474fd31b51'>backlog/tasks/task-2280 - Bring-fs.glob-and-fs.grep-to-Claude-Code-parity.md</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>USER_GUIDE.md</strong> <code>Document new fs.glob/fs.grep defaults and options</code> <code>+13/-2</code></summary>

<br/>

>Document new fs.glob/fs.grep defaults and options
>
><pre>
>• Updates the user guide to describe mtime-sorted glob results, optional &#x27;.gitignore&#x27; filtering, grep output modes, glob/type narrowing, direct-file behavior, and multiline regex constraints.
></pre>
>
><a href='https://github.com/rmusser01/tldw_server/pull/2323/files#diff-65ae34b05c09212c59b7991f1aed9f001102a1cce8b801df39582bef787f5799'>mcp_unified/USER_GUIDE.md</a>
<hr/>

</details>
</blockquote>

</details>

<details>
<summary><strong>Other</strong> (1)</summary>

<blockquote>
<details>
<summary><strong>pyproject.toml</strong> <code>Add pathspec dependency for .gitignore parsing</code> <code>+1/-0</code></summary>

<br/>

>Add pathspec dependency for .gitignore parsing
>
><pre>
>• Adds &#x27;pathspec&gt;=0.12.1&#x27; to support gitwildmatch-compatible &#x27;.gitignore&#x27; evaluation in filesystem searches.
></pre>
>
><a href='https://github.com/rmusser01/tldw_server/pull/2323/files#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711'>pyproject.toml</a>
<hr/>

</details>
</blockquote>

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">


<a href="https://www.qodo.ai"><img src="https://www.qodo.ai/wp-content/uploads/2025/03/qodo-logo.svg" width="80" alt="Qodo Logo"></a>
