### PR TITLE
Scheduled Tasks Phase 2B capability-aware frontend shell

### DIFF
--- a/Docs/superpowers/plans/2026-06-09-scheduled-tasks-phase2b-capability-aware-frontend-shell-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-06-09-scheduled-tasks-phase2b-capability-aware-frontend-shell-implementation-plan.md
@@ -2,7 +2,7 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Build the frontend-only Phase 2B.2 capability-aware shell for Watch and Ingest templates so `/scheduled-tasks` can display runtime capability, Limited availability, generated destination/notification copy, and safety messaging without promoting Watch/Ingest to Available before all gates pass.
+**Goal:** Build the frontend-only Phase 2B.2 capability-aware shell for Watch and Ingest templates so `/scheduled-tasks` can display runtime capability, Limited availability, generated source/destination/notification copy, and safety messaging without promoting Watch/Ingest to Available before all gates and an explicit creation-adapter guard pass.
 
 **Architecture:** Keep the implementation inside the existing ScheduledTasks feature folder. Add a pure capability-contract helper module that overlays capability metadata onto the existing template registry, then update the Create panel to render effective capability states and generated copy. Do not add backend calls, Watchlists creation adapters, source preview APIs, duplicate APIs, notification APIs, or Home result surfacing in this slice.
 
@@ -24,11 +24,11 @@ In scope:
 - Add a frontend capability model for Watch/Ingest template gates.
 - Add the `limited_availability` template state.
 - Keep Reminder as the only default Available template.
-- Keep Watch/Ingest default behavior non-creating. Tests may prove the pure resolver can model future all-gates availability, but the page default must not pass all gates or create Watch/Ingest tasks in this slice.
-- Generate review/destination/notification copy from capability metadata.
-- Render Limited availability, missing gate reasons, and result-only notification copy.
+- Keep Watch/Ingest default behavior non-creating. Tests may prove the pure resolver can model future all-gates availability, but only when an explicit creation adapter flag is true. The page default must not pass that adapter guard or create Watch/Ingest tasks in this slice.
+- Generate source-intent, destination, and notification copy from capability metadata.
+- Render Limited availability, missing gate reasons, source support, and result-only notification copy.
 - Add redaction-safe copy helpers for capability and preview-adjacent text.
-- Update tests so Watch/Ingest cannot appear in Available now unless all gates pass.
+- Update tests so Watch/Ingest cannot appear in Available now unless all gates and the explicit creation-adapter guard pass.
 - Preserve current Watchlists handoff behavior and exact copy that says no scheduled task was created.
 - Preserve extension route parity because the extension reuses the same component.
 
@@ -82,7 +82,7 @@ Current Phase 2A files already exist:
 - `apps/packages/ui/src/components/Option/ScheduledTasks/scheduled-task-template-capabilities.ts`
   - Pure Phase 2B frontend capability model.
   - Availability gate definitions.
-  - Result/notification copy generation.
+  - Source-intent, result, and notification copy generation.
   - Capability overlay for existing templates.
   - Redaction helpers for capability-sourced text.
 - `apps/packages/ui/src/components/Option/ScheduledTasks/__tests__/scheduled-task-template-capabilities.test.ts`
@@ -93,12 +93,12 @@ Current Phase 2A files already exist:
 - `apps/packages/ui/src/components/Option/ScheduledTasks/scheduled-task-templates.ts`
   - Add `limited_availability` to `ScheduledTaskTemplateState`.
   - Update Watch and Ingest base descriptions to avoid overpromising notifications/search/RAG.
-- Export helpers that allow filtering an effective template list, not only the static registry.
+  - Export helpers that allow filtering an effective template list, not only the static registry.
 - `apps/packages/ui/src/components/Option/ScheduledTasks/ScheduledTaskCreatePanel.tsx`
   - Accept optional `templateCapabilities` prop.
   - Resolve effective template states through the new capability helper.
   - Render Limited availability and missing gate copy.
-  - Render generated result/notification copy in selected Watch/Ingest panels.
+  - Render generated source/destination/notification copy in selected Watch/Ingest panels.
   - Keep non-Available states out of creation paths.
 - `apps/packages/ui/src/components/Option/ScheduledTasks/ScheduledTasksPage.tsx`
   - Pass the default no-contract capability map into `ScheduledTaskCreatePanel`.
@@ -107,7 +107,7 @@ Current Phase 2A files already exist:
   - Add label/filter coverage for `limited_availability`.
   - Add regression coverage that Available now excludes Limited availability.
 - `apps/packages/ui/src/components/Option/ScheduledTasks/__tests__/ScheduledTaskCreatePanel.test.tsx`
-  - Add coverage for Limited availability UI, generated copy, and no create CTA.
+  - Add coverage for Limited availability UI, generated source/destination/notification copy, no create CTA, and extension-width essentials.
 - `apps/packages/ui/src/components/Option/ScheduledTasks/__tests__/ScheduledTasksPage.test.tsx`
   - Update source-vendor empty-state copy assertions if needed.
   - Add route-level smoke that Watch/Ingest still do not create tasks.
@@ -129,11 +129,13 @@ The shell must enforce these rules:
 1. `reminder` remains `available`.
 2. `watch` and `ingest` default to `handoff_only` when no capability contract exists.
 3. `watch` and `ingest` become `limited_availability` when capability metadata exists but at least one required gate is missing.
-4. `watch` and `ingest` become `available` only when every required gate passes.
-5. `available_now` includes only effective state `available`.
-6. Limited availability must never render a create CTA or "scheduled" success copy.
-7. Generated result/notification copy must be based on capability metadata, not hardcoded promises.
-8. Phase 2B.2 product defaults must not provide all-gates capability data for Watch/Ingest because no Watchlists creation adapter exists in this slice.
+4. `watch` and `ingest` remain `limited_availability` when every required gate passes but `creationAdapterSupported !== true`.
+5. `watch` and `ingest` become `available` only when every required gate passes and `creationAdapterSupported === true`.
+6. `available_now` includes only effective state `available`.
+7. Limited availability must never render a create CTA or "scheduled" success copy.
+8. Generated source/destination/notification copy must be based on capability metadata, not hardcoded promises.
+9. Phase 2B.2 product defaults must not provide `creationAdapterSupported: true` for Watch/Ingest because no Watchlists creation adapter exists in this slice.
+10. `sourceIntent.can_create` describes source-level capability only. It must not be treated as a substitute for `creationAdapterSupported`.
 
 Required gates for Watch:
 
@@ -197,16 +199,26 @@ describe("scheduled task template capabilities", () => {
     expect(getMissingAvailabilityGates("watch", capability)).toContain("source_preview")
   })
 
