### PR TITLE
Harden MCP filesystem policy and command runtime defaults

### DIFF
--- a/Docs/superpowers/plans/2026-06-09-mcp-filesystem-policy-hardening-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-06-09-mcp-filesystem-policy-hardening-implementation-plan.md
@@ -1,0 +1,542 @@
+# MCP Filesystem Policy Hardening Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Harden MCP filesystem path/action enforcement and move the virtual CLI toward structured filesystem primitives without breaking legacy compatibility.
+
+**Architecture:** Keep the existing filesystem module and path-enforcement service as the policy boundary. First repair the adapter seam so module-derived path candidates reach the real service path, then add service/protocol regression tests for action-aware `path_grants`, then update the virtual CLI registry/adapters to prefer `fs.read` and expose explicit structured create semantics.
+
+**Tech Stack:** Python, pytest, FastAPI-side MCP Unified module, `mcp_unified` shared interfaces, Loguru, Bandit.
+
+---
+
+## File Structure
+
+- Modify `tldw_Server_API/app/core/MCP_unified/adapters/tldw_policy.py`
+  - Accept and forward optional `path_scope_candidates` in `TldwPathScopeEnforcer.evaluate_tool_call`.
+- Modify `tldw_Server_API/tests/MCP_unified/test_mcp_protocol_path_scope.py`
+  - Add service/protocol tests for action-aware `path_grants`, deny-overrides, and bundle fail-closed behavior.
+- Modify `tldw_Server_API/app/core/MCP_unified/command_runtime/registry.py`
+  - Update `cat` backing tools to include `fs.read` and legacy fallback `fs.read_text`.
+  - Add `write-create` backed by `fs.write`.
+  - Preserve only executable backing tools on descriptors returned by
+    `visible_commands`, so adapters can choose the preferred visible tool.
+- Modify `tldw_Server_API/app/core/MCP_unified/command_runtime/adapters.py`
+  - Route `cat` to `fs.read` when visible, otherwise legacy `fs.read_text`.
+  - Add `write-create <path> <content>` -> `fs.write` with `mode: "create"`.
+- Modify `tldw_Server_API/app/core/MCP_unified/modules/implementations/run_command_module.py`
+  - Treat `fs.write` as write-capable for `run`/`bash`/`shell` classification.
+- Modify `tldw_Server_API/app/core/MCP_unified/tests/test_command_runtime_registry.py`
+  - Update registry visibility and backend mapping expectations.
+- Modify `tldw_Server_API/app/core/MCP_unified/tests/test_run_command_module.py`
+  - Update `cat` assertions and add `write-create` coverage.
+- Modify `backlog/tasks/task-2331 - Harden-MCP-filesystem-path-policy-and-command-runtime-defaults.md`
+  - Keep plan, verification, and final summary current.
+
+## Task 1: Forward Module-Derived Path Candidates Through The Default Adapter
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/MCP_unified/adapters/tldw_policy.py`
+- Test: `tldw_Server_API/app/core/MCP_unified/tests/test_protocol_path_scope_candidates.py`
+
+- [ ] **Step 1: Write the failing adapter-forwarding test**
+
+Add a test that instantiates the real `TldwPathScopeEnforcer`, monkeypatches
+`get_mcp_hub_path_enforcement_service`, and verifies `PathScopeCandidate` values
+arrive at the fake service.
+
+```python
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_tldw_path_scope_enforcer_forwards_module_candidates(monkeypatch) -> None:
+    from tldw_Server_API.app.core.MCP_unified.adapters.tldw_policy import TldwPathScopeEnforcer
+    from tldw_Server_API.app.services import mcp_hub_path_enforcement_service as path_service_mod
+
+    class _Service:
+        def __init__(self) -> None:
+            self.calls = []
+
+        async def evaluate_tool_call(self, **kwargs):
+            self.calls.append(kwargs)
+            return {"enabled": True, "within_scope": True, "reason": None, "force_approval": False}
+
+    service = _Service()
+
+    async def _fake_service():
+        return service
+
+    monkeypatch.setattr(path_service_mod, "get_mcp_hub_path_enforcement_service", _fake_service)
+    candidates = [PathScopeCandidate(path="docs/a.txt", action="edit", source="test")]
+
+    result = await TldwPathScopeEnforcer().evaluate_tool_call(
+        effective_policy={"enabled": True},
+        context=_context(),
+        tool_name="fs.patch",
+        tool_args={"diff": "..."},
+        tool_def={"metadata": {"uses_filesystem": True}},
+        path_scope_candidates=candidates,
+    )
+
+    assert result["within_scope"] is True
+    assert service.calls[0]["path_scope_candidates"] == candidates
+```
+
+- [ ] **Step 2: Run the test and verify it fails**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m pytest \
+  tldw_Server_API/app/core/MCP_unified/tests/test_protocol_path_scope_candidates.py::test_tldw_path_scope_enforcer_forwards_module_candidates -q
+```
+
+Expected: `TypeError` because `TldwPathScopeEnforcer.evaluate_tool_call` does
+not accept `path_scope_candidates`.
+
+- [ ] **Step 3: Implement the adapter seam**
+
+Update the method signature and forwarding call:
+
+```python
+    async def evaluate_tool_call(
+        self,
+        *,
+        effective_policy: dict[str, Any] | None,
+        context: Any,
+        tool_name: str,
+        tool_args: Any,
+        tool_def: dict[str, Any] | None,
+        path_scope_candidates: list[Any] | None = None,
+    ) -> dict[str, Any]:
+        ...
+        return await service.evaluate_tool_call(
+            effective_policy=effective_policy,
+            context=context,
+            tool_name=tool_name,
+            tool_args=tool_args,
+            tool_def=tool_def,
+            path_scope_candidates=path_scope_candidates,
+        )
+```
+
+- [ ] **Step 4: Run the focused adapter test**
+
+Run the same pytest command from Step 2.
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit the seam**
+
+```bash
+git add tldw_Server_API/app/core/MCP_unified/adapters/tldw_policy.py \
+  tldw_Server_API/app/core/MCP_unified/tests/test_protocol_path_scope_candidates.py
+git commit -m "fix: forward MCP path scope candidates"
+```
+
+## Task 2: Add Action-Aware Path Grant Regression Tests
+
+**Files:**
+- Modify: `tldw_Server_API/tests/MCP_unified/test_mcp_protocol_path_scope.py`
+
+- [ ] **Step 1: Add minimal service test helpers**
+
+Reuse the existing file and add small helpers near the existing fake classes:
+
+```python
+def _filesystem_tool_def(name: str, action: str) -> dict:
+    return {
+        "name": name,
+        "description": name,
+        "inputSchema": {
+            "type": "object",
+            "properties": {"path": {"type": "string"}},
+            "required": ["path"],
+            "additionalProperties": False,
+        },
+        "metadata": {
+            "uses_filesystem": True,
+            "path_boundable": True,
+            "path_argument_hints": ["path"],
+            "path_scope_action": action,
+        },
+    }
+
+
+def _effective_path_policy(path_grants: list[dict]) -> dict:
+    return {
+        "enabled": True,
+        "allowed_tools": ["fs.read", "fs.edit", "fs.write", "fs.patch"],
+        "policy_document": {
+            "path_scope_mode": "workspace_root",
+            "path_grants": path_grants,
+        },
+    }
+```
+
+- [ ] **Step 2: Write failing read/edit/write action tests**
+
+Add tests that instantiate `McpHubPathEnforcementService` with
+`McpHubPathScopeService` and a `_FakeWorkspaceRootResolver` returning a temp
+workspace root.
+
+Coverage:
+
+```python
+@pytest.mark.asyncio
+async def test_path_grants_keep_read_edit_and_write_distinct(tmp_path) -> None:
+    # read grant allows fs.read
+    # same grant denies fs.edit and fs.write with path_action_not_granted
+    # edit grant allows fs.edit but denies fs.write
+    # write grant allows fs.write but denies fs.read/edit
+```
+
+Assert on:
+
+```python
+assert result["within_scope"] is False
+assert result["reason"] == "path_action_not_granted"
+assert result["scope_payload"]["path_decisions"][0]["requested_action"] == "write"
+assert result["scope_payload"]["path_decisions"][0]["redacted"] is True
+```
+
+- [ ] **Step 3: Write failing deny-override test**
+
+Add a test where grants allow `read/edit/write` on `docs` and deny `edit/write`
+on `docs/private`. Assert that `docs/private/a.txt` is denied for `fs.edit` and
+the path decision reports `path_action_denied` plus matched prefix
+`docs/private`.
+
+- [ ] **Step 4: Write failing patch bundle candidate test**
+
+Use direct service evaluation with `path_scope_candidates`:
+
+```python
+path_scope_candidates=[
+    PathScopeCandidate(path="docs/allowed.txt", action="edit", source="filesystem_diff"),
+    PathScopeCandidate(path="docs/new.txt", action="write", source="filesystem_diff", creates_file=True),
+]
+```
+
+With only an `edit` grant on `docs`, assert the bundle is denied because the
+create candidate requires `write`.
+
+- [ ] **Step 5: Run the new tests and verify current behavior**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m pytest \
+  tldw_Server_API/tests/MCP_unified/test_mcp_protocol_path_scope.py \
+  -k "path_grants_keep_read_edit_and_write_distinct or deny_override or patch_bundle" -q
+```
+
+Expected: these may already pass because the service implements the behavior. If
+they pass before implementation, keep them as regression coverage and document
+that no service code change was needed.
+
+- [ ] **Step 6: Implement only if a test exposes a real service bug**
+
+If a test fails, make the smallest change in:
+
+```text
+tldw_Server_API/app/services/mcp_hub_path_enforcement_service.py
+```
+
+Do not change the policy model. Expected fixes should be limited to preserving
+candidate action alignment, denial reason payloads, or redaction fields.
+
+- [ ] **Step 7: Commit the regression tests**
+
+```bash
+git add tldw_Server_API/tests/MCP_unified/test_mcp_protocol_path_scope.py \
+  tldw_Server_API/app/services/mcp_hub_path_enforcement_service.py
+git commit -m "test: cover MCP filesystem path grant actions"
+```
+
+Only include the service file if it actually changed.
+
+## Task 3: Prefer Structured Filesystem Primitives In The Virtual CLI
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/MCP_unified/command_runtime/registry.py`
+- Modify: `tldw_Server_API/app/core/MCP_unified/command_runtime/adapters.py`
+- Modify: `tldw_Server_API/app/core/MCP_unified/modules/implementations/run_command_module.py`
+- Modify: `tldw_Server_API/app/core/MCP_unified/tests/test_command_runtime_registry.py`
+- Modify: `tldw_Server_API/app/core/MCP_unified/tests/test_run_command_module.py`
+
+- [ ] **Step 1: Update registry tests first**
+
+Change expected mappings:
+
+```python
+assert registry.get_command("cat").backend_tools == ("fs.read", "fs.read_text")
+assert registry.get_command("write").backend_tools == ("fs.write_text",)
+assert registry.get_command("write-create").backend_tools == ("fs.write",)
+```
+
+Add visibility cases:
+
+```python
+visible = registry.visible_commands(allowed_tools={"fs.read"})
+assert "cat" in visible
+
+visible = registry.visible_commands(allowed_tools={"fs.read_text"})
+assert "cat" in visible
+
+visible = registry.visible_commands(allowed_tools={"fs.write"})
+assert "write-create" in visible
+assert "write" not in visible
+```
+
+- [ ] **Step 2: Run registry tests and verify they fail**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m pytest \
+  tldw_Server_API/app/core/MCP_unified/tests/test_command_runtime_registry.py -q
+```
+
+Expected: FAIL until registry mappings are updated.
+
+- [ ] **Step 3: Update the command registry**
+
+In `_DEFAULT_COMMANDS`, update/add descriptors:
+
+```python
+CommandDescriptor(
+    name="cat",
+    summary="Read a UTF-8 text file from the current workspace scope.",
+    backend_tools=("fs.read", "fs.read_text"),
+),
+CommandDescriptor(
+    name="write-create",
+    summary="Create a UTF-8 text file in the current workspace scope.",
+    backend_tools=("fs.write",),
+),
+```
+
+Leave `write` backed only by `fs.write_text`.
+
+Then update `CommandRegistry.visible_commands` so non-pure descriptors returned
+to the adapter retain only currently allowed backing tools:
+
+```python
+from dataclasses import dataclass, field, replace
+
+...
+
+def visible_commands(self, allowed_tools: set[str]) -> dict[str, CommandDescriptor]:
+    visible: dict[str, CommandDescriptor] = {}
+    for name, descriptor in self._commands.items():
+        if descriptor.pure_transform:
+            visible[name] = descriptor
+            continue
+        visible_backend_tools = tuple(tool for tool in descriptor.backend_tools if tool in allowed_tools)
+        if visible_backend_tools:
+            visible[name] = replace(descriptor, backend_tools=visible_backend_tools)
+    return visible
+```
+
+This keeps `cat` visible for either `fs.read` or `fs.read_text`, while allowing
+the adapter to prefer `fs.read` when both are visible.
+
+- [ ] **Step 4: Update run-module protocol stub and cat tests**
+
+In `test_run_command_module.py`, make `_ProtocolStub._handle_tools_list`
+include `fs.read` and `fs.write`.
+
+Add `fs.read` execution payload:
+
+```python
+if tool_name == "fs.read":
+    return {
+        "content": [{"type": "json", "json": {"path": "notes.txt", "content": self.read_text_content}}],
+        "tool": tool_name,
+    }
+```
+
+Update cat assertions from `fs.read_text` to `fs.read` where the stub exposes
+`fs.read`. Add a dedicated legacy fallback test with a stub that exposes
+`fs.read_text` but not `fs.read`.
+
+- [ ] **Step 5: Add write-create run tests**
+
+Add tests for:
+
+```python
+rendered = await module.execute_tool("run", {"command": "write-create notes.txt hello"}, context=context)
+assert protocol.prepare_calls[0].params["name"] == "fs.write"
+assert protocol.prepare_calls[0].params["arguments"] == {
+    "path": "notes.txt",
+    "content": "hello",
+    "mode": "create",
+}
+```
+
+Add a visibility/help test proving `write-create` appears when `fs.write` is
+visible and legacy `write` appears only when `fs.write_text` is visible.
+
+- [ ] **Step 6: Run command-runtime tests and verify failures**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m pytest \
+  tldw_Server_API/app/core/MCP_unified/tests/test_command_runtime_registry.py \
+  tldw_Server_API/app/core/MCP_unified/tests/test_run_command_module.py \
+  -q
+```
+
+Expected: FAIL until adapters and write classification are updated.
+
+- [ ] **Step 7: Implement adapter routing**
+
+In `PhaseOneCommandAdapters._governed_plan`:
+
+```python
+if command == "cat":
+    if len(argv) != 2:
+        return _UsageError("usage: cat <path>")
+    tool_name = "fs.read" if "fs.read" in self.context.visible_commands["cat"].backend_tools else "fs.read_text"
+    # Better: choose based on currently visible allowed tools, not descriptor tuple alone.
+```
+
+Use the actual visible backing set. Since Task 3 Step 3 filters descriptor
+backing tools to visible tools, add a small helper:
+
+```python
+def _visible_backend_tool(self, command: str, preferred: tuple[str, ...]) -> str | None:
+    descriptor = self.context.visible_commands.get(command)
+    if descriptor is None:
+        return None
+    available = set(descriptor.backend_tools)
+    for tool_name in preferred:
+        if tool_name in available:
+            return tool_name
+    return None
+```
+
+Do not infer from policy separately inside adapters; the filtered descriptor is
+the adapter's source of truth.
+
+Add:
+
+```python
+if command == "write-create":
+    if len(argv) < 3:
+        return _UsageError("usage: write-create <path> <content>")
+    return _GovernedCallPlan(
+        tool_name="fs.write",
+        arguments={"path": argv[1], "content": " ".join(argv[2:]), "mode": "create"},
+        renderer=self._render_write,
+    )
+```
+
+- [ ] **Step 8: Update write-call classification**
+
+In `run_command_module.py`, update:
+
+```python
+_RUN_WRITE_BACKEND_TOOLS = {"fs.write", "fs.write_text", "sandbox.run"}
+```
+
+Add or update tests proving `run.is_write_tool_call("run", {"command": "write-create notes.txt hi"})` returns `True`.
+
+- [ ] **Step 9: Run focused command tests**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m pytest \
+  tldw_Server_API/app/core/MCP_unified/tests/test_command_runtime_registry.py \
+  tldw_Server_API/app/core/MCP_unified/tests/test_run_command_module.py \
+  -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 10: Commit runtime changes**
+
+```bash
+git add tldw_Server_API/app/core/MCP_unified/command_runtime/registry.py \
+  tldw_Server_API/app/core/MCP_unified/command_runtime/adapters.py \
+  tldw_Server_API/app/core/MCP_unified/modules/implementations/run_command_module.py \
+  tldw_Server_API/app/core/MCP_unified/tests/test_command_runtime_registry.py \
+  tldw_Server_API/app/core/MCP_unified/tests/test_run_command_module.py
+git commit -m "feat: prefer structured MCP filesystem commands"
+```
+
+## Task 4: Validate, Document Skips, And Close Backlog
+
+**Files:**
+- Modify: `backlog/tasks/task-2331 - Harden-MCP-filesystem-path-policy-and-command-runtime-defaults.md`
+
+- [ ] **Step 1: Run all touched focused tests**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m pytest \
+  tldw_Server_API/app/core/MCP_unified/tests/test_protocol_path_scope_candidates.py \
+  tldw_Server_API/tests/MCP_unified/test_mcp_protocol_path_scope.py \
+  tldw_Server_API/app/core/MCP_unified/tests/test_command_runtime_registry.py \
+  tldw_Server_API/app/core/MCP_unified/tests/test_run_command_module.py \
+  -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run Bandit on touched implementation files**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m bandit -r \
+  tldw_Server_API/app/core/MCP_unified/adapters/tldw_policy.py \
+  tldw_Server_API/app/core/MCP_unified/command_runtime/registry.py \
+  tldw_Server_API/app/core/MCP_unified/command_runtime/adapters.py \
+  tldw_Server_API/app/core/MCP_unified/modules/implementations/run_command_module.py \
+  tldw_Server_API/app/services/mcp_hub_path_enforcement_service.py \
+  -f json -o /tmp/bandit_mcp_fs_policy_hardening.json
+```
+
+Expected: no new findings in touched code. If `mcp_hub_path_enforcement_service.py`
+was not modified, it may be removed from the Bandit command.
+
+- [ ] **Step 3: Run diff hygiene**
+
+Run:
+
+```bash
+git diff --check
+git status --short
+```
+
+Expected: no whitespace errors; only intentional files changed before final commit.
+
+- [ ] **Step 4: Update Backlog task**
+
+Record:
+
+- tests run and pass/fail status
+- Bandit output path and summary
+- any skipped implementation items, especially if `write-replace` is deferred
+- final summary of behavior changes
+
+- [ ] **Step 5: Commit final task updates**
+
+```bash
+git add 'backlog/tasks/task-2331 - Harden-MCP-filesystem-path-policy-and-command-runtime-defaults.md'
+git commit -m "chore: close MCP filesystem policy hardening task"
+```
+
+- [ ] **Step 6: Prepare PR summary**
+
+Include:
+
+- Change summary with both what changed and why.
+- Test commands and outcomes.
+- Explicit note that legacy `write` remains backed by `fs.write_text`.
+- Explicit note whether `write-replace` was implemented or deferred because of
+  preimage authorization syntax.

--- a/Docs/superpowers/specs/2026-06-09-mcp-filesystem-policy-hardening-design.md
+++ b/Docs/superpowers/specs/2026-06-09-mcp-filesystem-policy-hardening-design.md
@@ -1,0 +1,186 @@
+# MCP Filesystem Policy Hardening Design
+
+## Context
+
+The current `origin/dev` branch already includes the broad filesystem primitives:
+`fs.read`, `fs.write`, `fs.edit`, `fs.patch`, `fs.stat`, `fs.glob`, and
+`fs.grep`, plus legacy `fs.read_text` and `fs.write_text`. The newer tools carry
+file-policy metadata, hashes, read receipts, bounded reads, and module-derived
+path-scope candidates for unified diffs.
+
+The remaining risk is not missing primitives. It is making sure the policy
+boundary is action-aware before those primitives become the default surface:
+
+- `read` grants must not imply `edit` or `write`.
+- `edit` grants must not imply whole-file `write` unless explicitly granted.
+- `fs.patch` must enforce each changed file with the candidate action derived
+  from the diff: `edit` for modifying existing files and `write` for creating
+  files.
+- The host path-enforcement service already accepts module-derived candidates,
+  but the default `TldwPathScopeEnforcer` adapter must also accept and forward
+  them. Otherwise `fs.patch` can fail closed through the real runtime path while
+  passing isolated protocol tests.
+- The virtual CLI runtime still routes `cat` and `write` through legacy
+  `fs.read_text` and `fs.write_text`, so it does not yet prefer the structured
+  primitives where safe.
+
+## Goals
+
+1. Lock down action-specific filesystem policy behavior with focused regression
+   tests for `fs.read`, `fs.edit`, `fs.write`, and `fs.patch`.
+2. Prefer structured filesystem primitives in the virtual CLI runtime where the
+   command grammar can preserve semantics safely.
+3. Keep legacy tools available for compatibility, but avoid expanding their use
+   as the default path for new command/runtime behavior.
+4. Keep this as a small hardening slice. Larger shell alias parsing, locks,
+   temporary grants, and richer unified-diff compatibility remain separate
+   follow-up items.
+
+## Non-Goals
+
+- Do not add raw shell execution or the bash/shell alias parser in this branch.
+- Do not implement delete, rename, move, share/export, chmod/admin, or lock
+  actions.
+- Do not replace the existing path-enforcement service with a new policy engine.
+- Do not make a bare `write <path> <content>` command silently choose between
+  create and replace if the runtime cannot represent that choice explicitly.
+- Do not add a structured replace command that bypasses, hides, or weakens
+  `fs.write` preimage requirements.
+
+## Design
+
+### Policy Regression Coverage
+
+Add tests at the enforcement boundary rather than only checking tool metadata.
+The tests should exercise the real `McpHubPathEnforcementService` decision path
+with synthetic workspace scope data and effective policies that include
+`path_grants`.
+
+Required cases:
+
+- A profile with `read` on `docs` can run `fs.read` for `docs/a.txt`.
+- The same profile is denied for `fs.edit`, `fs.write`, and an `fs.patch` modify
+  candidate under `docs`.
+- A profile with `edit` on `docs` can run `fs.edit` and `fs.patch` modify
+  candidates under `docs`, but is denied for `fs.write` create/replace unless
+  `write` is separately granted.
+- A profile with `write` on `docs` can run `fs.write` and an `fs.patch` create
+  candidate under `docs`.
+- A `write` grant permits whole-file create/replace operations, but does not
+  imply `read` or bounded `edit` visibility. If a profile needs all three, it
+  must grant all three explicitly.
+- Internal preimage reads performed by `fs.write` replace mode are part of the
+  guarded `write` operation. They do not require a separate `read` grant, but
+  the caller still must satisfy `fs.write` preimage authorization with an
+  expected hash or read receipt.
+- A deny grant on a more specific prefix, such as `docs/private`, wins over a
+  broader allow grant on `docs`.
+- Patch bundles fail closed if any candidate path/action is not granted, even
+  when other files in the same diff are allowed.
+
+This coverage is the acceptance gate for making structured tools more visible.
+
+### Candidate Forwarding Boundary
+
+Update `TldwPathScopeEnforcer.evaluate_tool_call` to accept the same optional
+`path_scope_candidates` argument as the shared policy protocol and forward it to
+`McpHubPathEnforcementService.evaluate_tool_call`.
+
+This is intentionally a seam fix, not a new policy behavior. The service already
+knows how to evaluate candidate paths/actions; the adapter should not drop that
+context or force the protocol into the compatibility fallback.
+
+### Filesystem Tool Metadata
+
+Keep the existing metadata contract:
+
+- Direct path tools use `path_scope_action`.
+- `fs.patch` uses `path_scope_candidate_source: "module"` because one diff may
+  contain multiple files and mixed actions.
+- Legacy tools stay marked with `legacy_tool` and replacement metadata.
+
+Only adjust metadata if tests reveal a mismatch. The preferred outcome is to
+preserve the current contract and strengthen tests around it.
+
+### Virtual CLI Runtime
+
+Move command runtime defaults away from legacy primitives only where semantics
+are unambiguous:
+
+- Change `cat <path>` from `fs.read_text` to `fs.read`. The renderer already
+  accepts either `text` or `content`, so this should preserve CLI output while
+  adding hash/read-receipt behavior behind the scenes.
+- Preserve compatibility for profiles that still expose only `fs.read_text` if
+  the runtime can do so without making `cat` visible when neither read tool is
+  executable. The command registry and adapter must agree on the selected
+  backing tool: prefer `fs.read` when visible, fall back to `fs.read_text` only
+  when `fs.read` is unavailable and `fs.read_text` is visible.
+- Keep legacy `write <path> <content>` available for compatibility only if it
+  still maps to `fs.write_text`. Do not silently remap it to `fs.write`, because
+  `fs.write` requires an explicit `create` or `replace` mode and has stricter
+  preimage semantics.
+- Add explicit structured write commands:
+  `write-create <path> <content>` maps to `fs.write` with `mode: "create"`.
+  A replacement command may be added only if its syntax carries preimage
+  authorization, for example
+  `write-replace --expected-sha256 <hash> <path> <content>` or
+  `write-replace --read-receipt <receipt> <path> <content>`. If that parser
+  addition would broaden this slice too much, defer `write-replace` and keep
+  only `write-create`.
+- Update `RunCommandModule.is_write_tool_call` and its tests so structured
+  write commands backed by `fs.write` are classified as write-capable for
+  approval, audit, and prompt-surface purposes.
+
+This gives models a safer structured route without breaking callers that still
+depend on the old `write` command.
+
+### Diff-First Editing
+
+`fs.patch` remains the preferred edit primitive for generated changes when a
+unified diff is available. `fs.edit` remains a bounded exact-string fallback for
+small literal substitutions. This branch should not attempt full git-apply
+parity unless a current test proves the existing parser blocks normal use.
+
+If a minimal parser gap is found during implementation, it may be fixed in this
+branch only when it is directly required for the policy/runtime tests. Larger
+diff compatibility improvements stay in a follow-up task.
+
+## Error Handling
+
+Path-policy failures should keep the existing safe troubleshooting shape:
+
+- `within_scope: false`
+- `reason` or path-decision `reason_code`
+- redacted normalized relative paths and grant metadata
+- no raw file content
+- no absolute paths in user-facing denial payloads
+
+Patch enforcement should fail the whole request when any candidate is denied.
+Partial application must not occur.
+
+## Testing
+
+Focused test targets:
+
+- `tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_module.py`
+- `tldw_Server_API/app/core/MCP_unified/tests/test_protocol_path_scope_candidates.py`
+- `tldw_Server_API/app/core/MCP_unified/tests/test_command_runtime_registry.py`
+- `tldw_Server_API/app/core/MCP_unified/tests/test_command_runtime_execution.py`
+- `tldw_Server_API/app/core/MCP_unified/tests/test_run_command_module.py`
+- `tldw_Server_API/app/core/MCP_unified/adapters/tldw_policy.py`
+- `tldw_Server_API/tests/MCP_unified/test_mcp_protocol_path_scope.py` for
+  service/protocol path-scope enforcement coverage
+
+Validation commands should include the touched MCP test files and Bandit over
+the touched Python implementation files. Docs-only spec work can skip Bandit
+until code is touched.
+
+## Open Follow-Ups
+
+- Full shell alias parsing with command splitting, wrapper handling, and
+  structured tool dispatch.
+- Fuller unified-diff compatibility, including common git diff headers and
+  no-newline markers, if real workloads need it.
+- File lock leases, temporary session grants, and permission-change governance.
+- Observability/evaluation coverage for all tool families beyond this small
+  filesystem hardening pass.

--- a/apps/packages/ui/src/routes/option-setup.tsx
+++ b/apps/packages/ui/src/routes/option-setup.tsx
@@ -25,7 +25,7 @@ const OptionSetup = () => {
       <SetupRequiredPanel
         className="mx-auto mb-4 w-full max-w-3xl"
         title={t("setupRoute.recoveryTitle", "Setup operator recovery")}
-        titleHeadingLevel={showWizard ? 2 : 1}
+        titleHeadingLevel={2}
         message={t(
           "setupRoute.recoveryMessage",
           "Use this surface when first-run setup needs local operator recovery."

--- a/backlog/tasks/task-2331 - Harden-MCP-filesystem-path-policy-and-command-runtime-defaults.md
+++ b/backlog/tasks/task-2331 - Harden-MCP-filesystem-path-policy-and-command-runtime-defaults.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-2331
 title: Harden MCP filesystem path policy and command-runtime defaults
-status: In Progress
+status: Done
 labels:
 - mcp
 - filesystem
@@ -18,6 +18,14 @@ documentation:
 modified_files:
 - Docs/superpowers/specs/2026-06-09-mcp-filesystem-policy-hardening-design.md
 - Docs/superpowers/plans/2026-06-09-mcp-filesystem-policy-hardening-implementation-plan.md
+- tldw_Server_API/app/core/MCP_unified/adapters/tldw_policy.py
+- tldw_Server_API/app/core/MCP_unified/command_runtime/registry.py
+- tldw_Server_API/app/core/MCP_unified/command_runtime/adapters.py
+- tldw_Server_API/app/core/MCP_unified/modules/implementations/run_command_module.py
+- tldw_Server_API/app/core/MCP_unified/tests/test_protocol_path_scope_candidates.py
+- tldw_Server_API/tests/MCP_unified/test_mcp_protocol_path_scope.py
+- tldw_Server_API/app/core/MCP_unified/tests/test_command_runtime_registry.py
+- tldw_Server_API/app/core/MCP_unified/tests/test_run_command_module.py
 ---
 
 ## Description
@@ -39,21 +47,42 @@ Implementation plan written at Docs/superpowers/plans/2026-06-09-mcp-filesystem-
 ## Implementation Notes
 
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Committed implementation slices:
+- 9bc89b101b fix: forward MCP path scope candidates
+- 35bea990f6 test: cover MCP filesystem path grant actions
+- f9bfccc5f3 feat: prefer structured MCP filesystem commands
+
+Verification completed from worktree `/Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/mcp-fs-policy-hardening`:
+- `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_protocol_path_scope_candidates.py tldw_Server_API/tests/MCP_unified/test_mcp_protocol_path_scope.py tldw_Server_API/app/core/MCP_unified/tests/test_command_runtime_registry.py tldw_Server_API/app/core/MCP_unified/tests/test_run_command_module.py -q`
+  - Result: passed, 57 tests, 6 warnings in 4.50s.
+- `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m bandit -r tldw_Server_API/app/core/MCP_unified/adapters/tldw_policy.py tldw_Server_API/app/core/MCP_unified/command_runtime/registry.py tldw_Server_API/app/core/MCP_unified/command_runtime/adapters.py tldw_Server_API/app/core/MCP_unified/modules/implementations/run_command_module.py -f json -o /tmp/bandit_mcp_fs_policy_hardening.json`
+  - Result: passed; JSON report at `/tmp/bandit_mcp_fs_policy_hardening.json`; findings: 0; scanned LOC: 1311.
+- `git diff --check`
+  - Result: passed with no output.
+- `git status --short`
+  - Result before Backlog closeout edit: clean.
+
+Deferred scope:
+- `write-replace` remains deferred because preimage syntax is not implemented in this slice.
 
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
+MCP filesystem policy hardening is complete for this slice. Path scope candidates are now forwarded through the policy adapter so approval grants can be evaluated against the concrete filesystem paths involved in fs.read, fs.write, fs.edit, and fs.patch operations. Regression coverage now exercises action-aware path grants, including read/write/create/patch/edit behavior and denied-scope cases.
 
+The command runtime now prefers structured MCP filesystem commands where the server exposes them: virtual CLI read paths can route to `fs.read`, and write-create operations can route to structured write primitives instead of legacy `fs.read_text`/`fs.write_text` when safe. Visible command descriptors are filtered so structured routing is selected only when the relevant command is actually available.
+
+`write-replace` is intentionally deferred because the required preimage syntax is not implemented in this slice.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->

--- a/backlog/tasks/task-2331 - Harden-MCP-filesystem-path-policy-and-command-runtime-defaults.md
+++ b/backlog/tasks/task-2331 - Harden-MCP-filesystem-path-policy-and-command-runtime-defaults.md
@@ -14,8 +14,10 @@ references:
   use.
 documentation:
 - Docs/superpowers/specs/2026-06-09-mcp-filesystem-policy-hardening-design.md
+- Docs/superpowers/plans/2026-06-09-mcp-filesystem-policy-hardening-implementation-plan.md
 modified_files:
 - Docs/superpowers/specs/2026-06-09-mcp-filesystem-policy-hardening-design.md
+- Docs/superpowers/plans/2026-06-09-mcp-filesystem-policy-hardening-implementation-plan.md
 ---
 
 ## Description
@@ -31,7 +33,7 @@ Design and implement the next MCP filesystem slice: verify path/action constrain
 ## Implementation Plan
 
 <!-- SECTION:PLAN:BEGIN -->
-Design approved for A then B: first add path/action enforcement regression coverage for filesystem primitives, then update the virtual CLI runtime to prefer structured primitives where semantics are unambiguous. Local spec review added the adapter seam: TldwPathScopeEnforcer must accept and forward module-derived path_scope_candidates so fs.patch works through the real runtime path. Second review tightened command-runtime details: cat should prefer fs.read with a legacy fs.read_text fallback when safe; structured write-create may be added; write-replace must carry expected_sha256/read_receipt or be deferred; RunCommandModule write classification must include structured fs.write-backed commands; path-scope tests should extend the existing MCP protocol path-scope test file.
+Implementation plan written at Docs/superpowers/plans/2026-06-09-mcp-filesystem-policy-hardening-implementation-plan.md. It sequences work as: adapter candidate forwarding; action-aware path-grant regression tests; virtual CLI structured fs.read/write-create routing; focused tests, Bandit, and Backlog closeout. Plan review correction included filtered visible command descriptors so adapters can reliably choose fs.read over fs.read_text only when fs.read is actually visible.
 <!-- SECTION:PLAN:END -->
 
 ## Implementation Notes

--- a/backlog/tasks/task-2331 - Harden-MCP-filesystem-path-policy-and-command-runtime-defaults.md
+++ b/backlog/tasks/task-2331 - Harden-MCP-filesystem-path-policy-and-command-runtime-defaults.md
@@ -65,6 +65,14 @@ Verification completed from worktree `/Users/macbook-dev/Documents/GitHub/tldw_s
 Deferred scope:
 - `write-replace` remains deferred because preimage syntax is not implemented in this slice.
 
