### PR TITLE
TASK-2342: Add server-backed Skills search

### DIFF
--- a/Docs/Plans/IMPLEMENTATION_PLAN_skills_power_user_server_search_TASK_2342.md
+++ b/Docs/Plans/IMPLEMENTATION_PLAN_skills_power_user_server_search_TASK_2342.md
@@ -1,0 +1,23 @@
+## Stage 1: Server-Backed Search Contract
+**Goal**: Add a safe `q` list-query contract for Skills so matching is applied before pagination.
+**Success Criteria**: `GET /api/v1/skills?q=...&limit=...&offset=...` returns only matching skills, and `total` reflects the filtered result count.
+**Tests**: Focused Skills service and API tests that prove a match outside the first unfiltered page is returned.
+**Status**: Complete
+
+## Stage 2: Frontend API Wiring
+**Goal**: Let the shared frontend API client serialize the Skills search query while preserving existing callers.
+**Success Criteria**: `listSkills({ q, limit, offset })` builds the expected query string and omits empty values.
+**Tests**: Existing `tldw-api-client.boundary-slices` coverage extended for `q`.
+**Status**: Complete
+
+## Stage 3: Skills Manager Workflow
+**Goal**: Replace current-page-only filtering with server-backed search in the Skills manager.
+**Success Criteria**: Entering a search query requests page 1 with `q`, renders server-returned rows, and uses the filtered `total` for count and pagination.
+**Tests**: Existing Skills manager test suite covers search query calls, page reset, and rendering results absent from the initial page.
+**Status**: Complete
+
+## Stage 4: Verification and Closeout
+**Goal**: Verify the scoped change and document results.
+**Success Criteria**: Focused backend/frontend tests pass, Bandit runs on touched Python paths, whitespace diff check passes, and Backlog is updated.
+**Tests**: Focused pytest, focused Vitest, Bandit, and `git diff --check`.
+**Status**: Complete

--- a/apps/packages/ui/src/components/Option/Skills/Manager.tsx
+++ b/apps/packages/ui/src/components/Option/Skills/Manager.tsx
@@ -93,6 +93,7 @@ export const SkillsManager: React.FC = () => {
   const [importTextForm] = Form.useForm<ImportTextFormValues>()
 
   const offset = (page - 1) * pageSize
+  const searchQuery = search.trim()
 
   const {
     data,
@@ -101,24 +102,18 @@ export const SkillsManager: React.FC = () => {
     error,
     refetch
   } = useQuery<SkillsListResponse>({
-    queryKey: ["skills", page, pageSize],
-    queryFn: () => tldwClient.listSkills({ limit: pageSize, offset })
+    queryKey: ["skills", page, pageSize, searchQuery],
+    queryFn: () =>
+      tldwClient.listSkills({
+        ...(searchQuery ? { q: searchQuery } : {}),
+        limit: pageSize,
+        offset
+      })
   })
-
-  const filteredSkills = React.useMemo(() => {
-    if (!data?.skills) return []
-    if (!search.trim()) return data.skills
-    const q = search.toLowerCase()
-    return data.skills.filter(
-      (s) =>
-        s.name.toLowerCase().includes(q) ||
-        (s.description && s.description.toLowerCase().includes(q))
-      )
-  }, [data?.skills, search])
 
   const hasLoadedSkills = data != null && !isError
   const totalSkills = data?.total ?? 0
-  const hasSearch = search.trim().length > 0
+  const hasSearch = searchQuery.length > 0
   const isLibraryEmpty =
     hasLoadedSkills && !isLoading && totalSkills === 0 && !hasSearch
   const skillCountLabel = isError
@@ -609,7 +604,10 @@ export const SkillsManager: React.FC = () => {
             defaultValue: "Search skills..."
           })}
           value={search}
-          onChange={(e) => setSearch(e.target.value)}
+          onChange={(e) => {
+            setSearch(e.target.value)
+            setPage(1)
+          }}
           allowClear
           style={{ maxWidth: 360 }}
         />
@@ -697,7 +695,7 @@ export const SkillsManager: React.FC = () => {
       )}
 
       <Table
-        dataSource={filteredSkills}
+        dataSource={data?.skills ?? []}
         columns={columns}
         rowKey="name"
         loading={isLoading}

--- a/apps/packages/ui/src/components/Option/Skills/Manager.tsx
+++ b/apps/packages/ui/src/components/Option/Skills/Manager.tsx
@@ -39,6 +39,7 @@ import type {
 } from "@/types/skill"
 
 const DEFAULT_PAGE_SIZE = 10
