### PR TITLE
Add Scheduled Tasks results inbox and Home surfacing

### DIFF
--- a/Docs/superpowers/plans/2026-06-09-scheduled-tasks-phase3-results-inbox-home-surfacing-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-06-09-scheduled-tasks-phase3-results-inbox-home-surfacing-implementation-plan.md
@@ -4,7 +4,7 @@
 
 **Goal:** Implement the Phase 3 scheduled-task results discovery experience so users can see automation outcomes on Home and inside `/scheduled-tasks`, inspect exact task/run/result provenance, triage failures, and follow deep links back to the owning workspace without changing Watchlists or other domain-specific setup flows.
 
-**Architecture:** Add a frontend-owned scheduled-task result projection layer that can consume the existing `/api/v1/scheduled-tasks` task list now and later swap to a normalized result-inbox API. Extend the existing `/scheduled-tasks` query-state tab model with a Results tab, result/run deep-link parameters, result filters, and a detail drawer; do not add a separate `/scheduled-tasks/results` path route in this phase unless the route registry already supports nested options routes at implementation time. Add a Home aggregation adapter that merges scheduled-task result items into the existing Companion Home inbox and attention cards while preserving personalization behavior and Home layout ownership. Add notification-to-result link normalization and dedupe helpers so Home and notifications can point to the same exact result target without double-counting. Backend changes remain dependencies for this phase unless a normalized result endpoint already exists when implementation starts.
+**Architecture:** Add a frontend-owned scheduled-task result projection layer that can consume the existing `/api/v1/scheduled-tasks` task list now and later swap to a normalized result-inbox API. Extend the existing `/scheduled-tasks` query-state tab model with a Results tab, result/run deep-link parameters, result filters, and a detail drawer. Add `/scheduled-tasks/results` as a compatibility alias that opens the same Results tab state so PRD, Home, and notification links have a durable route. Add an automation-specific Home module that can render status, owner, and provenance compactly instead of flattening automation outcomes into generic Companion cards. Add notification-to-result link normalization and dedupe helpers with an explicit notification data source. Backend changes remain dependencies for this phase unless a normalized result endpoint already exists when implementation starts.
 
 **Tech Stack:** React, TypeScript, Ant Design, Tailwind utility classes in Companion Home, React Router search params, TanStack Query, existing `bgRequest` service layer, existing ScheduledTasks and CompanionHome components, Vitest, Testing Library, existing browser/extension route shells.
 
@@ -18,6 +18,7 @@
 - Phase 2B plan: `Docs/superpowers/plans/2026-06-09-scheduled-tasks-phase2b-capability-aware-frontend-shell-implementation-plan.md`
 - Backlog references: `TASK-494`, `TASK-496`, `TASK-498`
 - Planning task: `TASK-2331`
+- Plan amendment task: `TASK-2332`
 
 ## Current Evidence
 
@@ -45,10 +46,11 @@
 In scope:
 
 - Add `/scheduled-tasks?tab=results` to the existing tab model.
+- Add `/scheduled-tasks/results` as a route alias that resolves to the Results tab.
 - Add result/run deep-link parameters, with support for `task_id`, `run_id`, and `result_id`.
 - Add a source-agnostic result inbox list inside `/scheduled-tasks`.
 - Add a result detail drawer with task state, run state, output summary, provenance, owning workspace, and safe actions.
-- Add Home surfacing for scheduled-task result and failure signals inside existing inbox/attention patterns.
+- Add Home surfacing through an automation-specific module/card that can show result/failure state, owner, and exact deep links.
 - Add notification deep-link normalization for scheduled-task task/run/result targets.
 - Add dedupe keys so the same run/result does not appear twice across Home inbox and notification-derived items.
 - Preserve Companion Home personalization behavior while allowing scheduled-task signals to render without personalization.
@@ -65,7 +67,7 @@ Out of scope:
 - Building backend normalized result storage in this Phase 3 frontend plan.
 - Adding push notifications beyond linking to existing notification/event surfaces.
 - Replacing the existing Notifications service or Watchlists run notification logic.
-- Bulk management across many results beyond filters and review actions.
+- Bulk management across many results beyond filters and supported review actions.
 - Reworking Companion Home layout customization beyond adding scheduled-task-aware system signals.
 
 ## Backend Dependencies
@@ -86,7 +88,25 @@ The frontend implementation must be designed around these contracts, but this pl
   - Retries eligible failed runs without changing task configuration.
 - Notification payloads include exact `task_id`, `run_id`, `result_id`, owning workspace, and `href`.
 
-Until those endpoints exist, implementation should use a local projection adapter from `ScheduledTask[]` and `source_ref` fields, with clear capability copy and disabled/deep-link-only actions where direct review/retry cannot be performed.
+Until those endpoints exist, implementation should use a local projection adapter from `ScheduledTask[]` and `source_ref` fields, with clear capability copy and deep-link-only actions where direct review/retry cannot be performed.
+
+## Capability Modes
+
+The Results experience must expose only the behavior supported by the current data source. Do not show fake review state or mutation actions when the UI is only projecting task-list signals.
+
+| Mode | Data Source | User-Facing Label | Review State | Retry/Review Actions | Default Copy |
+| --- | --- | --- | --- | --- | --- |
+| `projected_signals` | `GET /api/v1/scheduled-tasks` only | Latest signals | Hidden | Hidden | “These signals are inferred from task status until result history is available.” |
+| `normalized_results_read` | `GET /api/v1/scheduled-tasks/results` | Results | Visible, read-only | Hidden unless mutation paths exist | “Review state comes from the scheduled-task results API.” |
+| `normalized_results_mutation` | Results API plus review/retry endpoints | Results | Visible and actionable | Shown only when item-level availability is true | “You can review results and retry eligible runs from here.” |
+
+Mode detection:
+
+- Use the existing OpenAPI support probe pattern to detect `/api/v1/scheduled-tasks/results`, `/api/v1/scheduled-tasks/results/{result_id}`, `POST /api/v1/scheduled-tasks/results/{result_id}/review`, and `POST /api/v1/scheduled-tasks/runs/{run_id}/retry`.
+- Default to `projected_signals` if the normalized result paths are absent or the probe fails open.
+- In `projected_signals`, hide the Review state filter, hide `Mark reviewed`, hide `Retry run`, and label the primary tab content “Latest automation signals” in supporting copy.
+- In `normalized_results_read`, show review state as information but hide mutation actions.
+- In `normalized_results_mutation`, show mutation actions only when the result item sets `reviewAvailable` or `retryAvailable`.
 
 ## Information Architecture
 
@@ -96,8 +116,9 @@ Until those endpoints exist, implementation should use a local projection adapte
   - Cross-automation counts, needs attention, running now, next run, newest results, and short links to Tasks/Results.
 - `Results`
   - Primary Phase 3 inbox for outcomes.
-  - Defaults to unreviewed newest first.
-  - Filters: Review state, result state, task type, owning workspace, time range.
+  - Defaults to newest actionable signal/result first.
+  - Filters: Signal/result state, task type, owning workspace, time range.
+  - Adds Review state filter only outside `projected_signals` mode.
   - Detail drawer opens from row/card or deep link.
 - `Tasks`
   - Existing task management table and task detail drawer.
@@ -107,15 +128,17 @@ Until those endpoints exist, implementation should use a local projection adapte
 
 Home:
 
-- Keep top summary cards, Inbox Preview, and Needs Attention.
-- Scheduled-task result items feed Inbox Preview when they are new/unreviewed.
-- Scheduled-task failed/stalled/blocked items feed Needs Attention.
+- Keep existing Companion Home Inbox Preview and Needs Attention behavior.
+- Add a fixed, automation-specific Home module titled `Automation Inbox` near the existing Home system cards.
+- `Automation Inbox` shows recent results, failed/stalled/blocked signals, owner, status, and exact deep links.
+- Do not add a movable Customize Home card in Phase 3; keep layout customization unchanged.
 - Home links point to `/scheduled-tasks?tab=results&result_id=...` or `/scheduled-tasks?tab=results&run_id=...`.
 - Items that belong to Watchlists also provide secondary links from the result detail drawer to Watchlists Activity/Reports.
 
 Notifications:
 
-- Existing notification payloads should normalize to the same scheduled-task result target shape used by Home.
+- Home loads recent notifications through `listNotifications({ limit: 50 })` when the notifications endpoint is available, and treats notification loading failure as non-blocking.
+- Existing notification payloads normalize to the same scheduled-task result target shape used by Home.
 - Notification clicks should prefer exact `result_id`, then exact `run_id`, then task-scoped Results tab.
 - Home and notification-derived result items should share a deterministic dedupe key: `result:<result_id>`, `run:<run_id>`, or `task:<task_id>:state:<state>:time:<occurredAt>`.
 - Watchlists run notifications remain Watchlists-owned, but when they are represented inside Scheduled Tasks they should link through the Scheduled Tasks result drawer with secondary Watchlists links.
@@ -142,14 +165,31 @@ export type ScheduledTaskResultOwner =
   | "reminders"
   | "external_workspace"
 