+PR #2327 follow-up on 2026-06-09:
+- Rebased against latest `origin/dev`; branch was already up to date.
+- Fixed CodeRabbit comment on `TldwPathScopeEnforcer.evaluate_tool_call` by using `list[PathScopeCandidate] | None` for `path_scope_candidates`.
+- Fixed CodeRabbit comment in `test_path_grants_keep_read_edit_and_write_distinct` by asserting allowed decisions through `scope_payload.path_decisions`, matching the service payload contract.
+- Verified Gemini command-visibility comments against current code. The hidden-command path already returns `Unknown command` with exit 127 through `visible_commands` checks before planning. Added regression coverage for hidden `knowledge`, `media`, and `mcp` commands; no implementation guard was needed.
+- Inspected failing UX Smoke Gate log. The failing assertion is unrelated to this MCP branch: `/setup` has two semantic `h1` elements in `apps/tldw-frontend/e2e/smoke/stage4-responsive-landmarks.spec.ts`, while this branch touches MCP/backend tests and Backlog docs only. CI will rerun after the follow-up push.
+- Follow-up verification: focused MCP pytest suite passed, 60 tests and 6 warnings; Bandit touched implementation scope passed with 0 findings at `/tmp/bandit_mcp_fs_policy_hardening_pr2327_followup.json`.
+
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-2331 - Harden-MCP-filesystem-path-policy-and-command-runtime-defaults.md
+++ b/backlog/tasks/task-2331 - Harden-MCP-filesystem-path-policy-and-command-runtime-defaults.md
@@ -1,0 +1,57 @@
+---
+id: TASK-2331
+title: Harden MCP filesystem path policy and command-runtime defaults
+status: In Progress
+labels:
+- mcp
+- filesystem
+- security
+- policy
+priority: High
+references:
+- 'User-approved approach: policy hardening first'
+- runtime routing second; diff parser expansion only where current gaps block real
+  use.
+documentation:
+- Docs/superpowers/specs/2026-06-09-mcp-filesystem-policy-hardening-design.md
+modified_files:
+- Docs/superpowers/specs/2026-06-09-mcp-filesystem-policy-hardening-design.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Design and implement the next MCP filesystem slice: verify path/action constraints for fs.read, fs.write, fs.edit, and fs.patch first, then update command-runtime defaults to prefer structured primitives over legacy fs.read_text/fs.write_text where safe.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Design approved for A then B: first add path/action enforcement regression coverage for filesystem primitives, then update the virtual CLI runtime to prefer structured primitives where semantics are unambiguous. Local spec review added the adapter seam: TldwPathScopeEnforcer must accept and forward module-derived path_scope_candidates so fs.patch works through the real runtime path. Second review tightened command-runtime details: cat should prefer fs.read with a legacy fs.read_text fallback when safe; structured write-create may be added; write-replace must carry expected_sha256/read_receipt or be deferred; RunCommandModule write classification must include structured fs.write-backed commands; path-scope tests should extend the existing MCP protocol path-scope test file.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-2331 - Harden-MCP-filesystem-path-policy-and-command-runtime-defaults.md
+++ b/backlog/tasks/task-2331 - Harden-MCP-filesystem-path-policy-and-command-runtime-defaults.md
@@ -26,6 +26,7 @@ modified_files:
 - tldw_Server_API/tests/MCP_unified/test_mcp_protocol_path_scope.py
 - tldw_Server_API/app/core/MCP_unified/tests/test_command_runtime_registry.py
 - tldw_Server_API/app/core/MCP_unified/tests/test_run_command_module.py