+const SKILLS_SEARCH_DEBOUNCE_MS = 300
 const SKILL_NAME_REGEX = /^[a-z][a-z0-9-]{0,63}$/
 
 interface ImportTextFormValues {
@@ -84,6 +85,7 @@ export const SkillsManager: React.FC = () => {
   const [page, setPage] = React.useState(1)
   const [pageSize, setPageSize] = React.useState(DEFAULT_PAGE_SIZE)
   const [search, setSearch] = React.useState("")
+  const [debouncedSearch, setDebouncedSearch] = React.useState("")
   const [drawerOpen, setDrawerOpen] = React.useState(false)
   const [importTextOpen, setImportTextOpen] = React.useState(false)
   const [editingSkill, setEditingSkill] = React.useState<SkillResponse | null>(null)
@@ -93,7 +95,18 @@ export const SkillsManager: React.FC = () => {
   const [importTextForm] = Form.useForm<ImportTextFormValues>()
 
   const offset = (page - 1) * pageSize
-  const searchQuery = search.trim()
+  const searchQuery = debouncedSearch.trim()
+
+  React.useEffect(() => {
+    if (search === debouncedSearch) return
+
+    const timer = window.setTimeout(() => {
+      setDebouncedSearch(search)
+      setPage(1)
+    }, SKILLS_SEARCH_DEBOUNCE_MS)
+
+    return () => window.clearTimeout(timer)
+  }, [debouncedSearch, search])
 
   const {
     data,
@@ -103,11 +116,12 @@ export const SkillsManager: React.FC = () => {
     refetch
   } = useQuery<SkillsListResponse>({
     queryKey: ["skills", page, pageSize, searchQuery],
-    queryFn: () =>
+    queryFn: ({ signal }) =>
       tldwClient.listSkills({
         ...(searchQuery ? { q: searchQuery } : {}),
         limit: pageSize,
-        offset
+        offset,
+        abortSignal: signal
       })
   })
 
@@ -604,10 +618,7 @@ export const SkillsManager: React.FC = () => {
             defaultValue: "Search skills..."
           })}
           value={search}
-          onChange={(e) => {
-            setSearch(e.target.value)
-            setPage(1)
-          }}
+          onChange={(e) => setSearch(e.target.value)}
           allowClear
           style={{ maxWidth: 360 }}
         />

--- a/apps/packages/ui/src/components/Option/Skills/__tests__/Manager.test.tsx
+++ b/apps/packages/ui/src/components/Option/Skills/__tests__/Manager.test.tsx
@@ -301,6 +301,57 @@ describe("SkillsManager imports", () => {
     expect(screen.queryByTestId("skills-empty-state")).not.toBeInTheDocument()
   })
 
+  it("uses server-backed search instead of filtering only the loaded page", async () => {
+    const firstPage = Array.from({ length: 10 }, (_, index) => makeSkill(index + 1))
+    const searchResult = {
+      name: "omega-research",
+      description: "Needle workflow for longform research synthesis",
+      argument_hint: null,
+      user_invocable: true,
+      disable_model_invocation: false,
+      context: "inline" as const
+    }
+
+    tldwClientMock.listSkills.mockImplementation(
+      (params: { q?: string; limit: number; offset: number }) => {
+        if (params.q === "needle") {
+          return Promise.resolve({
+            skills: [searchResult],
+            count: 1,
+            total: 1,
+            limit: params.limit,
+            offset: 0
+          })
+        }
+
+        return Promise.resolve({
+          skills: firstPage,
+          count: firstPage.length,
+          total: 12,
+          limit: params.limit,
+          offset: params.offset
+        })
+      }
+    )
+
+    renderManager()
+
+    expect(await screen.findByText("12 skills")).toBeInTheDocument()
+    fireEvent.change(screen.getByPlaceholderText("Search skills..."), {
+      target: { value: "needle" }
+    })
+
+    await waitFor(() => {
+      expect(tldwClientMock.listSkills).toHaveBeenLastCalledWith({
+        q: "needle",
+        limit: 10,
+        offset: 0
+      })
+    })
+    expect(await screen.findByText("omega-research")).toBeInTheDocument()
+    expect(screen.getByText("1 skill")).toBeInTheDocument()
+  })
+
   it("imports a skill from text via importSkill", async () => {
     renderManager()
 

--- a/apps/packages/ui/src/components/Option/Skills/__tests__/Manager.test.tsx
+++ b/apps/packages/ui/src/components/Option/Skills/__tests__/Manager.test.tsx
@@ -275,10 +275,14 @@ describe("SkillsManager imports", () => {
     fireEvent.click(within(secondPageItem).getByText("2"))
 
     await waitFor(() => {
-      expect(tldwClientMock.listSkills).toHaveBeenCalledWith({ limit: 10, offset: 10 })
+      expect(tldwClientMock.listSkills).toHaveBeenCalledWith(
+        expect.objectContaining({ limit: 10, offset: 10 })
+      )
     })
     await waitFor(() => {
-      expect(tldwClientMock.listSkills).toHaveBeenLastCalledWith({ limit: 10, offset: 0 })
+      expect(tldwClientMock.listSkills).toHaveBeenLastCalledWith(
+        expect.objectContaining({ limit: 10, offset: 0 })
+      )
     })
     expect(await screen.findByText("5 skills")).toBeInTheDocument()
     expect(screen.queryByText("No skills yet.")).not.toBeInTheDocument()
@@ -342,14 +346,77 @@ describe("SkillsManager imports", () => {
     })
 
     await waitFor(() => {
-      expect(tldwClientMock.listSkills).toHaveBeenLastCalledWith({
+      expect(tldwClientMock.listSkills).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          q: "needle",
+          limit: 10,
+          offset: 0
+        })
+      )
+    })
+    expect(await screen.findByText("omega-research")).toBeInTheDocument()
+    expect(screen.getByText("1 skill")).toBeInTheDocument()
+  })
+
+  it("debounces server-backed search requests while typing", async () => {
+    const firstPage = Array.from({ length: 10 }, (_, index) => makeSkill(index + 1))
+    const searchResult = {
+      name: "omega-research",
+      description: "Needle workflow for longform research synthesis",
+      argument_hint: null,
+      user_invocable: true,
+      disable_model_invocation: false,
+      context: "inline" as const
+    }
+
+    tldwClientMock.listSkills.mockImplementation(
+      (params: { q?: string; limit: number; offset: number }) => {
+        if (params.q === "needle") {
+          return Promise.resolve({
+            skills: [searchResult],
+            count: 1,
+            total: 1,
+            limit: params.limit,
+            offset: 0
+          })
+        }
+
+        return Promise.resolve({
+          skills: firstPage,
+          count: firstPage.length,
+          total: 12,
+          limit: params.limit,
+          offset: params.offset
+        })
+      }
+    )
+
+    renderManager()
+
+    expect(await screen.findByText("12 skills")).toBeInTheDocument()
+    fireEvent.change(screen.getByPlaceholderText("Search skills..."), {
+      target: { value: "needle" }
+    })
+
+    await new Promise((resolve) => setTimeout(resolve, 120))
+    expect(tldwClientMock.listSkills).not.toHaveBeenCalledWith(
+      expect.objectContaining({
         q: "needle",
         limit: 10,
         offset: 0
       })
+    )
+
+    await waitFor(() => {
+      expect(tldwClientMock.listSkills).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          q: "needle",
+          limit: 10,
+          offset: 0
+        })
+      )
     })
     expect(await screen.findByText("omega-research")).toBeInTheDocument()
-    expect(screen.getByText("1 skill")).toBeInTheDocument()
   })
 
   it("imports a skill from text via importSkill", async () => {

--- a/apps/packages/ui/src/services/__tests__/tldw-api-client.boundary-slices.test.ts
+++ b/apps/packages/ui/src/services/__tests__/tldw-api-client.boundary-slices.test.ts
@@ -83,6 +83,38 @@ describe("TldwApiClient Wave 5 boundary slices", () => {
     )
   })
 
+  it("serializes listSkills search queries and omits blank search values", async () => {
+    mocks.bgRequest.mockResolvedValue({
+      skills: [],
+      count: 0,
+      total: 0,
+      limit: 10,
+      offset: 0
+    })
+
+    const client = new TldwApiClient()
+    client.resolveApiPath = vi
+      .fn(async () => "/api/v1/skills") as typeof client.resolveApiPath
+
+    await client.listSkills({ q: "long form", limit: 10, offset: 20 })
+    await client.listSkills({ q: "   ", limit: 10 })
+
+    expect(mocks.bgRequest).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        path: "/api/v1/skills?q=long+form&limit=10&offset=20",
+        method: "GET"
+      })
+    )
+    expect(mocks.bgRequest).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        path: "/api/v1/skills?limit=10",
+        method: "GET"
+      })
+    )
+  })
+
   it("keeps presentation methods on the mixed presentations domain paths after class cleanup", async () => {
     const client = new TldwApiClient()
     client.ensureConfigForRequest = vi

--- a/apps/packages/ui/src/services/__tests__/tldw-api-client.boundary-slices.test.ts
+++ b/apps/packages/ui/src/services/__tests__/tldw-api-client.boundary-slices.test.ts
@@ -115,6 +115,35 @@ describe("TldwApiClient Wave 5 boundary slices", () => {
     )
   })
 
+  it("forwards listSkills abort signals to background requests", async () => {
+    mocks.bgRequest.mockResolvedValue({
+      skills: [],
+      count: 0,
+      total: 0,
+      limit: 10,
+      offset: 0
+    })
+
+    const client = new TldwApiClient()
+    client.resolveApiPath = vi
+      .fn(async () => "/api/v1/skills") as typeof client.resolveApiPath
+    const abortController = new AbortController()
+
+    await client.listSkills({
+      q: "research",
+      limit: 10,
+      abortSignal: abortController.signal
+    })
+
+    expect(mocks.bgRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        path: "/api/v1/skills?q=research&limit=10",
+        method: "GET",
+        abortSignal: abortController.signal
+      })
+    )
+  })
+
   it("keeps presentation methods on the mixed presentations domain paths after class cleanup", async () => {
     const client = new TldwApiClient()
     client.ensureConfigForRequest = vi

--- a/apps/packages/ui/src/services/tldw/domains/workspace-api.ts
+++ b/apps/packages/ui/src/services/tldw/domains/workspace-api.ts
@@ -706,11 +706,20 @@ export const workspaceApiMethods = {
   async listSkills(
     this: TldwApiClientCore,
     params?: {
+      q?: string
       limit?: number
       offset?: number
     }
   ): Promise<SkillsListPayload> {
-    const query = buildQuery(params)
+    const normalizedParams = params
+      ? {
+          ...params,
+          q: typeof params.q === "string" && params.q.trim().length > 0
+            ? params.q.trim()
+            : undefined
+        }
+      : undefined
+    const query = buildQuery(normalizedParams)
     const base = await this.resolveApiPath("skills.list", [
       "/api/v1/skills",
       "/api/v1/skills/"

--- a/apps/packages/ui/src/services/tldw/domains/workspace-api.ts
+++ b/apps/packages/ui/src/services/tldw/domains/workspace-api.ts
@@ -709,13 +709,15 @@ export const workspaceApiMethods = {
       q?: string
       limit?: number
       offset?: number
+      abortSignal?: AbortSignal
     }
   ): Promise<SkillsListPayload> {
+    const { abortSignal, ...queryParams } = params ?? {}
     const normalizedParams = params
       ? {
-          ...params,
-          q: typeof params.q === "string" && params.q.trim().length > 0
-            ? params.q.trim()
+          ...queryParams,
+          q: typeof queryParams.q === "string" && queryParams.q.trim().length > 0
+            ? queryParams.q.trim()
             : undefined
         }
       : undefined
@@ -726,7 +728,8 @@ export const workspaceApiMethods = {
     ])
     return await bgRequest<SkillsListPayload>({
       path: appendPathQuery(base, query),
-      method: "GET"
+      method: "GET",
+      abortSignal
     })
   },
 

--- a/backlog/tasks/task-2342 - Implement-Skills-power-user-server-backed-search.md
+++ b/backlog/tasks/task-2342 - Implement-Skills-power-user-server-backed-search.md
@@ -4,12 +4,12 @@ title: Implement Skills power-user server-backed search
 status: Done
 assignee: []
 created_date: ''
-updated_date: '2026-06-09 16:16'
+updated_date: 2026-06-09 16:20
 labels:
-  - skills
-  - webui
-  - ux
-  - power-user
+- skills
+- webui
+- ux
+- power-user
 dependencies: []
 priority: high
 ---
@@ -53,6 +53,8 @@ Docs/Plans/IMPLEMENTATION_PLAN_skills_power_user_server_search_TASK_2342.md
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
 
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+Review follow-up: Gemini requested debouncing Skills search input and moving page reset from onChange to a debounced-query effect. Reopened TASK-2342 for the PR review fix.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
@@ -60,12 +62,23 @@ Docs/Plans/IMPLEMENTATION_PLAN_skills_power_user_server_search_TASK_2342.md
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
 Implemented server-backed Skills search for the first power-user discovery slice. The Skills list API now accepts optional q, the service/database apply the search to name/description before pagination with parameterized LIKE patterns, and filtered totals drive pagination metadata. The frontend client serializes trimmed q values and omits blank searches. The Skills manager now keys queries by search text, requests server-filtered results, resets to page 1 on search changes, and renders backend-returned rows instead of filtering only the current page.
 
+Review follow-up:
+- Added an explicit SkillsListResponse return annotation to the list endpoint.
+- Documented include_hidden and q behavior on SkillsService.get_total_count.
+- Debounced Skills search input at 300ms before issuing server-backed q requests.
+- Moved page reset out of the input onChange handler and batched it with the debounced query update.
+- Forwarded React Query abort signals through listSkills to bgRequest and covered the transport behavior with a regression test.
+- Updated manager tests to assert query params while tolerating the transport abortSignal.
+- Kept verification commands portable in this task record rather than using machine-specific venv paths.
+
 Verification:
-- Red checks confirmed missing behavior before implementation: service rejected q, API ignored q and returned the first page, client sent blank q, and manager did not request q.
-- source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tldw_Server_API/tests/Skills/unit/test_skills_service.py tldw_Server_API/tests/Skills/integration/test_skills_api.py -q -> 92 passed, 6 warnings.
-- bunx vitest run src/services/__tests__/tldw-api-client.boundary-slices.test.ts src/components/Option/Skills/__tests__/Manager.test.tsx -> 18 passed.
-- source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m bandit tldw_Server_API/app/api/v1/endpoints/skills.py tldw_Server_API/app/core/Skills/skills_service.py tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py -f json -o /tmp/bandit_task2342.json -> 0 findings, 0 errors.
-- git diff --check -> passed.
+- Red checks confirmed the debounce regression failed before implementation because listSkills was called with q immediately.
+- Red check confirmed abortSignal was serialized as a query parameter before the client transport fix.
+- bunx vitest run src/components/Option/Skills/__tests__/Manager.test.tsx -t "debounces server-backed search" -> 1 passed, 12 skipped.
+- bunx vitest run src/services/__tests__/tldw-api-client.boundary-slices.test.ts -t "forwards listSkills abort signals" -> 1 passed, 6 skipped.
+- bunx vitest run src/services/__tests__/tldw-api-client.boundary-slices.test.ts src/components/Option/Skills/__tests__/Manager.test.tsx -> 20 passed.
+- After activating the project virtual environment: python -m pytest tldw_Server_API/tests/Skills/unit/test_skills_service.py tldw_Server_API/tests/Skills/integration/test_skills_api.py -q -> 92 passed, 6 warnings.
+- After activating the project virtual environment: python -m bandit tldw_Server_API/app/api/v1/endpoints/skills.py tldw_Server_API/app/core/Skills/skills_service.py tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py -f json -o /tmp/bandit_task2342_review.json -> 0 findings, 0 errors.
 
 Known skips/blockers: none.
 

--- a/backlog/tasks/task-2342 - Implement-Skills-power-user-server-backed-search.md
+++ b/backlog/tasks/task-2342 - Implement-Skills-power-user-server-backed-search.md
@@ -1,0 +1,83 @@
+---
+id: TASK-2342
+title: Implement Skills power-user server-backed search
+status: Done
+assignee: []
+created_date: ''
+updated_date: '2026-06-09 16:16'
+labels:
+  - skills
+  - webui
+  - ux
+  - power-user
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement the first power-user Skills discovery slice: make /skills search use a server-backed list query so large libraries can find matches outside the current page without client-only filtering.
+
+Scope:
+- Add a focused task plan for this reviewable slice.
+- Add backend tests proving the skills list query filters before pagination and reports filtered totals.
+- Add API/client/frontend tests for query-string search wiring.
+- Extend the Skills list API/service/DB contract with a safe q search parameter.
+- Update the Skills manager UI to request searched results from the server and reset pagination when search changes.
+
+Out of scope:
+- Bulk actions, dense mode, tag/type chips, shortcuts, import/export, and permissions changes.
+- Visual redesign beyond the search/pagination state needed for this slice.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 GET /api/v1/skills accepts optional q and applies it before limit/offset pagination.
+- [x] #2 Filtered list responses return only matching skills and total reflects the filtered result count.
+- [x] #3 The frontend API client serializes trimmed q with limit/offset and omits blank q values.
+- [x] #4 The Skills manager uses server-backed search results instead of filtering only the current page.
+- [x] #5 Changing the search query resets pagination to the first page and shows the filtered total/empty state.
+- [x] #6 Focused backend and frontend tests cover the search/pagination contract.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Docs/Plans/IMPLEMENTATION_PLAN_skills_power_user_server_search_TASK_2342.md
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Implemented server-backed Skills search for the first power-user discovery slice. The Skills list API now accepts optional q, the service/database apply the search to name/description before pagination with parameterized LIKE patterns, and filtered totals drive pagination metadata. The frontend client serializes trimmed q values and omits blank searches. The Skills manager now keys queries by search text, requests server-filtered results, resets to page 1 on search changes, and renders backend-returned rows instead of filtering only the current page.
+
+Verification:
+- Red checks confirmed missing behavior before implementation: service rejected q, API ignored q and returned the first page, client sent blank q, and manager did not request q.
+- source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tldw_Server_API/tests/Skills/unit/test_skills_service.py tldw_Server_API/tests/Skills/integration/test_skills_api.py -q -> 92 passed, 6 warnings.
+- bunx vitest run src/services/__tests__/tldw-api-client.boundary-slices.test.ts src/components/Option/Skills/__tests__/Manager.test.tsx -> 18 passed.
+- source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m bandit tldw_Server_API/app/api/v1/endpoints/skills.py tldw_Server_API/app/core/Skills/skills_service.py tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py -f json -o /tmp/bandit_task2342.json -> 0 findings, 0 errors.
+- git diff --check -> passed.
+
+Known skips/blockers: none.
+
+PR: https://github.com/rmusser01/tldw_server/pull/2330
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/tldw_Server_API/app/api/v1/endpoints/skills.py
+++ b/tldw_Server_API/app/api/v1/endpoints/skills.py
@@ -113,6 +113,11 @@ def _metadata_to_summary(metadata) -> SkillSummary:
 @router.get("/", response_model=SkillsListResponse)
 async def list_skills(
     include_hidden: bool = Query(False, description="Include hidden skills (user_invocable=false)"),
+    q: Optional[str] = Query(
+        None,
+        max_length=200,
+        description="Case-insensitive search across skill names and descriptions",
+    ),
     limit: int = Query(100, ge=1, le=500, description="Maximum number of skills to return"),
     offset: int = Query(0, ge=0, description="Offset for pagination"),
     service: SkillsService = Depends(get_skills_service),
@@ -125,10 +130,11 @@ async def list_skills(
     try:
         skills = await service.list_skills(
             include_hidden=include_hidden,
+            q=q,
             limit=limit,
             offset=offset,
         )
-        total = await service.get_total_count(include_hidden=include_hidden)
+        total = await service.get_total_count(include_hidden=include_hidden, q=q)
 
         return SkillsListResponse(
             skills=[_metadata_to_summary(s) for s in skills],

--- a/tldw_Server_API/app/api/v1/endpoints/skills.py
+++ b/tldw_Server_API/app/api/v1/endpoints/skills.py
@@ -121,7 +121,7 @@ async def list_skills(
     limit: int = Query(100, ge=1, le=500, description="Maximum number of skills to return"),
     offset: int = Query(0, ge=0, description="Offset for pagination"),
     service: SkillsService = Depends(get_skills_service),
-):
+) -> SkillsListResponse:
     """
     List available skills.
 

--- a/tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py
+++ b/tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py
@@ -15386,11 +15386,26 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
     def _skill_bool_value(self, value: bool) -> bool | int:
         return value if self.backend_type == BackendType.POSTGRESQL else int(value)
 
+    @staticmethod
+    def _skill_search_like_pattern(query: str | None) -> str | None:
+        """Return an escaped SQL LIKE pattern for skill search, or None when blank."""
+        normalized = (query or "").strip().lower()
+        if not normalized:
+            return None
+        escaped = (
+            normalized
+            .replace("\\", "\\\\")
+            .replace("%", "\\%")
+            .replace("_", "\\_")
+        )
+        return f"%{escaped}%"
+
     def list_skill_registry(
         self,
         *,
         include_hidden: bool = False,
         include_deleted: bool = False,
+        q: str | None = None,
         limit: int = 100,
         offset: int = 0,
     ) -> list[dict[str, Any]]:
@@ -15404,6 +15419,15 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
         if not include_hidden:
             clauses.append("user_invocable = ?")
             params.append(self._skill_bool_value(True))
+        search_pattern = self._skill_search_like_pattern(q)
+        if search_pattern is not None:
+            clauses.append(
+                "("
+                "LOWER(name) LIKE ? ESCAPE '\\' "
+                "OR LOWER(COALESCE(description, '')) LIKE ? ESCAPE '\\'"
+                ")"
+            )
+            params.extend([search_pattern, search_pattern])
         where_sql = f"WHERE {' AND '.join(clauses)}" if clauses else ""
         query = (
             "SELECT * FROM skill_registry "  # nosec B608
@@ -15423,6 +15447,7 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
         *,
         include_hidden: bool = False,
         include_deleted: bool = False,
+        q: str | None = None,
     ) -> int:
         """Return count of skills in registry."""
         self._ensure_skill_registry_table()
@@ -15434,6 +15459,15 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
         if not include_hidden:
             clauses.append("user_invocable = ?")
             params.append(self._skill_bool_value(True))
+        search_pattern = self._skill_search_like_pattern(q)
+        if search_pattern is not None:
+            clauses.append(
+                "("
+                "LOWER(name) LIKE ? ESCAPE '\\' "
+                "OR LOWER(COALESCE(description, '')) LIKE ? ESCAPE '\\'"
+                ")"
+            )
+            params.extend([search_pattern, search_pattern])
         where_sql = f"WHERE {' AND '.join(clauses)}" if clauses else ""
         query = f"SELECT COUNT(*) AS cnt FROM skill_registry {where_sql}"  # nosec B608
         try:

--- a/tldw_Server_API/app/core/Skills/skills_service.py
+++ b/tldw_Server_API/app/core/Skills/skills_service.py
@@ -443,6 +443,7 @@ class SkillsService:
     async def list_skills(
         self,
         include_hidden: bool = False,
+        q: str | None = None,
         limit: int = 100,
         offset: int = 0,
     ) -> list[SkillMetadata]:
@@ -451,6 +452,7 @@ class SkillsService:
 
         Args:
             include_hidden: If True, include skills with user_invocable=False
+            q: Optional case-insensitive search query for skill name or description
             limit: Maximum number of skills to return
             offset: Offset for pagination
 
@@ -462,6 +464,7 @@ class SkillsService:
         rows = db.list_skill_registry(
             include_hidden=include_hidden,
             include_deleted=False,
+            q=q,
             limit=limit,
             offset=offset,
         )
@@ -1025,13 +1028,14 @@ class SkillsService:
         rows = self._list_context_rows()
         return self._build_context_payload(rows)
 
-    async def get_total_count(self, include_hidden: bool = False) -> int:
+    async def get_total_count(self, include_hidden: bool = False, q: str | None = None) -> int:
         """Get total count of skills."""
         await self._sync_registry_async()
         db = self._get_db()
         return db.count_skill_registry(
             include_hidden=include_hidden,
             include_deleted=False,
+            q=q,
         )
 
     def _get_builtin_skills_dir(self) -> Path:

--- a/tldw_Server_API/app/core/Skills/skills_service.py
+++ b/tldw_Server_API/app/core/Skills/skills_service.py
@@ -1029,7 +1029,14 @@ class SkillsService:
         return self._build_context_payload(rows)
 
     async def get_total_count(self, include_hidden: bool = False, q: str | None = None) -> int:
-        """Get total count of skills."""
+        """
+        Get total count of skills.
+
+        Args:
+            include_hidden: Include skills hidden from user invocation.
+            q: Optional search string filtering skills by name or description;
+                empty values are ignored.
+        """
         await self._sync_registry_async()
         db = self._get_db()
         return db.count_skill_registry(

--- a/tldw_Server_API/tests/Skills/integration/test_skills_api.py
+++ b/tldw_Server_API/tests/Skills/integration/test_skills_api.py
@@ -330,6 +330,47 @@ class TestListSkills:
         assert data["has_more"] is False
         assert data["next_offset"] is None
 
+    def test_list_skills_search_filters_before_pagination(self, client):
+        for i in range(12):
+            r = client.post(
+                f"{SKILLS_PREFIX}/",
+                json={
+                    "name": f"alpha-{i:02d}",
+                    "content": "---\ndescription: General utility skill\n---\n\nCommon content",
+                },
+            )
+            assert r.status_code == 201, r.text
+
+        r = client.post(
+            f"{SKILLS_PREFIX}/",
+            json={
+                "name": "omega-research",
+                "content": (
+                    "---\n"
+                    "description: Needle workflow for longform research synthesis\n"
+                    "---\n\n"
+                    "Use this for longform synthesis."
+                ),
+            },
+        )
+        assert r.status_code == 201, r.text
+
+        r = client.get(f"{SKILLS_PREFIX}/?q=needle&limit=5&offset=0")
+        assert r.status_code == 200, r.text
+        data = r.json()
+
+        assert [skill["name"] for skill in data["skills"]] == ["omega-research"]
+        assert data["count"] == 1
+        assert data["total"] == 1
+        assert data["pagination"] == {
+            "mode": "offset",
+            "limit": 5,
+            "offset": 0,
+            "total": 1,
+            "has_more": False,
+            "next_offset": None,
+        }
+
 
 class TestCreateAndGetSkill:
     def test_create_skill_and_get(self, client):

--- a/tldw_Server_API/tests/Skills/unit/test_skills_service.py
+++ b/tldw_Server_API/tests/Skills/unit/test_skills_service.py
@@ -230,6 +230,34 @@ Content""")
         assert names1.isdisjoint(names2)
 
     @pytest.mark.asyncio
+    async def test_list_skills_search_filters_before_pagination(self, service):
+        """Search should find matching skills outside the first unfiltered page."""
+        for i in range(12):
+            await service.create_skill(
+                f"alpha-{i:02d}",
+                """---
+description: General utility skill
+---
+
+Common content
+""",
+            )
+        await service.create_skill(
+            "omega-research",
+            """---
+description: Needle workflow for longform research synthesis
+---
+
+Use this for longform synthesis.
+""",
+        )
+
+        skills = await service.list_skills(q="needle", limit=5, offset=0)
+
+        assert [skill.name for skill in skills] == ["omega-research"]
+        assert await service.get_total_count(q="needle") == 1
+
+    @pytest.mark.asyncio
     async def test_update_skill_content(self, service):
         """Test updating skill content."""
         await service.create_skill("update-test", "Original content")


### PR DESCRIPTION
## Change summary

- Add an optional `q` query parameter to the Skills list API and apply it in the registry query before pagination so matches outside the current page are returned.
- Thread filtered totals through the service/API response so pagination reflects the searched result set.
- Update the frontend API client and Skills manager to send trimmed search queries, omit blank searches, reset to page 1 on search changes, and render backend-returned rows instead of filtering only the current page.

## Scope

- TASK-2342 only: power-user server-backed search for `/skills`.
- Does not include bulk actions, dense mode, sorting/filter chips, import/export changes, permissions changes, or visual redesign work.

## Verification

- Red checks confirmed the previous behavior: service rejected `q`, API ignored `q`, blank client search serialized, and manager did not request `q`.
- `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tldw_Server_API/tests/Skills/unit/test_skills_service.py tldw_Server_API/tests/Skills/integration/test_skills_api.py -q` -> 92 passed, 6 warnings.
- `bunx vitest run src/services/__tests__/tldw-api-client.boundary-slices.test.ts src/components/Option/Skills/__tests__/Manager.test.tsx` -> 18 passed.
- `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m bandit tldw_Server_API/app/api/v1/endpoints/skills.py tldw_Server_API/app/core/Skills/skills_service.py tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py -f json -o /tmp/bandit_task2342.json` -> 0 findings, 0 errors.
- `git diff --check` -> passed.

## Backlog

- TASK-2342 marked Done with AC/DoD checked.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds server-backed search to the Skills list so matches are applied before pagination and pagination reflects the filtered total, with 300ms debounced input and request cancellation for smoother UX. Addresses TASK-2342 and lets users find skills beyond the current page.

- New Features
  - API: `GET /api/v1/skills` now accepts optional `q` (case-insensitive, max 200); filtering happens before `limit/offset`, and `total` reflects the filtered set.
  - DB/Service: Added safe, escaped LIKE patterns (`ESCAPE '\\'`) for name/description search; count queries respect `q`.
  - Frontend: `listSkills({ q, limit, offset, abortSignal })` trims `q`, omits blanks, and forwards `abortSignal`; the Skills Manager debounces search by 300ms, resets to page 1 on search change, keys queries by the search, and renders server-returned rows (no client-only filtering).

<sup>Written for commit 73d781b8b1385edcc5b378c343e16689a0ae4032. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2330?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

