### PR TITLE
Improve MCP filesystem patch parser fidelity

### DIFF
--- a/Docs/superpowers/plans/2026-06-09-mcp-filesystem-diff-parser-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-06-09-mcp-filesystem-diff-parser-implementation-plan.md
@@ -1,0 +1,126 @@
+# MCP Filesystem Diff Parser V2 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Improve `fs.patch` unified-diff fidelity for safe, governed agentic file editing.
+
+**Architecture:** Keep the parser in `filesystem_diff.py` and the filesystem enforcement in `filesystem_module.py`. Add parser state for no-final-newline markers and robust header path parsing without bypassing existing path grants, read receipts, hash checks, or atomic writes.
+
+**Tech Stack:** Python 3.11, pytest, existing MCP Unified filesystem module, Bandit.
+
+---
+
+### Task 1: Parser Fidelity Tests
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_patch_parser.py`
+
+- [ ] **Step 1: Add failing parser tests**
+
+Add tests for:
+- paths with spaces in `---` / `+++` headers;
+- applying a patch that preserves missing final newline;
+- rejecting orphan `\ No newline at end of file` markers.
+
+- [ ] **Step 2: Run parser tests and verify RED**
+
+Run:
+
+```bash
+source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest \
+  tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_patch_parser.py \
+  -q
+```
+
+Expected: new tests fail against current parser behavior.
+
+### Task 2: Parser Implementation
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_diff.py`
+
+- [ ] **Step 1: Extend hunk line model**
+
+Add a boolean field to `PatchHunkLine` to track whether that logical line has a trailing newline in the target file.
+
+- [ ] **Step 2: Preserve no-newline markers**
+
+When `_parse_hunk()` sees `\ No newline at end of file`, attach that state to the previous hunk line. Reject the marker if it appears before any hunk line.
+
+- [ ] **Step 3: Apply additions without forcing EOF newline**
+
+Update `apply_patch_to_text()` so added lines honor the parsed newline flag.
+
+- [ ] **Step 4: Improve header path parsing**
+
+Prefer tab-separated header metadata. Otherwise keep the full path text so filenames with spaces are preserved, then run existing path normalization.
+
+- [ ] **Step 5: Run parser tests and verify GREEN**
+
+Run the parser test command from Task 1.
+
+### Task 3: End-to-End `fs.patch` Coverage
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_module.py`
+
+- [ ] **Step 1: Add failing module test**
+
+Add an async test that patches an existing file to content without a final newline, using `expected_sha256_by_path`.
+
+- [ ] **Step 2: Run focused module test and verify RED/GREEN**
+
+Run:
+
+```bash
+source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest \
+  tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_module.py::test_filesystem_patch_preserves_no_final_newline \
+  -q
+```
+
+Expected: fail before implementation, pass after implementation.
+
+### Task 4: Final Verification And Backlog Closeout
+
+**Files:**
+- Modify: `backlog/tasks/task-2332 - Implement-MCP-filesystem-unified-diff-parser-and-governed-patch-primitive.md`
+
+- [ ] **Step 1: Run focused filesystem suite**
+
+```bash
+source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest \
+  tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_patch_parser.py \
+  tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_module.py \
+  -q
+```
+
+- [ ] **Step 2: Run Bandit**
+
+```bash
+source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m bandit -r \
+  tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_diff.py \
+  tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_module.py \
+  -f json -o /tmp/bandit_mcp_fs_diff_parser_v2.json
+```
+
+- [ ] **Step 3: Run diff hygiene**
+
+```bash
+git diff --check
+```
+
+- [ ] **Step 4: Update TASK-2332**
+
+Record implementation notes, verification results, known non-goals, and final summary.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Docs/superpowers/specs/2026-06-09-mcp-filesystem-diff-parser-design.md \
+  Docs/superpowers/plans/2026-06-09-mcp-filesystem-diff-parser-implementation-plan.md \
+  tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_diff.py \
+  tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_patch_parser.py \
+  tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_module.py \
+  "backlog/tasks/task-2332 - Implement-MCP-filesystem-unified-diff-parser-and-governed-patch-primitive.md"
+git commit -m "fix: improve MCP filesystem patch parser fidelity"
+```