+- apps/packages/ui/src/routes/option-setup.tsx
 ---
 
 ## Description
@@ -70,8 +71,9 @@ PR #2327 follow-up on 2026-06-09:
 - Fixed CodeRabbit comment on `TldwPathScopeEnforcer.evaluate_tool_call` by using `list[PathScopeCandidate] | None` for `path_scope_candidates`.
 - Fixed CodeRabbit comment in `test_path_grants_keep_read_edit_and_write_distinct` by asserting allowed decisions through `scope_payload.path_decisions`, matching the service payload contract.
 - Verified Gemini command-visibility comments against current code. The hidden-command path already returns `Unknown command` with exit 127 through `visible_commands` checks before planning. Added regression coverage for hidden `knowledge`, `media`, and `mcp` commands; no implementation guard was needed.
-- Inspected failing UX Smoke Gate log. The failing assertion is unrelated to this MCP branch: `/setup` has two semantic `h1` elements in `apps/tldw-frontend/e2e/smoke/stage4-responsive-landmarks.spec.ts`, while this branch touches MCP/backend tests and Backlog docs only. CI will rerun after the follow-up push.
+- Inspected the refreshed UX Smoke Gate failure. The `/setup` route rendered two semantic `h1` elements in the completed-setup state: the route-level hidden heading plus the recovery panel title. Fixed the route by keeping the hidden route heading as the page `h1` and rendering the recovery panel title as `h2`.
 - Follow-up verification: focused MCP pytest suite passed, 60 tests and 6 warnings; Bandit touched implementation scope passed with 0 findings at `/tmp/bandit_mcp_fs_policy_hardening_pr2327_followup.json`.