-  it("allows Watch only when every Watch gate passes", () => {
+  it("keeps Watch limited when gates pass but no creation adapter is supported", () => {
     const capability = buildScheduledTaskTemplateCapability("watch", {
+      passedGates: REQUIRED_WATCH_AVAILABILITY_GATES
+    })
+
+    expect(resolveTemplateCapabilityState("watch", capability)).toBe("limited_availability")
+  })
+
+  it("allows Watch only when every Watch gate and the creation adapter guard pass", () => {
+    const capability = buildScheduledTaskTemplateCapability("watch", {
+      creationAdapterSupported: true,
       passedGates: REQUIRED_WATCH_AVAILABILITY_GATES
     })
 
     expect(resolveTemplateCapabilityState("watch", capability)).toBe("available")
   })
 
-  it("does not require notification gate for Ingest availability", () => {
+  it("does not require notification gate for Ingest availability once creation is supported", () => {
     const capability = buildScheduledTaskTemplateCapability("ingest", {
+      creationAdapterSupported: true,
       passedGates: REQUIRED_INGEST_AVAILABILITY_GATES
     })
 
@@ -281,6 +293,7 @@ export interface ScheduledTaskResultDestinationMetadata {
 export interface ScheduledTaskTemplateCapability {
   templateId: ScheduledTaskTemplateId
   passedGates: readonly ScheduledTaskAvailabilityGate[]
+  creationAdapterSupported?: boolean
   sourceIntent?: ScheduledTaskSourceIntentCapability | null
   resultDestinations?: ScheduledTaskResultDestinationMetadata | null
   reason?: string | null
@@ -347,7 +360,13 @@ export const resolveTemplateCapabilityState = (
     return null
   }
 
-  return getMissingAvailabilityGates(templateId, capability).length === 0
+  if (getMissingAvailabilityGates(templateId, capability).length > 0) {
+    return "limited_availability"
+  }
+
+  // Keep this separate from sourceIntent.can_create. That flag describes source-level
+  // support, not whether this /scheduled-tasks shell has a real creation adapter.
+  return capability.creationAdapterSupported === true
     ? "available"
     : "limited_availability"
 }
@@ -370,6 +389,7 @@ export const buildScheduledTaskTemplateCapability = (
 ): ScheduledTaskTemplateCapability => ({
   templateId,
   passedGates: [],
+  creationAdapterSupported: false,
   sourceIntent: null,
   resultDestinations: null,
   reason: null,
@@ -504,7 +524,7 @@ git add apps/packages/ui/src/components/Option/ScheduledTasks/scheduled-task-tem
 git commit -m "feat: add limited scheduled task template state"
 ```
 
-## Task 3: Generate Result And Notification Copy From Metadata
+## Task 3: Generate Source, Result, And Notification Copy From Metadata
 
 **Files:**
 
@@ -517,10 +537,32 @@ Add tests:
 
 ```ts
 import {
+  buildSourceIntentCopy,
   buildResultDestinationCopy,
   buildNotificationPolicyCopy,
   redactCapabilityPreviewText
 } from "../scheduled-task-template-capabilities"
+
+it("generates source-intent copy from source support metadata", () => {
+  expect(
+    buildSourceIntentCopy({
+      sourceFamily: "feed",
+      can_watch: true,
+      can_ingest: false,
+      can_preview: true,
+      can_notify: false,
+      can_index_search: false,
+      can_index_rag: false,
+      can_create: false,
+      reason: "Ingest setup continues in Watchlists."
+    })
+  ).toEqual([
+    "Detected source: feed.",
+    "Watch: supported.",
+    "Ingest: not supported for this source yet.",
+    "Ingest setup continues in Watchlists."
+  ])
+})
 
 it("generates destination copy from metadata", () => {
   expect(
@@ -551,6 +593,27 @@ it("redacts private-looking preview text", () => {
   expect(redactCapabilityPreviewText("https://example.com/feed?token=secret")).toBe(
     "[redacted private source]"
   )
+  expect(redactCapabilityPreviewText("https://example.com/feed#private")).toBe(
+    "[redacted private source]"
+  )
+  expect(redactCapabilityPreviewText("https://example.com/feed?api_key=secret")).toBe(
+    "[redacted private source]"
+  )
+  expect(redactCapabilityPreviewText("https://example.com/feed?access_token=secret")).toBe(
+    "[redacted private source]"
+  )
+  expect(redactCapabilityPreviewText("https://example.com/feed?client_secret=secret")).toBe(
+    "[redacted private source]"
+  )
+  expect(redactCapabilityPreviewText("Authorization: Bearer abc123")).toBe(
+    "[redacted private source]"
+  )
+  expect(redactCapabilityPreviewText("api key: sk-test-secret")).toBe(
+    "[redacted private source]"
+  )
+  expect(redactCapabilityPreviewText("Provider response: token=private-value")).toBe(
+    "[redacted private source]"
+  )
   expect(redactCapabilityPreviewText("Public release feed")).toBe("Public release feed")
 })
 ```
@@ -569,6 +632,21 @@ Expected: fail because helpers are missing.
 Use deterministic copy and avoid raw implementation details:
 
 ```ts
+export const buildSourceIntentCopy = (
+  intent: ScheduledTaskSourceIntentCapability | null | undefined
+): string[] => {
+  if (!intent) {
+    return ["Source support: configured in Watchlists."]
+  }
+
+  return [
+    `Detected source: ${intent.sourceFamily.replace(/_/g, " ")}.`,
+    intent.can_watch ? "Watch: supported." : "Watch: not supported for this source yet.",
+    intent.can_ingest ? "Ingest: supported." : "Ingest: not supported for this source yet.",
+    ...(intent.reason ? [redactCapabilityPreviewText(intent.reason)] : [])
+  ]
+}
+
 export const buildResultDestinationCopy = (
   metadata: ScheduledTaskResultDestinationMetadata | null | undefined
 ): string[] => {
@@ -598,7 +676,7 @@ export const buildNotificationPolicyCopy = (
     : "Notifications are not available for this source yet."
 ```
 
-For redaction, reuse the same sensitive URL/prose logic if it can be exported cleanly from `scheduled-task-templates.ts`. If exporting creates circular responsibility, duplicate a small private-looking pattern in this module and add tests.
+For redaction, reuse the same sensitive URL/prose logic if it can be exported cleanly from `scheduled-task-templates.ts`. If exporting creates circular responsibility, duplicate a small private-looking pattern in this module and add tests. The redaction check must catch URL fragments, query params such as `token`, `api_key`, `access_token`, `client_secret`, `key`, `secret`, `password`, and `auth`, bearer tokens, prose such as `api key:` or `client secret:`, and provider snippets such as `Provider response: token=...`. Return one generic replacement string instead of partially masking secrets in this UI.
 
 - [ ] **Step 4: Run tests**
 
@@ -639,6 +717,17 @@ it("shows Limited availability without create language when a Watch gate is miss
     passedGates: REQUIRED_WATCH_AVAILABILITY_GATES.filter(
       (gate) => gate !== "source_preview"
     ),
+    sourceIntent: {
+      sourceFamily: "feed",
+      can_watch: true,
+      can_ingest: false,
+      can_preview: false,
+      can_notify: false,
+      can_index_search: false,
+      can_index_rag: false,
+      can_create: false,
+      reason: "Ingest setup continues in Watchlists."
+    },
     resultDestinations: {
       home_supported: false,
       notifications_supported: false,
@@ -658,6 +747,10 @@ it("shows Limited availability without create language when a Watch gate is miss
 
   expect(screen.getByText("Limited availability")).toBeInTheDocument()
   expect(screen.getByText(/source preview/i)).toBeInTheDocument()
+  expect(screen.getByText("Detected source: feed.")).toBeInTheDocument()
+  expect(screen.getByText("Watch: supported.")).toBeInTheDocument()
+  expect(screen.getByText("Ingest: not supported for this source yet.")).toBeInTheDocument()
+  expect(screen.getByText("Ingest setup continues in Watchlists.")).toBeInTheDocument()
   expect(screen.getByText("Home: not yet shown.")).toBeInTheDocument()
   expect(screen.getByText("Notifications: not available for this source yet.")).toBeInTheDocument()
   expect(screen.getByText("No scheduled task has been created yet.")).toBeInTheDocument()
@@ -682,9 +775,46 @@ it("keeps Available now from showing Limited availability templates", () => {
 
   // Click Available now and assert Reminder remains while Watch is absent.
 })
+
+it("keeps capability essentials visible in an extension-width container", () => {
+  const capability = buildScheduledTaskTemplateCapability("watch", {
+    passedGates: REQUIRED_WATCH_AVAILABILITY_GATES.filter(
+      (gate) => gate !== "source_preview"
+    ),
+    sourceIntent: {
+      sourceFamily: "feed",
+      can_watch: true,
+      can_ingest: false,
+      can_preview: false,
+      can_notify: false,
+      can_index_search: false,
+      can_index_rag: false,
+      can_create: false,
+      reason: "Preview is not available for this source yet."
+    }
+  })
+
+  render(
+    <div style={{ width: 360 }}>
+      <ScheduledTaskCreatePanel
+        selectedTemplateId="watch"
+        onSelectTemplate={vi.fn()}
+        onCreateReminder={vi.fn()}
+        templateCapabilities={{ watch: capability }}
+      />
+    </div>
+  )
+
+  expect(screen.getByText("Limited availability")).toBeInTheDocument()
+  expect(screen.getByText("Detected source: feed.")).toBeInTheDocument()
+  expect(screen.getByText("Preview is not available for this source yet.")).toBeInTheDocument()
+  expect(screen.queryByRole("button", { name: /Create watch/i })).not.toBeInTheDocument()
+})
 ```
 
 Complete the second test using the existing `Segmented` labels. If Ant Design renders segmented options as labels instead of buttons, use `getByText("Available now")` and click its closest interactive parent, matching current test patterns.
+
+The extension-width test is a jsdom presence test, not a pixel-perfect layout proof. It exists to prevent hiding the essential status, detected source, reason, and action-suppression copy behind desktop-only assumptions. If the implementation later adds browser e2e for the extension route, add a visual/narrow-viewport smoke there too.
 
 - [ ] **Step 2: Run failing component tests**
 
@@ -705,6 +835,7 @@ import {
   applyScheduledTaskTemplateCapabilities,
   buildNotificationPolicyCopy,
   buildResultDestinationCopy,
+  buildSourceIntentCopy,
   getMissingAvailabilityGates
 } from "./scheduled-task-template-capabilities"
 
@@ -739,6 +870,7 @@ Update `HandoffPanel` to accept capability:
 
 ```ts
 const missingGates = getMissingAvailabilityGates(template.id, capability)
+const sourceIntentCopy = buildSourceIntentCopy(capability?.sourceIntent)
 const resultDestinationCopy = buildResultDestinationCopy(capability?.resultDestinations)
 const notificationCopy = buildNotificationPolicyCopy(capability?.resultDestinations)
 ```
@@ -747,11 +879,12 @@ Render:
 
 - `Limited availability` tag via existing state label.
 - Missing gates as human-readable lines such as `Missing: source preview`.
+- Source support copy under a heading such as `Source support`, including detected source family, Watch/Ingest support, and capability reason text after redaction.
 - Destination copy under a heading such as `Result destinations`.
 - Notification copy under a heading such as `Notifications`.
 - Existing Watchlists setup and "No scheduled task has been created yet."
 
-Do not add a Watch/Ingest create API, mutation, or success path. Keep all-gates availability coverage in pure helper tests only unless a later Watchlists creation adapter is implemented. Component/page defaults should exercise Handoff only and Limited availability states, not an artificial all-gates Available product path.
+Do not add a Watch/Ingest create API, mutation, or success path. Keep all-gates plus adapter-guard availability coverage in pure helper tests only unless a later Watchlists creation adapter is implemented. Component/page defaults should exercise Handoff only and Limited availability states, not an artificial all-gates Available product path.
 
 - [ ] **Step 5: Run component tests**
 
@@ -829,7 +962,7 @@ Pass it from `ScheduledTasksPage`:
 />
 ```
 
-Use an empty default map so Watch/Ingest remain `handoff_only` until runtime capability contracts exist.
+Use an empty default map so Watch/Ingest remain `handoff_only` until runtime capability contracts and a real creation adapter exist. Do not set `creationAdapterSupported: true` in page defaults in Phase 2B.2.
 
 - [ ] **Step 4: Update empty-state copy**
 
@@ -919,7 +1052,11 @@ Check:
 - Watch/Ingest are not created from `/scheduled-tasks`.
 - Reminder remains the only default Available template.
 - Limited availability is not included in Available now.
+- Watch/Ingest can resolve to Available only when all required gates and `creationAdapterSupported === true` pass.
+- Source-intent copy is visible in Limited availability UI when metadata is present.
 - Home/search/RAG/notification copy is generated from metadata.
+- Capability text redacts URL fragments, secret query params, bearer/prose secrets, and provider snippets.
+- Extension-width component coverage keeps status, source, reason, and action-suppression copy present.
 - No hardcoded GitHub/YouTube primary IA copy was introduced.
 - Existing Watchlists handoff copy still says no task was created.
 - No backend/service API calls were added.
@@ -960,8 +1097,9 @@ After this plan is implemented:
 
 - `/scheduled-tasks?tab=create&template=watch` can explain Watch capability status without creating a task.
 - `/scheduled-tasks?tab=create&template=ingest` can explain Ingest capability status without promising search/RAG readiness.
-- Tests prove Watch/Ingest cannot appear in Available now unless all gates pass.
+- Tests prove Watch/Ingest cannot appear in Available now unless all gates and the explicit creation-adapter guard pass.
 - Tests prove missing preview produces Limited availability.
-- Result and notification copy is generated from metadata.
+- Source-intent, result, and notification copy is generated from metadata.
+- Redaction tests cover URL fragments, secret query params, bearer/prose secrets, and provider snippets.
 - Existing Reminder creation remains unchanged.
 - Existing Watchlists UX remains unchanged.

--- a/Docs/superpowers/plans/2026-06-09-scheduled-tasks-phase2b-capability-aware-frontend-shell-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-06-09-scheduled-tasks-phase2b-capability-aware-frontend-shell-implementation-plan.md
@@ -1,0 +1,967 @@
+# Scheduled Tasks Phase 2B Capability-Aware Frontend Shell Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build the frontend-only Phase 2B.2 capability-aware shell for Watch and Ingest templates so `/scheduled-tasks` can display runtime capability, Limited availability, generated destination/notification copy, and safety messaging without promoting Watch/Ingest to Available before all gates pass.
+
+**Architecture:** Keep the implementation inside the existing ScheduledTasks feature folder. Add a pure capability-contract helper module that overlays capability metadata onto the existing template registry, then update the Create panel to render effective capability states and generated copy. Do not add backend calls, Watchlists creation adapters, source preview APIs, duplicate APIs, notification APIs, or Home result surfacing in this slice.
+
+**Tech Stack:** React, TypeScript, Ant Design, React Router search params, TanStack Query, Vitest, Testing Library, existing ScheduledTasks components, existing scheduled-tasks control-plane service.
+
+---
+
+## Source Spec
+
+- `Docs/superpowers/specs/2026-06-09-scheduled-tasks-phase2b-watch-ingest-product-contract-design.md`
+- Backlog design tasks: `TASK-2324`, `TASK-2325`
+- Planning task: `TASK-2326`
+- Current branch: `codex/scheduled-tasks-phase2b-contract`
+
+## Scope
+
+In scope:
+
+- Add a frontend capability model for Watch/Ingest template gates.
+- Add the `limited_availability` template state.
+- Keep Reminder as the only default Available template.
+- Keep Watch/Ingest default behavior non-creating. Tests may prove the pure resolver can model future all-gates availability, but the page default must not pass all gates or create Watch/Ingest tasks in this slice.
+- Generate review/destination/notification copy from capability metadata.
+- Render Limited availability, missing gate reasons, and result-only notification copy.
+- Add redaction-safe copy helpers for capability and preview-adjacent text.
+- Update tests so Watch/Ingest cannot appear in Available now unless all gates pass.
+- Preserve current Watchlists handoff behavior and exact copy that says no scheduled task was created.
+- Preserve extension route parity because the extension reuses the same component.
+
+Out of scope:
+
+- Backend endpoints for capability health, preview, duplicate detection, creation, notification policy, or result destinations.
+- Watchlists source setup or prefilled deep-link adapter.
+- Creating Watch/Ingest tasks from `/scheduled-tasks`.
+- Home automation cards.
+- Source preview tables.
+- Duplicate warning UI beyond copy/model placeholders.
+- Bulk actions, run now, dry run, saved views, export.
+- Recurring RAG or Agent Task scheduling.
+
+## Pre-Implementation Requirement
+
+Before product-code edits, create a new implementation Backlog.md task such as `Implement Scheduled Tasks Phase 2B capability-aware frontend shell`.
+
+Link that task to:
+
+- `TASK-2326`
+- `TASK-2325`
+- `TASK-2324`
+- `Docs/superpowers/plans/2026-06-09-scheduled-tasks-phase2b-capability-aware-frontend-shell-implementation-plan.md`
+- `Docs/superpowers/specs/2026-06-09-scheduled-tasks-phase2b-watch-ingest-product-contract-design.md`
+
+Record modified files, verification commands, known skips, and final summary on the implementation task. `TASK-2326` tracks this implementation plan only.
+
+## Existing Code Context
+
+Current Phase 2A files already exist:
+
+- `apps/packages/ui/src/components/Option/ScheduledTasks/scheduled-task-templates.ts`
+  - Static template registry.
+  - Current states: `available`, `handoff_only`, `needs_setup`, `managed_in_watchlists`, `planned`, `unavailable`.
+  - Watch/Ingest/Advanced are currently `handoff_only`.
+  - Reminder is the only `available` template.
+- `apps/packages/ui/src/components/Option/ScheduledTasks/ScheduledTaskCreatePanel.tsx`
+  - Renders finder, filters, template cards, Reminder editor, planned panels, handoff panels.
+  - Handoff panels already avoid task-created language.
+  - Source/setup notes already reject private-looking URL params and prose secrets.
+- `apps/packages/ui/src/components/Option/ScheduledTasks/ScheduledTasksPage.tsx`
+  - Owns Overview/Tasks/Create tabs and passes selected template into Create panel.
+  - Does not currently fetch or pass template capability data.
+- Tests already cover template registry, matcher, handoff copy, source-note sanitization, route state, and page behavior.
+
+## File Structure
+
+### New Files
+
+- `apps/packages/ui/src/components/Option/ScheduledTasks/scheduled-task-template-capabilities.ts`
+  - Pure Phase 2B frontend capability model.
+  - Availability gate definitions.
+  - Result/notification copy generation.
+  - Capability overlay for existing templates.
+  - Redaction helpers for capability-sourced text.
+- `apps/packages/ui/src/components/Option/ScheduledTasks/__tests__/scheduled-task-template-capabilities.test.ts`
+  - Unit tests for gate enforcement, Limited availability, generated copy, source-intent metadata, and redaction.
+
+### Modified Files
+
+- `apps/packages/ui/src/components/Option/ScheduledTasks/scheduled-task-templates.ts`
+  - Add `limited_availability` to `ScheduledTaskTemplateState`.
+  - Update Watch and Ingest base descriptions to avoid overpromising notifications/search/RAG.
+- Export helpers that allow filtering an effective template list, not only the static registry.
+- `apps/packages/ui/src/components/Option/ScheduledTasks/ScheduledTaskCreatePanel.tsx`
+  - Accept optional `templateCapabilities` prop.
+  - Resolve effective template states through the new capability helper.
+  - Render Limited availability and missing gate copy.
+  - Render generated result/notification copy in selected Watch/Ingest panels.
+  - Keep non-Available states out of creation paths.
+- `apps/packages/ui/src/components/Option/ScheduledTasks/ScheduledTasksPage.tsx`
+  - Pass the default no-contract capability map into `ScheduledTaskCreatePanel`.
+  - Update empty-state copy to avoid source-vendor examples and overpromising.
+- `apps/packages/ui/src/components/Option/ScheduledTasks/__tests__/scheduled-task-templates.test.ts`
+  - Add label/filter coverage for `limited_availability`.
+  - Add regression coverage that Available now excludes Limited availability.
+- `apps/packages/ui/src/components/Option/ScheduledTasks/__tests__/ScheduledTaskCreatePanel.test.tsx`
+  - Add coverage for Limited availability UI, generated copy, and no create CTA.
+- `apps/packages/ui/src/components/Option/ScheduledTasks/__tests__/ScheduledTasksPage.test.tsx`
+  - Update source-vendor empty-state copy assertions if needed.
+  - Add route-level smoke that Watch/Ingest still do not create tasks.
+
+### Files To Avoid Changing
+
+- `apps/packages/ui/src/components/Option/Watchlists/**`
+- `apps/packages/ui/src/services/watchlists*.ts`
+- `apps/packages/ui/src/services/scheduled-tasks-control-plane.ts`
+- `tldw_Server_API/**`
+- Home, RAG, ACP, Jobs, Scheduler, Notifications.
+
+If implementation discovers that one of these files must change, stop and update the plan or create a smaller follow-up task. Do not silently expand Phase 2B.2 into a backend or Watchlists adapter.
+
+## Capability Model Rules
+
+The shell must enforce these rules:
+
+1. `reminder` remains `available`.
+2. `watch` and `ingest` default to `handoff_only` when no capability contract exists.
+3. `watch` and `ingest` become `limited_availability` when capability metadata exists but at least one required gate is missing.
+4. `watch` and `ingest` become `available` only when every required gate passes.
+5. `available_now` includes only effective state `available`.
+6. Limited availability must never render a create CTA or "scheduled" success copy.
+7. Generated result/notification copy must be based on capability metadata, not hardcoded promises.
+8. Phase 2B.2 product defaults must not provide all-gates capability data for Watch/Ingest because no Watchlists creation adapter exists in this slice.
+
+Required gates for Watch:
+
+- `capability_health`
+- `source_preview`
+- `duplicate_detection`
+- `created_entity_response`
+- `task_visibility`
+- `run_result_links`
+- `failure_contract`
+- `result_destination`
+- `notification_contract`
+- `safe_source_handling`
+- `watchlists_preservation`
+
+Required gates for Ingest:
+
+- `capability_health`
+- `source_preview`
+- `duplicate_detection`
+- `created_entity_response`
+- `task_visibility`
+- `run_result_links`
+- `failure_contract`
+- `result_destination`
+- `safe_source_handling`
+- `watchlists_preservation`
+
+Do not require `notification_contract` for Ingest unless a future task explicitly adds alerting as part of the first-time Ingest path.
+
+## Task 1: Add Capability Helper Module
+
+**Files:**
+
+- Create: `apps/packages/ui/src/components/Option/ScheduledTasks/scheduled-task-template-capabilities.ts`
+- Test: `apps/packages/ui/src/components/Option/ScheduledTasks/__tests__/scheduled-task-template-capabilities.test.ts`
+
+- [ ] **Step 1: Write failing tests for gate enforcement**
+
+Add tests:
+
+```ts
+import { describe, expect, it } from "vitest"
+import {
+  REQUIRED_INGEST_AVAILABILITY_GATES,
+  REQUIRED_WATCH_AVAILABILITY_GATES,
+  buildScheduledTaskTemplateCapability,
+  getMissingAvailabilityGates,
+  resolveTemplateCapabilityState
+} from "../scheduled-task-template-capabilities"
+
+describe("scheduled task template capabilities", () => {
+  it("requires preview before Watch can be available", () => {
+    const capability = buildScheduledTaskTemplateCapability("watch", {
+      passedGates: REQUIRED_WATCH_AVAILABILITY_GATES.filter(
+        (gate) => gate !== "source_preview"
+      )
+    })
+
+    expect(resolveTemplateCapabilityState("watch", capability)).toBe("limited_availability")
+    expect(getMissingAvailabilityGates("watch", capability)).toContain("source_preview")
+  })
+
+  it("allows Watch only when every Watch gate passes", () => {
+    const capability = buildScheduledTaskTemplateCapability("watch", {
+      passedGates: REQUIRED_WATCH_AVAILABILITY_GATES
+    })
+
+    expect(resolveTemplateCapabilityState("watch", capability)).toBe("available")
+  })
+
+  it("does not require notification gate for Ingest availability", () => {
+    const capability = buildScheduledTaskTemplateCapability("ingest", {
+      passedGates: REQUIRED_INGEST_AVAILABILITY_GATES
+    })
+
+    expect(resolveTemplateCapabilityState("ingest", capability)).toBe("available")
+  })
+})
+```
+
+- [ ] **Step 2: Run the failing tests**
+
+Run:
+
+```bash
+cd apps/packages/ui
+bunx vitest run src/components/Option/ScheduledTasks/__tests__/scheduled-task-template-capabilities.test.ts --maxWorkers=1 --no-file-parallelism
+```
+
+Expected: fail because the module does not exist.
+
+- [ ] **Step 3: Implement the capability model**
+
+Create a small pure module. Use explicit string unions so future API data must map through a typed boundary.
+
+```ts
+import type {
+  ScheduledTaskTemplate,
+  ScheduledTaskTemplateId,
+  ScheduledTaskTemplateState
+} from "./scheduled-task-templates"
+
+export type ScheduledTaskAvailabilityGate =
+  | "capability_health"
+  | "source_preview"
+  | "duplicate_detection"
+  | "created_entity_response"
+  | "task_visibility"
+  | "run_result_links"
+  | "failure_contract"
+  | "result_destination"
+  | "notification_contract"
+  | "safe_source_handling"
+  | "watchlists_preservation"
+
+export type ScheduledTaskSourceFamily =
+  | "unknown"
+  | "feed"
+  | "website"
+  | "repository_issues"
+  | "video_channel"
+  | "publication"
+  | "advisory"
+
+export interface ScheduledTaskSourceIntentCapability {
+  sourceFamily: ScheduledTaskSourceFamily
+  can_watch: boolean
+  can_ingest: boolean
+  can_preview: boolean
+  can_notify: boolean
+  can_index_search: boolean
+  can_index_rag: boolean
+  can_create: boolean
+  reason?: string | null
+}
+
+export interface ScheduledTaskResultDestinationMetadata {
+  home_supported: boolean
+  notifications_supported: boolean
+  search_indexed: boolean
+  rag_scope_included: boolean
+}
+
+export interface ScheduledTaskTemplateCapability {
+  templateId: ScheduledTaskTemplateId
+  passedGates: readonly ScheduledTaskAvailabilityGate[]
+  sourceIntent?: ScheduledTaskSourceIntentCapability | null
+  resultDestinations?: ScheduledTaskResultDestinationMetadata | null
+  reason?: string | null
+}
+
+export type ScheduledTaskTemplateCapabilityMap = Partial<
+  Record<ScheduledTaskTemplateId, ScheduledTaskTemplateCapability>
+>
+
+export const REQUIRED_WATCH_AVAILABILITY_GATES = [
+  "capability_health",
+  "source_preview",
+  "duplicate_detection",
+  "created_entity_response",
+  "task_visibility",
+  "run_result_links",
+  "failure_contract",
+  "result_destination",
+  "notification_contract",
+  "safe_source_handling",
+  "watchlists_preservation"
+] as const satisfies readonly ScheduledTaskAvailabilityGate[]
+
+export const REQUIRED_INGEST_AVAILABILITY_GATES = [
+  "capability_health",
+  "source_preview",
+  "duplicate_detection",
+  "created_entity_response",
+  "task_visibility",
+  "run_result_links",
+  "failure_contract",
+  "result_destination",
+  "safe_source_handling",
+  "watchlists_preservation"
+] as const satisfies readonly ScheduledTaskAvailabilityGate[]
+
+export const getRequiredAvailabilityGates = (
+  templateId: ScheduledTaskTemplateId
+): readonly ScheduledTaskAvailabilityGate[] =>
+  templateId === "watch"
+    ? REQUIRED_WATCH_AVAILABILITY_GATES
+    : templateId === "ingest"
+      ? REQUIRED_INGEST_AVAILABILITY_GATES
+      : []
+
+export const getMissingAvailabilityGates = (
+  templateId: ScheduledTaskTemplateId,
+  capability: ScheduledTaskTemplateCapability | null | undefined
+): ScheduledTaskAvailabilityGate[] => {
+  const required = getRequiredAvailabilityGates(templateId)
+  const passed = new Set(capability?.passedGates ?? [])
+  return required.filter((gate) => !passed.has(gate))
+}
+
+export const resolveTemplateCapabilityState = (
+  templateId: ScheduledTaskTemplateId,
+  capability: ScheduledTaskTemplateCapability | null | undefined
+): ScheduledTaskTemplateState | null => {
+  if (templateId !== "watch" && templateId !== "ingest") {
+    return null
+  }
+
+  if (!capability) {
+    return null
+  }
+
+  return getMissingAvailabilityGates(templateId, capability).length === 0
+    ? "available"
+    : "limited_availability"
+}
+
+export const applyScheduledTaskTemplateCapabilities = (
+  templates: readonly ScheduledTaskTemplate[],
+  capabilities: ScheduledTaskTemplateCapabilityMap | null | undefined
+): ScheduledTaskTemplate[] =>
+  templates.map((template) => {
+    const resolvedState = resolveTemplateCapabilityState(
+      template.id,
+      capabilities?.[template.id]
+    )
+    return resolvedState ? { ...template, state: resolvedState } : template
+  })
+
+export const buildScheduledTaskTemplateCapability = (
+  templateId: ScheduledTaskTemplateId,
+  overrides: Partial<ScheduledTaskTemplateCapability> = {}
+): ScheduledTaskTemplateCapability => ({
+  templateId,
+  passedGates: [],
+  sourceIntent: null,
+  resultDestinations: null,
+  reason: null,
+  ...overrides
+})
+```
+
+- [ ] **Step 4: Run tests**
+
+Run:
+
+```bash
+cd apps/packages/ui
+bunx vitest run src/components/Option/ScheduledTasks/__tests__/scheduled-task-template-capabilities.test.ts --maxWorkers=1 --no-file-parallelism
+```
+
+Expected: pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/packages/ui/src/components/Option/ScheduledTasks/scheduled-task-template-capabilities.ts \
+  apps/packages/ui/src/components/Option/ScheduledTasks/__tests__/scheduled-task-template-capabilities.test.ts
+git commit -m "feat: add scheduled task capability model"
+```
+
+## Task 2: Add Limited Availability To Template Registry
+
+**Files:**
+
+- Modify: `apps/packages/ui/src/components/Option/ScheduledTasks/scheduled-task-templates.ts`
+- Modify: `apps/packages/ui/src/components/Option/ScheduledTasks/__tests__/scheduled-task-templates.test.ts`
+
+- [ ] **Step 1: Write failing tests for Limited availability**
+
+Add assertions:
+
+```ts
+it("labels Limited availability", () => {
+  expect(getScheduledTaskTemplateStateLabel("limited_availability")).toBe(
+    "Limited availability"
+  )
+})
+
+it("does not include Limited availability in Available now", () => {
+  const templates = [
+    { ...getScheduledTaskTemplate("watch")!, state: "limited_availability" as const }
+  ]
+  expect(filterScheduledTaskTemplates("available_now", templates)).toEqual([])
+})
+```
+
+Expected TypeScript failure before implementation because `limited_availability` is not in the union and `filterScheduledTaskTemplates` does not accept a custom list.
+
+- [ ] **Step 2: Run the failing tests**
+
+```bash
+cd apps/packages/ui
+bunx vitest run src/components/Option/ScheduledTasks/__tests__/scheduled-task-templates.test.ts --maxWorkers=1 --no-file-parallelism
+```
+
+Expected: fail.
+
+- [ ] **Step 3: Update template state type and labels**
+
+Modify `ScheduledTaskTemplateState`:
+
+```ts
+export type ScheduledTaskTemplateState =
+  | "available"
+  | "limited_availability"
+  | "handoff_only"
+  | "needs_setup"
+  | "managed_in_watchlists"
+  | "planned"
+  | "unavailable"
+```
+
+Modify descriptions:
+
+```ts
+description: "Surface new matching items and notify when supported."
+description: "Add new source content to supported library, search, or knowledge destinations."
+```
+
+Modify `filterScheduledTaskTemplates` to accept an optional template list:
+
+```ts
+export const filterScheduledTaskTemplates = (
+  filterId: ScheduledTaskTemplateFilterId,
+  templates: readonly ScheduledTaskTemplate[] = SCHEDULED_TASK_TEMPLATES
+): readonly ScheduledTaskTemplate[] => {
+  if (filterId === "all") return templates
+  if (filterId === "available_now") {
+    return templates.filter((template) => template.state === "available")
+  }
+  return templates.filter((template) => template.category === filterId)
+}
+```
+
+Modify `getScheduledTaskTemplate` to accept an optional template list:
+
+```ts
+export const getScheduledTaskTemplate = (
+  id: ScheduledTaskTemplateId | string | null | undefined,
+  templates: readonly ScheduledTaskTemplate[] = SCHEDULED_TASK_TEMPLATES
+): ScheduledTaskTemplate | null =>
+  templates.find((template) => template.id === id) ?? null
+```
+
+Add state label:
+
+```ts
+case "limited_availability":
+  return "Limited availability"
+```
+
+- [ ] **Step 4: Run tests**
+
+```bash
+cd apps/packages/ui
+bunx vitest run src/components/Option/ScheduledTasks/__tests__/scheduled-task-templates.test.ts --maxWorkers=1 --no-file-parallelism
+```
+
+Expected: pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/packages/ui/src/components/Option/ScheduledTasks/scheduled-task-templates.ts \
+  apps/packages/ui/src/components/Option/ScheduledTasks/__tests__/scheduled-task-templates.test.ts
+git commit -m "feat: add limited scheduled task template state"
+```
+
+## Task 3: Generate Result And Notification Copy From Metadata
+
+**Files:**
+
+- Modify: `apps/packages/ui/src/components/Option/ScheduledTasks/scheduled-task-template-capabilities.ts`
+- Modify: `apps/packages/ui/src/components/Option/ScheduledTasks/__tests__/scheduled-task-template-capabilities.test.ts`
+
+- [ ] **Step 1: Write failing tests for copy generation**
+
+Add tests:
+
+```ts
+import {
+  buildResultDestinationCopy,
+  buildNotificationPolicyCopy,
+  redactCapabilityPreviewText
+} from "../scheduled-task-template-capabilities"
+
+it("generates destination copy from metadata", () => {
+  expect(
+    buildResultDestinationCopy({
+      home_supported: false,
+      notifications_supported: false,
+      search_indexed: false,
+      rag_scope_included: false
+    })
+  ).toEqual([
+    "Home: not yet shown.",
+    "Notifications: not available for this source yet.",
+    "Search: content may be saved but not searchable.",
+    "RAG: not included in the selected knowledge scope."
+  ])
+})
+
+it("generates notification copy from support state", () => {
+  expect(buildNotificationPolicyCopy({ notifications_supported: false })).toBe(
+    "Notifications are not available for this source yet."
+  )
+  expect(buildNotificationPolicyCopy({ notifications_supported: true })).toBe(
+    "Notifications can open exact task, run, or result detail when supported."
+  )
+})
+
+it("redacts private-looking preview text", () => {
+  expect(redactCapabilityPreviewText("https://example.com/feed?token=secret")).toBe(
+    "[redacted private source]"
+  )
+  expect(redactCapabilityPreviewText("Public release feed")).toBe("Public release feed")
+})
+```
+
+- [ ] **Step 2: Run failing tests**
+
+```bash
+cd apps/packages/ui
+bunx vitest run src/components/Option/ScheduledTasks/__tests__/scheduled-task-template-capabilities.test.ts --maxWorkers=1 --no-file-parallelism
+```
+
+Expected: fail because helpers are missing.
+
+- [ ] **Step 3: Implement copy helpers**
+
+Use deterministic copy and avoid raw implementation details:
+
+```ts
+export const buildResultDestinationCopy = (
+  metadata: ScheduledTaskResultDestinationMetadata | null | undefined
+): string[] => {
+  if (!metadata) {
+    return ["Results destination: configured in Watchlists."]
+  }
+
+  return [
+    metadata.home_supported ? "Home: latest results will appear." : "Home: not yet shown.",
+    metadata.notifications_supported
+      ? "Notifications: available when the task policy triggers."
+      : "Notifications: not available for this source yet.",
+    metadata.search_indexed
+      ? "Search: indexed when ingest completes."
+      : "Search: content may be saved but not searchable.",
+    metadata.rag_scope_included
+      ? "RAG: included in the selected knowledge scope."
+      : "RAG: not included in the selected knowledge scope."
+  ]
+}
+
+export const buildNotificationPolicyCopy = (
+  metadata: Pick<ScheduledTaskResultDestinationMetadata, "notifications_supported"> | null | undefined
+): string =>
+  metadata?.notifications_supported
+    ? "Notifications can open exact task, run, or result detail when supported."
+    : "Notifications are not available for this source yet."
+```
+
+For redaction, reuse the same sensitive URL/prose logic if it can be exported cleanly from `scheduled-task-templates.ts`. If exporting creates circular responsibility, duplicate a small private-looking pattern in this module and add tests.
+
+- [ ] **Step 4: Run tests**
+
+```bash
+cd apps/packages/ui
+bunx vitest run src/components/Option/ScheduledTasks/__tests__/scheduled-task-template-capabilities.test.ts --maxWorkers=1 --no-file-parallelism
+```
+
+Expected: pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/packages/ui/src/components/Option/ScheduledTasks/scheduled-task-template-capabilities.ts \
+  apps/packages/ui/src/components/Option/ScheduledTasks/__tests__/scheduled-task-template-capabilities.test.ts
+git commit -m "feat: add scheduled task capability copy helpers"
+```
+
+## Task 4: Integrate Capability States Into Create Panel
+
+**Files:**
+
+- Modify: `apps/packages/ui/src/components/Option/ScheduledTasks/ScheduledTaskCreatePanel.tsx`
+- Modify: `apps/packages/ui/src/components/Option/ScheduledTasks/__tests__/ScheduledTaskCreatePanel.test.tsx`
+
+- [ ] **Step 1: Write failing component tests**
+
+Add tests:
+
+```ts
+import {
+  REQUIRED_WATCH_AVAILABILITY_GATES,
+  buildScheduledTaskTemplateCapability
+} from "../scheduled-task-template-capabilities"
+
+it("shows Limited availability without create language when a Watch gate is missing", () => {
+  const capability = buildScheduledTaskTemplateCapability("watch", {
+    passedGates: REQUIRED_WATCH_AVAILABILITY_GATES.filter(
+      (gate) => gate !== "source_preview"
+    ),
+    resultDestinations: {
+      home_supported: false,
+      notifications_supported: false,
+      search_indexed: false,
+      rag_scope_included: false
+    }
+  })
+
+  render(
+    <ScheduledTaskCreatePanel
+      selectedTemplateId="watch"
+      onSelectTemplate={vi.fn()}
+      onCreateReminder={vi.fn()}
+      templateCapabilities={{ watch: capability }}
+    />
+  )
+
+  expect(screen.getByText("Limited availability")).toBeInTheDocument()
+  expect(screen.getByText(/source preview/i)).toBeInTheDocument()
+  expect(screen.getByText("Home: not yet shown.")).toBeInTheDocument()
+  expect(screen.getByText("Notifications: not available for this source yet.")).toBeInTheDocument()
+  expect(screen.getByText("No scheduled task has been created yet.")).toBeInTheDocument()
+  expect(screen.queryByRole("button", { name: /Create watch/i })).not.toBeInTheDocument()
+})
+
+it("keeps Available now from showing Limited availability templates", () => {
+  render(
+    <ScheduledTaskCreatePanel
+      selectedTemplateId={null}
+      onSelectTemplate={vi.fn()}
+      onCreateReminder={vi.fn()}
+      templateCapabilities={{
+        watch: buildScheduledTaskTemplateCapability("watch", {
+          passedGates: REQUIRED_WATCH_AVAILABILITY_GATES.filter(
+            (gate) => gate !== "source_preview"
+          )
+        })
+      }}
+    />
+  )
+
+  // Click Available now and assert Reminder remains while Watch is absent.
+})
+```
+
+Complete the second test using the existing `Segmented` labels. If Ant Design renders segmented options as labels instead of buttons, use `getByText("Available now")` and click its closest interactive parent, matching current test patterns.
+
+- [ ] **Step 2: Run failing component tests**
+
+```bash
+cd apps/packages/ui
+bunx vitest run src/components/Option/ScheduledTasks/__tests__/ScheduledTaskCreatePanel.test.tsx --maxWorkers=1 --no-file-parallelism
+```
+
+Expected: fail because `templateCapabilities` is not accepted and Limited availability is not rendered.
+
+- [ ] **Step 3: Add capability props and effective templates**
+
+Update props:
+
+```ts
+import type { ScheduledTaskTemplateCapabilityMap } from "./scheduled-task-template-capabilities"
+import {
+  applyScheduledTaskTemplateCapabilities,
+  buildNotificationPolicyCopy,
+  buildResultDestinationCopy,
+  getMissingAvailabilityGates
+} from "./scheduled-task-template-capabilities"
+
+export interface ScheduledTaskCreatePanelProps {
+  selectedTemplateId: ScheduledTaskTemplateId | null
+  onSelectTemplate: (templateId: ScheduledTaskTemplateId | null) => void
+  onCreateReminder: (payload: CreateScheduledTaskReminderPayload) => Promise<void> | void
+  savingReminder?: boolean
+  templateCapabilities?: ScheduledTaskTemplateCapabilityMap
+}
+```
+
+Resolve templates:
+
+```ts
+const effectiveTemplates = useMemo(
+  () => applyScheduledTaskTemplateCapabilities(SCHEDULED_TASK_TEMPLATES, templateCapabilities),
+  [templateCapabilities]
+)
+const selectedTemplate = getScheduledTaskTemplate(selectedTemplateId, effectiveTemplates)
+const templates = useMemo(
+  () => filterScheduledTaskTemplates(filterId, effectiveTemplates),
+  [effectiveTemplates, filterId]
+)
+```
+
+If `getScheduledTaskTemplate` currently accepts only the static registry, update it in Task 2 or here to accept an optional template list.
+
+- [ ] **Step 4: Render capability copy in non-Reminder panels**
+
+Update `HandoffPanel` to accept capability:
+
+```ts
+const missingGates = getMissingAvailabilityGates(template.id, capability)
+const resultDestinationCopy = buildResultDestinationCopy(capability?.resultDestinations)
+const notificationCopy = buildNotificationPolicyCopy(capability?.resultDestinations)
+```
+
+Render:
+
+- `Limited availability` tag via existing state label.
+- Missing gates as human-readable lines such as `Missing: source preview`.
+- Destination copy under a heading such as `Result destinations`.
+- Notification copy under a heading such as `Notifications`.
+- Existing Watchlists setup and "No scheduled task has been created yet."
+
+Do not add a Watch/Ingest create API, mutation, or success path. Keep all-gates availability coverage in pure helper tests only unless a later Watchlists creation adapter is implemented. Component/page defaults should exercise Handoff only and Limited availability states, not an artificial all-gates Available product path.
+
+- [ ] **Step 5: Run component tests**
+
+```bash
+cd apps/packages/ui
+bunx vitest run src/components/Option/ScheduledTasks/__tests__/ScheduledTaskCreatePanel.test.tsx --maxWorkers=1 --no-file-parallelism
+```
+
+Expected: pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/packages/ui/src/components/Option/ScheduledTasks/ScheduledTaskCreatePanel.tsx \
+  apps/packages/ui/src/components/Option/ScheduledTasks/__tests__/ScheduledTaskCreatePanel.test.tsx
+git commit -m "feat: render scheduled task capability states"
+```
+
+## Task 5: Wire Default Capability Shell Into Page
+
+**Files:**
+
+- Modify: `apps/packages/ui/src/components/Option/ScheduledTasks/ScheduledTasksPage.tsx`
+- Modify: `apps/packages/ui/src/components/Option/ScheduledTasks/__tests__/ScheduledTasksPage.test.tsx`
+
+- [ ] **Step 1: Write failing page regression tests**
+
+Add or update tests:
+
+```ts
+it("does not describe planned automation through GitHub or YouTube as primary IA", async () => {
+  renderWithQueryClient(<ScheduledTasksPage />, "/scheduled-tasks?tab=tasks")
+
+  expect(await screen.findByText("No scheduled tasks yet.")).toBeInTheDocument()
+  expect(screen.queryByText(/GitHub, YouTube/i)).not.toBeInTheDocument()
+  expect(screen.getByText(/Watch and Ingest setup continue in their owner workspaces/i)).toBeInTheDocument()
+})
+
+it("keeps Watch template non-creating from the page route", async () => {
+  renderWithQueryClient(<ScheduledTasksPage />, "/scheduled-tasks?tab=create&template=watch")
+
+  expect(await screen.findByText("No scheduled task has been created yet.")).toBeInTheDocument()
+  expect(screen.queryByRole("button", { name: /Create watch/i })).not.toBeInTheDocument()
+})
+```
+
+Adjust exact copy to match the final UI text. The intent is to prevent source-vendor IA and accidental create CTA.
+
+- [ ] **Step 2: Run failing page tests**
+
+```bash
+cd apps/packages/ui
+bunx vitest run src/components/Option/ScheduledTasks/__tests__/ScheduledTasksPage.test.tsx --maxWorkers=1 --no-file-parallelism
+```
+
+Expected: fail if old empty-state copy still mentions GitHub/YouTube or page route lacks the new copy.
+
+- [ ] **Step 3: Pass default capabilities into Create panel**
+
+In the capability module, add:
+
+```ts
+export const DEFAULT_SCHEDULED_TASK_TEMPLATE_CAPABILITIES: ScheduledTaskTemplateCapabilityMap = {}
+```
+
+Pass it from `ScheduledTasksPage`:
+
+```tsx
+<ScheduledTaskCreatePanel
+  selectedTemplateId={selectedTemplateId}
+  onSelectTemplate={handleSelectTemplate}
+  onCreateReminder={handleCreateReminderFromPanel}
+  savingReminder={saving}
+  templateCapabilities={DEFAULT_SCHEDULED_TASK_TEMPLATE_CAPABILITIES}
+/>
+```
+
+Use an empty default map so Watch/Ingest remain `handoff_only` until runtime capability contracts exist.
+
+- [ ] **Step 4: Update empty-state copy**
+
+Replace source-vendor examples:
+
+```tsx
+<Typography.Text type="secondary">
+  Create a reminder now. Watch and Ingest setup continue in their owner workspaces
+  until capability, preview, duplicate, creation, and result contracts are available.
+</Typography.Text>
+```
+
+- [ ] **Step 5: Run page tests**
+
+```bash
+cd apps/packages/ui
+bunx vitest run src/components/Option/ScheduledTasks/__tests__/ScheduledTasksPage.test.tsx --maxWorkers=1 --no-file-parallelism
+```
+
+Expected: pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/packages/ui/src/components/Option/ScheduledTasks/ScheduledTasksPage.tsx \
+  apps/packages/ui/src/components/Option/ScheduledTasks/__tests__/ScheduledTasksPage.test.tsx \
+  apps/packages/ui/src/components/Option/ScheduledTasks/scheduled-task-template-capabilities.ts
+git commit -m "feat: wire scheduled task capability shell"
+```
+
+## Task 6: Focused Full Verification
+
+**Files:**
+
+- Modify: implementation Backlog task final notes.
+
+- [ ] **Step 1: Run focused unit/component tests**
+
+```bash
+cd apps/packages/ui
+bunx vitest run \
+  src/components/Option/ScheduledTasks/__tests__/scheduled-task-template-capabilities.test.ts \
+  src/components/Option/ScheduledTasks/__tests__/scheduled-task-templates.test.ts \
+  src/components/Option/ScheduledTasks/__tests__/ScheduledTaskCreatePanel.test.tsx \
+  src/components/Option/ScheduledTasks/__tests__/ScheduledTasksPage.test.tsx \
+  --maxWorkers=1 --no-file-parallelism
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 2: Run route-state regression tests**
+
+```bash
+cd apps/packages/ui
+bunx vitest run src/components/Option/ScheduledTasks/__tests__/scheduled-task-route-state.test.ts --maxWorkers=1 --no-file-parallelism
+```
+
+Expected: pass.
+
+- [ ] **Step 3: Run formatting/whitespace check**
+
+```bash
+git diff --check
+```
+
+Expected: no output, exit 0.
+
+- [ ] **Step 4: Bandit scope decision**
+
+No Python code should be touched in this implementation. Record in the implementation Backlog task:
+
+```text
+Bandit skipped: Phase 2B.2 capability-aware frontend shell touched TypeScript/frontend files only and no Python backend code.
+```
+
+If any Python file is touched unexpectedly, run Bandit on the touched Python scope before final commit:
+
+```bash
+source .venv/bin/activate
+python -m bandit -r <touched_python_paths> -f json -o /tmp/bandit_scheduled_tasks_phase2b_capability_shell.json
+```
+
+- [ ] **Step 5: Self-review the diff**
+
+Check:
+
+- Watch/Ingest are not created from `/scheduled-tasks`.
+- Reminder remains the only default Available template.
+- Limited availability is not included in Available now.
+- Home/search/RAG/notification copy is generated from metadata.
+- No hardcoded GitHub/YouTube primary IA copy was introduced.
+- Existing Watchlists handoff copy still says no task was created.
+- No backend/service API calls were added.
+
+- [ ] **Step 6: Update Backlog implementation task**
+
+Record:
+
+- Files changed.
+- Tests run and results.
+- Bandit skip rationale or Bandit output path.
+- Known skips or blockers.
+- Final summary.
+
+- [ ] **Step 7: Final commit**
+
+```bash
+git status --short
+git add apps/packages/ui/src/components/Option/ScheduledTasks \
+  backlog/tasks/<implementation-task-file>.md
+git commit -m "feat: add scheduled task capability-aware create shell"
+```
+
+Expected: one final implementation commit if prior task commits were not already made, otherwise no extra commit needed beyond Backlog task finalization.
+
+## Implementation Notes
+
+- Keep all capability logic pure and testable. Do not hide behavior inside React state if it can be a helper.
+- Prefer passing capability data into `ScheduledTaskCreatePanel` as props so future runtime API integration can replace the default empty map without rewiring the component.
+- Avoid adding a fake backend or mock fetch in product code. Tests may provide capability fixtures directly.
+- Do not expose raw gate IDs in user-facing copy. Convert `source_preview` to `source preview`.
+- Do not use "Task created", "Watch scheduled", or "Ingest scheduled" unless the implementation actually calls a create API and gets a scheduled task ID.
+- Keep Ant Design components consistent with existing ScheduledTasks code.
+
+## Expected End State
+
+After this plan is implemented:
+
+- `/scheduled-tasks?tab=create&template=watch` can explain Watch capability status without creating a task.
+- `/scheduled-tasks?tab=create&template=ingest` can explain Ingest capability status without promising search/RAG readiness.
+- Tests prove Watch/Ingest cannot appear in Available now unless all gates pass.
+- Tests prove missing preview produces Limited availability.
+- Result and notification copy is generated from metadata.
+- Existing Reminder creation remains unchanged.
+- Existing Watchlists UX remains unchanged.

--- a/Docs/superpowers/specs/2026-06-09-scheduled-tasks-phase2b-watch-ingest-product-contract-design.md
+++ b/Docs/superpowers/specs/2026-06-09-scheduled-tasks-phase2b-watch-ingest-product-contract-design.md
@@ -3,13 +3,14 @@
 Date: 2026-06-09
 Status: Ready for review
 Owner: Codex brainstorming session
-Backlog: TASK-2324
+Backlog: TASK-2324, TASK-2325
 
 Related:
 
 - `Docs/superpowers/specs/2026-06-01-scheduled-tasks-automation-workbench-prd-design.md`
 - `Docs/superpowers/specs/2026-06-08-scheduled-tasks-automation-workbench-phase2-creation-design.md`
 - `backlog/tasks/task-2324 - Design-Scheduled-Tasks-Phase-2B-Watch-Ingest-product-contract.md`
+- `backlog/tasks/task-2325 - Revise-Scheduled-Tasks-Phase-2B-Watch-Ingest-contract-after-review.md`
 
 ## Summary
 
@@ -28,14 +29,16 @@ Move Watch and Ingest templates to available only after the product can support 
 1. User chooses a source-agnostic intent.
 2. User enters a visible, editable source.
 3. System reports whether the capability is ready.
-4. System previews what will be checked or ingested.
+4. System previews what will be checked or ingested before creation.
 5. System detects likely duplicates before creation.
-6. User reviews schedule, result destination, and domain ownership.
+6. User reviews schedule, notification behavior, result destination, and domain ownership.
 7. System creates the Watchlists-backed automation and returns exact task/domain IDs.
 8. User can open the created task detail from `/scheduled-tasks`.
 9. User can inspect runs, outputs, failures, and deeper settings through exact links.
 
-If any part of this loop is missing, the template should remain Handoff only, Needs setup, or Unavailable instead of pretending creation is supported.
+If any part of this loop is missing, the template should remain Limited availability, Handoff only, Needs setup, or Unavailable instead of pretending creation is fully supported.
+
+Preview is a hard gate for the first-time Available path. A source family without preview support may expose a Limited availability state for power-user handoff or domain-owned setup, but it should not appear as fully Available from `/scheduled-tasks`.
 
 ## Scope
 
@@ -62,7 +65,7 @@ Out of scope:
 | Term | Meaning |
 | --- | --- |
 | Watch | User wants to know when a source has new or changed matching items. The expected output is alerting, review, or awareness. |
-| Ingest | User wants new source content added to library, media, search, or knowledge surfaces. The expected output is indexed/searchable content. |
+| Ingest | User wants new source content added to library, media, search, or knowledge surfaces. The expected output is destination-specific processing status, such as saved, searchable, RAG-ready, skipped, or failed. |
 | Source | A user-visible input such as a URL, feed, site, repository, channel, publication, advisory page, registry, or other supported location. |
 | Source family | Optional system classification, such as feed, video channel, repo issues, website, publication, advisory, or unknown. This is not the primary IA. |
 | Preview | A non-destructive explanation of recent items or ingest candidates, with limits and confidence stated plainly. |
@@ -105,15 +108,18 @@ Watch and Ingest can be marked Available only when all gates pass for the curren
 | Gate | Required behavior | If missing |
 | --- | --- | --- |
 | Capability health | UI can ask whether Watch/Ingest creation is supported, disabled, degraded, or blocked. | Show Needs setup or Handoff only with recovery link. |
-| Source preview | UI can validate source input and show non-destructive recent items or ingest candidates. | Keep handoff-only or create with an explicit "Preview unavailable" warning only if product accepts that risk. |
+| Source preview | UI can validate source input and show non-destructive recent items or ingest candidates. | Do not mark Available. Use Limited availability, Needs setup, or Handoff only. |
 | Duplicate detection | UI can warn about same-intent and likely-same-source tasks before create. | Keep handoff-only for recurring automations that may spam users or waste ingest work. |
 | Created entity response | Create returns normalized scheduled task ID, domain entity ID, and exact links. | Do not show "created" from `/scheduled-tasks`. |
 | Task visibility | Created automation appears in `/scheduled-tasks` Tasks without requiring a page reload workaround. | Open Watchlists only and explain that central visibility is not available yet. |
 | Run/result links | Task detail can link to latest run, outputs, and domain activity when available. | Mark domain visibility incomplete and keep deep inspection in Watchlists. |
 | Failure contract | Failures have a stable reason, failed step, and recovery action. | Do not create from `/scheduled-tasks`; hand off to Watchlists. |
 | Result destination | Review and success states can say where results will appear. | Do not promise Home or task results. |
+| Notification contract | UI can explain when and how the user is notified, including disabled or unavailable channels. | Do not mark the default Watch alert path Available. Use Limited availability or explicit result-only copy if product accepts non-alerting watches. |
 | Safe source handling | Source values are visible, editable, and sanitized; secrets are not retained. | Drop unsafe prefill and require manual setup in Watchlists. |
 | Watchlists preservation | Existing Watchlists routes, controls, and workflows continue unchanged. | Block Phase 2B release. |
+
+Limited availability is not a synonym for Available. It means the product can identify a source or guide an expert user, but at least one first-time safety gate is missing. Limited availability should keep creation disabled or route the user to Watchlists unless product/design explicitly accepts the risk for a narrow source family.
 
 ## Product-Facing Contracts
 
@@ -122,13 +128,78 @@ These are contracts the UX needs. They are not implementation prescriptions.
 | Contract | Minimum fields or behavior | UX reason |
 | --- | --- | --- |
 | Capability health | `template`, `state`, `reason`, `setup_url`, `supported_source_families`, `limits`, `can_preview`, `can_create`, `can_pause_resume` | Prevents false availability and tells users what to fix. |
+| Source-intent capability | For each detected source family and intent: `can_watch`, `can_ingest`, `can_preview`, `can_notify`, `can_index_search`, `can_index_rag`, `can_create`, and reason fields | Keeps source-agnostic IA honest while still showing precise support for the current source. |
 | Source preview | Display source, normalized source key, detected source family, auth requirement, preview items/candidates, preview timestamp, known limitations | Lets users confirm they pasted the right source before scheduling. |
-| Duplicate detection | Exact duplicates, likely duplicates, matching reason, existing task URL, existing Watchlists URL, last run, status, allowed actions | Prevents duplicate alerts, duplicate ingests, and confusion about existing automations. |
+| Duplicate detection | Exact duplicates, likely duplicates, matching reason, matching scope, existing task URL, existing Watchlists URL, last run, status, allowed actions | Prevents duplicate alerts, duplicate ingests, and confusion about existing automations. |
 | Create response | Scheduled task ID, domain entity ID, task detail URL, Watchlists manage URL, next run, initial status, result destinations | Enables exact success navigation and trust that the task exists. |
 | Run/result link contract | Latest run URL, output URL, item/result URLs, count summaries, failure URL, domain activity URL | Makes `/scheduled-tasks` a monitoring surface without cloning Watchlists. |
 | Failure reason | Stable code, plain-language message, failed step, recoverability, suggested action, recovery URL, redacted diagnostic detail | Supports recovery without exposing raw logs or secrets. |
-| Result destination metadata | Whether results appear in task detail, Watchlists outputs, media/search, notifications, Home, or another domain | Allows review and success copy to be accurate. |
+| Notification policy | Supported channels, default channel, notify-on rules, quiet/disabled state, dedupe key, last delivery status, and exact notification deep link | Makes alerting trustworthy and prevents duplicate triage between notifications, Home, and task detail. |
+| Ingest destination status | Per candidate and per run: media saved, transcript available, search indexed, embeddings ready, RAG scope included, skipped, failed, or unsupported | Prevents "ingested" from overpromising searchable or RAG-ready content. |
+| Result destination metadata | Whether results appear in task detail, Watchlists outputs, media/search, notifications, Home, or another domain, with explicit unavailable states | Allows review and success copy to be generated from actual support. |
+| Redaction policy | Redacted source text, preview snippets, duplicate summaries, failure details, copied setup summaries, and logs for private/authenticated sources | Prevents source previews and handoffs from leaking tokens or private content. |
 | Return path | Watchlists can return users to exact `/scheduled-tasks` task detail after domain setup when a normalized task exists | Keeps the cross-surface workflow coherent. |
+
+## Source-Intent Capability Matrix
+
+The UI can stay source-agnostic only if the contract is precise after a user enters a source. Capability should be evaluated by intent, source family, and destination.
+
+| Capability | Watch | Ingest | UX behavior when false |
+| --- | --- | --- | --- |
+| `can_preview` | Required for Available | Required for Available | Show Limited availability or handoff. |
+| `can_create` | Required for Available | Required for Available | Continue in Watchlists. |
+| `can_notify` | Required for alert copy | Optional unless user expects alerts | Hide or disable notification promises. |
+| `can_index_search` | Not required | Required before saying searchable | Say content may be saved but not searchable. |
+| `can_index_rag` | Not required | Required before saying RAG-ready | Say content is not included in RAG scope yet. |
+| `can_pause_resume` | Required before shared controls appear | Required before shared controls appear | Keep pause/resume in Watchlists. |
+
+Source family detection should be presented as a hint: "Detected: feed" or "Detected: repository issues." It should never override the user's chosen intent without review.
+
+## Notification Contract
+
+Watch tasks are not successful unless the user understands when alerts happen. The review step should be generated from notification capability metadata:
+
+| Field | UX requirement |
+| --- | --- |
+| Supported channels | Show available channels and disabled channels with reasons. |
+| Default policy | State whether the task notifies on every new item, digest, threshold, failures only, or not at all. |
+| Notify-on rule | Explain the condition that triggers notification in user language. |
+| Dedupe key | Avoid sending a Home card and notification that behave like separate events for the same run/result. |
+| Delivery status | Task detail should show the last notification status when available. |
+| Deep link | Notifications should open exact task/run/result detail, not only `/scheduled-tasks` or Watchlists landing pages. |
+
+If notification support is unavailable, use copy like "Results will appear in task detail and Watchlists. Notifications are not available for this source yet."
+
+## Ingest Destination Contract
+
+Ingest should not use one success label for multiple processing stages. A run can save content but fail transcript extraction, search indexing, or RAG inclusion.
+
+| Destination state | User-facing meaning |
+| --- | --- |
+| Media saved | The item exists in the media/library destination. |
+| Transcript available | Text was extracted or transcribed and can be inspected. |
+| Search indexed | The item is searchable through the supported search surface. |
+| Embeddings ready | Vector indexing completed. |
+| RAG scope included | The item is available to the configured RAG/knowledge scope. |
+| Skipped duplicate | The item matched an existing item and was not reprocessed. |
+| Failed | The item was attempted and failed at a named step. |
+| Unsupported | This source or item type cannot be ingested by the current environment. |
+
+Review and success copy must be assembled from these states. Do not say "searchable" or "RAG-ready" unless those destinations are explicitly supported and complete.
+
+## Duplicate Policy
+
+Duplicate matching should be conservative enough for first-time users and flexible enough for power users.
+
+| Dimension | Policy |
+| --- | --- |
+| Scope | Check the current user or tenant boundary only. Do not reveal other users' private automations. |
+| Exact duplicate | Same canonical source key, same intent, same relevant destination, and materially same matching/filter preset. |
+| Likely duplicate | Same canonical source key with different schedule, destination, filter, or notification policy. |
+| Ingest item duplicate | Same canonical item ID, URL, content hash, or domain-provided stable ID where available. |
+| Primary action | Exact duplicate opens the existing task. Likely duplicate opens review of similar automations. |
+| Create anyway | Allowed only for likely duplicates when policy permits and the user has reviewed the similar automation. |
+| Copy | Explain what matched: source, intent, destination, filter, or schedule. |
 
 ## First-Time User Flow: Watch For New Items
 
@@ -161,7 +232,7 @@ Failure fallback:
 Example user goal: "Keep this source searchable." A YouTube channel ingest is one possible example, not the template name.
 
 1. User chooses Ingest new content.
-2. The template explains: "Use this when you want new source content added to your library and search surfaces."
+2. The template explains: "Use this when you want new source content added to supported library, search, or knowledge destinations."
 3. User enters a source. Placeholder: "Paste a channel, feed, site, publication, document source, or media source."
 4. System resolves the source and previews recent ingest candidates.
 5. Preview labels candidates as new, already ingested, unsupported, needs auth, or preview unavailable when known.
@@ -212,24 +283,55 @@ Return behavior after Watchlists setup:
 - If only a Watchlists entity exists, return to the exact Watchlists monitor/job/run/output.
 - If no central task visibility exists yet, the return copy should say: "This automation is managed in Watchlists. It will appear in Scheduled Tasks after central visibility is supported."
 
-## State Model
+## State Models
+
+Do not collapse template capability, task lifecycle, run state, and result outcome into one badge set. They answer different user questions and should be modeled separately.
+
+### Template Capability States
 
 | State | User-facing label | Required message |
 | --- | --- | --- |
-| Available | Available | "Create this scheduled task here." |
+| Available | Available | "Create this scheduled task here." All availability gates pass. |
+| Limited availability | Limited availability | Explain the missing gate and route to Watchlists or expert setup. Do not present this as the first-time create path. |
 | Needs setup | Setup required | Explain missing auth, connector, provider, or configuration with direct recovery. |
 | Handoff only | Continue in Watchlists | "No scheduled task has been created yet." |
 | Managed in Watchlists | Managed in Watchlists | "Scheduled Tasks shows status and links. Watchlists owns source and output settings." |
-| Preview unavailable | Preview unavailable | Explain whether creation is blocked or allowed with limited confidence. |
-| Duplicate exact | Already exists | Primary action opens existing task. |
-| Duplicate likely | Similar automation found | User reviews existing task before creating another. |
+| Planned | Planned capability | Explain future intent without enabled creation. |
+| Unavailable | Unavailable | Explain dependency or environment blocker with recovery when possible. |
+
+### Task Lifecycle States
+
+| State | User-facing label | Required message |
+| --- | --- | --- |
+| Draft | Draft | Created or started but not scheduled. |
 | Waiting | Waiting for next run | Show next run and timezone. |
+| Paused | Paused | Clarify user-controlled pause and show resume action when supported. |
+| Disabled | Disabled | Clarify that the task is not scheduled to run. |
+| Blocked | Blocked | Clarify dependency-controlled block, such as auth, source, policy, or provider. |
+| Managed elsewhere | Managed in Watchlists | Clarify that deep settings and some operations stay in Watchlists. |
+
+### Run States
+
+| State | User-facing label | Required message |
+| --- | --- | --- |
+| Queued | Queued | Show when the run is waiting for a worker or schedule slot when known. |
 | Running | Running now | Show current step, elapsed time, and last update if available. |
+| Completed | Completed | Show duration and whether results were produced. |
+| Failed | Needs attention | Show failed step, reason, and recovery action. |
+| Canceled | Canceled | Show whether cancellation was user-initiated or system-initiated when known. |
+| Partial | Partially completed | Show which items or destinations succeeded and which failed. |
+
+### Result Outcome States
+
+| State | User-facing label | Required message |
+| --- | --- | --- |
 | Found results | Found results | Show count and exact result/output link. |
-| Completed no results | No new results | Show last checked time. |
-| Needs attention | Needs attention | Show failed step, reason, and recovery action. |
-| Paused | Paused | Clarify user-controlled pause. |
-| Blocked | Blocked | Clarify dependency-controlled block. |
+| No new results | No new results | Show last checked time. |
+| Saved only | Saved, not searchable | Explain that content was saved but not indexed for search or RAG. |
+| Searchable | Searchable | Link to media/search surface. |
+| RAG-ready | Available to RAG | Link to knowledge/RAG scope when supported. |
+| Skipped duplicate | Skipped duplicate | Explain duplicate policy and link to existing item when available. |
+| Failed item | Item failed | Show failed step and recovery action. |
 
 ## UX Copy Recommendations
 
@@ -238,14 +340,15 @@ Template labels:
 | Context | Copy |
 | --- | --- |
 | Watch title | Watch for new items |
-| Watch description | Get notified when a source has new matching items. |
+| Watch description | Surface new matching items and notify when supported. |
 | Ingest title | Ingest new content |
-| Ingest description | Add new source content to your library and search surfaces. |
+| Ingest description | Add new source content to supported library, search, or knowledge destinations. |
 | Source field label | Source |
 | Source helper | Paste a source URL, feed, site, advisory, publication, channel, or other supported source. |
 | Preview CTA | Preview source |
 | Watch create CTA | Create watch |
 | Ingest create CTA | Create ingest |
+| Limited availability label | Limited availability |
 | Domain CTA | Open in Watchlists |
 | Duplicate primary | Open existing task |
 | Duplicate secondary | Review similar automation |
@@ -256,7 +359,9 @@ Review copy:
 
 - "Scheduled Tasks will show status, next run, and recent results. Watchlists owns source rules, ingest behavior, outputs, and reports."
 - "Preview shows recent items only. Future runs may find different items."
-- "Results destination: Scheduled Tasks detail, Watchlists outputs, and Home when automation results are supported there."
+- "Results destination: [generated from capability metadata]."
+- "Home: not yet shown" or "Home: latest results will appear" depending on result-destination metadata.
+- "Notifications: [generated from notification policy]."
 - "No scheduled task has been created yet."
 
 Success copy:
@@ -272,7 +377,8 @@ Error copy:
 | --- | --- |
 | Invalid source | "This source could not be recognized. Check the URL or continue setup in Watchlists." |
 | Auth required | "This source needs authorization before it can be checked." |
-| Rate limited | "The source could not be previewed because the provider is rate limited. Try again later or continue in Watchlists." |
+| Preview unavailable | "This source cannot be previewed from Scheduled Tasks yet. Continue setup in Watchlists." |
+| Rate limited | "The source could not be previewed because the provider is rate limited. Try again later or continue setup in Watchlists." |
 | Duplicate exact | "This source is already being watched or ingested by an existing task." |
 | Create failed | "The automation was not created. Your inputs are still here." |
 | Partial visibility | "Created in Watchlists, but central Scheduled Tasks visibility is not available yet." |
@@ -287,18 +393,28 @@ Avoid:
 
 ## Home Surfacing Model Dependency
 
-Phase 2B does not implement Home, but Watch/Ingest creation must return result-destination metadata so future Home cards can be trustworthy.
+Phase 2B does not implement Home, but Watch/Ingest creation must return result-destination metadata so future Home cards can be trustworthy. UI copy should be generated from metadata, not hardcoded promises.
 
 Home should eventually show:
 
 | Card type | Trigger | Primary action |
 | --- | --- | --- |
 | New watched items | Watch run finds reviewable items | Open exact task result or Watchlists output |
-| New ingested content | Ingest run adds searchable items | Open ingested media/search result |
+| New ingested content | Ingest run saves or indexes new items | Open ingested media, search result, or destination detail |
 | Needs attention | Watch/Ingest run fails or is blocked | Open task failure detail |
 | Running now | Long-running ingest is active | Open run detail |
 
 Home should dedupe notifications and cards for the same run/result. A user should not have to dismiss the same automation event in multiple places.
+
+Result destination examples:
+
+| Metadata | Review copy |
+| --- | --- |
+| `home_supported=false` | "Home: not yet shown." |
+| `home_supported=true` | "Home: latest results will appear." |
+| `notifications_supported=false` | "Notifications: not available for this source yet." |
+| `search_indexed=false` | "Search: content may be saved but not searchable." |
+| `rag_scope_included=false` | "RAG: not included in the selected knowledge scope." |
 
 ## Browser Extension Expectations
 
@@ -310,6 +426,8 @@ The extension may open the same Create route with current-page context, but it m
 - Show detected source family as a hint, not a decision.
 - If the current page is not recognized, leave the generic Source field empty.
 - In constrained widths, keep source, preview, duplicate warning, schedule, and review steps readable without horizontal scrolling.
+- Redact preview rows, duplicate summaries, failure messages, logs, and copied setup summaries for private or authenticated sources.
+- Never show private page titles, snippets, or provider response bodies in extension-sized preview states unless the user explicitly confirms them.
 
 Extension entry copy:
 
@@ -343,7 +461,9 @@ Extension entry copy:
 | Preview feels authoritative when it is partial | Users overtrust incomplete source checks | Label preview timestamp, limits, and unsupported fields. |
 | Handoff creates hidden side effects | Users cannot tell whether anything was scheduled | Handoff copy must say no task was created. |
 | Unsafe source prefill leaks secrets | URLs can contain tokens or private fragments | Sanitize and omit unsafe values; keep user confirmation visible. |
+| Private previews leak sensitive content | Source titles, snippets, duplicate summaries, or errors can expose private data | Apply redaction policy across preview, duplicate, error, log, and copy-summary surfaces. |
 | `/scheduled-tasks` and Watchlists states diverge | Users see conflicting status | Use domain links and explicit "Managed in Watchlists" ownership copy. |
+| State badges collapse different concepts | Users cannot tell capability, lifecycle, run, and result states apart | Keep four state models and render them in distinct UI locations. |
 | Backend failures surface as raw errors | Users cannot recover | Stable failure reasons and recovery links are required. |
 
 ## Acceptance Checklist
@@ -351,17 +471,23 @@ Extension entry copy:
 Before Phase 2B implementation starts:
 
 - Watch/Ingest availability gates are accepted by product/design.
+- Preview is accepted as a hard gate for Available.
+- Capability, lifecycle, run, and result state models are accepted as separate product concepts.
 - Watchlists ownership boundary is accepted by maintainers.
 - Source examples are source-agnostic and do not privilege GitHub/YouTube.
 - Handoff copy remains available for unsupported or degraded environments.
 - Success states require exact task and domain links.
 - Duplicate policy is agreed for exact and likely duplicates.
+- Notification, ingest destination, source-intent capability, and redaction contracts are accepted.
 - Result destination language is accurate for current and future surfaces.
 - Browser extension source-prefill safety rules are accepted.
 
 Before Watch/Ingest templates move to Available:
 
 - Capability health, preview, duplicate, create, and failure contracts exist.
+- Preview is available for the current source family and intent.
+- Notification and result-destination metadata can generate accurate review copy.
+- Ingest destination states distinguish saved, searchable, embeddings-ready, and RAG-ready outcomes.
 - Created automations appear in `/scheduled-tasks` Tasks.
 - Created automation success opens exact task detail.
 - Task detail links to exact Watchlists monitor/job/run/output when available.
@@ -376,6 +502,7 @@ Before Watch/Ingest templates move to Available:
 | Which Watchlists setup routes can safely accept prefilled source text? | Determines whether handoff is a deep link or copy-summary flow. |
 | Which source families can provide reliable preview in the first available slice? | Determines whether availability is global or family-specific. |
 | Should "Create anyway" be allowed for likely duplicates? | Affects power-user flexibility and duplicate-noise risk. |
+| Which notification channels are reliable enough for Watch first launch? | Determines whether alert copy can be part of the Available path. |
 | Which destinations can Ingest honestly promise at create time? | Prevents overpromising searchable or RAG-ready results. |
 | Should pause/resume be exposed from `/scheduled-tasks` for Watchlists-backed tasks? | Requires safe state synchronization and clear ownership copy. |
 | What is the minimum Home metadata contract for future result cards? | Avoids creating automations that cannot later surface useful outcomes. |
@@ -385,7 +512,7 @@ Before Watch/Ingest templates move to Available:
 | Slice | Outcome | Backend dependency posture |
 | --- | --- | --- |
 | 2B.1 Product contract | This spec accepted and linked from Backlog | None |
-| 2B.2 Capability-aware frontend shell | Watch/Ingest can display runtime Available/Needs setup/Handoff states when contracts exist | Depends on capability contract only |
+| 2B.2 Capability-aware frontend shell | Watch/Ingest can display runtime capability states, including Limited availability, but cannot promote templates to Available until all gates pass | Depends on capability contract only |
 | 2B.3 Watchlists creation handoff adapter | Source preview, duplicate warnings, and safe create for the first supported source families | Depends on Watchlists contracts |
 | 2B.4 Task detail/result links | Created Watch/Ingest tasks open exact details and domain links | Depends on created entity and run/result link contracts |
 | 2B.5 Home surfacing follow-up | Home can show latest Watch/Ingest results and failures | Depends on normalized result metadata |

--- a/Docs/superpowers/specs/2026-06-09-scheduled-tasks-phase2b-watch-ingest-product-contract-design.md
+++ b/Docs/superpowers/specs/2026-06-09-scheduled-tasks-phase2b-watch-ingest-product-contract-design.md
@@ -1,0 +1,391 @@
+# Scheduled Tasks Phase 2B Watch/Ingest Product Contract Design
+
+Date: 2026-06-09
+Status: Ready for review
+Owner: Codex brainstorming session
+Backlog: TASK-2324
+
+Related:
+
+- `Docs/superpowers/specs/2026-06-01-scheduled-tasks-automation-workbench-prd-design.md`
+- `Docs/superpowers/specs/2026-06-08-scheduled-tasks-automation-workbench-phase2-creation-design.md`
+- `backlog/tasks/task-2324 - Design-Scheduled-Tasks-Phase-2B-Watch-Ingest-product-contract.md`
+
+## Summary
+
+Phase 2B defines the product and UX contract required before the `/scheduled-tasks` Watch for new items and Ingest new content templates can move from handoff-only to available.
+
+The core decision is that Watch and Ingest are **source-agnostic user intents**, not vendor-specific task types. GitHub issues, YouTube channels, RSS feeds, websites, forums, package registries, vendor advisories, publications, and future source families are examples inside these intents. The UI should not imply that GitHub or YouTube are the primary product model.
+
+`/scheduled-tasks` should become a safe front door and shared lifecycle surface. Watchlists remains the deep workspace for source collections, monitors, scraping, ingest tuning, filters, outputs, reports, digests, and detailed activity. This spec must not remove, limit, or simplify existing Watchlists functionality.
+
+This document stays at the product and UX layer. Backend work is listed only as product-facing contract dependencies.
+
+## Product Decision
+
+Move Watch and Ingest templates to available only after the product can support a complete traceable loop:
+
+1. User chooses a source-agnostic intent.
+2. User enters a visible, editable source.
+3. System reports whether the capability is ready.
+4. System previews what will be checked or ingested.
+5. System detects likely duplicates before creation.
+6. User reviews schedule, result destination, and domain ownership.
+7. System creates the Watchlists-backed automation and returns exact task/domain IDs.
+8. User can open the created task detail from `/scheduled-tasks`.
+9. User can inspect runs, outputs, failures, and deeper settings through exact links.
+
+If any part of this loop is missing, the template should remain Handoff only, Needs setup, or Unavailable instead of pretending creation is supported.
+
+## Scope
+
+In scope:
+
+- Product contract for making Watch for new items actionable from `/scheduled-tasks`.
+- Product contract for making Ingest new content actionable from `/scheduled-tasks`.
+- First-time and power-user flows for Watch/Ingest.
+- Runtime capability, source preview, duplicate detection, creation response, deep-link, failure, and result-destination requirements.
+- UX copy and state guidance for available, degraded, blocked, duplicate, running, success, and failure states.
+- Browser extension expectations when the extension opens the same Create route.
+
+Out of scope:
+
+- Backend schema design, migrations, queue implementation, handler registration, or storage decisions.
+- Replacing Watchlists with a simplified Scheduled Tasks editor.
+- Vendor-specific GitHub or YouTube templates as the primary IA.
+- Recurring RAG and Agent Task availability.
+- Home implementation, beyond the metadata contract required for future surfacing.
+- Bulk source import, saved views, dry run, run-now, and cross-task Results/Runs tabs unless already supported by a safe domain contract.
+
+## Terms
+
+| Term | Meaning |
+| --- | --- |
+| Watch | User wants to know when a source has new or changed matching items. The expected output is alerting, review, or awareness. |
+| Ingest | User wants new source content added to library, media, search, or knowledge surfaces. The expected output is indexed/searchable content. |
+| Source | A user-visible input such as a URL, feed, site, repository, channel, publication, advisory page, registry, or other supported location. |
+| Source family | Optional system classification, such as feed, video channel, repo issues, website, publication, advisory, or unknown. This is not the primary IA. |
+| Preview | A non-destructive explanation of recent items or ingest candidates, with limits and confidence stated plainly. |
+| Duplicate | An existing task, monitor, source, or ingested item that appears to cover the same source and intent. |
+| Domain entity | The Watchlists-owned monitor, job, output, source, or run that backs the scheduled automation. |
+| Scheduled task | The normalized row and detail object visible from `/scheduled-tasks`. |
+
+## Source-Agnostic Intent Model
+
+The Create tab should present Watch and Ingest as user goals:
+
+| Intent | User wording | Example sources | Result promise |
+| --- | --- | --- | --- |
+| Watch for new items | "Tell me when something new appears." | Issues, feeds, advisories, publications, forums, site pages, package releases | New matching items appear as task results, notifications, Watchlists outputs, or Home cards when supported. |
+| Ingest new content | "Keep this source searchable." | Channels, feeds, pages, publications, documents, media sources, site sections | New content is processed into media, search, RAG, or other configured destinations when supported. |
+
+Source examples should appear as examples, helper text, or preview classifications. They should not become top-level navigation unless a future source marketplace exists.
+
+## Ownership Boundary
+
+| Concern | `/scheduled-tasks` owns | Watchlists owns |
+| --- | --- | --- |
+| Intent selection | Primary entry point and copy | Optional domain entry point |
+| Lightweight source entry | Visible, editable, sanitized source field | Source collection and curation |
+| Capability status | Summary and recovery link | Detailed service/source health |
+| Preview summary | Recent items/candidates and limitations | Full preview, scraping, filtering, and source diagnostics |
+| Duplicate warning | Existing task/source warning and action routing | Source/job-level duplicate details |
+| Creation | Safe front-door create only after contracts exist | Domain creation, validation, and deep config |
+| Schedule summary | Cadence, timezone, next-run preview | Advanced scheduling where applicable |
+| Results summary | Latest counts, status, and deep links | Outputs, reports, digests, item detail, activity |
+| Pause/resume | Only when safe support is reported | Full job controls |
+| Editing | Name, schedule, notification basics only when supported | Source rules, ingest behavior, filters, outputs, reports |
+
+Rule: if a setting changes how a source is collected, scraped, filtered, transformed, reported, or delivered in Watchlists, the deep editor stays in Watchlists. `/scheduled-tasks` can link to that setting but should not rebuild it.
+
+## Availability Gates
+
+Watch and Ingest can be marked Available only when all gates pass for the current environment and current user:
+
+| Gate | Required behavior | If missing |
+| --- | --- | --- |
+| Capability health | UI can ask whether Watch/Ingest creation is supported, disabled, degraded, or blocked. | Show Needs setup or Handoff only with recovery link. |
+| Source preview | UI can validate source input and show non-destructive recent items or ingest candidates. | Keep handoff-only or create with an explicit "Preview unavailable" warning only if product accepts that risk. |
+| Duplicate detection | UI can warn about same-intent and likely-same-source tasks before create. | Keep handoff-only for recurring automations that may spam users or waste ingest work. |
+| Created entity response | Create returns normalized scheduled task ID, domain entity ID, and exact links. | Do not show "created" from `/scheduled-tasks`. |
+| Task visibility | Created automation appears in `/scheduled-tasks` Tasks without requiring a page reload workaround. | Open Watchlists only and explain that central visibility is not available yet. |
+| Run/result links | Task detail can link to latest run, outputs, and domain activity when available. | Mark domain visibility incomplete and keep deep inspection in Watchlists. |
+| Failure contract | Failures have a stable reason, failed step, and recovery action. | Do not create from `/scheduled-tasks`; hand off to Watchlists. |
+| Result destination | Review and success states can say where results will appear. | Do not promise Home or task results. |
+| Safe source handling | Source values are visible, editable, and sanitized; secrets are not retained. | Drop unsafe prefill and require manual setup in Watchlists. |
+| Watchlists preservation | Existing Watchlists routes, controls, and workflows continue unchanged. | Block Phase 2B release. |
+
+## Product-Facing Contracts
+
+These are contracts the UX needs. They are not implementation prescriptions.
+
+| Contract | Minimum fields or behavior | UX reason |
+| --- | --- | --- |
+| Capability health | `template`, `state`, `reason`, `setup_url`, `supported_source_families`, `limits`, `can_preview`, `can_create`, `can_pause_resume` | Prevents false availability and tells users what to fix. |
+| Source preview | Display source, normalized source key, detected source family, auth requirement, preview items/candidates, preview timestamp, known limitations | Lets users confirm they pasted the right source before scheduling. |
+| Duplicate detection | Exact duplicates, likely duplicates, matching reason, existing task URL, existing Watchlists URL, last run, status, allowed actions | Prevents duplicate alerts, duplicate ingests, and confusion about existing automations. |
+| Create response | Scheduled task ID, domain entity ID, task detail URL, Watchlists manage URL, next run, initial status, result destinations | Enables exact success navigation and trust that the task exists. |
+| Run/result link contract | Latest run URL, output URL, item/result URLs, count summaries, failure URL, domain activity URL | Makes `/scheduled-tasks` a monitoring surface without cloning Watchlists. |
+| Failure reason | Stable code, plain-language message, failed step, recoverability, suggested action, recovery URL, redacted diagnostic detail | Supports recovery without exposing raw logs or secrets. |
+| Result destination metadata | Whether results appear in task detail, Watchlists outputs, media/search, notifications, Home, or another domain | Allows review and success copy to be accurate. |
+| Return path | Watchlists can return users to exact `/scheduled-tasks` task detail after domain setup when a normalized task exists | Keeps the cross-surface workflow coherent. |
+
+## First-Time User Flow: Watch For New Items
+
+Example user goal: "Tell me when a source has new relevant items." A GitHub issues monitor is one possible example, not the template name.
+
+1. User opens `/scheduled-tasks?tab=create` and chooses Watch for new items.
+2. The template explains: "Use this when you want alerts or review items when a source changes."
+3. User enters a source in a visible field. Placeholder: "Paste a source URL, feed, repo, site, advisory, or publication."
+4. System checks capability health and source preview.
+5. Preview shows recent items, detected source family, and limitations. If the source resembles issues, preview may show author type and bot/system hints where available.
+6. Duplicate check runs before scheduling and shows exact or likely existing watches.
+7. User chooses schedule, notification behavior, and basic matching preset when supported.
+8. Review screen answers:
+   - what source will be checked;
+   - what counts as a new item;
+   - when it runs;
+   - where results appear;
+   - what Watchlists still owns.
+9. User creates the automation.
+10. Success opens the created task detail in `/scheduled-tasks`, with secondary actions to open Watchlists or create another.
+
+Failure fallback:
+
+- If source preview or creation is not supported, show "Setup continues in Watchlists. No scheduled task has been created yet."
+- Preserve only safe user-visible source text in a copyable setup summary.
+- Link to Watchlists setup with the closest available route.
+
+## First-Time User Flow: Ingest New Content
+
+Example user goal: "Keep this source searchable." A YouTube channel ingest is one possible example, not the template name.
+
+1. User chooses Ingest new content.
+2. The template explains: "Use this when you want new source content added to your library and search surfaces."
+3. User enters a source. Placeholder: "Paste a channel, feed, site, publication, document source, or media source."
+4. System resolves the source and previews recent ingest candidates.
+5. Preview labels candidates as new, already ingested, unsupported, needs auth, or preview unavailable when known.
+6. User selects basic destination expectations only if the current product can honor them: media library, search index, RAG/knowledge, or Watchlists output.
+7. Duplicate detection warns about existing ingest tasks and already-ingested items.
+8. User chooses schedule and reviews processing expectations such as transcript/download/indexing limitations when known.
+9. User creates the automation.
+10. Success opens the task detail, showing next run, Watchlists manage link, and where ingested content will be visible.
+
+Failure fallback:
+
+- If the source cannot be resolved, keep the input visible and explain whether the issue is invalid source, auth, unsupported family, rate limit, or preview timeout.
+- If ingest is possible only through Watchlists, use the handoff flow and avoid "scheduled" language.
+
+## Power-User Flow
+
+Power users need direct, dense, reversible paths:
+
+| Need | UX requirement |
+| --- | --- |
+| Jump to template | `/scheduled-tasks?tab=create&template=watch` and `template=ingest` open the selected template. |
+| Paste and inspect quickly | Source field receives focus; Enter or primary action starts preview when safe. |
+| Avoid duplicates | Exact duplicate warning offers "Open existing task" as primary. Likely duplicate offers "Review existing" and, if policy allows, "Create anyway". |
+| Create repeatedly | Success offers "Create another" without losing template context. |
+| Inspect output | Created task detail shows latest run, latest result/output, and Watchlists deep links. |
+| Edit deep settings | "Open in Watchlists" routes to the specific monitor/job/source, not only the Watchlists landing page. |
+| Operate many tasks | Task table filters can distinguish Watch, Ingest, Managed in Watchlists, Needs attention, Paused, Running, and Waiting. |
+| Debug quickly | Failure summary shows failed step, last successful run, retry/recovery action, and domain activity link. |
+
+Do not add bulk management in Phase 2B unless existing safe actions and state refresh semantics are available. A slow but exact flow is better than fast bulk actions that can desynchronize Watchlists.
+
+## Handoff And Return Behavior
+
+Handoff remains required whenever the contract cannot create safely.
+
+Handoff panel requirements:
+
+- State the owner: "Setup continues in Watchlists."
+- State the side effect: "No scheduled task has been created yet."
+- Show the safe setup summary in editable text.
+- Explain why handoff is needed: missing capability, auth setup, source family unsupported, preview unavailable, or Watchlists owns deep configuration.
+- Link to the closest Watchlists destination.
+- Offer "Copy setup summary" when deep prefill is not supported.
+
+Return behavior after Watchlists setup:
+
+- If a normalized scheduled task exists, return to `/scheduled-tasks?tab=tasks&task_id=<id>`.
+- If only a Watchlists entity exists, return to the exact Watchlists monitor/job/run/output.
+- If no central task visibility exists yet, the return copy should say: "This automation is managed in Watchlists. It will appear in Scheduled Tasks after central visibility is supported."
+
+## State Model
+
+| State | User-facing label | Required message |
+| --- | --- | --- |
+| Available | Available | "Create this scheduled task here." |
+| Needs setup | Setup required | Explain missing auth, connector, provider, or configuration with direct recovery. |
+| Handoff only | Continue in Watchlists | "No scheduled task has been created yet." |
+| Managed in Watchlists | Managed in Watchlists | "Scheduled Tasks shows status and links. Watchlists owns source and output settings." |
+| Preview unavailable | Preview unavailable | Explain whether creation is blocked or allowed with limited confidence. |
+| Duplicate exact | Already exists | Primary action opens existing task. |
+| Duplicate likely | Similar automation found | User reviews existing task before creating another. |
+| Waiting | Waiting for next run | Show next run and timezone. |
+| Running | Running now | Show current step, elapsed time, and last update if available. |
+| Found results | Found results | Show count and exact result/output link. |
+| Completed no results | No new results | Show last checked time. |
+| Needs attention | Needs attention | Show failed step, reason, and recovery action. |
+| Paused | Paused | Clarify user-controlled pause. |
+| Blocked | Blocked | Clarify dependency-controlled block. |
+
+## UX Copy Recommendations
+
+Template labels:
+
+| Context | Copy |
+| --- | --- |
+| Watch title | Watch for new items |
+| Watch description | Get notified when a source has new matching items. |
+| Ingest title | Ingest new content |
+| Ingest description | Add new source content to your library and search surfaces. |
+| Source field label | Source |
+| Source helper | Paste a source URL, feed, site, advisory, publication, channel, or other supported source. |
+| Preview CTA | Preview source |
+| Watch create CTA | Create watch |
+| Ingest create CTA | Create ingest |
+| Domain CTA | Open in Watchlists |
+| Duplicate primary | Open existing task |
+| Duplicate secondary | Review similar automation |
+| Handoff primary | Continue in Watchlists |
+| Handoff secondary | Copy setup summary |
+
+Review copy:
+
+- "Scheduled Tasks will show status, next run, and recent results. Watchlists owns source rules, ingest behavior, outputs, and reports."
+- "Preview shows recent items only. Future runs may find different items."
+- "Results destination: Scheduled Tasks detail, Watchlists outputs, and Home when automation results are supported there."
+- "No scheduled task has been created yet."
+
+Success copy:
+
+- "Watch scheduled. Opening task detail."
+- "Ingest scheduled. Opening task detail."
+- "This automation is also managed in Watchlists."
+- "Next run: [date/time/timezone]."
+
+Error copy:
+
+| Condition | Message |
+| --- | --- |
+| Invalid source | "This source could not be recognized. Check the URL or continue setup in Watchlists." |
+| Auth required | "This source needs authorization before it can be checked." |
+| Rate limited | "The source could not be previewed because the provider is rate limited. Try again later or continue in Watchlists." |
+| Duplicate exact | "This source is already being watched or ingested by an existing task." |
+| Create failed | "The automation was not created. Your inputs are still here." |
+| Partial visibility | "Created in Watchlists, but central Scheduled Tasks visibility is not available yet." |
+
+Avoid:
+
+- "GitHub monitor" as a primary template label.
+- "YouTube ingest" as a primary template label.
+- "Task created" after handoff only.
+- "External" without naming the owner.
+- Raw implementation terms such as cron, APScheduler, job backend, handler, queue, or worker.
+
+## Home Surfacing Model Dependency
+
+Phase 2B does not implement Home, but Watch/Ingest creation must return result-destination metadata so future Home cards can be trustworthy.
+
+Home should eventually show:
+
+| Card type | Trigger | Primary action |
+| --- | --- | --- |
+| New watched items | Watch run finds reviewable items | Open exact task result or Watchlists output |
+| New ingested content | Ingest run adds searchable items | Open ingested media/search result |
+| Needs attention | Watch/Ingest run fails or is blocked | Open task failure detail |
+| Running now | Long-running ingest is active | Open run detail |
+
+Home should dedupe notifications and cards for the same run/result. A user should not have to dismiss the same automation event in multiple places.
+
+## Browser Extension Expectations
+
+The extension may open the same Create route with current-page context, but it must follow the same safety rules:
+
+- Prefill only visible, editable source text.
+- Do not silently preserve fragments, credential-like query parameters, invite codes, session tokens, or auth values.
+- Do not infer schedule, filters, notification policy, destination, or credentials from page context.
+- Show detected source family as a hint, not a decision.
+- If the current page is not recognized, leave the generic Source field empty.
+- In constrained widths, keep source, preview, duplicate warning, schedule, and review steps readable without horizontal scrolling.
+
+Extension entry copy:
+
+- "Create scheduled task from this page" when a safe source is available.
+- "Review source before scheduling" on the first step.
+- "Some setup may continue in Watchlists."
+
+## Accessibility And Usability Requirements
+
+- Template cards, tabs, wizard steps, duplicate warnings, and result links must be keyboard operable.
+- Status must use text plus icon, never color alone.
+- Preview loading and running updates should use polite live regions.
+- Focus should move to the first invalid field on validation failure.
+- After create success, focus should move to the opened task detail heading.
+- Duplicate warnings should be announced as status or alert depending on severity.
+- Source preview tables need column headers and responsive stacked rows at extension widths.
+- Date/time previews must include timezone and be announced with validation messages.
+- Icon-only actions need accessible names and tooltips.
+- Copyable setup summaries need visible confirmation when copied.
+- Reduced-motion preferences should be respected for progress and transition states.
+
+## Risks And Mitigations
+
+| Risk | Why it matters | Mitigation |
+| --- | --- | --- |
+| Watchlists is accidentally reduced to a modal | Existing Watchlists users lose deep workflows | Keep source rules, ingest behavior, outputs, reports, and activity in Watchlists. |
+| GitHub/YouTube examples distort IA | Users with other sources think they are unsupported | Use source-agnostic template names and broad source examples. |
+| Creation succeeds but task is hard to find | Users lose trust and cannot inspect results | Require scheduled task ID and exact detail URL in create response. |
+| Duplicate watches create alert noise | Users get spammed and may disable automation | Require duplicate detection before making templates available. |
+| Duplicate ingests waste resources | Processing and storage costs increase | Preview candidate status and explain duplicate/skipped policy. |
+| Preview feels authoritative when it is partial | Users overtrust incomplete source checks | Label preview timestamp, limits, and unsupported fields. |
+| Handoff creates hidden side effects | Users cannot tell whether anything was scheduled | Handoff copy must say no task was created. |
+| Unsafe source prefill leaks secrets | URLs can contain tokens or private fragments | Sanitize and omit unsafe values; keep user confirmation visible. |
+| `/scheduled-tasks` and Watchlists states diverge | Users see conflicting status | Use domain links and explicit "Managed in Watchlists" ownership copy. |
+| Backend failures surface as raw errors | Users cannot recover | Stable failure reasons and recovery links are required. |
+
+## Acceptance Checklist
+
+Before Phase 2B implementation starts:
+
+- Watch/Ingest availability gates are accepted by product/design.
+- Watchlists ownership boundary is accepted by maintainers.
+- Source examples are source-agnostic and do not privilege GitHub/YouTube.
+- Handoff copy remains available for unsupported or degraded environments.
+- Success states require exact task and domain links.
+- Duplicate policy is agreed for exact and likely duplicates.
+- Result destination language is accurate for current and future surfaces.
+- Browser extension source-prefill safety rules are accepted.
+
+Before Watch/Ingest templates move to Available:
+
+- Capability health, preview, duplicate, create, and failure contracts exist.
+- Created automations appear in `/scheduled-tasks` Tasks.
+- Created automation success opens exact task detail.
+- Task detail links to exact Watchlists monitor/job/run/output when available.
+- Existing Watchlists workflows are unchanged.
+- Handoff-only fallback still works when capability is unavailable.
+- Accessibility requirements are covered in interaction tests or manual QA.
+
+## Open Product Questions
+
+| Question | Why it matters |
+| --- | --- |
+| Which Watchlists setup routes can safely accept prefilled source text? | Determines whether handoff is a deep link or copy-summary flow. |
+| Which source families can provide reliable preview in the first available slice? | Determines whether availability is global or family-specific. |
+| Should "Create anyway" be allowed for likely duplicates? | Affects power-user flexibility and duplicate-noise risk. |
+| Which destinations can Ingest honestly promise at create time? | Prevents overpromising searchable or RAG-ready results. |
+| Should pause/resume be exposed from `/scheduled-tasks` for Watchlists-backed tasks? | Requires safe state synchronization and clear ownership copy. |
+| What is the minimum Home metadata contract for future result cards? | Avoids creating automations that cannot later surface useful outcomes. |
+
+## Recommended Delivery Slices
+
+| Slice | Outcome | Backend dependency posture |
+| --- | --- | --- |
+| 2B.1 Product contract | This spec accepted and linked from Backlog | None |
+| 2B.2 Capability-aware frontend shell | Watch/Ingest can display runtime Available/Needs setup/Handoff states when contracts exist | Depends on capability contract only |
+| 2B.3 Watchlists creation handoff adapter | Source preview, duplicate warnings, and safe create for the first supported source families | Depends on Watchlists contracts |
+| 2B.4 Task detail/result links | Created Watch/Ingest tasks open exact details and domain links | Depends on created entity and run/result link contracts |
+| 2B.5 Home surfacing follow-up | Home can show latest Watch/Ingest results and failures | Depends on normalized result metadata |

--- a/apps/packages/ui/src/components/Option/ScheduledTasks/ScheduledTaskCreatePanel.tsx
+++ b/apps/packages/ui/src/components/Option/ScheduledTasks/ScheduledTaskCreatePanel.tsx
@@ -10,6 +10,7 @@ import {
   buildResultDestinationCopy,
   buildSourceIntentCopy,
   getMissingAvailabilityGates,
+  redactCapabilityPreviewText,
   type ScheduledTaskTemplateCapability,
   type ScheduledTaskTemplateCapabilityMap
 } from "./scheduled-task-template-capabilities"
@@ -49,6 +50,36 @@ const containsPrivateLookingProse = (value: string): boolean =>
   PRIVATE_LOOKING_PROSE_PATTERN.test(value)
 
 const formatAvailabilityGateLabel = (gate: string): string => gate.replace(/_/g, " ")
+
+const WATCHLISTS_ADAPTER_UNAVAILABLE_COPY =
+  "Creation from Scheduled Tasks is not available yet. Continue setup in Watchlists."
+
+const OWNER_WORKSPACE_ADAPTER_UNAVAILABLE_COPY =
+  "Creation from Scheduled Tasks is not available yet. Choose the owner workspace to continue setup."
+
+const buildAvailabilityCopy = (
+  template: ScheduledTaskTemplate,
+  capability: ScheduledTaskTemplateCapability
+): string[] => {
+  const missingGateCopy = getMissingAvailabilityGates(template.id, capability).map(
+    (gate) => `Missing: ${formatAvailabilityGateLabel(gate)}`
+  )
+
+  if (missingGateCopy.length > 0 || capability.creationAdapterSupported === true) {
+    return missingGateCopy
+  }
+
+  const adapterCopy = requiresWatchlistsHandoff(template)
+    ? WATCHLISTS_ADAPTER_UNAVAILABLE_COPY
+    : OWNER_WORKSPACE_ADAPTER_UNAVAILABLE_COPY
+  const redactedReason = capability.reason
+    ? redactCapabilityPreviewText(capability.reason)
+    : null
+
+  return redactedReason && redactedReason !== adapterCopy
+    ? [adapterCopy, redactedReason]
+    : [adapterCopy]
+}
 
 const CapabilityCopyGroup: React.FC<{ title: string; lines: readonly string[] }> = ({
   title,
@@ -105,22 +136,16 @@ const HandoffPanel: React.FC<{
     (!safeSourceText || containsPrivateLookingProse(normalizedSourceNote))
   const hasSafeSourceNote = Boolean(normalizedSourceNote) && !hasUnsafeSource
   const watchlistsHandoff = requiresWatchlistsHandoff(template)
-  const missingGateCopy =
-    capability && watchlistsHandoff
-      ? getMissingAvailabilityGates(template.id, capability).map(
-          (gate) => `Missing: ${formatAvailabilityGateLabel(gate)}`
-        )
-      : []
-  const sourceIntentCopy =
-    capability && watchlistsHandoff ? buildSourceIntentCopy(capability.sourceIntent) : []
-  const resultDestinationCopy =
-    capability && watchlistsHandoff
-      ? buildResultDestinationCopy(capability.resultDestinations)
-      : []
-  const notificationCopy =
-    capability && watchlistsHandoff
-      ? [buildNotificationPolicyCopy(capability.resultDestinations)]
-      : []
+  const availabilityCopy = capability ? buildAvailabilityCopy(template, capability) : []
+  const sourceIntentCopy = capability ? buildSourceIntentCopy(capability.sourceIntent) : []
+  const shouldRenderDestinationFallback =
+    watchlistsHandoff || Boolean(capability?.resultDestinations)
+  const resultDestinationCopy = capability && shouldRenderDestinationFallback
+    ? buildResultDestinationCopy(capability.resultDestinations)
+    : []
+  const notificationCopy = capability && shouldRenderDestinationFallback
+    ? [buildNotificationPolicyCopy(capability.resultDestinations)]
+    : []
   const summaryLines = [
     `Template: ${template.title}`,
     `Intent: ${template.intent}`,
@@ -140,7 +165,7 @@ const HandoffPanel: React.FC<{
         {watchlistsHandoff ? (
           <Typography.Text strong>Setup continues in Watchlists.</Typography.Text>
         ) : null}
-        <CapabilityCopyGroup title="Availability" lines={missingGateCopy} />
+        <CapabilityCopyGroup title="Availability" lines={availabilityCopy} />
         <CapabilityCopyGroup title="Source support" lines={sourceIntentCopy} />
         <CapabilityCopyGroup title="Result destinations" lines={resultDestinationCopy} />
         <CapabilityCopyGroup title="Notifications" lines={notificationCopy} />

--- a/apps/packages/ui/src/components/Option/ScheduledTasks/ScheduledTaskCreatePanel.tsx
+++ b/apps/packages/ui/src/components/Option/ScheduledTasks/ScheduledTaskCreatePanel.tsx
@@ -5,6 +5,16 @@ import type { SegmentedValue } from "antd/es/segmented"
 import type { CreateScheduledTaskReminderPayload } from "@/services/scheduled-tasks-control-plane"
 import { ReminderTaskEditor } from "./ReminderTaskEditor"
 import {
+  applyScheduledTaskTemplateCapabilities,
+  buildNotificationPolicyCopy,
+  buildResultDestinationCopy,
+  buildSourceIntentCopy,
+  getMissingAvailabilityGates,
+  type ScheduledTaskTemplateCapability,
+  type ScheduledTaskTemplateCapabilityMap
+} from "./scheduled-task-template-capabilities"
+import {
+  SCHEDULED_TASK_TEMPLATES,
   SCHEDULED_TASK_TEMPLATE_FILTERS,
   filterScheduledTaskTemplates,
   findScheduledTaskTemplates,
@@ -21,6 +31,7 @@ export interface ScheduledTaskCreatePanelProps {
   onSelectTemplate: (templateId: ScheduledTaskTemplateId | null) => void
   onCreateReminder: (payload: CreateScheduledTaskReminderPayload) => Promise<void> | void
   savingReminder?: boolean
+  templateCapabilities?: ScheduledTaskTemplateCapabilityMap
 }
 
 const WATCHLISTS_HREF = "/watchlists"
@@ -36,6 +47,21 @@ const PRIVATE_LOOKING_PROSE_PATTERN =
 
 const containsPrivateLookingProse = (value: string): boolean =>
   PRIVATE_LOOKING_PROSE_PATTERN.test(value)
+
+const formatAvailabilityGateLabel = (gate: string): string => gate.replace(/_/g, " ")
+
+const CapabilityCopyGroup: React.FC<{ title: string; lines: readonly string[] }> = ({
+  title,
+  lines
+}) =>
+  lines.length > 0 ? (
+    <Space orientation="vertical" size={4}>
+      <Typography.Text strong>{title}</Typography.Text>
+      {lines.map((line) => (
+        <Typography.Text key={line}>{line}</Typography.Text>
+      ))}
+    </Space>
+  ) : null
 
 const TemplateCard: React.FC<{
   template: ScheduledTaskTemplate
@@ -67,7 +93,10 @@ const TemplateCard: React.FC<{
   </Card>
 )
 
-const HandoffPanel: React.FC<{ template: ScheduledTaskTemplate }> = ({ template }) => {
+const HandoffPanel: React.FC<{
+  template: ScheduledTaskTemplate
+  capability?: ScheduledTaskTemplateCapability | null
+}> = ({ template, capability }) => {
   const [sourceNote, setSourceNote] = useState("")
   const safeSourceText = toSafeHandoffSourceText(sourceNote)
   const normalizedSourceNote = sourceNote.trim()
@@ -76,6 +105,22 @@ const HandoffPanel: React.FC<{ template: ScheduledTaskTemplate }> = ({ template 
     (!safeSourceText || containsPrivateLookingProse(normalizedSourceNote))
   const hasSafeSourceNote = Boolean(normalizedSourceNote) && !hasUnsafeSource
   const watchlistsHandoff = requiresWatchlistsHandoff(template)
+  const missingGateCopy =
+    capability && watchlistsHandoff
+      ? getMissingAvailabilityGates(template.id, capability).map(
+          (gate) => `Missing: ${formatAvailabilityGateLabel(gate)}`
+        )
+      : []
+  const sourceIntentCopy =
+    capability && watchlistsHandoff ? buildSourceIntentCopy(capability.sourceIntent) : []
+  const resultDestinationCopy =
+    capability && watchlistsHandoff
+      ? buildResultDestinationCopy(capability.resultDestinations)
+      : []
+  const notificationCopy =
+    capability && watchlistsHandoff
+      ? [buildNotificationPolicyCopy(capability.resultDestinations)]
+      : []
   const summaryLines = [
     `Template: ${template.title}`,
     `Intent: ${template.intent}`,
@@ -95,6 +140,10 @@ const HandoffPanel: React.FC<{ template: ScheduledTaskTemplate }> = ({ template 
         {watchlistsHandoff ? (
           <Typography.Text strong>Setup continues in Watchlists.</Typography.Text>
         ) : null}
+        <CapabilityCopyGroup title="Availability" lines={missingGateCopy} />
+        <CapabilityCopyGroup title="Source support" lines={sourceIntentCopy} />
+        <CapabilityCopyGroup title="Result destinations" lines={resultDestinationCopy} />
+        <CapabilityCopyGroup title="Notifications" lines={notificationCopy} />
         <Typography.Text>No scheduled task has been created yet.</Typography.Text>
         <Input.TextArea
           aria-label="Optional source or setup note"
@@ -145,14 +194,25 @@ export const ScheduledTaskCreatePanel: React.FC<ScheduledTaskCreatePanelProps> =
   selectedTemplateId,
   onSelectTemplate,
   onCreateReminder,
-  savingReminder
+  savingReminder,
+  templateCapabilities
 }) => {
   const [finderText, setFinderText] = useState("")
   const [filterId, setFilterId] = useState<ScheduledTaskTemplateFilterId>("all")
-  const selectedTemplate = getScheduledTaskTemplate(selectedTemplateId)
+  const effectiveTemplates = useMemo(
+    () => applyScheduledTaskTemplateCapabilities(SCHEDULED_TASK_TEMPLATES, templateCapabilities),
+    [templateCapabilities]
+  )
+  const selectedTemplate = getScheduledTaskTemplate(selectedTemplateId, effectiveTemplates)
+  const selectedCapability = selectedTemplate
+    ? templateCapabilities?.[selectedTemplate.id] ?? null
+    : null
   const matches = useMemo(() => findScheduledTaskTemplates(finderText), [finderText])
   const bestMatch = matches[0] ?? null
-  const templates = useMemo(() => filterScheduledTaskTemplates(filterId), [filterId])
+  const templates = useMemo(
+    () => filterScheduledTaskTemplates(filterId, effectiveTemplates),
+    [effectiveTemplates, filterId]
+  )
   const templateStateLabels = useMemo(
     () =>
       new Map(
@@ -183,7 +243,7 @@ export const ScheduledTaskCreatePanel: React.FC<ScheduledTaskCreatePanelProps> =
       return <PlannedPanel template={selectedTemplate} />
     }
 
-    return <HandoffPanel template={selectedTemplate} />
+    return <HandoffPanel template={selectedTemplate} capability={selectedCapability} />
   }
 
   return (

--- a/apps/packages/ui/src/components/Option/ScheduledTasks/ScheduledTasksPage.tsx
+++ b/apps/packages/ui/src/components/Option/ScheduledTasks/ScheduledTasksPage.tsx
@@ -19,6 +19,7 @@ import { ReminderTaskEditor } from "./ReminderTaskEditor"
 import { ScheduledTaskOverview } from "./ScheduledTaskOverview"
 import { ScheduledTaskDetailDrawer } from "./ScheduledTaskDetailDrawer"
 import { ScheduledTaskCreatePanel } from "./ScheduledTaskCreatePanel"
+import { DEFAULT_SCHEDULED_TASK_TEMPLATE_CAPABILITIES } from "./scheduled-task-template-capabilities"
 import {
   SCHEDULED_TASK_TABS,
   buildScheduledTaskSearch,
@@ -391,8 +392,9 @@ export const ScheduledTasksPage: React.FC = () => {
             <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
               <Typography.Text strong>No scheduled tasks yet.</Typography.Text>
               <Typography.Text type="secondary">
-                Create a reminder now. Automation templates for GitHub, YouTube, RAG, and
-                agents are planned follow-up phases.
+                Create a reminder now. Watch and Ingest setup continue in their owner
+                workspaces until capability, preview, duplicate, creation, and result
+                contracts are available.
               </Typography.Text>
             </div>
           }
@@ -512,6 +514,7 @@ export const ScheduledTasksPage: React.FC = () => {
                           onSelectTemplate={handleSelectTemplate}
                           onCreateReminder={handleCreateReminderFromPanel}
                           savingReminder={saving}
+                          templateCapabilities={DEFAULT_SCHEDULED_TASK_TEMPLATE_CAPABILITIES}
                         />
                       )
             }))}

--- a/apps/packages/ui/src/components/Option/ScheduledTasks/__tests__/ScheduledTaskCreatePanel.test.tsx
+++ b/apps/packages/ui/src/components/Option/ScheduledTasks/__tests__/ScheduledTaskCreatePanel.test.tsx
@@ -6,6 +6,10 @@ import userEvent from "@testing-library/user-event"
 import { describe, expect, it, vi } from "vitest"
 
 import { ScheduledTaskCreatePanel } from "../ScheduledTaskCreatePanel"
+import {
+  REQUIRED_WATCH_AVAILABILITY_GATES,
+  buildScheduledTaskTemplateCapability
+} from "../scheduled-task-template-capabilities"
 
 describe("ScheduledTaskCreatePanel", () => {
   it("renders intent templates by state without source-vendor IA", () => {
@@ -57,6 +61,111 @@ describe("ScheduledTaskCreatePanel", () => {
       "href",
       "/watchlists"
     )
+  })
+
+  it("shows Limited availability capability copy without Watch create language", () => {
+    const capability = buildScheduledTaskTemplateCapability("watch", {
+      passedGates: REQUIRED_WATCH_AVAILABILITY_GATES.filter(
+        (gate) => gate !== "source_preview"
+      ),
+      sourceIntent: {
+        sourceFamily: "feed",
+        can_watch: true,
+        can_ingest: false,
+        can_preview: false,
+        can_notify: false,
+        can_index_search: false,
+        can_index_rag: false,
+        can_create: false,
+        reason: "Ingest setup continues in Watchlists."
+      },
+      resultDestinations: {
+        home_supported: false,
+        notifications_supported: false,
+        search_indexed: false,
+        rag_scope_included: false
+      }
+    })
+
+    render(
+      <ScheduledTaskCreatePanel
+        selectedTemplateId="watch"
+        onSelectTemplate={vi.fn()}
+        onCreateReminder={vi.fn()}
+        templateCapabilities={{ watch: capability }}
+      />
+    )
+
+    expect(screen.getByText("Limited availability")).toBeInTheDocument()
+    expect(screen.getByText(/source preview/i)).toBeInTheDocument()
+    expect(screen.getByText("Detected source: feed.")).toBeInTheDocument()
+    expect(screen.getByText("Watch: supported.")).toBeInTheDocument()
+    expect(screen.getByText("Ingest: not supported for this source yet.")).toBeInTheDocument()
+    expect(screen.getByText("Ingest setup continues in Watchlists.")).toBeInTheDocument()
+    expect(screen.getByText("Home: not yet shown.")).toBeInTheDocument()
+    expect(
+      screen.getByText("Notifications: not available for this source yet.")
+    ).toBeInTheDocument()
+    expect(screen.getByText("No scheduled task has been created yet.")).toBeInTheDocument()
+    expect(screen.queryByRole("button", { name: /Create watch/i })).not.toBeInTheDocument()
+  })
+
+  it("keeps Available now from showing Limited availability templates", async () => {
+    const user = userEvent.setup()
+    render(
+      <ScheduledTaskCreatePanel
+        selectedTemplateId={null}
+        onSelectTemplate={vi.fn()}
+        onCreateReminder={vi.fn()}
+        templateCapabilities={{
+          watch: buildScheduledTaskTemplateCapability("watch", {
+            passedGates: REQUIRED_WATCH_AVAILABILITY_GATES.filter(
+              (gate) => gate !== "source_preview"
+            )
+          })
+        }}
+      />
+    )
+
+    await user.click(screen.getByText("Available now"))
+
+    expect(screen.getByRole("button", { name: /Create reminder/i })).toBeInTheDocument()
+    expect(screen.queryByText("Watch for new items")).not.toBeInTheDocument()
+  })
+
+  it("keeps capability essentials visible in an extension-width container", () => {
+    const capability = buildScheduledTaskTemplateCapability("watch", {
+      passedGates: REQUIRED_WATCH_AVAILABILITY_GATES.filter(
+        (gate) => gate !== "source_preview"
+      ),
+      sourceIntent: {
+        sourceFamily: "feed",
+        can_watch: true,
+        can_ingest: false,
+        can_preview: false,
+        can_notify: false,
+        can_index_search: false,
+        can_index_rag: false,
+        can_create: false,
+        reason: "Preview is not available for this source yet."
+      }
+    })
+
+    render(
+      <div style={{ width: 360 }}>
+        <ScheduledTaskCreatePanel
+          selectedTemplateId="watch"
+          onSelectTemplate={vi.fn()}
+          onCreateReminder={vi.fn()}
+          templateCapabilities={{ watch: capability }}
+        />
+      </div>
+    )
+
+    expect(screen.getByText("Limited availability")).toBeInTheDocument()
+    expect(screen.getByText("Detected source: feed.")).toBeInTheDocument()
+    expect(screen.getByText("Preview is not available for this source yet.")).toBeInTheDocument()
+    expect(screen.queryByRole("button", { name: /Create watch/i })).not.toBeInTheDocument()
   })
 
   it("does not include sensitive URL text in handoff summary", async () => {

--- a/apps/packages/ui/src/components/Option/ScheduledTasks/__tests__/ScheduledTaskCreatePanel.test.tsx
+++ b/apps/packages/ui/src/components/Option/ScheduledTasks/__tests__/ScheduledTaskCreatePanel.test.tsx
@@ -110,6 +110,85 @@ describe("ScheduledTaskCreatePanel", () => {
     expect(screen.queryByRole("button", { name: /Create watch/i })).not.toBeInTheDocument()
   })
 
+  it("explains Limited availability when the creation adapter is the only blocker", () => {
+    const capability = buildScheduledTaskTemplateCapability("watch", {
+      passedGates: REQUIRED_WATCH_AVAILABILITY_GATES,
+      sourceIntent: {
+        sourceFamily: "publication",
+        can_watch: true,
+        can_ingest: false,
+        can_preview: true,
+        can_notify: true,
+        can_index_search: false,
+        can_index_rag: false,
+        can_create: false
+      },
+      resultDestinations: {
+        home_supported: true,
+        notifications_supported: true,
+        search_indexed: false,
+        rag_scope_included: false
+      }
+    })
+
+    render(
+      <ScheduledTaskCreatePanel
+        selectedTemplateId="watch"
+        onSelectTemplate={vi.fn()}
+        onCreateReminder={vi.fn()}
+        templateCapabilities={{ watch: capability }}
+      />
+    )
+
+    expect(screen.getByText("Limited availability")).toBeInTheDocument()
+    expect(
+      screen.getByText(
+        "Creation from Scheduled Tasks is not available yet. Continue setup in Watchlists."
+      )
+    ).toBeInTheDocument()
+    expect(screen.queryByText(/source preview/i)).not.toBeInTheDocument()
+    expect(screen.queryByRole("button", { name: /Create watch/i })).not.toBeInTheDocument()
+  })
+
+  it("renders capability metadata for non-Watchlists handoff templates", () => {
+    const capability = buildScheduledTaskTemplateCapability("advanced", {
+      sourceIntent: {
+        sourceFamily: "website",
+        can_watch: false,
+        can_ingest: false,
+        can_preview: true,
+        can_notify: false,
+        can_index_search: false,
+        can_index_rag: false,
+        can_create: false,
+        reason: "Advanced setup continues in the owner workspace."
+      }
+    })
+
+    render(
+      <ScheduledTaskCreatePanel
+        selectedTemplateId="advanced"
+        onSelectTemplate={vi.fn()}
+        onCreateReminder={vi.fn()}
+        templateCapabilities={{ advanced: capability }}
+      />
+    )
+
+    expect(screen.getByText("Choose destination")).toBeInTheDocument()
+    expect(screen.getByText("Detected source: website.")).toBeInTheDocument()
+    expect(
+      screen.getByText("Advanced setup continues in the owner workspace.")
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText(
+        "Creation from Scheduled Tasks is not available yet. Choose the owner workspace to continue setup."
+      )
+    ).toBeInTheDocument()
+    expect(
+      screen.queryByText("Results destination: configured in Watchlists.")
+    ).not.toBeInTheDocument()
+  })
+
   it("keeps Available now from showing Limited availability templates", async () => {
     const user = userEvent.setup()
     render(
@@ -201,14 +280,14 @@ describe("ScheduledTaskCreatePanel", () => {
 
     await user.type(
       screen.getByRole("textbox", { name: "Optional source or setup note" }),
-      "api key: sk-test-secret"
+      "api key: sample credential"
     )
 
     expect(screen.getByText(/private-looking values/)).toBeInTheDocument()
     expect(screen.getByLabelText("Setup summary")).not.toHaveTextContent(
-      "api key: sk-test-secret"
+      "api key: sample credential"
     )
-    expect(screen.getByLabelText("Setup summary")).not.toHaveTextContent("sk-test-secret")
+    expect(screen.getByLabelText("Setup summary")).not.toHaveTextContent("sample credential")
   })
 
   it("renders planned Recurring question without create controls", () => {

--- a/apps/packages/ui/src/components/Option/ScheduledTasks/__tests__/ScheduledTasksPage.test.tsx
+++ b/apps/packages/ui/src/components/Option/ScheduledTasks/__tests__/ScheduledTasksPage.test.tsx
@@ -43,6 +43,8 @@ import { ScheduledTasksPage } from "../ScheduledTasksPage"
 const fetchMock = vi.fn()
 vi.stubGlobal("fetch", fetchMock)
 
+const SLOW_SCHEDULE_FORM_TIMEOUT_MS = 20000
+
 const renderWithQueryClient = (
   ui: React.ReactElement,
   initialEntry = "/scheduled-tasks"
@@ -986,7 +988,7 @@ describe("ScheduledTasksPage", () => {
     expect(await screen.findByText("Cron is required for recurring reminders")).toBeInTheDocument()
     expect(screen.getByText("Timezone is required for recurring reminders")).toBeInTheDocument()
     expect(mocks.createScheduledTaskReminder).not.toHaveBeenCalled()
-  }, 10000)
+  }, SLOW_SCHEDULE_FORM_TIMEOUT_MS)
 
   it("does not create a recurring reminder with scheduler-invalid cron or timezone", async () => {
     const user = userEvent.setup()
@@ -1017,7 +1019,7 @@ describe("ScheduledTasksPage", () => {
     })
     expect(screen.getAllByText("Cron minute must be between 0 and 59.").length).toBeGreaterThan(0)
     expect(screen.getByText("Timezone must be a valid IANA timezone.")).toBeInTheDocument()
-  }, 10000)
+  }, SLOW_SCHEDULE_FORM_TIMEOUT_MS)
 
   it("does not create a one-time reminder with whitespace-only run_at", async () => {
     const user = userEvent.setup()
@@ -1068,7 +1070,7 @@ describe("ScheduledTasksPage", () => {
     })
     expect(screen.getByText("Cron is required for recurring reminders")).toBeInTheDocument()
     expect(screen.getByText("Timezone is required for recurring reminders")).toBeInTheDocument()
-  }, 10000)
+  }, SLOW_SCHEDULE_FORM_TIMEOUT_MS)
 
   it("preserves an existing recurring custom cron when editing unrelated fields", async () => {
     mocks.listScheduledTasks.mockResolvedValue({

--- a/apps/packages/ui/src/components/Option/ScheduledTasks/__tests__/ScheduledTasksPage.test.tsx
+++ b/apps/packages/ui/src/components/Option/ScheduledTasks/__tests__/ScheduledTasksPage.test.tsx
@@ -217,6 +217,20 @@ describe("ScheduledTasksPage", () => {
     expect(screen.getByRole("tab", { name: "Create" })).toHaveAttribute("aria-selected", "true")
   })
 
+  it("keeps Watch template non-creating from the page route", async () => {
+    mocks.listScheduledTasks.mockResolvedValue({
+      items: [],
+      total: 0,
+      partial: false,
+      errors: []
+    })
+
+    renderWithQueryClient(<ScheduledTasksPage />, "/scheduled-tasks?tab=create&template=watch")
+
+    expect(await screen.findByText("No scheduled task has been created yet.")).toBeInTheDocument()
+    expect(screen.queryByRole("button", { name: /Create watch/i })).not.toBeInTheDocument()
+  })
+
   it("opens a task detail deep link after task data loads", async () => {
     mocks.listScheduledTasks.mockResolvedValue({
       items: [
@@ -767,9 +781,10 @@ describe("ScheduledTasksPage", () => {
     expect(screen.queryByRole("button", { name: "Save reminder" })).not.toBeInTheDocument()
     expect(
       screen.getByText(
-        "Create a reminder now. Automation templates for GitHub, YouTube, RAG, and agents are planned follow-up phases."
+        "Create a reminder now. Watch and Ingest setup continue in their owner workspaces until capability, preview, duplicate, creation, and result contracts are available."
       )
     ).toBeInTheDocument()
+    expect(screen.queryByText(/GitHub, YouTube/i)).not.toBeInTheDocument()
   })
 
   it("opens the created reminder detail after successful creation", async () => {

--- a/apps/packages/ui/src/components/Option/ScheduledTasks/__tests__/scheduled-task-template-capabilities.test.ts
+++ b/apps/packages/ui/src/components/Option/ScheduledTasks/__tests__/scheduled-task-template-capabilities.test.ts
@@ -3,8 +3,12 @@ import { describe, expect, it } from "vitest"
 import {
   REQUIRED_INGEST_AVAILABILITY_GATES,
   REQUIRED_WATCH_AVAILABILITY_GATES,
+  buildNotificationPolicyCopy,
+  buildResultDestinationCopy,
   buildScheduledTaskTemplateCapability,
+  buildSourceIntentCopy,
   getMissingAvailabilityGates,
+  redactCapabilityPreviewText,
   resolveTemplateCapabilityState
 } from "../scheduled-task-template-capabilities"
 
@@ -44,5 +48,79 @@ describe("scheduled task template capabilities", () => {
     })
 
     expect(resolveTemplateCapabilityState("ingest", capability)).toBe("available")
+  })
+
+  it("generates source-intent copy from source support metadata", () => {
+    expect(
+      buildSourceIntentCopy({
+        sourceFamily: "feed",
+        can_watch: true,
+        can_ingest: false,
+        can_preview: true,
+        can_notify: false,
+        can_index_search: false,
+        can_index_rag: false,
+        can_create: false,
+        reason: "Ingest setup continues in Watchlists."
+      })
+    ).toEqual([
+      "Detected source: feed.",
+      "Watch: supported.",
+      "Ingest: not supported for this source yet.",
+      "Ingest setup continues in Watchlists."
+    ])
+  })
+
+  it("generates destination copy from metadata", () => {
+    expect(
+      buildResultDestinationCopy({
+        home_supported: false,
+        notifications_supported: false,
+        search_indexed: false,
+        rag_scope_included: false
+      })
+    ).toEqual([
+      "Home: not yet shown.",
+      "Notifications: not available for this source yet.",
+      "Search: content may be saved but not searchable.",
+      "RAG: not included in the selected knowledge scope."
+    ])
+  })
+
+  it("generates notification copy from support state", () => {
+    expect(buildNotificationPolicyCopy({ notifications_supported: false })).toBe(
+      "Notifications are not available for this source yet."
+    )
+    expect(buildNotificationPolicyCopy({ notifications_supported: true })).toBe(
+      "Notifications can open exact task, run, or result detail when supported."
+    )
+  })
+
+  it("redacts private-looking preview text", () => {
+    expect(redactCapabilityPreviewText("https://example.com/feed?token=secret")).toBe(
+      "[redacted private source]"
+    )
+    expect(redactCapabilityPreviewText("https://example.com/feed#private")).toBe(
+      "[redacted private source]"
+    )
+    expect(redactCapabilityPreviewText("https://example.com/feed?api_key=secret")).toBe(
+      "[redacted private source]"
+    )
+    expect(redactCapabilityPreviewText("https://example.com/feed?access_token=secret")).toBe(
+      "[redacted private source]"
+    )
+    expect(redactCapabilityPreviewText("https://example.com/feed?client_secret=secret")).toBe(
+      "[redacted private source]"
+    )
+    expect(redactCapabilityPreviewText("Authorization: Bearer abc123")).toBe(
+      "[redacted private source]"
+    )
+    expect(redactCapabilityPreviewText("api key: sk-test-secret")).toBe(
+      "[redacted private source]"
+    )
+    expect(redactCapabilityPreviewText("Provider response: token=private-value")).toBe(
+      "[redacted private source]"
+    )
+    expect(redactCapabilityPreviewText("Public release feed")).toBe("Public release feed")
   })
 })

--- a/apps/packages/ui/src/components/Option/ScheduledTasks/__tests__/scheduled-task-template-capabilities.test.ts
+++ b/apps/packages/ui/src/components/Option/ScheduledTasks/__tests__/scheduled-task-template-capabilities.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  REQUIRED_INGEST_AVAILABILITY_GATES,
+  REQUIRED_WATCH_AVAILABILITY_GATES,
+  buildScheduledTaskTemplateCapability,
+  getMissingAvailabilityGates,
+  resolveTemplateCapabilityState
+} from "../scheduled-task-template-capabilities"
+
+describe("scheduled task template capabilities", () => {
+  it("requires preview before Watch can be available", () => {
+    const capability = buildScheduledTaskTemplateCapability("watch", {
+      passedGates: REQUIRED_WATCH_AVAILABILITY_GATES.filter(
+        (gate) => gate !== "source_preview"
+      )
+    })
+
+    expect(resolveTemplateCapabilityState("watch", capability)).toBe("limited_availability")
+    expect(getMissingAvailabilityGates("watch", capability)).toContain("source_preview")
+  })
+
+  it("keeps Watch limited when gates pass but no creation adapter is supported", () => {
+    const capability = buildScheduledTaskTemplateCapability("watch", {
+      passedGates: REQUIRED_WATCH_AVAILABILITY_GATES
+    })
+
+    expect(resolveTemplateCapabilityState("watch", capability)).toBe("limited_availability")
+  })
+
+  it("allows Watch only when every Watch gate and the creation adapter guard pass", () => {
+    const capability = buildScheduledTaskTemplateCapability("watch", {
+      creationAdapterSupported: true,
+      passedGates: REQUIRED_WATCH_AVAILABILITY_GATES
+    })
+
+    expect(resolveTemplateCapabilityState("watch", capability)).toBe("available")
+  })
+
+  it("does not require notification gate for Ingest availability once creation is supported", () => {
+    const capability = buildScheduledTaskTemplateCapability("ingest", {
+      creationAdapterSupported: true,
+      passedGates: REQUIRED_INGEST_AVAILABILITY_GATES
+    })
+
+    expect(resolveTemplateCapabilityState("ingest", capability)).toBe("available")
+  })
+})

--- a/apps/packages/ui/src/components/Option/ScheduledTasks/__tests__/scheduled-task-template-capabilities.test.ts
+++ b/apps/packages/ui/src/components/Option/ScheduledTasks/__tests__/scheduled-task-template-capabilities.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest"
 
 import {
+  DEFAULT_SCHEDULED_TASK_TEMPLATE_CAPABILITIES,
   REQUIRED_INGEST_AVAILABILITY_GATES,
   REQUIRED_WATCH_AVAILABILITY_GATES,
   buildNotificationPolicyCopy,
@@ -13,6 +14,10 @@ import {
 } from "../scheduled-task-template-capabilities"
 
 describe("scheduled task template capabilities", () => {
+  it("exports an immutable default capability map", () => {
+    expect(Object.isFrozen(DEFAULT_SCHEDULED_TASK_TEMPLATE_CAPABILITIES)).toBe(true)
+  })
+
   it("requires preview before Watch can be available", () => {
     const capability = buildScheduledTaskTemplateCapability("watch", {
       passedGates: REQUIRED_WATCH_AVAILABILITY_GATES.filter(
@@ -71,6 +76,21 @@ describe("scheduled task template capabilities", () => {
     ])
   })
 
+  it("falls back to unknown source family when source metadata is partial", () => {
+    expect(
+      buildSourceIntentCopy({
+        sourceFamily: undefined as never,
+        can_watch: false,
+        can_ingest: false,
+        can_preview: false,
+        can_notify: false,
+        can_index_search: false,
+        can_index_rag: false,
+        can_create: false
+      })[0]
+    ).toBe("Detected source: unknown.")
+  })
+
   it("generates destination copy from metadata", () => {
     expect(
       buildResultDestinationCopy({
@@ -88,6 +108,7 @@ describe("scheduled task template capabilities", () => {
   })
 
   it("generates notification copy from support state", () => {
+    expect(buildNotificationPolicyCopy(null)).toBe("Notifications: configured in Watchlists.")
     expect(buildNotificationPolicyCopy({ notifications_supported: false })).toBe(
       "Notifications are not available for this source yet."
     )
@@ -112,10 +133,10 @@ describe("scheduled task template capabilities", () => {
     expect(redactCapabilityPreviewText("https://example.com/feed?client_secret=secret")).toBe(
       "[redacted private source]"
     )
-    expect(redactCapabilityPreviewText("Authorization: Bearer abc123")).toBe(
+    expect(redactCapabilityPreviewText("Authorization: Bearer sample-token")).toBe(
       "[redacted private source]"
     )
-    expect(redactCapabilityPreviewText("api key: sk-test-secret")).toBe(
+    expect(redactCapabilityPreviewText("api key: sample credential")).toBe(
       "[redacted private source]"
     )
     expect(redactCapabilityPreviewText("Provider response: token=private-value")).toBe(

--- a/apps/packages/ui/src/components/Option/ScheduledTasks/__tests__/scheduled-task-templates.test.ts
+++ b/apps/packages/ui/src/components/Option/ScheduledTasks/__tests__/scheduled-task-templates.test.ts
@@ -78,6 +78,28 @@ describe("scheduled task templates", () => {
     ])
   })
 
+  it("labels Limited availability", () => {
+    expect(getScheduledTaskTemplateStateLabel("limited_availability")).toBe(
+      "Limited availability"
+    )
+  })
+
+  it("does not include Limited availability in Available now", () => {
+    const templates = [
+      { ...getScheduledTaskTemplate("watch")!, state: "limited_availability" as const }
+    ]
+
+    expect(filterScheduledTaskTemplates("available_now", templates)).toEqual([])
+  })
+
+  it("can look up templates from an effective template list", () => {
+    const templates = [
+      { ...getScheduledTaskTemplate("watch")!, state: "limited_availability" as const }
+    ]
+
+    expect(getScheduledTaskTemplate("watch", templates)?.state).toBe("limited_availability")
+  })
+
   it("sanitizes unsafe handoff source text", () => {
     expect(toSafeHandoffSourceText("https://example.com/feed?token=secret")).toBe(null)
     expect(toSafeHandoffSourceText("https://example.com/feed")).toBe("https://example.com/feed")

--- a/apps/packages/ui/src/components/Option/ScheduledTasks/scheduled-task-template-capabilities.ts
+++ b/apps/packages/ui/src/components/Option/ScheduledTasks/scheduled-task-template-capabilities.ts
@@ -58,6 +58,8 @@ export type ScheduledTaskTemplateCapabilityMap = Partial<
   Record<ScheduledTaskTemplateId, ScheduledTaskTemplateCapability>
 >
 
+export const DEFAULT_SCHEDULED_TASK_TEMPLATE_CAPABILITIES: ScheduledTaskTemplateCapabilityMap = {}
+
 export const REQUIRED_WATCH_AVAILABILITY_GATES = [
   "capability_health",
   "source_preview",

--- a/apps/packages/ui/src/components/Option/ScheduledTasks/scheduled-task-template-capabilities.ts
+++ b/apps/packages/ui/src/components/Option/ScheduledTasks/scheduled-task-template-capabilities.ts
@@ -150,3 +150,80 @@ export const buildScheduledTaskTemplateCapability = (
   reason: null,
   ...overrides
 })
+
+const REDACTED_CAPABILITY_PREVIEW = "[redacted private source]"
+
+const SENSITIVE_CAPABILITY_URL_PARAM_PATTERN =
+  /(^|[?&#])([a-z0-9]+[_-])*(token|api[_-]?key|key|secret|session|sid|auth|code|invite|password)([_-][a-z0-9]+)*=/i
+
+const PRIVATE_CAPABILITY_PROSE_PATTERN =
+  /\b(api[_ -]?key|password|passphrase|secret|bearer\s+[A-Za-z0-9._-]+|access[_ -]?token|refresh[_ -]?token|client[_ -]?secret)\b|sk-[A-Za-z0-9_-]+/i
+
+const PROVIDER_SECRET_SNIPPET_PATTERN =
+  /\b(provider response|authorization|credential|header)\b.*\b(token|secret|api[_ -]?key|password|auth)\s*[:=]/i
+
+const appearsToBeUrl = (value: string): boolean =>
+  /^[a-z][a-z0-9+.-]*:\/\//i.test(value) ||
+  /^www\./i.test(value) ||
+  /^[a-z0-9][a-z0-9.-]*\.[a-z]{2,}([/:?#]|$)/i.test(value)
+
+export const redactCapabilityPreviewText = (value: string): string => {
+  const trimmed = value.trim()
+
+  if (
+    SENSITIVE_CAPABILITY_URL_PARAM_PATTERN.test(trimmed) ||
+    (appearsToBeUrl(trimmed) && trimmed.includes("#")) ||
+    PRIVATE_CAPABILITY_PROSE_PATTERN.test(trimmed) ||
+    PROVIDER_SECRET_SNIPPET_PATTERN.test(trimmed)
+  ) {
+    return REDACTED_CAPABILITY_PREVIEW
+  }
+
+  return trimmed
+}
+
+export const buildSourceIntentCopy = (
+  intent: ScheduledTaskSourceIntentCapability | null | undefined
+): string[] => {
+  if (!intent) {
+    return ["Source support: configured in Watchlists."]
+  }
+
+  return [
+    `Detected source: ${intent.sourceFamily.replace(/_/g, " ")}.`,
+    intent.can_watch ? "Watch: supported." : "Watch: not supported for this source yet.",
+    intent.can_ingest ? "Ingest: supported." : "Ingest: not supported for this source yet.",
+    ...(intent.reason ? [redactCapabilityPreviewText(intent.reason)] : [])
+  ]
+}
+
+export const buildResultDestinationCopy = (
+  metadata: ScheduledTaskResultDestinationMetadata | null | undefined
+): string[] => {
+  if (!metadata) {
+    return ["Results destination: configured in Watchlists."]
+  }
+
+  return [
+    metadata.home_supported ? "Home: latest results will appear." : "Home: not yet shown.",
+    metadata.notifications_supported
+      ? "Notifications: available when the task policy triggers."
+      : "Notifications: not available for this source yet.",
+    metadata.search_indexed
+      ? "Search: indexed when ingest completes."
+      : "Search: content may be saved but not searchable.",
+    metadata.rag_scope_included
+      ? "RAG: included in the selected knowledge scope."
+      : "RAG: not included in the selected knowledge scope."
+  ]
+}
+
+export const buildNotificationPolicyCopy = (
+  metadata:
+    | Pick<ScheduledTaskResultDestinationMetadata, "notifications_supported">
+    | null
+    | undefined
+): string =>
+  metadata?.notifications_supported
+    ? "Notifications can open exact task, run, or result detail when supported."
+    : "Notifications are not available for this source yet."

--- a/apps/packages/ui/src/components/Option/ScheduledTasks/scheduled-task-template-capabilities.ts
+++ b/apps/packages/ui/src/components/Option/ScheduledTasks/scheduled-task-template-capabilities.ts
@@ -116,14 +116,14 @@ export const resolveTemplateCapabilityState = (
   }
 
   if (getMissingAvailabilityGates(templateId, capability).length > 0) {
-    return "limited_availability" as ScheduledTaskTemplateState
+    return "limited_availability"
   }
 
   // Keep this separate from sourceIntent.can_create. That flag describes source-level
   // support, not whether this /scheduled-tasks shell has a real creation adapter.
   return capability.creationAdapterSupported === true
     ? "available"
-    : ("limited_availability" as ScheduledTaskTemplateState)
+    : "limited_availability"
 }
 
 export const applyScheduledTaskTemplateCapabilities = (

--- a/apps/packages/ui/src/components/Option/ScheduledTasks/scheduled-task-template-capabilities.ts
+++ b/apps/packages/ui/src/components/Option/ScheduledTasks/scheduled-task-template-capabilities.ts
@@ -1,0 +1,152 @@
+import type {
+  ScheduledTaskTemplate,
+  ScheduledTaskTemplateId,
+  ScheduledTaskTemplateState
+} from "./scheduled-task-templates"
+
+export type ScheduledTaskAvailabilityGate =
+  | "capability_health"
+  | "source_preview"
+  | "duplicate_detection"
+  | "created_entity_response"
+  | "task_visibility"
+  | "run_result_links"
+  | "failure_contract"
+  | "result_destination"
+  | "notification_contract"
+  | "safe_source_handling"
+  | "watchlists_preservation"
+
+export type ScheduledTaskSourceFamily =
+  | "unknown"
+  | "feed"
+  | "website"
+  | "repository_issues"
+  | "video_channel"
+  | "publication"
+  | "advisory"
+
+export interface ScheduledTaskSourceIntentCapability {
+  sourceFamily: ScheduledTaskSourceFamily
+  can_watch: boolean
+  can_ingest: boolean
+  can_preview: boolean
+  can_notify: boolean
+  can_index_search: boolean
+  can_index_rag: boolean
+  can_create: boolean
+  reason?: string | null
+}
+
+export interface ScheduledTaskResultDestinationMetadata {
+  home_supported: boolean
+  notifications_supported: boolean
+  search_indexed: boolean
+  rag_scope_included: boolean
+}
+
+export interface ScheduledTaskTemplateCapability {
+  templateId: ScheduledTaskTemplateId
+  passedGates: readonly ScheduledTaskAvailabilityGate[]
+  creationAdapterSupported?: boolean
+  sourceIntent?: ScheduledTaskSourceIntentCapability | null
+  resultDestinations?: ScheduledTaskResultDestinationMetadata | null
+  reason?: string | null
+}
+
+export type ScheduledTaskTemplateCapabilityMap = Partial<
+  Record<ScheduledTaskTemplateId, ScheduledTaskTemplateCapability>
+>
+
+export const REQUIRED_WATCH_AVAILABILITY_GATES = [
+  "capability_health",
+  "source_preview",
+  "duplicate_detection",
+  "created_entity_response",
+  "task_visibility",
+  "run_result_links",
+  "failure_contract",
+  "result_destination",
+  "notification_contract",
+  "safe_source_handling",
+  "watchlists_preservation"
+] as const satisfies readonly ScheduledTaskAvailabilityGate[]
+
+export const REQUIRED_INGEST_AVAILABILITY_GATES = [
+  "capability_health",
+  "source_preview",
+  "duplicate_detection",
+  "created_entity_response",
+  "task_visibility",
+  "run_result_links",
+  "failure_contract",
+  "result_destination",
+  "safe_source_handling",
+  "watchlists_preservation"
+] as const satisfies readonly ScheduledTaskAvailabilityGate[]
+
+export const getRequiredAvailabilityGates = (
+  templateId: ScheduledTaskTemplateId
+): readonly ScheduledTaskAvailabilityGate[] =>
+  templateId === "watch"
+    ? REQUIRED_WATCH_AVAILABILITY_GATES
+    : templateId === "ingest"
+      ? REQUIRED_INGEST_AVAILABILITY_GATES
+      : []
+
+export const getMissingAvailabilityGates = (
+  templateId: ScheduledTaskTemplateId,
+  capability: ScheduledTaskTemplateCapability | null | undefined
+): ScheduledTaskAvailabilityGate[] => {
+  const required = getRequiredAvailabilityGates(templateId)
+  const passed = new Set(capability?.passedGates ?? [])
+  return required.filter((gate) => !passed.has(gate))
+}
+
+export const resolveTemplateCapabilityState = (
+  templateId: ScheduledTaskTemplateId,
+  capability: ScheduledTaskTemplateCapability | null | undefined
+): ScheduledTaskTemplateState | null => {
+  if (templateId !== "watch" && templateId !== "ingest") {
+    return null
+  }
+
+  if (!capability) {
+    return null
+  }
+
+  if (getMissingAvailabilityGates(templateId, capability).length > 0) {
+    return "limited_availability" as ScheduledTaskTemplateState
+  }
+
+  // Keep this separate from sourceIntent.can_create. That flag describes source-level
+  // support, not whether this /scheduled-tasks shell has a real creation adapter.
+  return capability.creationAdapterSupported === true
+    ? "available"
+    : ("limited_availability" as ScheduledTaskTemplateState)
+}
+
+export const applyScheduledTaskTemplateCapabilities = (
+  templates: readonly ScheduledTaskTemplate[],
+  capabilities: ScheduledTaskTemplateCapabilityMap | null | undefined
+): ScheduledTaskTemplate[] =>
+  templates.map((template) => {
+    const resolvedState = resolveTemplateCapabilityState(
+      template.id,
+      capabilities?.[template.id]
+    )
+    return resolvedState ? { ...template, state: resolvedState } : template
+  })
+
+export const buildScheduledTaskTemplateCapability = (
+  templateId: ScheduledTaskTemplateId,
+  overrides: Partial<ScheduledTaskTemplateCapability> = {}
+): ScheduledTaskTemplateCapability => ({
+  templateId,
+  passedGates: [],
+  creationAdapterSupported: false,
+  sourceIntent: null,
+  resultDestinations: null,
+  reason: null,
+  ...overrides
+})

--- a/apps/packages/ui/src/components/Option/ScheduledTasks/scheduled-task-template-capabilities.ts
+++ b/apps/packages/ui/src/components/Option/ScheduledTasks/scheduled-task-template-capabilities.ts
@@ -54,11 +54,12 @@ export interface ScheduledTaskTemplateCapability {
   reason?: string | null
 }
 
-export type ScheduledTaskTemplateCapabilityMap = Partial<
-  Record<ScheduledTaskTemplateId, ScheduledTaskTemplateCapability>
+export type ScheduledTaskTemplateCapabilityMap = Readonly<
+  Partial<Record<ScheduledTaskTemplateId, ScheduledTaskTemplateCapability>>
 >
 
-export const DEFAULT_SCHEDULED_TASK_TEMPLATE_CAPABILITIES: ScheduledTaskTemplateCapabilityMap = {}
+export const DEFAULT_SCHEDULED_TASK_TEMPLATE_CAPABILITIES: ScheduledTaskTemplateCapabilityMap =
+  Object.freeze({})
 
 export const REQUIRED_WATCH_AVAILABILITY_GATES = [
   "capability_health",
@@ -191,8 +192,13 @@ export const buildSourceIntentCopy = (
     return ["Source support: configured in Watchlists."]
   }
 
+  const sourceFamily =
+    typeof intent.sourceFamily === "string" && intent.sourceFamily.trim()
+      ? intent.sourceFamily
+      : "unknown"
+
   return [
-    `Detected source: ${intent.sourceFamily.replace(/_/g, " ")}.`,
+    `Detected source: ${sourceFamily.replace(/_/g, " ")}.`,
     intent.can_watch ? "Watch: supported." : "Watch: not supported for this source yet.",
     intent.can_ingest ? "Ingest: supported." : "Ingest: not supported for this source yet.",
     ...(intent.reason ? [redactCapabilityPreviewText(intent.reason)] : [])
@@ -225,7 +231,12 @@ export const buildNotificationPolicyCopy = (
     | Pick<ScheduledTaskResultDestinationMetadata, "notifications_supported">
     | null
     | undefined
-): string =>
-  metadata?.notifications_supported
+): string => {
+  if (!metadata) {
+    return "Notifications: configured in Watchlists."
+  }
+
+  return metadata.notifications_supported
     ? "Notifications can open exact task, run, or result detail when supported."
     : "Notifications are not available for this source yet."
+}

--- a/apps/packages/ui/src/components/Option/ScheduledTasks/scheduled-task-templates.ts
+++ b/apps/packages/ui/src/components/Option/ScheduledTasks/scheduled-task-templates.ts
@@ -8,6 +8,7 @@ export type ScheduledTaskTemplateId =
 
 export type ScheduledTaskTemplateState =
   | "available"
+  | "limited_availability"
   | "handoff_only"
   | "needs_setup"
   | "managed_in_watchlists"
@@ -66,7 +67,7 @@ export const SCHEDULED_TASK_TEMPLATES: readonly ScheduledTaskTemplate[] = [
     category: "watch",
     title: "Watch for new items",
     intent: "Tell me when something new appears",
-    description: "Get notified when a source has new matching items.",
+    description: "Surface new matching items and notify when supported.",
     state: "handoff_only",
     primaryActionLabel: "Continue in Watchlists",
     secondaryActionLabel: "Copy setup summary",
@@ -83,7 +84,7 @@ export const SCHEDULED_TASK_TEMPLATES: readonly ScheduledTaskTemplate[] = [
     category: "ingest",
     title: "Ingest new content",
     intent: "Add new content to my library/search",
-    description: "Add new source content to your library and search surfaces.",
+    description: "Add new source content to supported library, search, or knowledge destinations.",
     state: "handoff_only",
     primaryActionLabel: "Continue in Watchlists",
     secondaryActionLabel: "Copy setup summary",
@@ -144,22 +145,24 @@ export const SCHEDULED_TASK_TEMPLATE_FILTERS: readonly ScheduledTaskTemplateFilt
 ] as const
 
 export const getScheduledTaskTemplate = (
-  id: ScheduledTaskTemplateId | string | null | undefined
+  id: ScheduledTaskTemplateId | string | null | undefined,
+  templates: readonly ScheduledTaskTemplate[] = SCHEDULED_TASK_TEMPLATES
 ): ScheduledTaskTemplate | null =>
-  SCHEDULED_TASK_TEMPLATES.find((template) => template.id === id) ?? null
+  templates.find((template) => template.id === id) ?? null
 
 export const filterScheduledTaskTemplates = (
-  filterId: ScheduledTaskTemplateFilterId
+  filterId: ScheduledTaskTemplateFilterId,
+  templates: readonly ScheduledTaskTemplate[] = SCHEDULED_TASK_TEMPLATES
 ): readonly ScheduledTaskTemplate[] => {
   if (filterId === "all") {
-    return SCHEDULED_TASK_TEMPLATES
+    return templates
   }
 
   if (filterId === "available_now") {
-    return SCHEDULED_TASK_TEMPLATES.filter((template) => template.state === "available")
+    return templates.filter((template) => template.state === "available")
   }
 
-  return SCHEDULED_TASK_TEMPLATES.filter((template) => template.category === filterId)
+  return templates.filter((template) => template.category === filterId)
 }
 
 const escapeRegExp = (value: string): string =>
@@ -204,6 +207,8 @@ export const getScheduledTaskTemplateStateLabel = (
   switch (state) {
     case "available":
       return "Available"
+    case "limited_availability":
+      return "Limited availability"
     case "handoff_only":
       return "Handoff only"
     case "needs_setup":

--- a/backlog/tasks/task-2320 - Design-Scheduled-Tasks-Automation-Workbench-Phase-2-creation-framework.md
+++ b/backlog/tasks/task-2320 - Design-Scheduled-Tasks-Automation-Workbench-Phase-2-creation-framework.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-2320
 title: Design Scheduled Tasks Automation Workbench Phase 2 creation framework
-status: In Progress
+status: Done
 labels:
 - scheduled-tasks
 - ux
@@ -28,11 +28,11 @@ Write the Phase 2 product/UX design spec for the Scheduled Tasks Automation Work
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Spec preserves Watchlists as a separate persona/job surface and does not collapse Watchlists into Scheduled Tasks.
-- [ ] #2 Spec treats GitHub and YouTube only as examples, not as primary source assumptions.
-- [ ] #3 Spec clearly separates Phase 2A frontend-only creation framework from Phase 2B backend/product contract dependencies.
-- [ ] #4 Spec covers Reminder, Watch for new items, Ingest new content, Recurring question, Agent task, and Advanced domain handoff states.
-- [ ] #5 Spec includes IA, create flow, prompt matcher behavior, capability states, home/task visibility expectations, error states, success states, deep links, accessibility, and implementation acceptance criteria.
+- [x] #1 Spec preserves Watchlists as a separate persona/job surface and does not collapse Watchlists into Scheduled Tasks.
+- [x] #2 Spec treats GitHub and YouTube only as examples, not as primary source assumptions.
+- [x] #3 Spec clearly separates Phase 2A frontend-only creation framework from Phase 2B backend/product contract dependencies.
+- [x] #4 Spec covers Reminder, Watch for new items, Ingest new content, Recurring question, Agent task, and Advanced domain handoff states.
+- [x] #5 Spec includes IA, create flow, prompt matcher behavior, capability states, home/task visibility expectations, error states, success states, deep links, accessibility, and implementation acceptance criteria.
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -55,10 +55,10 @@ Created the Phase 2 creation design spec and refined it after product/UX review.
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->

--- a/backlog/tasks/task-2321 - Plan-Scheduled-Tasks-Automation-Workbench-Phase-2A-creation-framework.md
+++ b/backlog/tasks/task-2321 - Plan-Scheduled-Tasks-Automation-Workbench-Phase-2A-creation-framework.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-2321
 title: Plan Scheduled Tasks Automation Workbench Phase 2A creation framework
-status: In Progress
+status: Done
 labels:
 - scheduled-tasks
 - webui
@@ -29,11 +29,11 @@ Write the implementation plan for Scheduled Tasks Automation Workbench Phase 2A.
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Plan is saved under Docs/superpowers/plans with exact file paths, tasks, tests, commands, and commit boundaries.
-- [ ] #2 Plan keeps Phase 2A frontend-first and does not introduce new backend contracts.
-- [ ] #3 Plan preserves Watchlists as the deep workspace and uses handoff-only panels where creation is not supported.
-- [ ] #4 Plan includes tests for routing, template matching, capability states, reminder success detail navigation, handoff copy, invalid tab/template/task links, and accessibility/responsive requirements where feasible.
-- [ ] #5 Plan records verification and Bandit skip rationale for documentation-only planning.
+- [x] #1 Plan is saved under Docs/superpowers/plans with exact file paths, tasks, tests, commands, and commit boundaries.
+- [x] #2 Plan keeps Phase 2A frontend-first and does not introduce new backend contracts.
+- [x] #3 Plan preserves Watchlists as the deep workspace and uses handoff-only panels where creation is not supported.
+- [x] #4 Plan includes tests for routing, template matching, capability states, reminder success detail navigation, handoff copy, invalid tab/template/task links, and accessibility/responsive requirements where feasible.
+- [x] #5 Plan records verification and Bandit skip rationale for documentation-only planning.
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -56,10 +56,10 @@ Created the Phase 2A create-framework implementation plan. The plan preserves Wa
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->

--- a/backlog/tasks/task-2324 - Design-Scheduled-Tasks-Phase-2B-Watch-Ingest-product-contract.md
+++ b/backlog/tasks/task-2324 - Design-Scheduled-Tasks-Phase-2B-Watch-Ingest-product-contract.md
@@ -1,0 +1,69 @@
+---
+id: TASK-2324
+title: Design Scheduled Tasks Phase 2B Watch/Ingest product contract
+status: Done
+assignee: []
+created_date: ''
+updated_date: '2026-06-09 01:13'
+labels:
+  - scheduled-tasks
+  - ux
+  - prd
+  - phase-2b
+  - watchlists
+dependencies: []
+references:
+  - TASK-2320
+  - TASK-2322
+  - >-
+    Docs/superpowers/specs/2026-06-08-scheduled-tasks-automation-workbench-phase2-creation-design.md
+  - >-
+    Docs/superpowers/specs/2026-06-01-scheduled-tasks-automation-workbench-prd-design.md
+documentation:
+  - >-
+    Docs/superpowers/specs/2026-06-09-scheduled-tasks-phase2b-watch-ingest-product-contract-design.md
+modified_files:
+  - >-
+    Docs/superpowers/specs/2026-06-09-scheduled-tasks-phase2b-watch-ingest-product-contract-design.md
+  - >-
+    backlog/tasks/task-2324 -
+    Design-Scheduled-Tasks-Phase-2B-Watch-Ingest-product-contract.md
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Define the product and UX contract for moving Scheduled Tasks Watch for new items and Ingest new content templates from handoff-only to safely actionable, while preserving Watchlists as the deep source/monitor/ingest workspace. Scope stays product/UX-first with backend/API work listed only as dependencies.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Spec defines when Watch and Ingest templates can move from handoff-only to available without duplicating or limiting Watchlists.
+- [x] #2 Spec treats GitHub, YouTube, RSS, sites, advisories, publications, and other sources as examples inside source-agnostic Watch/Ingest intents.
+- [x] #3 Spec covers capability health, preview, duplicate detection, created entity responses, task/detail links, failure reasons, result destinations, and recovery paths.
+- [x] #4 Spec defines first-time-user and power-user flows for Watch and Ingest from /scheduled-tasks plus handoff/return behavior with Watchlists.
+- [x] #5 Spec records backend/API dependencies only as contracts and does not prescribe implementation details.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Created the Phase 2B Watch/Ingest product contract spec. The spec defines source-agnostic Watch and Ingest intents, preserves Watchlists as the deep workspace, and lists capability health, preview, duplicate detection, creation response, deep-link, failure, result-destination, handoff, extension, and accessibility contracts required before the templates can become available from /scheduled-tasks.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Created the Phase 2B Watch/Ingest product contract spec and linked it from this Backlog task. The spec keeps GitHub/YouTube as examples only, defines when Watch/Ingest can move out of handoff-only, preserves Watchlists as the full source/monitor/ingest workspace, and records backend/API work only as product-facing dependencies. Verification: ran git diff --check after fixing an EOF whitespace issue; scanned the new spec and task record for unresolved planning markers with none found. Bandit is not applicable because this is documentation/backlog-only work.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-2325 - Revise-Scheduled-Tasks-Phase-2B-Watch-Ingest-contract-after-review.md
+++ b/backlog/tasks/task-2325 - Revise-Scheduled-Tasks-Phase-2B-Watch-Ingest-contract-after-review.md
@@ -1,0 +1,66 @@
+---
+id: TASK-2325
+title: Revise Scheduled Tasks Phase 2B Watch/Ingest contract after review
+status: Done
+assignee: []
+created_date: ''
+updated_date: '2026-06-09 01:39'
+labels:
+  - scheduled-tasks
+  - ux
+  - prd
+  - phase-2b
+  - review
+dependencies: []
+references:
+  - TASK-2324
+  - >-
+    Docs/superpowers/specs/2026-06-09-scheduled-tasks-phase2b-watch-ingest-product-contract-design.md
+documentation:
+  - >-
+    Docs/superpowers/specs/2026-06-09-scheduled-tasks-phase2b-watch-ingest-product-contract-design.md
+modified_files:
+  - >-
+    Docs/superpowers/specs/2026-06-09-scheduled-tasks-phase2b-watch-ingest-product-contract-design.md
+  - >-
+    backlog/tasks/task-2325 -
+    Revise-Scheduled-Tasks-Phase-2B-Watch-Ingest-contract-after-review.md
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Revise the Phase 2B Watch/Ingest product contract after UX review. Tighten preview availability, split state models, add notification and source-intent capability contracts, clarify ingest destinations, duplicate policy, Home copy, extension redaction, and delivery slice gating before implementation planning.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Spec makes preview a hard gate for Available and defines Limited availability without overclaiming first-time creation.
+- [x] #2 Spec splits template capability, task lifecycle, run state, and result outcome models.
+- [x] #3 Spec adds notification, source-intent capability, ingest destination, duplicate policy, result-destination, and redaction contracts.
+- [x] #4 Spec clarifies delivery slices so frontend capability states cannot promote Watch/Ingest to Available before all gates pass.
+- [x] #5 Verification is recorded and Bandit is documented as not applicable for docs-only work.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Revised the Phase 2B Watch/Ingest product contract after UX review. The spec now makes preview a hard gate for Available, defines Limited availability, splits template capability/task lifecycle/run/result state models, adds source-intent capability, notification, ingest destination, duplicate policy, result-destination, and redaction contracts, and clarifies that the 2B.2 frontend shell cannot promote Watch/Ingest to Available before all gates pass.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Updated the Phase 2B Watch/Ingest product contract after review. The revision hardens availability gates, prevents search/RAG/Home/notification overpromising, separates state models, adds missing product-facing contracts, and clarifies delivery sequencing before implementation planning. Verification: git diff --check passed; unresolved planning marker scan passed. Bandit is not applicable because this is documentation/backlog-only work.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-2326 - Plan-Scheduled-Tasks-Phase-2B-capability-aware-frontend-shell.md
+++ b/backlog/tasks/task-2326 - Plan-Scheduled-Tasks-Phase-2B-capability-aware-frontend-shell.md
@@ -1,0 +1,67 @@
+---
+id: TASK-2326
+title: Plan Scheduled Tasks Phase 2B capability-aware frontend shell
+status: Done
+assignee: []
+created_date: ''
+updated_date: '2026-06-09 01:55'
+labels:
+  - scheduled-tasks
+  - webui
+  - ux
+  - phase-2b
+  - implementation-plan
+dependencies: []
+references:
+  - TASK-2324
+  - TASK-2325
+  - >-
+    Docs/superpowers/specs/2026-06-09-scheduled-tasks-phase2b-watch-ingest-product-contract-design.md
+documentation:
+  - >-
+    Docs/superpowers/plans/2026-06-09-scheduled-tasks-phase2b-capability-aware-frontend-shell-implementation-plan.md
+modified_files:
+  - >-
+    Docs/superpowers/plans/2026-06-09-scheduled-tasks-phase2b-capability-aware-frontend-shell-implementation-plan.md
+  - >-
+    backlog/tasks/task-2326 -
+    Plan-Scheduled-Tasks-Phase-2B-capability-aware-frontend-shell.md
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Write an implementation plan for Scheduled Tasks Phase 2B.2 Capability-aware frontend shell. The plan should translate the hardened Watch/Ingest product contract into frontend-first work: runtime capability state modeling, Limited availability display, generated copy from metadata, source-intent capability handling, notification/result destination copy, redaction-safe preview messaging, and tests that prevent Watch/Ingest from becoming Available until all gates pass. Scope remains planning/docs only.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Plan is saved under Docs/superpowers/plans with exact file paths, tasks, tests, commands, expected outcomes, and commit boundaries.
+- [x] #2 Plan keeps Phase 2B.2 frontend-shell scoped and does not implement Watchlists backend contracts or promote Watch/Ingest to Available before all gates pass.
+- [x] #3 Plan covers template capability states, Limited availability, source-intent capability metadata, generated result/notification copy, redaction rules, and extension-sized behavior.
+- [x] #4 Plan includes focused tests for capability state gating, copy generation, unavailable/limited states, template filtering, route behavior, and regression protection against overpromising Home/search/RAG/notifications.
+- [x] #5 Verification is recorded and Bandit is documented as not applicable for docs-only planning.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Created the Phase 2B.2 capability-aware frontend shell implementation plan. The plan keeps the slice frontend-only, adds a pure capability overlay model, Limited availability, metadata-generated result/notification copy, redaction helpers, and tests that prevent Watch/Ingest from being treated as Available before all gates pass. Plan-document-reviewer subagent was not spawned because the available subagent tool requires explicit user permission for delegation; performed a local self-review instead.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Created the Phase 2B.2 capability-aware frontend shell implementation plan. It maps the hardened Watch/Ingest contract into TDD tasks for capability modeling, Limited availability, generated copy, Create panel integration, page wiring, and focused verification while explicitly excluding backend contracts and Watchlists creation adapters. Verification: git diff --check passed; unresolved planning marker scan passed. Bandit is not applicable because this is documentation/backlog-only planning work.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-2327 - Revise-Scheduled-Tasks-Phase-2B-capability-shell-plan-after-review.md
+++ b/backlog/tasks/task-2327 - Revise-Scheduled-Tasks-Phase-2B-capability-shell-plan-after-review.md
@@ -1,0 +1,54 @@
+---
+id: TASK-2327
+title: Revise Scheduled Tasks Phase 2B capability shell plan after review
+status: Done
+labels:
+- scheduled-tasks
+- webui
+- ux
+- phase-2b
+- implementation-plan
+- review
+priority: medium
+references:
+- TASK-2326
+- Docs/superpowers/plans/2026-06-09-scheduled-tasks-phase2b-capability-aware-frontend-shell-implementation-plan.md
+- Docs/superpowers/specs/2026-06-09-scheduled-tasks-phase2b-watch-ingest-product-contract-design.md
+modified_files:
+- Docs/superpowers/plans/2026-06-09-scheduled-tasks-phase2b-capability-aware-frontend-shell-implementation-plan.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Plan prevents Watch/Ingest templates from appearing Available in Phase 2B.2 unless a real creation adapter/frontdoor is explicitly supported.
+- [ ] #2 Plan requires source-intent detection details and reason copy to be visible and tested in the Create panel.
+- [ ] #3 Plan expands redaction test coverage for URL fragments, common secret query params, bearer/prose secrets, and provider snippets.
+- [ ] #4 Plan includes extension-width/narrow-container verification for the Create panel shell.
+- [ ] #5 Plan fixes the file-structure indentation issue found in review.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Addressed all review findings in the Phase 2B.2 capability-aware frontend shell plan. The plan now requires both all gates and creationAdapterSupported === true before Watch/Ingest can resolve Available, keeps page defaults non-creating, surfaces source-intent copy in UI/tests, expands redaction coverage for URL fragments/query secrets/bearer/prose/provider snippets, adds extension-width component coverage, and fixes the file-list indentation. Verification: git diff --check exited 0; stale wording and placeholder scan exited 1 with no matches. Bandit skipped because this is a docs-only plan revision with no Python touched.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Backlog task tracks the revision and final verification.
+- [ ] #2 Plan file is updated with focused changes only.
+- [ ] #3 Docs checks pass with no unresolved placeholders introduced.
+- [ ] #4 Changes are committed with the Backlog task update.
+<!-- DOD:END -->

--- a/backlog/tasks/task-2327 - Revise-Scheduled-Tasks-Phase-2B-capability-shell-plan-after-review.md
+++ b/backlog/tasks/task-2327 - Revise-Scheduled-Tasks-Phase-2B-capability-shell-plan-after-review.md
@@ -2,42 +2,44 @@
 id: TASK-2327
 title: Revise Scheduled Tasks Phase 2B capability shell plan after review
 status: Done
+assignee: []
+created_date: ''
+updated_date: '2026-06-09 04:32'
 labels:
-- scheduled-tasks
-- webui
-- ux
-- phase-2b
-- implementation-plan
-- review
-priority: medium
+  - scheduled-tasks
+  - webui
+  - ux
+  - phase-2b
+  - implementation-plan
+  - review
+dependencies: []
 references:
-- TASK-2326
-- Docs/superpowers/plans/2026-06-09-scheduled-tasks-phase2b-capability-aware-frontend-shell-implementation-plan.md
-- Docs/superpowers/specs/2026-06-09-scheduled-tasks-phase2b-watch-ingest-product-contract-design.md
-modified_files:
-- Docs/superpowers/plans/2026-06-09-scheduled-tasks-phase2b-capability-aware-frontend-shell-implementation-plan.md
+  - TASK-2326
+  - >-
+    Docs/superpowers/plans/2026-06-09-scheduled-tasks-phase2b-capability-aware-frontend-shell-implementation-plan.md
+  - >-
+    Docs/superpowers/specs/2026-06-09-scheduled-tasks-phase2b-watch-ingest-product-contract-design.md
+priority: medium
 ---
 
 ## Description
 
 <!-- SECTION:DESCRIPTION:BEGIN -->
-
 <!-- SECTION:DESCRIPTION:END -->
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Plan prevents Watch/Ingest templates from appearing Available in Phase 2B.2 unless a real creation adapter/frontdoor is explicitly supported.
-- [ ] #2 Plan requires source-intent detection details and reason copy to be visible and tested in the Create panel.
-- [ ] #3 Plan expands redaction test coverage for URL fragments, common secret query params, bearer/prose secrets, and provider snippets.
-- [ ] #4 Plan includes extension-width/narrow-container verification for the Create panel shell.
-- [ ] #5 Plan fixes the file-structure indentation issue found in review.
+- [x] #1 Plan prevents Watch/Ingest templates from appearing Available in Phase 2B.2 unless a real creation adapter/frontdoor is explicitly supported.
+- [x] #2 Plan requires source-intent detection details and reason copy to be visible and tested in the Create panel.
+- [x] #3 Plan expands redaction test coverage for URL fragments, common secret query params, bearer/prose secrets, and provider snippets.
+- [x] #4 Plan includes extension-width/narrow-container verification for the Create panel shell.
+- [x] #5 Plan fixes the file-structure indentation issue found in review.
 <!-- AC:END -->
 
 ## Implementation Notes
 
-<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
-
-<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+<!-- SECTION:NOTES:BEGIN -->
+<!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
@@ -47,8 +49,8 @@ Addressed all review findings in the Phase 2B.2 capability-aware frontend shell 
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Backlog task tracks the revision and final verification.
-- [ ] #2 Plan file is updated with focused changes only.
-- [ ] #3 Docs checks pass with no unresolved placeholders introduced.
-- [ ] #4 Changes are committed with the Backlog task update.
+- [x] #1 Backlog task tracks the revision and final verification.
+- [x] #2 Plan file is updated with focused changes only.
+- [x] #3 Docs checks pass with no unresolved placeholders introduced.
+- [x] #4 Changes are committed with the Backlog task update.
 <!-- DOD:END -->

--- a/backlog/tasks/task-2328 - Implement-Scheduled-Tasks-Phase-2B-capability-aware-frontend-shell.md
+++ b/backlog/tasks/task-2328 - Implement-Scheduled-Tasks-Phase-2B-capability-aware-frontend-shell.md
@@ -1,0 +1,59 @@
+---
+id: TASK-2328
+title: Implement Scheduled Tasks Phase 2B capability-aware frontend shell
+status: In Progress
+labels:
+- scheduled-tasks
+- webui
+- ux
+- phase-2b
+- frontend
+- implementation
+priority: high
+references:
+- TASK-2326
+- TASK-2325
+- TASK-2324
+- TASK-2327
+- Docs/superpowers/plans/2026-06-09-scheduled-tasks-phase2b-capability-aware-frontend-shell-implementation-plan.md
+- Docs/superpowers/specs/2026-06-09-scheduled-tasks-phase2b-watch-ingest-product-contract-design.md
+modified_files:
+- apps/packages/ui/src/components/Option/ScheduledTasks/scheduled-task-template-capabilities.ts
+- apps/packages/ui/src/components/Option/ScheduledTasks/__tests__/scheduled-task-template-capabilities.test.ts
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Add a pure ScheduledTasks capability helper module with gate enforcement, explicit creation-adapter guard, source intent/result/notification copy, and redaction coverage.
+- [ ] #2 Add limited_availability to ScheduledTasks template state, labels, filtering, and effective-template lookup without changing Reminder behavior.
+- [ ] #3 Render capability-aware Limited availability UI in the Create panel without Watch/Ingest create actions or scheduled success copy.
+- [ ] #4 Wire default empty capability shell through /scheduled-tasks so Watch/Ingest remain non-creating by default and source-vendor IA copy is avoided.
+- [ ] #5 Run focused ScheduledTasks unit/component tests plus whitespace verification; record Bandit skip rationale if no Python files are touched.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Implementation follows the Phase 2B.2 plan scope and avoids Watchlists/backend/Home/RAG/API changes.
+- [ ] #2 Tests are written before production changes and focused tests pass.
+- [ ] #3 No new placeholder markers or unscoped TODOs are introduced.
+- [ ] #4 Backlog task records files changed, verification, known skips, and final summary.
+- [ ] #5 Changes are committed in focused increments.
+<!-- DOD:END -->

--- a/backlog/tasks/task-2328 - Implement-Scheduled-Tasks-Phase-2B-capability-aware-frontend-shell.md
+++ b/backlog/tasks/task-2328 - Implement-Scheduled-Tasks-Phase-2B-capability-aware-frontend-shell.md
@@ -2,52 +2,47 @@
 id: TASK-2328
 title: Implement Scheduled Tasks Phase 2B capability-aware frontend shell
 status: Done
+assignee: []
+created_date: ''
+updated_date: '2026-06-09 04:32'
 labels:
-- scheduled-tasks
-- webui
-- ux
-- phase-2b
-- frontend
-- implementation
-priority: high
+  - scheduled-tasks
+  - webui
+  - ux
+  - phase-2b
+  - frontend
+  - implementation
+dependencies: []
 references:
-- TASK-2326
-- TASK-2325
-- TASK-2324
-- TASK-2327
-- Docs/superpowers/plans/2026-06-09-scheduled-tasks-phase2b-capability-aware-frontend-shell-implementation-plan.md
-- Docs/superpowers/specs/2026-06-09-scheduled-tasks-phase2b-watch-ingest-product-contract-design.md
-modified_files:
-- apps/packages/ui/src/components/Option/ScheduledTasks/scheduled-task-template-capabilities.ts
-- apps/packages/ui/src/components/Option/ScheduledTasks/__tests__/scheduled-task-template-capabilities.test.ts
-- apps/packages/ui/src/components/Option/ScheduledTasks/scheduled-task-templates.ts
-- apps/packages/ui/src/components/Option/ScheduledTasks/__tests__/scheduled-task-templates.test.ts
-- apps/packages/ui/src/components/Option/ScheduledTasks/ScheduledTaskCreatePanel.tsx
-- apps/packages/ui/src/components/Option/ScheduledTasks/__tests__/ScheduledTaskCreatePanel.test.tsx
-- apps/packages/ui/src/components/Option/ScheduledTasks/ScheduledTasksPage.tsx
-- apps/packages/ui/src/components/Option/ScheduledTasks/__tests__/ScheduledTasksPage.test.tsx
+  - TASK-2326
+  - TASK-2325
+  - TASK-2324
+  - TASK-2327
+  - >-
+    Docs/superpowers/plans/2026-06-09-scheduled-tasks-phase2b-capability-aware-frontend-shell-implementation-plan.md
+  - >-
+    Docs/superpowers/specs/2026-06-09-scheduled-tasks-phase2b-watch-ingest-product-contract-design.md
+priority: high
 ---
 
 ## Description
 
 <!-- SECTION:DESCRIPTION:BEGIN -->
-
 <!-- SECTION:DESCRIPTION:END -->
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Add a pure ScheduledTasks capability helper module with gate enforcement, explicit creation-adapter guard, source intent/result/notification copy, and redaction coverage.
-- [ ] #2 Add limited_availability to ScheduledTasks template state, labels, filtering, and effective-template lookup without changing Reminder behavior.
-- [ ] #3 Render capability-aware Limited availability UI in the Create panel without Watch/Ingest create actions or scheduled success copy.
-- [ ] #4 Wire default empty capability shell through /scheduled-tasks so Watch/Ingest remain non-creating by default and source-vendor IA copy is avoided.
-- [ ] #5 Run focused ScheduledTasks unit/component tests plus whitespace verification; record Bandit skip rationale if no Python files are touched.
+- [x] #1 Add a pure ScheduledTasks capability helper module with gate enforcement, explicit creation-adapter guard, source intent/result/notification copy, and redaction coverage.
+- [x] #2 Add limited_availability to ScheduledTasks template state, labels, filtering, and effective-template lookup without changing Reminder behavior.
+- [x] #3 Render capability-aware Limited availability UI in the Create panel without Watch/Ingest create actions or scheduled success copy.
+- [x] #4 Wire default empty capability shell through /scheduled-tasks so Watch/Ingest remain non-creating by default and source-vendor IA copy is avoided.
+- [x] #5 Run focused ScheduledTasks unit/component tests plus whitespace verification; record Bandit skip rationale if no Python files are touched.
 <!-- AC:END -->
 
 ## Implementation Notes
 
-<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
-
-<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+<!-- SECTION:NOTES:BEGIN -->
+<!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
@@ -57,9 +52,9 @@ Implemented the Phase 2B.2 capability-aware Scheduled Tasks frontend shell. Adde
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Implementation follows the Phase 2B.2 plan scope and avoids Watchlists/backend/Home/RAG/API changes.
-- [ ] #2 Tests are written before production changes and focused tests pass.
-- [ ] #3 No new placeholder markers or unscoped TODOs are introduced.
-- [ ] #4 Backlog task records files changed, verification, known skips, and final summary.
-- [ ] #5 Changes are committed in focused increments.
+- [x] #1 Implementation follows the Phase 2B.2 plan scope and avoids Watchlists/backend/Home/RAG/API changes.
+- [x] #2 Tests are written before production changes and focused tests pass.
+- [x] #3 No new placeholder markers or unscoped TODOs are introduced.
+- [x] #4 Backlog task records files changed, verification, known skips, and final summary.
+- [x] #5 Changes are committed in focused increments.
 <!-- DOD:END -->

--- a/backlog/tasks/task-2328 - Implement-Scheduled-Tasks-Phase-2B-capability-aware-frontend-shell.md
+++ b/backlog/tasks/task-2328 - Implement-Scheduled-Tasks-Phase-2B-capability-aware-frontend-shell.md
@@ -22,6 +22,8 @@ modified_files:
 - apps/packages/ui/src/components/Option/ScheduledTasks/__tests__/scheduled-task-template-capabilities.test.ts
 - apps/packages/ui/src/components/Option/ScheduledTasks/scheduled-task-templates.ts
 - apps/packages/ui/src/components/Option/ScheduledTasks/__tests__/scheduled-task-templates.test.ts
+- apps/packages/ui/src/components/Option/ScheduledTasks/ScheduledTaskCreatePanel.tsx
+- apps/packages/ui/src/components/Option/ScheduledTasks/__tests__/ScheduledTaskCreatePanel.test.tsx
 ---
 
 ## Description

--- a/backlog/tasks/task-2328 - Implement-Scheduled-Tasks-Phase-2B-capability-aware-frontend-shell.md
+++ b/backlog/tasks/task-2328 - Implement-Scheduled-Tasks-Phase-2B-capability-aware-frontend-shell.md
@@ -20,6 +20,8 @@ references:
 modified_files:
 - apps/packages/ui/src/components/Option/ScheduledTasks/scheduled-task-template-capabilities.ts
 - apps/packages/ui/src/components/Option/ScheduledTasks/__tests__/scheduled-task-template-capabilities.test.ts
+- apps/packages/ui/src/components/Option/ScheduledTasks/scheduled-task-templates.ts
+- apps/packages/ui/src/components/Option/ScheduledTasks/__tests__/scheduled-task-templates.test.ts
 ---
 
 ## Description

--- a/backlog/tasks/task-2328 - Implement-Scheduled-Tasks-Phase-2B-capability-aware-frontend-shell.md
+++ b/backlog/tasks/task-2328 - Implement-Scheduled-Tasks-Phase-2B-capability-aware-frontend-shell.md
@@ -24,6 +24,8 @@ modified_files:
 - apps/packages/ui/src/components/Option/ScheduledTasks/__tests__/scheduled-task-templates.test.ts
 - apps/packages/ui/src/components/Option/ScheduledTasks/ScheduledTaskCreatePanel.tsx
 - apps/packages/ui/src/components/Option/ScheduledTasks/__tests__/ScheduledTaskCreatePanel.test.tsx
+- apps/packages/ui/src/components/Option/ScheduledTasks/ScheduledTasksPage.tsx
+- apps/packages/ui/src/components/Option/ScheduledTasks/__tests__/ScheduledTasksPage.test.tsx
 ---
 
 ## Description

--- a/backlog/tasks/task-2328 - Implement-Scheduled-Tasks-Phase-2B-capability-aware-frontend-shell.md
+++ b/backlog/tasks/task-2328 - Implement-Scheduled-Tasks-Phase-2B-capability-aware-frontend-shell.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-2328
 title: Implement Scheduled Tasks Phase 2B capability-aware frontend shell
-status: In Progress
+status: Done
 labels:
 - scheduled-tasks
 - webui
@@ -52,7 +52,7 @@ modified_files:
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-
+Implemented the Phase 2B.2 capability-aware Scheduled Tasks frontend shell. Added a pure capability model with required Watch/Ingest gates, explicit creationAdapterSupported guard, source-intent/result/notification copy helpers, and private-source redaction. Added limited_availability state support, effective-template filtering/lookup, Create panel capability rendering, extension-width coverage, and page-level default empty capability wiring. Watch/Ingest remain non-creating by default and the empty state no longer frames GitHub or YouTube as primary IA. Verification: capability/template/Create panel/page focused suite passed with 65 tests using --testTimeout=20000 after the exact plan command exposed an existing 5s page-test timing variance; route-state regression passed with 8 tests; git diff --check exited 0; product touched-file placeholder scan had no matches. Bandit skipped because no Python files were touched.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-2329 - Rebase-PR-2325-and-address-scheduled-tasks-review-feedback.md
+++ b/backlog/tasks/task-2329 - Rebase-PR-2325-and-address-scheduled-tasks-review-feedback.md
@@ -1,0 +1,53 @@
+---
+id: TASK-2329
+title: Rebase PR 2325 and address scheduled tasks review feedback
+status: In Progress
+labels:
+- scheduled-tasks
+- webui
+- ux
+- phase-2b
+- pr-feedback
+- rebase
+priority: high
+references:
+- https://github.com/rmusser01/tldw_server/pull/2325
+- TASK-2328
+- TASK-2327
+- TASK-2326
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 PR branch is rebased onto the latest origin/dev without unresolved conflicts.
+- [ ] #2 All actionable PR review comments and check failures are inspected and either addressed or documented with technical rationale.
+- [ ] #3 Focused ScheduledTasks verification is rerun after any changes.
+- [ ] #4 Backlog task records final status, verification, and known skips.
+- [ ] #5 Branch is force-pushed safely after rebase and fixes.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Worktree is clean after final commit/push.
+- [ ] #2 PR is updated on GitHub.
+- [ ] #3 No unresolved actionable review comments remain unaddressed without rationale.
+- [ ] #4 Verification results are recorded.
+<!-- DOD:END -->

--- a/backlog/tasks/task-2329 - Rebase-PR-2325-and-address-scheduled-tasks-review-feedback.md
+++ b/backlog/tasks/task-2329 - Rebase-PR-2325-and-address-scheduled-tasks-review-feedback.md
@@ -2,41 +2,44 @@
 id: TASK-2329
 title: Rebase PR 2325 and address scheduled tasks review feedback
 status: In Progress
+assignee: []
+created_date: ''
+updated_date: '2026-06-09 04:42'
 labels:
-- scheduled-tasks
-- webui
-- ux
-- phase-2b
-- pr-feedback
-- rebase
-priority: high
+  - scheduled-tasks
+  - webui
+  - ux
+  - phase-2b
+  - pr-feedback
+  - rebase
+dependencies: []
 references:
-- https://github.com/rmusser01/tldw_server/pull/2325
-- TASK-2328
-- TASK-2327
-- TASK-2326
+  - 'https://github.com/rmusser01/tldw_server/pull/2325'
+  - TASK-2328
+  - TASK-2327
+  - TASK-2326
+priority: high
 ---
 
 ## Description
 
 <!-- SECTION:DESCRIPTION:BEGIN -->
-
 <!-- SECTION:DESCRIPTION:END -->
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 PR branch is rebased onto the latest origin/dev without unresolved conflicts.
-- [ ] #2 All actionable PR review comments and check failures are inspected and either addressed or documented with technical rationale.
-- [ ] #3 Focused ScheduledTasks verification is rerun after any changes.
-- [ ] #4 Backlog task records final status, verification, and known skips.
+- [x] #1 PR branch is rebased onto the latest origin/dev without unresolved conflicts.
+- [x] #2 All actionable PR review comments and check failures are inspected and either addressed or documented with technical rationale.
+- [x] #3 Focused ScheduledTasks verification is rerun after any changes.
+- [x] #4 Backlog task records final status, verification, and known skips.
 - [ ] #5 Branch is force-pushed safely after rebase and fixes.
 <!-- AC:END -->
 
 ## Implementation Notes
 
-<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
-
-<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+<!-- SECTION:NOTES:BEGIN -->
+Rebased branch onto origin/dev without conflicts. Addressed actionable PR feedback in ScheduledTasks capability helpers and Create panel: immutable default capability map, safe missing source-family fallback, distinct unknown notification metadata copy, adapter-only availability explanation, non-Watchlists capability metadata rendering, non-secret-looking redaction fixtures, stale Backlog checklist metadata, and slow recurring form test timeouts. Verification: focused ScheduledTasks batch passed with 69 tests; route-state regression passed with 8 tests; git diff --check exited 0; touched product placeholder scan had no matches. Bandit skipped because no Python files are touched.
+<!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
@@ -49,5 +52,5 @@ references:
 - [ ] #1 Worktree is clean after final commit/push.
 - [ ] #2 PR is updated on GitHub.
 - [ ] #3 No unresolved actionable review comments remain unaddressed without rationale.
-- [ ] #4 Verification results are recorded.
+- [x] #4 Verification results are recorded.
 <!-- DOD:END -->

--- a/backlog/tasks/task-2329 - Rebase-PR-2325-and-address-scheduled-tasks-review-feedback.md
+++ b/backlog/tasks/task-2329 - Rebase-PR-2325-and-address-scheduled-tasks-review-feedback.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-2329
 title: Rebase PR 2325 and address scheduled tasks review feedback
-status: In Progress
+status: Done
 assignee: []
 created_date: ''
-updated_date: '2026-06-09 04:42'
+updated_date: '2026-06-09 04:46'
 labels:
   - scheduled-tasks
   - webui
@@ -32,7 +32,7 @@ priority: high
 - [x] #2 All actionable PR review comments and check failures are inspected and either addressed or documented with technical rationale.
 - [x] #3 Focused ScheduledTasks verification is rerun after any changes.
 - [x] #4 Backlog task records final status, verification, and known skips.
-- [ ] #5 Branch is force-pushed safely after rebase and fixes.
+- [x] #5 Branch is force-pushed safely after rebase and fixes.
 <!-- AC:END -->
 
 ## Implementation Notes
@@ -44,13 +44,13 @@ Rebased branch onto origin/dev without conflicts. Addressed actionable PR feedba
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-
+Rebased PR #2325 onto latest origin/dev and force-pushed the updated branch. Addressed all actionable review feedback in b6997470: sourceFamily fallback, non-Watchlists capability metadata rendering, adapter-only Limited availability guidance, unknown notification metadata copy, frozen default capability map, neutral redaction test fixtures, stale Backlog checklists, and recurring form timeout reliability. Replied to all inline review threads and added a PR-level summary for the non-inline Qodo item. Verification: focused ScheduledTasks batch passed with 69 tests; route-state regression passed with 8 tests; git diff --check exited 0; touched product placeholder scan had no matches. Bandit skipped because no Python files were touched. GitHub checks were pending on the refreshed head when reviewed.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Worktree is clean after final commit/push.
-- [ ] #2 PR is updated on GitHub.
-- [ ] #3 No unresolved actionable review comments remain unaddressed without rationale.
+- [x] #1 Worktree is clean after final commit/push.
+- [x] #2 PR is updated on GitHub.
+- [x] #3 No unresolved actionable review comments remain unaddressed without rationale.
 - [x] #4 Verification results are recorded.
 <!-- DOD:END -->

--- a/backlog/tasks/task-2330 - Rebase-PR-2325-onto-latest-dev-follow-up.md
+++ b/backlog/tasks/task-2330 - Rebase-PR-2325-onto-latest-dev-follow-up.md
@@ -1,0 +1,43 @@
+---
+id: TASK-2330
+title: Rebase PR 2325 onto latest dev follow-up
+status: In Progress
+labels:
+- scheduled-tasks
+- webui
+- pr-feedback
+- rebase
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Track the follow-up request to rebase PR #2325 onto the latest origin/dev and update the PR branch.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Fetch latest origin/dev and rebase the PR branch without unresolved conflicts.
+- [ ] #2 Push the rebased branch safely to update PR #2325.
+- [ ] #3 Record final branch status and any verification/check status.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Worktree is clean after rebase/push.
+- [ ] #2 PR branch points at the rebased head on GitHub.
+- [ ] #3 Any conflicts or failures are documented with next steps.
+<!-- DOD:END -->

--- a/backlog/tasks/task-2330 - Rebase-PR-2325-onto-latest-dev-follow-up.md
+++ b/backlog/tasks/task-2330 - Rebase-PR-2325-onto-latest-dev-follow-up.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-2330
 title: Rebase PR 2325 onto latest dev follow-up
-status: In Progress
+status: Done
 labels:
 - scheduled-tasks
 - webui
@@ -18,26 +18,26 @@ Track the follow-up request to rebase PR #2325 onto the latest origin/dev and up
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Fetch latest origin/dev and rebase the PR branch without unresolved conflicts.
-- [ ] #2 Push the rebased branch safely to update PR #2325.
-- [ ] #3 Record final branch status and any verification/check status.
+- [x] #1 Fetch latest origin/dev and rebase the PR branch without unresolved conflicts.
+- [x] #2 Push the rebased branch safely to update PR #2325.
+- [x] #3 Record final branch status and any verification/check status.
 <!-- AC:END -->
 
 ## Implementation Notes
 
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
-
+Fetched origin/dev at 3386a87abe7432c4a0a004c2febd2feeecf8f932, rebased codex/scheduled-tasks-phase2b-contract successfully with no conflicts, and force-pushed the rebased branch with --force-with-lease. New local head after the rebase was 3287bfab403ef2cde7d8c6abdb83af97648cdccc before this closeout commit.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-
+Rebased PR #2325 onto latest origin/dev and updated the remote PR branch. Rebase completed without conflicts. Verification was limited to git status/base-head checks because this request only changed branch ancestry and Backlog task metadata.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Worktree is clean after rebase/push.
-- [ ] #2 PR branch points at the rebased head on GitHub.
-- [ ] #3 Any conflicts or failures are documented with next steps.
+- [x] #1 Worktree is clean after rebase/push.
+- [x] #2 PR branch points at the rebased head on GitHub.
+- [x] #3 Any conflicts or failures are documented with next steps.
 <!-- DOD:END -->

--- a/backlog/tasks/task-494 - Create-scheduled-tasks-Automation-Workbench-UX-PRD.md
+++ b/backlog/tasks/task-494 - Create-scheduled-tasks-Automation-Workbench-UX-PRD.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-494
 title: Create scheduled tasks Automation Workbench UX PRD
-status: In Progress
+status: Done
 assignee: []
 created_date: ''
 updated_date: 2026-06-07 23:49
@@ -28,11 +28,11 @@ Write a product/UX PRD for the target /scheduled-tasks Automation Workbench expe
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 PRD addresses the scheduled-tasks UX audit issues and defines the full target UX.
-- [ ] #2 PRD keeps backend/API/data-model details at dependency level rather than implementation detail.
-- [ ] #3 PRD explicitly preserves Watchlists as a separate first-class workflow/persona.
-- [ ] #4 PRD covers WebUI, Home surfacing, browser extension context-aware creation, states, copy, accessibility, success metrics, and phased delivery.
-- [ ] #5 Design document is saved under Docs/superpowers/specs and committed with related Backlog.md task updates.
+- [x] #1 PRD addresses the scheduled-tasks UX audit issues and defines the full target UX.
+- [x] #2 PRD keeps backend/API/data-model details at dependency level rather than implementation detail.
+- [x] #3 PRD explicitly preserves Watchlists as a separate first-class workflow/persona.
+- [x] #4 PRD covers WebUI, Home surfacing, browser extension context-aware creation, states, copy, accessibility, success metrics, and phased delivery.
+- [x] #5 Design document is saved under Docs/superpowers/specs and committed with related Backlog.md task updates.
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -55,10 +55,10 @@ Created the Scheduled Tasks Automation Workbench PRD and marked it ready for use
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->

--- a/backlog/tasks/task-496 - Plan-Scheduled-Tasks-Automation-Workbench-Phase-1-implementation.md
+++ b/backlog/tasks/task-496 - Plan-Scheduled-Tasks-Automation-Workbench-Phase-1-implementation.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-496
 title: Plan Scheduled Tasks Automation Workbench Phase 1 implementation
-status: In Progress
+status: Done
 labels:
 - plan
 - ux
@@ -28,11 +28,11 @@ Create an execution-ready implementation plan for Phase 1 of the Scheduled Tasks
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Implementation plan is saved under Docs/superpowers/plans.
-- [ ] #2 Plan is scoped to Phase 1 and leaves later RAG/ACP/template/extension work as follow-up plans.
-- [ ] #3 Plan includes exact files, test paths, commands, expected outcomes, and incremental task steps.
-- [ ] #4 Plan preserves existing Watchlists UX and uses deep links rather than moving Watchlists configuration into /scheduled-tasks.
-- [ ] #5 Plan passes plan-document-reviewer review and is committed with the Backlog task update.
+- [x] #1 Implementation plan is saved under Docs/superpowers/plans.
+- [x] #2 Plan is scoped to Phase 1 and leaves later RAG/ACP/template/extension work as follow-up plans.
+- [x] #3 Plan includes exact files, test paths, commands, expected outcomes, and incremental task steps.
+- [x] #4 Plan preserves existing Watchlists UX and uses deep links rather than moving Watchlists configuration into /scheduled-tasks.
+- [x] #5 Plan passes plan-document-reviewer review and is committed with the Backlog task update.
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -55,10 +55,10 @@ Created the Phase 1 implementation plan for the Scheduled Tasks Automation Workb
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->


### PR DESCRIPTION
<h3>PR Summary by Qodo</h3>

Phase 2B.2: Capability-aware Scheduled Tasks shell for Watch/Ingest (Limited availability)
<code>✨ Enhancement</code> <code>🧪 Tests</code> <code>📝 Documentation</code> <code>🕐 40+ Minutes</code>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>Walkthroughs</h3>

<details open>
<summary>User Description</summary>

<br/>

## Summary
- Adds the Phase 2B Watch/Ingest product contract and capability-aware frontend implementation plan.
- Adds a Scheduled Tasks capability model with required gates, explicit creation-adapter guard, source/result/notification copy helpers, and private-source redaction.
- Adds Limited availability UI in the Create panel and keeps Watch/Ingest non-creating by default from `/scheduled-tasks`.

## Test Plan
- [x] `bunx vitest run src/components/Option/ScheduledTasks/__tests__/scheduled-task-template-capabilities.test.ts src/components/Option/ScheduledTasks/__tests__/scheduled-task-templates.test.ts src/components/Option/ScheduledTasks/__tests__/ScheduledTaskCreatePanel.test.tsx src/components/Option/ScheduledTasks/__tests__/ScheduledTasksPage.test.tsx --maxWorkers=1 --no-file-parallelism --testTimeout=20000`
- [x] `bunx vitest run src/components/Option/ScheduledTasks/__tests__/scheduled-task-route-state.test.ts --maxWorkers=1 --no-file-parallelism`
- [x] `git diff --check`

## Change summary
Human-written Change summary required before merge per `Docs/superpowers/AI_GENERATED_PR_CHANGE_SUMMARY_POLICY_2026_04_17.md`.

## Notes
- Exact focused command without `--testTimeout=20000` exposed an existing 5s timing variance in `ScheduledTasksPage.test.tsx`; the same 65 tests passed with the higher timeout.
- Bandit skipped because this PR touches docs and frontend TypeScript only.

</details>

<details open>
<summary>AI Description</summary>

<br/>

<pre>
• Add a frontend capability model that gates Watch/Ingest availability and creation adapter support.
• Render Limited availability UI with generated source/result/notification copy and safe redaction.
• Keep Watch/Ingest non-creating from /scheduled-tasks and update regression tests + docs.
</pre>
</details>

<details>
<summary>Diagram</summary>

<br/>

```mermaid
graph TD
  A["ScheduledTasksPage"] --> B["ScheduledTaskCreatePanel"] --> C["Template registry"]
  B --> D["Capability model"] --> E["Copy + redaction"]
  D --> C
  F["Vitest tests"] --> D
  F --> B
  F --> A
```

</details>




<details>
<summary>High-Level Assessment</summary>

<br/>

The following are alternative approaches to this PR:

<details>
<summary><b>1. Centralize redaction logic in existing handoff sanitizer module</b></summary>

- ➕ Avoids duplicate private/secret-detection regexes diverging across modules
- ➕ Single place to tune sensitivity rules for URLs/prose/provider snippets
- ➖ May introduce awkward dependencies between template registry and capability helpers if not factored carefully
- ➖ Could broaden scope if existing sanitizer semantics must remain stable

</details>

<details>
<summary><b>2. Introduce a typed gate-&gt;label map instead of formatting snake_case at render time</b></summary>

- ➕ Avoids leaking internal gate IDs into UI as-is; enables curated UX labels per gate
- ➕ Makes copy localization/consistency easier later
- ➖ Slightly more upfront code and maintenance for a mapping table
- ➖ Still requires careful product wording decisions per gate

</details>

**Recommendation:** The PR’s approach (pure capability overlay + prop injection into CreatePanel + empty default map at the page) is the right Phase 2B.2 slice: it enables capability-aware UI without prematurely enabling Watch/Ingest creation. Consider a follow-up refactor to centralize redaction/sanitization and optionally curate per-gate user-facing labels once backend capability contracts begin populating real gate data.

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>File Changes</h3>

<details>
<summary><strong>Enhancement</strong> (4)</summary>

<blockquote>
<details>
<summary><strong>ScheduledTaskCreatePanel.tsx</strong> <code>Render capability-driven Limited availability details in Watch/Ingest handoff panel</code> <code>+65/-5</code></summary>

<br/>

>Render capability-driven Limited availability details in Watch/Ingest handoff panel
>
><pre>
>• Adds an optional templateCapabilities prop, overlays capability-derived states onto the template registry, and passes the selected capability into the Watch/Ingest panel. Renders missing gate reasons plus generated source/result/notification copy while preserving the non-creating handoff behavior and existing safety checks for private-looking source notes.
></pre>
>
><a href='https://github.com/rmusser01/tldw_server/pull/2325/files#diff-8c334162e5a5cb93a04be3ab5c23e9338407a85a94305c366fa5fe54fad64611'>apps/packages/ui/src/components/Option/ScheduledTasks/ScheduledTaskCreatePanel.tsx</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>ScheduledTasksPage.tsx</strong> <code>Wire default empty capability map and update empty-state copy</code> <code>+5/-2</code></summary>

<br/>

>Wire default empty capability map and update empty-state copy
>
><pre>
>• Supplies DEFAULT_SCHEDULED_TASK_TEMPLATE_CAPABILITIES to the Create panel so Watch/Ingest remain handoff-only by default. Updates the empty-state copy to avoid GitHub/YouTube-centric IA and to describe gating prerequisites at a high level.
></pre>
>
><a href='https://github.com/rmusser01/tldw_server/pull/2325/files#diff-5e4714bccb461c9583b0f2d71d461f93715d961d942e142244d4b76c86e216cf'>apps/packages/ui/src/components/Option/ScheduledTasks/ScheduledTasksPage.tsx</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>scheduled-task-template-capabilities.ts</strong> <code>Introduce Scheduled Tasks capability model with gates, copy helpers, and redaction</code> <code>+231/-0</code></summary>

<br/>

>Introduce Scheduled Tasks capability model with gates, copy helpers, and redaction
>
><pre>
>• Adds a pure capability overlay module with required gates for Watch vs Ingest, missing-gate computation, and state resolution that requires both all gates and creationAdapterSupported. Provides metadata-driven copy helpers and a redaction helper to suppress private-looking URLs/fragments/secret-like prose/provider snippets; exports an empty default capability map for page wiring.
></pre>
>
><a href='https://github.com/rmusser01/tldw_server/pull/2325/files#diff-8d089b4d6a9b5234bf3870a79bc8bb9184a3801e514983ca1344c314e3060d44'>apps/packages/ui/src/components/Option/ScheduledTasks/scheduled-task-template-capabilities.ts</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>scheduled-task-templates.ts</strong> <code>Add limited_availability state and enable filtering/lookup on effective template lists</code> <code>+13/-8</code></summary>

<br/>

>Add limited_availability state and enable filtering/lookup on effective template lists
>
><pre>
>• Extends ScheduledTaskTemplateState with limited_availability and adds its user-facing label. Updates Watch/Ingest descriptions to avoid overpromising notifications/search/RAG, and updates getScheduledTaskTemplate/filterScheduledTaskTemplates to accept an optional template list for capability-overlaid filtering.
></pre>
>
><a href='https://github.com/rmusser01/tldw_server/pull/2325/files#diff-6a96e4c7eef967fd873a53088148c74f1cf7dd425a883a094a338e5aeb527a90'>apps/packages/ui/src/components/Option/ScheduledTasks/scheduled-task-templates.ts</a>
<hr/>

</details>
</blockquote>

</details>

<details>
<summary><strong>Tests</strong> (4)</summary>

<blockquote>
<details>
<summary><strong>ScheduledTaskCreatePanel.test.tsx</strong> <code>Add Create panel regressions for Limited availability and no-create behavior</code> <code>+109/-0</code></summary>

<br/>

>Add Create panel regressions for Limited availability and no-create behavior
>
><pre>
>• Adds component tests that assert Limited availability rendering with missing-gate copy, metadata-driven copy blocks, and suppression of any Watch create CTA. Includes an extension-width smoke test to ensure essential status/copy remains present in narrow containers and a filter regression that Available now excludes limited_availability.
></pre>
>
><a href='https://github.com/rmusser01/tldw_server/pull/2325/files#diff-95b0067b86a2647044c3563e1ecb66329c3c2a6b312b521c396e0d1ca1081f3d'>apps/packages/ui/src/components/Option/ScheduledTasks/__tests__/ScheduledTaskCreatePanel.test.tsx</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>ScheduledTasksPage.test.tsx</strong> <code>Add route regression to keep Watch non-creating and update empty-state assertions</code> <code>+16/-1</code></summary>

<br/>

>Add route regression to keep Watch non-creating and update empty-state assertions
>
><pre>
>• Adds a route-level test ensuring /scheduled-tasks?tab=create&amp;template=watch does not expose a Watch create CTA and still shows handoff copy. Updates the empty-state copy assertion and ensures GitHub/YouTube wording no longer appears.
></pre>
>
><a href='https://github.com/rmusser01/tldw_server/pull/2325/files#diff-70cb80d55f5a5a73a05510726b4484939734361dc55e0252a7d11bc122d0f072'>apps/packages/ui/src/components/Option/ScheduledTasks/__tests__/ScheduledTasksPage.test.tsx</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>scheduled-task-template-capabilities.test.ts</strong> <code>Add unit tests for capability gating, copy generation, and redaction</code> <code>+126/-0</code></summary>

<br/>

>Add unit tests for capability gating, copy generation, and redaction
>
><pre>
>• Covers required gate enforcement, explicit creationAdapterSupported guard behavior, and the notification-gate exception for Ingest. Verifies metadata-driven copy helpers and redaction of private-looking URL/prose/provider-snippet inputs.
></pre>
>
><a href='https://github.com/rmusser01/tldw_server/pull/2325/files#diff-e3c7881feb2d84a51c2a76d3cad76924ddf7ef3b3d80e5a7bf2df46783634718'>apps/packages/ui/src/components/Option/ScheduledTasks/__tests__/scheduled-task-template-capabilities.test.ts</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>scheduled-task-templates.test.ts</strong> <code>Add template-state tests for limited_availability and effective-list helpers</code> <code>+22/-0</code></summary>

<br/>

>Add template-state tests for limited_availability and effective-list helpers
>
><pre>
>• Adds coverage for the new Limited availability label, verifies Available now excludes limited_availability, and tests template lookup using an effective template list rather than only the static registry.
></pre>
>
><a href='https://github.com/rmusser01/tldw_server/pull/2325/files#diff-8c29e64c9487254e2edc8f9f99a5b6bf1d9f43c01de7fb5bc9babf604dd96289'>apps/packages/ui/src/components/Option/ScheduledTasks/__tests__/scheduled-task-templates.test.ts</a>
<hr/>

</details>
</blockquote>

</details>

<details>
<summary><strong>Documentation</strong> (11)</summary>

<blockquote>
<details>
<summary><strong>2026-06-09-scheduled-tasks-phase2b-capability-aware-frontend-shell-implementation-plan.md</strong> <code>Add Phase 2B.2 capability-aware frontend shell implementation plan</code> <code>+1105/-0</code></summary>

<br/>

>Add Phase 2B.2 capability-aware frontend shell implementation plan
>
><pre>
>• Introduces a detailed, task-by-task plan for adding capability modeling, Limited availability UI, copy generation, redaction, and focused verification. Explicitly scopes out backend/Watchlists adapter work and enforces non-creating defaults from /scheduled-tasks.
></pre>
>
><a href='https://github.com/rmusser01/tldw_server/pull/2325/files#diff-ccb0910a12fec7d503b373e91a2080354ab9b69d3124b3cf6b6203a56f947bfc'>Docs/superpowers/plans/2026-06-09-scheduled-tasks-phase2b-capability-aware-frontend-shell-implementation-plan.md</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>2026-06-09-scheduled-tasks-phase2b-watch-ingest-product-contract-design.md</strong> <code>Add Phase 2B Watch/Ingest product contract spec</code> <code>+518/-0</code></summary>

<br/>

>Add Phase 2B Watch/Ingest product contract spec
>
><pre>
>• Defines the product/UX contract and availability gates required before Watch/Ingest can be safely created from /scheduled-tasks. Clarifies source-agnostic intent model, Watchlists ownership boundary, state model separation, redaction expectations, and extension constraints.
></pre>
>
><a href='https://github.com/rmusser01/tldw_server/pull/2325/files#diff-27c6c38a25236bdd5d9f8e429d4b9b1023c00f92bc65b99fced9e7085f427c3f'>Docs/superpowers/specs/2026-06-09-scheduled-tasks-phase2b-watch-ingest-product-contract-design.md</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>task-2320 - Design-Scheduled-Tasks-Automation-Workbench-Phase-2-creation-framework.md</strong> <code>Mark TASK-2320 design task as Done</code> <code>+12/-12</code></summary>

<br/>

>Mark TASK-2320 design task as Done
>
><pre>
>• Updates task status and checks acceptance criteria/definition-of-done boxes to reflect completion.
></pre>
>
><a href='https://github.com/rmusser01/tldw_server/pull/2325/files#diff-eb71626f1ace21453dead6634ccc31bad88dd74cae9ff471c166368b90f7758e'>backlog/tasks/task-2320 - Design-Scheduled-Tasks-Automation-Workbench-Phase-2-creation-framework.md</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>task-2321 - Plan-Scheduled-Tasks-Automation-Workbench-Phase-2A-creation-framework.md</strong> <code>Mark TASK-2321 planning task as Done</code> <code>+12/-12</code></summary>

<br/>

>Mark TASK-2321 planning task as Done
>
><pre>
>• Updates task status and checks acceptance criteria/definition-of-done boxes to reflect completion.
></pre>
>
><a href='https://github.com/rmusser01/tldw_server/pull/2325/files#diff-1a22325c6f52e380630209950424cb2cc282ef5e3f99d549a7ecaed4bb3fdd66'>backlog/tasks/task-2321 - Plan-Scheduled-Tasks-Automation-Workbench-Phase-2A-creation-framework.md</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>task-2324 - Design-Scheduled-Tasks-Phase-2B-Watch-Ingest-product-contract.md</strong> <code>Add TASK-2324 backlog record for Phase 2B Watch/Ingest contract</code> <code>+69/-0</code></summary>

<br/>

>Add TASK-2324 backlog record for Phase 2B Watch/Ingest contract
>
><pre>
>• Creates a new backlog task linking to the new Phase 2B contract spec, with acceptance criteria and final summary recorded.
></pre>
>
><a href='https://github.com/rmusser01/tldw_server/pull/2325/files#diff-7462c6e5a9f0faf077e0eb99601fe6dd81f43f3163bfbd8b1fb5fc8715463426'>backlog/tasks/task-2324 - Design-Scheduled-Tasks-Phase-2B-Watch-Ingest-product-contract.md</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>task-2325 - Revise-Scheduled-Tasks-Phase-2B-Watch-Ingest-contract-after-review.md</strong> <code>Add TASK-2325 backlog record for contract revisions after review</code> <code>+66/-0</code></summary>

<br/>

>Add TASK-2325 backlog record for contract revisions after review
>
><pre>
>• Creates a new backlog task capturing the post-review hardening of the Phase 2B contract spec, including gates, state models, and redaction/notification/destination contracts.
></pre>
>
><a href='https://github.com/rmusser01/tldw_server/pull/2325/files#diff-d3fc05425eff3066637c18e7bb29d780e89502704ac1eca996ff991fb033b3d7'>backlog/tasks/task-2325 - Revise-Scheduled-Tasks-Phase-2B-Watch-Ingest-contract-after-review.md</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>task-2326 - Plan-Scheduled-Tasks-Phase-2B-capability-aware-frontend-shell.md</strong> <code>Add TASK-2326 backlog record for Phase 2B.2 capability-shell plan</code> <code>+67/-0</code></summary>

<br/>

>Add TASK-2326 backlog record for Phase 2B.2 capability-shell plan
>
><pre>
>• Creates a new backlog task linking to the Phase 2B.2 implementation plan and documenting verification and scope constraints.
></pre>
>
><a href='https://github.com/rmusser01/tldw_server/pull/2325/files#diff-5f40dbed5aea8eb8b41a847cac248d2136b7aef72c7af4fd5110e0a49203d921'>backlog/tasks/task-2326 - Plan-Scheduled-Tasks-Phase-2B-capability-aware-frontend-shell.md</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>task-2327 - Revise-Scheduled-Tasks-Phase-2B-capability-shell-plan-after-review.md</strong> <code>Add TASK-2327 backlog record for plan revisions after review</code> <code>+54/-0</code></summary>

<br/>

>Add TASK-2327 backlog record for plan revisions after review
>
><pre>
>• Creates a new backlog task capturing review-driven plan requirements (creation adapter guard, redaction expansion, extension-width checks). Note: AC/DOD checkboxes remain unchecked in the file content.
></pre>
>
><a href='https://github.com/rmusser01/tldw_server/pull/2325/files#diff-cb26b1b7b06ecc18dded9398fb3e49ced4ae381d229e3f94811e0adb69780910'>backlog/tasks/task-2327 - Revise-Scheduled-Tasks-Phase-2B-capability-shell-plan-after-review.md</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>task-2328 - Implement-Scheduled-Tasks-Phase-2B-capability-aware-frontend-shell.md</strong> <code>Add TASK-2328 backlog record documenting the Phase 2B.2 implementation</code> <code>+65/-0</code></summary>

<br/>

>Add TASK-2328 backlog record documenting the Phase 2B.2 implementation
>
><pre>
>• Creates a new backlog task enumerating touched files and recording a detailed final summary including test commands, the page-test timeout variance note, and Bandit skip rationale. Note: AC/DOD checkboxes remain unchecked in the file content.
></pre>
>
><a href='https://github.com/rmusser01/tldw_server/pull/2325/files#diff-9bcd1140e077acc28d237ad0c1fe1521956ca552da09428f7ad92c54d6fcdabd'>backlog/tasks/task-2328 - Implement-Scheduled-Tasks-Phase-2B-capability-aware-frontend-shell.md</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>task-494 - Create-scheduled-tasks-Automation-Workbench-UX-PRD.md</strong> <code>Mark TASK-494 PRD task as Done</code> <code>+12/-12</code></summary>

<br/>

>Mark TASK-494 PRD task as Done
>
><pre>
>• Updates task status and checks acceptance criteria/definition-of-done boxes to reflect completion.
></pre>
>
><a href='https://github.com/rmusser01/tldw_server/pull/2325/files#diff-d3d3f0e4acf4bc1b51be22315885b9b4dac7b94c8dbab051a904fbf2952a083e'>backlog/tasks/task-494 - Create-scheduled-tasks-Automation-Workbench-UX-PRD.md</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>task-496 - Plan-Scheduled-Tasks-Automation-Workbench-Phase-1-implementation.md</strong> <code>Mark TASK-496 plan task as Done</code> <code>+12/-12</code></summary>

<br/>

>Mark TASK-496 plan task as Done
>
><pre>
>• Updates task status and checks acceptance criteria/definition-of-done boxes to reflect completion.
></pre>
>
><a href='https://github.com/rmusser01/tldw_server/pull/2325/files#diff-8c0f03638a7881da4887989743dab7b715400b1729a623da259bcbe8bc2f54fe'>backlog/tasks/task-496 - Plan-Scheduled-Tasks-Automation-Workbench-Phase-1-implementation.md</a>
<hr/>

</details>
</blockquote>

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">


<a href="https://www.qodo.ai"><img src="https://www.qodo.ai/wp-content/uploads/2025/03/qodo-logo.svg" width="80" alt="Qodo Logo"></a>