--- a/Docs/superpowers/specs/2026-06-09-mcp-filesystem-diff-parser-design.md
+++ b/Docs/superpowers/specs/2026-06-09-mcp-filesystem-diff-parser-design.md
@@ -1,0 +1,75 @@
+# MCP Filesystem Diff Parser V2 Design
+
+## Goal
+
+Improve the existing MCP filesystem patch path so `fs.patch` can be safely preferred over raw edit/write for common agentic file edits. This slice focuses on parser fidelity and deterministic patch application inside the already-governed filesystem module.
+
+## Current State
+
+`fs.read`, `fs.edit`, `fs.patch`, and `fs.write` already exist. `fs.patch` already:
+
+- parses unified diffs into file and hunk plans;
+- extracts path scope candidates before policy enforcement;
+- requires hashes or read receipts for existing-file edits;
+- supports dry runs, create gating, rollback-on-partial-write, and non-content result metadata.
+
+The remaining gap is that the parser is too narrow for real model-produced diffs. It rejects or mishandles cases that should be deterministic and safe, especially paths with spaces and `\ No newline at end of file` markers.
+
+## Scope
+
+This slice will:
+
+1. Preserve final-line no-newline markers during parse and apply.
+2. Parse file header paths with spaces when unambiguous.
+3. Accept git-style preamble lines before `---` / `+++` headers without treating them as patch content.
+4. Keep unsafe paths rejected after normalization, including absolute paths, drive-qualified paths, empty segments, `.` segments, and `..` traversal.
+5. Keep delete and rename application unsupported until separate path-policy verbs exist.
+6. Add focused tests for parser behavior and end-to-end `fs.patch` application.
+
+## Non-Goals
+
+- No `fs.delete`, `fs.rename`, or `fs.move` execution in this slice.
+- No fuzzy patch matching.
+- No binary patch support.
+- No raw shell or raw edit routing changes.
+- No frontend changes.
+
+## Design
+
+`filesystem_diff.py` remains the parser and in-memory patch engine. It will extend `PatchHunkLine` with an EOF-newline flag so the parser can represent `\ No newline at end of file` without leaking file contents into result metadata.
+
+Header path parsing will prefer tab-separated metadata when present. When no tab exists, it will preserve the full remaining path text instead of truncating at the first space. This supports common model output like `--- a/docs/my note.txt` and `+++ b/docs/my note.txt` while retaining existing normalization checks.
+
+Unsupported operations remain explicit:
+
+- delete patches return `delete_not_supported`;
+- rename patches return `rename_not_supported`;
+- mode-only patches without hunks return `invalid_diff`.
+
+`FilesystemModule` continues to govern `fs.patch` through `extract_path_scope_candidates()`, `_resolve_workspace_path_no_follow()`, preimage checks, read receipts, hash checks, and atomic writes. This slice should not add a side path around those checks.
+
+## Testing
+
+Focused tests should cover:
+
+- parsing paths with spaces in file headers;
+- applying a patch that preserves a missing final newline;
+- rejecting malformed orphan no-newline markers;
+- `fs.patch` end-to-end write preserving no-final-newline content;
+- existing parser/module tests continuing to pass.
+
+Verification before PR closeout:
+
+```bash
+source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest \
+  tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_patch_parser.py \
+  tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_module.py \
+  -q
+
+source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m bandit -r \
+  tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_diff.py \
+  tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_module.py \
+  -f json -o /tmp/bandit_mcp_fs_diff_parser_v2.json
+
+git diff --check
+```

--- a/backlog/tasks/task-2332 - Implement-MCP-filesystem-unified-diff-parser-and-governed-patch-primitive.md
+++ b/backlog/tasks/task-2332 - Implement-MCP-filesystem-unified-diff-parser-and-governed-patch-primitive.md
@@ -58,9 +58,25 @@ Implementation:
 - Changed header path parsing to preserve unambiguous paths with spaces while retaining normalization checks.
 - Added end-to-end `fs.patch` coverage for no-final-newline output.
 
+PR review follow-up:
+- Reopened after rebasing onto `origin/dev` on 2026-06-09.
+- Addressed still-valid review findings: helper docstrings, stripping space-separated header timestamp metadata without truncating paths containing spaces, and preserving tab-separated diff header metadata through `fs.patch` input sanitization.
+
 Verification:
 - Parser focused: 14 passed, 4 warnings.
 - Parser + filesystem module focused: 97 passed, 4 warnings.