+- Frontend lint was attempted for `apps/packages/ui/src/routes/option-setup.tsx`, but this worktree has no frontend `node_modules`; `bun run lint -- apps/packages/ui/src/routes/option-setup.tsx` failed with `eslint: command not found`.
 
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 

--- a/tldw_Server_API/app/core/MCP_unified/adapters/tldw_policy.py
+++ b/tldw_Server_API/app/core/MCP_unified/adapters/tldw_policy.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from typing import Any
 
+from mcp_unified.interfaces.path_scope import PathScopeCandidate
+
 
 class TldwEffectivePolicyResolver:
     """Resolve the effective MCP Hub policy for a request context."""
@@ -69,7 +71,7 @@ class TldwPathScopeEnforcer:
         tool_name: str,
         tool_args: Any,
         tool_def: dict[str, Any] | None,
-        path_scope_candidates: list[Any] | None = None,
+        path_scope_candidates: list[PathScopeCandidate] | None = None,
     ) -> dict[str, Any]:
         from tldw_Server_API.app.services.mcp_hub_path_enforcement_service import (
             get_mcp_hub_path_enforcement_service,

--- a/tldw_Server_API/app/core/MCP_unified/adapters/tldw_policy.py
+++ b/tldw_Server_API/app/core/MCP_unified/adapters/tldw_policy.py
@@ -69,6 +69,7 @@ class TldwPathScopeEnforcer:
         tool_name: str,
         tool_args: Any,
         tool_def: dict[str, Any] | None,
+        path_scope_candidates: list[Any] | None = None,
     ) -> dict[str, Any]:
         from tldw_Server_API.app.services.mcp_hub_path_enforcement_service import (
             get_mcp_hub_path_enforcement_service,
@@ -81,6 +82,7 @@ class TldwPathScopeEnforcer:
             tool_name=tool_name,
             tool_args=tool_args,
             tool_def=tool_def,
+            path_scope_candidates=path_scope_candidates,
         )
 
 

--- a/tldw_Server_API/app/core/MCP_unified/command_runtime/adapters.py
+++ b/tldw_Server_API/app/core/MCP_unified/command_runtime/adapters.py
@@ -248,8 +248,11 @@ class PhaseOneCommandAdapters:
         if command == "cat":
             if len(argv) != 2:
                 return _UsageError("usage: cat <path>")
+            tool_name = self._visible_backend_tool("cat", ("fs.read", "fs.read_text"))
+            if tool_name is None:
+                return _UsageError(self._unknown_command_message(command), exit_code=127)
             return _GovernedCallPlan(
-                tool_name="fs.read_text",
+                tool_name=tool_name,
                 arguments={"path": argv[1]},
                 renderer=self._render_cat,
             )
@@ -259,6 +262,14 @@ class PhaseOneCommandAdapters:
             return _GovernedCallPlan(
                 tool_name="fs.write_text",
                 arguments={"path": argv[1], "content": " ".join(argv[2:])},
+                renderer=self._render_write,
+            )
+        if command == "write-create":
+            if len(argv) < 3:
+                return _UsageError("usage: write-create <path> <content>")
+            return _GovernedCallPlan(
+                tool_name="fs.write",
+                arguments={"path": argv[1], "content": " ".join(argv[2:]), "mode": "create"},
                 renderer=self._render_write,
             )
         if command == "stat":
@@ -307,6 +318,23 @@ class PhaseOneCommandAdapters:
             )
         return _UsageError(self._unknown_command_message(command), exit_code=127)
 
+    def _visible_backend_tool(self, command: str, preferred: tuple[str, ...]) -> str | None:
+        descriptor = self.context.visible_commands.get(command)
+        if descriptor is None:
+            return None
+        available = set(descriptor.backend_tools)
+        for tool_name in preferred:
+            if tool_name in available:
+                return tool_name
+        return None
+
+    def _command_has_visible_backend(self, command: str, tool_name: str) -> bool:
+        return self._visible_backend_tool(command, (tool_name,)) is not None
+
+    @staticmethod
+    def _unavailable_backend_error(tool_name: str) -> _UsageError:
+        return _UsageError(f"{tool_name} unavailable in this context")
+
     def _knowledge_plan(self, argv: list[str]) -> _GovernedCallPlan | _UsageError:
         if len(argv) < 2:
             return _UsageError("usage: knowledge <search|get> ...")
@@ -314,6 +342,8 @@ class PhaseOneCommandAdapters:
         if sub == "search":
             if len(argv) < 3:
                 return _UsageError("usage: knowledge search <query>")