+export type ScheduledTaskResultsCapabilityMode =
+  | "projected_signals"
+  | "normalized_results_read"
+  | "normalized_results_mutation"
+
+export type ScheduledTaskResultSignalKind =
+  | "result"
+  | "failure"
+  | "running"
+  | "completed_no_results"
+
 export interface ScheduledTaskResultItem {
   id: string
+  capabilityMode: ScheduledTaskResultsCapabilityMode
+  signalKind: ScheduledTaskResultSignalKind
   taskId: string
   runId: string | null
   resultId: string | null
   taskTitle: string
+  resultKind: string
   title: string
   summary: string
+  matchReason: string | null
+  matchedRuleLabel: string | null
+  outputLabel: string | null
   state: ScheduledTaskResultState
   severity: ScheduledTaskResultSeverity
   reviewed: boolean
@@ -163,6 +203,7 @@ export interface ScheduledTaskResultItem {
   taskHref: string
   runHref: string | null
   resultHref: string | null
+  domainHref: string | null
   notificationIds: number[]
   dedupeKey: string
   retryAvailable: boolean
@@ -180,6 +221,16 @@ Projection rules:
 - Watchlists result items must include Watchlists deep links from `buildWatchlistTaskLinks`; Scheduled Tasks remains the triage surface.
 - Multiple events for the same run/result collapse into one visible Home result item, with notification ids retained for future read/dismiss actions.
 
+Mixed-state rules:
+
+- Never reduce a task to one result item only because its task-level product status has one label.
+- If one task has both failure tokens and output/result ids, create a failure signal and a result signal. The failure signal appears in Needs attention; the result signal appears in Results/Automation Inbox if it is otherwise visible.
+- If a latest run failed after producing an output, the detail drawer must say both: “Run needs attention” and “Output was produced.”
+- Exact result ids dedupe only result signals. Exact run ids can dedupe run-level signals only when `signalKind` is the same. Fallback dedupe keys include `signalKind` so failures do not erase results.
+- A task-level `found_results` signal without an output id uses `task:<taskId>:state:result:time:<lastRunAt>` as a fallback key.
+- A task-level failure without a run id uses `task:<taskId>:state:failure:time:<lastRunAt>` as a fallback key.
+- Review state is durable only in `normalized_results_read` and `normalized_results_mutation`; projected result signals are treated as not reviewable.
+
 ## UX Requirements
 
 First-time user:
@@ -192,11 +243,12 @@ First-time user:
 
 Power user:
 
-- Can filter by state, task type, owner, and review state.
+- Can filter by state, task type, owner, and review state when durable review data exists.
 - Can deep-link directly to a run/result drawer.
 - Can open the owning workspace in one click.
 - Can scan many results without detail drawers.
-- Can mark items reviewed where supported, retry eligible failures where supported, and see why unavailable actions are disabled.
+- Can mark items reviewed where supported and retry eligible failures where supported.
+- Does not see unsupported mutation buttons in row actions.
 - Can preserve fast task management in the Tasks tab without result cards making the table slower to scan.
 
 ## Empty, Loading, Error, Running, And Success States
@@ -208,18 +260,17 @@ Scheduled Tasks Results tab:
 - Empty after filters: “No results match these filters” with clear-filters action.
 - Loading: “Loading results and latest run state” with polite live region.
 - Partial: reuse `RecoveryCallout`, preserve visible results, and show dependency diagnostics.
-- Unsupported normalized result API: show current task-derived results and a capability note, not a dead-end error.
+- Unsupported normalized result API: show current task-derived signals and a capability note, not a dead-end error.
 - Running: show “Running now” tag, started time if available, and no retry/review actions.
-- Failed: show failure hint, owning workspace, last attempt time, retry action if contract says eligible, otherwise recovery link.
-- Success: show result count/output summary, reviewed state, and primary action “Review result”.
+- Failed: show failure hint, owning workspace, last attempt time, retry action only when item and capability mode allow it, otherwise recovery link.
+- Success: show result count/output summary, reviewed state only when durable, and primary action “Open result” or “Review result” depending on capability mode.
 
 Home:
 
-- Empty Inbox Preview: should remain Companion/Home appropriate, but if scheduled-task support is available add “Scheduled-task results will appear here when automations produce new output.”
-- Empty Needs Attention: if scheduled-task support is available add “Failed or blocked automations will appear here.”
+- Empty Automation Inbox: “Automation results and failures will appear here after scheduled tasks run.”
 - Loading Home: do not block the whole Home page on scheduled-task result loading; render cards with available companion items and update counts when scheduled-task items resolve.
 - Partial Home: show companion items and scheduled-task items independently; one degraded source must not erase the other.
-- Success Home: scheduled-task items include title, short summary, status tag text in summary, and deep link to the exact result/run.
+- Success Home: scheduled-task items include title, short summary, visible status text, owner, and deep link to the exact result/run.
 
 ## Copy Recommendations
 
@@ -228,18 +279,20 @@ Use these strings unless implementation discovers stronger local wording:
 - Results tab label: `Results`
 - Results page title: `Scheduled task results`
 - Results page subtitle: `Review outputs, failures, and run state from recurring automations. Source-specific setup stays in the owning workspace.`
-- Filter label: `Review state`
-- Filter values: `Unreviewed`, `Reviewed`, `All`
+- Projected-mode subtitle: `Latest signals inferred from task status. Durable review state appears when the results API is available.`
+- Filter label, normalized result modes only: `Review state`
+- Filter values, normalized result modes only: `Unreviewed`, `Reviewed`, `All`
 - Filter label: `Result state`
 - Filter values: `Found results`, `Needs attention`, `Running`, `Completed/no results`, `Paused/disabled`
-- Primary action: `Review result`
+- Primary action in projected mode: `Open signal`
+- Primary action with durable results: `Review result`
 - Failure action: `Inspect failure`
 - Retry action: `Retry run`
-- Disabled retry tooltip: `Retry is unavailable until run retry support is available for this task type.`
 - Review action: `Mark reviewed`
-- Disabled review tooltip: `Review state is not available from this server yet.`
+- Unsupported-action detail note: `Review and retry actions appear when this server supports them for the selected result.`
 - Watchlists owner note: `This monitor is configured in Watchlists. Scheduled Tasks shows status and links to the exact run or report.`
-- Home inbox item prefix: `Automation result`
+- Home module title: `Automation Inbox`
+- Home result item prefix: `Automation result`
 - Home attention item prefix: `Automation needs attention`
 - Result detail provenance heading: `Why this is here`
 - Result detail action heading: `Continue in`
@@ -258,6 +311,7 @@ Avoid:
 - Result cards/rows expose one clear accessible name: task title plus result state.
 - Detail drawer has an accessible title and focus returns to the opening result row/card.
 - Status is represented by text and tag tone, never color alone.
+- Automation Home module exposes status and owner as text, not only color or position.
 - Running/loading states use `role="status"` and `aria-live="polite"`.
 - Partial/error states preserve diagnostics labels already used by `RecoveryCallout`.
 - Filter controls have visible text labels and `aria-label` where visible labels are not programmatically associated.
@@ -281,13 +335,15 @@ Avoid:
 - `apps/packages/ui/src/components/Option/ScheduledTasks/ScheduledTaskResultsPanel.tsx`
   - Results list/table, filters, counts, empty states, partial capability note, and open-detail callbacks.
 - `apps/packages/ui/src/components/Option/ScheduledTasks/ScheduledTaskResultDetailDrawer.tsx`
-  - Result/run detail, provenance, owner links, retry/review actions with availability states.
+  - Result/run detail, provenance, owner links, retry/review actions only when available.
+- `apps/packages/ui/src/components/Option/CompanionHome/cards/AutomationInboxCard.tsx`
+  - Automation-specific Home module with compact status, owner, deep-link, and failure/result treatment.
 - `apps/packages/ui/src/components/Option/ScheduledTasks/__tests__/scheduled-task-results.test.ts`
   - Pure projection, filtering, deep-link, and Home adapter coverage.
 - `apps/packages/ui/src/components/Option/ScheduledTasks/__tests__/ScheduledTaskResultsPanel.test.tsx`
   - Component coverage for list, filters, empty states, loading, failure, and action availability.
 - `apps/packages/ui/src/components/Option/ScheduledTasks/__tests__/ScheduledTaskResultDetailDrawer.test.tsx`
-  - Drawer provenance, owner links, disabled actions, and accessibility coverage.
+  - Drawer provenance, owner links, capability-aware actions, and accessibility coverage.
 
 ### Modified Files
 
@@ -295,6 +351,10 @@ Avoid:
   - Add `results` tab.
   - Parse/build `result_id` and `run_id`.
   - Preserve `task_id` for both Tasks and Results where relevant.
+- `apps/tldw-frontend/extension/routes/route-registry.tsx`
+  - Add `/scheduled-tasks/results` alias to the scheduled-tasks route element.
+- `apps/tldw-frontend/pages/scheduled-tasks/results.tsx`
+  - Add hosted WebUI alias that loads the existing scheduled-tasks route.
 - `apps/packages/ui/src/components/Option/ScheduledTasks/ScheduledTasksPage.tsx`
   - Add Results tab.
   - Build projected result items from task data.
@@ -312,7 +372,7 @@ Avoid:
   - Preserve Watchlists owner copy.
 - `apps/packages/ui/src/components/Option/CompanionHome/CompanionHomePage.tsx`
   - Load scheduled-task Home signals independently from Companion personalization.
-  - Merge scheduled-task inbox and attention signals into existing system cards.
+  - Render `AutomationInboxCard` near existing Home system cards.
   - Keep Home usable if scheduled-task result loading fails.
 - `apps/packages/ui/src/components/Option/CompanionHome/hooks.ts`
   - Add a hook or adapter for non-personalized scheduled-task Home signals.
@@ -320,7 +380,7 @@ Avoid:
 - `apps/packages/ui/src/services/companion-home.ts`
   - Extend `CompanionHomeSource` with a scheduled-task source.
   - Extend `CompanionHomeEntityType` with a scheduled-task result entity.
-  - Keep the existing fixed Home cards; do not add a separate Automations card in Phase 3.
+  - Keep existing Companion cards unchanged; automation rendering lives in `AutomationInboxCard`.
 - `apps/packages/ui/src/services/notifications.ts`
   - Add pure helpers only if needed to normalize scheduled-task notification link targets.
   - Do not change notification stream subscription behavior.
@@ -329,7 +389,9 @@ Avoid:
 - `apps/packages/ui/src/components/Option/ScheduledTasks/__tests__/ScheduledTasksPage.test.tsx`
   - Add Results tab, result deep-link, missing result, partial state, and Watchlists-preservation tests.
 - `apps/packages/ui/src/components/Option/CompanionHome/__tests__/CompanionHomePage.test.tsx`
-  - Add Home scheduled-task result merge, personalization-off behavior, partial failure, and link tests.
+  - Add Automation Inbox rendering, personalization-off behavior, partial failure, and link tests.
+- `apps/packages/ui/src/components/Option/CompanionHome/__tests__/AutomationInboxCard.test.tsx`
+  - Add status, owner, result/failure, empty, and exact-link coverage.
 - `apps/packages/ui/src/components/Option/CompanionHome/__tests__/CardShell.test.tsx`
   - Update only if scheduled-task status metadata changes card rendering.
 - `apps/packages/ui/src/services/__tests__/notifications.test.ts`
@@ -355,25 +417,32 @@ Avoid:
 - Watchlists result links reuse existing `buildWatchlistTaskLinks`.
 - Result items have exact Home and `/scheduled-tasks` deep links.
 - Projection never exposes raw unknown objects directly in UI copy.
+- Capability mode is explicit and defaults to `projected_signals`.
+- Mixed failure-plus-output states produce separate failure and result signals.
 
 **Tests:**
 
 - `scheduled-task-results.test.ts`
-  - Projects found-results task into unreviewed success result.
-  - Projects failed task into attention result with recovery summary.
+  - Projects found-results task into a new success signal in projected mode.
+  - Projects failed task into an attention signal with recovery summary.
   - Projects Watchlists latest output/run links.
   - Excludes normal waiting tasks from default Home items.
   - Includes completed/no-results only under matching filters.
   - Sanitizes unsafe or empty source reference values.
+  - Hides durable review semantics in `projected_signals`.
+  - Produces both failure and result signals for a task with failure status and output ids.
+  - Keeps fallback dedupe keys separate by `signalKind`.
 
 **Tasks:**
 
 - [ ] Add `scheduled-task-results.ts` types and helpers.
 - [ ] Add `scheduled-task-result-links.ts` URL and dedupe helpers.
+- [ ] Add capability-mode detection helpers that can accept OpenAPI path availability.
 - [ ] Add result item sorting by newest `occurredAt`, then severity, then title.
 - [ ] Add `buildScheduledTaskResultHref` for `result_id`, `run_id`, and `task_id`.
 - [ ] Add `findScheduledTaskResultByRouteState`.
-- [ ] Add Home adapter returning inbox and attention item arrays.
+- [ ] Add Home adapter returning automation inbox items with status and owner metadata.
+- [ ] Add mixed-state projection rules before React rendering work starts.
 - [ ] Run `bunx vitest run apps/packages/ui/src/components/Option/ScheduledTasks/__tests__/scheduled-task-results.test.ts`.
 
 ## Stage 2: Results Route State And Results Tab
@@ -383,6 +452,7 @@ Avoid:
 **Success Criteria:**
 
 - `?tab=results` is a first-class tab.
+- `/scheduled-tasks/results` opens the same Results tab experience.
 - `result_id`, `run_id`, and `task_id` are parsed and serialized safely.
 - Invalid tabs still fall back to Overview.
 - Existing `?tab=tasks&task_id=...` drawer behavior remains unchanged.
@@ -399,12 +469,16 @@ Avoid:
   - Opens Results tab from URL.
   - Opens result drawer from result deep link after task data loads.
   - Shows missing-result alert without leaving Results.
+- Browser smoke or route-level coverage:
+  - `/scheduled-tasks/results` loads the scheduled-tasks page and selects Results.
 
 **Tasks:**
 
 - [ ] Update `ScheduledTaskTabId` and `SCHEDULED_TASK_TABS`.
 - [ ] Extend `ScheduledTaskRouteState` with `resultId` and `runId`.
 - [ ] Update `buildScheduledTaskSearch`.
+- [ ] Add extension route alias for `/scheduled-tasks/results`.
+- [ ] Add hosted WebUI alias page for `/scheduled-tasks/results`.
 - [ ] Add Results tab rendering to `ScheduledTasksPage.tsx`.
 - [ ] Keep task-detail state separate from result-detail state.
 - [ ] Run the route-state and page tests.
@@ -416,27 +490,34 @@ Avoid:
 **Success Criteria:**
 
 - Users can scan result state, task, owner, last run/result time, and primary action.
-- Filters support review state, result state, owner, and task type.
+- Filters support result/signal state, owner, and task type.
+- Review-state filters appear only in normalized result modes.
 - Drawer explains what happened, why it is shown, where it came from, and what can be done next.
-- Retry/review actions show honest availability, using disabled copy until backend support exists.
+- Retry/review actions are hidden unless capability mode and item availability support them.
+- The drawer uses a short capability note instead of disabled mutation buttons when actions are unsupported.
 
 **Tests:**
 
 - `ScheduledTaskResultsPanel.test.tsx`
   - Renders success, failure, running, and completed/no-results items.
-  - Filters by unreviewed, needs attention, task type, and owner.
+  - Filters by needs attention, task type, and owner in projected mode.
+  - Filters by unreviewed/reviewed only in normalized result modes.
+  - Hides Review state filter in `projected_signals`.
   - Shows all three empty states: no tasks, no results, no filter matches.
   - Emits accessible action names.
 - `ScheduledTaskResultDetailDrawer.test.tsx`
   - Shows provenance and owner.
+  - Shows match reason, matched rule label, output label, and domain deep link when present.
   - Shows Watchlists deep links for Watchlist-owned results.
-  - Shows disabled retry/review actions with explanatory copy when unsupported.
+  - Hides unsupported retry/review buttons and shows one capability note instead.
+  - Shows retry/review buttons when capability mode and item availability allow them.
   - Uses role/dialog title that includes the result title.
 
 **Tasks:**
 
 - [ ] Implement `ScheduledTaskResultsPanel.tsx`.
 - [ ] Implement `ScheduledTaskResultDetailDrawer.tsx`.
+- [ ] Implement capability-aware filter/action visibility.
 - [ ] Add list/table responsive behavior for extension width.
 - [ ] Add result action wiring in `ScheduledTasksPage.tsx`.
 - [ ] Add missing-result and partial-dependency alerts.
@@ -449,22 +530,28 @@ Avoid:
 **Success Criteria:**
 
 - Notification payloads with `link_url`, `source_task_id`, `source_task_run_id`, or source job metadata resolve to Scheduled Tasks result deep links when possible.
+- Home notification-derived automation items come from `listNotifications({ limit: 50 })`.
 - Home result items and notification-derived items share deterministic dedupe keys.
 - Exact result ids win over run ids, and run ids win over task-scoped fallback links.
 - Existing notification stream, mark-read, dismiss, and snooze behavior is unchanged.
+- Notification loading failure does not block Scheduled Tasks or Home rendering.
 
 **Tests:**
 
 - `scheduled-task-results.test.ts`
   - Builds the same dedupe key for task projection and notification-derived result for the same run.
   - Keeps separate keys for separate runs from the same task.
+  - Keeps separate fallback keys for failure and result signals from the same task/run when no exact result id exists.
 - `notifications.test.ts`
   - Covers scheduled-task notification link helper if implemented in `notifications.ts`.
+- `CompanionHomePage.test.tsx`
+  - Keeps Automation Inbox rendered from task projection when notification loading fails.
 
 **Tasks:**
 
 - [ ] Add notification target normalization to `scheduled-task-result-links.ts` or `notifications.ts`.
 - [ ] Add dedupe-key generation and merge helpers.
+- [ ] Add non-blocking recent notification load for Home automation signals.
 - [ ] Preserve existing notification service behavior.
 - [ ] Run scheduled-task result and notification service tests.
 
@@ -474,7 +561,7 @@ Avoid:
 
 **Success Criteria:**
 
-- Overview shows newest results and needs-review count.
+- Overview shows newest results or signals and a needs-review count only when durable review state exists.
 - Tasks table exposes a `Results` action only when result signals exist.
 - Task drawer links to latest run/result when known.
 - Watchlists copy remains clear that configuration is managed in Watchlists.
@@ -500,25 +587,29 @@ Avoid:
 
 ## Stage 6: Home Surfacing
 
-**Goal:** Surface scheduled-task results and failures on Home without requiring Companion personalization and without replacing existing Home cards.
+**Goal:** Surface scheduled-task results and failures on Home without requiring Companion personalization and without overloading generic Companion cards.
 
 **Success Criteria:**
 
-- Home Inbox Preview includes new scheduled-task result items.
-- Home Needs Attention includes failed/blocked scheduled-task items.
+- Home renders a dedicated `Automation Inbox` module with result and failure items.
+- The automation module shows status text, owner, timestamp, summary, and exact deep link.
 - Scheduled-task Home signals load independently of Companion personalization.
 - Personalization-off Home can still show scheduled-task automation signals.
 - If scheduled-task load fails, Companion Home still renders and shows available companion items.
 - Home items deep-link to exact `/scheduled-tasks?tab=results...` targets.
+- Existing Companion Inbox Preview and Needs Attention cards keep their current companion-centered behavior.
 
 **Tests:**
 
 - `CompanionHomePage.test.tsx`
-  - Merges scheduled-task result item into Inbox Preview.
-  - Merges scheduled-task failure into Needs Attention.
+  - Renders Automation Inbox with scheduled-task result item.
+  - Renders Automation Inbox with scheduled-task failure item.
   - Renders scheduled-task items when `hasPersonalization` is false.
   - Keeps companion items when scheduled-task load fails.
   - Home links open exact scheduled-task result routes.
+- `AutomationInboxCard.test.tsx`
+  - Renders empty, loading, partial, result, failure, and mixed-state items.
+  - Exposes status and owner as visible text.
 - Pure helper tests in `scheduled-task-results.test.ts`
   - Maps result item to `CompanionHomeItem` using the scheduled-task source/entity type extensions.
   - Dedupes scheduled-task Home items against notification-derived items for the same run/result.
@@ -527,7 +618,9 @@ Avoid:
 
 - [ ] Add scheduled-task Home signal hook/adapter.
 - [ ] Extend `CompanionHomeSource` and `CompanionHomeEntityType` for scheduled-task result items.
-- [ ] Merge scheduled-task inbox and attention items after companion snapshot resolution.
+- [ ] Implement `AutomationInboxCard.tsx`.
+- [ ] Render `AutomationInboxCard` after `WhatsNextCard` and before generic Companion inbox/attention cards.
+- [ ] Merge task-projected and notification-derived automation items for the module.
 - [ ] Keep existing layout and Customize Home behavior unchanged.
 - [ ] Add loading and partial-failure behavior that does not block Home.
 - [ ] Run CompanionHome tests.
@@ -543,12 +636,15 @@ Avoid:
 - Extension-width layout works at 360px and desktop layout works at 1280px+.
 - Empty/error/loading/running/success states use final copy from this plan or stronger local copy.
 - No generic source-vendor copy appears in generic Scheduled Tasks UI.
+- Projected mode does not use durable-review language.
+- Unsupported mutation actions are not visible in row actions.
 
 **Tests And Checks:**
 
 - Component tests above.
 - Browser smoke after implementation if a dev server is practical:
   - `/scheduled-tasks`
+  - `/scheduled-tasks/results`
   - `/scheduled-tasks?tab=results`
   - `/scheduled-tasks?tab=results&task_id=...`
   - Home route used by the options UI.
@@ -561,6 +657,7 @@ Avoid:
 
 - [ ] Review all new visible copy against copy recommendations.
 - [ ] Search for source-specific examples in generic UI.
+- [ ] Search for unsupported review/retry buttons in projected-mode rendering.
 - [ ] Verify drawer focus and accessible labels.
 - [ ] Verify no nested cards or decorative layout drift in Home.
 - [ ] Record screenshots or browser observations in the implementation Backlog task.
@@ -586,6 +683,7 @@ bunx vitest run apps/packages/ui/src/components/Option/ScheduledTasks/__tests__/
 bunx vitest run apps/packages/ui/src/components/Option/ScheduledTasks/__tests__/ScheduledTasksPage.test.tsx
 bunx vitest run apps/packages/ui/src/components/Option/ScheduledTasks/__tests__/ScheduledTaskDetailDrawer.test.tsx
 bunx vitest run apps/packages/ui/src/components/Option/CompanionHome/__tests__/CompanionHomePage.test.tsx
+bunx vitest run apps/packages/ui/src/components/Option/CompanionHome/__tests__/AutomationInboxCard.test.tsx
 bunx vitest run apps/packages/ui/src/services/__tests__/notifications.test.ts
 git diff --check
 ```
@@ -605,20 +703,23 @@ If implementation touches only frontend and docs, record: `Bandit skipped becaus
 - Prefer additive route-state changes. Do not replace existing `task_id` behavior for the Tasks tab.
 - Keep task state and result state separate. A task can be waiting while its latest result is unreviewed, or failed while an older result still exists.
 - Keep Home loading independent. Scheduled-task results should improve Home, not make it fragile.
-- Use the query-tab URL shape as the shipped route shape for this phase. Add a separate `/scheduled-tasks/results` alias only as a later route-registry enhancement.
+- Use the query-tab URL shape internally, but ship `/scheduled-tasks/results` as an alias so PRD, Home, and notification links stay stable.
 - Use Watchlists deep links for source-owned details; do not duplicate Watchlists reports or run logs.
 - Deduplicate by exact result id first, exact run id second, and task/time/state fallback last.
-- Treat backend retry/review endpoints as capability-gated actions. Disabled actions with explanatory copy are better than optimistic buttons that fail.
+- Treat backend retry/review endpoints as capability-gated actions. Hide unsupported mutation buttons in lists; use one concise capability note in details instead of disabled-button clutter.
 - Keep source names generic in default UI and let task titles/source labels carry domain specificity.
 
 ## PR Review Checklist
 
 - [ ] `/scheduled-tasks?tab=results` is discoverable from Overview, Tasks, Home, and direct URL.
+- [ ] `/scheduled-tasks/results` aliases to the same Results experience.
 - [ ] Result drawer answers: what happened, when, where from, owning workspace, next action.
-- [ ] Home shows scheduled-task results even when Companion personalization is not enabled.
+- [ ] Home shows an Automation Inbox even when Companion personalization is not enabled.
 - [ ] Watchlists UX remains intact and domain configuration is not moved.
 - [ ] Result and failure states are understandable without color.
 - [ ] Extension-width layout has no horizontal overflow except intentional tables.
 - [ ] No backend-only promise appears in frontend copy before the backend supports it.
+- [ ] Projected mode does not claim durable review state or expose unsupported retry/review buttons.
+- [ ] Mixed failure-plus-output states preserve both signals.
 - [ ] Tests cover missing deep links and partial dependency failures.
 - [ ] Backlog task records verification, known skips, and final summary.

--- a/Docs/superpowers/plans/2026-06-09-scheduled-tasks-phase3-results-inbox-home-surfacing-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-06-09-scheduled-tasks-phase3-results-inbox-home-surfacing-implementation-plan.md
@@ -1,0 +1,624 @@
+# Scheduled Tasks Phase 3 Results Inbox And Home Surfacing Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement the Phase 3 scheduled-task results discovery experience so users can see automation outcomes on Home and inside `/scheduled-tasks`, inspect exact task/run/result provenance, triage failures, and follow deep links back to the owning workspace without changing Watchlists or other domain-specific setup flows.
+
+**Architecture:** Add a frontend-owned scheduled-task result projection layer that can consume the existing `/api/v1/scheduled-tasks` task list now and later swap to a normalized result-inbox API. Extend the existing `/scheduled-tasks` query-state tab model with a Results tab, result/run deep-link parameters, result filters, and a detail drawer; do not add a separate `/scheduled-tasks/results` path route in this phase unless the route registry already supports nested options routes at implementation time. Add a Home aggregation adapter that merges scheduled-task result items into the existing Companion Home inbox and attention cards while preserving personalization behavior and Home layout ownership. Add notification-to-result link normalization and dedupe helpers so Home and notifications can point to the same exact result target without double-counting. Backend changes remain dependencies for this phase unless a normalized result endpoint already exists when implementation starts.
+
+**Tech Stack:** React, TypeScript, Ant Design, Tailwind utility classes in Companion Home, React Router search params, TanStack Query, existing `bgRequest` service layer, existing ScheduledTasks and CompanionHome components, Vitest, Testing Library, existing browser/extension route shells.
+
+---
+
+## Source Inputs
+
+- Product/design spec: `Docs/superpowers/specs/2026-06-01-scheduled-tasks-automation-workbench-prd-design.md`
+- Phase 1 plan: `Docs/superpowers/plans/2026-06-01-scheduled-tasks-automation-workbench-phase1-implementation-plan.md`
+- Phase 2A plan: `Docs/superpowers/plans/2026-06-08-scheduled-tasks-automation-workbench-phase2a-create-framework-implementation-plan.md`
+- Phase 2B plan: `Docs/superpowers/plans/2026-06-09-scheduled-tasks-phase2b-capability-aware-frontend-shell-implementation-plan.md`
+- Backlog references: `TASK-494`, `TASK-496`, `TASK-498`
+- Planning task: `TASK-2331`
+
+## Current Evidence
+
+- `/scheduled-tasks` is a single options route with query-state tabs in `apps/packages/ui/src/components/Option/ScheduledTasks/scheduled-task-route-state.ts`.
+- Existing tabs are `overview`, `tasks`, and `create`; unsupported tabs fall back to Overview with non-blocking copy.
+- `ScheduledTasksPage.tsx` loads `/api/v1/scheduled-tasks`, shows partial dependency failures, and renders task overview, table, creation panel, and a task detail drawer.
+- `scheduled-task-status.ts` already maps raw task state into product statuses and builds safe Watchlists deep links for settings, activity, reports, latest run, and latest output.
+- Watchlists jobs are intentionally read-only from Scheduled Tasks and retain “Managed in Watchlists” copy.
+- Companion Home has fixed system cards for `Inbox Preview` and `Needs Attention`, but its current data model is companion-personalization centered: `canonical_inbox`, `goal`, `reading`, and `note`.
+- Companion Home returns an empty snapshot when personalization is unavailable, so scheduled-task outcomes need a non-personalized path to Home.
+- `apps/packages/ui/src/services/notifications.ts` already exposes notification fields such as `link_type`, `link_id`, `link_url`, `source_task_id`, `source_task_run_id`, `source_job_id`, and source metadata that can support exact scheduled-task result links once normalized.
+- The extension and hosted WebUI share the same UI package components.
+
+## Product Decisions
+
+- Scheduled Tasks is the cross-automation control and monitoring surface.
+- Watchlists remains the owner for monitor setup, source tuning, run activity, and reports.
+- GitHub and YouTube are examples only; Phase 3 must use source-agnostic result language such as “source”, “match”, “ingested item”, “run”, “output”, and “owning workspace”.
+- Home should surface “something happened” and “something needs attention”; detailed configuration and domain output review stays behind deep links.
+- Phase 3 should not implement recurring RAG query creation or ACP/agent schedule creation. Those remain Phase 4 work.
+- Phase 3 can show result discovery for task families already represented by the Scheduled Tasks control plane, including reminders and Watchlist-backed monitors, but it must not imply unavailable creation adapters exist.
+
+## Scope
+
+In scope:
+
+- Add `/scheduled-tasks?tab=results` to the existing tab model.
+- Add result/run deep-link parameters, with support for `task_id`, `run_id`, and `result_id`.
+- Add a source-agnostic result inbox list inside `/scheduled-tasks`.
+- Add a result detail drawer with task state, run state, output summary, provenance, owning workspace, and safe actions.
+- Add Home surfacing for scheduled-task result and failure signals inside existing inbox/attention patterns.
+- Add notification deep-link normalization for scheduled-task task/run/result targets.
+- Add dedupe keys so the same run/result does not appear twice across Home inbox and notification-derived items.
+- Preserve Companion Home personalization behavior while allowing scheduled-task signals to render without personalization.
+- Add empty, loading, partial, unsupported, success, no-new-results, running, failure, and review-complete states.
+- Add copy that explains where results came from and where to continue.
+- Add accessibility and extension-width requirements to implementation tests.
+- Add analytics-free state logic; do not add telemetry.
+
+Out of scope:
+
+- Moving Watchlists setup, source tuning, run logs, or report builders into `/scheduled-tasks`.
+- Source-specific first-class UI for GitHub, YouTube, or any specific provider.
+- Creating Watch/Ingest/RAG/ACP/agent scheduled tasks if creation adapters are not already available.
+- Building backend normalized result storage in this Phase 3 frontend plan.
+- Adding push notifications beyond linking to existing notification/event surfaces.
+- Replacing the existing Notifications service or Watchlists run notification logic.
+- Bulk management across many results beyond filters and review actions.
+- Reworking Companion Home layout customization beyond adding scheduled-task-aware system signals.
+
+## Backend Dependencies
+
+The frontend implementation must be designed around these contracts, but this planning branch does not implement them:
+
+- `GET /api/v1/scheduled-tasks/results`
+  - Returns normalized result inbox items across task primitives.
+  - Supports filters: status, review state, task id, owning workspace, time range, result type.
+  - Returns partial dependency metadata with recoverable source errors.
+- `GET /api/v1/scheduled-tasks/results/{result_id}`
+  - Returns detail fields, provenance, run summary, source references, result links, and safe action availability.
+- `GET /api/v1/scheduled-tasks/runs/{run_id}`
+  - Returns run state, timestamps, logs/events summary, failure hints, retry eligibility, and output ids.
+- `POST /api/v1/scheduled-tasks/results/{result_id}/review`
+  - Marks reviewed, snoozed, dismissed, or important.
+- `POST /api/v1/scheduled-tasks/runs/{run_id}/retry`
+  - Retries eligible failed runs without changing task configuration.
+- Notification payloads include exact `task_id`, `run_id`, `result_id`, owning workspace, and `href`.
+
+Until those endpoints exist, implementation should use a local projection adapter from `ScheduledTask[]` and `source_ref` fields, with clear capability copy and disabled/deep-link-only actions where direct review/retry cannot be performed.
+
+## Information Architecture
+
+`/scheduled-tasks` tabs:
+
+- `Overview`
+  - Cross-automation counts, needs attention, running now, next run, newest results, and short links to Tasks/Results.
+- `Results`
+  - Primary Phase 3 inbox for outcomes.
+  - Defaults to unreviewed newest first.
+  - Filters: Review state, result state, task type, owning workspace, time range.
+  - Detail drawer opens from row/card or deep link.
+- `Tasks`
+  - Existing task management table and task detail drawer.
+  - Adds a per-row “Results” action only when the task has result signals.
+- `Create`
+  - Existing creation framework. No Phase 3 creation expansion.
+
+Home:
+
+- Keep top summary cards, Inbox Preview, and Needs Attention.
+- Scheduled-task result items feed Inbox Preview when they are new/unreviewed.
+- Scheduled-task failed/stalled/blocked items feed Needs Attention.
+- Home links point to `/scheduled-tasks?tab=results&result_id=...` or `/scheduled-tasks?tab=results&run_id=...`.
+- Items that belong to Watchlists also provide secondary links from the result detail drawer to Watchlists Activity/Reports.
+
+Notifications:
+
+- Existing notification payloads should normalize to the same scheduled-task result target shape used by Home.
+- Notification clicks should prefer exact `result_id`, then exact `run_id`, then task-scoped Results tab.
+- Home and notification-derived result items should share a deterministic dedupe key: `result:<result_id>`, `run:<run_id>`, or `task:<task_id>:state:<state>:time:<occurredAt>`.
+- Watchlists run notifications remain Watchlists-owned, but when they are represented inside Scheduled Tasks they should link through the Scheduled Tasks result drawer with secondary Watchlists links.
+
+## Result Item Model
+
+Create a frontend model that can be produced from current `ScheduledTask[]` and later from a normalized API:
+
+```ts
+export type ScheduledTaskResultState =
+  | "new"
+  | "reviewed"
+  | "running"
+  | "completed_no_results"
+  | "failed"
+  | "blocked"
+  | "paused"
+
+export type ScheduledTaskResultSeverity = "info" | "success" | "warning" | "error"
+
+export type ScheduledTaskResultOwner =
+  | "scheduled_tasks"
+  | "watchlists"
+  | "reminders"
+  | "external_workspace"
+
+export interface ScheduledTaskResultItem {
+  id: string
+  taskId: string
+  runId: string | null
+  resultId: string | null
+  taskTitle: string
+  title: string
+  summary: string
+  state: ScheduledTaskResultState
+  severity: ScheduledTaskResultSeverity
+  reviewed: boolean
+  owner: ScheduledTaskResultOwner
+  ownerLabel: string
+  occurredAt: string | null
+  sourceLabel: string | null
+  provenance: Array<{ label: string; value: string }>
+  primaryHref: string
+  sourceHref: string | null
+  taskHref: string
+  runHref: string | null
+  resultHref: string | null
+  notificationIds: number[]
+  dedupeKey: string
+  retryAvailable: boolean
+  reviewAvailable: boolean
+}
+```
+
+Projection rules:
+
+- `found_results` tasks produce `new` success items when `source_ref` has a result/output count or latest output id.
+- `needs_attention` and `blocked` tasks produce attention items with failure-oriented recovery copy.
+- `running` tasks produce running items only in `/scheduled-tasks`; Home should not surface normal running state unless the run appears stalled.
+- `completed` tasks with no result signal are visible behind a “Completed/no results” filter but are not Home inbox items.
+- Disabled, paused, and draft tasks appear only when filters request them.
+- Watchlists result items must include Watchlists deep links from `buildWatchlistTaskLinks`; Scheduled Tasks remains the triage surface.
+- Multiple events for the same run/result collapse into one visible Home result item, with notification ids retained for future read/dismiss actions.
+
+## UX Requirements
+
+First-time user:
+
+- Can explain what the Results tab is from the empty state and header copy.
+- Sees where results will appear on Home.
+- Can distinguish “no tasks yet”, “tasks exist but no results yet”, “results found”, and “task failed”.
+- Understands when a result is managed elsewhere and why the primary setup action opens another workspace.
+- Can inspect provenance without reading raw ids first.
+
+Power user:
+
+- Can filter by state, task type, owner, and review state.
+- Can deep-link directly to a run/result drawer.
+- Can open the owning workspace in one click.
+- Can scan many results without detail drawers.
+- Can mark items reviewed where supported, retry eligible failures where supported, and see why unavailable actions are disabled.
+- Can preserve fast task management in the Tasks tab without result cards making the table slower to scan.
+
+## Empty, Loading, Error, Running, And Success States
+
+Scheduled Tasks Results tab:
+
+- Empty when no tasks exist: “No scheduled tasks yet” with Create action and copy explaining results appear after an automation runs.
+- Empty when tasks exist but no results: “No results to review” with next-run summary and link to Tasks.
+- Empty after filters: “No results match these filters” with clear-filters action.
+- Loading: “Loading results and latest run state” with polite live region.
+- Partial: reuse `RecoveryCallout`, preserve visible results, and show dependency diagnostics.
+- Unsupported normalized result API: show current task-derived results and a capability note, not a dead-end error.
+- Running: show “Running now” tag, started time if available, and no retry/review actions.
+- Failed: show failure hint, owning workspace, last attempt time, retry action if contract says eligible, otherwise recovery link.
+- Success: show result count/output summary, reviewed state, and primary action “Review result”.
+
+Home:
+
+- Empty Inbox Preview: should remain Companion/Home appropriate, but if scheduled-task support is available add “Scheduled-task results will appear here when automations produce new output.”
+- Empty Needs Attention: if scheduled-task support is available add “Failed or blocked automations will appear here.”
+- Loading Home: do not block the whole Home page on scheduled-task result loading; render cards with available companion items and update counts when scheduled-task items resolve.
+- Partial Home: show companion items and scheduled-task items independently; one degraded source must not erase the other.
+- Success Home: scheduled-task items include title, short summary, status tag text in summary, and deep link to the exact result/run.
+
+## Copy Recommendations
+
+Use these strings unless implementation discovers stronger local wording:
+
+- Results tab label: `Results`
+- Results page title: `Scheduled task results`
+- Results page subtitle: `Review outputs, failures, and run state from recurring automations. Source-specific setup stays in the owning workspace.`
+- Filter label: `Review state`
+- Filter values: `Unreviewed`, `Reviewed`, `All`
+- Filter label: `Result state`
+- Filter values: `Found results`, `Needs attention`, `Running`, `Completed/no results`, `Paused/disabled`
+- Primary action: `Review result`
+- Failure action: `Inspect failure`
+- Retry action: `Retry run`
+- Disabled retry tooltip: `Retry is unavailable until run retry support is available for this task type.`
+- Review action: `Mark reviewed`
+- Disabled review tooltip: `Review state is not available from this server yet.`
+- Watchlists owner note: `This monitor is configured in Watchlists. Scheduled Tasks shows status and links to the exact run or report.`
+- Home inbox item prefix: `Automation result`
+- Home attention item prefix: `Automation needs attention`
+- Result detail provenance heading: `Why this is here`
+- Result detail action heading: `Continue in`
+- Completed/no results copy: `The latest run completed and did not produce new results.`
+
+Avoid:
+
+- Source-vendor-first labels such as “GitHub results” or “YouTube ingest results” in generic Scheduled Tasks UI.
+- “Notification sent” unless the notification system confirms delivery.
+- “Searchable” unless ingest/search indexing has confirmed completion.
+- “Managed here” for external tasks.
+
+## Accessibility And Usability Requirements
+
+- Results tab is keyboard reachable through the existing Ant Design tablist.
+- Result cards/rows expose one clear accessible name: task title plus result state.
+- Detail drawer has an accessible title and focus returns to the opening result row/card.
+- Status is represented by text and tag tone, never color alone.
+- Running/loading states use `role="status"` and `aria-live="polite"`.
+- Partial/error states preserve diagnostics labels already used by `RecoveryCallout`.
+- Filter controls have visible text labels and `aria-label` where visible labels are not programmatically associated.
+- Extension-width layout at 360px must keep filters, cards, and action buttons from overflowing.
+- Desktop table view must keep stable columns and use horizontal scroll where needed.
+- Result summaries truncate only after preserving full text in `title` or drawer detail.
+- Deep-link-only actions use links; mutation actions use buttons.
+
+## File Structure
+
+### New Files
+
+- `apps/packages/ui/src/components/Option/ScheduledTasks/scheduled-task-results.ts`
+  - Result item types.
+  - Projection from `ScheduledTask[]`.
+  - Sort/filter helpers.
+  - Result detail lookup by `result_id`, `run_id`, or `task_id`.
+  - Home item adapter.
+- `apps/packages/ui/src/components/Option/ScheduledTasks/scheduled-task-result-links.ts`
+  - Pure URL and dedupe-key helpers for task, run, result, Home, and notification targets.
+- `apps/packages/ui/src/components/Option/ScheduledTasks/ScheduledTaskResultsPanel.tsx`
+  - Results list/table, filters, counts, empty states, partial capability note, and open-detail callbacks.
+- `apps/packages/ui/src/components/Option/ScheduledTasks/ScheduledTaskResultDetailDrawer.tsx`
+  - Result/run detail, provenance, owner links, retry/review actions with availability states.
+- `apps/packages/ui/src/components/Option/ScheduledTasks/__tests__/scheduled-task-results.test.ts`
+  - Pure projection, filtering, deep-link, and Home adapter coverage.
+- `apps/packages/ui/src/components/Option/ScheduledTasks/__tests__/ScheduledTaskResultsPanel.test.tsx`
+  - Component coverage for list, filters, empty states, loading, failure, and action availability.
+- `apps/packages/ui/src/components/Option/ScheduledTasks/__tests__/ScheduledTaskResultDetailDrawer.test.tsx`
+  - Drawer provenance, owner links, disabled actions, and accessibility coverage.
+
+### Modified Files
+
+- `apps/packages/ui/src/components/Option/ScheduledTasks/scheduled-task-route-state.ts`
+  - Add `results` tab.
+  - Parse/build `result_id` and `run_id`.
+  - Preserve `task_id` for both Tasks and Results where relevant.
+- `apps/packages/ui/src/components/Option/ScheduledTasks/ScheduledTasksPage.tsx`
+  - Add Results tab.
+  - Build projected result items from task data.
+  - Route result deep links to detail drawer.
+  - Add missing-result non-blocking alert.
+  - Keep existing task detail route behavior intact.
+- `apps/packages/ui/src/components/Option/ScheduledTasks/ScheduledTaskOverview.tsx`
+  - Add newest result/needs-review summary or link to Results.
+  - Keep existing total/attention/running/next-run cards readable.
+- `apps/packages/ui/src/components/Option/ScheduledTasks/ScheduledTaskTable.tsx`
+  - Add row action to view task results only when result signals exist.
+  - Keep edit/delete behavior limited to native reminders.
+- `apps/packages/ui/src/components/Option/ScheduledTasks/ScheduledTaskDetailDrawer.tsx`
+  - Add latest result/run link when available.
+  - Preserve Watchlists owner copy.
+- `apps/packages/ui/src/components/Option/CompanionHome/CompanionHomePage.tsx`
+  - Load scheduled-task Home signals independently from Companion personalization.
+  - Merge scheduled-task inbox and attention signals into existing system cards.
+  - Keep Home usable if scheduled-task result loading fails.
+- `apps/packages/ui/src/components/Option/CompanionHome/hooks.ts`
+  - Add a hook or adapter for non-personalized scheduled-task Home signals.
+  - Avoid blocking `fetchCompanionHomeSnapshot`.
+- `apps/packages/ui/src/services/companion-home.ts`
+  - Extend `CompanionHomeSource` with a scheduled-task source.
+  - Extend `CompanionHomeEntityType` with a scheduled-task result entity.
+  - Keep the existing fixed Home cards; do not add a separate Automations card in Phase 3.
+- `apps/packages/ui/src/services/notifications.ts`
+  - Add pure helpers only if needed to normalize scheduled-task notification link targets.
+  - Do not change notification stream subscription behavior.
+- `apps/packages/ui/src/components/Option/ScheduledTasks/__tests__/scheduled-task-route-state.test.ts`
+  - Update tab contract and deep-link builder assertions.
+- `apps/packages/ui/src/components/Option/ScheduledTasks/__tests__/ScheduledTasksPage.test.tsx`
+  - Add Results tab, result deep-link, missing result, partial state, and Watchlists-preservation tests.
+- `apps/packages/ui/src/components/Option/CompanionHome/__tests__/CompanionHomePage.test.tsx`
+  - Add Home scheduled-task result merge, personalization-off behavior, partial failure, and link tests.
+- `apps/packages/ui/src/components/Option/CompanionHome/__tests__/CardShell.test.tsx`
+  - Update only if scheduled-task status metadata changes card rendering.
+- `apps/packages/ui/src/services/__tests__/notifications.test.ts`
+  - Add scheduled-task link normalization coverage if `notifications.ts` gains helper functions.
+
+### Files To Avoid Changing
+
+- `apps/packages/ui/src/components/Option/Watchlists/**`
+  - Exception: only add tests if a broken deep link requires proving an existing Watchlists query parameter contract.
+- `apps/packages/ui/src/services/watchlists*.ts`
+- `tldw_Server_API/**`
+- Browser extension background networking unless a route/path allowlist rejects the new result URLs.
+
+## Implementation Stages
+
+## Stage 1: Result Projection Contract
+
+**Goal:** Create a source-agnostic frontend result model that works with current task-list data and can later map to a normalized backend result API.
+
+**Success Criteria:**
+
+- `ScheduledTask[]` can project to stable `ScheduledTaskResultItem[]`.
+- Watchlists result links reuse existing `buildWatchlistTaskLinks`.
+- Result items have exact Home and `/scheduled-tasks` deep links.
+- Projection never exposes raw unknown objects directly in UI copy.
+
+**Tests:**
+
+- `scheduled-task-results.test.ts`
+  - Projects found-results task into unreviewed success result.
+  - Projects failed task into attention result with recovery summary.
+  - Projects Watchlists latest output/run links.
+  - Excludes normal waiting tasks from default Home items.
+  - Includes completed/no-results only under matching filters.
+  - Sanitizes unsafe or empty source reference values.
+
+**Tasks:**
+
+- [ ] Add `scheduled-task-results.ts` types and helpers.
+- [ ] Add `scheduled-task-result-links.ts` URL and dedupe helpers.
+- [ ] Add result item sorting by newest `occurredAt`, then severity, then title.
+- [ ] Add `buildScheduledTaskResultHref` for `result_id`, `run_id`, and `task_id`.
+- [ ] Add `findScheduledTaskResultByRouteState`.
+- [ ] Add Home adapter returning inbox and attention item arrays.
+- [ ] Run `bunx vitest run apps/packages/ui/src/components/Option/ScheduledTasks/__tests__/scheduled-task-results.test.ts`.
+
+## Stage 2: Results Route State And Results Tab
+
+**Goal:** Extend `/scheduled-tasks` IA with a Results tab and deep-linkable result drawer while preserving existing tab fallbacks.
+
+**Success Criteria:**
+
+- `?tab=results` is a first-class tab.
+- `result_id`, `run_id`, and `task_id` are parsed and serialized safely.
+- Invalid tabs still fall back to Overview.
+- Existing `?tab=tasks&task_id=...` drawer behavior remains unchanged.
+
+**Tests:**
+
+- `scheduled-task-route-state.test.ts`
+  - Accepts `results`.
+  - Builds `?tab=results&result_id=...`.
+  - Builds `?tab=results&run_id=...`.
+  - Preserves task links for task-scoped result views.
+  - Keeps invalid-tab fallback behavior.
+- `ScheduledTasksPage.test.tsx`
+  - Opens Results tab from URL.
+  - Opens result drawer from result deep link after task data loads.
+  - Shows missing-result alert without leaving Results.
+
+**Tasks:**
+
+- [ ] Update `ScheduledTaskTabId` and `SCHEDULED_TASK_TABS`.
+- [ ] Extend `ScheduledTaskRouteState` with `resultId` and `runId`.
+- [ ] Update `buildScheduledTaskSearch`.
+- [ ] Add Results tab rendering to `ScheduledTasksPage.tsx`.
+- [ ] Keep task-detail state separate from result-detail state.
+- [ ] Run the route-state and page tests.
+
+## Stage 3: Results Panel And Detail Drawer
+
+**Goal:** Build the main Phase 3 inspection workflow inside Scheduled Tasks.
+
+**Success Criteria:**
+
+- Users can scan result state, task, owner, last run/result time, and primary action.
+- Filters support review state, result state, owner, and task type.
+- Drawer explains what happened, why it is shown, where it came from, and what can be done next.
+- Retry/review actions show honest availability, using disabled copy until backend support exists.
+
+**Tests:**
+
+- `ScheduledTaskResultsPanel.test.tsx`
+  - Renders success, failure, running, and completed/no-results items.
+  - Filters by unreviewed, needs attention, task type, and owner.
+  - Shows all three empty states: no tasks, no results, no filter matches.
+  - Emits accessible action names.
+- `ScheduledTaskResultDetailDrawer.test.tsx`
+  - Shows provenance and owner.
+  - Shows Watchlists deep links for Watchlist-owned results.
+  - Shows disabled retry/review actions with explanatory copy when unsupported.
+  - Uses role/dialog title that includes the result title.
+
+**Tasks:**
+
+- [ ] Implement `ScheduledTaskResultsPanel.tsx`.
+- [ ] Implement `ScheduledTaskResultDetailDrawer.tsx`.
+- [ ] Add list/table responsive behavior for extension width.
+- [ ] Add result action wiring in `ScheduledTasksPage.tsx`.
+- [ ] Add missing-result and partial-dependency alerts.
+- [ ] Run component tests.
+
+## Stage 4: Notification Links And Dedupe
+
+**Goal:** Normalize scheduled-task notification targets and prevent duplicate Home/notification result cards for the same run or result.
+
+**Success Criteria:**
+
+- Notification payloads with `link_url`, `source_task_id`, `source_task_run_id`, or source job metadata resolve to Scheduled Tasks result deep links when possible.
+- Home result items and notification-derived items share deterministic dedupe keys.
+- Exact result ids win over run ids, and run ids win over task-scoped fallback links.
+- Existing notification stream, mark-read, dismiss, and snooze behavior is unchanged.
+
+**Tests:**
+
+- `scheduled-task-results.test.ts`
+  - Builds the same dedupe key for task projection and notification-derived result for the same run.
+  - Keeps separate keys for separate runs from the same task.
+- `notifications.test.ts`
+  - Covers scheduled-task notification link helper if implemented in `notifications.ts`.
+
+**Tasks:**
+
+- [ ] Add notification target normalization to `scheduled-task-result-links.ts` or `notifications.ts`.
+- [ ] Add dedupe-key generation and merge helpers.
+- [ ] Preserve existing notification service behavior.
+- [ ] Run scheduled-task result and notification service tests.
+
+## Stage 5: Overview And Task Cross-Links
+
+**Goal:** Make results discoverable from existing Scheduled Tasks views without slowing down task management.
+
+**Success Criteria:**
+
+- Overview shows newest results and needs-review count.
+- Tasks table exposes a `Results` action only when result signals exist.
+- Task drawer links to latest run/result when known.
+- Watchlists copy remains clear that configuration is managed in Watchlists.
+
+**Tests:**
+
+- `ScheduledTasksPage.test.tsx`
+  - Overview shows result summary and link to Results.
+  - Tasks row with result signal has `View results`.
+  - Watchlists row still has Watchlists settings/activity/reports links.
+  - Reminder row still has native edit/delete.
+- `ScheduledTaskDetailDrawer.test.tsx`
+  - Latest result link appears when projection provides it.
+  - Watchlists owner copy is unchanged.
+
+**Tasks:**
+
+- [ ] Update `ScheduledTaskOverview.tsx`.
+- [ ] Update `ScheduledTaskTable.tsx`.
+- [ ] Update `ScheduledTaskDetailDrawer.tsx`.
+- [ ] Confirm no Watchlists-owned edit controls are introduced.
+- [ ] Run ScheduledTasks tests.
+
+## Stage 6: Home Surfacing
+
+**Goal:** Surface scheduled-task results and failures on Home without requiring Companion personalization and without replacing existing Home cards.
+
+**Success Criteria:**
+
+- Home Inbox Preview includes new scheduled-task result items.
+- Home Needs Attention includes failed/blocked scheduled-task items.
+- Scheduled-task Home signals load independently of Companion personalization.
+- Personalization-off Home can still show scheduled-task automation signals.
+- If scheduled-task load fails, Companion Home still renders and shows available companion items.
+- Home items deep-link to exact `/scheduled-tasks?tab=results...` targets.
+
+**Tests:**
+
+- `CompanionHomePage.test.tsx`
+  - Merges scheduled-task result item into Inbox Preview.
+  - Merges scheduled-task failure into Needs Attention.
+  - Renders scheduled-task items when `hasPersonalization` is false.
+  - Keeps companion items when scheduled-task load fails.
+  - Home links open exact scheduled-task result routes.
+- Pure helper tests in `scheduled-task-results.test.ts`
+  - Maps result item to `CompanionHomeItem` using the scheduled-task source/entity type extensions.
+  - Dedupes scheduled-task Home items against notification-derived items for the same run/result.
+
+**Tasks:**
+
+- [ ] Add scheduled-task Home signal hook/adapter.
+- [ ] Extend `CompanionHomeSource` and `CompanionHomeEntityType` for scheduled-task result items.
+- [ ] Merge scheduled-task inbox and attention items after companion snapshot resolution.
+- [ ] Keep existing layout and Customize Home behavior unchanged.
+- [ ] Add loading and partial-failure behavior that does not block Home.
+- [ ] Run CompanionHome tests.
+
+## Stage 7: UX Polish, Responsive Checks, And Copy Review
+
+**Goal:** Verify the experience against the first-time and power-user workflows before implementation is considered complete.
+
+**Success Criteria:**
+
+- First-time flow explains no tasks, no results, and where future results appear.
+- Power-user flow supports scanning, filtering, deep-linking, and owner handoff.
+- Extension-width layout works at 360px and desktop layout works at 1280px+.
+- Empty/error/loading/running/success states use final copy from this plan or stronger local copy.
+- No generic source-vendor copy appears in generic Scheduled Tasks UI.
+
+**Tests And Checks:**
+
+- Component tests above.
+- Browser smoke after implementation if a dev server is practical:
+  - `/scheduled-tasks`
+  - `/scheduled-tasks?tab=results`
+  - `/scheduled-tasks?tab=results&task_id=...`
+  - Home route used by the options UI.
+- Manual checks:
+  - Keyboard tab through Results filters, result list, drawer actions.
+  - 360px width overflow check.
+  - Color-independent status comprehension.
+
+**Tasks:**
+
+- [ ] Review all new visible copy against copy recommendations.
+- [ ] Search for source-specific examples in generic UI.
+- [ ] Verify drawer focus and accessible labels.
+- [ ] Verify no nested cards or decorative layout drift in Home.
+- [ ] Record screenshots or browser observations in the implementation Backlog task.
+
+## Stage 8: Documentation, Backlog, And Verification
+
+**Goal:** Finish with a clean, reviewable implementation branch.
+
+**Success Criteria:**
+
+- Implementation Backlog task links this plan and records touched files.
+- Tests pass for touched ScheduledTasks and CompanionHome areas.
+- Bandit is run for touched backend scope if backend files are touched; otherwise record docs/frontend-only skip rationale.
+- Final summary explains what changed and why.
+
+**Commands:**
+
+```bash
+bunx vitest run apps/packages/ui/src/components/Option/ScheduledTasks/__tests__/scheduled-task-results.test.ts
+bunx vitest run apps/packages/ui/src/components/Option/ScheduledTasks/__tests__/scheduled-task-route-state.test.ts
+bunx vitest run apps/packages/ui/src/components/Option/ScheduledTasks/__tests__/ScheduledTaskResultsPanel.test.tsx
+bunx vitest run apps/packages/ui/src/components/Option/ScheduledTasks/__tests__/ScheduledTaskResultDetailDrawer.test.tsx
+bunx vitest run apps/packages/ui/src/components/Option/ScheduledTasks/__tests__/ScheduledTasksPage.test.tsx
+bunx vitest run apps/packages/ui/src/components/Option/ScheduledTasks/__tests__/ScheduledTaskDetailDrawer.test.tsx
+bunx vitest run apps/packages/ui/src/components/Option/CompanionHome/__tests__/CompanionHomePage.test.tsx
+bunx vitest run apps/packages/ui/src/services/__tests__/notifications.test.ts
+git diff --check
+```
+
+Bandit:
+
+```bash
+source .venv/bin/activate
+python -m bandit -r <backend_touched_paths> -f json -o /tmp/bandit_scheduled_tasks_phase3.json
+```
+
+If implementation touches only frontend and docs, record: `Bandit skipped because no Python/backend files were changed.`
+
+## Implementation Notes For Future Workers
+
+- Start with pure projection tests before rendering. It is easier to stabilize UX states when result semantics are tested outside React.
+- Prefer additive route-state changes. Do not replace existing `task_id` behavior for the Tasks tab.
+- Keep task state and result state separate. A task can be waiting while its latest result is unreviewed, or failed while an older result still exists.
+- Keep Home loading independent. Scheduled-task results should improve Home, not make it fragile.
+- Use the query-tab URL shape as the shipped route shape for this phase. Add a separate `/scheduled-tasks/results` alias only as a later route-registry enhancement.
+- Use Watchlists deep links for source-owned details; do not duplicate Watchlists reports or run logs.
+- Deduplicate by exact result id first, exact run id second, and task/time/state fallback last.
+- Treat backend retry/review endpoints as capability-gated actions. Disabled actions with explanatory copy are better than optimistic buttons that fail.
+- Keep source names generic in default UI and let task titles/source labels carry domain specificity.
+
+## PR Review Checklist
+
+- [ ] `/scheduled-tasks?tab=results` is discoverable from Overview, Tasks, Home, and direct URL.
+- [ ] Result drawer answers: what happened, when, where from, owning workspace, next action.
+- [ ] Home shows scheduled-task results even when Companion personalization is not enabled.
+- [ ] Watchlists UX remains intact and domain configuration is not moved.
+- [ ] Result and failure states are understandable without color.
+- [ ] Extension-width layout has no horizontal overflow except intentional tables.
+- [ ] No backend-only promise appears in frontend copy before the backend supports it.
+- [ ] Tests cover missing deep links and partial dependency failures.
+- [ ] Backlog task records verification, known skips, and final summary.

--- a/Docs/superpowers/plans/2026-06-09-scheduled-tasks-phase3-results-inbox-home-surfacing-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-06-09-scheduled-tasks-phase3-results-inbox-home-surfacing-implementation-plan.md
@@ -549,11 +549,11 @@ Avoid:
 
 **Tasks:**
 
-- [ ] Add notification target normalization to `scheduled-task-result-links.ts` or `notifications.ts`.
-- [ ] Add dedupe-key generation and merge helpers.
+- [x] Add notification target normalization to `scheduled-task-result-links.ts` or `notifications.ts`.
+- [x] Add dedupe-key generation and merge helpers.
 - [ ] Add non-blocking recent notification load for Home automation signals.
-- [ ] Preserve existing notification service behavior.
-- [ ] Run scheduled-task result and notification service tests.
+- [x] Preserve existing notification service behavior.
+- [x] Run scheduled-task result and notification service tests.
 
 ## Stage 5: Overview And Task Cross-Links
 

--- a/Docs/superpowers/plans/2026-06-09-scheduled-tasks-phase3-results-inbox-home-surfacing-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-06-09-scheduled-tasks-phase3-results-inbox-home-surfacing-implementation-plan.md
@@ -670,6 +670,7 @@ Avoid:
 - At a 390px viewport, `/scheduled-tasks?tab=results` preserved the active Results tab, projected-mode note, empty state, and primary action without obvious text loss in the DOM evidence.
 - `/companion` rendered `Automation Inbox` even when personalization was unavailable, placed before `Inbox Preview`, and kept the existing Companion cards intact.
 - At a 390px viewport, `/companion` preserved `Automation Inbox` ahead of `Inbox Preview` with non-personalized empty-state copy visible.
+- 390px overflow measurements showed no horizontal overflow on `/scheduled-tasks?tab=results` or `/companion` (`scrollWidth` matched `clientWidth` at 390px).
 
 ## Stage 8: Documentation, Backlog, And Verification
 
@@ -706,6 +707,13 @@ python -m bandit -r <backend_touched_paths> -f json -o /tmp/bandit_scheduled_tas
 
 If implementation touches only frontend and docs, record: `Bandit skipped because no Python/backend files were changed.`
 
+**Stage 8 Verification Results:**
+
+- `./node_modules/.bin/vitest run src/components/Option/ScheduledTasks/__tests__ src/components/Option/CompanionHome/__tests__ src/services/__tests__/notifications.test.ts` from `apps/packages/ui`: 19 test files passed, 181 tests passed.
+- `git diff --check`: passed with no whitespace errors.
+- Browser smoke used WebUI on `http://localhost:18001` and a temporary read-only mock API on `http://127.0.0.1:8000`; `/scheduled-tasks`, `/scheduled-tasks?tab=results`, and `/companion` rendered without the readiness gate.
+- Bandit skipped because this Phase 3 closeout touched frontend, docs, and Backlog task files only; no Python/backend files were changed.
+
 ## Implementation Notes For Future Workers
 
 - Start with pure projection tests before rendering. It is easier to stabilize UX states when result semantics are tested outside React.
@@ -720,15 +728,15 @@ If implementation touches only frontend and docs, record: `Bandit skipped becaus
 
 ## PR Review Checklist
 
-- [ ] `/scheduled-tasks?tab=results` is discoverable from Overview, Tasks, Home, and direct URL.
-- [ ] `/scheduled-tasks/results` aliases to the same Results experience.
-- [ ] Result drawer answers: what happened, when, where from, owning workspace, next action.
-- [ ] Home shows an Automation Inbox even when Companion personalization is not enabled.
-- [ ] Watchlists UX remains intact and domain configuration is not moved.
-- [ ] Result and failure states are understandable without color.
-- [ ] Extension-width layout has no horizontal overflow except intentional tables.
-- [ ] No backend-only promise appears in frontend copy before the backend supports it.
-- [ ] Projected mode does not claim durable review state or expose unsupported retry/review buttons.
-- [ ] Mixed failure-plus-output states preserve both signals.
-- [ ] Tests cover missing deep links and partial dependency failures.
-- [ ] Backlog task records verification, known skips, and final summary.
+- [x] `/scheduled-tasks?tab=results` is discoverable from Overview, Tasks, Home, and direct URL.
+- [x] `/scheduled-tasks/results` aliases to the same Results experience.
+- [x] Result drawer answers: what happened, when, where from, owning workspace, next action.
+- [x] Home shows an Automation Inbox even when Companion personalization is not enabled.
+- [x] Watchlists UX remains intact and domain configuration is not moved.
+- [x] Result and failure states are understandable without color.
+- [x] Extension-width layout has no horizontal overflow except intentional tables.
+- [x] No backend-only promise appears in frontend copy before the backend supports it.
+- [x] Projected mode does not claim durable review state or expose unsupported retry/review buttons.
+- [x] Mixed failure-plus-output states preserve both signals.
+- [x] Tests cover missing deep links and partial dependency failures.
+- [x] Backlog task records verification, known skips, and final summary.

--- a/Docs/superpowers/plans/2026-06-09-scheduled-tasks-phase3-results-inbox-home-surfacing-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-06-09-scheduled-tasks-phase3-results-inbox-home-surfacing-implementation-plan.md
@@ -515,13 +515,13 @@ Avoid:
 
 **Tasks:**
 
-- [ ] Implement `ScheduledTaskResultsPanel.tsx`.
-- [ ] Implement `ScheduledTaskResultDetailDrawer.tsx`.
-- [ ] Implement capability-aware filter/action visibility.
-- [ ] Add list/table responsive behavior for extension width.
-- [ ] Add result action wiring in `ScheduledTasksPage.tsx`.
-- [ ] Add missing-result and partial-dependency alerts.
-- [ ] Run component tests.
+- [x] Implement `ScheduledTaskResultsPanel.tsx`.
+- [x] Implement `ScheduledTaskResultDetailDrawer.tsx`.
+- [x] Implement capability-aware filter/action visibility.
+- [x] Add list/table responsive behavior for extension width.
+- [x] Add result action wiring in `ScheduledTasksPage.tsx`.
+- [x] Add missing-result and partial-dependency alerts.
+- [x] Run component tests.
 
 ## Stage 4: Notification Links And Dedupe
 

--- a/Docs/superpowers/plans/2026-06-09-scheduled-tasks-phase3-results-inbox-home-surfacing-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-06-09-scheduled-tasks-phase3-results-inbox-home-surfacing-implementation-plan.md
@@ -579,11 +579,11 @@ Avoid:
 
 **Tasks:**
 
-- [ ] Update `ScheduledTaskOverview.tsx`.
-- [ ] Update `ScheduledTaskTable.tsx`.
-- [ ] Update `ScheduledTaskDetailDrawer.tsx`.
-- [ ] Confirm no Watchlists-owned edit controls are introduced.
-- [ ] Run ScheduledTasks tests.
+- [x] Update `ScheduledTaskOverview.tsx`.
+- [x] Update `ScheduledTaskTable.tsx`.
+- [x] Update `ScheduledTaskDetailDrawer.tsx`.
+- [x] Confirm no Watchlists-owned edit controls are introduced.
+- [x] Run ScheduledTasks tests.
 
 ## Stage 6: Home Surfacing
 

--- a/Docs/superpowers/plans/2026-06-09-scheduled-tasks-phase3-results-inbox-home-surfacing-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-06-09-scheduled-tasks-phase3-results-inbox-home-surfacing-implementation-plan.md
@@ -551,7 +551,7 @@ Avoid:
 
 - [x] Add notification target normalization to `scheduled-task-result-links.ts` or `notifications.ts`.
 - [x] Add dedupe-key generation and merge helpers.
-- [ ] Add non-blocking recent notification load for Home automation signals.
+- [x] Add non-blocking recent notification load for Home automation signals.
 - [x] Preserve existing notification service behavior.
 - [x] Run scheduled-task result and notification service tests.
 
@@ -616,14 +616,14 @@ Avoid:
 
 **Tasks:**
 
-- [ ] Add scheduled-task Home signal hook/adapter.
-- [ ] Extend `CompanionHomeSource` and `CompanionHomeEntityType` for scheduled-task result items.
-- [ ] Implement `AutomationInboxCard.tsx`.
-- [ ] Render `AutomationInboxCard` after `WhatsNextCard` and before generic Companion inbox/attention cards.
-- [ ] Merge task-projected and notification-derived automation items for the module.
-- [ ] Keep existing layout and Customize Home behavior unchanged.
-- [ ] Add loading and partial-failure behavior that does not block Home.
-- [ ] Run CompanionHome tests.
+- [x] Add scheduled-task Home signal hook/adapter.
+- [x] Extend `CompanionHomeSource` and `CompanionHomeEntityType` for scheduled-task result items.
+- [x] Implement `AutomationInboxCard.tsx`.
+- [x] Render `AutomationInboxCard` after `WhatsNextCard` and before generic Companion inbox/attention cards.
+- [x] Merge task-projected and notification-derived automation items for the module.
+- [x] Keep existing layout and Customize Home behavior unchanged.
+- [x] Add loading and partial-failure behavior that does not block Home.
+- [x] Run CompanionHome tests.
 
 ## Stage 7: UX Polish, Responsive Checks, And Copy Review
 

--- a/Docs/superpowers/plans/2026-06-09-scheduled-tasks-phase3-results-inbox-home-surfacing-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-06-09-scheduled-tasks-phase3-results-inbox-home-surfacing-implementation-plan.md
@@ -279,7 +279,7 @@ Use these strings unless implementation discovers stronger local wording:
 - Results tab label: `Results`
 - Results page title: `Scheduled task results`
 - Results page subtitle: `Review outputs, failures, and run state from recurring automations. Source-specific setup stays in the owning workspace.`
-- Projected-mode subtitle: `Latest signals inferred from task status. Durable review state appears when the results API is available.`
+- Projected-mode subtitle: `Latest signals inferred from task status. Result history and item actions appear when the results API is available.`
 - Filter label, normalized result modes only: `Review state`
 - Filter values, normalized result modes only: `Unreviewed`, `Reviewed`, `All`
 - Filter label: `Result state`
@@ -655,12 +655,21 @@ Avoid:
 
 **Tasks:**
 
-- [ ] Review all new visible copy against copy recommendations.
-- [ ] Search for source-specific examples in generic UI.
-- [ ] Search for unsupported review/retry buttons in projected-mode rendering.
-- [ ] Verify drawer focus and accessible labels.
-- [ ] Verify no nested cards or decorative layout drift in Home.
-- [ ] Record screenshots or browser observations in the implementation Backlog task.
+- [x] Review all new visible copy against copy recommendations.
+- [x] Search for source-specific examples in generic UI.
+- [x] Search for unsupported review/retry buttons in projected-mode rendering.
+- [x] Verify drawer focus and accessible labels.
+- [x] Verify no nested cards or decorative layout drift in Home.
+- [x] Record screenshots or browser observations in the implementation Backlog task.
+
+**Stage 7 Browser Observations:**
+
+- Started the WebUI at `http://localhost:18001` and a temporary read-only mock API at `http://127.0.0.1:8000` for health, OpenAPI, scheduled-task, and notification empty responses.
+- `/scheduled-tasks` rendered the Scheduled Tasks shell after the readiness gate passed, with Overview, Results, Tasks, and Create tabs visible.
+- `/scheduled-tasks?tab=results` rendered the Results tab with source-agnostic projected-mode copy, no readiness gate, the `No scheduled tasks yet` empty state, and a visible `Create scheduled task` action.
+- At a 390px viewport, `/scheduled-tasks?tab=results` preserved the active Results tab, projected-mode note, empty state, and primary action without obvious text loss in the DOM evidence.
+- `/companion` rendered `Automation Inbox` even when personalization was unavailable, placed before `Inbox Preview`, and kept the existing Companion cards intact.
+- At a 390px viewport, `/companion` preserved `Automation Inbox` ahead of `Inbox Preview` with non-personalized empty-state copy visible.
 
 ## Stage 8: Documentation, Backlog, And Verification
 

--- a/Docs/superpowers/plans/2026-06-09-scheduled-tasks-phase3-results-inbox-home-surfacing-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-06-09-scheduled-tasks-phase3-results-inbox-home-surfacing-implementation-plan.md
@@ -435,15 +435,15 @@ Avoid:
 
 **Tasks:**
 
-- [ ] Add `scheduled-task-results.ts` types and helpers.
-- [ ] Add `scheduled-task-result-links.ts` URL and dedupe helpers.
-- [ ] Add capability-mode detection helpers that can accept OpenAPI path availability.
-- [ ] Add result item sorting by newest `occurredAt`, then severity, then title.
-- [ ] Add `buildScheduledTaskResultHref` for `result_id`, `run_id`, and `task_id`.
-- [ ] Add `findScheduledTaskResultByRouteState`.
-- [ ] Add Home adapter returning automation inbox items with status and owner metadata.
-- [ ] Add mixed-state projection rules before React rendering work starts.
-- [ ] Run `bunx vitest run apps/packages/ui/src/components/Option/ScheduledTasks/__tests__/scheduled-task-results.test.ts`.
+- [x] Add `scheduled-task-results.ts` types and helpers.
+- [x] Add `scheduled-task-result-links.ts` URL and dedupe helpers.
+- [x] Add capability-mode detection helpers that can accept OpenAPI path availability.
+- [x] Add result item sorting by newest `occurredAt`, then severity, then title.
+- [x] Add `buildScheduledTaskResultHref` for `result_id`, `run_id`, and `task_id`.
+- [x] Add `findScheduledTaskResultByRouteState`.
+- [x] Add Home adapter returning automation inbox items with status and owner metadata.
+- [x] Add mixed-state projection rules before React rendering work starts.
+- [x] Run `bunx vitest run apps/packages/ui/src/components/Option/ScheduledTasks/__tests__/scheduled-task-results.test.ts`.
 
 ## Stage 2: Results Route State And Results Tab
 
@@ -474,14 +474,14 @@ Avoid:
 
 **Tasks:**
 
-- [ ] Update `ScheduledTaskTabId` and `SCHEDULED_TASK_TABS`.
-- [ ] Extend `ScheduledTaskRouteState` with `resultId` and `runId`.
-- [ ] Update `buildScheduledTaskSearch`.
-- [ ] Add extension route alias for `/scheduled-tasks/results`.
-- [ ] Add hosted WebUI alias page for `/scheduled-tasks/results`.
-- [ ] Add Results tab rendering to `ScheduledTasksPage.tsx`.
-- [ ] Keep task-detail state separate from result-detail state.
-- [ ] Run the route-state and page tests.
+- [x] Update `ScheduledTaskTabId` and `SCHEDULED_TASK_TABS`.
+- [x] Extend `ScheduledTaskRouteState` with `resultId` and `runId`.
+- [x] Update `buildScheduledTaskSearch`.
+- [x] Add extension route alias for `/scheduled-tasks/results`.
+- [x] Add hosted WebUI alias page for `/scheduled-tasks/results`.
+- [x] Add Results tab rendering to `ScheduledTasksPage.tsx`.
+- [x] Keep task-detail state separate from result-detail state.
+- [x] Run the route-state and page tests.
 
 ## Stage 3: Results Panel And Detail Drawer
 

--- a/apps/packages/ui/src/components/Option/CompanionHome/CompanionHomePage.tsx
+++ b/apps/packages/ui/src/components/Option/CompanionHome/CompanionHomePage.tsx
@@ -14,9 +14,15 @@ import {
   type CompanionHomeLayoutCard
 } from "@/store/companion-home-layout"
 
-import { createEmptySnapshot, useCompanionHomeData, useCompanionHomeLayout } from "./hooks"
+import {
+  createEmptySnapshot,
+  useCompanionHomeData,
+  useCompanionHomeLayout,
+  useScheduledTaskHomeSignals
+} from "./hooks"
 import { CustomizeHomeDrawer } from "./CustomizeHomeDrawer"
 import { GettingStartedSection } from "./GettingStartedSection"
+import { AutomationInboxCard } from "./cards/AutomationInboxCard"
 import { GoalsFocusCard } from "./cards/GoalsFocusCard"
 import { InboxPreviewCard } from "./cards/InboxPreviewCard"
 import { NeedsAttentionCard } from "./cards/NeedsAttentionCard"
@@ -94,6 +100,19 @@ export function CompanionHomePage({
     hasPersonalization,
     onPersonalizationEnabled
   })
+  const {
+    items: scheduledTaskSignalItems,
+    loading: scheduledTaskSignalsLoading,
+    partial: scheduledTaskSignalsPartial,
+    error: scheduledTaskSignalsError,
+    refresh: refreshScheduledTaskSignals
+  } = useScheduledTaskHomeSignals({
+    enabled: !capsLoading
+  })
+  const refreshHome = React.useCallback(() => {
+    refresh()
+    refreshScheduledTaskSignals()
+  }, [refresh, refreshScheduledTaskSignals])
   const hasConversationRoute =
     Boolean(capabilities?.hasPersonalization) &&
     Boolean(capabilities?.hasPersona) &&
@@ -311,7 +330,7 @@ export function CompanionHomePage({
             </button>
             <button
               className="rounded-full border border-border bg-surface px-4 py-2 text-sm font-medium text-text transition-colors hover:border-primary/40 hover:bg-primary/5"
-              onClick={refresh}
+              onClick={refreshHome}
               type="button"
             >
               Refresh
@@ -392,6 +411,12 @@ export function CompanionHomePage({
 
       <div className="grid gap-4 xl:grid-cols-2">
         <WhatsNextCard />
+        <AutomationInboxCard
+          items={scheduledTaskSignalItems}
+          loading={scheduledTaskSignalsLoading}
+          partial={scheduledTaskSignalsPartial}
+          error={scheduledTaskSignalsError}
+        />
         <InboxPreviewCard items={resolvedSnapshot.inbox} state={inboxState} />
         <NeedsAttentionCard
           items={resolvedSnapshot.needsAttention}

--- a/apps/packages/ui/src/components/Option/CompanionHome/__tests__/AutomationInboxCard.test.tsx
+++ b/apps/packages/ui/src/components/Option/CompanionHome/__tests__/AutomationInboxCard.test.tsx
@@ -1,0 +1,111 @@
+// @vitest-environment jsdom
+
+import { render, screen } from "@testing-library/react"
+import { describe, expect, it } from "vitest"
+import { MemoryRouter } from "react-router-dom"
+
+import { AutomationInboxCard } from "../cards/AutomationInboxCard"
+
+const renderCard = (
+  props: Partial<React.ComponentProps<typeof AutomationInboxCard>> = {}
+) =>
+  render(
+    <MemoryRouter>
+      <AutomationInboxCard
+        items={[]}
+        loading={false}
+        partial={false}
+        error={null}
+        {...props}
+      />
+    </MemoryRouter>
+  )
+
+describe("AutomationInboxCard", () => {
+  it("renders an empty state that explains where automation results appear", () => {
+    renderCard()
+
+    expect(screen.getByRole("heading", { name: "Automation Inbox" })).toBeInTheDocument()
+    expect(screen.getByText("No automation results yet")).toBeInTheDocument()
+    expect(
+      screen.getByText("Results and failures from scheduled tasks appear here after a run.")
+    ).toBeInTheDocument()
+  })
+
+  it("renders a named loading state without blocking the rest of Home", () => {
+    renderCard({ loading: true })
+
+    expect(screen.getByText("Loading automation signals")).toBeInTheDocument()
+    expect(
+      screen.getByText("Checking recent scheduled-task results and notifications.")
+    ).toBeInTheDocument()
+  })
+
+  it("shows status, owner, summary, timestamp, and exact result links for items", () => {
+    renderCard({
+      items: [
+        {
+          id: "result:202",
+          title: "Release monitor",
+          summary: "Found 2 results from Release feed.",
+          statusLabel: "New result",
+          ownerLabel: "Watchlists",
+          href: "/scheduled-tasks?tab=results&result_id=202",
+          updatedAt: "2030-01-01T09:00:00Z",
+          severity: "success",
+          dedupeKey: "result:202"
+        },
+        {
+          id: "run:103:state:failure",
+          title: "Broken monitor",
+          summary: "Broken monitor needs attention. Open details to inspect the latest run.",
+          statusLabel: "Needs attention",
+          ownerLabel: "Watchlists",
+          href: "/scheduled-tasks?tab=results&run_id=103",
+          updatedAt: "2030-01-01T09:05:00Z",
+          severity: "error",
+          dedupeKey: "run:103:state:failure"
+        }
+      ]
+    })
+
+    expect(screen.getByRole("link", { name: /Release monitor/i })).toHaveAttribute(
+      "href",
+      "/scheduled-tasks?tab=results&result_id=202"
+    )
+    expect(screen.getByText("New result")).toBeInTheDocument()
+    expect(screen.getAllByText("Watchlists").length).toBeGreaterThan(0)
+    expect(screen.getAllByText("Updated Jan 1").length).toBeGreaterThan(0)
+    expect(screen.getByRole("link", { name: /Broken monitor/i })).toHaveAttribute(
+      "href",
+      "/scheduled-tasks?tab=results&run_id=103"
+    )
+    expect(screen.getByText("Needs attention")).toBeInTheDocument()
+  })
+
+  it("keeps visible items while naming a partial automation load failure", () => {
+    renderCard({
+      partial: true,
+      error: "Recent automation notifications could not be loaded.",
+      items: [
+        {
+          id: "result:202",
+          title: "Release monitor",
+          summary: "Found 1 result.",
+          statusLabel: "New result",
+          ownerLabel: "Watchlists",
+          href: "/scheduled-tasks?tab=results&result_id=202",
+          updatedAt: null,
+          severity: "success",
+          dedupeKey: "result:202"
+        }
+      ]
+    })
+
+    expect(screen.getByText("Release monitor")).toBeInTheDocument()
+    expect(screen.getByText("Partial automation data")).toBeInTheDocument()
+    expect(
+      screen.getByText("Recent automation notifications could not be loaded.")
+    ).toBeInTheDocument()
+  })
+})

--- a/apps/packages/ui/src/components/Option/CompanionHome/__tests__/CompanionHomePage.test.tsx
+++ b/apps/packages/ui/src/components/Option/CompanionHome/__tests__/CompanionHomePage.test.tsx
@@ -7,6 +7,8 @@ import { MemoryRouter } from "react-router-dom"
 const mocks = vi.hoisted(() => ({
   fetchCompanionHomeSnapshot: vi.fn(),
   fetchPersonalizationProfile: vi.fn(),
+  listScheduledTasks: vi.fn(),
+  listNotifications: vi.fn(),
   updatePersonalizationOptIn: vi.fn(),
   loadCompanionHomeLayout: vi.fn(),
   saveCompanionHomeLayout: vi.fn(),
@@ -56,6 +58,28 @@ vi.mock("@/services/companion", () => ({
   updatePersonalizationOptIn: (...args: unknown[]) =>
     mocks.updatePersonalizationOptIn(...args)
 }))
+
+vi.mock("@/services/scheduled-tasks-control-plane", async () => {
+  const actual = await vi.importActual<typeof import("@/services/scheduled-tasks-control-plane")>(
+    "@/services/scheduled-tasks-control-plane"
+  )
+
+  return {
+    ...actual,
+    listScheduledTasks: (...args: unknown[]) => mocks.listScheduledTasks(...args)
+  }
+})
+
+vi.mock("@/services/notifications", async () => {
+  const actual = await vi.importActual<typeof import("@/services/notifications")>(
+    "@/services/notifications"
+  )
+
+  return {
+    ...actual,
+    listNotifications: (...args: unknown[]) => mocks.listNotifications(...args)
+  }
+})
 
 vi.mock("@/store/companion-home-layout", async () => {
   const actual = await vi.importActual<typeof import("@/store/companion-home-layout")>(
@@ -215,6 +239,29 @@ const buildSnapshot = (overrides: Record<string, unknown> = {}) => ({
   ...overrides
 })
 
+const buildScheduledTask = (overrides: Record<string, unknown> = {}) => ({
+  id: "watchlist_job:release",
+  primitive: "watchlist_job",
+  title: "Release monitor",
+  description: "Track releases",
+  status: "scheduled",
+  enabled: true,
+  schedule_summary: "Every morning",
+  timezone: "UTC",
+  next_run_at: "2030-01-02T09:00:00Z",
+  last_run_at: "2030-01-01T09:00:00Z",
+  edit_mode: "external",
+  manage_url: "/watchlists?tab=jobs",
+  source_ref: {
+    job_id: 42,
+    latest_run_id: 101,
+    latest_output_id: 202,
+    result_count: 2,
+    source_label: "Release feed"
+  },
+  ...overrides
+})
+
 const renderPage = (
   props: Partial<React.ComponentProps<typeof CompanionHomePage>> = {}
 ) =>
@@ -230,6 +277,16 @@ describe("CompanionHomePage", () => {
     mocks.capabilitiesState.capabilities = { hasPersonalization: true, hasPersona: true }
     mocks.capabilitiesState.loading = false
     mocks.fetchCompanionHomeSnapshot.mockResolvedValue(buildSnapshot())
+    mocks.listScheduledTasks.mockResolvedValue({
+      items: [],
+      total: 0,
+      partial: false,
+      errors: []
+    })
+    mocks.listNotifications.mockResolvedValue({
+      items: [],
+      total: 0
+    })
     mocks.fetchPersonalizationProfile.mockResolvedValue({
       enabled: true,
       updated_at: "2026-03-20T10:00:00Z"
@@ -287,10 +344,31 @@ describe("CompanionHomePage", () => {
 
   it("shows a setup band and inbox card instead of a dead-end when personalization is unavailable", async () => {
     mocks.capabilitiesState.capabilities = { hasPersonalization: false, hasPersona: false }
+    mocks.listScheduledTasks.mockResolvedValueOnce({
+      items: [
+        buildScheduledTask({
+          title: "Source monitor",
+          source_ref: {
+            job_id: 55,
+            latest_run_id: 155,
+            latest_output_id: 255,
+            result_count: 1
+          }
+        })
+      ],
+      total: 1,
+      partial: false,
+      errors: []
+    })
 
     renderPage()
 
     expect(await screen.findByText("Companion setup required")).toBeInTheDocument()
+    expect(screen.getByRole("heading", { name: "Automation Inbox" })).toBeInTheDocument()
+    expect(screen.getByRole("link", { name: /Source monitor/i })).toHaveAttribute(
+      "href",
+      "/scheduled-tasks?tab=results&result_id=255"
+    )
     expect(screen.getByRole("heading", { name: "Inbox Preview" })).toBeInTheDocument()
     expect(screen.getAllByText("Registry setup required").length).toBeGreaterThan(0)
     expect(
@@ -301,6 +379,7 @@ describe("CompanionHomePage", () => {
     ).not.toBeInTheDocument()
     expect(mocks.fetchCompanionHomeSnapshot).not.toHaveBeenCalled()
     expect(mocks.fetchPersonalizationProfile).not.toHaveBeenCalled()
+    expect(mocks.listScheduledTasks).toHaveBeenCalledTimes(1)
   })
 
   it("renders the default core dashboard cards", async () => {
@@ -311,6 +390,7 @@ describe("CompanionHomePage", () => {
     })
 
     expect(screen.getByRole("heading", { name: "Inbox Preview" })).toBeInTheDocument()
+    expect(screen.getByRole("heading", { name: "Automation Inbox" })).toBeInTheDocument()
     expect(screen.getByRole("heading", { name: "Needs Attention" })).toBeInTheDocument()
     expect(screen.getByRole("heading", { name: "Resume Work" })).toBeInTheDocument()
     expect(screen.getByRole("heading", { name: "Goals / Focus" })).toBeInTheDocument()
@@ -322,6 +402,84 @@ describe("CompanionHomePage", () => {
     expect(within(summary).getByText("Goals")).toBeInTheDocument()
     expect(within(summary).getByText("Reading")).toBeInTheDocument()
     expect(within(summary).getByText("Resume")).toBeInTheDocument()
+  })
+
+  it("renders scheduled-task result and failure signals in Automation Inbox", async () => {
+    mocks.listScheduledTasks.mockResolvedValueOnce({
+      items: [
+        buildScheduledTask(),
+        buildScheduledTask({
+          id: "watchlist_job:failed",
+          title: "Broken monitor",
+          status: "failed",
+          source_ref: {
+            job_id: 43,
+            latest_run_id: 103
+          }
+        })
+      ],
+      total: 2,
+      partial: false,
+      errors: []
+    })
+
+    renderPage()
+
+    expect(await screen.findByRole("heading", { name: "Automation Inbox" })).toBeInTheDocument()
+    expect(screen.getByRole("link", { name: /Release monitor/i })).toHaveAttribute(
+      "href",
+      "/scheduled-tasks?tab=results&result_id=202"
+    )
+    expect(screen.getByText("New result")).toBeInTheDocument()
+    expect(screen.getAllByText("Watchlists").length).toBeGreaterThan(0)
+    expect(screen.getByRole("link", { name: /Broken monitor/i })).toHaveAttribute(
+      "href",
+      "/scheduled-tasks?tab=results&run_id=103"
+    )
+    expect(screen.getByText("Needs attention")).toBeInTheDocument()
+  })
+
+  it("keeps Companion Home usable when scheduled-task loading fails", async () => {
+    mocks.listScheduledTasks.mockRejectedValueOnce(new Error("scheduled tasks unavailable"))
+
+    renderPage()
+
+    expect(await screen.findByRole("heading", { name: "Inbox Preview" })).toBeInTheDocument()
+    expect(screen.getByText("Unread reflection")).toBeInTheDocument()
+    expect(screen.getByRole("heading", { name: "Automation Inbox" })).toBeInTheDocument()
+    expect(screen.getByText("Automation signals unavailable")).toBeInTheDocument()
+  })
+
+  it("dedupes notification-derived automation signals against projected task results", async () => {
+    mocks.listScheduledTasks.mockResolvedValueOnce({
+      items: [buildScheduledTask()],
+      total: 1,
+      partial: false,
+      errors: []
+    })
+    mocks.listNotifications.mockResolvedValueOnce({
+      total: 1,
+      items: [
+        {
+          id: 91,
+          kind: "job_completed",
+          title: "Release monitor notification",
+          message: "Output ready",
+          severity: "info",
+          created_at: "2030-01-01T09:05:00Z",
+          link_type: "scheduled_task_result",
+          link_id: "202",
+          source_task_id: "watchlist_job:release",
+          source_task_run_id: "101"
+        }
+      ]
+    })
+
+    renderPage()
+
+    expect(await screen.findByRole("heading", { name: "Automation Inbox" })).toBeInTheDocument()
+    expect(screen.getAllByRole("link", { name: /Release monitor/i })).toHaveLength(1)
+    expect(mocks.listNotifications).toHaveBeenCalledWith({ limit: 50 })
   })
 
   it("does not flash the default core layout before the persisted layout resolves", async () => {

--- a/apps/packages/ui/src/components/Option/CompanionHome/cards/AutomationInboxCard.tsx
+++ b/apps/packages/ui/src/components/Option/CompanionHome/cards/AutomationInboxCard.tsx
@@ -1,0 +1,127 @@
+import { Link } from "react-router-dom"
+
+import type {
+  ScheduledTaskAutomationHomeItem,
+  ScheduledTaskResultSeverity
+} from "../../ScheduledTasks/scheduled-task-results"
+
+type AutomationInboxCardProps = {
+  items: ScheduledTaskAutomationHomeItem[]
+  loading: boolean
+  partial: boolean
+  error: string | null
+  maxItems?: number
+}
+
+const formatUpdatedAt = (value: string | null | undefined): string => {
+  if (!value) return "Updated recently"
+  const timestamp = Date.parse(value)
+  if (!Number.isFinite(timestamp)) return "Updated recently"
+  return `Updated ${new Intl.DateTimeFormat("en", {
+    month: "short",
+    day: "numeric"
+  }).format(new Date(timestamp))}`
+}
+
+const severityClasses = (severity: ScheduledTaskResultSeverity): string => {
+  if (severity === "error") {
+    return "border-danger/30 bg-danger/10 text-danger"
+  }
+  if (severity === "warning") {
+    return "border-warn/30 bg-warn/10 text-warn"
+  }
+  if (severity === "success") {
+    return "border-success/30 bg-success/10 text-success"
+  }
+  return "border-primary/30 bg-primary/10 text-primary"
+}
+
+export function AutomationInboxCard({
+  items,
+  loading,
+  partial,
+  error,
+  maxItems = 4
+}: AutomationInboxCardProps) {
+  const visibleItems = items.slice(0, maxItems)
+  const hasItems = visibleItems.length > 0
+  const subtitle = loading && !hasItems
+    ? "Checking now"
+    : items.length > 0
+      ? `${items.length} signal${items.length === 1 ? "" : "s"}`
+      : error
+        ? "0 signals"
+        : "Nothing new from automations."
+  const emptyLabel = loading
+    ? "Loading automation signals"
+    : error && !hasItems
+      ? error
+      : "No automation results yet"
+  const emptyDescription = loading
+    ? "Checking recent scheduled-task results and notifications."
+    : error && !hasItems
+      ? "Scheduled-task results are temporarily unavailable. Other Home cards remain available."
+      : "Results and failures from scheduled tasks appear here after a run."
+
+  return (
+    <section className="rounded-3xl border border-border/80 bg-surface/90 p-5 shadow-sm backdrop-blur-sm">
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <h2 className="text-lg font-semibold text-text">Automation Inbox</h2>
+          <p className="mt-1 text-sm text-text-muted">{subtitle}</p>
+        </div>
+        <span className="rounded-full border border-border/70 bg-bg/70 px-3 py-1 text-xs font-semibold uppercase tracking-[0.16em] text-text-muted">
+          {items.length}
+        </span>
+      </div>
+
+      {error && partial && hasItems ? (
+        <div className="mt-4 rounded-2xl border border-warn/30 bg-warn/10 px-4 py-3">
+          <div className="text-sm font-semibold text-text">Partial automation data</div>
+          <p className="mt-1 text-sm leading-6 text-text-muted">{error}</p>
+        </div>
+      ) : null}
+
+      {hasItems ? (
+        <ul className="mt-4 space-y-3">
+          {visibleItems.map((item) => (
+            <li
+              key={item.id}
+              className="rounded-2xl border border-border/70 bg-bg/60 p-3"
+            >
+              <Link
+                className="block rounded-xl focus:outline-none focus-visible:ring-2 focus-visible:ring-focus"
+                to={item.href}
+              >
+                <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+                  <div className="min-w-0">
+                    <div className="text-sm font-semibold text-text">{item.title}</div>
+                    <div className="mt-2 flex flex-wrap gap-2">
+                      <span
+                        className={`rounded-full border px-2 py-1 text-xs font-semibold ${severityClasses(item.severity)}`}
+                      >
+                        {item.statusLabel}
+                      </span>
+                      <span className="rounded-full border border-border/70 bg-surface/75 px-2 py-1 text-xs font-semibold text-text-muted">
+                        {item.ownerLabel}
+                      </span>
+                    </div>
+                  </div>
+                  <span className="shrink-0 text-xs text-text-muted">
+                    {formatUpdatedAt(item.updatedAt)}
+                  </span>
+                </div>
+                <p className="mt-2 text-sm leading-6 text-text-muted">{item.summary}</p>
+              </Link>
+            </li>
+          ))}
+        </ul>
+      ) : (
+        <div className="mt-4 rounded-2xl border border-dashed border-border/70 bg-bg/60 p-4">
+          <div className="text-sm font-semibold text-text">{emptyLabel}</div>
+          <p className="mt-2 text-sm leading-6 text-text-muted">{emptyDescription}</p>
+        </div>
+      )}
+    </section>
+  )
+}

--- a/apps/packages/ui/src/components/Option/CompanionHome/cards/AutomationInboxCard.tsx
+++ b/apps/packages/ui/src/components/Option/CompanionHome/cards/AutomationInboxCard.tsx
@@ -1,4 +1,5 @@
 import { Link } from "react-router-dom"
+import { useTranslation } from "react-i18next"
 
 import type {
   ScheduledTaskAutomationHomeItem,
@@ -43,31 +44,61 @@ export function AutomationInboxCard({
   error,
   maxItems = 4
 }: AutomationInboxCardProps) {
+  const { t } = useTranslation()
   const visibleItems = items.slice(0, maxItems)
   const hasItems = visibleItems.length > 0
+  const signalCountLabel = `${items.length} signal${items.length === 1 ? "" : "s"}`
   const subtitle = loading && !hasItems
-    ? "Checking now"
+    ? t("companionHome.automationInbox.checking", { defaultValue: "Checking now" })
     : items.length > 0
-      ? `${items.length} signal${items.length === 1 ? "" : "s"}`
+      ? t("companionHome.automationInbox.signalCount", {
+          count: items.length,
+          defaultValue: signalCountLabel
+        })
       : error
-        ? "0 signals"
-        : "Nothing new from automations."
+        ? t("companionHome.automationInbox.zeroSignals", { defaultValue: "0 signals" })
+        : t(
+            "companionHome.automationInbox.nothingNew",
+            { defaultValue: "Nothing new from automations." }
+          )
   const emptyLabel = loading
-    ? "Loading automation signals"
+    ? t(
+        "companionHome.automationInbox.loadingLabel",
+        { defaultValue: "Loading automation signals" }
+      )
     : error && !hasItems
       ? error
-      : "No automation results yet"
+      : t(
+          "companionHome.automationInbox.emptyLabel",
+          { defaultValue: "No automation results yet" }
+        )
   const emptyDescription = loading
-    ? "Checking recent scheduled-task results and notifications."
+    ? t(
+        "companionHome.automationInbox.loadingDescription",
+        { defaultValue: "Checking recent scheduled-task results and notifications." }
+      )
     : error && !hasItems
-      ? "Scheduled-task results are temporarily unavailable. Other Home cards remain available."
-      : "Results and failures from scheduled tasks appear here after a run."
+      ? t(
+          "companionHome.automationInbox.errorDescription",
+          {
+            defaultValue:
+              "Scheduled-task results are temporarily unavailable. Other Home cards remain available."
+          }
+        )
+      : t(
+          "companionHome.automationInbox.emptyDescription",
+          { defaultValue: "Results and failures from scheduled tasks appear here after a run." }
+        )
 
   return (
     <section className="rounded-3xl border border-border/80 bg-surface/90 p-5 shadow-sm backdrop-blur-sm">
       <div className="flex items-start justify-between gap-3">
         <div>
-          <h2 className="text-lg font-semibold text-text">Automation Inbox</h2>
+          <h2 className="text-lg font-semibold text-text">
+            {t("companionHome.automationInbox.title", {
+              defaultValue: "Automation Inbox"
+            })}
+          </h2>
           <p className="mt-1 text-sm text-text-muted">{subtitle}</p>
         </div>
         <span className="rounded-full border border-border/70 bg-bg/70 px-3 py-1 text-xs font-semibold uppercase tracking-[0.16em] text-text-muted">
@@ -77,7 +108,12 @@ export function AutomationInboxCard({
 
       {error && partial && hasItems ? (
         <div className="mt-4 rounded-2xl border border-warn/30 bg-warn/10 px-4 py-3">
-          <div className="text-sm font-semibold text-text">Partial automation data</div>
+          <div className="text-sm font-semibold text-text">
+            {t(
+              "companionHome.automationInbox.partialTitle",
+              { defaultValue: "Partial automation data" }
+            )}
+          </div>
           <p className="mt-1 text-sm leading-6 text-text-muted">{error}</p>
         </div>
       ) : null}

--- a/apps/packages/ui/src/components/Option/CompanionHome/hooks.ts
+++ b/apps/packages/ui/src/components/Option/CompanionHome/hooks.ts
@@ -10,12 +10,21 @@ import {
   type CompanionHomeSnapshot,
   type CompanionHomeSurface
 } from "@/services/companion-home"
+import { listNotifications } from "@/services/notifications"
+import { listScheduledTasks } from "@/services/scheduled-tasks-control-plane"
 import {
   DEFAULT_COMPANION_HOME_LAYOUT,
   loadCompanionHomeLayout,
   saveCompanionHomeLayout,
   type CompanionHomeLayoutCard
 } from "@/store/companion-home-layout"
+import {
+  buildScheduledTaskAutomationHomeItems,
+  buildScheduledTaskAutomationHomeItemsFromNotifications,
+  mergeScheduledTaskAutomationHomeItems,
+  projectScheduledTaskResults,
+  type ScheduledTaskAutomationHomeItem
+} from "../ScheduledTasks/scheduled-task-results"
 
 export const createEmptySnapshot = (
   surface: CompanionHomeSurface
@@ -153,6 +162,104 @@ export const useCompanionHomeData = ({
     enablingCompanion,
     refresh,
     enableCompanion
+  }
+}
+
+type UseScheduledTaskHomeSignalsArgs = {
+  enabled: boolean
+}
+
+type UseScheduledTaskHomeSignalsResult = {
+  items: ScheduledTaskAutomationHomeItem[]
+  loading: boolean
+  partial: boolean
+  error: string | null
+  refresh: () => void
+}
+
+export const useScheduledTaskHomeSignals = ({
+  enabled
+}: UseScheduledTaskHomeSignalsArgs): UseScheduledTaskHomeSignalsResult => {
+  const [items, setItems] = React.useState<ScheduledTaskAutomationHomeItem[]>([])
+  const [loading, setLoading] = React.useState(true)
+  const [partial, setPartial] = React.useState(false)
+  const [error, setError] = React.useState<string | null>(null)
+  const [refreshToken, setRefreshToken] = React.useState(0)
+
+  React.useEffect(() => {
+    if (!enabled) return
+
+    let cancelled = false
+    setLoading(true)
+    setError(null)
+
+    const load = async () => {
+      const [tasksResult, notificationsResult] = await Promise.allSettled([
+        listScheduledTasks(),
+        listNotifications({ limit: 50 })
+      ])
+
+      if (cancelled) {
+        return
+      }
+
+      const projectedItems =
+        tasksResult.status === "fulfilled"
+          ? buildScheduledTaskAutomationHomeItems(
+              projectScheduledTaskResults(tasksResult.value.items)
+            )
+          : []
+      const notificationItems =
+        notificationsResult.status === "fulfilled"
+          ? buildScheduledTaskAutomationHomeItemsFromNotifications(
+              notificationsResult.value.items
+            )
+          : []
+      const nextPartial =
+        tasksResult.status === "rejected" ||
+        notificationsResult.status === "rejected" ||
+        (tasksResult.status === "fulfilled" && tasksResult.value.partial)
+
+      let nextError: string | null = null
+      if (tasksResult.status === "rejected") {
+        nextError =
+          notificationItems.length > 0
+            ? "Some scheduled-task signals could not be loaded."
+            : "Automation signals unavailable"
+      } else if (notificationsResult.status === "rejected") {
+        nextError = "Recent automation notifications could not be loaded."
+      } else if (tasksResult.value.partial) {
+        nextError = "Some scheduled-task sources are temporarily unavailable."
+      }
+
+      setItems(
+        mergeScheduledTaskAutomationHomeItems([
+          projectedItems,
+          notificationItems
+        ])
+      )
+      setPartial(nextPartial)
+      setError(nextError)
+      setLoading(false)
+    }
+
+    void load()
+
+    return () => {
+      cancelled = true
+    }
+  }, [enabled, refreshToken])
+
+  const refresh = React.useCallback(() => {
+    setRefreshToken((value) => value + 1)
+  }, [])
+
+  return {
+    items,
+    loading,
+    partial,
+    error,
+    refresh
   }
 }
 

--- a/apps/packages/ui/src/components/Option/CompanionHome/hooks.ts
+++ b/apps/packages/ui/src/components/Option/CompanionHome/hooks.ts
@@ -206,7 +206,7 @@ export const useScheduledTaskHomeSignals = ({
       const projectedItems =
         tasksResult.status === "fulfilled"
           ? buildScheduledTaskAutomationHomeItems(
-              projectScheduledTaskResults(tasksResult.value.items)
+              projectScheduledTaskResults(tasksResult.value?.items ?? [])
             )
           : []
       const notificationItems =
@@ -218,7 +218,7 @@ export const useScheduledTaskHomeSignals = ({
       const nextPartial =
         tasksResult.status === "rejected" ||
         notificationsResult.status === "rejected" ||
-        (tasksResult.status === "fulfilled" && tasksResult.value.partial)
+        (tasksResult.status === "fulfilled" && Boolean(tasksResult.value?.partial))
 
       let nextError: string | null = null
       if (tasksResult.status === "rejected") {
@@ -228,7 +228,7 @@ export const useScheduledTaskHomeSignals = ({
             : "Automation signals unavailable"
       } else if (notificationsResult.status === "rejected") {
         nextError = "Recent automation notifications could not be loaded."
-      } else if (tasksResult.value.partial) {
+      } else if (tasksResult.value?.partial) {
         nextError = "Some scheduled-task sources are temporarily unavailable."
       }
 

--- a/apps/packages/ui/src/components/Option/ScheduledTasks/ScheduledTaskDetailDrawer.tsx
+++ b/apps/packages/ui/src/components/Option/ScheduledTasks/ScheduledTaskDetailDrawer.tsx
@@ -9,10 +9,12 @@ import {
   scheduledTaskStatusToneToTagColor
 } from "./scheduled-task-status"
 import { WatchlistTaskActionLinks } from "./WatchlistTaskActionLinks"
+import type { ScheduledTaskResultItem } from "./scheduled-task-results"
 
 export interface ScheduledTaskDetailDrawerProps {
   open: boolean
   task: ScheduledTask | null
+  latestResult?: ScheduledTaskResultItem | null
   onClose: () => void
   onEditReminder: (task: ScheduledTask) => void
   onDeleteReminder: (task: ScheduledTask) => void
@@ -108,6 +110,7 @@ const renderTaskActions = ({
 export const ScheduledTaskDetailDrawer: React.FC<ScheduledTaskDetailDrawerProps> = ({
   open,
   task,
+  latestResult = null,
   onClose,
   onEditReminder,
   onDeleteReminder
@@ -163,7 +166,16 @@ export const ScheduledTaskDetailDrawer: React.FC<ScheduledTaskDetailDrawerProps>
 
           <div>
             <Typography.Title level={5}>Actions</Typography.Title>
-            {renderTaskActions({ task, onEditReminder, onDeleteReminder })}
+            <Space orientation="vertical" size={8}>
+              {latestResult ? (
+                <div>
+                  <Button href={latestResult.primaryHref}>
+                    Open latest result signal
+                  </Button>
+                </div>
+              ) : null}
+              {renderTaskActions({ task, onEditReminder, onDeleteReminder })}
+            </Space>
           </div>
 
           {task.primitive === "watchlist_job" ? (

--- a/apps/packages/ui/src/components/Option/ScheduledTasks/ScheduledTaskOverview.tsx
+++ b/apps/packages/ui/src/components/Option/ScheduledTasks/ScheduledTaskOverview.tsx
@@ -1,14 +1,17 @@
 import React from "react"
-import { Card, Col, Row, Tag, Typography } from "antd"
+import { Button, Card, Col, Row, Space, Tag, Typography } from "antd"
 import type { ScheduledTask } from "@/services/scheduled-tasks-control-plane"
 import {
   SCHEDULED_TASK_ATTENTION_STATUS_KEYS,
   getScheduledTaskProductStatus
 } from "./scheduled-task-status"
+import type { ScheduledTaskResultItem } from "./scheduled-task-results"
 
 export interface ScheduledTaskOverviewProps {
   tasks: ScheduledTask[]
   partial: boolean
+  results?: ScheduledTaskResultItem[]
+  onOpenResult?: (result: ScheduledTaskResultItem) => void
 }
 
 const countLabel = (count: number, singular: string, plural = `${singular}s`): string =>
@@ -69,7 +72,9 @@ const OverviewPanel: React.FC<OverviewPanelProps> = ({
 
 export const ScheduledTaskOverview: React.FC<ScheduledTaskOverviewProps> = ({
   tasks,
-  partial
+  partial,
+  results = [],
+  onOpenResult
 }) => {
   const statuses = tasks.map(getScheduledTaskProductStatus)
   const needsAttentionCount = statuses.filter(
@@ -79,6 +84,7 @@ export const ScheduledTaskOverview: React.FC<ScheduledTaskOverviewProps> = ({
     (status) => status.key === "running"
   ).length
   const nextRunTimestamp = findNextRunTimestamp(tasks)
+  const latestResult = results[0] ?? null
 
   return (
     <section aria-label="Scheduled task overview">
@@ -116,6 +122,23 @@ export const ScheduledTaskOverview: React.FC<ScheduledTaskOverviewProps> = ({
           </OverviewPanel>
         </Col>
       </Row>
+      {latestResult ? (
+        <Card size="small" style={{ marginTop: 12 }}>
+          <Space orientation="vertical" size={6} style={{ width: "100%" }}>
+            <Typography.Text type="secondary">Latest result signal</Typography.Text>
+            <Typography.Text strong>{latestResult.title}</Typography.Text>
+            <Typography.Text type="secondary">{latestResult.summary}</Typography.Text>
+            {onOpenResult ? (
+              <Button
+                size="small"
+                onClick={() => onOpenResult(latestResult)}
+              >
+                Open latest result signal
+              </Button>
+            ) : null}
+          </Space>
+        </Card>
+      ) : null}
     </section>
   )
 }

--- a/apps/packages/ui/src/components/Option/ScheduledTasks/ScheduledTaskResultDetailDrawer.tsx
+++ b/apps/packages/ui/src/components/Option/ScheduledTasks/ScheduledTaskResultDetailDrawer.tsx
@@ -1,0 +1,155 @@
+import React from "react"
+import { Alert, Button, Descriptions, Drawer, Space, Tag, Typography } from "antd"
+
+import { formatScheduledTaskTimestamp } from "./scheduled-task-status"
+import type { ScheduledTaskResultItem } from "./scheduled-task-results"
+
+export interface ScheduledTaskResultDetailDrawerProps {
+  open: boolean
+  result: ScheduledTaskResultItem | null
+  onClose: () => void
+  onReviewResult: (result: ScheduledTaskResultItem) => void
+  onRetryRun: (result: ScheduledTaskResultItem) => void
+}
+
+const UNSUPPORTED_ACTION_COPY =
+  "Review and retry actions appear when this server supports them for the selected result."
+
+const severityToTagColor = (severity: ScheduledTaskResultItem["severity"]): string => {
+  switch (severity) {
+    case "success":
+      return "green"
+    case "warning":
+      return "gold"
+    case "error":
+      return "red"
+    default:
+      return "processing"
+  }
+}
+
+const statusLabel = (result: ScheduledTaskResultItem): string => {
+  if (result.signalKind === "result") return "Found results"
+  if (result.state === "blocked") return "Blocked"
+  if (result.signalKind === "failure") return "Needs attention"
+  if (result.state === "paused") return "Paused"
+  if (result.signalKind === "running") return "Running now"
+  return "Completed/no results"
+}
+
+const optionalDescriptionItem = (
+  label: string,
+  value: string | number | null | undefined
+): React.ReactNode => {
+  if (value === null || value === undefined || String(value).trim() === "") {
+    return null
+  }
+
+  return (
+    <Descriptions.Item label={label} key={label}>
+      {String(value)}
+    </Descriptions.Item>
+  )
+}
+
+const renderActionLinks = (result: ScheduledTaskResultItem): React.ReactNode => {
+  const links: Array<{ href: string | null; label: string }> = [
+    { href: result.resultHref, label: "Open result" },
+    { href: result.runHref, label: "Open run" },
+    { href: result.sourceHref, label: "Open owner workspace" }
+  ]
+  const visibleLinks = links.filter((link): link is { href: string; label: string } =>
+    Boolean(link.href)
+  )
+
+  if (visibleLinks.length === 0) {
+    return <Typography.Text type="secondary">No owner links are available yet.</Typography.Text>
+  }
+
+  return (
+    <Space wrap>
+      {visibleLinks.map((link) => (
+        <Button key={link.label} href={link.href}>
+          {link.label}
+        </Button>
+      ))}
+    </Space>
+  )
+}
+
+export const ScheduledTaskResultDetailDrawer: React.FC<
+  ScheduledTaskResultDetailDrawerProps
+> = ({ open, result, onClose, onReviewResult, onRetryRun }) => {
+  const titleId = React.useId()
+  const drawerTitle = result ? `${result.title} result` : "Scheduled task result"
+
+  return (
+    <Drawer
+      aria-labelledby={titleId}
+      title={<span id={titleId}>{drawerTitle}</span>}
+      open={open}
+      onClose={onClose}
+      size={560}
+    >
+      {result ? (
+        <Space orientation="vertical" size="large" style={{ width: "100%" }}>
+          <div>
+            <Typography.Title level={5}>Why this is here</Typography.Title>
+            <Typography.Paragraph type="secondary" style={{ marginBottom: 0 }}>
+              {result.summary}
+            </Typography.Paragraph>
+          </div>
+
+          <Descriptions bordered size="small" column={1}>
+            <Descriptions.Item label="State">
+              <Tag color={severityToTagColor(result.severity)}>
+                {statusLabel(result)}
+              </Tag>
+            </Descriptions.Item>
+            <Descriptions.Item label="Owner">{result.ownerLabel}</Descriptions.Item>
+            <Descriptions.Item label="Task type">{result.taskTypeLabel}</Descriptions.Item>
+            {optionalDescriptionItem("Task id", result.taskId)}
+            {optionalDescriptionItem("Run id", result.runId)}
+            {optionalDescriptionItem("Result id", result.resultId)}
+            {optionalDescriptionItem("Result count", result.resultCount)}
+            {optionalDescriptionItem("Source", result.sourceLabel)}
+            {optionalDescriptionItem("Matched rule", result.matchedRuleLabel)}
+            {optionalDescriptionItem("Output", result.outputLabel)}
+            <Descriptions.Item label="Last signal">
+              {formatScheduledTaskTimestamp(result.occurredAt, "No run time")}
+            </Descriptions.Item>
+          </Descriptions>
+
+          <div>
+            <Typography.Title level={5}>Continue in</Typography.Title>
+            {renderActionLinks(result)}
+          </div>
+
+          <div>
+            <Typography.Title level={5}>Actions</Typography.Title>
+            {result.reviewAvailable || result.retryAvailable ? (
+              <Space wrap>
+                {result.reviewAvailable ? (
+                  <Button type="primary" onClick={() => onReviewResult(result)}>
+                    Mark reviewed
+                  </Button>
+                ) : null}
+                {result.retryAvailable ? (
+                  <Button onClick={() => onRetryRun(result)}>
+                    Retry run
+                  </Button>
+                ) : null}
+              </Space>
+            ) : (
+              <Alert type="info" showIcon title={UNSUPPORTED_ACTION_COPY} />
+            )}
+          </div>
+        </Space>
+      ) : (
+        <Typography.Text type="secondary">Select a result to inspect.</Typography.Text>
+      )}
+    </Drawer>
+  )
+}
+
+export default ScheduledTaskResultDetailDrawer

--- a/apps/packages/ui/src/components/Option/ScheduledTasks/ScheduledTaskResultsPanel.tsx
+++ b/apps/packages/ui/src/components/Option/ScheduledTasks/ScheduledTaskResultsPanel.tsx
@@ -1,0 +1,402 @@
+import React, { useMemo, useState } from "react"
+import { Alert, Button, Empty, Input, Select, Space, Table, Tag, Typography } from "antd"
+import type { ColumnsType } from "antd/es/table"
+
+import { formatScheduledTaskTimestamp } from "./scheduled-task-status"
+import {
+  filterScheduledTaskResults,
+  type ScheduledTaskResultItem,
+  type ScheduledTaskResultOwner,
+  type ScheduledTaskResultSignalKind,
+  type ScheduledTaskResultState,
+  type ScheduledTaskResultsCapabilityMode
+} from "./scheduled-task-results"
+
+export interface ScheduledTaskResultsPanelProps {
+  results: ScheduledTaskResultItem[]
+  taskCount: number
+  capabilityMode: ScheduledTaskResultsCapabilityMode
+  onCreateTask: () => void
+  onOpenResult: (result: ScheduledTaskResultItem) => void
+}
+
+type ResultStateFilter =
+  | "all"
+  | "result"
+  | "failure"
+  | "running"
+  | "completed_no_results"
+
+type ReviewStateFilter = "all" | "unreviewed" | "reviewed"
+
+const resultStateOptions: Array<{ value: ResultStateFilter; label: string }> = [
+  { value: "all", label: "All states" },
+  { value: "result", label: "Found results" },
+  { value: "failure", label: "Needs attention" },
+  { value: "running", label: "Running" },
+  { value: "completed_no_results", label: "Completed/no results" }
+]
+
+const reviewStateOptions: Array<{ value: ReviewStateFilter; label: string }> = [
+  { value: "all", label: "All" },
+  { value: "unreviewed", label: "Unreviewed" },
+  { value: "reviewed", label: "Reviewed" }
+]
+
+const severityToTagColor = (severity: ScheduledTaskResultItem["severity"]): string => {
+  switch (severity) {
+    case "success":
+      return "green"
+    case "warning":
+      return "gold"
+    case "error":
+      return "red"
+    default:
+      return "processing"
+  }
+}
+
+const resultStatusLabel = (result: ScheduledTaskResultItem): string => {
+  if (result.signalKind === "result") return "Found results"
+  if (result.state === "blocked") return "Blocked"
+  if (result.signalKind === "failure") return "Needs attention"
+  if (result.state === "paused") return "Paused"
+  if (result.signalKind === "running") return "Running now"
+  return "Completed/no results"
+}
+
+const stateFilterToSignalKinds = (
+  stateFilter: ResultStateFilter
+): ScheduledTaskResultSignalKind[] | null => {
+  switch (stateFilter) {
+    case "result":
+      return ["result"]
+    case "failure":
+      return ["failure"]
+    case "running":
+      return ["running"]
+    case "completed_no_results":
+      return ["completed_no_results"]
+    default:
+      return null
+  }
+}
+
+const stateFilterToStates = (
+  stateFilter: ResultStateFilter
+): ScheduledTaskResultState[] | null => {
+  if (stateFilter === "completed_no_results") {
+    return ["completed_no_results"]
+  }
+  return null
+}
+
+const hasActiveFilters = ({
+  searchText,
+  stateFilter,
+  taskTypeFilter,
+  ownerFilter,
+  reviewStateFilter
+}: {
+  searchText: string
+  stateFilter: ResultStateFilter
+  taskTypeFilter: string
+  ownerFilter: string
+  reviewStateFilter: ReviewStateFilter
+}): boolean =>
+  Boolean(searchText.trim()) ||
+  stateFilter !== "all" ||
+  taskTypeFilter !== "all" ||
+  ownerFilter !== "all" ||
+  reviewStateFilter !== "all"
+
+export const ScheduledTaskResultsPanel: React.FC<ScheduledTaskResultsPanelProps> = ({
+  results,
+  taskCount,
+  capabilityMode,
+  onCreateTask,
+  onOpenResult
+}) => {
+  const [searchText, setSearchText] = useState("")
+  const [stateFilter, setStateFilter] = useState<ResultStateFilter>("all")
+  const [taskTypeFilter, setTaskTypeFilter] = useState("all")
+  const [ownerFilter, setOwnerFilter] = useState<ScheduledTaskResultOwner | "all">("all")
+  const [reviewStateFilter, setReviewStateFilter] = useState<ReviewStateFilter>("all")
+  const canShowReviewState = capabilityMode !== "projected_signals"
+
+  const taskTypeOptions = useMemo(() => {
+    const uniqueTypes = Array.from(new Set(results.map((result) => result.taskTypeLabel)))
+    return [
+      { value: "all", label: "All types" },
+      ...uniqueTypes.map((type) => ({ value: type, label: type }))
+    ]
+  }, [results])
+
+  const ownerOptions = useMemo(() => {
+    const ownerMap = new Map<ScheduledTaskResultOwner, string>()
+    results.forEach((result) => {
+      ownerMap.set(result.owner, result.ownerLabel)
+    })
+    return [
+      { value: "all", label: "All owners" },
+      ...Array.from(ownerMap.entries()).map(([value, label]) => ({ value, label }))
+    ]
+  }, [results])
+
+  const filteredResults = useMemo(() => {
+    const signalKinds = stateFilterToSignalKinds(stateFilter)
+    const states = stateFilterToStates(stateFilter)
+    const reviewState =
+      canShowReviewState && reviewStateFilter !== "all" ? reviewStateFilter : "all"
+    const byStructuredFilters = filterScheduledTaskResults(results, {
+      ...(signalKinds ? { signalKinds } : {}),
+      ...(states ? { states } : {}),
+      ...(ownerFilter !== "all" ? { owners: [ownerFilter] } : {}),
+      reviewState
+    })
+    const normalizedSearch = searchText.trim().toLowerCase()
+
+    return byStructuredFilters.filter((result) => {
+      const taskTypeMatches =
+        taskTypeFilter === "all" || result.taskTypeLabel === taskTypeFilter
+      const searchMatches =
+        !normalizedSearch ||
+        [
+          result.title,
+          result.summary,
+          result.ownerLabel,
+          result.taskTypeLabel,
+          result.sourceLabel,
+          result.matchedRuleLabel,
+          result.outputLabel,
+          resultStatusLabel(result)
+        ].some((value) => String(value || "").toLowerCase().includes(normalizedSearch))
+
+      return taskTypeMatches && searchMatches
+    })
+  }, [
+    canShowReviewState,
+    ownerFilter,
+    results,
+    reviewStateFilter,
+    searchText,
+    stateFilter,
+    taskTypeFilter
+  ])
+
+  const resetFilters = () => {
+    setSearchText("")
+    setStateFilter("all")
+    setTaskTypeFilter("all")
+    setOwnerFilter("all")
+    setReviewStateFilter("all")
+  }
+
+  const activeFilters = hasActiveFilters({
+    searchText,
+    stateFilter,
+    taskTypeFilter,
+    ownerFilter,
+    reviewStateFilter
+  })
+
+  const columns: ColumnsType<ScheduledTaskResultItem> = [
+    {
+      title: "Result",
+      key: "result",
+      render: (_, result) => (
+        <Space orientation="vertical" size={4}>
+          <Typography.Text strong>{result.title}</Typography.Text>
+          <Typography.Text type="secondary">{result.summary}</Typography.Text>
+          <Space wrap size={4}>
+            <Tag>{result.taskTypeLabel}</Tag>
+            <Tag>{result.ownerLabel}</Tag>
+          </Space>
+        </Space>
+      )
+    },
+    {
+      title: "State",
+      key: "state",
+      render: (_, result) => (
+        <Tag color={severityToTagColor(result.severity)}>
+          {resultStatusLabel(result)}
+        </Tag>
+      )
+    },
+    {
+      title: "Last signal",
+      key: "occurredAt",
+      render: (_, result) => (
+        <Typography.Text>
+          {formatScheduledTaskTimestamp(result.occurredAt, "No run time")}
+        </Typography.Text>
+      )
+    },
+    {
+      title: "Actions",
+      key: "actions",
+      render: (_, result) => (
+        <Button
+          size="small"
+          aria-label={`Open signal for ${result.title}`}
+          onClick={() => onOpenResult(result)}
+        >
+          Open signal
+        </Button>
+      )
+    }
+  ]
+
+  if (taskCount === 0) {
+    return (
+      <Space orientation="vertical" size={16} style={{ width: "100%" }}>
+        <PanelHeader capabilityMode={capabilityMode} />
+        <Empty
+          image={Empty.PRESENTED_IMAGE_SIMPLE}
+          description={
+            <Space orientation="vertical" size={4}>
+              <Typography.Text strong>No scheduled tasks yet</Typography.Text>
+              <Typography.Text type="secondary">
+                Results and failures appear here after an automation runs.
+              </Typography.Text>
+            </Space>
+          }
+        >
+          <Button type="primary" onClick={onCreateTask}>
+            Create scheduled task
+          </Button>
+        </Empty>
+      </Space>
+    )
+  }
+
+  if (results.length === 0) {
+    return (
+      <Space orientation="vertical" size={16} style={{ width: "100%" }}>
+        <PanelHeader capabilityMode={capabilityMode} />
+        <Empty
+          image={Empty.PRESENTED_IMAGE_SIMPLE}
+          description={
+            <Space orientation="vertical" size={4}>
+              <Typography.Text strong>No results to review</Typography.Text>
+              <Typography.Text type="secondary">
+                The latest scheduled runs have not produced new results or failures.
+              </Typography.Text>
+            </Space>
+          }
+        />
+      </Space>
+    )
+  }
+
+  return (
+    <Space orientation="vertical" size={16} style={{ width: "100%" }}>
+      <PanelHeader capabilityMode={capabilityMode} />
+      <Space wrap>
+        <Input
+          allowClear
+          aria-label="Search scheduled task results"
+          placeholder="Search results"
+          value={searchText}
+          onChange={(event) => setSearchText(event.target.value)}
+          style={{ width: 240 }}
+        />
+        <Space align="center" size={8}>
+          <Typography.Text type="secondary">Result state</Typography.Text>
+          <Select
+            aria-label="Result state filter"
+            value={stateFilter}
+            onChange={(value) => setStateFilter(value)}
+            options={resultStateOptions}
+            style={{ width: 190 }}
+          />
+        </Space>
+        <Space align="center" size={8}>
+          <Typography.Text type="secondary">Task type</Typography.Text>
+          <Select
+            aria-label="Task type filter"
+            value={taskTypeFilter}
+            onChange={(value) => setTaskTypeFilter(value)}
+            options={taskTypeOptions}
+            style={{ width: 190 }}
+          />
+        </Space>
+        <Space align="center" size={8}>
+          <Typography.Text type="secondary">Owner</Typography.Text>
+          <Select
+            aria-label="Owner filter"
+            value={ownerFilter}
+            onChange={(value) => setOwnerFilter(value)}
+            options={ownerOptions}
+            style={{ width: 170 }}
+          />
+        </Space>
+        {canShowReviewState ? (
+          <Space align="center" size={8}>
+            <Typography.Text type="secondary">Review state</Typography.Text>
+            <Select
+              aria-label="Review state filter"
+              value={reviewStateFilter}
+              onChange={(value) => setReviewStateFilter(value)}
+              options={reviewStateOptions}
+              style={{ width: 160 }}
+            />
+          </Space>
+        ) : null}
+      </Space>
+
+      {filteredResults.length === 0 ? (
+        <Empty
+          image={Empty.PRESENTED_IMAGE_SIMPLE}
+          description={
+            <Space orientation="vertical" size={4}>
+              <Typography.Text strong>No results match these filters</Typography.Text>
+              <Typography.Text type="secondary">
+                Adjust the result state, task type, owner, or search filters.
+              </Typography.Text>
+            </Space>
+          }
+        >
+          {activeFilters ? <Button onClick={resetFilters}>Clear filters</Button> : null}
+        </Empty>
+      ) : (
+        <Table<ScheduledTaskResultItem>
+          rowKey="id"
+          columns={columns}
+          dataSource={filteredResults}
+          pagination={false}
+          scroll={{ x: "max-content" }}
+        />
+      )}
+    </Space>
+  )
+}
+
+const PanelHeader: React.FC<{ capabilityMode: ScheduledTaskResultsCapabilityMode }> = ({
+  capabilityMode
+}) => (
+  <Space orientation="vertical" size={12} style={{ width: "100%" }}>
+    <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+      <Typography.Title level={3} style={{ marginBottom: 0 }}>
+        Scheduled task results
+      </Typography.Title>
+      <Typography.Paragraph type="secondary" style={{ marginBottom: 0 }}>
+        Review outputs, failures, and run state from recurring automations.
+        Source-specific setup stays in the owning workspace.
+      </Typography.Paragraph>
+    </div>
+    <Alert
+      type="info"
+      showIcon
+      title={capabilityMode === "projected_signals" ? "Latest automation signals" : "Results"}
+      description={
+        capabilityMode === "projected_signals"
+          ? "Latest signals inferred from task status. Durable review state appears when the results API is available."
+          : "Review state comes from the scheduled-task results API."
+      }
+    />
+  </Space>
+)
+
+export default ScheduledTaskResultsPanel

--- a/apps/packages/ui/src/components/Option/ScheduledTasks/ScheduledTaskResultsPanel.tsx
+++ b/apps/packages/ui/src/components/Option/ScheduledTasks/ScheduledTaskResultsPanel.tsx
@@ -279,7 +279,7 @@ export const ScheduledTaskResultsPanel: React.FC<ScheduledTaskResultsPanelProps>
           image={Empty.PRESENTED_IMAGE_SIMPLE}
           description={
             <Space orientation="vertical" size={4}>
-              <Typography.Text strong>No results to review</Typography.Text>
+              <Typography.Text strong>No automation signals yet</Typography.Text>
               <Typography.Text type="secondary">
                 The latest scheduled runs have not produced new results or failures.
               </Typography.Text>
@@ -382,7 +382,7 @@ const PanelHeader: React.FC<{ capabilityMode: ScheduledTaskResultsCapabilityMode
         Scheduled task results
       </Typography.Title>
       <Typography.Paragraph type="secondary" style={{ marginBottom: 0 }}>
-        Review outputs, failures, and run state from recurring automations.
+        Inspect outputs, failures, and run state from recurring automations.
         Source-specific setup stays in the owning workspace.
       </Typography.Paragraph>
     </div>
@@ -392,7 +392,7 @@ const PanelHeader: React.FC<{ capabilityMode: ScheduledTaskResultsCapabilityMode
       title={capabilityMode === "projected_signals" ? "Latest automation signals" : "Results"}
       description={
         capabilityMode === "projected_signals"
-          ? "Latest signals inferred from task status. Durable review state appears when the results API is available."
+          ? "Latest signals inferred from task status. Result history and item actions appear when the results API is available."
           : "Review state comes from the scheduled-task results API."
       }
     />

--- a/apps/packages/ui/src/components/Option/ScheduledTasks/ScheduledTaskTable.tsx
+++ b/apps/packages/ui/src/components/Option/ScheduledTasks/ScheduledTaskTable.tsx
@@ -16,6 +16,7 @@ import {
   type ScheduledTaskStatusKey
 } from "./scheduled-task-status"
 import { WatchlistTaskActionLinks } from "./WatchlistTaskActionLinks"
+import type { ScheduledTaskResultItem } from "./scheduled-task-results"
 
 export interface ScheduledTaskTableRowActionContext {
   task: ScheduledTask
@@ -23,8 +24,10 @@ export interface ScheduledTaskTableRowActionContext {
 
 export interface ScheduledTaskTableProps {
   tasks: ScheduledTask[]
+  results?: ScheduledTaskResultItem[]
   onCreateReminder: () => void
   onInspectTask: (task: ScheduledTask) => void
+  onOpenTaskResults?: (task: ScheduledTask) => void
   onEditReminder: (task: ScheduledTask) => void
   onDeleteReminder: (task: ScheduledTask) => void
 }
@@ -96,8 +99,10 @@ const typeFilterOptions: Array<{
 
 export const ScheduledTaskTable: React.FC<ScheduledTaskTableProps> = ({
   tasks,
+  results = [],
   onCreateReminder,
   onInspectTask,
+  onOpenTaskResults,
   onEditReminder,
   onDeleteReminder
 }) => {
@@ -119,6 +124,29 @@ export const ScheduledTaskTable: React.FC<ScheduledTaskTableProps> = ({
       }),
     [tasks, searchText, statusFilter, typeFilter]
   )
+  const resultCountByTaskId = useMemo(() => {
+    const counts = new Map<string, number>()
+    results.forEach((result) => {
+      counts.set(result.taskId, (counts.get(result.taskId) ?? 0) + 1)
+    })
+    return counts
+  }, [results])
+
+  const renderResultsButton = (task: ScheduledTask) => {
+    if (!onOpenTaskResults || !resultCountByTaskId.has(task.id)) {
+      return null
+    }
+
+    return (
+      <Button
+        size="small"
+        aria-label={rowActionLabel("View results for", task)}
+        onClick={() => onOpenTaskResults(task)}
+      >
+        Results
+      </Button>
+    )
+  }
 
   const columns: ColumnsType<ScheduledTask> = [
     {
@@ -210,6 +238,7 @@ export const ScheduledTaskTable: React.FC<ScheduledTaskTableProps> = ({
               >
                 Inspect
               </Button>
+              {renderResultsButton(task)}
               <Button
                 size="small"
                 aria-label={rowActionLabel("Edit", task)}
@@ -238,6 +267,7 @@ export const ScheduledTaskTable: React.FC<ScheduledTaskTableProps> = ({
             >
               Inspect
             </Button>
+            {renderResultsButton(task)}
             <WatchlistTaskActionLinks
               task={task}
               size="small"

--- a/apps/packages/ui/src/components/Option/ScheduledTasks/ScheduledTasksPage.tsx
+++ b/apps/packages/ui/src/components/Option/ScheduledTasks/ScheduledTasksPage.tsx
@@ -178,6 +178,13 @@ export const ScheduledTasksPage: React.FC = () => {
     },
     [createdTaskFallback, selectedTaskId, tasks]
   )
+  const selectedTaskLatestResult = React.useMemo(
+    () =>
+      selectedTask
+        ? projectedResults.find((result) => result.taskId === selectedTask.id) ?? null
+        : null,
+    [projectedResults, selectedTask]
+  )
   const hasLoadedTasks = Boolean(tasksQuery.data)
   const hasWatchlistJob = tasks.some((task) => task.primitive === "watchlist_job")
   const selectedTemplate = React.useMemo(
@@ -411,6 +418,8 @@ export const ScheduledTasksPage: React.FC = () => {
         <ScheduledTaskOverview
           tasks={tasks}
           partial={Boolean(tasksQuery.data?.partial)}
+          results={projectedResults}
+          onOpenResult={openResultSignal}
         />
       ) : null}
 
@@ -431,6 +440,10 @@ export const ScheduledTasksPage: React.FC = () => {
       runId: result.runId,
       taskId: result.taskId
     })
+  }
+
+  const openTaskResults = (task: ScheduledTask) => {
+    updateRoute({ tab: "results", taskId: task.id })
   }
 
   const renderResultsTab = () => (
@@ -475,8 +488,10 @@ export const ScheduledTasksPage: React.FC = () => {
       {hasLoadedTasks && tasks.length > 0 ? (
         <ScheduledTaskTable
           tasks={tasks}
+          results={projectedResults}
           onCreateReminder={openCreateReminder}
           onInspectTask={openTaskDetail}
+          onOpenTaskResults={openTaskResults}
           onEditReminder={openEditReminder}
           onDeleteReminder={handleDeleteReminder}
         />
@@ -600,6 +615,7 @@ export const ScheduledTasksPage: React.FC = () => {
             <ScheduledTaskDetailDrawer
               open
               task={selectedTask}
+              latestResult={selectedTaskLatestResult}
               onClose={closeTaskDetail}
               onEditReminder={openEditReminder}
               onDeleteReminder={handleDeleteReminder}

--- a/apps/packages/ui/src/components/Option/ScheduledTasks/ScheduledTasksPage.tsx
+++ b/apps/packages/ui/src/components/Option/ScheduledTasks/ScheduledTasksPage.tsx
@@ -89,13 +89,20 @@ export const ScheduledTasksPage: React.FC = () => {
       runId?: string | null
       resultId?: string | null
     }) => {
+      const normalizedPath = location.pathname.replace(/\/+$/, "")
+      const onResultsAlias = normalizedPath.endsWith("/scheduled-tasks/results")
+      if (tab === "overview" && onResultsAlias) {
+        navigate("/scheduled-tasks")
+        return
+      }
+
       setSearchParams(
         new URLSearchParams(
           buildScheduledTaskSearch({ tab, templateId, taskId, runId, resultId })
         )
       )
     },
-    [setSearchParams]
+    [location.pathname, navigate, setSearchParams]
   )
 
   React.useEffect(() => {

--- a/apps/packages/ui/src/components/Option/ScheduledTasks/ScheduledTasksPage.tsx
+++ b/apps/packages/ui/src/components/Option/ScheduledTasks/ScheduledTasksPage.tsx
@@ -2,7 +2,7 @@ import React, { useState } from "react"
 import { Alert, Button, Empty, Space, Spin, Tabs, Typography, message } from "antd"
 import { useQuery } from "@tanstack/react-query"
 import { useTranslation } from "react-i18next"
-import { useNavigate, useSearchParams } from "react-router-dom"
+import { useLocation, useNavigate, useSearchParams } from "react-router-dom"
 import { RecoveryCallout, buildCapabilityState } from "@/components/ui/state"
 import { useCanonicalConnectionConfig } from "@/hooks/useCanonicalConnectionConfig"
 import {
@@ -27,6 +27,10 @@ import {
   type ScheduledTaskTabId
 } from "./scheduled-task-route-state"
 import {
+  findScheduledTaskResultByRouteState,
+  projectScheduledTaskResults
+} from "./scheduled-task-results"
+import {
   getScheduledTaskTemplate,
   type ScheduledTaskTemplateId
 } from "./scheduled-task-templates"
@@ -44,6 +48,7 @@ const LoadingState: React.FC = () => (
 )
 
 export const ScheduledTasksPage: React.FC = () => {
+  const location = useLocation()
   const navigate = useNavigate()
   const [searchParams, setSearchParams] = useSearchParams()
   const { t } = useTranslation(["scheduledTasks", "common"])
@@ -58,21 +63,34 @@ export const ScheduledTasksPage: React.FC = () => {
     boolean | null
   >(null)
   const routeState = React.useMemo(
-    () => parseScheduledTaskRouteState(searchParams),
-    [searchParams]
+    () =>
+      parseScheduledTaskRouteState(searchParams, {
+        defaultTab: location.pathname.replace(/\/+$/, "").endsWith("/scheduled-tasks/results")
+          ? "results"
+          : "overview"
+      }),
+    [location.pathname, searchParams]
   )
 
   const updateRoute = React.useCallback(
     ({
       tab,
       templateId,
-      taskId
+      taskId,
+      runId,
+      resultId
     }: {
       tab: ScheduledTaskTabId
       templateId?: string | null
       taskId?: string | null
+      runId?: string | null
+      resultId?: string | null
     }) => {
-      setSearchParams(new URLSearchParams(buildScheduledTaskSearch({ tab, templateId, taskId })))
+      setSearchParams(
+        new URLSearchParams(
+          buildScheduledTaskSearch({ tab, templateId, taskId, runId, resultId })
+        )
+      )
     },
     [setSearchParams]
   )
@@ -138,6 +156,17 @@ export const ScheduledTasksPage: React.FC = () => {
   })
 
   const tasks = tasksQuery.data?.items ?? []
+  const projectedResults = React.useMemo(
+    () => projectScheduledTaskResults(tasks, { includeCompletedNoResults: true }),
+    [tasks]
+  )
+  const selectedResult = React.useMemo(
+    () =>
+      routeState.tab === "results"
+        ? findScheduledTaskResultByRouteState(projectedResults, routeState)
+        : null,
+    [projectedResults, routeState]
+  )
   const selectedTask = React.useMemo(
     () => {
       const refreshedTask = tasks.find((task) => task.id === selectedTaskId)
@@ -361,6 +390,13 @@ export const ScheduledTasksPage: React.FC = () => {
     Boolean(routeState.taskId) &&
     !tasks.some((task) => task.id === routeState.taskId) &&
     selectedTaskId !== routeState.taskId
+  const hasResultRouteTarget =
+    routeState.tab === "results" &&
+    Boolean(routeState.resultId || routeState.runId || routeState.taskId)
+  const missingRouteResult =
+    hasLoadedTasks &&
+    hasResultRouteTarget &&
+    selectedResult === null
 
   const renderOverviewTab = () => (
     <Space orientation="vertical" size={16} style={{ width: "100%" }}>
@@ -377,6 +413,114 @@ export const ScheduledTasksPage: React.FC = () => {
           showIcon
           title="Watchlists remains the full workspace for monitor setup, source tuning, run activity, and reports."
         />
+      ) : null}
+    </Space>
+  )
+
+  const openResultSignal = (
+    resultId: string | null,
+    runId: string | null,
+    taskId: string
+  ) => {
+    updateRoute({ tab: "results", resultId, runId, taskId })
+  }
+
+  const renderResultsTab = () => (
+    <Space orientation="vertical" size={16} style={{ width: "100%" }}>
+      <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+        <Typography.Title level={3} style={{ marginBottom: 0 }}>
+          Scheduled task results
+        </Typography.Title>
+        <Typography.Paragraph type="secondary" style={{ marginBottom: 0 }}>
+          Review outputs, failures, and run state from recurring automations.
+          Source-specific setup stays in the owning workspace.
+        </Typography.Paragraph>
+      </div>
+
+      <Alert
+        type="info"
+        showIcon
+        title="Latest automation signals"
+        description="Latest signals inferred from task status. Durable review state appears when the results API is available."
+      />
+
+      {missingRouteResult ? (
+        <Alert type="warning" showIcon title="Result signal not found." />
+      ) : null}
+
+      {selectedResult ? (
+        <Alert
+          type={selectedResult.severity === "error" ? "error" : "success"}
+          showIcon
+          title={`Selected signal: ${selectedResult.title}`}
+          description={selectedResult.summary}
+        />
+      ) : null}
+
+      {hasLoadedTasks && tasks.length === 0 ? (
+        <Empty
+          image={Empty.PRESENTED_IMAGE_SIMPLE}
+          description={
+            <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+              <Typography.Text strong>No scheduled tasks yet</Typography.Text>
+              <Typography.Text type="secondary">
+                Results and failures appear here after an automation runs.
+              </Typography.Text>
+            </div>
+          }
+        >
+          <Button type="primary" onClick={openCreateReminder}>
+            Create scheduled task
+          </Button>
+        </Empty>
+      ) : null}
+
+      {hasLoadedTasks && tasks.length > 0 && projectedResults.length === 0 ? (
+        <Empty
+          image={Empty.PRESENTED_IMAGE_SIMPLE}
+          description={
+            <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+              <Typography.Text strong>No results to review</Typography.Text>
+              <Typography.Text type="secondary">
+                The latest scheduled runs have not produced new results or failures.
+              </Typography.Text>
+            </div>
+          }
+        />
+      ) : null}
+
+      {projectedResults.length > 0 ? (
+        <section aria-label="Scheduled task results">
+          <Space orientation="vertical" size={12} style={{ width: "100%" }}>
+            {projectedResults.map((result) => (
+              <div
+                key={result.id}
+                style={{
+                  border: "1px solid var(--ant-color-border, #d9d9d9)",
+                  borderRadius: 8,
+                  padding: 12
+                }}
+              >
+                <Space orientation="vertical" size={4} style={{ width: "100%" }}>
+                  <Typography.Text strong>{result.title}</Typography.Text>
+                  <Typography.Text type="secondary">{result.summary}</Typography.Text>
+                  <Typography.Text type="secondary">
+                    {result.ownerLabel} - {result.state.replace(/_/g, " ")}
+                  </Typography.Text>
+                  <Button
+                    type="link"
+                    style={{ alignSelf: "flex-start", paddingInline: 0 }}
+                    onClick={() => {
+                      openResultSignal(result.resultId, result.runId, result.taskId)
+                    }}
+                  >
+                    Open signal for {result.title}
+                  </Button>
+                </Space>
+              </div>
+            ))}
+          </Space>
+        </section>
       ) : null}
     </Space>
   )
@@ -506,6 +650,8 @@ export const ScheduledTasksPage: React.FC = () => {
               children:
                 tab.id === "overview"
                   ? renderOverviewTab()
+                  : tab.id === "results"
+                    ? renderResultsTab()
                   : tab.id === "tasks"
                     ? renderTasksTab()
                     : (

--- a/apps/packages/ui/src/components/Option/ScheduledTasks/ScheduledTasksPage.tsx
+++ b/apps/packages/ui/src/components/Option/ScheduledTasks/ScheduledTasksPage.tsx
@@ -19,6 +19,8 @@ import { ReminderTaskEditor } from "./ReminderTaskEditor"
 import { ScheduledTaskOverview } from "./ScheduledTaskOverview"
 import { ScheduledTaskDetailDrawer } from "./ScheduledTaskDetailDrawer"
 import { ScheduledTaskCreatePanel } from "./ScheduledTaskCreatePanel"
+import { ScheduledTaskResultsPanel } from "./ScheduledTaskResultsPanel"
+import { ScheduledTaskResultDetailDrawer } from "./ScheduledTaskResultDetailDrawer"
 import { DEFAULT_SCHEDULED_TASK_TEMPLATE_CAPABILITIES } from "./scheduled-task-template-capabilities"
 import {
   SCHEDULED_TASK_TABS,
@@ -28,7 +30,8 @@ import {
 } from "./scheduled-task-route-state"
 import {
   findScheduledTaskResultByRouteState,
-  projectScheduledTaskResults
+  projectScheduledTaskResults,
+  type ScheduledTaskResultItem
 } from "./scheduled-task-results"
 import {
   getScheduledTaskTemplate,
@@ -263,6 +266,10 @@ export const ScheduledTasksPage: React.FC = () => {
     updateRoute({ tab: "tasks" })
   }
 
+  const closeResultDetail = () => {
+    updateRoute({ tab: "results" })
+  }
+
   const openCreateReminder = () => {
     closeTaskDetail()
     setEditingTask(null)
@@ -417,111 +424,27 @@ export const ScheduledTasksPage: React.FC = () => {
     </Space>
   )
 
-  const openResultSignal = (
-    resultId: string | null,
-    runId: string | null,
-    taskId: string
-  ) => {
-    updateRoute({ tab: "results", resultId, runId, taskId })
+  const openResultSignal = (result: ScheduledTaskResultItem) => {
+    updateRoute({
+      tab: "results",
+      resultId: result.resultId,
+      runId: result.runId,
+      taskId: result.taskId
+    })
   }
 
   const renderResultsTab = () => (
     <Space orientation="vertical" size={16} style={{ width: "100%" }}>
-      <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
-        <Typography.Title level={3} style={{ marginBottom: 0 }}>
-          Scheduled task results
-        </Typography.Title>
-        <Typography.Paragraph type="secondary" style={{ marginBottom: 0 }}>
-          Review outputs, failures, and run state from recurring automations.
-          Source-specific setup stays in the owning workspace.
-        </Typography.Paragraph>
-      </div>
-
-      <Alert
-        type="info"
-        showIcon
-        title="Latest automation signals"
-        description="Latest signals inferred from task status. Durable review state appears when the results API is available."
-      />
-
       {missingRouteResult ? (
         <Alert type="warning" showIcon title="Result signal not found." />
       ) : null}
-
-      {selectedResult ? (
-        <Alert
-          type={selectedResult.severity === "error" ? "error" : "success"}
-          showIcon
-          title={`Selected signal: ${selectedResult.title}`}
-          description={selectedResult.summary}
-        />
-      ) : null}
-
-      {hasLoadedTasks && tasks.length === 0 ? (
-        <Empty
-          image={Empty.PRESENTED_IMAGE_SIMPLE}
-          description={
-            <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
-              <Typography.Text strong>No scheduled tasks yet</Typography.Text>
-              <Typography.Text type="secondary">
-                Results and failures appear here after an automation runs.
-              </Typography.Text>
-            </div>
-          }
-        >
-          <Button type="primary" onClick={openCreateReminder}>
-            Create scheduled task
-          </Button>
-        </Empty>
-      ) : null}
-
-      {hasLoadedTasks && tasks.length > 0 && projectedResults.length === 0 ? (
-        <Empty
-          image={Empty.PRESENTED_IMAGE_SIMPLE}
-          description={
-            <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
-              <Typography.Text strong>No results to review</Typography.Text>
-              <Typography.Text type="secondary">
-                The latest scheduled runs have not produced new results or failures.
-              </Typography.Text>
-            </div>
-          }
-        />
-      ) : null}
-
-      {projectedResults.length > 0 ? (
-        <section aria-label="Scheduled task results">
-          <Space orientation="vertical" size={12} style={{ width: "100%" }}>
-            {projectedResults.map((result) => (
-              <div
-                key={result.id}
-                style={{
-                  border: "1px solid var(--ant-color-border, #d9d9d9)",
-                  borderRadius: 8,
-                  padding: 12
-                }}
-              >
-                <Space orientation="vertical" size={4} style={{ width: "100%" }}>
-                  <Typography.Text strong>{result.title}</Typography.Text>
-                  <Typography.Text type="secondary">{result.summary}</Typography.Text>
-                  <Typography.Text type="secondary">
-                    {result.ownerLabel} - {result.state.replace(/_/g, " ")}
-                  </Typography.Text>
-                  <Button
-                    type="link"
-                    style={{ alignSelf: "flex-start", paddingInline: 0 }}
-                    onClick={() => {
-                      openResultSignal(result.resultId, result.runId, result.taskId)
-                    }}
-                  >
-                    Open signal for {result.title}
-                  </Button>
-                </Space>
-              </div>
-            ))}
-          </Space>
-        </section>
-      ) : null}
+      <ScheduledTaskResultsPanel
+        results={projectedResults}
+        taskCount={tasks.length}
+        capabilityMode="projected_signals"
+        onCreateTask={openCreateReminder}
+        onOpenResult={openResultSignal}
+      />
     </Space>
   )
 
@@ -673,13 +596,24 @@ export const ScheduledTasksPage: React.FC = () => {
             onClose={closeEditor}
             onSubmit={handleSubmit}
           />
-          <ScheduledTaskDetailDrawer
-            open={Boolean(selectedTask)}
-            task={selectedTask}
-            onClose={closeTaskDetail}
-            onEditReminder={openEditReminder}
-            onDeleteReminder={handleDeleteReminder}
-          />
+          {selectedTask ? (
+            <ScheduledTaskDetailDrawer
+              open
+              task={selectedTask}
+              onClose={closeTaskDetail}
+              onEditReminder={openEditReminder}
+              onDeleteReminder={handleDeleteReminder}
+            />
+          ) : null}
+          {routeState.tab === "results" && selectedResult ? (
+            <ScheduledTaskResultDetailDrawer
+              open
+              result={selectedResult}
+              onClose={closeResultDetail}
+              onReviewResult={() => undefined}
+              onRetryRun={() => undefined}
+            />
+          ) : null}
         </>
       ) : null}
     </div>

--- a/apps/packages/ui/src/components/Option/ScheduledTasks/__tests__/ScheduledTaskDetailDrawer.test.tsx
+++ b/apps/packages/ui/src/components/Option/ScheduledTasks/__tests__/ScheduledTaskDetailDrawer.test.tsx
@@ -5,6 +5,7 @@ import { render, screen } from "@testing-library/react"
 import { describe, expect, it, vi } from "vitest"
 import type { ScheduledTask } from "@/services/scheduled-tasks-control-plane"
 import { ScheduledTaskDetailDrawer } from "../ScheduledTaskDetailDrawer"
+import { projectScheduledTaskResults } from "../scheduled-task-results"
 
 const reminderTask: ScheduledTask = {
   id: "reminder_task:1",
@@ -96,10 +97,13 @@ describe("ScheduledTaskDetailDrawer", () => {
   })
 
   it("shows Watchlists task links without moving workspace configuration into the drawer", () => {
+    const [latestResult] = projectScheduledTaskResults([watchlistTask])
+
     render(
       <ScheduledTaskDetailDrawer
         open
         task={watchlistTask}
+        latestResult={latestResult}
         onClose={vi.fn()}
         onEditReminder={vi.fn()}
         onDeleteReminder={vi.fn()}
@@ -131,6 +135,10 @@ describe("ScheduledTaskDetailDrawer", () => {
     expect(screen.getByRole("link", { name: "Open latest report" })).toHaveAttribute(
       "href",
       "/watchlists?tab=outputs&output_id=202&open_output=1"
+    )
+    expect(screen.getByRole("link", { name: "Open latest result signal" })).toHaveAttribute(
+      "href",
+      "/scheduled-tasks?tab=results&result_id=202"
     )
     expect(screen.getByText(/Watchlists remains the full workspace/i)).toBeInTheDocument()
   })

--- a/apps/packages/ui/src/components/Option/ScheduledTasks/__tests__/ScheduledTaskResultDetailDrawer.test.tsx
+++ b/apps/packages/ui/src/components/Option/ScheduledTasks/__tests__/ScheduledTaskResultDetailDrawer.test.tsx
@@ -1,0 +1,139 @@
+// @vitest-environment jsdom
+
+import React from "react"
+import { render, screen } from "@testing-library/react"
+import { describe, expect, it, vi } from "vitest"
+
+import type { ScheduledTask } from "@/services/scheduled-tasks-control-plane"
+
+import { ScheduledTaskResultDetailDrawer } from "../ScheduledTaskResultDetailDrawer"
+import { projectScheduledTaskResults } from "../scheduled-task-results"
+
+const buildTask = (overrides: Partial<ScheduledTask> = {}): ScheduledTask => ({
+  id: "watchlist_job:release",
+  primitive: "watchlist_job",
+  title: "Release monitor",
+  description: "Track release notes",
+  status: "scheduled",
+  enabled: true,
+  schedule_summary: "Every morning",
+  timezone: "UTC",
+  next_run_at: "2030-01-02T09:00:00Z",
+  last_run_at: "2030-01-01T09:00:00Z",
+  edit_mode: "external",
+  manage_url: "/watchlists?tab=jobs",
+  source_ref: {
+    job_id: 42,
+    latest_run_id: 101,
+    latest_output_id: 202,
+    result_count: 3,
+    source_label: "Release feed",
+    matched_rule_label: "New release"
+  },
+  ...overrides
+})
+
+const buildResult = () =>
+  projectScheduledTaskResults([buildTask()], {
+    capabilityMode: "projected_signals"
+  })[0]
+
+describe("ScheduledTaskResultDetailDrawer", () => {
+  it("shows result provenance, owner, ids, and Watchlists deep links", () => {
+    const result = buildResult()
+
+    render(
+      <ScheduledTaskResultDetailDrawer
+        open
+        result={result}
+        onClose={vi.fn()}
+        onReviewResult={vi.fn()}
+        onRetryRun={vi.fn()}
+      />
+    )
+
+    expect(screen.getByRole("dialog", { name: /Release monitor/i })).toBeInTheDocument()
+    expect(screen.getByText("Why this is here")).toBeInTheDocument()
+    expect(screen.getByText("Found 3 results from Release feed.")).toBeInTheDocument()
+    expect(screen.getByText("Watchlists")).toBeInTheDocument()
+    expect(screen.getByText("Release feed")).toBeInTheDocument()
+    expect(screen.getByText("New release")).toBeInTheDocument()
+    expect(screen.getByText("Result id")).toBeInTheDocument()
+    expect(screen.getByText("202")).toBeInTheDocument()
+    expect(screen.getByText("Run id")).toBeInTheDocument()
+    expect(screen.getByText("101")).toBeInTheDocument()
+    expect(screen.getByRole("link", { name: "Open result" })).toHaveAttribute(
+      "href",
+      "/watchlists?tab=outputs&output_id=202&open_output=1"
+    )
+    expect(screen.getByRole("link", { name: "Open run" })).toHaveAttribute(
+      "href",
+      "/watchlists?tab=runs&run_id=101&open_run=1"
+    )
+    expect(screen.getByRole("link", { name: "Open owner workspace" })).toHaveAttribute(
+      "href",
+      "/watchlists?tab=jobs"
+    )
+  })
+
+  it("hides unsupported review and retry buttons in projected mode", () => {
+    render(
+      <ScheduledTaskResultDetailDrawer
+        open
+        result={buildResult()}
+        onClose={vi.fn()}
+        onReviewResult={vi.fn()}
+        onRetryRun={vi.fn()}
+      />
+    )
+
+    expect(screen.queryByRole("button", { name: "Mark reviewed" })).not.toBeInTheDocument()
+    expect(screen.queryByRole("button", { name: "Retry run" })).not.toBeInTheDocument()
+    expect(
+      screen.getByText("Review and retry actions appear when this server supports them for the selected result.")
+    ).toBeInTheDocument()
+  })
+
+  it("shows mutation actions only when item capabilities allow them", () => {
+    const reviewableResult = projectScheduledTaskResults([buildTask()], {
+      capabilityMode: "normalized_results_mutation"
+    })[0]
+    const retryableFailure = projectScheduledTaskResults(
+      [
+        buildTask({
+          id: "watchlist_job:failure",
+          title: "Failure monitor",
+          status: "failed",
+          source_ref: { job_id: 42, latest_run_id: 101 }
+        })
+      ],
+      { capabilityMode: "normalized_results_mutation" }
+    )[0]
+
+    const { rerender } = render(
+      <ScheduledTaskResultDetailDrawer
+        open
+        result={reviewableResult}
+        onClose={vi.fn()}
+        onReviewResult={vi.fn()}
+        onRetryRun={vi.fn()}
+      />
+    )
+
+    expect(screen.getByRole("button", { name: "Mark reviewed" })).toBeInTheDocument()
+    expect(screen.queryByRole("button", { name: "Retry run" })).not.toBeInTheDocument()
+
+    rerender(
+      <ScheduledTaskResultDetailDrawer
+        open
+        result={retryableFailure}
+        onClose={vi.fn()}
+        onReviewResult={vi.fn()}
+        onRetryRun={vi.fn()}
+      />
+    )
+
+    expect(screen.getByRole("button", { name: "Retry run" })).toBeInTheDocument()
+    expect(screen.queryByRole("button", { name: "Mark reviewed" })).not.toBeInTheDocument()
+  })
+})

--- a/apps/packages/ui/src/components/Option/ScheduledTasks/__tests__/ScheduledTaskResultsPanel.test.tsx
+++ b/apps/packages/ui/src/components/Option/ScheduledTasks/__tests__/ScheduledTaskResultsPanel.test.tsx
@@ -176,7 +176,7 @@ describe("ScheduledTaskResultsPanel", () => {
       />
     )
 
-    expect(screen.getByText("No results to review")).toBeInTheDocument()
+    expect(screen.getByText("No automation signals yet")).toBeInTheDocument()
   })
 
   it("opens a result with an accessible action name", async () => {

--- a/apps/packages/ui/src/components/Option/ScheduledTasks/__tests__/ScheduledTaskResultsPanel.test.tsx
+++ b/apps/packages/ui/src/components/Option/ScheduledTasks/__tests__/ScheduledTaskResultsPanel.test.tsx
@@ -1,0 +1,204 @@
+// @vitest-environment jsdom
+
+import React from "react"
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { describe, expect, it, vi } from "vitest"
+
+import type { ScheduledTask } from "@/services/scheduled-tasks-control-plane"
+
+import { ScheduledTaskResultsPanel } from "../ScheduledTaskResultsPanel"
+import { projectScheduledTaskResults } from "../scheduled-task-results"
+
+const buildTask = (overrides: Partial<ScheduledTask>): ScheduledTask => ({
+  id: "watchlist_job:1",
+  primitive: "watchlist_job",
+  title: "Morning monitor",
+  description: "Track a source",
+  status: "scheduled",
+  enabled: true,
+  schedule_summary: "Every morning",
+  timezone: "UTC",
+  next_run_at: "2030-01-02T09:00:00Z",
+  last_run_at: "2030-01-01T09:00:00Z",
+  edit_mode: "external",
+  manage_url: "/watchlists?tab=jobs",
+  source_ref: { job_id: 1 },
+  ...overrides
+})
+
+const buildResults = () =>
+  projectScheduledTaskResults(
+    [
+      buildTask({
+        id: "watchlist_job:result",
+        title: "Release monitor",
+        source_ref: {
+          job_id: 42,
+          latest_run_id: 101,
+          latest_output_id: 202,
+          result_count: 3,
+          source_label: "Release feed"
+        }
+      }),
+      buildTask({
+        id: "reminder_task:failed",
+        primitive: "reminder_task",
+        title: "Follow up",
+        status: "failed",
+        edit_mode: "native",
+        manage_url: null,
+        source_ref: { task_id: "failed", run_id: 77 }
+      }),
+      buildTask({
+        id: "watchlist_job:running",
+        title: "Running monitor",
+        status: "running",
+        source_ref: { job_id: 43, latest_run_id: 103 }
+      }),
+      buildTask({
+        id: "watchlist_job:completed",
+        title: "Quiet monitor",
+        status: "completed",
+        source_ref: { job_id: 44, latest_run_id: 104 }
+      })
+    ],
+    { includeCompletedNoResults: true }
+  )
+
+describe("ScheduledTaskResultsPanel", () => {
+  it("renders projected success, failure, running, and completed-no-results signals", () => {
+    render(
+      <ScheduledTaskResultsPanel
+        results={buildResults()}
+        taskCount={4}
+        capabilityMode="projected_signals"
+        onCreateTask={vi.fn()}
+        onOpenResult={vi.fn()}
+      />
+    )
+
+    expect(screen.getByRole("heading", { name: "Scheduled task results" })).toBeInTheDocument()
+    expect(screen.getByText("Latest automation signals")).toBeInTheDocument()
+    expect(screen.getByText("Release monitor")).toBeInTheDocument()
+    expect(screen.getByText("Found 3 results from Release feed.")).toBeInTheDocument()
+    expect(screen.getByText("Follow up")).toBeInTheDocument()
+    expect(screen.getByText("Needs attention")).toBeInTheDocument()
+    expect(screen.getByText("Running monitor")).toBeInTheDocument()
+    expect(screen.getByText("Running now")).toBeInTheDocument()
+    expect(screen.getByText("Quiet monitor")).toBeInTheDocument()
+    expect(screen.getByText("Completed/no results")).toBeInTheDocument()
+    expect(screen.getAllByText("Watchlists").length).toBeGreaterThan(0)
+    expect(screen.getByText("Reminders")).toBeInTheDocument()
+  })
+
+  it("filters by result state, task type, and owner in projected mode", async () => {
+    const user = userEvent.setup()
+    render(
+      <ScheduledTaskResultsPanel
+        results={buildResults()}
+        taskCount={4}
+        capabilityMode="projected_signals"
+        onCreateTask={vi.fn()}
+        onOpenResult={vi.fn()}
+      />
+    )
+
+    await user.click(screen.getByRole("combobox", { name: "Result state filter" }))
+    await user.click(await screen.findByTitle("Needs attention"))
+
+    expect(screen.getByText("Follow up")).toBeInTheDocument()
+    expect(screen.queryByText("Release monitor")).not.toBeInTheDocument()
+
+    await user.click(screen.getByRole("combobox", { name: "Task type filter" }))
+    await user.click(await screen.findByTitle("Watchlist monitor"))
+
+    expect(screen.getByText("No results match these filters")).toBeInTheDocument()
+
+    await user.click(screen.getByRole("button", { name: "Clear filters" }))
+    await user.click(screen.getByRole("combobox", { name: "Owner filter" }))
+    await user.click(await screen.findByTitle("Watchlists"))
+
+    expect(screen.getByText("Release monitor")).toBeInTheDocument()
+    expect(screen.queryByText("Follow up")).not.toBeInTheDocument()
+  })
+
+  it("hides review-state filtering in projected mode and shows it in normalized modes", () => {
+    const { rerender } = render(
+      <ScheduledTaskResultsPanel
+        results={buildResults()}
+        taskCount={4}
+        capabilityMode="projected_signals"
+        onCreateTask={vi.fn()}
+        onOpenResult={vi.fn()}
+      />
+    )
+
+    expect(screen.queryByRole("combobox", { name: "Review state filter" })).not.toBeInTheDocument()
+
+    rerender(
+      <ScheduledTaskResultsPanel
+        results={buildResults()}
+        taskCount={4}
+        capabilityMode="normalized_results_read"
+        onCreateTask={vi.fn()}
+        onOpenResult={vi.fn()}
+      />
+    )
+
+    expect(screen.getByRole("combobox", { name: "Review state filter" })).toBeInTheDocument()
+  })
+
+  it("distinguishes no tasks, no results, and no filter matches", async () => {
+    const user = userEvent.setup()
+    const onCreateTask = vi.fn()
+    const { rerender } = render(
+      <ScheduledTaskResultsPanel
+        results={[]}
+        taskCount={0}
+        capabilityMode="projected_signals"
+        onCreateTask={onCreateTask}
+        onOpenResult={vi.fn()}
+      />
+    )
+
+    expect(screen.getByText("No scheduled tasks yet")).toBeInTheDocument()
+    await user.click(screen.getByRole("button", { name: "Create scheduled task" }))
+    expect(onCreateTask).toHaveBeenCalledTimes(1)
+
+    rerender(
+      <ScheduledTaskResultsPanel
+        results={[]}
+        taskCount={2}
+        capabilityMode="projected_signals"
+        onCreateTask={onCreateTask}
+        onOpenResult={vi.fn()}
+      />
+    )
+
+    expect(screen.getByText("No results to review")).toBeInTheDocument()
+  })
+
+  it("opens a result with an accessible action name", async () => {
+    const user = userEvent.setup()
+    const onOpenResult = vi.fn()
+    render(
+      <ScheduledTaskResultsPanel
+        results={buildResults()}
+        taskCount={4}
+        capabilityMode="projected_signals"
+        onCreateTask={vi.fn()}
+        onOpenResult={onOpenResult}
+      />
+    )
+
+    await user.click(screen.getByRole("button", { name: "Open signal for Release monitor" }))
+
+    expect(onOpenResult).toHaveBeenCalledWith(
+      expect.objectContaining({
+        taskTitle: "Release monitor",
+        resultId: "202"
+      })
+    )
+  })
+})

--- a/apps/packages/ui/src/components/Option/ScheduledTasks/__tests__/ScheduledTaskResultsPanel.test.tsx
+++ b/apps/packages/ui/src/components/Option/ScheduledTasks/__tests__/ScheduledTaskResultsPanel.test.tsx
@@ -57,6 +57,12 @@ const buildResults = () =>
         source_ref: { job_id: 43, latest_run_id: 103 }
       }),
       buildTask({
+        id: "watchlist_job:paused",
+        title: "Paused monitor",
+        status: "paused",
+        source_ref: { job_id: 45, latest_run_id: 105 }
+      }),
+      buildTask({
         id: "watchlist_job:completed",
         title: "Quiet monitor",
         status: "completed",
@@ -67,11 +73,11 @@ const buildResults = () =>
   )
 
 describe("ScheduledTaskResultsPanel", () => {
-  it("renders projected success, failure, running, and completed-no-results signals", () => {
+  it("renders projected success, failure, running, paused, and completed-no-results signals", () => {
     render(
       <ScheduledTaskResultsPanel
         results={buildResults()}
-        taskCount={4}
+        taskCount={5}
         capabilityMode="projected_signals"
         onCreateTask={vi.fn()}
         onOpenResult={vi.fn()}
@@ -86,6 +92,9 @@ describe("ScheduledTaskResultsPanel", () => {
     expect(screen.getByText("Needs attention")).toBeInTheDocument()
     expect(screen.getByText("Running monitor")).toBeInTheDocument()
     expect(screen.getByText("Running now")).toBeInTheDocument()
+    expect(screen.getByText("Paused monitor")).toBeInTheDocument()
+    expect(screen.getByText("Paused monitor is paused.")).toBeInTheDocument()
+    expect(screen.getByText("Paused")).toBeInTheDocument()
     expect(screen.getByText("Quiet monitor")).toBeInTheDocument()
     expect(screen.getByText("Completed/no results")).toBeInTheDocument()
     expect(screen.getAllByText("Watchlists").length).toBeGreaterThan(0)

--- a/apps/packages/ui/src/components/Option/ScheduledTasks/__tests__/ScheduledTasksPage.test.tsx
+++ b/apps/packages/ui/src/components/Option/ScheduledTasks/__tests__/ScheduledTasksPage.test.tsx
@@ -253,7 +253,7 @@ describe("ScheduledTasksPage", () => {
 
     expect(await screen.findByRole("tab", { name: "Results" })).toHaveAttribute("aria-selected", "true")
     expect(await screen.findByRole("heading", { level: 3, name: "Scheduled task results" })).toBeInTheDocument()
-    expect(screen.getByText("Latest signals inferred from task status. Durable review state appears when the results API is available.")).toBeInTheDocument()
+    expect(screen.getByText("Latest signals inferred from task status. Result history and item actions appear when the results API is available.")).toBeInTheDocument()
     expect(screen.getByRole("button", { name: "Open signal for Release monitor" })).toBeInTheDocument()
     expect(screen.getByText("Found 3 results from Release feed.")).toBeInTheDocument()
   })

--- a/apps/packages/ui/src/components/Option/ScheduledTasks/__tests__/ScheduledTasksPage.test.tsx
+++ b/apps/packages/ui/src/components/Option/ScheduledTasks/__tests__/ScheduledTasksPage.test.tsx
@@ -448,9 +448,11 @@ describe("ScheduledTasksPage", () => {
     expect(screen.getByText("1 needs attention")).toBeInTheDocument()
     expect(screen.getByText("1 running now")).toBeInTheDocument()
     expect(screen.getByText("Next upcoming run")).toBeInTheDocument()
+    expect(screen.getByText("Latest result signal")).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Open latest result signal" })).toBeInTheDocument()
     expect(screen.getAllByText(/2030/).length).toBeGreaterThan(0)
     expect(screen.getByText(/Watchlists remains the full workspace/)).toBeInTheDocument()
-    expect(screen.queryByText("Review notes")).not.toBeInTheDocument()
+    expect(screen.queryByRole("columnheader", { name: "Task" })).not.toBeInTheDocument()
   })
 
   it("renders task rows and Watchlists links inside the Tasks tab", async () => {
@@ -509,9 +511,11 @@ describe("ScheduledTasksPage", () => {
     expect(within(reminderRow as HTMLElement).getByText("No completed runs yet")).toBeInTheDocument()
 
     expect(screen.getByRole("button", { name: "Inspect Review notes" })).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "View results for Review notes" })).toBeInTheDocument()
     expect(await screen.findByRole("button", { name: "Edit Review notes" })).toBeInTheDocument()
     expect(screen.getByRole("button", { name: "Delete Review notes" })).toBeInTheDocument()
     expect(await screen.findByText("Morning digest")).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "View results for Morning digest" })).toBeInTheDocument()
     expect(
       await screen.findByRole("link", { name: "Open monitor settings for Morning digest" })
     ).toHaveAttribute("href", "/watchlists?tab=jobs")

--- a/apps/packages/ui/src/components/Option/ScheduledTasks/__tests__/ScheduledTasksPage.test.tsx
+++ b/apps/packages/ui/src/components/Option/ScheduledTasks/__tests__/ScheduledTasksPage.test.tsx
@@ -297,6 +297,33 @@ describe("ScheduledTasksPage", () => {
     expect(screen.queryByText("Result signal not found.")).not.toBeInTheDocument()
   })
 
+  it("can navigate from the Results alias path back to Overview", async () => {
+    mocks.listScheduledTasks.mockResolvedValue({
+      items: [],
+      total: 0,
+      partial: false,
+      errors: []
+    })
+    const user = userEvent.setup()
+
+    renderWithQueryClient(<ScheduledTasksPage />, "/scheduled-tasks/results")
+
+    expect(await screen.findByRole("tab", { name: "Results" })).toHaveAttribute(
+      "aria-selected",
+      "true"
+    )
+
+    await user.click(screen.getByRole("tab", { name: "Overview" }))
+
+    await waitFor(() => {
+      expect(screen.getByRole("tab", { name: "Overview" })).toHaveAttribute(
+        "aria-selected",
+        "true"
+      )
+    })
+    expect(screen.getByText("Total scheduled tasks")).toBeInTheDocument()
+  })
+
   it("shows a non-blocking missing-result message for stale Results deep links", async () => {
     mocks.listScheduledTasks.mockResolvedValue({
       items: [],
@@ -656,7 +683,7 @@ describe("ScheduledTasksPage", () => {
     await waitFor(() => {
       expect(screen.queryByRole("dialog", { name: /Review notes/i })).not.toBeInTheDocument()
     })
-  })
+  }, SLOW_SCHEDULE_FORM_TIMEOUT_MS)
 
   it("deletes the selected reminder from the detail drawer and does not leave stale drawer state", async () => {
     const user = userEvent.setup()
@@ -772,7 +799,7 @@ describe("ScheduledTasksPage", () => {
 
     expect(screen.getByText("Healthy reminder")).toBeInTheDocument()
     expect(screen.queryByText("Blocked monitor")).not.toBeInTheDocument()
-  })
+  }, SLOW_SCHEDULE_FORM_TIMEOUT_MS)
 
   it("counts blocked tasks as needing attention in the overview", async () => {
     mocks.listScheduledTasks.mockResolvedValue({
@@ -954,7 +981,7 @@ describe("ScheduledTasksPage", () => {
     const drawer = await screen.findByRole("dialog", { name: /Daily review/i })
     expect(within(drawer).getByText("Reminder")).toBeInTheDocument()
     expect(mocks.listScheduledTasks).toHaveBeenCalledTimes(2)
-  })
+  }, SLOW_SCHEDULE_FORM_TIMEOUT_MS)
 
   it("keeps the created reminder detail open from the API response until the list catches up", async () => {
     const user = userEvent.setup()
@@ -999,7 +1026,7 @@ describe("ScheduledTasksPage", () => {
     const drawer = await screen.findByRole("dialog", { name: /Pending reminder/i })
     expect(within(drawer).getByText("Reminder")).toBeInTheDocument()
     expect(screen.queryByText("Task not found.")).not.toBeInTheDocument()
-  })
+  }, SLOW_SCHEDULE_FORM_TIMEOUT_MS)
 
   it("does not create a one-time reminder without run_at", async () => {
     const user = userEvent.setup()
@@ -1020,7 +1047,7 @@ describe("ScheduledTasksPage", () => {
       expect(mocks.createScheduledTaskReminder).not.toHaveBeenCalled()
     })
     expect(screen.getByText("Run at is required for one-time reminders")).toBeInTheDocument()
-  })
+  }, SLOW_SCHEDULE_FORM_TIMEOUT_MS)
 
   it("creates a daily recurring reminder with cron and timezone from safer controls", async () => {
     const user = userEvent.setup()
@@ -1293,5 +1320,5 @@ describe("ScheduledTasksPage", () => {
     await waitFor(() => {
       expect(mocks.deleteScheduledTaskReminder).toHaveBeenCalledWith("reminder_task:1")
     })
-  })
+  }, SLOW_SCHEDULE_FORM_TIMEOUT_MS)
 })

--- a/apps/packages/ui/src/components/Option/ScheduledTasks/__tests__/ScheduledTasksPage.test.tsx
+++ b/apps/packages/ui/src/components/Option/ScheduledTasks/__tests__/ScheduledTasksPage.test.tsx
@@ -219,6 +219,102 @@ describe("ScheduledTasksPage", () => {
     expect(screen.getByRole("tab", { name: "Create" })).toHaveAttribute("aria-selected", "true")
   })
 
+  it("opens the Results tab from the URL and renders projected result signals", async () => {
+    mocks.listScheduledTasks.mockResolvedValue({
+      items: [
+        {
+          id: "watchlist_job:release",
+          primitive: "watchlist_job",
+          title: "Release monitor",
+          description: "Track releases",
+          status: "scheduled",
+          enabled: true,
+          schedule_summary: "Every morning",
+          timezone: "UTC",
+          next_run_at: "2030-04-06T09:00:00+00:00",
+          last_run_at: "2030-04-05T09:00:00+00:00",
+          edit_mode: "external",
+          manage_url: "/watchlists?tab=jobs",
+          source_ref: {
+            job_id: 42,
+            latest_run_id: 101,
+            latest_output_id: 202,
+            result_count: 3,
+            source_label: "Release feed"
+          }
+        }
+      ],
+      total: 1,
+      partial: false,
+      errors: []
+    })
+
+    renderWithQueryClient(<ScheduledTasksPage />, "/scheduled-tasks?tab=results")
+
+    expect(await screen.findByRole("tab", { name: "Results" })).toHaveAttribute("aria-selected", "true")
+    expect(await screen.findByRole("heading", { level: 3, name: "Scheduled task results" })).toBeInTheDocument()
+    expect(screen.getByText("Latest signals inferred from task status. Durable review state appears when the results API is available.")).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Open signal for Release monitor" })).toBeInTheDocument()
+    expect(screen.getByText("Found 3 results from Release feed.")).toBeInTheDocument()
+  })
+
+  it("opens the Results tab from the alias path and selects a result signal", async () => {
+    mocks.listScheduledTasks.mockResolvedValue({
+      items: [
+        {
+          id: "watchlist_job:release",
+          primitive: "watchlist_job",
+          title: "Release monitor",
+          description: "Track releases",
+          status: "scheduled",
+          enabled: true,
+          schedule_summary: "Every morning",
+          timezone: "UTC",
+          next_run_at: "2030-04-06T09:00:00+00:00",
+          last_run_at: "2030-04-05T09:00:00+00:00",
+          edit_mode: "external",
+          manage_url: "/watchlists?tab=jobs",
+          source_ref: {
+            job_id: 42,
+            latest_run_id: 101,
+            latest_output_id: 202,
+            result_count: 1
+          }
+        }
+      ],
+      total: 1,
+      partial: false,
+      errors: []
+    })
+
+    renderWithQueryClient(
+      <ScheduledTasksPage />,
+      "/scheduled-tasks/results?result_id=202"
+    )
+
+    expect(await screen.findByRole("tab", { name: "Results" })).toHaveAttribute("aria-selected", "true")
+    expect(await screen.findByText("Selected signal: Release monitor")).toBeInTheDocument()
+    expect(screen.queryByText("Result signal not found.")).not.toBeInTheDocument()
+  })
+
+  it("shows a non-blocking missing-result message for stale Results deep links", async () => {
+    mocks.listScheduledTasks.mockResolvedValue({
+      items: [],
+      total: 0,
+      partial: false,
+      errors: []
+    })
+
+    renderWithQueryClient(
+      <ScheduledTasksPage />,
+      "/scheduled-tasks?tab=results&result_id=missing"
+    )
+
+    expect(await screen.findByRole("tab", { name: "Results" })).toHaveAttribute("aria-selected", "true")
+    expect(await screen.findByText("Result signal not found.")).toBeInTheDocument()
+    expect(screen.getByText("No scheduled tasks yet")).toBeInTheDocument()
+  })
+
   it("keeps Watch template non-creating from the page route", async () => {
     mocks.listScheduledTasks.mockResolvedValue({
       items: [],

--- a/apps/packages/ui/src/components/Option/ScheduledTasks/__tests__/ScheduledTasksPage.test.tsx
+++ b/apps/packages/ui/src/components/Option/ScheduledTasks/__tests__/ScheduledTasksPage.test.tsx
@@ -258,7 +258,7 @@ describe("ScheduledTasksPage", () => {
     expect(screen.getByText("Found 3 results from Release feed.")).toBeInTheDocument()
   })
 
-  it("opens the Results tab from the alias path and selects a result signal", async () => {
+  it("opens the Results tab from the alias path and opens the result drawer", async () => {
     mocks.listScheduledTasks.mockResolvedValue({
       items: [
         {
@@ -293,7 +293,7 @@ describe("ScheduledTasksPage", () => {
     )
 
     expect(await screen.findByRole("tab", { name: "Results" })).toHaveAttribute("aria-selected", "true")
-    expect(await screen.findByText("Selected signal: Release monitor")).toBeInTheDocument()
+    expect(await screen.findByRole("dialog", { name: /Release monitor/i })).toBeInTheDocument()
     expect(screen.queryByText("Result signal not found.")).not.toBeInTheDocument()
   })
 

--- a/apps/packages/ui/src/components/Option/ScheduledTasks/__tests__/scheduled-task-results.test.ts
+++ b/apps/packages/ui/src/components/Option/ScheduledTasks/__tests__/scheduled-task-results.test.ts
@@ -9,6 +9,7 @@ import {
 } from "../scheduled-task-result-links"
 import {
   buildScheduledTaskAutomationHomeItems,
+  findScheduledTaskResultByRouteState,
   filterScheduledTaskResults,
   projectScheduledTaskResults,
   resolveScheduledTaskResultsCapabilityMode
@@ -204,6 +205,33 @@ describe("scheduled task result helpers", () => {
         occurredAt: "2030-01-01T09:00:00Z"
       })
     ).toBe("task:watchlist_job:42:state:failure:time:2030-01-01T09:00:00Z")
+  })
+
+  it("finds projected results by result, run, then task route state", () => {
+    const results = projectScheduledTaskResults([
+      buildTask({
+        id: "watchlist_job:release",
+        title: "Release monitor",
+        source_ref: {
+          job_id: 42,
+          latest_run_id: 101,
+          latest_output_id: 202,
+          result_count: 1
+        }
+      })
+    ])
+
+    expect(findScheduledTaskResultByRouteState(results, { resultId: "202" })?.taskTitle).toBe(
+      "Release monitor"
+    )
+    expect(findScheduledTaskResultByRouteState(results, { runId: "101" })?.taskTitle).toBe(
+      "Release monitor"
+    )
+    expect(
+      findScheduledTaskResultByRouteState(results, { taskId: "watchlist_job:release" })
+        ?.taskTitle
+    ).toBe("Release monitor")
+    expect(findScheduledTaskResultByRouteState(results, { resultId: "missing" })).toBeNull()
   })
 
   it("normalizes notification targets without replacing notification behavior", () => {

--- a/apps/packages/ui/src/components/Option/ScheduledTasks/__tests__/scheduled-task-results.test.ts
+++ b/apps/packages/ui/src/components/Option/ScheduledTasks/__tests__/scheduled-task-results.test.ts
@@ -5,6 +5,7 @@ import type { ScheduledTask } from "@/services/scheduled-tasks-control-plane"
 import {
   buildScheduledTaskResultDedupeKey,
   buildScheduledTaskResultHref,
+  mergeScheduledTaskNotificationTargets,
   normalizeScheduledTaskNotificationTarget
 } from "../scheduled-task-result-links"
 import {
@@ -254,6 +255,163 @@ describe("scheduled task result helpers", () => {
       runId: "101",
       taskId: "watchlist_job:42",
       href: "/scheduled-tasks?tab=results&result_id=202"
+    })
+  })
+
+  it("normalizes notification targets by exact result, run, then task priority across link shapes", () => {
+    expect(
+      normalizeScheduledTaskNotificationTarget({
+        id: 10,
+        kind: "job_completed",
+        title: "Output ready",
+        message: "Output ready",
+        severity: "info",
+        created_at: "2030-01-01T09:00:00Z",
+        link_type: "scheduled_task_run",
+        link_id: "101",
+        link_url: "/scheduled-tasks?tab=results&result_id=202&run_id=303&task_id=watchlist_job%3A42",
+        source_task_id: "watchlist_job:42",
+        source_task_run_id: "404"
+      })
+    ).toMatchObject({
+      resultId: "202",
+      runId: "404",
+      taskId: "watchlist_job:42",
+      href: "/scheduled-tasks?tab=results&result_id=202",
+      dedupeKey: "result:202"
+    })
+
+    expect(
+      normalizeScheduledTaskNotificationTarget({
+        id: 11,
+        kind: "job_failed",
+        title: "Run failed",
+        message: "Run failed",
+        severity: "error",
+        created_at: "2030-01-01T09:05:00Z",
+        link_type: "scheduled_task_run",
+        link_id: "101",
+        source_job_id: 42
+      })
+    ).toMatchObject({
+      resultId: null,
+      runId: "101",
+      taskId: "watchlist_job:42",
+      href: "/scheduled-tasks?tab=results&run_id=101",
+      dedupeKey: "run:101:state:failure"
+    })
+
+    expect(
+      normalizeScheduledTaskNotificationTarget({
+        id: 12,
+        kind: "job_completed",
+        title: "Task completed",
+        message: "Task completed",
+        severity: "info",
+        created_at: "2030-01-01T09:10:00Z",
+        link_type: "scheduled_task",
+        link_id: "watchlist_job:42"
+      })
+    ).toMatchObject({
+      resultId: null,
+      runId: null,
+      taskId: "watchlist_job:42",
+      href: "/scheduled-tasks?tab=results&task_id=watchlist_job%3A42"
+    })
+  })
+
+  it("shares dedupe keys between projected task signals and notification-derived targets", () => {
+    const [failureResult] = projectScheduledTaskResults([
+      buildTask({
+        id: "watchlist_job:failure",
+        title: "Failure monitor",
+        status: "failed",
+        source_ref: {
+          job_id: 42,
+          latest_run_id: 101
+        }
+      })
+    ])
+    const notificationTarget = normalizeScheduledTaskNotificationTarget({
+      id: 13,
+      kind: "job_failed",
+      title: "Run failed",
+      message: "Run failed",
+      severity: "error",
+      created_at: "2030-01-01T09:00:00Z",
+      source_task_id: "watchlist_job:failure",
+      source_task_run_id: "101"
+    })
+
+    expect(notificationTarget?.dedupeKey).toBe(failureResult?.dedupeKey)
+
+    expect(
+      buildScheduledTaskResultDedupeKey({
+        signalKind: "failure",
+        taskId: "watchlist_job:42",
+        runId: "101",
+        resultId: null
+      })
+    ).not.toBe(
+      buildScheduledTaskResultDedupeKey({
+        signalKind: "result",
+        taskId: "watchlist_job:42",
+        runId: "101",
+        resultId: null
+      })
+    )
+  })
+
+  it("merges notification targets by dedupe key while preserving notification ids", () => {
+    const first = normalizeScheduledTaskNotificationTarget({
+      id: 14,
+      kind: "job_completed",
+      title: "Output ready",
+      message: "Output ready",
+      severity: "info",
+      created_at: "2030-01-01T09:00:00Z",
+      link_type: "scheduled_task_result",
+      link_id: "202",
+      source_task_id: "watchlist_job:42",
+      source_task_run_id: "101"
+    })
+    const duplicate = normalizeScheduledTaskNotificationTarget({
+      id: 15,
+      kind: "job_completed",
+      title: "Output ready again",
+      message: "Output ready again",
+      severity: "info",
+      created_at: "2030-01-01T09:05:00Z",
+      link_url: "/scheduled-tasks?tab=results&result_id=202",
+      source_task_id: "watchlist_job:42",
+      source_task_run_id: "101"
+    })
+    const distinctRun = normalizeScheduledTaskNotificationTarget({
+      id: 16,
+      kind: "job_failed",
+      title: "Next run failed",
+      message: "Next run failed",
+      severity: "error",
+      created_at: "2030-01-01T09:10:00Z",
+      source_task_id: "watchlist_job:42",
+      source_task_run_id: "102"
+    })
+
+    const merged = mergeScheduledTaskNotificationTargets([
+      first,
+      duplicate,
+      distinctRun,
+      null
+    ])
+
+    expect(merged).toHaveLength(2)
+    expect(merged[0]).toMatchObject({
+      dedupeKey: "result:202",
+      notificationIds: [14, 15]
+    })
+    expect(merged[1]).toMatchObject({
+      dedupeKey: "run:102:state:failure",
+      notificationIds: [16]
     })
   })
 })

--- a/apps/packages/ui/src/components/Option/ScheduledTasks/__tests__/scheduled-task-results.test.ts
+++ b/apps/packages/ui/src/components/Option/ScheduledTasks/__tests__/scheduled-task-results.test.ts
@@ -10,8 +10,11 @@ import {
 } from "../scheduled-task-result-links"
 import {
   buildScheduledTaskAutomationHomeItems,
+  buildScheduledTaskAutomationHomeItemsFromNotifications,
+  buildScheduledTaskCompanionHomeItems,
   findScheduledTaskResultByRouteState,
   filterScheduledTaskResults,
+  mergeScheduledTaskAutomationHomeItems,
   projectScheduledTaskResults,
   resolveScheduledTaskResultsCapabilityMode
 } from "../scheduled-task-results"
@@ -183,6 +186,27 @@ describe("scheduled task result helpers", () => {
     expect(filterScheduledTaskResults(results, { states: ["completed_no_results"] })).toHaveLength(1)
     expect(buildScheduledTaskAutomationHomeItems(results).map((item) => item.title)).toEqual([
       "Found"
+    ])
+  })
+
+  it("maps scheduled-task automation items to Companion Home item shape", () => {
+    const results = projectScheduledTaskResults([
+      buildTask({
+        id: "watchlist_job:result",
+        title: "Found",
+        source_ref: { job_id: 3, latest_output_id: 303, result_count: 1 }
+      })
+    ])
+
+    expect(buildScheduledTaskCompanionHomeItems(buildScheduledTaskAutomationHomeItems(results))).toEqual([
+      expect.objectContaining({
+        id: "automation:result:303",
+        entityId: "result:303",
+        entityType: "scheduled_task_result",
+        source: "scheduled_task",
+        title: "Found",
+        href: "/scheduled-tasks?tab=results&result_id=303"
+      })
     ])
   })
 
@@ -413,5 +437,60 @@ describe("scheduled task result helpers", () => {
       dedupeKey: "run:102:state:failure",
       notificationIds: [16]
     })
+  })
+
+  it("dedupes Home automation items from projected tasks and notifications", () => {
+    const projectedItems = buildScheduledTaskAutomationHomeItems(
+      projectScheduledTaskResults([
+        buildTask({
+          id: "watchlist_job:release",
+          title: "Release monitor",
+          source_ref: {
+            job_id: 42,
+            latest_run_id: 101,
+            latest_output_id: 202,
+            result_count: 1
+          }
+        })
+      ])
+    )
+    const notificationItems = buildScheduledTaskAutomationHomeItemsFromNotifications([
+      {
+        id: 17,
+        kind: "job_completed",
+        title: "Release monitor notification",
+        message: "Output ready",
+        severity: "info",
+        created_at: "2030-01-01T09:05:00Z",
+        link_type: "scheduled_task_result",
+        link_id: "202",
+        source_task_id: "watchlist_job:release",
+        source_task_run_id: "101"
+      },
+      {
+        id: 18,
+        kind: "job_failed",
+        title: "Different run failed",
+        message: "The latest run failed.",
+        severity: "error",
+        created_at: "2030-01-01T09:10:00Z",
+        source_task_id: "watchlist_job:release",
+        source_task_run_id: "102"
+      }
+    ])
+
+    const merged = mergeScheduledTaskAutomationHomeItems([
+      projectedItems,
+      notificationItems
+    ])
+
+    expect(merged.map((item) => item.dedupeKey)).toEqual([
+      "run:102:state:failure",
+      "result:202"
+    ])
+    expect(merged.filter((item) => item.dedupeKey === "result:202")).toHaveLength(1)
+    expect(merged.find((item) => item.dedupeKey === "result:202")?.title).toBe(
+      "Release monitor notification"
+    )
   })
 })

--- a/apps/packages/ui/src/components/Option/ScheduledTasks/__tests__/scheduled-task-results.test.ts
+++ b/apps/packages/ui/src/components/Option/ScheduledTasks/__tests__/scheduled-task-results.test.ts
@@ -1,0 +1,231 @@
+import { describe, expect, it } from "vitest"
+
+import type { ScheduledTask } from "@/services/scheduled-tasks-control-plane"
+
+import {
+  buildScheduledTaskResultDedupeKey,
+  buildScheduledTaskResultHref,
+  normalizeScheduledTaskNotificationTarget
+} from "../scheduled-task-result-links"
+import {
+  buildScheduledTaskAutomationHomeItems,
+  filterScheduledTaskResults,
+  projectScheduledTaskResults,
+  resolveScheduledTaskResultsCapabilityMode
+} from "../scheduled-task-results"
+
+const buildTask = (overrides: Partial<ScheduledTask>): ScheduledTask => ({
+  id: "watchlist_job:1",
+  primitive: "watchlist_job",
+  title: "Morning monitor",
+  description: "Track a source",
+  status: "scheduled",
+  enabled: true,
+  schedule_summary: "Every morning",
+  timezone: "UTC",
+  next_run_at: "2030-01-02T09:00:00Z",
+  last_run_at: "2030-01-01T09:00:00Z",
+  edit_mode: "external",
+  manage_url: "/watchlists?tab=jobs",
+  source_ref: { job_id: 1 },
+  ...overrides
+})
+
+describe("scheduled task result helpers", () => {
+  it("defaults to projected signals when normalized result endpoints are unavailable", () => {
+    expect(resolveScheduledTaskResultsCapabilityMode({})).toBe("projected_signals")
+    expect(
+      resolveScheduledTaskResultsCapabilityMode({
+        "/api/v1/scheduled-tasks/results": {
+          get: {}
+        }
+      })
+    ).toBe("normalized_results_read")
+    expect(
+      resolveScheduledTaskResultsCapabilityMode({
+        "/api/v1/scheduled-tasks/results": { get: {} },
+        "/api/v1/scheduled-tasks/results/{result_id}/review": { post: {} }
+      })
+    ).toBe("normalized_results_mutation")
+  })
+
+  it("projects found-result tasks into non-reviewable success signals in projected mode", () => {
+    const [result] = projectScheduledTaskResults([
+      buildTask({
+        title: "Release monitor",
+        status: "scheduled",
+        source_ref: {
+          job_id: 42,
+          latest_run_id: 101,
+          latest_output_id: 202,
+          result_count: 3,
+          source_label: "Release feed",
+          matched_rule_label: "New items"
+        }
+      })
+    ])
+
+    expect(result).toMatchObject({
+      capabilityMode: "projected_signals",
+      signalKind: "result",
+      state: "new",
+      severity: "success",
+      reviewed: false,
+      reviewAvailable: false,
+      retryAvailable: false,
+      taskTitle: "Release monitor",
+      resultId: "202",
+      runId: "101",
+      sourceLabel: "Release feed",
+      matchedRuleLabel: "New items",
+      owner: "watchlists",
+      ownerLabel: "Watchlists"
+    })
+    expect(result?.primaryHref).toBe("/scheduled-tasks?tab=results&result_id=202")
+    expect(result?.resultHref).toBe("/watchlists?tab=outputs&output_id=202&open_output=1")
+    expect(result?.runHref).toBe("/watchlists?tab=runs&run_id=101&open_run=1")
+  })
+
+  it("projects failed tasks into attention signals with recovery copy", () => {
+    const [result] = projectScheduledTaskResults([
+      buildTask({
+        id: "reminder_task:failed",
+        primitive: "reminder_task",
+        title: "Follow up",
+        status: "failed",
+        edit_mode: "native",
+        manage_url: null,
+        source_ref: {
+          task_id: "failed",
+          run_id: 77,
+          error_msg: "Request timed out"
+        }
+      })
+    ])
+
+    expect(result).toMatchObject({
+      signalKind: "failure",
+      state: "failed",
+      severity: "error",
+      taskId: "reminder_task:failed",
+      runId: "77",
+      retryAvailable: false
+    })
+    expect(result?.summary).toContain("needs attention")
+    expect(result?.primaryHref).toBe("/scheduled-tasks?tab=results&run_id=77")
+  })
+
+  it("keeps result and failure signals separate for failed tasks that produced output", () => {
+    const results = projectScheduledTaskResults([
+      buildTask({
+        title: "Mixed state monitor",
+        status: "failed with results",
+        source_ref: {
+          job_id: 42,
+          latest_run_id: 101,
+          latest_output_id: 202,
+          result_count: 1
+        }
+      })
+    ])
+
+    expect(results.map((result) => result.signalKind).sort()).toEqual([
+      "failure",
+      "result"
+    ])
+    expect(new Set(results.map((result) => result.dedupeKey)).size).toBe(2)
+  })
+
+  it("does not leak private-looking source reference values into provenance", () => {
+    const [result] = projectScheduledTaskResults([
+      buildTask({
+        title: "Private source monitor",
+        source_ref: {
+          latest_output_id: 202,
+          result_count: 1,
+          source_label: "https://example.com/feed?token=secret",
+          link_url: "https://example.com/feed?api_key=secret",
+          matched_rule_label: "Authorization: Bearer secret"
+        }
+      })
+    ])
+
+    const serialized = JSON.stringify(result)
+    expect(serialized).not.toContain("token=secret")
+    expect(serialized).not.toContain("api_key=secret")
+    expect(serialized).not.toContain("Bearer secret")
+    expect(result?.sourceLabel).toBeNull()
+    expect(result?.matchedRuleLabel).toBeNull()
+  })
+
+  it("excludes waiting tasks and completed-no-result signals from default Home items", () => {
+    const results = projectScheduledTaskResults(
+      [
+        buildTask({ id: "watchlist_job:waiting", title: "Waiting", source_ref: { job_id: 1 } }),
+        buildTask({
+          id: "watchlist_job:completed",
+          title: "Completed",
+          status: "completed",
+          source_ref: { job_id: 2 }
+        }),
+        buildTask({
+          id: "watchlist_job:result",
+          title: "Found",
+          source_ref: { job_id: 3, latest_output_id: 303, result_count: 1 }
+        })
+      ],
+      { includeCompletedNoResults: true }
+    )
+
+    expect(results.some((result) => result.state === "completed_no_results")).toBe(true)
+    expect(filterScheduledTaskResults(results, { states: ["completed_no_results"] })).toHaveLength(1)
+    expect(buildScheduledTaskAutomationHomeItems(results).map((item) => item.title)).toEqual([
+      "Found"
+    ])
+  })
+
+  it("builds safe result hrefs and dedupe keys", () => {
+    expect(buildScheduledTaskResultHref({ resultId: "202", runId: "101", taskId: "x" })).toBe(
+      "/scheduled-tasks?tab=results&result_id=202"
+    )
+    expect(buildScheduledTaskResultHref({ runId: "101", taskId: "x" })).toBe(
+      "/scheduled-tasks?tab=results&run_id=101"
+    )
+    expect(buildScheduledTaskResultHref({ taskId: "watchlist_job:42" })).toBe(
+      "/scheduled-tasks?tab=results&task_id=watchlist_job%3A42"
+    )
+    expect(
+      buildScheduledTaskResultDedupeKey({
+        signalKind: "failure",
+        taskId: "watchlist_job:42",
+        runId: null,
+        resultId: null,
+        state: "failed",
+        occurredAt: "2030-01-01T09:00:00Z"
+      })
+    ).toBe("task:watchlist_job:42:state:failure:time:2030-01-01T09:00:00Z")
+  })
+
+  it("normalizes notification targets without replacing notification behavior", () => {
+    expect(
+      normalizeScheduledTaskNotificationTarget({
+        id: 9,
+        kind: "job_completed",
+        title: "Done",
+        message: "Output ready",
+        severity: "info",
+        created_at: "2030-01-01T09:00:00Z",
+        link_type: "scheduled_task_result",
+        link_id: "202",
+        source_task_id: "watchlist_job:42",
+        source_task_run_id: "101"
+      })
+    ).toMatchObject({
+      notificationId: 9,
+      resultId: "202",
+      runId: "101",
+      taskId: "watchlist_job:42",
+      href: "/scheduled-tasks?tab=results&result_id=202"
+    })
+  })
+})

--- a/apps/packages/ui/src/components/Option/ScheduledTasks/__tests__/scheduled-task-results.test.ts
+++ b/apps/packages/ui/src/components/Option/ScheduledTasks/__tests__/scheduled-task-results.test.ts
@@ -120,6 +120,25 @@ describe("scheduled task result helpers", () => {
     expect(result?.primaryHref).toBe("/scheduled-tasks?tab=results&run_id=77")
   })
 
+  it("projects paused tasks without running copy", () => {
+    const [result] = projectScheduledTaskResults([
+      buildTask({
+        id: "watchlist_job:paused",
+        title: "Paused monitor",
+        status: "paused",
+        source_ref: { job_id: 9 }
+      })
+    ])
+
+    expect(result).toMatchObject({
+      signalKind: "running",
+      state: "paused",
+      severity: "warning",
+      summary: "Paused monitor is paused."
+    })
+    expect(buildScheduledTaskAutomationHomeItems([result])).toEqual([])
+  })
+
   it("keeps result and failure signals separate for failed tasks that produced output", () => {
     const results = projectScheduledTaskResults([
       buildTask({

--- a/apps/packages/ui/src/components/Option/ScheduledTasks/__tests__/scheduled-task-route-state.test.ts
+++ b/apps/packages/ui/src/components/Option/ScheduledTasks/__tests__/scheduled-task-route-state.test.ts
@@ -14,7 +14,8 @@ describe("scheduled task route state", () => {
     })
   })
 
-  it("accepts tasks and create tabs", () => {
+  it("accepts results, tasks, and create tabs", () => {
+    expect(parseScheduledTaskRouteState(new URLSearchParams("tab=results")).tab).toBe("results")
     expect(parseScheduledTaskRouteState(new URLSearchParams("tab=tasks")).tab).toBe("tasks")
     expect(parseScheduledTaskRouteState(new URLSearchParams("tab=create")).tab).toBe("create")
   })
@@ -26,25 +27,53 @@ describe("scheduled task route state", () => {
     })
   })
 
-  it("keeps valid template and task ids", () => {
+  it("keeps valid template, task, run, and result ids", () => {
     expect(
       parseScheduledTaskRouteState(new URLSearchParams("tab=create&template=watch"))
     ).toMatchObject({ tab: "create", templateId: "watch" })
     expect(
       parseScheduledTaskRouteState(new URLSearchParams("tab=tasks&task_id=reminder_task%3A2"))
     ).toMatchObject({ tab: "tasks", taskId: "reminder_task:2" })
+    expect(
+      parseScheduledTaskRouteState(
+        new URLSearchParams(
+          "tab=results&result_id=202&run_id=101&task_id=watchlist_job%3A2"
+        )
+      )
+    ).toMatchObject({
+      tab: "results",
+      resultId: "202",
+      runId: "101",
+      taskId: "watchlist_job:2"
+    })
   })
 
   it("normalizes whitespace-only parsed params to null", () => {
     expect(
       parseScheduledTaskRouteState(
-        new URLSearchParams("tab=%20%20&template=%20%20&task_id=%20%20")
+        new URLSearchParams(
+          "tab=%20%20&template=%20%20&task_id=%20%20&run_id=%20%20&result_id=%20%20"
+        )
       )
     ).toMatchObject({
       tab: "overview",
       invalidTab: null,
       templateId: null,
-      taskId: null
+      taskId: null,
+      runId: null,
+      resultId: null
+    })
+  })
+
+  it("rejects newline-bearing parsed ids instead of serializing unsafe route state", () => {
+    expect(
+      parseScheduledTaskRouteState(
+        new URLSearchParams("tab=results&result_id=202%0Asecret&run_id=101%0Dsecret")
+      )
+    ).toMatchObject({
+      tab: "results",
+      resultId: null,
+      runId: null
     })
   })
 
@@ -52,18 +81,41 @@ describe("scheduled task route state", () => {
     expect(buildScheduledTaskSearch({ tab: "tasks", taskId: "reminder_task:2" })).toBe(
       "?tab=tasks&task_id=reminder_task%3A2"
     )
+    expect(
+      buildScheduledTaskSearch({
+        tab: "results",
+        resultId: "202",
+        runId: "101",
+        taskId: "watchlist_job:2"
+      })
+    ).toBe("?tab=results&result_id=202&run_id=101&task_id=watchlist_job%3A2")
   })
 
   it("omits whitespace-only template and task ids when building search strings", () => {
     expect(buildScheduledTaskSearch({ tab: "create", templateId: "   " })).toBe("?tab=create")
     expect(buildScheduledTaskSearch({ tab: "tasks", taskId: "   " })).toBe("?tab=tasks")
+    expect(buildScheduledTaskSearch({ tab: "results", resultId: "   ", runId: "   " })).toBe(
+      "?tab=results"
+    )
   })
 
-  it("exposes exactly the Phase 2A tabs", () => {
+  it("uses the Phase 3 scheduled task information architecture tabs", () => {
     expect(SCHEDULED_TASK_TABS.map((tab) => tab.id)).toEqual([
       "overview",
+      "results",
       "tasks",
       "create"
     ])
+  })
+
+  it("can default alias routes into the Results tab without a tab query param", () => {
+    expect(
+      parseScheduledTaskRouteState(new URLSearchParams("result_id=202"), {
+        defaultTab: "results"
+      })
+    ).toMatchObject({
+      tab: "results",
+      resultId: "202"
+    })
   })
 })

--- a/apps/packages/ui/src/components/Option/ScheduledTasks/scheduled-task-result-links.ts
+++ b/apps/packages/ui/src/components/Option/ScheduledTasks/scheduled-task-result-links.ts
@@ -23,11 +23,15 @@ export interface ScheduledTaskResultDedupeKeyInput {
 
 export interface ScheduledTaskNotificationTarget {
   notificationId: number
+  notificationIds: number[]
+  signalKind: ScheduledTaskResultSignalKind
   resultId: string | null
   runId: string | null
   taskId: string | null
   href: string
   dedupeKey: string
+  createdAt: string
+  severity: string
 }
 
 const normalizeRouteId = (value: unknown): string | null => {
@@ -80,15 +84,67 @@ const shouldTreatLinkIdAsResult = (linkType: string | null | undefined): boolean
   return normalized.includes("result") || normalized.includes("output")
 }
 
+const shouldTreatLinkIdAsRun = (linkType: string | null | undefined): boolean => {
+  if (!linkType) {
+    return false
+  }
+
+  return linkType.toLowerCase().includes("run")
+}
+
+const shouldTreatLinkIdAsTask = (linkType: string | null | undefined): boolean => {
+  if (!linkType) {
+    return false
+  }
+
+  if (shouldTreatLinkIdAsResult(linkType) || shouldTreatLinkIdAsRun(linkType)) {
+    return false
+  }
+
+  const normalized = linkType.toLowerCase()
+  return normalized.includes("task") || normalized.includes("job")
+}
+
+const readNotificationField = (
+  notification: NotificationItem,
+  names: readonly string[]
+): string | null => {
+  const record = notification as unknown as Record<string, unknown>
+  for (const name of names) {
+    const value = normalizeRouteId(record[name])
+    if (value) {
+      return value
+    }
+  }
+  return null
+}
+
 const buildTaskIdFromNotification = (notification: NotificationItem): string | null => {
   const sourceTaskId = normalizeRouteId(notification.source_task_id)
   if (sourceTaskId) {
     return sourceTaskId
   }
 
+  const directTaskId = readNotificationField(notification, [
+    "task_id",
+    "taskId",
+    "scheduled_task_id",
+    "scheduledTaskId"
+  ])
+  if (directTaskId) {
+    return directTaskId
+  }
+
   const taskIdFromUrl = readQueryParam(notification.link_url, ["task_id", "taskId"])
   if (taskIdFromUrl) {
     return taskIdFromUrl
+  }
+
+  if (shouldTreatLinkIdAsTask(notification.link_type)) {
+    const linkTaskId = normalizeRouteId(notification.link_id)
+    if (linkTaskId) {
+      return linkTaskId
+    }
   }
 
   const sourceJobId = normalizeRouteId(notification.source_job_id)
@@ -97,6 +153,44 @@ const buildTaskIdFromNotification = (notification: NotificationItem): string | n
   }
 
   return null
+}
+
+const inferNotificationSignalKind = (
+  notification: NotificationItem,
+  resultId: string | null
+): ScheduledTaskResultSignalKind => {
+  if (resultId) {
+    return "result"
+  }
+
+  const normalized = [
+    notification.kind,
+    notification.severity,
+    notification.link_type,
+    notification.title,
+    notification.message
+  ]
+    .filter(Boolean)
+    .join(" ")
+    .toLowerCase()
+
+  if (
+    normalized.includes("fail") ||
+    normalized.includes("error") ||
+    normalized.includes("blocked")
+  ) {
+    return "failure"
+  }
+
+  if (
+    normalized.includes("running") ||
+    normalized.includes("started") ||
+    normalized.includes("processing")
+  ) {
+    return "running"
+  }
+
+  return "completed_no_results"
 }
 
 export const buildScheduledTaskResultHref = ({
@@ -151,6 +245,16 @@ export const normalizeScheduledTaskNotificationTarget = (
   notification: NotificationItem
 ): ScheduledTaskNotificationTarget | null => {
   const resultId =
+    readNotificationField(notification, [
+      "result_id",
+      "resultId",
+      "output_id",
+      "outputId",
+      "source_result_id",
+      "sourceResultId",
+      "source_output_id",
+      "sourceOutputId"
+    ]) ??
     (shouldTreatLinkIdAsResult(notification.link_type)
       ? normalizeRouteId(notification.link_id)
       : null) ??
@@ -162,6 +266,17 @@ export const normalizeScheduledTaskNotificationTarget = (
     ])
   const runId =
     normalizeRouteId(notification.source_task_run_id) ??
+    readNotificationField(notification, [
+      "run_id",
+      "runId",
+      "scheduled_task_run_id",
+      "scheduledTaskRunId",
+      "source_run_id",
+      "sourceRunId"
+    ]) ??
+    (shouldTreatLinkIdAsRun(notification.link_type)
+      ? normalizeRouteId(notification.link_id)
+      : null) ??
     readQueryParam(notification.link_url, ["run_id", "runId"])
   const taskId = buildTaskIdFromNotification(notification)
 
@@ -170,19 +285,68 @@ export const normalizeScheduledTaskNotificationTarget = (
   }
 
   const href = buildScheduledTaskResultHref({ resultId, runId, taskId })
+  const signalKind = inferNotificationSignalKind(notification, resultId)
   return {
     notificationId: notification.id,
+    notificationIds: [notification.id],
+    signalKind,
     resultId,
     runId,
     taskId,
     href,
     dedupeKey: buildScheduledTaskResultDedupeKey({
-      signalKind: resultId ? "result" : "failure",
+      signalKind,
       taskId,
       runId,
       resultId,
       state: notification.severity,
       occurredAt: notification.created_at
-    })
+    }),
+    createdAt: notification.created_at,
+    severity: String(notification.severity)
   }
+}
+
+const targetIsNewer = (
+  candidate: ScheduledTaskNotificationTarget,
+  current: ScheduledTaskNotificationTarget
+): boolean => {
+  const candidateTime = Date.parse(candidate.createdAt)
+  const currentTime = Date.parse(current.createdAt)
+  if (Number.isFinite(candidateTime) && Number.isFinite(currentTime)) {
+    return candidateTime > currentTime
+  }
+  return candidate.notificationId > current.notificationId
+}
+
+const uniqueNotificationIds = (
+  first: readonly number[],
+  second: readonly number[]
+): number[] => Array.from(new Set([...first, ...second])).sort((a, b) => a - b)
+
+export const mergeScheduledTaskNotificationTargets = (
+  targets: Array<ScheduledTaskNotificationTarget | null | undefined>
+): ScheduledTaskNotificationTarget[] => {
+  const merged = new Map<string, ScheduledTaskNotificationTarget>()
+
+  targets.forEach((target) => {
+    if (!target) return
+
+    const existing = merged.get(target.dedupeKey)
+    if (!existing) {
+      merged.set(target.dedupeKey, {
+        ...target,
+        notificationIds: uniqueNotificationIds(target.notificationIds, [])
+      })
+      return
+    }
+
+    const preferred = targetIsNewer(target, existing) ? target : existing
+    merged.set(target.dedupeKey, {
+      ...preferred,
+      notificationIds: uniqueNotificationIds(existing.notificationIds, target.notificationIds)
+    })
+  })
+
+  return Array.from(merged.values())
 }

--- a/apps/packages/ui/src/components/Option/ScheduledTasks/scheduled-task-result-links.ts
+++ b/apps/packages/ui/src/components/Option/ScheduledTasks/scheduled-task-result-links.ts
@@ -1,0 +1,188 @@
+import type { NotificationItem } from "@/services/notifications"
+
+export type ScheduledTaskResultSignalKind =
+  | "result"
+  | "failure"
+  | "running"
+  | "completed_no_results"
+
+export interface ScheduledTaskResultHrefInput {
+  resultId?: string | number | null
+  runId?: string | number | null
+  taskId?: string | number | null
+}
+
+export interface ScheduledTaskResultDedupeKeyInput {
+  signalKind: ScheduledTaskResultSignalKind
+  taskId?: string | number | null
+  runId?: string | number | null
+  resultId?: string | number | null
+  state?: string | null
+  occurredAt?: string | null
+}
+
+export interface ScheduledTaskNotificationTarget {
+  notificationId: number
+  resultId: string | null
+  runId: string | null
+  taskId: string | null
+  href: string
+  dedupeKey: string
+}
+
+const normalizeRouteId = (value: unknown): string | null => {
+  if (typeof value === "number") {
+    return Number.isSafeInteger(value) && value >= 0 ? String(value) : null
+  }
+
+  if (typeof value !== "string") {
+    return null
+  }
+
+  const trimmed = value.trim()
+  if (!trimmed || /[\r\n]/.test(trimmed)) {
+    return null
+  }
+
+  return trimmed
+}
+
+const readQueryParam = (
+  url: string | null | undefined,
+  names: readonly string[]
+): string | null => {
+  const normalizedUrl = normalizeRouteId(url)
+  if (!normalizedUrl) {
+    return null
+  }
+
+  try {
+    const parsed = new URL(normalizedUrl, "http://tldw.local")
+    for (const name of names) {
+      const value = normalizeRouteId(parsed.searchParams.get(name))
+      if (value) {
+        return value
+      }
+    }
+  } catch {
+    return null
+  }
+
+  return null
+}
+
+const shouldTreatLinkIdAsResult = (linkType: string | null | undefined): boolean => {
+  if (!linkType) {
+    return false
+  }
+
+  const normalized = linkType.toLowerCase()
+  return normalized.includes("result") || normalized.includes("output")
+}
+
+const buildTaskIdFromNotification = (notification: NotificationItem): string | null => {
+  const sourceTaskId = normalizeRouteId(notification.source_task_id)
+  if (sourceTaskId) {
+    return sourceTaskId
+  }
+
+  const taskIdFromUrl = readQueryParam(notification.link_url, ["task_id", "taskId"])
+  if (taskIdFromUrl) {
+    return taskIdFromUrl
+  }
+
+  const sourceJobId = normalizeRouteId(notification.source_job_id)
+  if (sourceJobId) {
+    return `watchlist_job:${sourceJobId}`
+  }
+
+  return null
+}
+
+export const buildScheduledTaskResultHref = ({
+  resultId,
+  runId,
+  taskId
+}: ScheduledTaskResultHrefInput): string => {
+  const params = new URLSearchParams()
+  params.set("tab", "results")
+
+  const normalizedResultId = normalizeRouteId(resultId)
+  const normalizedRunId = normalizeRouteId(runId)
+  const normalizedTaskId = normalizeRouteId(taskId)
+
+  if (normalizedResultId) {
+    params.set("result_id", normalizedResultId)
+  } else if (normalizedRunId) {
+    params.set("run_id", normalizedRunId)
+  } else if (normalizedTaskId) {
+    params.set("task_id", normalizedTaskId)
+  }
+
+  return `/scheduled-tasks?${params.toString()}`
+}
+
+export const buildScheduledTaskResultDedupeKey = ({
+  signalKind,
+  taskId,
+  runId,
+  resultId,
+  state,
+  occurredAt
+}: ScheduledTaskResultDedupeKeyInput): string => {
+  const normalizedResultId = normalizeRouteId(resultId)
+  const normalizedRunId = normalizeRouteId(runId)
+  const normalizedTaskId = normalizeRouteId(taskId) ?? "unknown"
+  const normalizedOccurredAt = normalizeRouteId(occurredAt)
+  const normalizedState = normalizeRouteId(state) ?? "unknown"
+
+  if (signalKind === "result" && normalizedResultId) {
+    return `result:${normalizedResultId}`
+  }
+
+  if (normalizedRunId) {
+    return `run:${normalizedRunId}:state:${signalKind}`
+  }
+
+  return `task:${normalizedTaskId}:state:${signalKind}:time:${normalizedOccurredAt ?? normalizedState}`
+}
+
+export const normalizeScheduledTaskNotificationTarget = (
+  notification: NotificationItem
+): ScheduledTaskNotificationTarget | null => {
+  const resultId =
+    (shouldTreatLinkIdAsResult(notification.link_type)
+      ? normalizeRouteId(notification.link_id)
+      : null) ??
+    readQueryParam(notification.link_url, [
+      "result_id",
+      "resultId",
+      "output_id",
+      "outputId"
+    ])
+  const runId =
+    normalizeRouteId(notification.source_task_run_id) ??
+    readQueryParam(notification.link_url, ["run_id", "runId"])
+  const taskId = buildTaskIdFromNotification(notification)
+
+  if (!resultId && !runId && !taskId) {
+    return null
+  }
+
+  const href = buildScheduledTaskResultHref({ resultId, runId, taskId })
+  return {
+    notificationId: notification.id,
+    resultId,
+    runId,
+    taskId,
+    href,
+    dedupeKey: buildScheduledTaskResultDedupeKey({
+      signalKind: resultId ? "result" : "failure",
+      taskId,
+      runId,
+      resultId,
+      state: notification.severity,
+      occurredAt: notification.created_at
+    })
+  }
+}

--- a/apps/packages/ui/src/components/Option/ScheduledTasks/scheduled-task-results.ts
+++ b/apps/packages/ui/src/components/Option/ScheduledTasks/scheduled-task-results.ts
@@ -1,0 +1,627 @@
+import type { ScheduledTask } from "@/services/scheduled-tasks-control-plane"
+
+import {
+  buildScheduledTaskResultDedupeKey,
+  buildScheduledTaskResultHref,
+  type ScheduledTaskResultSignalKind
+} from "./scheduled-task-result-links"
+import {
+  buildWatchlistTaskLinks,
+  getScheduledTaskProductStatus,
+  getScheduledTaskTypeLabel
+} from "./scheduled-task-status"
+
+export type ScheduledTaskResultsCapabilityMode =
+  | "projected_signals"
+  | "normalized_results_read"
+  | "normalized_results_mutation"
+
+export type ScheduledTaskResultState =
+  | "new"
+  | "reviewed"
+  | "running"
+  | "completed_no_results"
+  | "failed"
+  | "blocked"
+  | "paused"
+
+export type ScheduledTaskResultSeverity = "info" | "success" | "warning" | "error"
+
+export type ScheduledTaskResultOwner =
+  | "scheduled_tasks"
+  | "watchlists"
+  | "reminders"
+  | "external_workspace"
+
+export interface ScheduledTaskResultItem {
+  id: string
+  capabilityMode: ScheduledTaskResultsCapabilityMode
+  signalKind: ScheduledTaskResultSignalKind
+  state: ScheduledTaskResultState
+  severity: ScheduledTaskResultSeverity
+  taskId: string
+  taskTitle: string
+  taskTypeLabel: string
+  owner: ScheduledTaskResultOwner
+  ownerLabel: string
+  resultId: string | null
+  runId: string | null
+  resultCount: number | null
+  sourceLabel: string | null
+  matchedRuleLabel: string | null
+  outputLabel: string | null
+  title: string
+  summary: string
+  occurredAt: string | null
+  primaryHref: string
+  resultHref: string | null
+  runHref: string | null
+  sourceHref: string | null
+  domainHref: string | null
+  dedupeKey: string
+  reviewed: boolean
+  reviewAvailable: boolean
+  retryAvailable: boolean
+}
+
+export interface ScheduledTaskResultProjectionOptions {
+  capabilityMode?: ScheduledTaskResultsCapabilityMode
+  includeCompletedNoResults?: boolean
+}
+
+export interface ScheduledTaskResultFilterOptions {
+  states?: ScheduledTaskResultState[]
+  signalKinds?: ScheduledTaskResultSignalKind[]
+  reviewState?: "all" | "reviewed" | "unreviewed"
+  owners?: ScheduledTaskResultOwner[]
+}
+
+export interface ScheduledTaskAutomationHomeItem {
+  id: string
+  title: string
+  summary: string
+  statusLabel: string
+  ownerLabel: string
+  href: string
+  updatedAt: string | null
+  severity: ScheduledTaskResultSeverity
+  dedupeKey: string
+}
+
+const RUN_ID_KEYS = [
+  "run_id",
+  "runId",
+  "last_run_id",
+  "lastRunId",
+  "latest_run_id",
+  "latestRunId"
+] as const
+
+const RESULT_ID_KEYS = [
+  "result_id",
+  "resultId",
+  "output_id",
+  "outputId",
+  "last_result_id",
+  "lastResultId",
+  "last_output_id",
+  "lastOutputId",
+  "latest_result_id",
+  "latestResultId",
+  "latest_output_id",
+  "latestOutputId"
+] as const
+
+const RESULT_COUNT_KEYS = [
+  "result_count",
+  "resultCount",
+  "results_count",
+  "resultsCount",
+  "output_count",
+  "outputCount",
+  "outputs_count",
+  "outputsCount"
+] as const
+
+const SOURCE_LABEL_KEYS = [
+  "source_label",
+  "sourceLabel",
+  "source_name",
+  "sourceName",
+  "origin_label",
+  "originLabel",
+  "scope_label",
+  "scopeLabel"
+] as const
+
+const MATCHED_RULE_LABEL_KEYS = [
+  "matched_rule_label",
+  "matchedRuleLabel",
+  "rule_label",
+  "ruleLabel",
+  "query_label",
+  "queryLabel",
+  "filter_label",
+  "filterLabel"
+] as const
+
+const PRIVATE_VALUE_PATTERN =
+  /(authorization\s*:|bearer\s+|api[_-]?key\s*=|access[_-]?token\s*=|token\s*=|client[_-]?secret\s*=|secret\s*=|password\s*=)/i
+
+const RESULT_STATUS_TOKENS = [
+  "found",
+  "match",
+  "matched",
+  "matches",
+  "matching",
+  "result",
+  "results",
+  "output",
+  "outputs"
+] as const
+
+const FAILURE_STATUS_TOKENS = [
+  "fail",
+  "failed",
+  "failing",
+  "failure",
+  "error",
+  "missed"
+] as const
+
+const BLOCKED_STATUS_TOKENS = [
+  "blocked",
+  "auth",
+  "permission",
+  "unavailable",
+  "dependency"
+] as const
+
+const RUNNING_STATUS_TOKENS = ["running", "active", "processing", "in_progress"] as const
+const PAUSED_STATUS_TOKENS = ["paused"] as const
+const COMPLETED_STATUS_TOKENS = ["complete", "completed", "success", "done", "finished"] as const
+
+const SEVERITY_ORDER: Record<ScheduledTaskResultSeverity, number> = {
+  error: 0,
+  warning: 1,
+  success: 2,
+  info: 3
+}
+
+const statusIncludes = (status: string, tokens: readonly string[]): boolean => {
+  const normalized = status.toLowerCase()
+  return tokens.some((token) => {
+    const escapedToken = token.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
+    return new RegExp(`(^|[^a-z0-9])${escapedToken}($|[^a-z0-9])`).test(
+      normalized
+    )
+  })
+}
+
+const isRecord = (value: unknown): value is Record<string, unknown> => {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value)
+}
+
+const normalizeId = (value: unknown): string | null => {
+  if (typeof value === "number") {
+    return Number.isSafeInteger(value) && value >= 0 ? String(value) : null
+  }
+
+  if (typeof value !== "string") {
+    return null
+  }
+
+  const trimmed = value.trim()
+  if (!trimmed || /[\r\n]/.test(trimmed)) {
+    return null
+  }
+
+  return trimmed
+}
+
+const toPositiveInteger = (value: unknown): number | null => {
+  if (typeof value === "number" && Number.isSafeInteger(value) && value > 0) {
+    return value
+  }
+
+  if (typeof value !== "string") {
+    return null
+  }
+
+  const trimmed = value.trim()
+  if (!/^\d+$/.test(trimmed)) {
+    return null
+  }
+
+  const parsed = Number(trimmed)
+  return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : null
+}
+
+const firstId = (
+  sourceRef: Record<string, unknown>,
+  keys: readonly string[]
+): string | null => {
+  for (const key of keys) {
+    const value = normalizeId(sourceRef[key])
+    if (value) {
+      return value
+    }
+  }
+  return null
+}
+
+const firstPositiveInteger = (
+  sourceRef: Record<string, unknown>,
+  keys: readonly string[]
+): number | null => {
+  for (const key of keys) {
+    const value = toPositiveInteger(sourceRef[key])
+    if (value !== null) {
+      return value
+    }
+  }
+  return null
+}
+
+const sanitizeProvenanceText = (value: unknown): string | null => {
+  if (typeof value !== "string" && typeof value !== "number" && typeof value !== "boolean") {
+    return null
+  }
+
+  const trimmed = String(value).trim()
+  if (!trimmed || /[\r\n]/.test(trimmed) || PRIVATE_VALUE_PATTERN.test(trimmed)) {
+    return null
+  }
+
+  return trimmed
+}
+
+const firstSanitizedText = (
+  sourceRef: Record<string, unknown>,
+  keys: readonly string[]
+): string | null => {
+  for (const key of keys) {
+    const value = sanitizeProvenanceText(sourceRef[key])
+    if (value) {
+      return value
+    }
+  }
+  return null
+}
+
+const hasPositiveResultSignal = (sourceRef: Record<string, unknown>): boolean =>
+  firstPositiveInteger(sourceRef, RESULT_COUNT_KEYS) !== null ||
+  firstId(sourceRef, RESULT_ID_KEYS) !== null
+
+const inferOwner = (
+  task: ScheduledTask
+): { owner: ScheduledTaskResultOwner; ownerLabel: string } => {
+  if (task.primitive === "watchlist_job") {
+    return { owner: "watchlists", ownerLabel: "Watchlists" }
+  }
+
+  if (task.primitive === "reminder_task") {
+    return { owner: "reminders", ownerLabel: "Reminders" }
+  }
+
+  if (task.edit_mode === "external") {
+    return { owner: "external_workspace", ownerLabel: "External automation" }
+  }
+
+  return { owner: "scheduled_tasks", ownerLabel: "Scheduled Tasks" }
+}
+
+const buildOutputLabel = (
+  signalKind: ScheduledTaskResultSignalKind,
+  resultCount: number | null,
+  resultId: string | null
+): string | null => {
+  if (signalKind !== "result") {
+    return null
+  }
+
+  if (resultCount !== null) {
+    return `${resultCount} ${resultCount === 1 ? "result" : "results"}`
+  }
+
+  if (resultId) {
+    return `Output ${resultId}`
+  }
+
+  return "Results ready"
+}
+
+const buildResultSummary = (
+  task: ScheduledTask,
+  signalKind: ScheduledTaskResultSignalKind,
+  state: ScheduledTaskResultState,
+  resultCount: number | null,
+  sourceLabel: string | null
+): string => {
+  if (signalKind === "result") {
+    const countText =
+      resultCount !== null
+        ? `${resultCount} ${resultCount === 1 ? "result" : "results"}`
+        : "results"
+    return sourceLabel ? `Found ${countText} from ${sourceLabel}.` : `Found ${countText}.`
+  }
+
+  if (signalKind === "running") {
+    return `${task.title} is running now.`
+  }
+
+  if (signalKind === "completed_no_results") {
+    return `${task.title} completed its latest run without new results.`
+  }
+
+  if (state === "blocked") {
+    return `${task.title} is blocked by a required setup or dependency issue.`
+  }
+
+  return `${task.title} needs attention. Open details to inspect the latest run.`
+}
+
+const buildStatusLabel = (
+  signalKind: ScheduledTaskResultSignalKind,
+  state: ScheduledTaskResultState
+): string => {
+  if (signalKind === "result") {
+    return state === "reviewed" ? "Reviewed" : "New result"
+  }
+
+  if (state === "blocked") {
+    return "Blocked"
+  }
+
+  if (signalKind === "failure") {
+    return "Needs attention"
+  }
+
+  if (signalKind === "running") {
+    return "Running now"
+  }
+
+  return "Completed"
+}
+
+const canMutateResults = (mode: ScheduledTaskResultsCapabilityMode): boolean =>
+  mode === "normalized_results_mutation"
+
+const createResultItem = (
+  task: ScheduledTask,
+  signalKind: ScheduledTaskResultSignalKind,
+  state: ScheduledTaskResultState,
+  severity: ScheduledTaskResultSeverity,
+  capabilityMode: ScheduledTaskResultsCapabilityMode
+): ScheduledTaskResultItem => {
+  const sourceRef = isRecord(task.source_ref) ? task.source_ref : {}
+  const runId = firstId(sourceRef, RUN_ID_KEYS)
+  const resultId = signalKind === "result" ? firstId(sourceRef, RESULT_ID_KEYS) : null
+  const resultCount = signalKind === "result" ? firstPositiveInteger(sourceRef, RESULT_COUNT_KEYS) : null
+  const sourceLabel = firstSanitizedText(sourceRef, SOURCE_LABEL_KEYS)
+  const matchedRuleLabel = firstSanitizedText(sourceRef, MATCHED_RULE_LABEL_KEYS)
+  const occurredAt = task.last_run_at || null
+  const watchlistLinks = buildWatchlistTaskLinks(task)
+  const { owner, ownerLabel } = inferOwner(task)
+  const primaryHref = buildScheduledTaskResultHref({
+    resultId,
+    runId,
+    taskId: task.id
+  })
+  const resultHref = signalKind === "result" ? watchlistLinks.latestOutputUrl : null
+  const runHref = watchlistLinks.latestRunUrl
+  const sourceHref = watchlistLinks.settingsUrl
+  const domainHref = resultHref ?? runHref ?? sourceHref
+  const dedupeKey = buildScheduledTaskResultDedupeKey({
+    signalKind,
+    taskId: task.id,
+    runId,
+    resultId,
+    state,
+    occurredAt
+  })
+  const outputLabel = buildOutputLabel(signalKind, resultCount, resultId)
+  const title = task.title || getScheduledTaskTypeLabel(task)
+
+  return {
+    id: dedupeKey,
+    capabilityMode,
+    signalKind,
+    state,
+    severity,
+    taskId: task.id,
+    taskTitle: title,
+    taskTypeLabel: getScheduledTaskTypeLabel(task),
+    owner,
+    ownerLabel,
+    resultId,
+    runId,
+    resultCount,
+    sourceLabel,
+    matchedRuleLabel,
+    outputLabel,
+    title,
+    summary: buildResultSummary(task, signalKind, state, resultCount, sourceLabel),
+    occurredAt,
+    primaryHref,
+    resultHref,
+    runHref,
+    sourceHref,
+    domainHref,
+    dedupeKey,
+    reviewed: false,
+    reviewAvailable: canMutateResults(capabilityMode) && signalKind === "result",
+    retryAvailable: canMutateResults(capabilityMode) && signalKind === "failure"
+  }
+}
+
+const pathHasMethod = (
+  methods: unknown,
+  methodName: "get" | "post" | "patch" | "delete"
+): boolean => {
+  return isRecord(methods) && Object.keys(methods).some(
+    (method) => method.toLowerCase() === methodName
+  )
+}
+
+export const resolveScheduledTaskResultsCapabilityMode = (
+  paths: Record<string, unknown> | null | undefined
+): ScheduledTaskResultsCapabilityMode => {
+  if (!paths) {
+    return "projected_signals"
+  }
+
+  const entries = Object.entries(paths)
+  const hasReadableResults = entries.some(([path, methods]) => {
+    const normalizedPath = path.toLowerCase()
+    return (
+      normalizedPath.endsWith("/scheduled-tasks/results") &&
+      pathHasMethod(methods, "get")
+    )
+  })
+
+  if (!hasReadableResults) {
+    return "projected_signals"
+  }
+
+  const hasResultMutation = entries.some(([path, methods]) => {
+    const normalizedPath = path.toLowerCase()
+    return (
+      (normalizedPath.includes("/scheduled-tasks/results/") &&
+        (normalizedPath.endsWith("/review") || normalizedPath.endsWith("/retry"))) &&
+      pathHasMethod(methods, "post")
+    )
+  })
+
+  return hasResultMutation ? "normalized_results_mutation" : "normalized_results_read"
+}
+
+export const projectScheduledTaskResults = (
+  tasks: ScheduledTask[],
+  options: ScheduledTaskResultProjectionOptions = {}
+): ScheduledTaskResultItem[] => {
+  const capabilityMode = options.capabilityMode ?? "projected_signals"
+  const includeCompletedNoResults = options.includeCompletedNoResults ?? false
+  const results: ScheduledTaskResultItem[] = []
+
+  tasks.forEach((task) => {
+    if (!task.enabled) {
+      return
+    }
+
+    const status = task.status || ""
+    const sourceRef = isRecord(task.source_ref) ? task.source_ref : {}
+    const productStatus = getScheduledTaskProductStatus(task)
+    const hasFailure =
+      productStatus.key === "needs_attention" || statusIncludes(status, FAILURE_STATUS_TOKENS)
+    const hasBlocked =
+      productStatus.key === "blocked" || statusIncludes(status, BLOCKED_STATUS_TOKENS)
+    const isRunning =
+      productStatus.key === "running" || statusIncludes(status, RUNNING_STATUS_TOKENS)
+    const isPaused =
+      productStatus.key === "paused" || statusIncludes(status, PAUSED_STATUS_TOKENS)
+    const isCompleted =
+      productStatus.key === "completed" || statusIncludes(status, COMPLETED_STATUS_TOKENS)
+    const hasResult =
+      productStatus.key === "found_results" ||
+      statusIncludes(status, RESULT_STATUS_TOKENS) ||
+      hasPositiveResultSignal(sourceRef)
+
+    if (hasFailure) {
+      results.push(createResultItem(task, "failure", "failed", "error", capabilityMode))
+    }
+
+    if (!hasFailure && hasBlocked) {
+      results.push(createResultItem(task, "failure", "blocked", "warning", capabilityMode))
+    }
+
+    if (hasResult) {
+      results.push(createResultItem(task, "result", "new", "success", capabilityMode))
+    }
+
+    if (!hasFailure && !hasBlocked && !hasResult && isRunning) {
+      results.push(createResultItem(task, "running", "running", "info", capabilityMode))
+    }
+
+    if (!hasFailure && !hasBlocked && !hasResult && !isRunning && isPaused) {
+      results.push(createResultItem(task, "running", "paused", "warning", capabilityMode))
+    }
+
+    if (
+      includeCompletedNoResults &&
+      !hasFailure &&
+      !hasBlocked &&
+      !hasResult &&
+      !isRunning &&
+      !isPaused &&
+      isCompleted
+    ) {
+      results.push(
+        createResultItem(task, "completed_no_results", "completed_no_results", "info", capabilityMode)
+      )
+    }
+  })
+
+  return results.sort((a, b) => {
+    const severityDelta = SEVERITY_ORDER[a.severity] - SEVERITY_ORDER[b.severity]
+    if (severityDelta !== 0) {
+      return severityDelta
+    }
+
+    const aTime = a.occurredAt ? Date.parse(a.occurredAt) : 0
+    const bTime = b.occurredAt ? Date.parse(b.occurredAt) : 0
+    if (aTime !== bTime) {
+      return bTime - aTime
+    }
+
+    return a.title.localeCompare(b.title)
+  })
+}
+
+export const filterScheduledTaskResults = (
+  results: ScheduledTaskResultItem[],
+  options: ScheduledTaskResultFilterOptions
+): ScheduledTaskResultItem[] => {
+  return results.filter((result) => {
+    if (options.states && !options.states.includes(result.state)) {
+      return false
+    }
+
+    if (options.signalKinds && !options.signalKinds.includes(result.signalKind)) {
+      return false
+    }
+
+    if (options.owners && !options.owners.includes(result.owner)) {
+      return false
+    }
+
+    if (options.reviewState === "reviewed" && !result.reviewed) {
+      return false
+    }
+
+    if (options.reviewState === "unreviewed" && result.reviewed) {
+      return false
+    }
+
+    return true
+  })
+}
+
+export const buildScheduledTaskAutomationHomeItems = (
+  results: ScheduledTaskResultItem[]
+): ScheduledTaskAutomationHomeItem[] => {
+  return results
+    .filter((result) => result.signalKind === "result" || result.signalKind === "failure")
+    .filter((result) => result.state !== "completed_no_results")
+    .map((result) => ({
+      id: result.id,
+      title: result.title,
+      summary: result.summary,
+      statusLabel: buildStatusLabel(result.signalKind, result.state),
+      ownerLabel: result.ownerLabel,
+      href: result.primaryHref,
+      updatedAt: result.occurredAt,
+      severity: result.severity,
+      dedupeKey: result.dedupeKey
+    }))
+}

--- a/apps/packages/ui/src/components/Option/ScheduledTasks/scheduled-task-results.ts
+++ b/apps/packages/ui/src/components/Option/ScheduledTasks/scheduled-task-results.ts
@@ -11,6 +11,8 @@ import {
   getScheduledTaskTypeLabel
 } from "./scheduled-task-status"
 
+export type { ScheduledTaskResultSignalKind } from "./scheduled-task-result-links"
+
 export type ScheduledTaskResultsCapabilityMode =
   | "projected_signals"
   | "normalized_results_read"

--- a/apps/packages/ui/src/components/Option/ScheduledTasks/scheduled-task-results.ts
+++ b/apps/packages/ui/src/components/Option/ScheduledTasks/scheduled-task-results.ts
@@ -88,6 +88,12 @@ export interface ScheduledTaskAutomationHomeItem {
   dedupeKey: string
 }
 
+export interface ScheduledTaskResultRouteTarget {
+  resultId?: string | null
+  runId?: string | null
+  taskId?: string | null
+}
+
 const RUN_ID_KEYS = [
   "run_id",
   "runId",
@@ -605,6 +611,28 @@ export const filterScheduledTaskResults = (
 
     return true
   })
+}
+
+export const findScheduledTaskResultByRouteState = (
+  results: ScheduledTaskResultItem[],
+  routeState: ScheduledTaskResultRouteTarget
+): ScheduledTaskResultItem | null => {
+  const resultId = normalizeId(routeState.resultId)
+  if (resultId) {
+    return results.find((result) => result.resultId === resultId) ?? null
+  }
+
+  const runId = normalizeId(routeState.runId)
+  if (runId) {
+    return results.find((result) => result.runId === runId) ?? null
+  }
+
+  const taskId = normalizeId(routeState.taskId)
+  if (taskId) {
+    return results.find((result) => result.taskId === taskId) ?? null
+  }
+
+  return null
 }
 
 export const buildScheduledTaskAutomationHomeItems = (

--- a/apps/packages/ui/src/components/Option/ScheduledTasks/scheduled-task-results.ts
+++ b/apps/packages/ui/src/components/Option/ScheduledTasks/scheduled-task-results.ts
@@ -358,6 +358,10 @@ const buildResultSummary = (
     return sourceLabel ? `Found ${countText} from ${sourceLabel}.` : `Found ${countText}.`
   }
 
+  if (state === "paused") {
+    return `${task.title} is paused.`
+  }
+
   if (signalKind === "running") {
     return `${task.title} is running now.`
   }
@@ -383,6 +387,10 @@ const buildStatusLabel = (
 
   if (state === "blocked") {
     return "Blocked"
+  }
+
+  if (state === "paused") {
+    return "Paused"
   }
 
   if (signalKind === "failure") {

--- a/apps/packages/ui/src/components/Option/ScheduledTasks/scheduled-task-results.ts
+++ b/apps/packages/ui/src/components/Option/ScheduledTasks/scheduled-task-results.ts
@@ -1,8 +1,12 @@
+import type { CompanionHomeItem } from "@/services/companion-home"
+import type { NotificationItem } from "@/services/notifications"
 import type { ScheduledTask } from "@/services/scheduled-tasks-control-plane"
 
 import {
   buildScheduledTaskResultDedupeKey,
   buildScheduledTaskResultHref,
+  mergeScheduledTaskNotificationTargets,
+  normalizeScheduledTaskNotificationTarget,
   type ScheduledTaskResultSignalKind
 } from "./scheduled-task-result-links"
 import {
@@ -655,3 +659,151 @@ export const buildScheduledTaskAutomationHomeItems = (
       dedupeKey: result.dedupeKey
     }))
 }
+
+const normalizeNotificationHomeSeverity = (
+  notification: NotificationItem,
+  signalKind: ScheduledTaskResultSignalKind
+): ScheduledTaskResultSeverity => {
+  if (signalKind === "result") {
+    return "success"
+  }
+
+  const severity = String(notification.severity || "").toLowerCase()
+  if (severity.includes("error") || severity.includes("danger")) {
+    return "error"
+  }
+  if (severity.includes("warn") || severity.includes("blocked")) {
+    return "warning"
+  }
+  return signalKind === "failure" ? "error" : "info"
+}
+
+const inferNotificationOwnerLabel = (notification: NotificationItem): string => {
+  const taskId = String(notification.source_task_id || "")
+  const domain = String(notification.source_domain || "").toLowerCase()
+  const jobType = String(notification.source_job_type || "").toLowerCase()
+
+  if (
+    taskId.startsWith("watchlist_job:") ||
+    domain.includes("watchlist") ||
+    jobType.includes("watchlist") ||
+    notification.source_job_id != null
+  ) {
+    return "Watchlists"
+  }
+
+  if (taskId.startsWith("reminder_task:")) {
+    return "Reminders"
+  }
+
+  return "Scheduled Tasks"
+}
+
+const stateForNotificationTarget = (
+  signalKind: ScheduledTaskResultSignalKind,
+  severity: ScheduledTaskResultSeverity
+): ScheduledTaskResultState => {
+  if (signalKind === "result") {
+    return "new"
+  }
+  if (signalKind === "running") {
+    return "running"
+  }
+  if (signalKind === "completed_no_results") {
+    return "completed_no_results"
+  }
+  return severity === "warning" ? "blocked" : "failed"
+}
+
+export const buildScheduledTaskAutomationHomeItemsFromNotifications = (
+  notifications: NotificationItem[]
+): ScheduledTaskAutomationHomeItem[] => {
+  const notificationsById = new Map(
+    notifications.map((notification) => [notification.id, notification])
+  )
+
+  return mergeScheduledTaskNotificationTargets(
+    notifications.map(normalizeScheduledTaskNotificationTarget)
+  )
+    .filter((target) => target.signalKind === "result" || target.signalKind === "failure")
+    .map((target) => {
+      const notification = notificationsById.get(target.notificationId)
+      const severity = notification
+        ? normalizeNotificationHomeSeverity(notification, target.signalKind)
+        : target.signalKind === "result"
+          ? "success"
+          : "error"
+      const state = stateForNotificationTarget(target.signalKind, severity)
+
+      return {
+        id: `notification:${target.notificationId}`,
+        title: notification?.title || "Automation result",
+        summary: notification?.message || "Open Scheduled Tasks to inspect this automation signal.",
+        statusLabel: buildStatusLabel(target.signalKind, state),
+        ownerLabel: notification ? inferNotificationOwnerLabel(notification) : "Scheduled Tasks",
+        href: target.href,
+        updatedAt: target.createdAt || notification?.created_at || null,
+        severity,
+        dedupeKey: target.dedupeKey
+      }
+    })
+}
+
+const parseHomeItemTime = (item: ScheduledTaskAutomationHomeItem): number => {
+  const timestamp = item.updatedAt ? Date.parse(item.updatedAt) : 0
+  return Number.isFinite(timestamp) ? timestamp : 0
+}
+
+const shouldPreferHomeItem = (
+  candidate: ScheduledTaskAutomationHomeItem,
+  current: ScheduledTaskAutomationHomeItem
+): boolean => {
+  const candidateTime = parseHomeItemTime(candidate)
+  const currentTime = parseHomeItemTime(current)
+  if (candidateTime !== currentTime) {
+    return candidateTime > currentTime
+  }
+
+  return SEVERITY_ORDER[candidate.severity] < SEVERITY_ORDER[current.severity]
+}
+
+export const mergeScheduledTaskAutomationHomeItems = (
+  itemGroups: ScheduledTaskAutomationHomeItem[][]
+): ScheduledTaskAutomationHomeItem[] => {
+  const merged = new Map<string, ScheduledTaskAutomationHomeItem>()
+
+  itemGroups.flat().forEach((item) => {
+    const existing = merged.get(item.dedupeKey)
+    if (!existing || shouldPreferHomeItem(item, existing)) {
+      merged.set(item.dedupeKey, item)
+    }
+  })
+
+  return Array.from(merged.values()).sort((a, b) => {
+    const severityDelta = SEVERITY_ORDER[a.severity] - SEVERITY_ORDER[b.severity]
+    if (severityDelta !== 0) {
+      return severityDelta
+    }
+
+    const timeDelta = parseHomeItemTime(b) - parseHomeItemTime(a)
+    if (timeDelta !== 0) {
+      return timeDelta
+    }
+
+    return a.title.localeCompare(b.title)
+  })
+}
+
+export const buildScheduledTaskCompanionHomeItems = (
+  items: ScheduledTaskAutomationHomeItem[]
+): CompanionHomeItem[] =>
+  items.map((item) => ({
+    id: `automation:${item.dedupeKey}`,
+    entityId: item.dedupeKey,
+    entityType: "scheduled_task_result",
+    source: "scheduled_task",
+    title: item.title,
+    summary: `${item.statusLabel} - ${item.ownerLabel}. ${item.summary}`,
+    updatedAt: item.updatedAt,
+    href: item.href
+  }))

--- a/apps/packages/ui/src/components/Option/ScheduledTasks/scheduled-task-route-state.ts
+++ b/apps/packages/ui/src/components/Option/ScheduledTasks/scheduled-task-route-state.ts
@@ -1,4 +1,4 @@
-export type ScheduledTaskTabId = "overview" | "tasks" | "create"
+export type ScheduledTaskTabId = "overview" | "results" | "tasks" | "create"
 
 export interface ScheduledTaskTabDefinition {
   id: ScheduledTaskTabId
@@ -10,10 +10,17 @@ export interface ScheduledTaskRouteState {
   invalidTab: string | null
   templateId: string | null
   taskId: string | null
+  runId: string | null
+  resultId: string | null
+}
+
+export interface ParseScheduledTaskRouteStateOptions {
+  defaultTab?: ScheduledTaskTabId
 }
 
 export const SCHEDULED_TASK_TABS: readonly ScheduledTaskTabDefinition[] = [
   { id: "overview", label: "Overview" },
+  { id: "results", label: "Results" },
   { id: "tasks", label: "Tasks" },
   { id: "create", label: "Create" }
 ] as const
@@ -24,41 +31,72 @@ const SCHEDULED_TASK_TAB_IDS = new Set<ScheduledTaskTabId>(
 
 const normalizeNullableParam = (value: string | null): string | null => {
   const trimmed = String(value ?? "").trim()
+  if (/[\r\n]/.test(trimmed)) return null
   return trimmed || null
 }
 
 export const parseScheduledTaskRouteState = (
-  params: URLSearchParams
+  params: URLSearchParams,
+  options: ParseScheduledTaskRouteStateOptions = {}
 ): ScheduledTaskRouteState => {
   const rawTab = normalizeNullableParam(params.get("tab"))
-  const tab =
-    rawTab && SCHEDULED_TASK_TAB_IDS.has(rawTab as ScheduledTaskTabId)
-      ? (rawTab as ScheduledTaskTabId)
+  const defaultTab =
+    options.defaultTab && SCHEDULED_TASK_TAB_IDS.has(options.defaultTab)
+      ? options.defaultTab
       : "overview"
+  const isRawTabValid = rawTab
+    ? SCHEDULED_TASK_TAB_IDS.has(rawTab as ScheduledTaskTabId)
+    : false
+  const tab =
+    rawTab && isRawTabValid
+      ? (rawTab as ScheduledTaskTabId)
+      : rawTab
+        ? "overview"
+        : defaultTab
+
+  const invalidTab =
+    rawTab && !isRawTabValid ? rawTab : null
+
+  const templateId = normalizeNullableParam(params.get("template"))
+  const taskId = normalizeNullableParam(params.get("task_id"))
+  const runId = normalizeNullableParam(params.get("run_id"))
+  const resultId = normalizeNullableParam(params.get("result_id"))
 
   return {
     tab,
-    invalidTab: rawTab && tab === "overview" && rawTab !== "overview" ? rawTab : null,
-    templateId: normalizeNullableParam(params.get("template")),
-    taskId: normalizeNullableParam(params.get("task_id"))
+    invalidTab,
+    templateId,
+    taskId,
+    runId,
+    resultId
   }
 }
 
 export const buildScheduledTaskSearch = ({
   tab,
   templateId,
-  taskId
+  taskId,
+  runId,
+  resultId
 }: {
   tab: ScheduledTaskTabId
   templateId?: string | null
   taskId?: string | null
+  runId?: string | null
+  resultId?: string | null
 }): string => {
   const params = new URLSearchParams()
   const normalizedTemplateId = normalizeNullableParam(templateId ?? null)
   const normalizedTaskId = normalizeNullableParam(taskId ?? null)
+  const normalizedRunId = normalizeNullableParam(runId ?? null)
+  const normalizedResultId = normalizeNullableParam(resultId ?? null)
   if (tab !== "overview") params.set("tab", tab)
   if (normalizedTemplateId && tab === "create") params.set("template", normalizedTemplateId)
-  if (normalizedTaskId && tab === "tasks") params.set("task_id", normalizedTaskId)
+  if (normalizedResultId && tab === "results") params.set("result_id", normalizedResultId)
+  if (normalizedRunId && tab === "results") params.set("run_id", normalizedRunId)
+  if (normalizedTaskId && (tab === "tasks" || tab === "results")) {
+    params.set("task_id", normalizedTaskId)
+  }
   const serialized = params.toString()
   return serialized ? `?${serialized}` : ""
 }

--- a/apps/packages/ui/src/routes/__tests__/scheduled-tasks-route.test.tsx
+++ b/apps/packages/ui/src/routes/__tests__/scheduled-tasks-route.test.tsx
@@ -10,6 +10,7 @@ const extensionRouteRegistryRelativePath =
 const webRouteRelativePath = "apps/packages/ui/src/routes/option-scheduled-tasks.tsx"
 const extensionRouteRelativePath =
   "apps/tldw-frontend/extension/routes/option-scheduled-tasks.tsx"
+const hostedResultsAliasRelativePath = "apps/tldw-frontend/pages/scheduled-tasks/results.tsx"
 
 const resolveWorkspaceRoot = (startDirectory: string): string => {
   let currentDirectory = startDirectory
@@ -39,6 +40,7 @@ const extensionRouteRegistrySource = readFileSync(
   "utf8"
 )
 const extensionRoutePath = resolve(workspaceRoot, extensionRouteRelativePath)
+const hostedResultsAliasPath = resolve(workspaceRoot, hostedResultsAliasRelativePath)
 
 describe("scheduled tasks route wiring", () => {
   it("registers the scheduled tasks route shell", () => {
@@ -50,6 +52,12 @@ describe("scheduled tasks route wiring", () => {
   it("registers the scheduled tasks page in both web and extension route registries", () => {
     expect(webRouteRegistrySource).toContain('path: "/scheduled-tasks"')
     expect(extensionRouteRegistrySource).toContain('path: "/scheduled-tasks"')
+  })
+
+  it("registers scheduled tasks Results aliases across route surfaces", () => {
+    expect(webRouteRegistrySource).toContain('path: "/scheduled-tasks/results"')
+    expect(extensionRouteRegistrySource).toContain('path: "/scheduled-tasks/results"')
+    expect(existsSync(hostedResultsAliasPath)).toBe(true)
   })
 
   it("uses a dedicated extension scheduled tasks route shell", () => {

--- a/apps/packages/ui/src/routes/__tests__/scheduled-tasks-route.test.tsx
+++ b/apps/packages/ui/src/routes/__tests__/scheduled-tasks-route.test.tsx
@@ -58,6 +58,8 @@ describe("scheduled tasks route wiring", () => {
     expect(webRouteRegistrySource).toContain('path: "/scheduled-tasks/results"')
     expect(extensionRouteRegistrySource).toContain('path: "/scheduled-tasks/results"')
     expect(existsSync(hostedResultsAliasPath)).toBe(true)
+    const hostedResultsAliasSource = readFileSync(hostedResultsAliasPath, "utf8")
+    expect(hostedResultsAliasSource).toContain("option-scheduled-tasks")
   })
 
   it("uses a dedicated extension scheduled tasks route shell", () => {

--- a/apps/packages/ui/src/routes/route-registry.tsx
+++ b/apps/packages/ui/src/routes/route-registry.tsx
@@ -362,6 +362,11 @@ export const ROUTE_DEFINITIONS: RouteDefinition[] = [
     path: "/scheduled-tasks",
     element: <OptionScheduledTasks />,
   },
+  {
+    kind: "options",
+    path: "/scheduled-tasks/results",
+    element: <OptionScheduledTasks />,
+  },
   { kind: "options", path: "/kanban", element: <OptionKanbanPlayground /> },
   {
     kind: "options",

--- a/apps/packages/ui/src/services/companion-home.ts
+++ b/apps/packages/ui/src/services/companion-home.ts
@@ -10,9 +10,19 @@ import { tldwClient } from "@/services/tldw/TldwApiClient"
 
 export type CompanionHomeSurface = "options" | "sidepanel"
 
-export type CompanionHomeSource = "canonical_inbox" | "goal" | "reading" | "note"
+export type CompanionHomeSource =
+  | "canonical_inbox"
+  | "goal"
+  | "reading"
+  | "note"
+  | "scheduled_task"
 
-export type CompanionHomeEntityType = "notification" | "goal" | "reading_item" | "note"
+export type CompanionHomeEntityType =
+  | "notification"
+  | "goal"
+  | "reading_item"
+  | "note"
+  | "scheduled_task_result"
 
 export type CompanionHomeDegradedSource = "workspace" | "reading" | "notes"
 

--- a/apps/tldw-frontend/extension/routes/route-registry.tsx
+++ b/apps/tldw-frontend/extension/routes/route-registry.tsx
@@ -637,6 +637,11 @@ export const ROUTE_DEFINITIONS: RouteDefinition[] = [
       order: 3.4
     }
   },
+  {
+    kind: "options",
+    path: "/scheduled-tasks/results",
+    element: <OptionScheduledTasks />
+  },
   { kind: "options", path: "/kanban", element: <OptionKanbanPlayground /> },
   {
     kind: "options",

--- a/apps/tldw-frontend/pages/scheduled-tasks/results.tsx
+++ b/apps/tldw-frontend/pages/scheduled-tasks/results.tsx
@@ -1,0 +1,3 @@
+import dynamic from "next/dynamic"
+
+export default dynamic(() => import("@/routes/option-scheduled-tasks"), { ssr: false })

--- a/backlog/tasks/task-2331 - Plan-Scheduled-Tasks-Phase-3-results-inbox-and-Home-surfacing.md
+++ b/backlog/tasks/task-2331 - Plan-Scheduled-Tasks-Phase-3-results-inbox-and-Home-surfacing.md
@@ -1,0 +1,64 @@
+---
+id: TASK-2331
+title: Plan Scheduled Tasks Phase 3 results inbox and Home surfacing
+status: Done
+labels:
+- scheduled-tasks
+- webui
+- home
+- ux
+- implementation-plan
+priority: high
+references:
+- TASK-494
+- TASK-496
+- TASK-498
+- Docs/superpowers/specs/2026-06-01-scheduled-tasks-automation-workbench-prd-design.md
+- Docs/superpowers/plans/2026-06-09-scheduled-tasks-phase3-results-inbox-home-surfacing-implementation-plan.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Create an implementation-ready plan for Scheduled Tasks Automation Workbench Phase 3: results inbox, Home automation surfacing, exact task/run/result deep links, failure triage, and notification/Home dedupe.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Plan is saved under Docs/superpowers/plans with exact files, tests, commands, and staged implementation tasks.
+- [x] #2 Plan scopes Phase 3 to results discovery and Home surfacing, leaving recurring RAG and ACP/agent schedule creation to later Phase 4 work.
+- [x] #3 Plan preserves Watchlists, Home, Notifications, and Scheduled Tasks ownership boundaries with deep links instead of moving domain configuration.
+- [x] #4 Plan covers first-time user and power-user workflows, empty/loading/error/success states, accessibility, responsive extension-sized layouts, and copy recommendations.
+- [x] #5 Plan review is completed or findings are addressed/documented, and Backlog records verification and known skips.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+- Cleanup: verified the stale Scheduled Tasks Phase 2B planning item is already Done on latest `origin/dev`; no cleanup edit was required for that task.
+- Added implementation plan: `Docs/superpowers/plans/2026-06-09-scheduled-tasks-phase3-results-inbox-home-surfacing-implementation-plan.md`.
+- Plan review findings addressed:
+  - Clarified that Phase 3 ships as `/scheduled-tasks?tab=results` rather than assuming a new nested route.
+  - Made Home integration concrete by extending the Companion Home item source/entity types for scheduled-task result items instead of leaving the type strategy open.
+  - Added notification target normalization and dedupe requirements so Home and notification-derived result items resolve to the same exact task/run/result targets.
+  - Kept Watchlists as the owner of monitor setup, source tuning, activity, and reports; Scheduled Tasks only links into those surfaces.
+- Verification:
+  - Unresolved-marker scan passed for the plan and Backlog task.
+  - `git diff --cached --check` passed.
+  - Bandit skipped because this is docs/Backlog-only planning work with no Python/backend file changes.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Created and reviewed the Scheduled Tasks Phase 3 implementation plan for results inbox and Home surfacing. The plan is scoped to product/UX and frontend implementation work, with backend APIs listed as dependencies. It covers `/scheduled-tasks` Results IA, result projection, exact deep links, Home inbox/attention surfacing, notification dedupe, empty/error/loading/success states, accessibility, responsive checks, tests, and explicit Watchlists preservation boundaries.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed.
+- [x] #2 Plan document added and referenced from this task.
+- [x] #3 Verification recorded, including docs scans and Bandit skip rationale for docs-only work.
+- [x] #4 Final summary added.
+- [x] #5 Changes committed on the planning branch.
+<!-- DOD:END -->

--- a/backlog/tasks/task-2332 - Address-Scheduled-Tasks-Phase-3-plan-review-findings.md
+++ b/backlog/tasks/task-2332 - Address-Scheduled-Tasks-Phase-3-plan-review-findings.md
@@ -1,0 +1,68 @@
+---
+id: TASK-2332
+title: Address Scheduled Tasks Phase 3 plan review findings
+status: Done
+labels:
+- scheduled-tasks
+- webui
+- home
+- ux
+- implementation-plan
+priority: high
+references:
+- TASK-2331
+- Docs/superpowers/plans/2026-06-09-scheduled-tasks-phase3-results-inbox-home-surfacing-implementation-plan.md
+- Docs/superpowers/specs/2026-06-01-scheduled-tasks-automation-workbench-prd-design.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Patch the Phase 3 results inbox and Home surfacing implementation plan to resolve identified UX/product risks before implementation: review-state capability modes, mixed task/result states, route contract, Home rendering strategy, notification dedupe source, structured provenance, and unsupported action visibility.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Plan defines capability modes so projected task-list signals do not pretend to support durable review state or mutation actions.
+- [x] #2 Plan defines mixed-state rules for failed runs with outputs and other task/result status conflicts.
+- [x] #3 Plan reconciles the PRD /scheduled-tasks/results route with the current query-tab implementation strategy.
+- [x] #4 Plan clarifies Home rendering strategy, notification dedupe source, and structured provenance fields.
+- [x] #5 Plan updates tests/tasks/copy guidance for unsupported retry/review actions and avoids action graveyards.
+- [x] #6 Backlog records verification and final summary.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+- Updated the Phase 3 plan to add explicit capability modes:
+  - `projected_signals`
+  - `normalized_results_read`
+  - `normalized_results_mutation`
+- Added rules that hide durable review filters/actions and retry/review mutation buttons in projected mode.
+- Added mixed-state projection rules so failed tasks with produced output keep both the failure signal and the result signal.
+- Reconciled routing by keeping query-tab state internally while adding `/scheduled-tasks/results` as a route alias for PRD/Home/notification stability.
+- Changed Home surfacing from generic Companion card merging to a dedicated `Automation Inbox` module with status, owner, and exact deep links.
+- Clarified notification dedupe source as a non-blocking `listNotifications({ limit: 50 })` load.
+- Added structured provenance fields: `resultKind`, `matchReason`, `matchedRuleLabel`, `outputLabel`, and `domainHref`.
+- Updated stages, file structure, tests, copy guidance, and PR checklist to reflect the above.
+- Verification:
+  - Consistency scan passed for unresolved markers and stale old-plan phrases.
+  - `git diff --check` passed.
+  - Bandit skipped because this amendment touched only Markdown planning/Backlog files.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Addressed all identified Phase 3 plan review issues before implementation. The plan now prevents fake review-state UX in projected mode, preserves mixed result/failure states, ships a stable `/scheduled-tasks/results` alias, uses a dedicated Home Automation Inbox, defines the notification dedupe source, structures provenance fields, and hides unsupported mutation actions instead of presenting disabled action clutter.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-2333 - Implement-Scheduled-Tasks-Phase-3-result-projection-foundation.md
+++ b/backlog/tasks/task-2333 - Implement-Scheduled-Tasks-Phase-3-result-projection-foundation.md
@@ -1,0 +1,58 @@
+---
+id: TASK-2333
+title: Implement Scheduled Tasks Phase 3 result projection foundation
+status: Done
+labels:
+- scheduled-tasks
+- webui
+- home
+- implementation
+priority: high
+modified_files:
+- apps/packages/ui/src/components/Option/ScheduledTasks/scheduled-task-result-links.ts
+- apps/packages/ui/src/components/Option/ScheduledTasks/scheduled-task-results.ts
+- apps/packages/ui/src/components/Option/ScheduledTasks/__tests__/scheduled-task-results.test.ts
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement Stage 1 of the amended Scheduled Tasks Phase 3 plan: capability modes, result/signal projection from scheduled task list data, result deep links, notification/home dedupe helpers, mixed failure-plus-output rules, and pure unit tests.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Pure result projection model and helpers are implemented for scheduled task list data.
+- [x] #2 Capability modes distinguish projected signals from normalized results and hide durable review semantics in projected mode.
+- [x] #3 Mixed failure-plus-output task states produce separate failure and result signals with separate dedupe keys.
+- [x] #4 Result URL helpers build task, run, result, Home, and notification targets safely.
+- [x] #5 Unit tests cover projection, capability modes, mixed states, dedupe keys, and unsafe source reference sanitization.
+- [x] #6 Verification and Bandit/frontend-only rationale are recorded in Backlog.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Implemented the Stage 1 result projection foundation as pure UI helpers. Added route/dedupe helpers for scheduled task result, run, and task targets; notification target normalization that preserves notification behavior while creating scheduled-task result deep links; capability mode detection for projected/read/mutation result support; and a projection model that turns scheduled task list data into result, failure, running, and completed-without-results signals.
+
+The projected mode intentionally keeps reviewAvailable and retryAvailable false so the UI does not imply durable result-review or retry semantics until normalized backend result mutation APIs exist. Mixed failed-with-output states now create separate failure and result signals with separate dedupe keys. Provenance labels are sanitized and private-looking source references such as token, api_key, Authorization/Bearer, secret, and password values are not surfaced.
+
+Verification: `./node_modules/.bin/vitest run src/components/Option/ScheduledTasks/__tests__/scheduled-task-results.test.ts` passed (8 tests). `./node_modules/.bin/vitest run src/components/Option/ScheduledTasks/__tests__` passed (9 files, 119 tests). Bandit skipped because this task touched only frontend TypeScript test/helper files and Backlog task metadata; no Python code was changed.
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Implemented Scheduled Tasks Phase 3 Stage 1 result projection helpers and tests. The UI can now derive safe result/failure/running/completed-no-result signals from existing scheduled-task list data, route Home/notification clicks into `/scheduled-tasks?tab=results`, hide review/retry affordances in projected mode, separate mixed failure/output states, and scrub private-looking provenance values. Focused and full Scheduled Tasks component Vitest suites passed; Bandit was not applicable because no Python files were touched.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-2334 - Implement-Scheduled-Tasks-Phase-3-results-route-state-and-tab-shell.md
+++ b/backlog/tasks/task-2334 - Implement-Scheduled-Tasks-Phase-3-results-route-state-and-tab-shell.md
@@ -1,0 +1,71 @@
+---
+id: TASK-2334
+title: Implement Scheduled Tasks Phase 3 results route state and tab shell
+status: Done
+labels:
+- scheduled-tasks
+- webui
+- routing
+- implementation
+priority: high
+modified_files:
+- Docs/superpowers/plans/2026-06-09-scheduled-tasks-phase3-results-inbox-home-surfacing-implementation-plan.md
+- apps/packages/ui/src/components/Option/ScheduledTasks/ScheduledTasksPage.tsx
+- apps/packages/ui/src/components/Option/ScheduledTasks/scheduled-task-route-state.ts
+- apps/packages/ui/src/components/Option/ScheduledTasks/scheduled-task-results.ts
+- apps/packages/ui/src/components/Option/ScheduledTasks/__tests__/ScheduledTasksPage.test.tsx
+- apps/packages/ui/src/components/Option/ScheduledTasks/__tests__/scheduled-task-route-state.test.ts
+- apps/packages/ui/src/routes/route-registry.tsx
+- apps/packages/ui/src/routes/__tests__/scheduled-tasks-route.test.tsx
+- apps/tldw-frontend/extension/routes/route-registry.tsx
+- apps/tldw-frontend/pages/scheduled-tasks/results.tsx
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement Stage 2 of the Scheduled Tasks Phase 3 plan: make Results a first-class `/scheduled-tasks` tab, parse and build result/run/task deep links, add `/scheduled-tasks/results` aliases for extension and hosted WebUI, add a minimal Results tab shell wired to projected result items, and preserve existing Tasks tab detail behavior.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 `?tab=results` is accepted as a first-class Scheduled Tasks tab and invalid tabs still fall back to Overview.
+- [x] #2 `result_id`, `run_id`, and `task_id` are parsed and serialized safely for the Results tab without breaking Tasks tab task-detail behavior.
+- [x] #3 `/scheduled-tasks/results` aliases to the same Scheduled Tasks route in the extension and hosted WebUI.
+- [x] #4 ScheduledTasksPage renders a Results tab shell from projected result items and can deep-link to result/run/task-scoped results without a dead-end.
+- [x] #5 Focused route-state and ScheduledTasksPage tests cover the new tab, deep-link builders, alias route behavior where practical, and missing-result handling.
+- [x] #6 Verification and Bandit/frontend-only rationale are recorded in Backlog.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Docs/superpowers/plans/2026-06-09-scheduled-tasks-phase3-results-inbox-home-surfacing-implementation-plan.md
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Added Results to the Scheduled Tasks tab IA and extended route parsing/building with safe `result_id`, `run_id`, and task-scoped result route state. Newline-bearing route ids are rejected before serialization. Invalid tabs continue to fall back to Overview.
+
+ScheduledTasksPage now defaults `/scheduled-tasks/results` aliases into the Results tab, projects current task-list data into latest automation signals, renders a minimal source-agnostic Results shell, supports exact result/run/task selection, and shows a non-blocking missing-result warning for stale deep links. Existing Tasks tab task-detail state remains separate.
+
+Added `/scheduled-tasks/results` route entries to shared and extension registries and added the hosted Next.js alias page. Verification: `./node_modules/.bin/vitest run src/components/Option/ScheduledTasks/__tests__/scheduled-task-route-state.test.ts src/components/Option/ScheduledTasks/__tests__/ScheduledTasksPage.test.tsx src/routes/__tests__/scheduled-tasks-route.test.tsx` passed (3 files, 47 tests). `./node_modules/.bin/vitest run src/components/Option/ScheduledTasks/__tests__` passed (9 files, 124 tests). Bandit skipped because this task touched only frontend TypeScript/TSX, route-page, Markdown plan, and Backlog files; no Python code was changed.
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Implemented Scheduled Tasks Phase 3 Stage 2 route and tab shell. Results is now a first-class Scheduled Tasks tab with safe `result_id`, `run_id`, and task-scoped route state, `/scheduled-tasks/results` aliases exist for shared, extension, and hosted WebUI surfaces, and ScheduledTasksPage renders a projected latest-signals shell with exact deep-link selection and missing-result handling while preserving the existing Tasks tab drawer behavior. Focused Stage 2 tests and the full ScheduledTasks component test folder passed. Bandit was not applicable because no Python/backend files were touched.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-2335 - Implement-Scheduled-Tasks-Phase-3-results-panel-and-detail-drawer.md
+++ b/backlog/tasks/task-2335 - Implement-Scheduled-Tasks-Phase-3-results-panel-and-detail-drawer.md
@@ -1,0 +1,67 @@
+---
+id: TASK-2335
+title: Implement Scheduled Tasks Phase 3 results panel and detail drawer
+status: Done
+labels:
+- scheduled-tasks
+- webui
+- ux
+- implementation
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement Stage 3 of the Scheduled Tasks Phase 3 plan: replace the temporary Results tab shell with a source-agnostic results panel, filters, capability-aware action visibility, and a result detail drawer that explains provenance, owner, run/result state, and next links without showing unsupported review or retry controls.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Results panel renders success, failure, running, and completed/no-results projected signals with visible state and owner text.
+- [x] #2 Projected-mode filters support result state, task type, and owner while hiding durable Review state filters.
+- [x] #3 Empty states distinguish no tasks, no results, and no filter matches.
+- [x] #4 Detail drawer shows result summary, provenance labels, owner, task/run/result ids where available, and Watchlists deep links for Watchlist-owned results.
+- [x] #5 Retry/review controls are hidden in projected mode and a concise capability note explains when they appear.
+- [x] #6 ScheduledTasksPage opens/closes the result drawer from result rows and result/run/task deep links while preserving task detail drawer behavior.
+- [x] #7 Focused panel, drawer, page, and Scheduled Tasks tests pass; verification and Bandit/frontend-only rationale are recorded.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Docs/superpowers/plans/2026-06-09-scheduled-tasks-phase3-results-inbox-home-surfacing-implementation-plan.md
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+- Added `ScheduledTaskResultsPanel.tsx` with source-agnostic projected result scanning, state/type/owner filters, normalized-mode review filtering, and separate no-task/no-result/no-filter-match empty states.
+- Added `ScheduledTaskResultDetailDrawer.tsx` with provenance, owner, task/run/result ids, result summary, Watchlists deep links, and capability-aware review/retry controls.
+- Wired `ScheduledTasksPage.tsx` Results rows and result/run/task deep links to the detail drawer while preserving the existing Tasks drawer route behavior.
+- Gave the result drawer an explicit `aria-labelledby` target because Ant Design's test-mode generated drawer id can collide with other generated ids, producing an empty accessible dialog name.
+- Rendered page-level task/result detail drawers only when active to avoid inactive overlay DOM competing in the accessibility tree.
+- Updated `ScheduledTasksPage.test.tsx` to assert direct result drawer opening from `/scheduled-tasks/results?result_id=...`.
+- Verification:
+  - `./node_modules/.bin/vitest run src/components/Option/ScheduledTasks/__tests__/ScheduledTaskResultsPanel.test.tsx src/components/Option/ScheduledTasks/__tests__/ScheduledTaskResultDetailDrawer.test.tsx src/components/Option/ScheduledTasks/__tests__/ScheduledTasksPage.test.tsx` passed 41 tests.
+  - `./node_modules/.bin/vitest run src/components/Option/ScheduledTasks/__tests__` passed 133 tests.
+  - `git diff --check` passed.
+  - `./node_modules/.bin/tsc --noEmit` failed with Node heap exhaustion; `node --max-old-space-size=8192 ./node_modules/typescript/bin/tsc --noEmit` completed and failed only on existing unrelated Notes, background, and voice-cloning type errors. Touched Scheduled Tasks type errors found by the first high-heap run were fixed before final verification.
+- Bandit skipped because this task touched only frontend TypeScript/TSX files, tests, Backlog metadata, and the implementation plan; no Python/backend files changed.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Implemented the Scheduled Tasks Results panel and detail drawer for projected result signals. The Results tab now has filterable source-agnostic result rows, accurate empty states, deep-link-driven result inspection, Watchlists continuation links, and hidden retry/review actions unless future result capabilities support them.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-2336 - Implement-Scheduled-Tasks-Phase-3-notification-links-and-dedupe.md
+++ b/backlog/tasks/task-2336 - Implement-Scheduled-Tasks-Phase-3-notification-links-and-dedupe.md
@@ -1,0 +1,64 @@
+---
+id: TASK-2336
+title: Implement Scheduled Tasks Phase 3 notification links and dedupe
+status: Done
+labels:
+- scheduled-tasks
+- webui
+- ux
+- implementation
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement Stage 4 of the Scheduled Tasks Phase 3 plan: normalize scheduled-task notification targets, add deterministic dedupe helpers for task/run/result signals, preserve existing notification behavior, and add focused tests for notification-derived result links and dedupe behavior.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Notification payloads with link_url, source_task_id, source_task_run_id, source_job_id, source metadata, or task/run/result ids resolve to scheduled-task Results deep links when possible.
+- [x] #2 Exact result ids win over run ids, and run ids win over task-scoped fallback links.
+- [x] #3 Dedupe keys keep separate runs separate and keep failure/result signals separate when no exact result id exists.
+- [x] #4 Existing notification stream, mark-read, dismiss, and snooze behavior is unchanged; helpers remain pure unless needed by Home in a later stage.
+- [x] #5 Focused scheduled-task result/link and notification service tests pass; verification and Bandit/frontend-only rationale are recorded.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Docs/superpowers/plans/2026-06-09-scheduled-tasks-phase3-results-inbox-home-surfacing-implementation-plan.md
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+- Extended `scheduled-task-result-links.ts` to normalize result, run, and task notification targets from direct fields, `link_url`, `link_type`/`link_id`, source task/run ids, and Watchlists job ids.
+- Added signal-kind inference for notification-derived targets so failures, running signals, results, and completed/no-result notifications do not collapse into the same run-level dedupe key.
+- Added `notificationIds`, `signalKind`, `createdAt`, and `severity` to normalized scheduled-task notification targets for later Home merging.
+- Added `mergeScheduledTaskNotificationTargets` to collapse duplicate notification targets by dedupe key while preserving all notification ids.
+- Kept notification service behavior unchanged; Stage 4 helper tests import the pure scheduled-task link helper, and existing notification service tests still cover stream, list, read, dismiss, and snooze behavior.
+- Left the plan's non-blocking Home notification load item unchecked because it belongs with the Home integration in Stage 6.
+- Verification:
+  - `./node_modules/.bin/vitest run src/components/Option/ScheduledTasks/__tests__/scheduled-task-results.test.ts` passed 12 tests.
+  - `./node_modules/.bin/vitest run src/components/Option/ScheduledTasks/__tests__` passed 136 tests.
+  - `./node_modules/.bin/vitest run src/services/__tests__/notifications.test.ts` passed 9 tests.
+- Bandit skipped because this task touched only frontend TypeScript tests/helpers, Backlog metadata, and the implementation plan; no Python/backend files changed.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Implemented scheduled-task notification target normalization and dedupe helpers. Result ids now take priority over run ids, run ids take priority over task-scoped fallbacks, and duplicate notification-derived targets retain their source notification ids without changing existing notification service behavior.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-2337 - Implement-Scheduled-Tasks-Phase-3-overview-and-task-cross-links.md
+++ b/backlog/tasks/task-2337 - Implement-Scheduled-Tasks-Phase-3-overview-and-task-cross-links.md
@@ -1,0 +1,65 @@
+---
+id: TASK-2337
+title: Implement Scheduled Tasks Phase 3 overview and task cross-links
+status: Done
+assignee: []
+created_date: ''
+updated_date: '2026-06-09 07:20'
+labels:
+  - scheduled-tasks
+  - webui
+  - ux
+  - implementation
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement Stage 5 of the Scheduled Tasks Phase 3 plan: make projected results discoverable from the Scheduled Tasks overview, task table, and task detail drawer while preserving Watchlists as the owner for external monitor setup and management.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Overview surfaces newest projected result signals and provides a clear link to the Results tab without durable review-count claims in projected mode.
+- [x] #2 Tasks table exposes a Results action only for tasks that have projected result signals, while native reminder edit/delete and Watchlists owner controls remain unchanged.
+- [x] #3 Task detail drawer links to the latest result/run when known and preserves Watchlists owner copy.
+- [x] #4 No Watchlists-owned edit controls are introduced in Scheduled Tasks.
+- [x] #5 Focused overview/table/detail/page tests and full Scheduled Tasks tests pass; verification and Bandit/frontend-only rationale are recorded.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Docs/superpowers/plans/2026-06-09-scheduled-tasks-phase3-results-inbox-home-surfacing-implementation-plan.md
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+- ScheduledTaskOverview now renders the newest projected result signal with a direct action into the Results tab, without review-count copy in projected mode.
+- ScheduledTaskTable now computes task result presence from projected result items and only shows a Results row action when at least one projected signal exists for that task.
+- ScheduledTaskDetailDrawer now accepts the latest result signal and exposes an exact latest-result link before the existing native reminder or Watchlists-owned actions.
+- Watchlists rows still show Watchlists settings/activity/reports links and remain read-only from Scheduled Tasks; no Watchlists-owned edit controls were added.
+- Verification: ./node_modules/.bin/vitest run src/components/Option/ScheduledTasks/__tests__/ScheduledTasksPage.test.tsx src/components/Option/ScheduledTasks/__tests__/ScheduledTaskDetailDrawer.test.tsx passed 36 tests.
+- Verification: ./node_modules/.bin/vitest run src/components/Option/ScheduledTasks/__tests__ passed 136 tests.
+- Verification: git diff --check passed before task finalization.
+- Bandit: skipped because this slice only changes frontend TypeScript/React and Backlog/plan text, not Python executable code.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Implemented Scheduled Tasks Stage 5 overview and task cross-links. Projected result signals are now discoverable from Overview, task rows expose a gated Results action, and task details link to the latest known result while preserving Watchlists ownership boundaries.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-2338 - Implement-Scheduled-Tasks-Phase-3-Home-Automation-Inbox-surfacing.md
+++ b/backlog/tasks/task-2338 - Implement-Scheduled-Tasks-Phase-3-Home-Automation-Inbox-surfacing.md
@@ -57,8 +57,6 @@ Docs/superpowers/plans/2026-06-09-scheduled-tasks-phase3-results-inbox-home-surf
 Implemented Scheduled Tasks Phase 3 Home surfacing. Home now includes a fixed Automation Inbox module that can show scheduled-task result and failure signals without Companion personalization, merge projected task signals with notification-derived signals, handle partial failures without blocking existing Home cards, and deep-link to exact Scheduled Tasks result/run/task targets.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
-<!-- SECTION:FINAL_SUMMARY:END -->
-
 ## Definition of Done
 <!-- DOD:BEGIN -->
 - [x] #1 Acceptance criteria completed

--- a/backlog/tasks/task-2338 - Implement-Scheduled-Tasks-Phase-3-Home-Automation-Inbox-surfacing.md
+++ b/backlog/tasks/task-2338 - Implement-Scheduled-Tasks-Phase-3-Home-Automation-Inbox-surfacing.md
@@ -1,0 +1,70 @@
+---
+id: TASK-2338
+title: Implement Scheduled Tasks Phase 3 Home Automation Inbox surfacing
+status: Done
+assignee: []
+created_date: ''
+updated_date: '2026-06-09 07:32'
+labels:
+  - scheduled-tasks
+  - webui
+  - ux
+  - implementation
+  - companion-home
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement Stage 6 of the Scheduled Tasks Phase 3 plan: surface scheduled-task result and attention signals on Companion Home through a dedicated Automation Inbox module that loads independently of Companion personalization and deep-links to Scheduled Tasks results.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Home renders a dedicated Automation Inbox module with scheduled-task result and failure items.
+- [x] #2 Automation Inbox shows visible status, owner, timestamp, summary, and exact Scheduled Tasks result/run/task deep links.
+- [x] #3 Scheduled-task Home signals load independently of Companion personalization and still render when personalization is unavailable.
+- [x] #4 Scheduled-task loading or notification loading failure does not block existing Companion Home cards or items.
+- [x] #5 Existing Companion Inbox Preview, Needs Attention, layout customization, and Watchlists ownership behavior remain unchanged.
+- [x] #6 Focused CompanionHome and scheduled-task helper tests pass; verification and Bandit/frontend-only rationale are recorded.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Docs/superpowers/plans/2026-06-09-scheduled-tasks-phase3-results-inbox-home-surfacing-implementation-plan.md
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+- Added a dedicated AutomationInboxCard for Home with empty, loading, partial, result, and failure states.
+- Added useScheduledTaskHomeSignals so scheduled-task Home signals load independently from Companion personalization using listScheduledTasks and non-blocking listNotifications({ limit: 50 }).
+- Added scheduled-task automation Home adapters for projected task results, notification-derived result targets, CompanionHomeItem mapping, and dedupe across identical run/result signals.
+- Extended CompanionHomeSource and CompanionHomeEntityType with scheduled_task and scheduled_task_result.
+- Rendered Automation Inbox after WhatsNextCard and before the existing Companion Inbox Preview and Needs Attention cards; Customize Home layout data and existing Companion cards are unchanged.
+- Verification: ./node_modules/.bin/vitest run src/components/Option/CompanionHome/__tests__/AutomationInboxCard.test.tsx src/components/Option/CompanionHome/__tests__/CompanionHomePage.test.tsx src/components/Option/ScheduledTasks/__tests__/scheduled-task-results.test.ts passed 29 tests.
+- Verification: ./node_modules/.bin/vitest run src/components/Option/CompanionHome/__tests__ passed 34 tests.
+- Verification: ./node_modules/.bin/vitest run src/components/Option/ScheduledTasks/__tests__ passed 138 tests.
+- Bandit: skipped because this slice only changes frontend TypeScript/React and Backlog/plan text, not Python executable code.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Implemented Scheduled Tasks Phase 3 Home surfacing. Home now includes a fixed Automation Inbox module that can show scheduled-task result and failure signals without Companion personalization, merge projected task signals with notification-derived signals, handle partial failures without blocking existing Home cards, and deep-link to exact Scheduled Tasks result/run/task targets.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or documented frontend-only skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-2339 - Verify-Scheduled-Tasks-Phase-3-UX-polish-responsive-and-copy-closeout.md
+++ b/backlog/tasks/task-2339 - Verify-Scheduled-Tasks-Phase-3-UX-polish-responsive-and-copy-closeout.md
@@ -1,0 +1,68 @@
+---
+id: TASK-2339
+title: Verify Scheduled Tasks Phase 3 UX polish responsive and copy closeout
+status: Done
+assignee: []
+created_date: ''
+updated_date: '2026-06-09 07:53'
+labels:
+  - scheduled-tasks
+  - webui
+  - ux
+  - verification
+  - companion-home
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement Stage 7 of the Scheduled Tasks Phase 3 plan: verify first-time and power-user UX, final visible copy, source-agnostic language, projected-mode capability boundaries, accessibility labels, responsive behavior, and browser observations for Scheduled Tasks Results and Home Automation Inbox.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 New visible copy explains no tasks, no results, result discovery, Home surfacing, and partial failures without backend promises not supported in projected mode.
+- [x] #2 Generic Scheduled Tasks UI does not hard-code GitHub, YouTube, or other example-source copy.
+- [x] #3 Projected mode does not show durable-review language or unsupported retry/review actions outside capability-gated detail notes.
+- [x] #4 Drawer focus, accessible names, keyboard flow, and color-independent status text are verified or findings are fixed.
+- [x] #5 Home Automation Inbox does not introduce nested-card/layout drift or Customize Home regressions.
+- [x] #6 Responsive/browser observations are recorded for scheduled-tasks routes and Home, or a clear environment blocker is documented.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Docs/superpowers/plans/2026-06-09-scheduled-tasks-phase3-results-inbox-home-surfacing-implementation-plan.md
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Stage 7 copy and UX closeout completed.
+
+- Fixed projected-mode copy in ScheduledTaskResultsPanel so it says result history and item actions appear when the results API is available, avoiding durable-review language in task-list projection mode.
+- Updated ScheduledTasksPage and ScheduledTaskResultsPanel tests for the final projected-mode copy.
+- Searched generic Scheduled Tasks UI for GitHub/YouTube/vendor-first copy; only internal capability ids and tests/templates contain example source categories, not generic user-facing Results UI.
+- Verified projected-mode Review state filter, Mark reviewed, and Retry run remain hidden unless normalized result capability/item availability allows them.
+- Verified result/detail drawers use accessible titles and existing tests cover capability-aware action visibility.
+- Browser smoke used WebUI on http://localhost:18001 plus a temporary read-only mock API on http://127.0.0.1:8000 for health, OpenAPI, scheduled-task, and notification empty responses. /scheduled-tasks and /scheduled-tasks?tab=results rendered without the readiness gate. Results empty state and Create action were visible on desktop and 390px viewport. /companion rendered Automation Inbox before Inbox Preview with personalization unavailable on desktop and 390px viewport.
+- Bandit skipped because this stage touched frontend, docs, and Backlog task files only; no Python/backend files changed.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Scheduled Tasks Phase 3 Stage 7 UX polish is complete. Projected-mode copy no longer implies durable review state, source-agnostic language was audited, unsupported mutation actions remain capability-gated, and browser observations were recorded for Scheduled Tasks Results and Home Automation Inbox in desktop and mobile-sized viewports.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or documented frontend-only skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-2340 - Close-out-Scheduled-Tasks-Phase-3-final-verification.md
+++ b/backlog/tasks/task-2340 - Close-out-Scheduled-Tasks-Phase-3-final-verification.md
@@ -1,0 +1,69 @@
+---
+id: TASK-2340
+title: Close out Scheduled Tasks Phase 3 final verification
+status: Done
+assignee: []
+created_date: ''
+updated_date: '2026-06-09 08:01'
+labels:
+  - scheduled-tasks
+  - webui
+  - verification
+  - companion-home
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement Stage 8 of the Scheduled Tasks Phase 3 results inbox and Home surfacing plan: final documentation/backlog verification, focused test evidence, frontend-only Bandit skip rationale, PR checklist closeout, and clean branch status.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Final plan Stage 8 and PR review checklist reflect verification status.
+- [x] #2 Backlog records touched files, verification results, frontend-only Bandit skip rationale, and final summary.
+- [x] #3 Focused ScheduledTasks, CompanionHome, notification helper tests, and git diff checks are run from the current worktree with results recorded.
+- [x] #4 No uncommitted repo changes remain after the final closeout commit, except intentionally running local dev/test processes are stopped first.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Docs/superpowers/plans/2026-06-09-scheduled-tasks-phase3-results-inbox-home-surfacing-implementation-plan.md
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Stage 8 final verification and closeout in progress.
+
+Verification evidence:
+- Focused frontend suite: ./node_modules/.bin/vitest run src/components/Option/ScheduledTasks/__tests__ src/components/Option/CompanionHome/__tests__ src/services/__tests__/notifications.test.ts from apps/packages/ui passed: 19 test files, 181 tests.
+- git diff --check passed before Stage 7 commit; rerunning after Stage 8 documentation updates before final commit.
+- Browser smoke used WebUI on http://localhost:18001 plus temporary read-only mock API on http://127.0.0.1:8000 for health, OpenAPI, scheduled-task, and notification empty responses. Scheduled Tasks Results and Companion Home rendered without readiness gate at desktop and 390px viewport.
+- 390px overflow measurement showed no horizontal overflow for /scheduled-tasks?tab=results or /companion: scrollWidth matched clientWidth at 390px.
+- Temporary local Node listeners on ports 18001 and 8000 were stopped after browser verification; lsof returned no listeners for both ports.
+- Bandit skipped because this phase closeout touched frontend, docs, and Backlog task files only; no Python/backend files changed.
+
+Final closeout:
+- Final git diff --check after Stage 8 documentation/task updates passed with exit code 0.
+- Remaining uncommitted files before final commit are the implementation plan verification update and this Backlog task file.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Scheduled Tasks Phase 3 final verification is complete. The focused frontend suite passed with 19 files and 181 tests, browser smoke covered Results and Companion Home at desktop and 390px with no measured horizontal overflow, temporary smoke servers were stopped, git diff --check passed, and Bandit was skipped with a frontend/docs-only rationale.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-2340 - Close-out-Scheduled-Tasks-Phase-3-final-verification.md
+++ b/backlog/tasks/task-2340 - Close-out-Scheduled-Tasks-Phase-3-final-verification.md
@@ -4,7 +4,7 @@ title: Close out Scheduled Tasks Phase 3 final verification
 status: Done
 assignee: []
 created_date: ''
-updated_date: '2026-06-09 08:01'
+updated_date: '2026-06-09 14:05'
 labels:
   - scheduled-tasks
   - webui
@@ -50,6 +50,9 @@ Verification evidence:
 Final closeout:
 - Final git diff --check after Stage 8 documentation/task updates passed with exit code 0.
 - Remaining uncommitted files before final commit are the implementation plan verification update and this Backlog task file.
+
+PR link:
+- Draft PR: https://github.com/rmusser01/tldw_server/pull/2328
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-2341 - Rebase-Scheduled-Tasks-Phase-3-PR-and-address-review-feedback.md
+++ b/backlog/tasks/task-2341 - Rebase-Scheduled-Tasks-Phase-3-PR-and-address-review-feedback.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-2341
 title: Rebase Scheduled Tasks Phase 3 PR and address review feedback
-status: In Progress
+status: Done
 labels:
 - scheduled-tasks
 - webui
@@ -18,13 +18,13 @@ Rebase PR #2328 onto the latest dev branch and address all actionable review com
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 PR branch is rebased onto latest origin/dev and pushed back to PR #2328.
+- [x] #1 PR branch is rebased onto latest origin/dev and pushed back to PR #2328.
 - [x] #2 Alias route overview navigation trap is fixed with regression coverage.
 - [x] #3 Paused projected signals do not display running copy and have regression coverage.
 - [x] #4 Invalid Ant Design Space orientation props in touched Scheduled Tasks components are corrected.
 - [x] #5 Hosted results alias test verifies the alias module target, not only file existence.
 - [x] #6 Duplicate Backlog final-summary marker in TASK-2338 is repaired.
-- [ ] #7 All still-relevant review threads are resolved or answered with rationale.
+- [x] #7 All still-relevant review threads are resolved or answered with rationale.
 - [x] #8 Focused frontend tests and git diff checks are run and recorded.
 <!-- AC:END -->
 
@@ -45,6 +45,8 @@ Rebase on origin/dev, verify each reviewer finding against current code, impleme
 - Wrapped Automation Inbox visible copy in `useTranslation` defaults using the repo's object-overload style.
 - Removed the duplicate final summary marker from TASK-2338.
 - Verified the Gemini `Space direction` suggestion against the installed AntD runtime. Using `direction` emits `Warning: [antd: Space] direction is deprecated. Please use orientation instead.`, so `orientation` is intentionally retained.
+- Force-pushed the rebased branch to PR #2328 with `--force-with-lease` after commit `3f9fed2cca`.
+- Replied to and resolved all PR review threads. AntD `Space` comments were resolved as false positives with runtime warning evidence; actionable alias, paused-state, route-test, Backlog-marker, optional-chaining, and i18n comments were resolved with fix references.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary
@@ -55,10 +57,10 @@ Rebased PR #2328 on latest dev and addressed review feedback for Scheduled Tasks
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
+- [x] #1 Acceptance criteria completed
 - [x] #2 Tests or verification recorded
 - [x] #3 Documentation updated when relevant
 - [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
 - [x] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->

--- a/backlog/tasks/task-2341 - Rebase-Scheduled-Tasks-Phase-3-PR-and-address-review-feedback.md
+++ b/backlog/tasks/task-2341 - Rebase-Scheduled-Tasks-Phase-3-PR-and-address-review-feedback.md
@@ -1,0 +1,64 @@
+---
+id: TASK-2341
+title: Rebase Scheduled Tasks Phase 3 PR and address review feedback
+status: In Progress
+labels:
+- scheduled-tasks
+- webui
+- pr-review
+- rebase
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Rebase PR #2328 onto the latest dev branch and address all actionable review comments from Qodo, CodeRabbit, and Gemini for Scheduled Tasks Phase 3 Results Inbox and Home surfacing.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 PR branch is rebased onto latest origin/dev and pushed back to PR #2328.
+- [x] #2 Alias route overview navigation trap is fixed with regression coverage.
+- [x] #3 Paused projected signals do not display running copy and have regression coverage.
+- [x] #4 Invalid Ant Design Space orientation props in touched Scheduled Tasks components are corrected.
+- [x] #5 Hosted results alias test verifies the alias module target, not only file existence.
+- [x] #6 Duplicate Backlog final-summary marker in TASK-2338 is repaired.
+- [ ] #7 All still-relevant review threads are resolved or answered with rationale.
+- [x] #8 Focused frontend tests and git diff checks are run and recorded.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Rebase on origin/dev, verify each reviewer finding against current code, implement minimal fixes, run focused ScheduledTasks/routes/CompanionHome tests, update Backlog, push the rebased branch.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+- Rebased `codex/scheduled-tasks-phase3-results-home` onto `origin/dev` without conflicts.
+- Fixed the `/scheduled-tasks/results` alias trap by navigating Overview back to `/scheduled-tasks` before clearing query state.
+- Fixed paused projected signal summary/status ordering and added projector plus Results panel coverage.
+- Strengthened the hosted alias route test to read the module and assert it targets `option-scheduled-tasks`.
+- Added optional chaining/default empty items in Companion Home scheduled-task signal projection.
+- Wrapped Automation Inbox visible copy in `useTranslation` defaults using the repo's object-overload style.
+- Removed the duplicate final summary marker from TASK-2338.
+- Verified the Gemini `Space direction` suggestion against the installed AntD runtime. Using `direction` emits `Warning: [antd: Space] direction is deprecated. Please use orientation instead.`, so `orientation` is intentionally retained.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Rebased PR #2328 on latest dev and addressed review feedback for Scheduled Tasks Phase 3 Results/Home surfacing. The review-fix patch closes the Results alias navigation trap, corrects paused signal copy, strengthens route alias coverage, handles partial/undefined scheduled-task responses defensively, internationalizes Automation Inbox copy, documents the AntD Space false positive, and repairs the duplicate Backlog marker. Verification: focused Vitest suite passed 20 files / 187 tests; `git diff --check` passed; `rg` confirmed no `Space direction` props in Scheduled Tasks. Bandit was not run because touched code is frontend/tests/docs/backlog only, with no Python/backend changes.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## Summary
- Adds the Scheduled Tasks Results experience, result projection/linking, detail drawers, and source-agnostic empty/capability states.
- Surfaces scheduled-task result and failure signals on Companion Home through a dedicated Automation Inbox that works without personalization.
- Adds notification/result dedupe, overview/task cross-links, route aliases, UX polish, responsive verification notes, and Backlog closeout records.

## Test Plan
- [x] `./node_modules/.bin/vitest run src/components/Option/ScheduledTasks/__tests__ src/components/Option/CompanionHome/__tests__ src/services/__tests__/notifications.test.ts` from `apps/packages/ui` passed: 19 files, 181 tests.
- [x] `git diff --check` passed.
- [x] Browser smoke covered `/scheduled-tasks`, `/scheduled-tasks?tab=results`, and `/companion` at desktop and 390px with temporary local mock API responses.
- [x] Bandit skipped: frontend/docs/Backlog-only changes, no Python/backend files touched.

## Change summary
Human-authored Change summary required before marking ready for review/merge per `Docs/superpowers/AI_GENERATED_PR_CHANGE_SUMMARY_POLICY_2026_04_17.md`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Scheduled Tasks Results experience and a Home Automation Inbox so users can see automation outcomes, triage failures, and deep‑link to exact runs or results. Uses projected signals from the task list and notifications; frontend‑only.

- **New Features**
  - Results tab with a results panel, filters, capability modes, and a result detail drawer; supports success, failure, running, and completed‑no‑results signals with deep links via `task_id`, `run_id`, and `result_id`.
  - Route alias `/scheduled-tasks/results` for web, extension, and hosted Next.js; route state parsing and tests included.
  - Overview, Task table, and task detail drawer surface newest signals and provide cross‑links into Results.
  - Companion Home adds an Automation Inbox card showing recent scheduled‑task results and failures from tasks and notifications; notification targets normalized/deduped and links resolved to the best result/run/task page; types extended and tests added.

- **Bug Fixes**
  - Fixed `/scheduled-tasks/results` alias navigation edge case and strengthened the hosted‑alias test to verify the module target.
  - Corrected projected‑mode copy and state labels so paused items don’t show running language.
  - Cleaned up UI props and minor link/accessibility polish in Scheduled Tasks components.

<sup>Written for commit c9a47c915e0c0159893842d9bc83782d66c3287a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2328?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