+- PR review focused RED tests before implementation:
+  - `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_patch_parser.py::test_parse_unified_diff_preserves_safe_paths_with_spaces tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_module.py::test_filesystem_patch_preserves_tab_header_metadata_during_sanitization -q`
+  - Result: 2 expected failures for header metadata parsed as part of the path.
+- PR review focused verification:
+  - `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_patch_parser.py tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_module.py -q`
+  - Result: 99 passed, 4 warnings.
+- `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m py_compile tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_diff.py tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_module.py`
+  - Result: passed with no output.
+- Review Bandit: `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m bandit -r tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_diff.py tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_module.py -f json -o /tmp/bandit_mcp_fs_diff_parser_v2_review.json`
+  - Result: 0 findings, 2583 LOC scanned.
+- Review `git diff --check`
+  - Result: passed with no output.
 - Bandit: `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m bandit -r tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_diff.py tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_module.py -f json -o /tmp/bandit_mcp_fs_diff_parser_v2.json`
   - Result: 0 findings, 2554 LOC scanned.
 - `git diff --check`

--- a/backlog/tasks/task-2332 - Implement-MCP-filesystem-unified-diff-parser-and-governed-patch-primitive.md
+++ b/backlog/tasks/task-2332 - Implement-MCP-filesystem-unified-diff-parser-and-governed-patch-primitive.md
@@ -1,0 +1,87 @@
+---
+id: TASK-2332
+title: Implement MCP filesystem unified diff parser and governed patch primitive
+status: Done
+labels:
+- mcp
+- filesystem
+- security
+- policy
+- implementation
+priority: High
+documentation:
+- Docs/superpowers/specs/2026-06-09-mcp-filesystem-diff-parser-design.md
+- Docs/superpowers/plans/2026-06-09-mcp-filesystem-diff-parser-implementation-plan.md
+modified_files:
+- Docs/superpowers/specs/2026-06-09-mcp-filesystem-diff-parser-design.md
+- Docs/superpowers/plans/2026-06-09-mcp-filesystem-diff-parser-implementation-plan.md
+- tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_module.py
+- tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_diff.py
+- tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_patch_parser.py
+- tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_module.py
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement the next MCP filesystem slice: a robust unified diff parser and governed fs.patch primitive that prefers structured patching over raw edits, while keeping fs.read/fs.write/fs.patch under workspace/path/action grants with hashes, safe failures, and audit-friendly result metadata.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Unified diff parser preserves `\ No newline at end of file` markers for additions, removals, and context lines without corrupting line counts.
+- [x] #2 Unified diff parser accepts safe file paths containing spaces in standard `---` / `+++` headers while continuing to reject unsafe absolute, drive-qualified, empty, dot, and traversal paths.
+- [x] #3 `fs.patch` end-to-end application preserves missing final-newline content and continues to require hashes or read receipts for existing-file edits.
+- [x] #4 Delete and rename diffs remain explicitly unsupported until separate path-policy action verbs exist.
+- [x] #5 Focused parser/module tests, Bandit on touched Python scope, and `git diff --check` pass before PR.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Design and implementation plan added:
+- `Docs/superpowers/specs/2026-06-09-mcp-filesystem-diff-parser-design.md`
+- `Docs/superpowers/plans/2026-06-09-mcp-filesystem-diff-parser-implementation-plan.md`
+
+Baseline verification from clean `origin/dev` worktree:
+- `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_patch_parser.py tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_module.py -q`
+  - Result: 93 passed, 4 warnings.
+
+RED parser tests before implementation:
+- `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_patch_parser.py -q`
+  - Result: 3 expected failures for path truncation at spaces, forced final newline on additions, and orphan no-newline marker acceptance.
+
+Implementation:
+- Extended parsed hunk lines with `has_trailing_newline`.
+- Attached `\ No newline at end of file` markers to the preceding hunk line and rejected orphan/duplicate markers.
+- Updated in-memory patch application so added lines do not force a final newline when the diff says none exists.
+- Changed header path parsing to preserve unambiguous paths with spaces while retaining normalization checks.
+- Added end-to-end `fs.patch` coverage for no-final-newline output.
+
+Verification:
+- Parser focused: 14 passed, 4 warnings.
+- Parser + filesystem module focused: 97 passed, 4 warnings.
+- Bandit: `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m bandit -r tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_diff.py tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_module.py -f json -o /tmp/bandit_mcp_fs_diff_parser_v2.json`
+  - Result: 0 findings, 2554 LOC scanned.
+- `git diff --check`
+  - Result: passed with no output.
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Improved the MCP filesystem unified diff parser used by `fs.patch`. The parser now preserves `\ No newline at end of file` markers, rejects orphan/duplicate no-newline markers, and keeps safe header paths with spaces instead of truncating them. `fs.patch` now preserves missing-final-newline output end to end while continuing to use the existing path scope, hash/read-receipt, atomic write, dry-run, and rollback behavior.
+
+Delete and rename patch application remain intentionally unsupported until separate path-policy action verbs are implemented.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_diff.py
+++ b/tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_diff.py
@@ -12,6 +12,11 @@ PatchFileAction = Literal["modify", "create"]
 
 _HUNK_HEADER = re.compile(r"^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@(?: .*)?$")
 _NO_NEWLINE_MARKER = r"\ No newline at end of file"
