### PR TITLE
Add Skills beginner success actions

### DIFF
--- a/apps/packages/ui/src/components/Option/Skills/Manager.tsx
+++ b/apps/packages/ui/src/components/Option/Skills/Manager.tsx
@@ -25,7 +25,8 @@ import {
   Play,
   FileDown,
   FileText,
-  Database
+  Database,
+  Copy
 } from "lucide-react"
 import { useTranslation } from "react-i18next"
 import { useAntdNotification } from "@/hooks/useAntdNotification"
@@ -46,6 +47,35 @@ interface ImportTextFormValues {
   overwrite?: boolean
 }
 
+interface SkillsSuccessAction {
+  title: string
+  description: string
+  skillName?: string
+  testLabel?: string
+  viewLabel?: string
+}
+
+interface SeedSkillsResult {
+  count?: number
+  seeded?: unknown
+}
+
+const getResponseSkillName = (result: unknown): string | undefined => {
+  if (!result || typeof result !== "object") return undefined
+  const name = (result as { name?: unknown }).name
+  const trimmedName = typeof name === "string" ? name.trim() : ""
+  return SKILL_NAME_REGEX.test(trimmedName) ? trimmedName : undefined
+}
+
+const getSeededSkillNames = (result: SeedSkillsResult | undefined): string[] => {
+  if (!Array.isArray(result?.seeded)) return []
+  return result.seeded
+    .map((name) => (typeof name === "string" ? name.trim() : ""))
+    .filter((name): name is string => SKILL_NAME_REGEX.test(name))
+}
+
+const buildSkillInvocation = (skillName: string) => `/skill ${skillName}`
+
 export const SkillsManager: React.FC = () => {
   const { t } = useTranslation(["option", "common"])
   const queryClient = useQueryClient()
@@ -58,6 +88,8 @@ export const SkillsManager: React.FC = () => {
   const [importTextOpen, setImportTextOpen] = React.useState(false)
   const [editingSkill, setEditingSkill] = React.useState<SkillResponse | null>(null)
   const [previewSkill, setPreviewSkill] = React.useState<string | null>(null)
+  const [successAction, setSuccessAction] =
+    React.useState<SkillsSuccessAction | null>(null)
   const [importTextForm] = Form.useForm<ImportTextFormValues>()
 
   const offset = (page - 1) * pageSize
@@ -117,6 +149,7 @@ export const SkillsManager: React.FC = () => {
     mutationFn: (name: string) => tldwClient.deleteSkill(name),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["skills"] })
+      setSuccessAction(null)
       notification.success({
         message: t("option:skills.deleteSuccess", { defaultValue: "Skill deleted" })
       })
@@ -135,10 +168,22 @@ export const SkillsManager: React.FC = () => {
       content: string
       overwrite?: boolean
     }) => tldwClient.importSkill(payload),