+            if not self._command_has_visible_backend("knowledge", "knowledge.search"):
+                return self._unavailable_backend_error("knowledge.search")
             return _GovernedCallPlan(
                 tool_name="knowledge.search",
                 arguments={"query": " ".join(argv[2:])},
@@ -322,6 +352,8 @@ class PhaseOneCommandAdapters:
         if sub == "get":
             if len(argv) != 4:
                 return _UsageError("usage: knowledge get <source> <id>")
+            if not self._command_has_visible_backend("knowledge", "knowledge.get"):
+                return self._unavailable_backend_error("knowledge.get")
             return _GovernedCallPlan(
                 tool_name="knowledge.get",
                 arguments={"source": argv[2], "id": self._coerce_scalar(argv[3])},
@@ -336,6 +368,8 @@ class PhaseOneCommandAdapters:
         if sub == "search":
             if len(argv) < 3:
                 return _UsageError("usage: media search <query>")
+            if not self._command_has_visible_backend("media", "media.search"):
+                return self._unavailable_backend_error("media.search")
             return _GovernedCallPlan(
                 tool_name="media.search",
                 arguments={"query": " ".join(argv[2:])},
@@ -344,6 +378,8 @@ class PhaseOneCommandAdapters:
         if sub == "get":
             if len(argv) != 3:
                 return _UsageError("usage: media get <media_id>")
+            if not self._command_has_visible_backend("media", "media.get"):
+                return self._unavailable_backend_error("media.get")
             return _GovernedCallPlan(
                 tool_name="media.get",
                 arguments={"media_id": self._coerce_scalar(argv[2])},
@@ -356,18 +392,24 @@ class PhaseOneCommandAdapters:
             return _UsageError("usage: mcp <tools|modules|catalogs>")
         sub = argv[1]
         if sub == "tools":
+            if not self._command_has_visible_backend("mcp", "mcp.tools.list"):
+                return self._unavailable_backend_error("mcp.tools.list")
             return _GovernedCallPlan(
                 tool_name="mcp.tools.list",
                 arguments={},
                 renderer=self._render_json_payload,
             )
         if sub == "modules":
+            if not self._command_has_visible_backend("mcp", "mcp.modules.list"):
+                return self._unavailable_backend_error("mcp.modules.list")
             return _GovernedCallPlan(
                 tool_name="mcp.modules.list",
                 arguments={},
                 renderer=self._render_json_payload,
             )
         if sub == "catalogs":
+            if not self._command_has_visible_backend("mcp", "mcp.catalogs.list"):
+                return self._unavailable_backend_error("mcp.catalogs.list")
             return _GovernedCallPlan(
                 tool_name="mcp.catalogs.list",
                 arguments={},
@@ -589,7 +631,11 @@ class PhaseOneCommandAdapters:
             text = decoded.get("text")
             if text is None:
                 text = decoded.get("content")
-            return str(text or "")
+            rendered = str(text or "")
+            if decoded.get("truncated") is True:
+                separator = "" if not rendered or rendered.endswith("\n") else "\n"
+                rendered = f"{rendered}{separator}{self._render_cat_truncation_marker(decoded)}"
+            return rendered
         return str(decoded or "")
 
     def _render_write(self, payload: Any) -> str:
@@ -602,6 +648,19 @@ class PhaseOneCommandAdapters:
             if path:
                 return f"wrote file: {path}"
         return str(decoded or "")
+
+    @staticmethod
+    def _render_cat_truncation_marker(decoded: dict[str, Any]) -> str:
+        metadata: list[str] = []
+        for key in ("bytes_returned", "bytes_total", "lines_returned"):
+            value = decoded.get(key)
+            if isinstance(value, int) and not isinstance(value, bool):
+                metadata.append(f"{key}={value}")
+        reason = decoded.get("truncation_reason")
+        if isinstance(reason, str) and reason.strip():
+            metadata.append(f"truncation_reason={reason.strip().replace(chr(10), ' ').replace(chr(13), ' ')}")
+        details = f": {' '.join(metadata)}" if metadata else ""
+        return f"[truncated{details}]"
 
     def _render_json_payload(self, payload: Any) -> str:
         decoded = self._extract_json_content(payload)

--- a/tldw_Server_API/app/core/MCP_unified/command_runtime/registry.py
+++ b/tldw_Server_API/app/core/MCP_unified/command_runtime/registry.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from typing import Final
 
 
@@ -34,8 +34,12 @@ class CommandRegistry:
     def visible_commands(self, allowed_tools: set[str]) -> dict[str, CommandDescriptor]:
         visible: dict[str, CommandDescriptor] = {}
         for name, descriptor in self._commands.items():
-            if descriptor.pure_transform or any(tool in allowed_tools for tool in descriptor.backend_tools):
+            if descriptor.pure_transform:
                 visible[name] = descriptor
+                continue
+            visible_backend_tools = tuple(tool for tool in descriptor.backend_tools if tool in allowed_tools)
+            if visible_backend_tools:
+                visible[name] = replace(descriptor, backend_tools=visible_backend_tools)
         return visible
 
 
@@ -57,12 +61,17 @@ _DEFAULT_COMMANDS: Final[tuple[CommandDescriptor, ...]] = (
     CommandDescriptor(
         name="cat",
         summary="Read a UTF-8 text file from the current workspace scope.",
-        backend_tools=("fs.read_text",),
+        backend_tools=("fs.read", "fs.read_text"),
     ),
     CommandDescriptor(
         name="write",
         summary="Write a UTF-8 text file in the current workspace scope.",
         backend_tools=("fs.write_text",),
+    ),
+    CommandDescriptor(
+        name="write-create",
+        summary="Create a UTF-8 text file in the current workspace scope.",
+        backend_tools=("fs.write",),
     ),
     CommandDescriptor(
         name="grep",
@@ -126,7 +135,7 @@ _DEFAULT_COMMANDS: Final[tuple[CommandDescriptor, ...]] = (
     CommandDescriptor(
         name="mcp",
         summary="Inspect visible MCP modules and tools.",
-        backend_tools=("mcp.modules.list", "mcp.tools.list"),
+        backend_tools=("mcp.modules.list", "mcp.tools.list", "mcp.catalogs.list"),
     ),
     CommandDescriptor(
         name="sandbox",

--- a/tldw_Server_API/app/core/MCP_unified/modules/implementations/run_command_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/modules/implementations/run_command_module.py
@@ -26,7 +26,7 @@ from ..base import BaseModule, ModuleConfig, create_tool_definition
 
 RUN_PARENT_IDEMPOTENCY_KEY_METADATA_KEY = "run_parent_idempotency_key"
 
-_RUN_WRITE_BACKEND_TOOLS = {"fs.write_text", "sandbox.run"}
+_RUN_WRITE_BACKEND_TOOLS = {"fs.write", "fs.write_text", "sandbox.run"}
 _RUN_TOOL_NAME = "run"
 _RUN_TOOL_ALIASES = ("bash", "shell")
 _RUN_TOOL_NAMES = frozenset((_RUN_TOOL_NAME, *_RUN_TOOL_ALIASES))

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_command_runtime_registry.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_command_runtime_registry.py
@@ -41,11 +41,16 @@ def test_registry_exposes_phase_one_mappings():
     registry = build_default_registry()
 
     assert registry.get_command("ls").backend_tools == ("fs.list",)
-    assert registry.get_command("cat").backend_tools == ("fs.read_text",)
+    assert registry.get_command("cat").backend_tools == ("fs.read", "fs.read_text")
     assert registry.get_command("write").backend_tools == ("fs.write_text",)
+    assert registry.get_command("write-create").backend_tools == ("fs.write",)
     assert registry.get_command("knowledge").backend_tools == ("knowledge.search", "knowledge.get")
     assert registry.get_command("media").backend_tools == ("media.search", "media.get")
-    assert registry.get_command("mcp").backend_tools == ("mcp.modules.list", "mcp.tools.list")
+    assert registry.get_command("mcp").backend_tools == (
+        "mcp.modules.list",
+        "mcp.tools.list",
+        "mcp.catalogs.list",
+    )
     assert registry.get_command("sandbox").backend_tools == ("sandbox.run",)
     assert registry.get_command("grep").pure_transform is True
     assert registry.get_command("stat").backend_tools == ("fs.stat",)
@@ -53,3 +58,28 @@ def test_registry_exposes_phase_one_mappings():
     assert registry.get_command("find").backend_tools == ("fs.glob",)
     assert registry.get_command("rg").backend_tools == ("fs.grep",)
     assert registry.get_command("grep-files").backend_tools == ("fs.grep",)
+
+
+def test_registry_filters_visible_backend_tools_for_multi_backend_commands() -> None:
+    registry = build_default_registry()
+
+    visible = registry.visible_commands(allowed_tools={"fs.read"})
+    assert "cat" in visible
+    assert visible["cat"].backend_tools == ("fs.read",)
+
+    visible = registry.visible_commands(allowed_tools={"fs.read_text"})
+    assert "cat" in visible
+    assert visible["cat"].backend_tools == ("fs.read_text",)
+
+    visible = registry.visible_commands(allowed_tools={"fs.write"})
+    assert "write-create" in visible
+    assert "write" not in visible
+
+
+def test_registry_filters_visible_backend_tools_for_mcp_catalogs() -> None:
+    registry = build_default_registry()
+
+    visible = registry.visible_commands(allowed_tools={"mcp.catalogs.list"})
+
+    assert "mcp" in visible
+    assert visible["mcp"].backend_tools == ("mcp.catalogs.list",)

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_protocol_path_scope_candidates.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_protocol_path_scope_candidates.py
@@ -210,6 +210,46 @@ async def test_protocol_passes_module_path_candidates_to_enforcer() -> None:
 
 @pytest.mark.unit
 @pytest.mark.asyncio
+async def test_tldw_path_scope_enforcer_forwards_module_candidates(monkeypatch) -> None:
+    from tldw_Server_API.app.core.MCP_unified.adapters.tldw_policy import TldwPathScopeEnforcer
+    from tldw_Server_API.app.services import mcp_hub_path_enforcement_service as path_service_mod
+
+    class _Service:
+        def __init__(self) -> None:
+            self.calls: list[dict[str, Any]] = []
+
+        async def evaluate_tool_call(self, **kwargs: Any) -> dict[str, Any]:
+            self.calls.append(kwargs)
+            return {
+                "enabled": True,
+                "within_scope": True,
+                "reason": None,
+                "force_approval": False,
+            }
+
+    service = _Service()
+
+    async def _fake_service() -> _Service:
+        return service
+
+    monkeypatch.setattr(path_service_mod, "get_mcp_hub_path_enforcement_service", _fake_service)
+    candidates = [PathScopeCandidate(path="docs/a.txt", action="edit", source="test")]
+
+    result = await TldwPathScopeEnforcer().evaluate_tool_call(
+        effective_policy={"enabled": True},
+        context=_context(),
+        tool_name="fs.patch",
+        tool_args={"diff": "..."},
+        tool_def={"metadata": {"uses_filesystem": True}},
+        path_scope_candidates=candidates,
+    )
+
+    assert result["within_scope"] is True  # nosec B101
+    assert service.calls[0]["path_scope_candidates"] == candidates  # nosec B101
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
 async def test_protocol_fails_closed_when_module_candidates_unavailable() -> None:
     module = _PatchModule(include_candidate_hook=False)
     protocol = _build_protocol(module, _RecordingPathEnforcer())

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_run_command_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_run_command_module.py
@@ -42,7 +42,9 @@ class _ProtocolStub:
         return {
             "tools": [
                 {"name": "fs.list", "module": "filesystem", "canExecute": True},
+                {"name": "fs.read", "module": "filesystem", "canExecute": True},
                 {"name": "fs.read_text", "module": "filesystem", "canExecute": True},
+                {"name": "fs.write", "module": "filesystem", "canExecute": True},
                 {"name": "fs.write_text", "module": "filesystem", "canExecute": True},
                 {"name": "fs.stat", "module": "filesystem", "canExecute": True},
                 {"name": "fs.glob", "module": "filesystem", "canExecute": True},
@@ -91,6 +93,16 @@ class _ProtocolStub:
         if tool_name == "fs.write_text":
             return {
                 "content": [{"type": "json", "json": {"path": "notes.txt", "bytes_written": 5}}],
+                "tool": tool_name,
+            }
+        if tool_name == "fs.write":
+            return {
+                "content": [{"type": "json", "json": {"path": "notes.txt", "bytes_written": 5}}],
+                "tool": tool_name,
+            }
+        if tool_name == "fs.read":
+            return {
+                "content": [{"type": "json", "json": {"path": "notes.txt", "content": self.read_text_content}}],
                 "tool": tool_name,
             }
         if tool_name == "fs.read_text":
@@ -259,8 +271,72 @@ async def test_run_plain_grep_still_filters_stdin_instead_of_calling_fs_grep() -
 
     assert "ERROR one" in rendered
     assert "INFO two" not in rendered
+    assert [call.params["name"] for call in protocol.prepare_calls] == ["fs.read"]
+    assert [call.params["name"] for call in protocol.execute_calls] == ["fs.read"]
+
+
+@pytest.mark.asyncio
+async def test_run_cat_falls_back_to_legacy_read_text_when_structured_read_is_hidden() -> None:
+    class _LegacyReadOnlyProtocolStub(_ProtocolStub):
+        async def _handle_tools_list(self, params: dict[str, Any], context: RequestContext) -> dict[str, Any]:
+            del params, context
+            self.tools_list_calls += 1
+            return {
+                "tools": [
+                    {"name": "fs.read_text", "module": "filesystem", "canExecute": True},
+                ]
+            }
+
+    protocol = _LegacyReadOnlyProtocolStub()
+    module = _build_module(protocol)
+    context = RequestContext(request_id="run-cat-legacy-read", user_id="1", client_id="unit")
+
+    rendered = await module.execute_tool("run", {"command": "cat notes.txt"}, context=context)
+
+    assert "hello" in rendered
     assert [call.params["name"] for call in protocol.prepare_calls] == ["fs.read_text"]
-    assert [call.params["name"] for call in protocol.execute_calls] == ["fs.read_text"]
+    assert [call.params["arguments"] for call in protocol.prepare_calls] == [{"path": "notes.txt"}]
+
+
+@pytest.mark.asyncio
+async def test_run_cat_surfaces_structured_read_truncation_metadata() -> None:
+    class _TruncatedReadProtocolStub(_ProtocolStub):
+        async def execute_prepared_tool_call(self, prepared: _PreparedCall) -> dict[str, Any]:
+            self.execute_calls.append(prepared)
+            tool_name = str(prepared.params.get("name") or "")
+            if tool_name == "fs.read":
+                return {
+                    "content": [
+                        {
+                            "type": "json",
+                            "json": {
+                                "path": "/private/workspace/notes.txt",
+                                "content": "first chunk\n",
+                                "truncated": True,
+                                "bytes_returned": 12,
+                                "bytes_total": 128,
+                                "lines_returned": 1,
+                                "truncation_reason": "byte_limit",
+                            },
+                        }
+                    ],
+                    "tool": tool_name,
+                }
+            return await super().execute_prepared_tool_call(prepared)
+
+    protocol = _TruncatedReadProtocolStub()
+    module = _build_module(protocol)
+    context = RequestContext(request_id="run-cat-truncated", user_id="1", client_id="unit")
+
+    rendered = await module.execute_tool("run", {"command": "cat notes.txt"}, context=context)
+
+    assert "first chunk" in rendered
+    assert "truncated" in rendered.lower()
+    assert "bytes_returned=12" in rendered
+    assert "bytes_total=128" in rendered
+    assert "lines_returned=1" in rendered
+    assert "truncation_reason=byte_limit" in rendered
+    assert "/private/workspace" not in rendered
 
 
 @pytest.mark.asyncio
@@ -289,6 +365,72 @@ async def test_run_help_policy_filters_filesystem_aliases() -> None:
 
 
 @pytest.mark.asyncio
+async def test_run_help_shows_write_create_only_when_structured_write_is_visible() -> None:
+    class _StructuredWriteProtocolStub(_ProtocolStub):
+        async def _handle_tools_list(self, params: dict[str, Any], context: RequestContext) -> dict[str, Any]:
+            del params, context
+            return {
+                "tools": [
+                    {"name": "fs.write", "module": "filesystem", "canExecute": True},
+                ]
+            }
+
+    module = _build_module(_StructuredWriteProtocolStub())
+    context = RequestContext(request_id="run-help-write-create", user_id="1", client_id="unit")
+
+    rendered = await module.execute_tool("run", {"command": "--help"}, context=context)
+
+    commands = {line.split()[0] for line in rendered.splitlines() if line.startswith("  ")}
+    assert "write-create" in commands
+    assert "write" not in commands
+
+
+@pytest.mark.asyncio
+async def test_run_help_shows_legacy_write_only_when_legacy_write_text_is_visible() -> None:
+    class _LegacyWriteProtocolStub(_ProtocolStub):
+        async def _handle_tools_list(self, params: dict[str, Any], context: RequestContext) -> dict[str, Any]:
+            del params, context
+            return {
+                "tools": [
+                    {"name": "fs.write_text", "module": "filesystem", "canExecute": True},
+                ]
+            }
+
+    module = _build_module(_LegacyWriteProtocolStub())
+    context = RequestContext(request_id="run-help-legacy-write", user_id="1", client_id="unit")
+
+    rendered = await module.execute_tool("run", {"command": "--help"}, context=context)
+
+    commands = {line.split()[0] for line in rendered.splitlines() if line.startswith("  ")}
+    assert "write" in commands
+    assert "write-create" not in commands
+
+
+@pytest.mark.asyncio
+async def test_run_mcp_catalogs_does_not_prepare_hidden_catalogs_subtool() -> None:
+    class _McpToolsOnlyProtocolStub(_ProtocolStub):
+        async def _handle_tools_list(self, params: dict[str, Any], context: RequestContext) -> dict[str, Any]:
+            del params, context
+            return {
+                "tools": [
+                    {"name": "mcp.tools.list", "module": "mcp", "canExecute": True},
+                ]
+            }
+
+    protocol = _McpToolsOnlyProtocolStub()
+    module = _build_module(protocol)
+    context = RequestContext(request_id="run-mcp-hidden-catalogs", user_id="1", client_id="unit")
+
+    rendered = await module.execute_tool("run", {"command": "mcp catalogs"}, context=context)
+
+    assert "unavailable in this context" in rendered
+    assert "mcp.catalogs.list" in rendered
+    assert "[exit:2 |" in rendered
+    assert protocol.prepare_calls == []
+    assert protocol.execute_calls == []
+
+
+@pytest.mark.asyncio
 async def test_bash_alias_returns_governed_alias_usage_errors() -> None:
     protocol = _ProtocolStub()
     module = _build_module(protocol)
@@ -314,6 +456,23 @@ async def test_run_cat_without_path_returns_usage() -> None:
     assert "[exit:2 |" in rendered
     assert protocol.prepare_calls == []
     assert protocol.execute_calls == []
+
+
+@pytest.mark.asyncio
+async def test_run_write_create_uses_structured_write_create_mode() -> None:
+    protocol = _ProtocolStub()
+    module = _build_module(protocol)
+    context = RequestContext(request_id="run-write-create", user_id="1", client_id="unit")
+
+    rendered = await module.execute_tool("run", {"command": "write-create notes.txt hello"}, context=context)
+
+    assert "wrote 5 bytes to notes.txt" in rendered
+    assert protocol.prepare_calls[0].params["name"] == "fs.write"
+    assert protocol.prepare_calls[0].params["arguments"] == {
+        "path": "notes.txt",
+        "content": "hello",
+        "mode": "create",
+    }
 
 
 @pytest.mark.asyncio
@@ -364,7 +523,7 @@ async def test_run_derives_step_idempotency_from_parent_key() -> None:
 @pytest.mark.asyncio
 async def test_run_uses_lexical_preflighted_step_for_identical_command_after_skipped_branch() -> None:
     protocol = _ProtocolStub()
-    protocol.execute_errors["fs.read_text"] = FileNotFoundError("Path not found: missing.txt")
+    protocol.execute_errors["fs.read"] = FileNotFoundError("Path not found: missing.txt")
     module = _build_module(protocol)
     context = RequestContext(request_id="run-skipped-branch", user_id="1", client_id="unit")
 
@@ -379,12 +538,12 @@ async def test_run_uses_lexical_preflighted_step_for_identical_command_after_ski
 
     assert "[exit:0 |" in rendered
     assert [call.params["name"] for call in protocol.prepare_calls] == [
-        "fs.read_text",
+        "fs.read",
         "fs.write_text",
         "fs.write_text",
     ]
     assert [call.params["name"] for call in protocol.execute_calls] == [
-        "fs.read_text",
+        "fs.read",
         "fs.write_text",
     ]
     assert protocol.execute_calls[1].idempotency_key == derive_step_idempotency_key(
@@ -397,7 +556,7 @@ async def test_run_uses_lexical_preflighted_step_for_identical_command_after_ski
 @pytest.mark.asyncio
 async def test_run_converts_governed_file_errors_into_cli_result() -> None:
     protocol = _ProtocolStub()
-    protocol.execute_errors["fs.read_text"] = FileNotFoundError("Path not found: notes.txt")
+    protocol.execute_errors["fs.read"] = FileNotFoundError("Path not found: notes.txt")
     module = _build_module(protocol)
     context = RequestContext(request_id="run-cat-missing", user_id="1", client_id="unit")
 
@@ -581,3 +740,9 @@ async def test_run_resolve_protocol_uses_standalone_protocol_when_server_protoco
     protocol = await module._resolve_protocol()
 
     assert isinstance(protocol, MCPProtocol)
+
+
+def test_run_write_classification_detects_structured_write_create_command() -> None:
+    module = _build_module(_ProtocolStub())
+
+    assert module.is_write_tool_call("run", {"command": "write-create notes.txt hi"}) is True

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_run_command_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_run_command_module.py
@@ -407,6 +407,32 @@ async def test_run_help_shows_legacy_write_only_when_legacy_write_text_is_visibl
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("command", "command_name"),
+    [
+        ("knowledge search vector", "knowledge"),
+        ("media search lecture", "media"),
+        ("mcp tools", "mcp"),
+    ],
+)
+async def test_run_returns_unknown_for_hidden_multi_backend_commands(
+    command: str,
+    command_name: str,
+) -> None:
+    protocol = _ProtocolStub()
+    module = _build_module(protocol)
+    context = RequestContext(request_id=f"run-hidden-{command_name}", user_id="1", client_id="unit")
+
+    rendered = await module.execute_tool("run", {"command": command}, context=context)
+
+    assert f"Unknown command: {command_name}" in rendered
+    assert "unavailable in this context" not in rendered
+    assert "[exit:127 |" in rendered
+    assert protocol.prepare_calls == []
+    assert protocol.execute_calls == []
+
+
+@pytest.mark.asyncio
 async def test_run_mcp_catalogs_does_not_prepare_hidden_catalogs_subtool() -> None:
     class _McpToolsOnlyProtocolStub(_ProtocolStub):
         async def _handle_tools_list(self, params: dict[str, Any], context: RequestContext) -> dict[str, Any]:

--- a/tldw_Server_API/tests/MCP_unified/test_mcp_protocol_path_scope.py
+++ b/tldw_Server_API/tests/MCP_unified/test_mcp_protocol_path_scope.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from types import SimpleNamespace
+
 import pytest
 
 
@@ -102,6 +104,36 @@ class _FakeWorkspaceRootResolver:
     async def resolve_for_context(self, **kwargs) -> dict:  # noqa: ANN003
         self.calls.append(dict(kwargs))
         return dict(self.result)
+
+
+def _filesystem_tool_def(name: str, action: str) -> dict:
+    return {
+        "name": name,
+        "description": name,
+        "inputSchema": {
+            "type": "object",
+            "properties": {"path": {"type": "string"}},
+            "required": ["path"],
+            "additionalProperties": False,
+        },
+        "metadata": {
+            "uses_filesystem": True,
+            "path_boundable": True,
+            "path_argument_hints": ["path"],
+            "path_scope_action": action,
+        },
+    }
+
+
+def _effective_path_policy(path_grants: list[dict]) -> dict:
+    return {
+        "enabled": True,
+        "allowed_tools": ["fs.read", "fs.edit", "fs.write", "fs.patch"],
+        "policy_document": {
+            "path_scope_mode": "workspace_root",
+            "path_grants": path_grants,
+        },
+    }
 
 
 @pytest.mark.asyncio
@@ -777,6 +809,185 @@ def test_path_scope_key_includes_active_workspace_id() -> None:
     )
 
     assert scope_key_a != scope_key_b
+
+
+@pytest.mark.asyncio
+async def test_path_grants_keep_read_edit_and_write_distinct(tmp_path) -> None:
+    from tldw_Server_API.app.services.mcp_hub_path_enforcement_service import (
+        McpHubPathEnforcementService,
+    )
+    from tldw_Server_API.app.services.mcp_hub_path_scope_service import McpHubPathScopeService
+
+    workspace_root = str(tmp_path)
+    path_service = McpHubPathEnforcementService(
+        path_scope_service=McpHubPathScopeService(
+            sandbox_service=object(),
+            workspace_root_resolver=_FakeWorkspaceRootResolver(
+                {
+                    "workspace_root": workspace_root,
+                    "workspace_id": "workspace-actions",
+                    "source": "test_workspace",
+                    "reason": None,
+                }
+            ),
+        )
+    )
+    context = SimpleNamespace(
+        user_id="7",
+        session_id="sess-actions",
+        metadata={"workspace_id": "workspace-actions"},
+    )
+
+    async def _evaluate(path_grants: list[dict], tool_name: str, action: str) -> dict:
+        return await path_service.evaluate_tool_call(
+            effective_policy=_effective_path_policy(path_grants),
+            context=context,
+            tool_name=tool_name,
+            tool_args={"path": "docs/a.txt"},
+            tool_def=_filesystem_tool_def(tool_name, action),
+        )
+
+    def _assert_not_granted(result: dict, requested_action: str) -> None:
+        assert result["within_scope"] is False  # nosec B101
+        assert result["reason"] == "path_action_not_granted"  # nosec B101
+        assert workspace_root not in repr(result)  # nosec B101
+        decision = result["scope_payload"]["path_decisions"][0]
+        assert decision["requested_action"] == requested_action  # nosec B101
+        assert decision["reason_code"] == "path_action_not_granted"  # nosec B101
+        assert decision["redacted"] is True  # nosec B101
+
+    read_policy_grants = [{"prefix": "docs", "actions": ["read"]}]
+    read_allowed = await _evaluate(read_policy_grants, "fs.read", "read")
+    read_edit_denied = await _evaluate(read_policy_grants, "fs.edit", "edit")
+    read_write_denied = await _evaluate(read_policy_grants, "fs.write", "write")
+
+    assert read_allowed["within_scope"] is True  # nosec B101
+    assert read_allowed["path_decisions"][0]["requested_action"] == "read"  # nosec B101
+    _assert_not_granted(read_edit_denied, "edit")
+    _assert_not_granted(read_write_denied, "write")
+
+    edit_policy_grants = [{"prefix": "docs", "actions": ["edit"]}]
+    edit_allowed = await _evaluate(edit_policy_grants, "fs.edit", "edit")
+    edit_read_denied = await _evaluate(edit_policy_grants, "fs.read", "read")
+    edit_write_denied = await _evaluate(edit_policy_grants, "fs.write", "write")
+
+    assert edit_allowed["within_scope"] is True  # nosec B101
+    assert edit_allowed["path_decisions"][0]["requested_action"] == "edit"  # nosec B101
+    _assert_not_granted(edit_read_denied, "read")
+    _assert_not_granted(edit_write_denied, "write")
+
+    write_policy_grants = [{"prefix": "docs", "actions": ["write"]}]
+    write_allowed = await _evaluate(write_policy_grants, "fs.write", "write")
+    write_read_denied = await _evaluate(write_policy_grants, "fs.read", "read")
+    write_edit_denied = await _evaluate(write_policy_grants, "fs.edit", "edit")
+
+    assert write_allowed["within_scope"] is True  # nosec B101
+    assert write_allowed["path_decisions"][0]["requested_action"] == "write"  # nosec B101
+    _assert_not_granted(write_read_denied, "read")
+    _assert_not_granted(write_edit_denied, "edit")
+
+
+@pytest.mark.asyncio
+async def test_path_grants_deny_override_wins_for_nested_prefix(tmp_path) -> None:
+    from tldw_Server_API.app.services.mcp_hub_path_enforcement_service import (
+        McpHubPathEnforcementService,
+    )
+    from tldw_Server_API.app.services.mcp_hub_path_scope_service import McpHubPathScopeService
+
+    path_service = McpHubPathEnforcementService(
+        path_scope_service=McpHubPathScopeService(
+            sandbox_service=object(),
+            workspace_root_resolver=_FakeWorkspaceRootResolver(
+                {
+                    "workspace_root": str(tmp_path),
+                    "workspace_id": "workspace-deny-override",
+                    "source": "test_workspace",
+                    "reason": None,
+                }
+            ),
+        )
+    )
+
+    result = await path_service.evaluate_tool_call(
+        effective_policy=_effective_path_policy(
+            [
+                {"prefix": "docs", "actions": ["read", "edit", "write"]},
+                {"prefix": "docs/private", "actions": ["edit", "write"], "effect": "deny"},
+            ]
+        ),
+        context=SimpleNamespace(
+            user_id="7",
+            session_id="sess-deny-override",
+            metadata={"workspace_id": "workspace-deny-override"},
+        ),
+        tool_name="fs.edit",
+        tool_args={"path": "docs/private/a.txt"},
+        tool_def=_filesystem_tool_def("fs.edit", "edit"),
+    )
+
+    assert result["within_scope"] is False  # nosec B101
+    assert result["reason"] == "path_action_denied"  # nosec B101
+    decision = result["scope_payload"]["path_decisions"][0]
+    assert decision["reason_code"] == "path_action_denied"  # nosec B101
+    assert decision["matched_grant_prefix"] == "docs/private"  # nosec B101
+    assert decision["matched_grant_effect"] == "deny"  # nosec B101
+
+
+@pytest.mark.asyncio
+async def test_path_grants_patch_bundle_fails_closed_when_create_needs_write(tmp_path) -> None:
+    from mcp_unified.interfaces.path_scope import PathScopeCandidate
+
+    from tldw_Server_API.app.services.mcp_hub_path_enforcement_service import (
+        McpHubPathEnforcementService,
+    )
+    from tldw_Server_API.app.services.mcp_hub_path_scope_service import McpHubPathScopeService
+
+    path_service = McpHubPathEnforcementService(
+        path_scope_service=McpHubPathScopeService(
+            sandbox_service=object(),
+            workspace_root_resolver=_FakeWorkspaceRootResolver(
+                {
+                    "workspace_root": str(tmp_path),
+                    "workspace_id": "workspace-patch-bundle",
+                    "source": "test_workspace",
+                    "reason": None,
+                }
+            ),
+        )
+    )
+
+    result = await path_service.evaluate_tool_call(
+        effective_policy=_effective_path_policy(
+            [
+                {"prefix": "docs", "actions": ["edit"]},
+            ]
+        ),
+        context=SimpleNamespace(
+            user_id="7",
+            session_id="sess-patch-bundle",
+            metadata={"workspace_id": "workspace-patch-bundle"},
+        ),
+        tool_name="fs.patch",
+        tool_args={"diff": "not-inspected-here"},
+        tool_def=_filesystem_tool_def("fs.patch", "edit"),
+        path_scope_candidates=[
+            PathScopeCandidate(path="docs/allowed.txt", action="edit", source="filesystem_diff"),
+            PathScopeCandidate(
+                path="docs/new.txt",
+                action="write",
+                source="filesystem_diff",
+                creates_file=True,
+            ),
+        ],
+    )
+
+    assert result["within_scope"] is False  # nosec B101
+    assert result["reason"] == "path_action_not_granted"  # nosec B101
+    decisions = result["scope_payload"]["path_decisions"]
+    write_decision = next(decision for decision in decisions if decision["requested_action"] == "write")
+    assert write_decision["normalized_path"] == "docs/new.txt"  # nosec B101
+    assert write_decision["reason_code"] == "path_action_not_granted"  # nosec B101
+    assert write_decision["redacted"] is True  # nosec B101
 
 
 @pytest.mark.asyncio

--- a/tldw_Server_API/tests/MCP_unified/test_mcp_protocol_path_scope.py
+++ b/tldw_Server_API/tests/MCP_unified/test_mcp_protocol_path_scope.py
@@ -862,7 +862,7 @@ async def test_path_grants_keep_read_edit_and_write_distinct(tmp_path) -> None:
     read_write_denied = await _evaluate(read_policy_grants, "fs.write", "write")
 
     assert read_allowed["within_scope"] is True  # nosec B101
-    assert read_allowed["path_decisions"][0]["requested_action"] == "read"  # nosec B101
+    assert read_allowed["scope_payload"]["path_decisions"][0]["requested_action"] == "read"  # nosec B101
     _assert_not_granted(read_edit_denied, "edit")
     _assert_not_granted(read_write_denied, "write")
 
@@ -872,7 +872,7 @@ async def test_path_grants_keep_read_edit_and_write_distinct(tmp_path) -> None:
     edit_write_denied = await _evaluate(edit_policy_grants, "fs.write", "write")
 
     assert edit_allowed["within_scope"] is True  # nosec B101
-    assert edit_allowed["path_decisions"][0]["requested_action"] == "edit"  # nosec B101
+    assert edit_allowed["scope_payload"]["path_decisions"][0]["requested_action"] == "edit"  # nosec B101
     _assert_not_granted(edit_read_denied, "read")
     _assert_not_granted(edit_write_denied, "write")
 
@@ -882,7 +882,7 @@ async def test_path_grants_keep_read_edit_and_write_distinct(tmp_path) -> None:
     write_edit_denied = await _evaluate(write_policy_grants, "fs.edit", "edit")
 
     assert write_allowed["within_scope"] is True  # nosec B101
-    assert write_allowed["path_decisions"][0]["requested_action"] == "write"  # nosec B101
+    assert write_allowed["scope_payload"]["path_decisions"][0]["requested_action"] == "write"  # nosec B101
     _assert_not_granted(write_read_denied, "read")
     _assert_not_granted(write_edit_denied, "edit")
 


### PR DESCRIPTION
<h3>PR Summary by Qodo</h3>

Harden MCP filesystem policy and command runtime defaults
<code>✨ Enhancement</code> <code>🐞 Bug fix</code> <code>🧪 Tests</code> <code>📝 Documentation</code> <code>🕐 20-40 Minutes</code>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>Walkthroughs</h3>

<details open>
<summary>User Description</summary>

<br/>

## Summary
- Forward module-derived path scope candidates through the tldw MCP policy adapter.
- Add regression coverage for action-aware filesystem path grants, deny overrides, and mixed patch candidates.
- Prefer structured `fs.read` and `fs.write` create routing in the virtual command runtime while preserving legacy fallbacks and visible-tool filtering.
- Close TASK-2331 with verification notes and document deferred `write-replace` scope.

## Test Plan
- [x] `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_protocol_path_scope_candidates.py tldw_Server_API/tests/MCP_unified/test_mcp_protocol_path_scope.py tldw_Server_API/app/core/MCP_unified/tests/test_command_runtime_registry.py tldw_Server_API/app/core/MCP_unified/tests/test_run_command_module.py -q` - 57 passed, 6 warnings
- [x] `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m bandit -r tldw_Server_API/app/core/MCP_unified/adapters/tldw_policy.py tldw_Server_API/app/core/MCP_unified/command_runtime/registry.py tldw_Server_API/app/core/MCP_unified/command_runtime/adapters.py tldw_Server_API/app/core/MCP_unified/modules/implementations/run_command_module.py -f json -o /tmp/bandit_mcp_fs_policy_hardening_final.json` - 0 findings
- [x] `git diff --check`

## Change summary
Maintainer note: this PR was materially AI-authored. Replace this section with a human-written Change summary before merge per `Docs/superpowers/AI_GENERATED_PR_CHANGE_SUMMARY_POLICY_2026_04_17.md`.

</details>

<details open>
<summary>AI Description</summary>

<br/>

<pre>
• Fix <b><i>TldwPathScopeEnforcer.evaluate_tool_call</i></b> to accept and forward <b><i>path_scope_candidates</i></b> to
  the underlying enforcement service, closing a seam that caused <b><i>fs.patch</i></b> to bypass module-derived
  path/action context.
• Update the virtual CLI command registry so <b><i>cat</i></b> prefers <b><i>fs.read</i></b> over legacy <b><i>fs.read_text</i></b>
  (with fallback), and add a new <b><i>write-create</i></b> command backed by <b><i>fs.write</i></b> with <b><i>mode: &quot;create&quot;</i></b>.
• Filter <b><i>visible_commands</i></b> to return only currently-allowed backend tools per descriptor, enabling
  adapters to reliably select the preferred structured tool.
• Add <b><i>fs.write</i></b> to the write-classification set in <b><i>RunCommandModule</i></b> so <b><i>write-create</i></b> is
  correctly flagged for approval/audit.
• Add regression tests covering action-aware path grants (read/edit/write isolation), deny-override
  for nested prefixes, and patch-bundle fail-closed behavior.
• Add design spec, implementation plan, and backlog task closure docs for TASK-2331.
</pre>
</details>

<details>
<summary>Diagram</summary>

<br/>

```mermaid
graph TD
    A["run / bash / shell\n(RunCommandModule)"] --> B["CommandRegistry\n(registry.py)"]
    B --> C["visible_commands\n(filtered descriptors)"]
    C --> D["PhaseOneCommandAdapters\n(adapters.py)"]
    D --> E["fs.read / fs.read_text\n(cat routing)"]
    D --> F["fs.write mode=create\n(write-create)"]
    D --> G["fs.write_text\n(legacy write)"]
    H["MCP Protocol\n(fs.patch / fs.edit)"] --> I["TldwPathScopeEnforcer\n(tldw_policy.py)"]
    I --> J[("McpHubPathEnforcementService")]
    I -.->|"path_scope_candidates\n(NEW)"|J

    subgraph Legend
      direction LR
      _svc["Module / Service"] ~~~ _db[("Enforcement Service")] ~~~ _tool["Tool Endpoint"]
    end
```

</details>




<details>
<summary>High-Level Assessment</summary>

<br/>

The PR&#x27;s approach is well-suited to the problem. The seam fix (forwarding `path_scope_candidates`) is the minimal correct change — the enforcement service already had the capability, the adapter was simply dropping the context. The registry filtering approach (returning cloned descriptors with only visible backend tools) is clean and avoids duplicating policy logic in adapters. Deferring `write-replace` until preimage authorization syntax is available is the right call. No meaningfully better alternatives were identified.

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>File Changes</h3>

<details>
<summary><strong>Enhancement</strong> (2)</summary>

<blockquote>
<details>
<summary><strong>registry.py</strong> <code>Add fs.read preference and write-create command to registry</code> <code>+13/-4</code></summary>

<br/>

>Add fs.read preference and write-create command to registry
>
><pre>
>• Updates &#x27;cat&#x27; backend tools to &#x27;(&quot;fs.read&quot;, &quot;fs.read_text&quot;)&#x27; so the structured tool is preferred. Adds a new &#x27;write-create&#x27; descriptor backed by &#x27;fs.write&#x27;. Refactors &#x27;visible_commands&#x27; to return filtered descriptors containing only currently-allowed backend tools, enabling adapters to select the best available tool without separate policy inspection. Also adds &#x27;mcp.catalogs.list&#x27; to the &#x27;mcp&#x27; command&#x27;s backend tools.
></pre>
>
><a href='https://github.com/rmusser01/tldw_server/pull/2327/files#diff-75aade3d45d0aa309ae1148c3bbf17a047bdb4f1c6a9e2b24e49acb7f4fa8902'>tldw_Server_API/app/core/MCP_unified/command_runtime/registry.py</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>adapters.py</strong> <code>Route cat to fs.read and add write-create command adapter</code> <code>+61/-2</code></summary>

<br/>

>Route cat to fs.read and add write-create command adapter
>
><pre>
>• Updates &#x27;_governed_plan&#x27; for &#x27;cat&#x27; to use &#x27;_visible_backend_tool&#x27; helper to prefer &#x27;fs.read&#x27; over &#x27;fs.read_text&#x27;. Adds &#x27;write-create&#x27; command routing to &#x27;fs.write&#x27; with &#x27;mode: &quot;create&quot;&#x27;. Adds &#x27;_visible_backend_tool&#x27;, &#x27;_command_has_visible_backend&#x27;, and &#x27;_unavailable_backend_error&#x27; helpers. Applies backend-availability guards to &#x27;knowledge&#x27;, &#x27;media&#x27;, and &#x27;mcp&#x27; sub-commands. Enhances &#x27;_render_cat&#x27; to append a truncation marker when &#x27;fs.read&#x27; returns a truncated response.
></pre>
>
><a href='https://github.com/rmusser01/tldw_server/pull/2327/files#diff-5a9dcd758151412dd96bdf2c1b640667e4416425511e0a0a7dd2de4a700c6796'>tldw_Server_API/app/core/MCP_unified/command_runtime/adapters.py</a>
<hr/>

</details>
</blockquote>

</details>

<details>
<summary><strong>Bug fix</strong> (2)</summary>

<blockquote>
<details>
<summary><strong>tldw_policy.py</strong> <code>Forward path_scope_candidates through TldwPathScopeEnforcer</code> <code>+2/-0</code></summary>

<br/>

>Forward path_scope_candidates through TldwPathScopeEnforcer
>
><pre>
>• Adds an optional &#x27;path_scope_candidates&#x27; parameter to &#x27;TldwPathScopeEnforcer.evaluate_tool_call&#x27; and forwards it to the underlying &#x27;McpHubPathEnforcementService&#x27;. This closes a seam where module-derived path/action candidates for &#x27;fs.patch&#x27; were silently dropped before reaching the real enforcement service.
></pre>
>
><a href='https://github.com/rmusser01/tldw_server/pull/2327/files#diff-12ec74522daab857ee8a6f7a44ace3113f59661346bff2432ec28762600bea35'>tldw_Server_API/app/core/MCP_unified/adapters/tldw_policy.py</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>run_command_module.py</strong> <code>Add fs.write to write-classification set for approval/audit</code> <code>+1/-1</code></summary>

<br/>

>Add fs.write to write-classification set for approval/audit
>
><pre>
>• Adds &#x27;fs.write&#x27; to &#x27;_RUN_WRITE_BACKEND_TOOLS&#x27; so that &#x27;write-create&#x27; commands backed by the structured write primitive are correctly classified as write-capable for approval gating and audit purposes.
></pre>
>
><a href='https://github.com/rmusser01/tldw_server/pull/2327/files#diff-54be7292069fca961e1d1c62ab0994567bb5a60516b83c4e8459688d3c0db933'>tldw_Server_API/app/core/MCP_unified/modules/implementations/run_command_module.py</a>
<hr/>

</details>
</blockquote>

</details>

<details>
<summary><strong>Tests</strong> (4)</summary>

<blockquote>
<details>
<summary><strong>test_command_runtime_registry.py</strong> <code>Update registry tests for new backend mappings and visibility filtering</code> <code>+32/-2</code></summary>

<br/>

>Update registry tests for new backend mappings and visibility filtering
>
><pre>
>• Updates &#x27;test_registry_exposes_phase_one_mappings&#x27; to assert the new &#x27;cat&#x27;, &#x27;write-create&#x27;, and &#x27;mcp&#x27; backend tool tuples. Adds &#x27;test_registry_filters_visible_backend_tools_for_multi_backend_commands&#x27; and &#x27;test_registry_filters_visible_backend_tools_for_mcp_catalogs&#x27; to verify that &#x27;visible_commands&#x27; returns filtered descriptors per allowed tool set.
></pre>
>
><a href='https://github.com/rmusser01/tldw_server/pull/2327/files#diff-f7f656fb9759a11ce43ac8b83108b0823585d269c3ad4517f8336f7f4ffd0697'>tldw_Server_API/app/core/MCP_unified/tests/test_command_runtime_registry.py</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>test_protocol_path_scope_candidates.py</strong> <code>Add integration test for TldwPathScopeEnforcer candidate forwarding</code> <code>+40/-0</code></summary>

<br/>

>Add integration test for TldwPathScopeEnforcer candidate forwarding
>
><pre>
>• Adds &#x27;test_tldw_path_scope_enforcer_forwards_module_candidates&#x27; which monkeypatches the path enforcement service and verifies that &#x27;PathScopeCandidate&#x27; values passed to &#x27;TldwPathScopeEnforcer.evaluate_tool_call&#x27; are forwarded to the underlying service.
></pre>
>
><a href='https://github.com/rmusser01/tldw_server/pull/2327/files#diff-5da9a9f1d8a2854ed0e842098a55d3c7c42f693f43538744e257a3570d964fff'>tldw_Server_API/app/core/MCP_unified/tests/test_protocol_path_scope_candidates.py</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>test_run_command_module.py</strong> <code>Expand run module tests for structured read/write and truncation</code> <code>+170/-5</code></summary>

<br/>

>Expand run module tests for structured read/write and truncation
>
><pre>
>• Updates the protocol stub to expose &#x27;fs.read&#x27; and &#x27;fs.write&#x27; and adds corresponding execution handlers. Adds tests for: legacy &#x27;fs.read_text&#x27; fallback when &#x27;fs.read&#x27; is hidden; truncation metadata rendering from &#x27;fs.read&#x27;; &#x27;write-create&#x27; routing to &#x27;fs.write&#x27; with &#x27;mode: create&#x27;; help visibility for &#x27;write-create&#x27; vs legacy &#x27;write&#x27;; &#x27;mcp catalogs&#x27; unavailability when &#x27;mcp.catalogs.list&#x27; is hidden; and write-classification detection for &#x27;write-create&#x27;.
></pre>
>
><a href='https://github.com/rmusser01/tldw_server/pull/2327/files#diff-0d553336abee6a3227f3a9e03a55bd67e2a611f50f04a149fd5f1a37e3c39497'>tldw_Server_API/app/core/MCP_unified/tests/test_run_command_module.py</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>test_mcp_protocol_path_scope.py</strong> <code>Add action-aware path grant regression tests at service boundary</code> <code>+211/-0</code></summary>

<br/>

>Add action-aware path grant regression tests at service boundary
>
><pre>
>• Adds three new async tests exercising &#x27;McpHubPathEnforcementService&#x27; directly: &#x27;test_path_grants_keep_read_edit_and_write_distinct&#x27; verifies read/edit/write grants are strictly isolated; &#x27;test_path_grants_deny_override_wins_for_nested_prefix&#x27; verifies deny grants on nested prefixes override broader allow grants; &#x27;test_path_grants_patch_bundle_fails_closed_when_create_needs_write&#x27; verifies that a patch bundle with a create candidate fails closed when only an edit grant is present.
></pre>
>
><a href='https://github.com/rmusser01/tldw_server/pull/2327/files#diff-48b2a59b17abab35c89f728bd4f635930d08bc21fd638ae2e2972038d39bfc84'>tldw_Server_API/tests/MCP_unified/test_mcp_protocol_path_scope.py</a>
<hr/>

</details>
</blockquote>

</details>

<details>
<summary><strong>Documentation</strong> (3)</summary>

<blockquote>
<details>
<summary><strong>task-2331 - Harden-MCP-filesystem-path-policy-and-command-runtime-defaults.md</strong> <code>Close TASK-2331 with verification notes and deferred scope</code> <code>+88/-0</code></summary>

<br/>

>Close TASK-2331 with verification notes and deferred scope
>
><pre>
>• New backlog task file documenting TASK-2331 as Done, recording implementation commit SHAs, test/Bandit verification results, and explicitly noting that &#x27;write-replace&#x27; is deferred because preimage syntax is not implemented in this slice.
></pre>
>
><a href='https://github.com/rmusser01/tldw_server/pull/2327/files#diff-aeed0cb23b6f2269bb50f30991f90f1d5d6474d18da500657f73e78f1df7bfe3'>backlog/tasks/task-2331 - Harden-MCP-filesystem-path-policy-and-command-runtime-defaults.md</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>2026-06-09-mcp-filesystem-policy-hardening-design.md</strong> <code>Add MCP filesystem policy hardening design spec</code> <code>+186/-0</code></summary>

<br/>

>Add MCP filesystem policy hardening design spec
>
><pre>
>• New design document covering the goals, non-goals, policy regression coverage requirements, candidate forwarding boundary, virtual CLI routing strategy, and open follow-ups for this hardening slice.
></pre>
>
><a href='https://github.com/rmusser01/tldw_server/pull/2327/files#diff-085dbecdb26294943d452fe2713510c69878f7d3ff92ce5d5d69f4aad15c97ea'>Docs/superpowers/specs/2026-06-09-mcp-filesystem-policy-hardening-design.md</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>2026-06-09-mcp-filesystem-policy-hardening-implementation-plan.md</strong> <code>Add step-by-step implementation plan for MCP filesystem hardening</code> <code>+542/-0</code></summary>

<br/>

>Add step-by-step implementation plan for MCP filesystem hardening
>
><pre>
>• New implementation plan document with four tasks (adapter seam, regression tests, virtual CLI routing, validation/closeout), each broken into numbered steps with code snippets, expected test outcomes, and commit commands.
></pre>
>
><a href='https://github.com/rmusser01/tldw_server/pull/2327/files#diff-1a5f9b3e48c984782099cba8b61e01076d165f1bc96896bb500f68a37d8021b8'>Docs/superpowers/plans/2026-06-09-mcp-filesystem-policy-hardening-implementation-plan.md</a>
<hr/>

</details>
</blockquote>

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">


<a href="https://www.qodo.ai"><img src="https://www.qodo.ai/wp-content/uploads/2025/03/qodo-logo.svg" width="80" alt="Qodo Logo"></a>