+_HEADER_TIMESTAMP_METADATA = re.compile(
+    r"\s+\d{4}-\d{2}-\d{2}"
+    r"(?:[ T]\d{2}:\d{2}:\d{2}(?:\.\d+)?)?"
+    r"(?:\s*(?:[+-]\d{4}|[+-]\d{2}:?\d{2}|Z))?$"
+)
 
 
 class FilesystemPatchError(ValueError):
@@ -215,15 +220,32 @@ def _parse_hunk(lines: list[str], start_index: int) -> tuple[PatchHunk, int]:
 
 
 def _parse_header_path(raw_path: str) -> str | None:
+    """Normalize a unified-diff file header path while stripping safe metadata.
+
+    Tab-separated metadata is removed first because GNU/Git-style diffs commonly
+    place timestamps after a tab. When no tab exists, only a trailing
+    timestamp-shaped suffix is stripped so paths containing spaces remain intact.
+    Returns None for `/dev/null` create/delete sentinels.
+    """
+
     candidate = raw_path.rstrip()
     if "\t" in candidate:
         candidate = candidate.split("\t", 1)[0]
+    else:
+        candidate = _strip_space_separated_header_metadata(candidate)
     candidate = candidate.strip()
     if candidate == "/dev/null":
         return None
     if candidate.startswith("a/") or candidate.startswith("b/"):
         candidate = candidate[2:]
     return _normalize_patch_path(candidate)
+
+
+def _strip_space_separated_header_metadata(candidate: str) -> str:
+    """Strip common space-separated timestamp metadata from a diff header path."""
+
+    stripped = _HEADER_TIMESTAMP_METADATA.sub("", candidate).rstrip()
+    return stripped or candidate
 
 
 def _normalize_patch_path(raw_path: str) -> str:
@@ -261,4 +283,6 @@ def _line_body(line: str) -> str:
 
 
 def _line_has_trailing_newline(line: str) -> bool:
+    """Return whether a split line retained an LF, CRLF, or CR terminator."""
+
     return line.endswith(("\n", "\r"))

--- a/tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_diff.py
+++ b/tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_diff.py
@@ -11,6 +11,7 @@ PatchLineKind = Literal["context", "add", "remove"]
 PatchFileAction = Literal["modify", "create"]
 
 _HUNK_HEADER = re.compile(r"^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@(?: .*)?$")
+_NO_NEWLINE_MARKER = r"\ No newline at end of file"
 
 
 class FilesystemPatchError(ValueError):
@@ -27,6 +28,7 @@ class PatchHunkLine:
 
     kind: PatchLineKind
     text: str
+    has_trailing_newline: bool = True
 
 
 @dataclass(frozen=True, slots=True)
@@ -130,12 +132,16 @@ def apply_patch_to_text(original: str, patch_file: PatchFile) -> str:
 
         for hunk_line in hunk.lines:
             if hunk_line.kind == "add":
-                output.append(f"{hunk_line.text}{newline}")
+                output.append(hunk_line.text)
+                if hunk_line.has_trailing_newline:
+                    output.append(newline)
                 continue
 
             if cursor >= len(original_lines):
                 raise FilesystemPatchError("patch_context_mismatch")
             if _line_body(original_lines[cursor]) != hunk_line.text:
+                raise FilesystemPatchError("patch_context_mismatch")
+            if _line_has_trailing_newline(original_lines[cursor]) != hunk_line.has_trailing_newline:
                 raise FilesystemPatchError("patch_context_mismatch")
             if hunk_line.kind == "context":
                 output.append(original_lines[cursor])
@@ -164,7 +170,17 @@ def _parse_hunk(lines: list[str], start_index: int) -> tuple[PatchHunk, int]:
     while index < len(lines) and not lines[index].startswith("@@ ") and not lines[index].startswith("--- "):
         raw_line = lines[index]
         index += 1
-        if raw_line == r"\ No newline at end of file":
+        if raw_line == _NO_NEWLINE_MARKER:
+            if not hunk_lines:
+                raise FilesystemPatchError("invalid_no_newline_marker")
+            previous = hunk_lines[-1]
+            if not previous.has_trailing_newline:
+                raise FilesystemPatchError("invalid_no_newline_marker")
+            hunk_lines[-1] = PatchHunkLine(
+                kind=previous.kind,
+                text=previous.text,
+                has_trailing_newline=False,
+            )
             continue
         if not raw_line:
             raise FilesystemPatchError("invalid_hunk_line")
@@ -199,9 +215,10 @@ def _parse_hunk(lines: list[str], start_index: int) -> tuple[PatchHunk, int]:
 
 
 def _parse_header_path(raw_path: str) -> str | None:
-    candidate = raw_path.strip().split("\t", 1)[0].strip()
-    if " " in candidate:
-        candidate = candidate.split(" ", 1)[0].strip()
+    candidate = raw_path.rstrip()
+    if "\t" in candidate:
+        candidate = candidate.split("\t", 1)[0]
+    candidate = candidate.strip()
     if candidate == "/dev/null":
         return None
     if candidate.startswith("a/") or candidate.startswith("b/"):
@@ -241,3 +258,7 @@ def _line_body(line: str) -> str:
     if line.endswith("\n") or line.endswith("\r"):
         return line[:-1]
     return line
+
+
+def _line_has_trailing_newline(line: str) -> bool:
+    return line.endswith(("\n", "\r"))

--- a/tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_module.py
@@ -453,6 +453,11 @@ class FilesystemModule(BaseModule):
                 key: value if key in {"old_string", "new_string"} else self.sanitize_input(value)
                 for key, value in raw_args.items()
             }
+        elif tool_name == "fs.patch":
+            args = {
+                key: self._sanitize_patch_diff(value) if key == "diff" else self.sanitize_input(value)
+                for key, value in raw_args.items()
+            }
         else:
             args = self.sanitize_input(raw_args)
         self.validate_tool_arguments(tool_name, args)
@@ -1055,6 +1060,14 @@ class FilesystemModule(BaseModule):
         if isinstance(input_data, list):
             return [self.sanitize_input(v, _depth + 1) for v in input_data]
         return input_data
+
+    @staticmethod
+    def _sanitize_patch_diff(input_data: Any) -> Any:
+        """Sanitize diff text while preserving unified-diff tabs and newlines."""
+
+        if not isinstance(input_data, str):
+            return input_data
+        return "".join(ch for ch in input_data if ch >= " " or ch in {"\n", "\r", "\t"})
 
     async def _resolve_workspace_root(self, context: Any | None) -> Path:
         metadata = getattr(context, "metadata", None)

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_module.py
@@ -1256,6 +1256,39 @@ async def test_filesystem_patch_dry_run_does_not_write(tmp_path: Path) -> None:
 
 
 @pytest.mark.asyncio