-    onSuccess: () => {
+    onSuccess: (result, variables) => {
       queryClient.invalidateQueries({ queryKey: ["skills"] })
       setImportTextOpen(false)
       importTextForm.resetFields()
+      const skillName = getResponseSkillName(result) ?? variables.name
+      if (skillName) {
+        setSuccessAction({
+          title: t("option:skills.importSuccess", { defaultValue: "Skill imported" }),
+          description: t("option:skills.importSuccessActionDesc", {
+            defaultValue:
+              "Next, test it here or open the skill to confirm the imported details."
+          }),
+          skillName,
+          viewLabel: t("option:skills.viewSkill", { defaultValue: "View skill" })
+        })
+      }
       notification.success({
         message: t("option:skills.importSuccess", { defaultValue: "Skill imported" })
       })
@@ -153,9 +198,29 @@ export const SkillsManager: React.FC = () => {
 
   const seedBuiltinsMutation = useMutation({
     mutationFn: (overwrite: boolean = false) => tldwClient.seedSkills({ overwrite }),
-    onSuccess: (result: { count?: number } | undefined) => {
+    onSuccess: (result: SeedSkillsResult | undefined) => {
       queryClient.invalidateQueries({ queryKey: ["skills"] })
       const count = Number(result?.count ?? 0)
+      const seededSkillNames = getSeededSkillNames(result)
+      const suggestedSkillName =
+        seededSkillNames.includes("summarize") ? "summarize" : seededSkillNames[0]
+      if (suggestedSkillName) {
+        setSuccessAction({
+          title: t("option:skills.seedSuccess", {
+            defaultValue: "Built-in skills seeded"
+          }),
+          description: t("option:skills.seedSuccessActionDesc", {
+            defaultValue:
+              "Try a built-in skill now, or copy the chat invocation for later."
+          }),
+          skillName: suggestedSkillName,
+          testLabel: t("option:skills.testSpecificSkill", {
+            defaultValue: `Test ${suggestedSkillName}`,
+            skillName: suggestedSkillName
+          }),
+          viewLabel: t("option:skills.viewSkill", { defaultValue: "View skill" })
+        })
+      }
       notification.success({
         message: t("option:skills.seedSuccess", { defaultValue: "Built-in skills seeded" }),
         description: t("option:skills.seedSuccessDesc", {
@@ -173,6 +238,7 @@ export const SkillsManager: React.FC = () => {
   })
 
   const handleNew = () => {
+    setSuccessAction(null)
     setEditingSkill(null)
     setDrawerOpen(true)
   }
@@ -227,8 +293,20 @@ export const SkillsManager: React.FC = () => {
 
   const handleImportFile = async (file: File) => {
     try {
-      await tldwClient.importSkillFile(file)
+      const result = await tldwClient.importSkillFile(file)
       queryClient.invalidateQueries({ queryKey: ["skills"] })
+      const skillName = getResponseSkillName(result)
+      if (skillName) {
+        setSuccessAction({
+          title: t("option:skills.importSuccess", { defaultValue: "Skill imported" }),
+          description: t("option:skills.importSuccessActionDesc", {
+            defaultValue:
+              "Next, test it here or open the skill to confirm the imported details."
+          }),
+          skillName,
+          viewLabel: t("option:skills.viewSkill", { defaultValue: "View skill" })
+        })
+      }
       notification.success({
         message: t("option:skills.importSuccess", { defaultValue: "Skill imported" })
       })
@@ -242,6 +320,7 @@ export const SkillsManager: React.FC = () => {
   }
 
   const openImportTextModal = () => {
+    setSuccessAction(null)
     importTextForm.resetFields()
     importTextForm.setFieldsValue({ overwrite: false, content: "" })
     setImportTextOpen(true)
@@ -273,9 +352,47 @@ export const SkillsManager: React.FC = () => {
     setEditingSkill(null)
   }
 
-  const handleDrawerSaved = () => {
+  const handleDrawerSaved = (savedSkillName?: string) => {
+    const wasCreating = !editingSkill
     queryClient.invalidateQueries({ queryKey: ["skills"] })
     handleDrawerClose()
+    if (wasCreating && savedSkillName) {
+      setSuccessAction({
+        title: t("option:skills.createSuccess", { defaultValue: "Skill created" }),
+        description: t("option:skills.createSuccessActionDesc", {
+          defaultValue:
+            "Next, test it here or copy the chat invocation for a conversation."
+        }),
+        skillName: savedSkillName,
+        viewLabel: t("option:skills.viewSkill", { defaultValue: "View skill" })
+      })
+    }
+  }
+
+  const handleCopyInvocation = async (skillName: string) => {
+    try {
+      const writeText = navigator.clipboard?.writeText
+      if (!writeText) {
+        throw new Error(
+          t("option:skills.copyInvocationUnavailable", {
+            defaultValue: "Clipboard is not available in this browser context."
+          })
+        )
+      }
+      await writeText.call(navigator.clipboard, buildSkillInvocation(skillName))
+      notification.success({
+        message: t("option:skills.copyInvocationSuccess", {
+          defaultValue: "Skill invocation copied"
+        })
+      })
+    } catch (err: any) {
+      notification.error({
+        message: t("option:skills.copyInvocationError", {
+          defaultValue: "Failed to copy skill invocation"
+        }),
+        description: err?.message
+      })
+    }
   }
 
   const columns: ColumnsType<SkillSummary> = [
@@ -529,6 +646,53 @@ export const SkillsManager: React.FC = () => {
               {t("common:tryAgain", { defaultValue: "Try again" })}
             </Button>
           }
+        />
+      )}
+
+      {successAction && (
+        <Alert
+          data-testid="skills-success-actions"
+          type="success"
+          showIcon
+          title={successAction.title}
+          description={successAction.description}
+          closable
+          onClose={() => setSuccessAction(null)}
+          action={(() => {
+            const skillName = successAction.skillName
+            if (!skillName) return undefined
+            const invocation = buildSkillInvocation(skillName)
+            return (
+              <div className="flex flex-wrap items-center gap-2">
+                <Button
+                  size="small"
+                  icon={<Play size={14} />}
+                  onClick={() => setPreviewSkill(skillName)}
+                >
+                  {successAction.testLabel ??
+                    t("option:skills.testRun", { defaultValue: "Test run" })}
+                </Button>
+                <Button
+                  size="small"
+                  icon={<Pen size={14} />}
+                  onClick={() => void handleEdit(skillName)}
+                >
+                  {successAction.viewLabel ??
+                    t("option:skills.viewSkill", { defaultValue: "View skill" })}
+                </Button>
+                <Button
+                  size="small"
+                  icon={<Copy size={14} />}
+                  onClick={() => void handleCopyInvocation(skillName)}
+                >
+                  {t("option:skills.copyInvocation", {
+                    defaultValue: `Copy ${invocation}`,
+                    invocation
+                  })}
+                </Button>
+              </div>
+            )
+          })()}
         />
       )}
 

--- a/apps/packages/ui/src/components/Option/Skills/SkillDrawer.tsx
+++ b/apps/packages/ui/src/components/Option/Skills/SkillDrawer.tsx
@@ -31,7 +31,7 @@ interface SkillDrawerProps {
   open: boolean
   skill: SkillResponse | null
   onClose: () => void
-  onSaved: () => void
+  onSaved: (skillName?: string) => void
 }
 
 export const SkillDrawer: React.FC<SkillDrawerProps> = ({
@@ -153,11 +153,14 @@ export const SkillDrawer: React.FC<SkillDrawerProps> = ({
   const createMutation = useMutation({
     mutationFn: (values: SkillCreate) =>
       tldwClient.createSkill(values),
-    onSuccess: () => {
+    onSuccess: (result, values) => {
       notification.success({
         message: t("option:skills.createSuccess", { defaultValue: "Skill created" })
       })
-      onSaved()
+      const responseName = typeof result?.name === "string" ? result.name.trim() : ""
+      const savedName =
+        SKILL_NAME_REGEX.test(responseName) ? responseName : values.name
+      onSaved(savedName)
     },
     onError: (err: any) => {
       const desc =

--- a/apps/packages/ui/src/components/Option/Skills/__tests__/Manager.test.tsx
+++ b/apps/packages/ui/src/components/Option/Skills/__tests__/Manager.test.tsx
@@ -20,6 +20,7 @@ const notificationMock = vi.hoisted(() => ({
 }))
 
 const skillDrawerMock = vi.hoisted(() => vi.fn())
+const skillPreviewMock = vi.hoisted(() => vi.fn())
 
 vi.mock("@/services/tldw/TldwApiClient", () => ({
   tldwClient: tldwClientMock
@@ -45,14 +46,26 @@ vi.mock("react-i18next", () => ({
 }))
 
 vi.mock("../SkillDrawer", () => ({
-  SkillDrawer: (props: { open: boolean }) => {
+  SkillDrawer: (props: { open: boolean; onSaved: (skillName?: string) => void }) => {
     skillDrawerMock(props)
-    return props.open ? <div data-testid="skill-drawer-open">Skill drawer open</div> : null
+    return props.open ? (
+      <div data-testid="skill-drawer-open">
+        Skill drawer open
+        <button type="button" onClick={() => props.onSaved("created-skill")}>
+          Complete create
+        </button>
+      </div>
+    ) : null
   }
 }))
 
 vi.mock("../SkillPreview", () => ({
-  SkillPreview: () => null
+  SkillPreview: (props: { skillName: string | null }) => {
+    skillPreviewMock(props)
+    return props.skillName ? (
+      <div data-testid="skill-preview-open">Test run: {props.skillName}</div>
+    ) : null
+  }
 }))
 
 const makeSkill = (index: number) => ({
@@ -66,8 +79,10 @@ const makeSkill = (index: number) => ({
 
 describe("SkillsManager imports", () => {
   let queryClient: QueryClient
+  let originalClipboard: Clipboard | undefined
 
   beforeEach(() => {
+    originalClipboard = navigator.clipboard
     queryClient = new QueryClient({
       defaultOptions: {
         queries: { retry: false },
@@ -75,6 +90,12 @@ describe("SkillsManager imports", () => {
       }
     })
     vi.clearAllMocks()
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: {
+        writeText: vi.fn().mockResolvedValue(undefined)
+      }
+    })
     tldwClientMock.listSkills.mockResolvedValue({
       skills: [],
       count: 0,
@@ -85,7 +106,7 @@ describe("SkillsManager imports", () => {
     tldwClientMock.importSkill.mockResolvedValue({ name: "imported-skill" })
     tldwClientMock.importSkillFile.mockResolvedValue({ name: "imported-file-skill" })
     tldwClientMock.seedSkills.mockResolvedValue({
-      seeded: ["summarize", "code-review", "feynman-technique"],
+      seeded: [" summarize ", "code-review", "feynman-technique"],
       count: 3
     })
 
@@ -118,6 +139,14 @@ describe("SkillsManager imports", () => {
     cleanup()
     Modal.destroyAll()
     message.destroy()
+    if (originalClipboard) {
+      Object.defineProperty(navigator, "clipboard", {
+        configurable: true,
+        value: originalClipboard
+      })
+    } else {
+      Reflect.deleteProperty(navigator, "clipboard")
+    }
   })
 
   const renderManager = () =>
@@ -301,6 +330,49 @@ describe("SkillsManager imports", () => {
         overwrite: false
       })
     })
+
+    const successActions = await screen.findByTestId("skills-success-actions")
+    expect(successActions).toHaveTextContent("Skill imported")
+    fireEvent.click(within(successActions).getByRole("button", { name: "View skill" }))
+
+    await waitFor(() => {
+      expect(tldwClientMock.getSkill).toHaveBeenCalledWith("imported-skill")
+    })
+  })
+
+  it("falls back to the validated import name when the API returns an invalid name", async () => {
+    tldwClientMock.importSkill.mockResolvedValueOnce({ name: "Imported Skill" })
+
+    renderManager()
+
+    await waitFor(() => {
+      expect(tldwClientMock.listSkills).toHaveBeenCalled()
+    })
+
+    fireEvent.click(screen.getByRole("button", { name: "Import" }))
+    fireEvent.click(await screen.findByText("Import Text"))
+
+    const dialog = await screen.findByRole("dialog", {
+      name: "Import Skill from Text"
+    })
+
+    fireEvent.change(within(dialog).getByLabelText("Name"), {
+      target: { value: "fallback-skill" }
+    })
+    fireEvent.change(within(dialog).getByLabelText("SKILL.md Content"), {
+      target: {
+        value: "---\nname: fallback-skill\ndescription: imported\n---\n\nBody"
+      }
+    })
+
+    fireEvent.click(within(dialog).getByRole("button", { name: "Import" }))
+
+    const successActions = await screen.findByTestId("skills-success-actions")
+    fireEvent.click(within(successActions).getByRole("button", { name: "View skill" }))
+
+    await waitFor(() => {
+      expect(tldwClientMock.getSkill).toHaveBeenCalledWith("fallback-skill")
+    })
   })
 
   it("keeps file import flow functional via importSkillFile", async () => {
@@ -336,6 +408,17 @@ describe("SkillsManager imports", () => {
     await waitFor(() => {
       expect(tldwClientMock.seedSkills).toHaveBeenCalledWith({ overwrite: false })
     })
+
+    const successActions = await screen.findByTestId("skills-success-actions")
+    expect(successActions).toHaveTextContent("Built-in skills seeded")
+
+    fireEvent.click(within(successActions).getByRole("button", { name: "Test summarize" }))
+    expect(screen.getByTestId("skill-preview-open")).toHaveTextContent("summarize")
+
+    fireEvent.click(within(successActions).getByRole("button", { name: "Copy /skill summarize" }))
+    await waitFor(() => {
+      expect(navigator.clipboard.writeText).toHaveBeenCalledWith("/skill summarize")
+    })
   })
 
   it("seeds built-in skills with overwrite via seedSkills action", async () => {
@@ -350,6 +433,33 @@ describe("SkillsManager imports", () => {
 
     await waitFor(() => {
       expect(tldwClientMock.seedSkills).toHaveBeenCalledWith({ overwrite: true })
+    })
+  })
+
+  it("offers test-run and copy-invocation actions after creating a skill", async () => {
+    renderManager()
+
+    await waitFor(() => {
+      expect(tldwClientMock.listSkills).toHaveBeenCalled()
+    })
+
+    fireEvent.click(screen.getByRole("button", { name: "New Skill" }))
+    fireEvent.click(await screen.findByRole("button", { name: "Complete create" }))
+
+    const successActions = await screen.findByTestId("skills-success-actions")
+    expect(successActions).toHaveTextContent("Skill created")
+
+    fireEvent.click(within(successActions).getByRole("button", { name: "Test run" }))
+    expect(screen.getByTestId("skill-preview-open")).toHaveTextContent("created-skill")
+
+    fireEvent.click(
+      within(successActions).getByRole("button", {
+        name: "Copy /skill created-skill"
+      })
+    )
+
+    await waitFor(() => {
+      expect(navigator.clipboard.writeText).toHaveBeenCalledWith("/skill created-skill")
     })
   })
 })

--- a/apps/packages/ui/src/components/Option/Skills/__tests__/SkillDrawer.test.tsx
+++ b/apps/packages/ui/src/components/Option/Skills/__tests__/SkillDrawer.test.tsx
@@ -1,6 +1,6 @@
 import React from "react"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
-import { act, cleanup, fireEvent, render, screen } from "@testing-library/react"
+import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react"
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import { Modal } from "antd"
 import { SkillDrawer } from "../SkillDrawer"
@@ -38,7 +38,9 @@ vi.mock("react-i18next", () => ({
   })
 }))
 
-const renderDrawer = () => {
+const renderDrawer = (
+  props: Partial<React.ComponentProps<typeof SkillDrawer>> = {}
+) => {
   const queryClient = new QueryClient({
     defaultOptions: {
       queries: { retry: false },
@@ -51,8 +53,8 @@ const renderDrawer = () => {
       <SkillDrawer
         open
         skill={null}
-        onClose={vi.fn()}
-        onSaved={vi.fn()}
+        onClose={props.onClose ?? vi.fn()}
+        onSaved={props.onSaved ?? vi.fn()}
       />
     </QueryClientProvider>
   )
@@ -175,5 +177,26 @@ describe("SkillDrawer guided templates", () => {
     })
 
     expect(getContentEditor().value).toContain("Extract structured information")
+  })
+
+  it("falls back to the validated form name when the API returns an invalid created name", async () => {
+    const onSaved = vi.fn()
+    tldwClientMock.createSkill.mockResolvedValueOnce({ name: "Created Skill" })
+
+    renderDrawer({ onSaved })
+
+    fireEvent.change(screen.getByLabelText("Name"), {
+      target: { value: "created-skill" }
+    })
+    fireEvent.click(screen.getByRole("button", { name: "Save" }))
+
+    await waitFor(() => {
+      expect(tldwClientMock.createSkill).toHaveBeenCalledWith(
+        expect.objectContaining({ name: "created-skill" })
+      )
+    })
+    await waitFor(() => {
+      expect(onSaved).toHaveBeenCalledWith("created-skill")
+    })
   })
 })

--- a/apps/tldw-frontend/e2e/workflows/tier-5-specialized/skills.spec.ts
+++ b/apps/tldw-frontend/e2e/workflows/tier-5-specialized/skills.spec.ts
@@ -8,15 +8,217 @@
  *
  * Run: npx playwright test e2e/workflows/tier-5-specialized/skills.spec.ts
  */
+import type { Page, Route } from "@playwright/test"
 import {
   test,
   expect,
   skipIfServerUnavailable,
   assertNoCriticalErrors,
 } from "../../utils/fixtures"
+import { seedAuth, TEST_CONFIG } from "../../utils/helpers"
+
+const seededSkillSummary = {
+  name: "summarize",
+  description: "Summarize source material",
+  argument_hint: "[text]",
+  user_invocable: true,
+  disable_model_invocation: false,
+  context: "inline",
+}
+
+const seededSkillResponse = {
+  ...seededSkillSummary,
+  id: "skill-summarize",
+  allowed_tools: null,
+  model: null,
+  content:
+    "---\ndescription: Summarize source material\nargument-hint: \"[text]\"\ncontext: inline\n---\n\nSummarize this source: $ARGUMENTS",
+  raw_content: null,
+  supporting_files: null,
+  directory_path: "/mock/skills/summarize",
+  created_at: "2026-06-01T00:00:00Z",
+  last_modified: "2026-06-01T00:00:00Z",
+  version: 1,
+}
+
+type TldwConnectionStore = {
+  getState: () => { state: Record<string, unknown> }
+  setState: (value: { state: Record<string, unknown> }) => void
+}
+
+type TldwConnectionStoreWindow = Window & {
+  __tldw_useConnectionStore?: TldwConnectionStore
+}
+
+const fulfillJson = async (route: Route, payload: unknown, status = 200) => {
+  await route.fulfill({
+    status,
+    contentType: "application/json",
+    body: JSON.stringify(payload),
+  })
+}
+
+async function mockSkillsBeginnerApi(page: Page) {
+  let seeded = false
+
+  await page.route(/\/api\/v1\/health(?:\?.*)?$/, async (route) => {
+    await fulfillJson(route, { status: "healthy" })
+  })
+
+  await page.route(/\/openapi\.json(?:\?.*)?$/, async (route) => {
+    await fulfillJson(route, {
+      openapi: "3.0.0",
+      info: { title: "Mock tldw API", version: "test" },
+      paths: {
+        "/api/v1/skills": { get: {}, post: {} },
+        "/api/v1/skills/context": { get: {} },
+        "/api/v1/skills/seed": { post: {} },
+        "/api/v1/skills/{name}": { get: {}, put: {}, delete: {} },
+        "/api/v1/skills/{name}/execute": { post: {} },
+      },
+    })
+  })
+
+  await page.route(/\/api\/v1\/skills(?:\/)?(?:\?.*)?$/, async (route) => {
+    if (route.request().method() !== "GET") {
+      await fulfillJson(route, {}, 405)
+      return
+    }
+    const skills = seeded ? [seededSkillSummary] : []
+    await fulfillJson(route, {
+      skills,
+      count: skills.length,
+      total: skills.length,
+      limit: 10,
+      offset: 0,
+    })
+  })
+
+  await page.route(/\/api\/v1\/skills\/context(?:\/)?(?:\?.*)?$/, async (route) => {
+    await fulfillJson(route, {
+      available_skills: seeded ? [seededSkillSummary] : [],
+      context_text: seeded ? "/skill summarize [text]" : "",
+    })
+  })
+
+  await page.route(/\/api\/v1\/skills\/seed(?:\/)?(?:\?.*)?$/, async (route) => {
+    if (route.request().method() !== "POST") {
+      await fulfillJson(route, {}, 405)
+      return
+    }
+    seeded = true
+    await fulfillJson(route, { seeded: ["summarize"], count: 1 })
+  })
+
+  await page.route(/\/api\/v1\/skills\/summarize(?:\/)?(?:\?.*)?$/, async (route) => {
+    await fulfillJson(route, seededSkillResponse)
+  })
+
+  await page.route(
+    /\/api\/v1\/skills\/summarize\/execute(?:\/)?(?:\?.*)?$/,
+    async (route) => {
+      if (route.request().method() !== "POST") {
+        await fulfillJson(route, {}, 405)
+        return
+      }
+      await fulfillJson(route, {
+        skill_name: "summarize",
+        rendered_prompt: "Summarize this source: A long article about Skills UX",
+        allowed_tools: null,
+        model_override: null,
+        execution_mode: "inline",
+        fork_output: null,
+      })
+    }
+  )
+}
+
+async function forceSkillsConnectionState(page: Page) {
+  await page.waitForFunction(
+    () =>
+      typeof (window as TldwConnectionStoreWindow).__tldw_useConnectionStore
+        ?.getState === "function",
+    null,
+    { timeout: 15_000 }
+  )
+  await page.evaluate(() => {
+    const store = (window as TldwConnectionStoreWindow).__tldw_useConnectionStore
+    if (!store) throw new Error("Connection store is unavailable")
+    const prev = store.getState().state
+    const now = Date.now()
+    store.setState({
+      state: {
+        ...prev,
+        phase: "connected",
+        isConnected: true,
+        isChecking: false,
+        offlineBypass: true,
+        errorKind: "none",
+        lastError: null,
+        lastStatusCode: null,
+        lastCheckedAt: now,
+        knowledgeStatus: "ready",
+        knowledgeLastCheckedAt: now,
+        knowledgeError: null,
+        configStep: "health",
+        hasCompletedFirstRun: true,
+      },
+    })
+  })
+}
+
+test.describe("Skills beginner journey (mocked)", () => {
+  test("seeds built-ins, opens test run, and persists after refresh", async ({
+    page,
+    diagnostics,
+  }) => {
+    await mockSkillsBeginnerApi(page)
+    await seedAuth(page, {
+      serverUrl: TEST_CONFIG.serverUrl,
+      allowOffline: true,
+    })
+
+    await page.goto("/skills", { waitUntil: "domcontentloaded" })
+    await forceSkillsConnectionState(page)
+
+    await expect(
+      page.getByRole("heading", { name: "Start with a reusable skill" })
+    ).toBeVisible()
+    const emptyState = page.getByTestId("skills-empty-state")
+    await expect(emptyState).toBeVisible()
+
+    await emptyState.getByRole("button", { name: "Seed built-ins" }).click()
+
+    const successActions = page.getByTestId("skills-success-actions")
+    await expect(successActions).toContainText("Built-in skills seeded")
+    await expect(successActions.getByRole("button", { name: "Test summarize" }))
+      .toBeVisible()
+    await expect(page.getByText("Summarize source material")).toBeVisible()
+
+    await successActions.getByRole("button", { name: "Test summarize" }).click()
+    const previewDialog = page.getByRole("dialog", { name: "Preview Skill" })
+    await expect(previewDialog).toBeVisible()
+    await previewDialog
+      .getByPlaceholder("Enter test arguments...")
+      .fill("A long article about Skills UX")
+    await previewDialog.getByRole("button", { name: "Preview" }).click()
+    await expect(previewDialog.getByText("Rendered Prompt")).toBeVisible()
+    await expect(
+      previewDialog.locator("textarea").last()
+    ).toHaveValue("Summarize this source: A long article about Skills UX")
+
+    await page.reload({ waitUntil: "domcontentloaded" })
+    await forceSkillsConnectionState(page)
+    await expect(page.getByText("Summarize source material")).toBeVisible()
+    await expect(page.getByTestId("skills-empty-state")).toHaveCount(0)
+
+    await assertNoCriticalErrors(diagnostics)
+  })
+})
 
 test.describe("Skills", () => {
   test.beforeEach(async ({ authedPage, serverInfo }) => {
+    void authedPage
     skipIfServerUnavailable(serverInfo)
   })
 

--- a/backlog/tasks/task-530.3 - Implement-Skills-success-actions-and-beginner-journey.md
+++ b/backlog/tasks/task-530.3 - Implement-Skills-success-actions-and-beginner-journey.md
@@ -1,0 +1,110 @@
+---
+id: TASK-530.3
+title: Implement Skills success actions and beginner journey
+status: Done
+assignee: []
+created_date: ''
+updated_date: '2026-06-09 08:34'
+labels:
+  - skills
+  - webui
+  - ux
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/pull/2324'
+parent_task_id: TASK-530
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Continue the Skills beginner activation plan after the empty-state and guided-template PRs. Add post-create/import/seed next actions and deterministic beginner journey coverage without pulling in unrelated Skills power-user or backend work.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Create, import, and seed success paths expose useful next actions such as Test run, View skill, or Copy invocation where the current UI has enough context.
+- [x] #2 Copied chat invocation strings use the confirmed /skill <name> [args] command syntax and avoid implying unsupported commands are required.
+- [x] #3 The beginner Playwright journey is deterministic with mocked Skills API routes and covers empty state, seeding, test-run entry, and refresh persistence.
+- [x] #4 Focused Skills component tests cover the new success-action behavior without regressing create, import, seed, or template flows.
+- [x] #5 Verification results and any skips are recorded in this task.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented:
+- Added a dismissible success-action banner after create, text import, eligible file import, and built-in seeding when the API response gives enough skill context.
+- Success actions open the existing SkillPreview modal, open the saved skill for review, and copy the confirmed chat invocation syntax /skill <name>.
+- Extended SkillDrawer saved callback to pass the created skill name without changing edit behavior.
+- Added focused SkillsManager coverage for import view, seed test-run, and create test-run/copy actions.
+- Added a deterministic mocked Playwright beginner journey covering empty state, seeding, success-action test-run entry, preview execution, and refresh persistence.
+
+Verification:
+- RED: bunx vitest run src/components/Option/Skills/__tests__/Manager.test.tsx --maxWorkers=1 failed before implementation because [data-testid="skills-success-actions"] was missing after import, seed, and create.
+- PASS: bunx vitest run src/components/Option/Skills/__tests__/Manager.test.tsx --maxWorkers=1 -> 10 tests passed.
+- PASS: bunx vitest run src/components/Option/Skills/__tests__/Manager.test.tsx src/components/Option/Skills/__tests__/SkillDrawer.test.tsx src/components/Option/Skills/__tests__/SkillsWorkspace.test.tsx --maxWorkers=1 -> 3 files, 20 tests passed.
+- PASS: TLDW_WEB_CMD=bun-run-dev-webpack npx playwright test e2e/workflows/tier-5-specialized/skills.spec.ts -g Skills-beginner-journey --reporter=line -> 1 passed. Required escalation because the sandbox blocks binding the local Next dev server to port 8080.
+- PASS: ./node_modules/.bin/eslint --no-warn-ignored e2e/workflows/tier-5-specialized/skills.spec.ts -> exit 0.
+- PASS: git diff --check -> exit 0.
+- TYPECHECK BASELINE: NODE_OPTIONS=--max-old-space-size=8192 ../../tldw-frontend/node_modules/.bin/tsc -p tsconfig.json --noEmit runs but fails on existing non-Skills issues: missing OpenUI modules, Notes test prop drift, background response union typing, route-registry helper missing typescript, and voice-cloning ArrayBuffer typing.
+- BANDIT: skipped because touched implementation is frontend TypeScript and Playwright only; no Python code changed.
+
+Local environment note:
+- Ignored dependency symlinks were used for local verification only: apps/node_modules and apps/tldw-frontend/node_modules. They are ignored and not staged.
+
+PR: https://github.com/rmusser01/tldw_server/pull/2324
+
+Review follow-up on 2026-06-09:
+- Rebased branch on latest origin/dev.
+- Addressed Qodo seeded-name correctness comment by trimming seeded names and filtering to valid skill names before labels/copy actions.
+- Addressed Qodo E2E reliability comment by adding an explicit 15s timeout to the connection-store wait.
+- Addressed Gemini suggestions by guarding navigator.clipboard availability and removing success-action JSX non-null assertions.
+
+Follow-up verification:
+- PASS: bunx vitest run src/components/Option/Skills/__tests__/Manager.test.tsx --maxWorkers=1 -> 10 tests passed.
+- PASS: bunx vitest run src/components/Option/Skills/__tests__/Manager.test.tsx src/components/Option/Skills/__tests__/SkillDrawer.test.tsx src/components/Option/Skills/__tests__/SkillsWorkspace.test.tsx --maxWorkers=1 -> 3 files, 20 tests passed.
+- PASS: ./node_modules/.bin/eslint --no-warn-ignored e2e/workflows/tier-5-specialized/skills.spec.ts -> exit 0.
+- PASS: TLDW_WEB_CMD=bun-run-dev-webpack npx playwright test e2e/workflows/tier-5-specialized/skills.spec.ts -g Skills-beginner-journey --reporter=line -> 1 passed.
+- PASS: git diff --check -> exit 0.
+
+CodeRabbit follow-up on 2026-06-09:
+- Restored the mocked navigator.clipboard after each SkillsManager test to avoid cross-test leakage.
+- Validated API-returned skill names against SKILL_NAME_REGEX before using them for import/create success actions.
+- Added regression coverage for invalid API-returned names falling back to validated user-provided names.
+
+CodeRabbit follow-up verification:
+- PASS: bunx vitest run src/components/Option/Skills/__tests__/Manager.test.tsx src/components/Option/Skills/__tests__/SkillDrawer.test.tsx --maxWorkers=1 -> 2 files, 16 tests passed.
+- PASS: bunx vitest run src/components/Option/Skills/__tests__/Manager.test.tsx src/components/Option/Skills/__tests__/SkillDrawer.test.tsx src/components/Option/Skills/__tests__/SkillsWorkspace.test.tsx --maxWorkers=1 -> 3 files, 22 tests passed.
+- PASS: ./node_modules/.bin/eslint --no-warn-ignored ../packages/ui/src/components/Option/Skills/Manager.tsx ../packages/ui/src/components/Option/Skills/SkillDrawer.tsx ../packages/ui/src/components/Option/Skills/__tests__/Manager.test.tsx ../packages/ui/src/components/Option/Skills/__tests__/SkillDrawer.test.tsx -> exit 0.
+- PASS: TLDW_WEB_CMD=bun-run-dev-webpack npx playwright test e2e/workflows/tier-5-specialized/skills.spec.ts -g Skills-beginner-journey --reporter=line -> 1 passed.
+- PASS: git diff --check -> exit 0.
+
+Post-review rebase verification:
+- PASS: git rebase origin/dev -> clean.
+- PASS: bunx vitest run src/components/Option/Skills/__tests__/Manager.test.tsx -t "imports a skill from text via importSkill" --maxWorkers=1 --reporter=verbose -> 1 passed.
+- PASS: bunx vitest run src/components/Option/Skills/__tests__/Manager.test.tsx src/components/Option/Skills/__tests__/SkillDrawer.test.tsx src/components/Option/Skills/__tests__/SkillsWorkspace.test.tsx --maxWorkers=1 -> 3 files, 22 tests passed.
+- PASS: ./node_modules/.bin/eslint --no-warn-ignored ../packages/ui/src/components/Option/Skills/Manager.tsx ../packages/ui/src/components/Option/Skills/SkillDrawer.tsx ../packages/ui/src/components/Option/Skills/__tests__/Manager.test.tsx ../packages/ui/src/components/Option/Skills/__tests__/SkillDrawer.test.tsx -> exit 0.
+- PASS: TLDW_WEB_CMD=bun-run-dev-webpack npx playwright test e2e/workflows/tier-5-specialized/skills.spec.ts -g Skills-beginner-journey --reporter=line -> 1 passed.
+- PASS: git diff --check -> exit 0.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Implemented Skills success actions and deterministic beginner journey coverage for TASK-530.3. The `/skills` page now gives beginners concrete next steps after create/import/seed: test the skill, view it, or copy `/skill <name>`. Added focused Vitest coverage and a mocked Playwright journey for empty-state seeding through preview and refresh persistence. Verification is recorded above; broader UI typecheck remains blocked by existing non-Skills baseline errors.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+- [x] #7 Focused Skills Vitest tests pass.
+- [x] #8 Relevant Playwright beginner journey either passes or has a documented environment blocker.
+- [x] #9 No unrelated files, dependency artifacts, or broad refactors are included.
+<!-- DOD:END -->


### PR DESCRIPTION
<h3>PR Summary by Qodo</h3>

Add Skills success-action banner for create/import/seed + beginner e2e journey
<code>✨ Enhancement</code> <code>🧪 Tests</code> <code>📝 Documentation</code> <code>🕐 20-40 Minutes</code>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>Walkthroughs</h3>

<details open>
<summary>User Description</summary>

<br/>

## Summary
- Add a dismissible Skills success-action banner after create, text import, eligible file import, and built-in seed flows.
- Wire success actions to test run, view skill, and copy the confirmed `/skill <name>` chat invocation.
- Add focused SkillsManager coverage and a deterministic mocked beginner Playwright journey for empty state -> seed -> test run -> refresh persistence.

## Verification
- `bunx vitest run src/components/Option/Skills/__tests__/Manager.test.tsx --maxWorkers=1` -> 10 tests passed.
- `bunx vitest run src/components/Option/Skills/__tests__/Manager.test.tsx src/components/Option/Skills/__tests__/SkillDrawer.test.tsx src/components/Option/Skills/__tests__/SkillsWorkspace.test.tsx --maxWorkers=1` -> 3 files, 20 tests passed.
- `TLDW_WEB_CMD='bun run dev:webpack -- -p 8080' npx playwright test e2e/workflows/tier-5-specialized/skills.spec.ts -g "Skills beginner journey" --reporter=line` -> 1 passed.
- `./node_modules/.bin/eslint --no-warn-ignored e2e/workflows/tier-5-specialized/skills.spec.ts` -> exit 0.
- `git diff --check` -> exit 0.
- UI TypeScript check attempted with larger heap and fails on existing non-Skills baseline issues: missing OpenUI modules, Notes test prop drift, background response union typing, route-registry helper missing `typescript`, and voice-cloning ArrayBuffer typing.
- Bandit skipped: frontend TypeScript/Playwright-only change, no Python touched.

## Change summary
Human owner must replace this placeholder with the required human-written Change summary before merge, per `Docs/superpowers/AI_GENERATED_PR_CHANGE_SUMMARY_POLICY_2026_04_17.md`.

</details>

<details open>
<summary>AI Description</summary>

<br/>

<pre>
• Add a dismissible success-action banner after skill create/import/seed flows.
• Enable next-step actions: test run, view skill, and copy <b><i>/skill </i></b> invocation.
• Extend unit and Playwright coverage with a deterministic mocked beginner journey.
</pre>
</details>

<details>
<summary>Diagram</summary>

<br/>

```mermaid
graph TD
  U["User"] --> SM["SkillsManager"] --> API["tldwClient Skills API"]
  API --> SM --> SA["Success banner"] --> ACT{Actions}
  ACT --> PRE["SkillPreview modal"]
  ACT --> DR["SkillDrawer (view/edit)"]
  ACT --> CLP["Clipboard /skill <name>"]
  SM --> TST["Vitest UI tests"]
  SM --> E2E["Playwright mocked journey"]

  subgraph Legend
    direction LR
    _ui["UI component"] ~~~ _dec{"Decision"} ~~~ _ext["External/IO"]
  end
```

</details>




<details>
<summary>High-Level Assessment</summary>

<br/>

The following are alternative approaches to this PR:

<details>
<summary><b>1. Inline actions in existing toast notifications</b></summary>

- ➕ Less persistent UI state; avoids a new on-page banner region
- ➕ Actions appear closer to the success event timing
- ➖ Toasts can disappear before a beginner acts
- ➖ Harder to include multiple buttons and keep them accessible

</details>

<details>
<summary><b>2. Extract a reusable &#x27;SuccessActionsBanner&#x27; component/hook</b></summary>

- ➕ Keeps Manager.tsx smaller and easier to extend
- ➕ Centralizes parsing/formatting (skill name, invocation string, labels)
- ➖ Extra indirection for a single-page feature
- ➖ May be premature unless additional pages adopt the pattern

</details>

**Recommendation:** The PR’s approach (a dismissible, persistent banner in SkillsManager) is appropriate for beginner guidance because it stays visible through the next action and supports multiple buttons. If the pattern expands beyond SkillsManager, consider extracting the banner/action-builder into a small shared component or hook to reduce Manager.tsx growth.

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>File Changes</h3>

<details>
<summary><strong>Enhancement</strong> (2)</summary>

<blockquote>
<details>
<summary><strong>Manager.tsx</strong> <code>Add success-action banner with test/view/copy next steps</code> <code>+157/-5</code></summary>

<br/>

>Add success-action banner with test/view/copy next steps
>
><pre>
>• Introduces a success-action state and helper parsing for skill names from create/import/seed responses. Renders a dismissible success Alert with buttons to open SkillPreview, open the SkillDrawer for viewing, and copy the &#x27;/skill &lt;name&gt;&#x27; invocation to the clipboard; clears the banner on other flows (new/import/delete).
></pre>
>
><a href='https://github.com/rmusser01/tldw_server/pull/2324/files#diff-9e402bd6cb1c23737bd77d4314b743be8f20d336524f7b9f4a007086ba00fb9f'>apps/packages/ui/src/components/Option/Skills/Manager.tsx</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>SkillDrawer.tsx</strong> <code>Return created skill name via onSaved callback</code> <code>+7/-3</code></summary>

<br/>

>Return created skill name via onSaved callback
>
><pre>
>• Extends the drawer&#x27;s onSaved callback to optionally include the saved skill name. Uses API result name when available, otherwise falls back to the submitted name so callers can show contextual post-create actions.
></pre>
>
><a href='https://github.com/rmusser01/tldw_server/pull/2324/files#diff-385835898a71ed6c87ff308a1c3da9a6dace92456d4524aae15e2e73765d4414'>apps/packages/ui/src/components/Option/Skills/SkillDrawer.tsx</a>
<hr/>

</details>
</blockquote>

</details>

<details>
<summary><strong>Tests</strong> (2)</summary>

<blockquote>
<details>
<summary><strong>Manager.test.tsx</strong> <code>Add coverage for success-action banner and clipboard copy</code> <code>+62/-3</code></summary>

<br/>

>Add coverage for success-action banner and clipboard copy
>
><pre>
>• Updates mocks to support returning a created skill name and observing SkillPreview invocations. Adds assertions for import→view action, seed→test action, and create→test + copy-invocation behavior including navigator.clipboard.writeText calls.
></pre>
>
><a href='https://github.com/rmusser01/tldw_server/pull/2324/files#diff-f95e954b79f553961e59e1bb2eb532808ab0731af3fcf82f4f4af1944ad5e726'>apps/packages/ui/src/components/Option/Skills/__tests__/Manager.test.tsx</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>skills.spec.ts</strong> <code>Add deterministic mocked beginner Skills journey</code> <code>+200/-0</code></summary>

<br/>

>Add deterministic mocked beginner Skills journey
>
><pre>
>• Adds a mocked Skills API route set (health/openapi/list/context/seed/get/execute) and forces a connected state in the client store. Implements an end-to-end journey covering empty state, seeding built-ins, launching a test run, executing preview, and verifying persistence after reload.
></pre>
>
><a href='https://github.com/rmusser01/tldw_server/pull/2324/files#diff-dbe95d6b6eaaba1a7d15c3358f2bddd68672c2ace43992b112f2341a7c09c770'>apps/tldw-frontend/e2e/workflows/tier-5-specialized/skills.spec.ts</a>
<hr/>

</details>
</blockquote>

</details>

<details>
<summary><strong>Documentation</strong> (1)</summary>

<blockquote>
<details>
<summary><strong>task-530.3 - Implement-Skills-success-actions-and-beginner-journey.md</strong> <code>Record TASK-530.3 implementation notes and verification</code> <code>+73/-0</code></summary>

<br/>

>Record TASK-530.3 implementation notes and verification
>
><pre>
>• Adds a completed task record describing the success-action banner, new next-step behavior, and deterministic Playwright journey. Captures verification commands/results and documents existing baseline typecheck blockers unrelated to Skills.
></pre>
>
><a href='https://github.com/rmusser01/tldw_server/pull/2324/files#diff-1fa8bc2c977af2c33497e3025ec6f4cfc6f11bee936209be089f8501fea4fec2'>backlog/tasks/task-530.3 - Implement-Skills-success-actions-and-beginner-journey.md</a>
<hr/>

</details>
</blockquote>

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">


<a href="https://www.qodo.ai"><img src="https://www.qodo.ai/wp-content/uploads/2025/03/qodo-logo.svg" width="80" alt="Qodo Logo"></a>