+async def test_filesystem_patch_preserves_no_final_newline(tmp_path: Path) -> None:
+    workspace_root = tmp_path / "workspace"
+    docs_dir = workspace_root / "docs"
+    docs_dir.mkdir(parents=True, exist_ok=True)
+    original = "alpha\nbeta\n"
+    target = docs_dir / "story.txt"
+    target.write_text(original, encoding="utf-8")
+    resolver = _FakeWorkspaceRootResolver({"workspace_root": str(workspace_root)})
+    mod = FilesystemModule(ModuleConfig(name="filesystem"), workspace_root_resolver=resolver)
+    context = RequestContext(request_id="req-fs-patch-no-final-newline", user_id="1", metadata={})
+
+    result = await mod.execute_tool(
+        "fs.patch",
+        {
+            "diff": """--- a/docs/story.txt
++++ b/docs/story.txt
+@@ -1,2 +1,2 @@
+ alpha
+-beta
++BETTA
+\\ No newline at end of file
+""",
+            "expected_sha256_by_path": {"docs/story.txt": hashlib.sha256(original.encode("utf-8")).hexdigest()},
+        },
+        context=context,
+    )
+
+    assert target.read_bytes() == b"alpha\nBETTA"  # nosec B101
+    assert result["files"][0]["sha256_after"] == hashlib.sha256(b"alpha\nBETTA").hexdigest()  # nosec B101
+    assert result["files"][0]["bytes_after"] == len(b"alpha\nBETTA")  # nosec B101
+
+
+@pytest.mark.asyncio
 async def test_filesystem_patch_rechecks_preimage_immediately_before_write(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_module.py
@@ -1110,6 +1110,38 @@ async def test_filesystem_patch_applies_existing_file_with_expected_hash(tmp_pat
 
 
 @pytest.mark.asyncio
+async def test_filesystem_patch_preserves_tab_header_metadata_during_sanitization(tmp_path: Path) -> None:
+    workspace_root = tmp_path / "workspace"
+    docs_dir = workspace_root / "docs"
+    docs_dir.mkdir(parents=True, exist_ok=True)
+    original = "alpha\nbeta\ngamma\n"
+    target = docs_dir / "story.txt"
+    target.write_text(original, encoding="utf-8")
+    resolver = _FakeWorkspaceRootResolver({"workspace_root": str(workspace_root)})
+    mod = FilesystemModule(ModuleConfig(name="filesystem"), workspace_root_resolver=resolver)
+    context = RequestContext(request_id="req-fs-patch-tab-header", user_id="1", metadata={})
+
+    result = await mod.execute_tool(
+        "fs.patch",
+        {
+            "diff": """--- a/docs/story.txt\t2026-06-09 12:00:00.000000000 +0000
++++ b/docs/story.txt\t2026-06-09 12:00:01.000000000 +0000
+@@ -1,3 +1,3 @@
+ alpha
+-beta
++BETTA
+ gamma
+""",
+            "expected_sha256_by_path": {"docs/story.txt": hashlib.sha256(original.encode("utf-8")).hexdigest()},
+        },
+        context=context,
+    )
+
+    assert target.read_text(encoding="utf-8") == "alpha\nBETTA\ngamma\n"  # nosec B101
+    assert result["files"][0]["path"] == "docs/story.txt"  # nosec B101
+
+
+@pytest.mark.asyncio
 async def test_filesystem_patch_rolls_back_previous_writes_on_partial_failure(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_patch_parser.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_patch_parser.py
@@ -38,8 +38,8 @@ def test_parse_unified_diff_modify_headers_and_hunk_ranges() -> None:
 
 def test_parse_unified_diff_preserves_safe_paths_with_spaces() -> None:
     parsed = parse_unified_diff(
-        """--- a/docs/my note.txt
-+++ b/docs/my note.txt
+        """--- a/docs/my note.txt 2026-06-09 12:00:00.000000000 +0000
++++ b/docs/my note.txt 2026-06-09 12:00:01.000000000 +0000
 @@ -1 +1 @@
 -alpha
 +beta
@@ -51,6 +51,23 @@ def test_parse_unified_diff_preserves_safe_paths_with_spaces() -> None:
 
     assert parsed[0].old_path == "docs/my note.txt"  # nosec B101
     assert parsed[0].new_path == "docs/my note.txt"  # nosec B101
+
+
+def test_parse_unified_diff_strips_date_only_header_metadata() -> None:
+    parsed = parse_unified_diff(
+        """--- a/docs/story.txt 2026-06-09
++++ b/docs/story.txt 2026-06-10
+@@ -1 +1 @@
+-alpha
++beta
+""",
+        max_files=10,
+        max_hunks=10,
+        max_bytes=10_000,
+    )
+
+    assert parsed[0].old_path == "docs/story.txt"  # nosec B101
+    assert parsed[0].new_path == "docs/story.txt"  # nosec B101
 
 
 def test_parse_unified_diff_create_and_reject_delete() -> None:

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_patch_parser.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_patch_parser.py
@@ -36,6 +36,23 @@ def test_parse_unified_diff_modify_headers_and_hunk_ranges() -> None:
     assert [line.text for line in hunk.lines] == ["alpha", "beta", "BETTA", "gamma"]  # nosec B101
 
 
+def test_parse_unified_diff_preserves_safe_paths_with_spaces() -> None:
+    parsed = parse_unified_diff(
+        """--- a/docs/my note.txt
++++ b/docs/my note.txt
+@@ -1 +1 @@
+-alpha
++beta
+""",
+        max_files=10,
+        max_hunks=10,
+        max_bytes=10_000,
+    )
+
+    assert parsed[0].old_path == "docs/my note.txt"  # nosec B101
+    assert parsed[0].new_path == "docs/my note.txt"  # nosec B101
+
+
 def test_parse_unified_diff_create_and_reject_delete() -> None:
     created = parse_unified_diff(
         """--- /dev/null
@@ -135,6 +152,45 @@ def test_apply_patch_rejects_add_only_hunk_beyond_end_of_file() -> None:
         apply_patch_to_text("alpha\n", parsed[0])
 
     assert exc_info.value.reason_code == "patch_context_mismatch"  # nosec B101
+
+
+def test_apply_patch_to_text_preserves_missing_final_newline() -> None:
+    parsed = parse_unified_diff(
+        """--- a/docs/story.txt
++++ b/docs/story.txt
+@@ -1,2 +1,2 @@
+ alpha
+-beta
+\\ No newline at end of file
++BETTA
+\\ No newline at end of file
+""",
+        max_files=10,
+        max_hunks=10,
+        max_bytes=10_000,
+    )
+
+    result = apply_patch_to_text("alpha\nbeta", parsed[0])
+
+    assert result == "alpha\nBETTA"  # nosec B101
+
+
+def test_parse_unified_diff_rejects_orphan_no_newline_marker() -> None:
+    with pytest.raises(FilesystemPatchError) as exc_info:
+        parse_unified_diff(
+            """--- a/docs/story.txt
++++ b/docs/story.txt
+@@ -1 +1 @@
+\\ No newline at end of file
+-alpha
++beta
+""",
+            max_files=10,
+            max_hunks=10,
+            max_bytes=10_000,
+        )
+
+    assert exc_info.value.reason_code == "invalid_no_newline_marker"  # nosec B101
 
 
 def test_apply_patch_to_text_modifies_content_in_memory() -> None:


### PR DESCRIPTION
## Summary

- Improves the MCP filesystem unified diff parser used by `fs.patch`.
- Preserves `\ No newline at end of file` markers so patch output can intentionally omit a final newline.
- Keeps safe header paths with spaces instead of truncating at the first space.
- Adds parser and end-to-end `fs.patch` regression coverage.

## Verification

- `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_patch_parser.py tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_module.py -q`
  - `97 passed, 4 warnings`
- `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m bandit -r tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_diff.py tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_module.py -f json -o /tmp/bandit_mcp_fs_diff_parser_v2_final.json`
  - `0 findings`
- `git diff --check`
  - passed

## Merge Note

Per the AI-generated PR merge gate, a human-authored `Change summary` explaining what changed and why must be added before this PR is merge-ready.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves the MCP filesystem unified diff parser used by `fs.patch` for more faithful, deterministic patching. Addresses TASK-2332 by preserving EOF newline markers, accepting header paths with spaces, and stripping tab/timestamp header metadata without breaking paths.

- **Bug Fixes**
  - Preserve `\ No newline at end of file` per line; reject orphan/duplicate markers and match trailing-newline state during apply.
  - Parse `---`/`+++` paths with spaces and strip header metadata (tabs/timestamps) without truncating paths; still run normalization and scope checks.
  - Sanitize `fs.patch` input while preserving tabs/newlines in diff headers; apply additions without forcing a final newline so missing-final-newline is preserved end to end.

<sup>Written for commit 8661aae36a66d7a644dc600ea7351a66f77140a1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2329?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

