### PR TITLE
Add MCP filesystem lock lease tools

### DIFF
--- a/Docs/superpowers/plans/2026-06-09-mcp-filesystem-lock-leases-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-06-09-mcp-filesystem-lock-leases-implementation-plan.md
@@ -8,7 +8,7 @@
 
 **Tests**: Add failing filesystem module tests for descriptor presence, argument validation, acquire success, active conflict, renewal, expiry, release, wrong-token conflict, and path escape rejection.
 
-**Status**: Not Started
+**Status**: Complete
 
 ## Stage 2: Mutation Validation
 
@@ -18,7 +18,7 @@
 
 **Tests**: Add failing tests for `fs.write replace` and `fs.patch` requiring active matching leases, including multi-file patch paths derived from the diff.
 
-**Status**: Not Started
+**Status**: Complete
 
 ## Stage 3: Documentation, Backlog, And Verification
 
@@ -28,4 +28,4 @@
 
 **Tests**: Run focused filesystem MCP tests, compile touched Python files, Bandit on touched Python implementation scope, and `git diff --check`.
 
-**Status**: Not Started
+**Status**: Complete

--- a/Docs/superpowers/plans/2026-06-09-mcp-filesystem-lock-leases-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-06-09-mcp-filesystem-lock-leases-implementation-plan.md
@@ -1,0 +1,31 @@
+# MCP Filesystem Lock Leases Implementation Plan
+
+## Stage 1: Lock Manager And Tool Contract
+
+**Goal**: Add process-local lock lease primitives and expose `fs.lock_acquire` / `fs.lock_release` in the filesystem tool catalog.
+
+**Success Criteria**: Tool descriptors exist with strict schemas, `lock` path-action metadata, bounded TTL/owner fields, and no absolute path leakage.
+
+**Tests**: Add failing filesystem module tests for descriptor presence, argument validation, acquire success, active conflict, renewal, expiry, release, wrong-token conflict, and path escape rejection.
+
+**Status**: Not Started
+
+## Stage 2: Mutation Validation
+
+**Goal**: Add optional lock validation to `fs.edit`, `fs.patch`, and `fs.write` without replacing existing hash/read-receipt checks.
+
+**Success Criteria**: Mutations accept `lock_lease_id`; when the module setting requires locks, missing or mismatched leases fail with stable reason codes before writing; valid leases allow the existing mutation paths to proceed.
+
+**Tests**: Add failing tests for `fs.write replace` and `fs.patch` requiring active matching leases, including multi-file patch paths derived from the diff.
+
+**Status**: Not Started
+
+## Stage 3: Documentation, Backlog, And Verification
+
+**Goal**: Document process-local limits and record verification.
+
+**Success Criteria**: The package user guide mentions advisory lock usage and limitations; TASK-2300 records implementation notes, test output, Bandit output, and known future shared-store follow-up.
+
+**Tests**: Run focused filesystem MCP tests, compile touched Python files, Bandit on touched Python implementation scope, and `git diff --check`.
+
+**Status**: Not Started

--- a/Docs/superpowers/specs/2026-06-09-mcp-filesystem-lock-leases-design.md
+++ b/Docs/superpowers/specs/2026-06-09-mcp-filesystem-lock-leases-design.md
@@ -1,0 +1,109 @@
+# MCP Filesystem Lock Leases Design
+
+## Goal
+
+Add advisory filesystem lock leases for MCP safe file tools so agents can reduce edit races before calling `fs.patch` or `fs.write`. This first slice is process-local and in-memory, matching the approved short-term scope. It must not pretend to coordinate across multiple server processes, hosts, or persisted restarts.
+
+## Scope
+
+This slice adds two tools to the existing filesystem MCP module:
+
+- `fs.lock_acquire`: acquire or renew an exclusive advisory lease for one workspace-relative path.
+- `fs.lock_release`: release a lease by path and lease token.
+
+The tools use the same trusted workspace-root resolution and path normalization as `fs.write` / `fs.patch`. Lock paths are returned only as normalized workspace-relative paths. Responses must not include absolute host paths.
+
+Lock acquisition may target a nonexisting file for create flows, but the parent path must resolve inside the workspace. If the target already exists as a symlink, acquisition fails with `file_not_regular` because the mutation tools would reject the same target.
+
+## Non-Goals
+
+- No shared DB-backed lock table.
+- No filesystem lock files.
+- No mandatory locks for every deployment.
+- No delete, rename, move, share, chmod, or admin file actions.
+- No bypass of hash/read-receipt preimage checks. Locks reduce races; they do not replace preimage validation.
+
+## Lease Model
+
+Each lease is keyed by a normalized workspace identity plus workspace-relative path. The initial workspace identity is the resolved workspace-root path string. This is process-local metadata, not a cross-process guarantee.
+
+A lease contains:
+
+- `lease_id`: opaque server-generated token.
+- `path`: normalized workspace-relative path.
+- `owner`: caller-supplied owner label, sanitized and bounded.
+- `expires_at`: UTC ISO timestamp.
+- `ttl_seconds`: bounded TTL actually granted.
+- `workspace_id` and `session_id`: optional context metadata when available.
+
+Acquire behavior:
+
+- If no active lease exists, create one.
+- If an active lease exists with the same `lease_id`, renew it.
+- If an active lease exists with a different `lease_id`, fail with `lock_conflict`.
+- Expired leases are cleaned opportunistically before decisions.
+
+Release behavior:
+
+- Release succeeds only when the caller supplies the matching path and `lease_id`.
+- Releasing a missing or expired lease is idempotent and returns `released: false`.
+- Releasing with a wrong active `lease_id` fails with `lock_conflict`.
+
+## Mutation Validation
+
+`fs.patch`, `fs.write`, and `fs.edit` get an optional `lock_lease_id` argument. The default is advisory-only: mutations do not require a lock unless module setting `require_lock_for_mutation` is true.
+
+When a `lock_lease_id` is supplied, the mutation validates that every affected path has an active matching lease before writing. When the setting requires locks, missing `lock_lease_id` fails with `lock_required`.
+
+Validation happens after path resolution and before final write commit. Existing preimage checks and immediate preimage rechecks remain authoritative.
+
+## Safety And Policy
+
+Lock acquire/release are management tools but not write tools. They require path-scope action `lock`, with file-policy metadata for the `lock` action. If the current policy implementation does not know `lock`, this slice must fail closed or add the action metadata in the approved file-policy action registry. If the taxonomy already knows `lock` but marks it unimplemented, this slice should flip that metadata to implemented once the tools land.
+
+The tools should be path-boundable through `path_argument_hints: ["path"]`. For `fs.patch`, lock validation must use parsed patch paths, not caller-supplied path hints.
+
+## Result Shape
+
+Acquire success:
+
+```json
+{
+  "acquired": true,
+  "renewed": false,
+  "path": "docs/story.txt",
+  "lease_id": "opaque-token",
+  "owner": "agent-1",
+  "expires_at": "2026-06-09T16:30:00Z",
+  "ttl_seconds": 300
+}
+```
+
+Conflict:
+
+```json
+{
+  "reason_code": "lock_conflict",
+  "path": "docs/story.txt",
+  "held": true,
+  "held_owner": "agent-1",
+  "expires_at": "2026-06-09T16:30:00Z"
+}
+```
+
+Conflict payloads are actionable but safe: no absolute paths, no process IDs, no raw context metadata beyond the caller-supplied owner label.
+
+## Testing
+
+Focused tests should cover:
+
+- Tool descriptors and strict argument validation.
+- Acquire, conflict, renew, TTL expiry, and release behavior.
+- Path escape rejection through existing workspace resolution.
+- Optional lock validation for `fs.write replace`.
+- Optional lock validation for `fs.patch` with module-derived patch paths.
+- Existing hash/read-receipt preimage tests stay green.
+
+## Follow-Up
+
+A later slice can replace the in-memory manager with a filesystem- or DB-backed implementation through a small lock-manager interface. That slice should define cross-process ownership, cleanup, and admin inspection semantics explicitly.

--- a/Docs/superpowers/specs/2026-06-09-mcp-filesystem-lock-leases-design.md
+++ b/Docs/superpowers/specs/2026-06-09-mcp-filesystem-lock-leases-design.md
@@ -51,7 +51,7 @@ Release behavior:
 
 ## Mutation Validation
 
-`fs.patch`, `fs.write`, and `fs.edit` get an optional `lock_lease_id` argument. The default is advisory-only: mutations do not require a lock unless module setting `require_lock_for_mutation` is true.
+`fs.edit` and `fs.write` get an optional `lock_lease_id` argument. `fs.patch` gets `lock_lease_id_by_path` so multi-file diffs can validate each parsed path independently. The default is advisory-only: mutations do not require a lock unless module setting `require_lock_for_mutation` is true.
 
 When a `lock_lease_id` is supplied, the mutation validates that every affected path has an active matching lease before writing. When the setting requires locks, missing `lock_lease_id` fails with `lock_required`.
 

--- a/backlog/tasks/task-2300 - Add-MCP-filesystem-lock-lease-tools.md
+++ b/backlog/tasks/task-2300 - Add-MCP-filesystem-lock-lease-tools.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-2300
 title: Add MCP filesystem lock lease tools
-status: In Progress
+status: Done
 labels:
 - mcp
 - filesystem
@@ -40,7 +40,7 @@ Approved scope:
 - Future filesystem/DB/shared lock stores stay behind a follow-up seam.
 
 Baseline:
-- `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_module.py tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_patch_parser.py -q`
+- `source .venv/bin/activate && python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_module.py tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_patch_parser.py -q`
   - Result: 99 passed, 4 warnings.
 
 Implementation:
@@ -55,14 +55,29 @@ Red checks:
 - `test_filesystem_write_rejects_lock_that_expires_before_commit` initially failed because writes still committed after a lease expired between preimage authorization and commit.
 
 Verification:
-- `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_file_policy_actions.py tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_module.py tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_patch_parser.py -q`
+- `source .venv/bin/activate && python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_file_policy_actions.py tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_module.py tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_patch_parser.py -q`
   - Result: 109 passed, 4 warnings.
-- `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m py_compile tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_module.py tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_locks.py mcp_unified/interfaces/file_policy_actions.py tldw_Server_API/app/core/MCP_unified/tests/test_file_policy_actions.py tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_module.py`
+- `source .venv/bin/activate && python -m py_compile tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_module.py tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_locks.py mcp_unified/interfaces/file_policy_actions.py tldw_Server_API/app/core/MCP_unified/tests/test_file_policy_actions.py tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_module.py`
   - Result: passed.
-- `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m bandit -r tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_module.py tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_locks.py mcp_unified/interfaces/file_policy_actions.py -f json -o /tmp/bandit_mcp_fs_lock_leases.json`
+- `source .venv/bin/activate && python -m bandit -r tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_module.py tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_locks.py mcp_unified/interfaces/file_policy_actions.py -f json -o /tmp/bandit_mcp_fs_lock_leases.json`
   - Result: passed, 0 findings.
 - `git diff --check`
   - Result: passed.
+
+PR review follow-up:
+- Rebased PR #2331 on latest `origin/dev`.
+- Offloaded lock acquire/release path checks through `asyncio.to_thread(...)`.
+- Added explicit `lock_missing` response for failed renewals of expired or missing leases.
+- Added bounded rotating expired-lease sweeps in the process-local lock manager.
+- Normalized release lease tokens consistently with renewal and mutation validation.
+- Rejected blank mutation lease IDs instead of treating them as omitted.
+- Revalidated leases before creating parent directories in patch/write commit paths.
+- Removed `time` from `filesystem_locks.__all__`.
+- Cleaned task status and replaced machine-specific verification paths with repo-relative commands.
+
+Review follow-up verification:
+- `source .venv/bin/activate && python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_file_policy_actions.py tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_module.py tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_patch_parser.py -q`
+  - Result: 115 passed, 4 warnings.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-2300 - Add-MCP-filesystem-lock-lease-tools.md
+++ b/backlog/tasks/task-2300 - Add-MCP-filesystem-lock-lease-tools.md
@@ -68,7 +68,9 @@ Verification:
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Implemented in PR #2331: https://github.com/rmusser01/tldw_server/pull/2331
 
+This slice adds process-local advisory filesystem lock leases, exposes `fs.lock_acquire` and `fs.lock_release`, wires optional lease validation into `fs.edit`, `fs.patch`, and `fs.write`, and documents that shared/persistent lock stores are deferred. Verification completed with focused MCP filesystem tests, compile checks, Bandit on touched implementation scope, and `git diff --check`.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
@@ -77,6 +79,6 @@ Verification:
 - [x] #2 Tests or verification recorded
 - [x] #3 Documentation updated when relevant
 - [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
+- [x] #5 Final summary added
 - [x] #6 Known skips or blockers documented
 <!-- DOD:END -->

--- a/backlog/tasks/task-2300 - Add-MCP-filesystem-lock-lease-tools.md
+++ b/backlog/tasks/task-2300 - Add-MCP-filesystem-lock-lease-tools.md
@@ -22,12 +22,12 @@ Add optional filesystem lock leases alongside hashes/read receipts. Include `fs.
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 `fs.lock_acquire` and `fs.lock_release` are exposed with strict schemas, `lock` path-action metadata, safe result payloads, and path-boundable descriptors.
-- [ ] #2 Process-local in-memory leases support acquire, renew, conflict, expiry cleanup, release, and wrong-token conflict without leaking absolute paths.
-- [ ] #3 `fs.edit`, `fs.patch`, and `fs.write` accept optional lock lease validation and can require active matching locks through module settings without weakening hash/read-receipt preimage checks.
-- [ ] #4 Regression tests cover lock tools, safe conflicts, TTL expiry, path escapes, and mutation validation for `fs.patch` and `fs.write`.
-- [ ] #5 Documentation and task notes clearly state this slice is process-local advisory locking, with shared/persistent stores deferred.
-- [ ] #6 Focused filesystem tests, compile checks, Bandit on touched Python scope, and `git diff --check` pass.
+- [x] #1 `fs.lock_acquire` and `fs.lock_release` are exposed with strict schemas, `lock` path-action metadata, safe result payloads, and path-boundable descriptors.
+- [x] #2 Process-local in-memory leases support acquire, renew, conflict, expiry cleanup, release, and wrong-token conflict without leaking absolute paths.
+- [x] #3 `fs.edit`, `fs.patch`, and `fs.write` accept optional lock lease validation and can require active matching locks through module settings without weakening hash/read-receipt preimage checks.
+- [x] #4 Regression tests cover lock tools, safe conflicts, TTL expiry, path escapes, and mutation validation for `fs.patch` and `fs.write`.
+- [x] #5 Documentation and task notes clearly state this slice is process-local advisory locking, with shared/persistent stores deferred.
+- [x] #6 Focused filesystem tests, compile checks, Bandit on touched Python scope, and `git diff --check` pass.
 <!-- AC:END -->
 
 ## Implementation Notes
@@ -42,6 +42,27 @@ Approved scope:
 Baseline:
 - `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_module.py tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_patch_parser.py -q`
   - Result: 99 passed, 4 warnings.
+
+Implementation:
+- Added a process-local `InMemoryFilesystemLockManager` with acquire, renew, release, validate, TTL expiry cleanup, and safe conflict payload helpers.
+- Added `fs.lock_acquire` and `fs.lock_release` descriptors/execution paths with `lock` file-policy metadata.
+- Added optional `lock_lease_id` validation to `fs.edit` and `fs.write`, and `lock_lease_id_by_path` validation to `fs.patch`.
+- Added `require_lock_for_mutation` enforcement and a second pre-commit lease validation so a lease that expires after preimage authorization cannot still commit a write.
+- Marked the `lock` file-policy action as implemented and updated package user-guide documentation with the process-local advisory limitation.
+
+Red checks:
+- Lock-focused tests initially failed for missing `fs.lock_*` tools/module and missing `require_lock_for_mutation` enforcement.
+- `test_filesystem_write_rejects_lock_that_expires_before_commit` initially failed because writes still committed after a lease expired between preimage authorization and commit.
+
+Verification:
+- `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_file_policy_actions.py tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_module.py tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_patch_parser.py -q`
+  - Result: 109 passed, 4 warnings.
+- `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m py_compile tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_module.py tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_locks.py mcp_unified/interfaces/file_policy_actions.py tldw_Server_API/app/core/MCP_unified/tests/test_file_policy_actions.py tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_module.py`
+  - Result: passed.
+- `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m bandit -r tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_module.py tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_locks.py mcp_unified/interfaces/file_policy_actions.py -f json -o /tmp/bandit_mcp_fs_lock_leases.json`
+  - Result: passed, 0 findings.
+- `git diff --check`
+  - Result: passed.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary
@@ -52,10 +73,10 @@ Baseline:
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
 - [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->

--- a/backlog/tasks/task-2300 - Add-MCP-filesystem-lock-lease-tools.md
+++ b/backlog/tasks/task-2300 - Add-MCP-filesystem-lock-lease-tools.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-2300
 title: Add MCP filesystem lock lease tools
-status: To Do
+status: In Progress
 labels:
 - mcp
 - filesystem
@@ -10,6 +10,8 @@ labels:
 - followup
 references:
 - Docs/superpowers/specs/2026-06-07-mcp-fs-patch-write-safe-edit-tools-design.md
+- Docs/superpowers/specs/2026-06-09-mcp-filesystem-lock-leases-design.md
+- Docs/superpowers/plans/2026-06-09-mcp-filesystem-lock-leases-implementation-plan.md
 ---
 
 ## Description
@@ -20,12 +22,26 @@ Add optional filesystem lock leases alongside hashes/read receipts. Include `fs.
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
+- [ ] #1 `fs.lock_acquire` and `fs.lock_release` are exposed with strict schemas, `lock` path-action metadata, safe result payloads, and path-boundable descriptors.
+- [ ] #2 Process-local in-memory leases support acquire, renew, conflict, expiry cleanup, release, and wrong-token conflict without leaking absolute paths.
+- [ ] #3 `fs.edit`, `fs.patch`, and `fs.write` accept optional lock lease validation and can require active matching locks through module settings without weakening hash/read-receipt preimage checks.
+- [ ] #4 Regression tests cover lock tools, safe conflicts, TTL expiry, path escapes, and mutation validation for `fs.patch` and `fs.write`.
+- [ ] #5 Documentation and task notes clearly state this slice is process-local advisory locking, with shared/persistent stores deferred.
+- [ ] #6 Focused filesystem tests, compile checks, Bandit on touched Python scope, and `git diff --check` pass.
 <!-- AC:END -->
 
 ## Implementation Notes
 
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Started implementation slice on 2026-06-09 in worktree `.worktrees/mcp-fs-lock-leases`.
 
+Approved scope:
+- Process-local in-memory advisory locks for the first slice.
+- Future filesystem/DB/shared lock stores stay behind a follow-up seam.
+
+Baseline:
+- `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_module.py tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_patch_parser.py -q`
+  - Result: 99 passed, 4 warnings.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary

--- a/mcp_unified/USER_GUIDE.md
+++ b/mcp_unified/USER_GUIDE.md
@@ -152,6 +152,18 @@ This read-before-mutate flow protects against stale edits: if a file changes
 after the model read it, the expected hash or receipt no longer matches and the
 write is rejected instead of silently overwriting newer content.
 
+For concurrent editing workflows, `fs.lock_acquire` and `fs.lock_release`
+provide process-local advisory leases for workspace-relative file paths. A
+successful acquire returns a `lease_id` that callers can pass to `fs.edit` and
+`fs.write` as `lock_lease_id`, or to `fs.patch` as
+`lock_lease_id_by_path`. Leases do not replace hashes or read receipts; mutation
+tools still run their normal preimage checks. Operators can set
+`require_lock_for_mutation=true` on the filesystem module when they want
+mutations to fail with `lock_required` unless the caller supplies a matching
+active lease. This first implementation is process-local and advisory: use it
+to reduce races within one running gateway process, not as a durable or
+cross-process distributed lock.
+
 Example action-aware path grants:
 
 ```json
@@ -178,14 +190,15 @@ The executable filesystem actions today are:
   metadata.
 - `edit`: bounded existing-file edits through `fs.patch` or `fs.edit`.
 - `write`: deliberate whole-file create or replace through `fs.write`.
+- `lock`: acquire or release advisory path locks through `fs.lock_acquire` and
+  `fs.lock_release`.
 
 The reserved action names are `delete`, `rename`, `move`, `share`, `export`,
-`chmod`, `admin`, and `lock`. Profiles may author and preview these grants now
-so policy intent is explicit, but they do not become executable until a
-dedicated safe tool for that operation lands. Do not treat these actions as
-aliases for `write`: `share` and `export` are exfiltration-sensitive, `delete`,
-`rename`, and `move` are destructive, `chmod` and `admin` are administrative,
-and `lock` is a concurrency-control action.
+`chmod`, and `admin`. Profiles may author and preview these grants now so policy
+intent is explicit, but they do not become executable until a dedicated safe
+tool for that operation lands. Do not treat these actions as aliases for
+`write`: `share` and `export` are exfiltration-sensitive, `delete`, `rename`,
+and `move` are destructive, and `chmod` and `admin` are administrative.
 
 Operators that prefer inherited policy authoring can keep the executable
 runtime contract flat by compiling `path_grant_authoring` into `path_grants`.
@@ -224,8 +237,8 @@ source, and redaction status. They should not include raw file content, read
 receipts, raw diffs, or absolute host paths.
 
 `fs.read_text` and `fs.write_text` remain compatibility tools for older clients.
-New profiles and front-ends should prefer `fs.read`, `fs.patch`, `fs.edit`, and
-`fs.write`.
+New profiles and front-ends should prefer `fs.read`, `fs.patch`, `fs.edit`,
+`fs.write`, and the lock tools when coordinating edits.
 
 Recommendation catalog patches only change discovery metadata. They do not grant
 execution authority, start external servers, create credential grants, or bypass

--- a/mcp_unified/interfaces/file_policy_actions.py
+++ b/mcp_unified/interfaces/file_policy_actions.py
@@ -34,7 +34,7 @@ FILE_POLICY_ACTIONS = frozenset(
         "lock",
     }
 )
-FILE_POLICY_EXISTING_TOOL_ACTIONS = frozenset({"read", "edit", "write"})
+FILE_POLICY_EXISTING_TOOL_ACTIONS = frozenset({"read", "edit", "write", "lock"})
 FILE_POLICY_DESTRUCTIVE_ACTIONS = frozenset({"delete", "rename", "move"})
 FILE_POLICY_EXFILTRATION_ACTIONS = frozenset({"share", "export"})
 FILE_POLICY_ADMIN_ACTIONS = frozenset({"chmod", "admin"})
@@ -138,7 +138,7 @@ _ACTION_METADATA: dict[str, FilePolicyActionMetadata] = {
         action="lock",
         family="lock",
         description="Acquire or release coordination locks for allowed workspace paths.",
-        implemented=False,
+        implemented=True,
         risk="coordination",
     ),
 }

--- a/tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_locks.py
+++ b/tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_locks.py
@@ -69,8 +69,11 @@ class FilesystemLockMissing(ValueError):
 class InMemoryFilesystemLockManager:
     """Thread-safe, process-local advisory lock lease manager."""
 
-    def __init__(self, *, token_bytes: int = 24) -> None:
+    def __init__(self, *, token_bytes: int = 24, sweep_interval: int = 64, max_sweep_entries: int = 512) -> None:
         self._token_bytes = max(16, token_bytes)
+        self._sweep_interval = max(1, sweep_interval)
+        self._max_sweep_entries = max(1, max_sweep_entries)
+        self._operation_count = 0
         self._leases: dict[tuple[str, str], FilesystemLockLease] = {}
         self._lock = threading.RLock()
 
@@ -91,6 +94,7 @@ class InMemoryFilesystemLockManager:
         now = time.time()
         expires_at = now + max(1, ttl_seconds)
         with self._lock:
+            self._maybe_sweep_expired_locked(now=now)
             active = self._active_lease_locked(key, now=now)
             if active is not None:
                 if lease_id != active.lease_id:
@@ -107,6 +111,9 @@ class InMemoryFilesystemLockManager:
                 )
                 self._leases[key] = renewed
                 return renewed, True
+
+            if lease_id is not None:
+                raise FilesystemLockMissing()
 
             acquired = FilesystemLockLease(
                 workspace_key=workspace_key,
@@ -126,10 +133,12 @@ class InMemoryFilesystemLockManager:
 
         key = (workspace_key, path)
         with self._lock:
-            active = self._active_lease_locked(key, now=time.time())
+            now = time.time()
+            self._maybe_sweep_expired_locked(now=now)
+            active = self._active_lease_locked(key, now=now)
             if active is None:
                 return None
-            if active.lease_id != lease_id:
+            if active.lease_id != lease_id.strip():
                 raise FilesystemLockConflict(active)
             del self._leases[key]
             return active
@@ -139,7 +148,9 @@ class InMemoryFilesystemLockManager:
 
         key = (workspace_key, path)
         with self._lock:
-            active = self._active_lease_locked(key, now=time.time())
+            now = time.time()
+            self._maybe_sweep_expired_locked(now=now)
+            active = self._active_lease_locked(key, now=now)
             if active is None:
                 raise FilesystemLockMissing()
             if active.lease_id != lease_id:
@@ -155,11 +166,23 @@ class InMemoryFilesystemLockManager:
             return None
         return lease
 
+    def _maybe_sweep_expired_locked(self, *, now: float) -> None:
+        self._operation_count += 1
+        if self._operation_count % self._sweep_interval != 0 and len(self._leases) <= self._max_sweep_entries:
+            return
+
+        for _ in range(min(self._max_sweep_entries, len(self._leases))):
+            key, lease = next(iter(self._leases.items()))
+            if lease.expires_at <= now:
+                del self._leases[key]
+            else:
+                self._leases.pop(key)
+                self._leases[key] = lease
+
 
 __all__ = [
     "FilesystemLockConflict",
     "FilesystemLockLease",
     "FilesystemLockMissing",
     "InMemoryFilesystemLockManager",
-    "time",
 ]

--- a/tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_locks.py
+++ b/tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_locks.py
@@ -1,0 +1,165 @@
+"""Process-local advisory lock leases for MCP filesystem tools."""
+
+from __future__ import annotations
+
+import secrets
+import threading
+import time
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any
+
+
+@dataclass(frozen=True, slots=True)
+class FilesystemLockLease:
+    """A caller-held advisory lease for one workspace-relative path."""
+
+    workspace_key: str
+    path: str
+    lease_id: str
+    owner: str
+    expires_at: float
+    ttl_seconds: int
+    workspace_id: str | None = None
+    session_id: str | None = None
+
+    def expires_at_iso(self) -> str:
+        """Return the lease expiry timestamp in UTC ISO-8601 form."""
+
+        return datetime.fromtimestamp(self.expires_at, tz=timezone.utc).isoformat()
+
+    def safe_payload(self) -> dict[str, Any]:
+        """Return non-sensitive lease metadata safe for tool responses."""
+
+        return {
+            "path": self.path,
+            "lease_id": self.lease_id,
+            "owner": self.owner,
+            "expires_at": self.expires_at_iso(),
+            "ttl_seconds": self.ttl_seconds,
+        }
+
+    def conflict_payload(self) -> dict[str, Any]:
+        """Return non-sensitive lock holder details for conflict responses."""
+
+        return {
+            "reason_code": "lock_conflict",
+            "path": self.path,
+            "held": True,
+            "held_owner": self.owner,
+            "expires_at": self.expires_at_iso(),
+        }
+
+
+class FilesystemLockConflict(ValueError):
+    """Raised when an active lease is held by another token."""
+
+    def __init__(self, lease: FilesystemLockLease) -> None:
+        super().__init__("lock_conflict")
+        self.lease = lease
+
+
+class FilesystemLockMissing(ValueError):
+    """Raised when no active lease exists for a requested token/path pair."""
+
+    def __init__(self) -> None:
+        super().__init__("lock_missing")
+
+
+class InMemoryFilesystemLockManager:
+    """Thread-safe, process-local advisory lock lease manager."""
+
+    def __init__(self, *, token_bytes: int = 24) -> None:
+        self._token_bytes = max(16, token_bytes)
+        self._leases: dict[tuple[str, str], FilesystemLockLease] = {}
+        self._lock = threading.RLock()
+
+    def acquire(
+        self,
+        *,
+        workspace_key: str,
+        path: str,
+        owner: str,
+        ttl_seconds: int,
+        lease_id: str | None = None,
+        workspace_id: str | None = None,
+        session_id: str | None = None,
+    ) -> tuple[FilesystemLockLease, bool]:
+        """Acquire a new lease or renew the current lease when the token matches."""
+
+        key = (workspace_key, path)
+        now = time.time()
+        expires_at = now + max(1, ttl_seconds)
+        with self._lock:
+            active = self._active_lease_locked(key, now=now)
+            if active is not None:
+                if lease_id != active.lease_id:
+                    raise FilesystemLockConflict(active)
+                renewed = FilesystemLockLease(
+                    workspace_key=workspace_key,
+                    path=path,
+                    lease_id=active.lease_id,
+                    owner=owner,
+                    expires_at=expires_at,
+                    ttl_seconds=max(1, ttl_seconds),
+                    workspace_id=workspace_id,
+                    session_id=session_id,
+                )
+                self._leases[key] = renewed
+                return renewed, True
+
+            acquired = FilesystemLockLease(
+                workspace_key=workspace_key,
+                path=path,
+                lease_id=secrets.token_urlsafe(self._token_bytes),
+                owner=owner,
+                expires_at=expires_at,
+                ttl_seconds=max(1, ttl_seconds),
+                workspace_id=workspace_id,
+                session_id=session_id,
+            )
+            self._leases[key] = acquired
+            return acquired, False
+
+    def release(self, *, workspace_key: str, path: str, lease_id: str) -> FilesystemLockLease | None:
+        """Release a lease when the caller presents the active token."""
+
+        key = (workspace_key, path)
+        with self._lock:
+            active = self._active_lease_locked(key, now=time.time())
+            if active is None:
+                return None
+            if active.lease_id != lease_id:
+                raise FilesystemLockConflict(active)
+            del self._leases[key]
+            return active
+
+    def validate(self, *, workspace_key: str, path: str, lease_id: str) -> FilesystemLockLease:
+        """Return the active lease when the caller presents the current token."""
+
+        key = (workspace_key, path)
+        with self._lock:
+            active = self._active_lease_locked(key, now=time.time())
+            if active is None:
+                raise FilesystemLockMissing()
+            if active.lease_id != lease_id:
+                raise FilesystemLockConflict(active)
+            return active
+
+    def _active_lease_locked(self, key: tuple[str, str], *, now: float) -> FilesystemLockLease | None:
+        lease = self._leases.get(key)
+        if lease is None:
+            return None
+        if lease.expires_at <= now:
+            del self._leases[key]
+            return None
+        return lease
+
+
+__all__ = [
+    "FilesystemLockConflict",
+    "FilesystemLockLease",
+    "FilesystemLockMissing",
+    "InMemoryFilesystemLockManager",
+    "time",
+]

--- a/tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_module.py
@@ -595,10 +595,10 @@ class FilesystemModule(BaseModule):
             return result
 
         if tool_name == "fs.lock_acquire":
-            target = self._resolve_workspace_path_no_follow(workspace_root, str(args.get("path")))
-            return self._acquire_lock(
+            return await asyncio.to_thread(
+                self._acquire_lock_for_path,
                 workspace_root,
-                target,
+                str(args.get("path")),
                 str(args.get("owner")),
                 self._bounded_lock_ttl(args.get("ttl_seconds")),
                 args.get("lease_id"),
@@ -606,8 +606,12 @@ class FilesystemModule(BaseModule):
             )
 
         if tool_name == "fs.lock_release":
-            target = self._resolve_workspace_path_no_follow(workspace_root, str(args.get("path")))
-            return self._release_lock(workspace_root, target, str(args.get("lease_id")))
+            return await asyncio.to_thread(
+                self._release_lock_for_path,
+                workspace_root,
+                str(args.get("path")),
+                str(args.get("lease_id")),
+            )
 
         if tool_name == "fs.edit":
             target = self._resolve_workspace_path_no_follow(workspace_root, str(args.get("path")))
@@ -911,10 +915,11 @@ class FilesystemModule(BaseModule):
                 raise ValueError("old_string is required")
             if not isinstance(new_string, str):
                 raise ValueError("new_string must be a string")
-            for key in ("expected_sha256", "read_receipt", "lock_lease_id"):
+            for key in ("expected_sha256", "read_receipt"):
                 value = arguments.get(key)
                 if value is not None and not isinstance(value, str):
                     raise ValueError(f"{key} must be a string")
+            self._validate_optional_nonempty_string_argument(arguments, "lock_lease_id")
             self._validate_bool_argument(arguments, "replace_all")
             self._validate_bool_argument(arguments, "dry_run")
             return
@@ -939,7 +944,7 @@ class FilesystemModule(BaseModule):
                 raise ValueError("diff is required")
             self._validate_optional_string_map_argument(arguments, "expected_sha256_by_path")
             self._validate_optional_string_map_argument(arguments, "read_receipt_by_path")
-            self._validate_optional_string_map_argument(arguments, "lock_lease_id_by_path")
+            self._validate_optional_nonempty_string_map_argument(arguments, "lock_lease_id_by_path")
             self._validate_bool_argument(arguments, "create_parent_directories")
             self._validate_bool_argument(arguments, "allow_create")
             self._validate_bool_argument(arguments, "dry_run")
@@ -969,10 +974,11 @@ class FilesystemModule(BaseModule):
                 raise ValueError("content must be a string")
             if mode not in {"create", "replace"}:
                 raise ValueError("mode must be create or replace")
-            for key in ("expected_sha256", "read_receipt", "lock_lease_id"):
+            for key in ("expected_sha256", "read_receipt"):
                 value = arguments.get(key)
                 if value is not None and not isinstance(value, str):
                     raise ValueError(f"{key} must be a string")
+            self._validate_optional_nonempty_string_argument(arguments, "lock_lease_id")
             self._validate_bool_argument(arguments, "dry_run")
             return
 
@@ -1134,6 +1140,25 @@ class FilesystemModule(BaseModule):
             isinstance(map_key, str) and isinstance(map_value, str) for map_key, map_value in value.items()
         ):
             raise ValueError(f"{key} must be an object with string values")
+
+    @staticmethod
+    def _validate_optional_nonempty_string_argument(arguments: dict[str, Any], key: str) -> None:
+        value = arguments.get(key)
+        if value is None:
+            return
+        if not isinstance(value, str) or not value.strip():
+            raise ValueError(f"{key} must be a non-empty string")
+
+    @staticmethod
+    def _validate_optional_nonempty_string_map_argument(arguments: dict[str, Any], key: str) -> None:
+        value = arguments.get(key)
+        if value is None:
+            return
+        if not isinstance(value, dict) or not all(
+            isinstance(map_key, str) and isinstance(map_value, str) and bool(map_value.strip())
+            for map_key, map_value in value.items()
+        ):
+            raise ValueError(f"{key} must be an object with non-empty string values")
 
     async def extract_path_scope_candidates(
         self,
@@ -1932,6 +1957,18 @@ class FilesystemModule(BaseModule):
             truncated=False,
         )
 
+    def _acquire_lock_for_path(
+        self,
+        workspace_root: Path,
+        raw_path: str,
+        owner: str,
+        ttl_seconds: int,
+        lease_id: Any,
+        context: Any | None,
+    ) -> dict[str, Any]:
+        target = self._resolve_workspace_path_no_follow(workspace_root, raw_path)
+        return self._acquire_lock(workspace_root, target, owner, ttl_seconds, lease_id, context)
+
     def _acquire_lock(
         self,
         workspace_root: Path,
@@ -1959,6 +1996,14 @@ class FilesystemModule(BaseModule):
                 **exc.lease.conflict_payload(),
                 "eval": self._lock_eval_metadata("fs.lock_acquire"),
             }
+        except FilesystemLockMissing:
+            return {
+                "acquired": False,
+                "reason_code": "lock_missing",
+                "path": rel_path,
+                "held": False,
+                "eval": self._lock_eval_metadata("fs.lock_acquire"),
+            }
         return {
             "acquired": True,
             "renewed": renewed,
@@ -1966,13 +2011,17 @@ class FilesystemModule(BaseModule):
             "eval": self._lock_eval_metadata("fs.lock_acquire"),
         }
 
+    def _release_lock_for_path(self, workspace_root: Path, raw_path: str, lease_id: str) -> dict[str, Any]:
+        target = self._resolve_workspace_path_no_follow(workspace_root, raw_path)
+        return self._release_lock(workspace_root, target, lease_id)
+
     def _release_lock(self, workspace_root: Path, target: Path, lease_id: str) -> dict[str, Any]:
         rel_path = self._to_workspace_relative_path(workspace_root, target)
         try:
             released = self._lock_leases.release(
                 workspace_key=self._workspace_lock_key(workspace_root),
                 path=rel_path,
-                lease_id=lease_id,
+                lease_id=lease_id.strip(),
             )
         except FilesystemLockConflict as exc:
             return {
@@ -1996,8 +2045,9 @@ class FilesystemModule(BaseModule):
         }
 
     def _validate_mutation_lock(self, workspace_root: Path, rel_path: str, lease_id: Any) -> None:
-        has_lease = isinstance(lease_id, str) and bool(lease_id.strip())
-        if not has_lease:
+        if lease_id is not None and (not isinstance(lease_id, str) or not lease_id.strip()):
+            raise ValueError("lock_lease_id must be a non-empty string")
+        if lease_id is None:
             if self._setting_bool("require_lock_for_mutation", False):
                 raise ValueError("lock_required")
             return
@@ -2048,8 +2098,6 @@ class FilesystemModule(BaseModule):
             try:
                 for plan in plans:
                     target = plan["_target"]
-                    if plan["_create_parent_directories"]:
-                        target.parent.mkdir(parents=True, exist_ok=True)
                     self._validate_mutation_lock(
                         workspace_root,
                         str(plan["result"]["path"]),
@@ -2060,6 +2108,8 @@ class FilesystemModule(BaseModule):
                         plan["result"].get("sha256_before"),
                         int(plan["result"].get("bytes_before") or 0),
                     )
+                    if plan["_create_parent_directories"]:
+                        target.parent.mkdir(parents=True, exist_ok=True)
                     self._atomic_write_text_file(target, str(plan["_text_after"]))
                     written.append(plan)
             except Exception as exc:
@@ -2583,9 +2633,9 @@ class FilesystemModule(BaseModule):
 
         sha256_after = hashlib.sha256(data_after).hexdigest()
         if not dry_run:
-            target.parent.mkdir(parents=True, exist_ok=True)
             self._validate_mutation_lock(workspace_root, rel_path, lock_lease_id)
             self._assert_preimage_unchanged(target, sha256_before, bytes_before)
+            target.parent.mkdir(parents=True, exist_ok=True)
             self._atomic_write_text_file(target, content)
 
         result: dict[str, Any] = {

--- a/tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_module.py
@@ -4,6 +4,8 @@ Workspace-bounded filesystem MCP module.
 Exposes:
 - fs.list
 - fs.edit
+- fs.lock_acquire
+- fs.lock_release
 - fs.read
 - fs.read_text
 - fs.patch
@@ -42,6 +44,7 @@ from tldw_Server_API.app.services.mcp_hub_workspace_root_resolver import (
 from ...tool_observability import build_execution_eval_metadata
 from ..base import BaseModule, ModuleConfig, create_tool_definition
 from .filesystem_diff import FilesystemPatchError, PatchFile, apply_patch_to_text, parse_unified_diff
+from .filesystem_locks import FilesystemLockConflict, FilesystemLockMissing, InMemoryFilesystemLockManager
 from .filesystem_receipts import ReadReceiptError, ReadReceiptManager
 
 
@@ -108,6 +111,7 @@ class FilesystemModule(BaseModule):
             secret=config.settings.get("read_receipt_secret"),
             ttl_seconds=self._setting_positive_int("read_receipt_ttl_seconds", 1_800),
         )
+        self._lock_leases = InMemoryFilesystemLockManager()
 
     async def on_initialize(self) -> None:
         logger.info(f"Initializing Filesystem module: {self.name}")
@@ -206,6 +210,7 @@ class FilesystemModule(BaseModule):
                     "new_string": {"type": "string", "description": "Replacement literal text"},
                     "expected_sha256": {"type": "string"},
                     "read_receipt": {"type": "string"},
+                    "lock_lease_id": {"type": "string"},
                     "replace_all": {"type": "boolean", "default": False},
                     "dry_run": {"type": "boolean", "default": False},
                 },
@@ -228,6 +233,60 @@ class FilesystemModule(BaseModule):
         )
         edit_tool["inputSchema"]["additionalProperties"] = False
 
+        lock_acquire_tool = create_tool_definition(
+            name="fs.lock_acquire",
+            description="Acquire or renew a process-local advisory lock lease for one workspace path.",
+            parameters={
+                "properties": {
+                    "path": {"type": "string", "description": "Workspace-relative or absolute path"},
+                    "owner": {"type": "string", "description": "Non-secret caller label for diagnostics"},
+                    "ttl_seconds": {"type": "integer", "minimum": 1},
+                    "lease_id": {"type": "string", "description": "Existing lease token to renew"},
+                },
+                "required": ["path", "owner"],
+            },
+            metadata={
+                "category": "management",
+                "readOnlyHint": False,
+                "write_capable": False,
+                "capabilities": ["filesystem.lock"],
+                "path_scope_action": "lock",
+                **_file_policy_metadata("lock"),
+                "eval": {
+                    "task_families": ["filesystem_lock"],
+                    "expected_result_kind": "structured_filesystem_lock",
+                },
+                **shared_path_metadata,
+            },
+        )
+        lock_acquire_tool["inputSchema"]["additionalProperties"] = False
+
+        lock_release_tool = create_tool_definition(
+            name="fs.lock_release",
+            description="Release a process-local advisory lock lease for one workspace path.",
+            parameters={
+                "properties": {
+                    "path": {"type": "string", "description": "Workspace-relative or absolute path"},
+                    "lease_id": {"type": "string", "description": "Active lease token to release"},
+                },
+                "required": ["path", "lease_id"],
+            },
+            metadata={
+                "category": "management",
+                "readOnlyHint": False,
+                "write_capable": False,
+                "capabilities": ["filesystem.lock"],
+                "path_scope_action": "lock",
+                **_file_policy_metadata("lock"),
+                "eval": {
+                    "task_families": ["filesystem_lock"],
+                    "expected_result_kind": "structured_filesystem_lock",
+                },
+                **shared_path_metadata,
+            },
+        )
+        lock_release_tool["inputSchema"]["additionalProperties"] = False
+
         patch_tool = create_tool_definition(
             name="fs.patch",
             description="Apply a bounded unified diff to workspace files after preimage checks.",
@@ -239,6 +298,10 @@ class FilesystemModule(BaseModule):
                         "additionalProperties": {"type": "string"},
                     },
                     "read_receipt_by_path": {
+                        "type": "object",
+                        "additionalProperties": {"type": "string"},
+                    },
+                    "lock_lease_id_by_path": {
                         "type": "object",
                         "additionalProperties": {"type": "string"},
                     },
@@ -275,6 +338,7 @@ class FilesystemModule(BaseModule):
                     "mode": {"type": "string", "enum": ["create", "replace"]},
                     "expected_sha256": {"type": "string"},
                     "read_receipt": {"type": "string"},
+                    "lock_lease_id": {"type": "string"},
                     "dry_run": {"type": "boolean", "default": False},
                 },
                 "required": ["path", "content", "mode"],
@@ -437,6 +501,8 @@ class FilesystemModule(BaseModule):
             list_tool,
             read_tool,
             edit_tool,
+            lock_acquire_tool,
+            lock_release_tool,
             read_text_tool,
             patch_tool,
             write_tool,
@@ -528,6 +594,21 @@ class FilesystemModule(BaseModule):
             )
             return result
 
+        if tool_name == "fs.lock_acquire":
+            target = self._resolve_workspace_path_no_follow(workspace_root, str(args.get("path")))
+            return self._acquire_lock(
+                workspace_root,
+                target,
+                str(args.get("owner")),
+                self._bounded_lock_ttl(args.get("ttl_seconds")),
+                args.get("lease_id"),
+                context,
+            )
+
+        if tool_name == "fs.lock_release":
+            target = self._resolve_workspace_path_no_follow(workspace_root, str(args.get("path")))
+            return self._release_lock(workspace_root, target, str(args.get("lease_id")))
+
         if tool_name == "fs.edit":
             target = self._resolve_workspace_path_no_follow(workspace_root, str(args.get("path")))
             return await asyncio.to_thread(
@@ -538,6 +619,7 @@ class FilesystemModule(BaseModule):
                 str(args.get("new_string")),
                 args.get("expected_sha256"),
                 args.get("read_receipt"),
+                args.get("lock_lease_id"),
                 bool(args.get("replace_all", False)),
                 bool(args.get("dry_run", False)),
                 self._setting_positive_int("edit_preimage_max_bytes", 5_000_000),
@@ -553,6 +635,7 @@ class FilesystemModule(BaseModule):
                 patch_files,
                 self._string_map_argument(args.get("expected_sha256_by_path")),
                 self._string_map_argument(args.get("read_receipt_by_path")),
+                self._string_map_argument(args.get("lock_lease_id_by_path")),
                 bool(args.get("allow_create", False)),
                 bool(args.get("create_parent_directories", False)),
                 bool(args.get("dry_run", False)),
@@ -571,6 +654,7 @@ class FilesystemModule(BaseModule):
                 str(args.get("mode")),
                 args.get("expected_sha256"),
                 args.get("read_receipt"),
+                args.get("lock_lease_id"),
                 bool(args.get("dry_run", False)),
                 self._setting_positive_int("write_max_bytes", 5_000_000),
                 self._setting_positive_int("write_preimage_max_bytes", 5_000_000),
@@ -722,6 +806,13 @@ class FilesystemModule(BaseModule):
             return raw_value.strip().lower() in {"1", "true", "yes", "on", "y"}
         return bool(raw_value)
 
+    def _bounded_lock_ttl(self, value: Any) -> int:
+        return self._bounded_positive_int(
+            value,
+            self._setting_positive_int("lock_default_ttl_seconds", 300),
+            maximum=self._setting_positive_int("lock_max_ttl_seconds", 3_600),
+        )
+
     def validate_tool_arguments(self, tool_name: str, arguments: dict[str, Any]) -> None:
         if tool_name == "fs.list":
             unknown = sorted(set(arguments) - {"path"})
@@ -765,6 +856,36 @@ class FilesystemModule(BaseModule):
             self._validate_bool_argument(arguments, "include_receipt")
             return
 
+        if tool_name == "fs.lock_acquire":
+            unknown = sorted(set(arguments) - {"path", "owner", "ttl_seconds", "lease_id"})
+            if unknown:
+                raise ValueError(f"unknown arguments: {', '.join(unknown)}")
+            path = arguments.get("path")
+            owner = arguments.get("owner")
+            lease_id = arguments.get("lease_id")
+            if not isinstance(path, str) or not path.strip():
+                raise ValueError("path is required")
+            if not isinstance(owner, str) or not owner.strip():
+                raise ValueError("owner is required")
+            if len(owner.strip()) > 128:
+                raise ValueError("owner is too long")
+            self._validate_positive_int_argument(arguments, "ttl_seconds")
+            if lease_id is not None and (not isinstance(lease_id, str) or not lease_id.strip()):
+                raise ValueError("lease_id must be a string")
+            return
+
+        if tool_name == "fs.lock_release":
+            unknown = sorted(set(arguments) - {"path", "lease_id"})
+            if unknown:
+                raise ValueError(f"unknown arguments: {', '.join(unknown)}")
+            path = arguments.get("path")
+            lease_id = arguments.get("lease_id")
+            if not isinstance(path, str) or not path.strip():
+                raise ValueError("path is required")
+            if not isinstance(lease_id, str) or not lease_id.strip():
+                raise ValueError("lease_id is required")
+            return
+
         if tool_name == "fs.edit":
             unknown = sorted(
                 set(arguments)
@@ -774,6 +895,7 @@ class FilesystemModule(BaseModule):
                     "new_string",
                     "expected_sha256",
                     "read_receipt",
+                    "lock_lease_id",
                     "replace_all",
                     "dry_run",
                 }
@@ -789,7 +911,7 @@ class FilesystemModule(BaseModule):
                 raise ValueError("old_string is required")
             if not isinstance(new_string, str):
                 raise ValueError("new_string must be a string")
-            for key in ("expected_sha256", "read_receipt"):
+            for key in ("expected_sha256", "read_receipt", "lock_lease_id"):
                 value = arguments.get(key)
                 if value is not None and not isinstance(value, str):
                     raise ValueError(f"{key} must be a string")
@@ -804,6 +926,7 @@ class FilesystemModule(BaseModule):
                     "diff",
                     "expected_sha256_by_path",
                     "read_receipt_by_path",
+                    "lock_lease_id_by_path",
                     "create_parent_directories",
                     "allow_create",
                     "dry_run",
@@ -816,6 +939,7 @@ class FilesystemModule(BaseModule):
                 raise ValueError("diff is required")
             self._validate_optional_string_map_argument(arguments, "expected_sha256_by_path")
             self._validate_optional_string_map_argument(arguments, "read_receipt_by_path")
+            self._validate_optional_string_map_argument(arguments, "lock_lease_id_by_path")
             self._validate_bool_argument(arguments, "create_parent_directories")
             self._validate_bool_argument(arguments, "allow_create")
             self._validate_bool_argument(arguments, "dry_run")
@@ -830,6 +954,7 @@ class FilesystemModule(BaseModule):
                     "mode",
                     "expected_sha256",
                     "read_receipt",
+                    "lock_lease_id",
                     "dry_run",
                 }
             )
@@ -844,7 +969,7 @@ class FilesystemModule(BaseModule):
                 raise ValueError("content must be a string")
             if mode not in {"create", "replace"}:
                 raise ValueError("mode must be create or replace")
-            for key in ("expected_sha256", "read_receipt"):
+            for key in ("expected_sha256", "read_receipt", "lock_lease_id"):
                 value = arguments.get(key)
                 if value is not None and not isinstance(value, str):
                     raise ValueError(f"{key} must be a string")
@@ -1777,12 +1902,124 @@ class FilesystemModule(BaseModule):
             return {}
         return {str(key): str(map_value) for key, map_value in dict(value).items()}
 
+    @staticmethod
+    def _workspace_lock_key(workspace_root: Path) -> str:
+        return str(workspace_root)
+
+    @staticmethod
+    def _context_session_id(context: Any | None) -> str | None:
+        return _first_nonempty(
+            getattr(context, "session_id", None),
+            FilesystemModule._context_metadata_value(context, "session_id"),
+        )
+
+    @staticmethod
+    def _assert_lockable_file_target(target: Path) -> None:
+        if target.is_symlink():
+            raise ValueError("file_not_regular")
+        if target.exists() and not target.is_file():
+            raise ValueError("file_not_regular")
+
+    @staticmethod
+    def _lock_eval_metadata(tool_name: str) -> dict[str, Any]:
+        return build_execution_eval_metadata(
+            tool_name=tool_name,
+            tool_prompt_id=f"mcp.{tool_name}.v1",
+            tool_prompt_version="2026.06.09",
+            action_family="filesystem_lock",
+            result_kind="structured_filesystem_lock",
+            path_filter_used=True,
+            truncated=False,
+        )
+
+    def _acquire_lock(
+        self,
+        workspace_root: Path,
+        target: Path,
+        owner: str,
+        ttl_seconds: int,
+        lease_id: Any,
+        context: Any | None,
+    ) -> dict[str, Any]:
+        self._assert_lockable_file_target(target)
+        rel_path = self._to_workspace_relative_path(workspace_root, target)
+        try:
+            lease, renewed = self._lock_leases.acquire(
+                workspace_key=self._workspace_lock_key(workspace_root),
+                path=rel_path,
+                owner=owner.strip(),
+                ttl_seconds=ttl_seconds,
+                lease_id=str(lease_id).strip() if isinstance(lease_id, str) and lease_id.strip() else None,
+                workspace_id=self._context_metadata_value(context, "workspace_id"),
+                session_id=self._context_session_id(context),
+            )
+        except FilesystemLockConflict as exc:
+            return {
+                "acquired": False,
+                **exc.lease.conflict_payload(),
+                "eval": self._lock_eval_metadata("fs.lock_acquire"),
+            }
+        return {
+            "acquired": True,
+            "renewed": renewed,
+            **lease.safe_payload(),
+            "eval": self._lock_eval_metadata("fs.lock_acquire"),
+        }
+
+    def _release_lock(self, workspace_root: Path, target: Path, lease_id: str) -> dict[str, Any]:
+        rel_path = self._to_workspace_relative_path(workspace_root, target)
+        try:
+            released = self._lock_leases.release(
+                workspace_key=self._workspace_lock_key(workspace_root),
+                path=rel_path,
+                lease_id=lease_id,
+            )
+        except FilesystemLockConflict as exc:
+            return {
+                "released": False,
+                **exc.lease.conflict_payload(),
+                "eval": self._lock_eval_metadata("fs.lock_release"),
+            }
+        if released is None:
+            return {
+                "released": False,
+                "reason_code": "lock_missing",
+                "path": rel_path,
+                "held": False,
+                "eval": self._lock_eval_metadata("fs.lock_release"),
+            }
+        return {
+            "released": True,
+            "path": rel_path,
+            "owner": released.owner,
+            "eval": self._lock_eval_metadata("fs.lock_release"),
+        }
+
+    def _validate_mutation_lock(self, workspace_root: Path, rel_path: str, lease_id: Any) -> None:
+        has_lease = isinstance(lease_id, str) and bool(lease_id.strip())
+        if not has_lease:
+            if self._setting_bool("require_lock_for_mutation", False):
+                raise ValueError("lock_required")
+            return
+
+        try:
+            self._lock_leases.validate(
+                workspace_key=self._workspace_lock_key(workspace_root),
+                path=rel_path,
+                lease_id=str(lease_id).strip(),
+            )
+        except FilesystemLockMissing as exc:
+            raise ValueError("lock_missing") from exc
+        except FilesystemLockConflict as exc:
+            raise ValueError("lock_conflict") from exc
+
     def _apply_patch_files(
         self,
         workspace_root: Path,
         patch_files: tuple[PatchFile, ...],
         expected_sha256_by_path: dict[str, str],
         read_receipt_by_path: dict[str, str],
+        lock_lease_id_by_path: dict[str, str],
         allow_create: bool,
         create_parent_directories: bool,
         dry_run: bool,
@@ -1796,6 +2033,7 @@ class FilesystemModule(BaseModule):
                 patch_file,
                 expected_sha256_by_path,
                 read_receipt_by_path,
+                lock_lease_id_by_path,
                 allow_create,
                 create_parent_directories,
                 preimage_max_bytes,
@@ -1812,6 +2050,11 @@ class FilesystemModule(BaseModule):
                     target = plan["_target"]
                     if plan["_create_parent_directories"]:
                         target.parent.mkdir(parents=True, exist_ok=True)
+                    self._validate_mutation_lock(
+                        workspace_root,
+                        str(plan["result"]["path"]),
+                        plan["_lock_lease_id"],
+                    )
                     self._assert_preimage_unchanged(
                         target,
                         plan["result"].get("sha256_before"),
@@ -1869,6 +2112,7 @@ class FilesystemModule(BaseModule):
         patch_file: PatchFile,
         expected_sha256_by_path: dict[str, str],
         read_receipt_by_path: dict[str, str],
+        lock_lease_id_by_path: dict[str, str],
         allow_create: bool,
         create_parent_directories: bool,
         preimage_max_bytes: int,
@@ -1880,6 +2124,7 @@ class FilesystemModule(BaseModule):
             raise ValueError("invalid_patch_path")
         target = self._resolve_workspace_path_no_follow(workspace_root, rel_path)
         response_path = self._to_workspace_relative_path(workspace_root, target)
+        self._validate_mutation_lock(workspace_root, response_path, lock_lease_id_by_path.get(response_path))
         additions, deletions = self._patch_line_counts(patch_file)
 
         if patch_file.action == "create":
@@ -1940,6 +2185,7 @@ class FilesystemModule(BaseModule):
             "_text_before": text_before,
             "_existed_before": not created,
             "_create_parent_directories": create_parent_directories,
+            "_lock_lease_id": lock_lease_id_by_path.get(response_path),
             "result": {
                 "path": response_path,
                 "action": action,
@@ -2132,6 +2378,7 @@ class FilesystemModule(BaseModule):
         new_string: str,
         expected_sha256: Any,
         read_receipt: Any,
+        lock_lease_id: Any,
         replace_all: bool,
         dry_run: bool,
         preimage_max_bytes: int,
@@ -2150,6 +2397,7 @@ class FilesystemModule(BaseModule):
             raise ValueError("binary content is not supported by fs.edit")
 
         rel_path = self._to_workspace_relative_path(workspace_root, target)
+        self._validate_mutation_lock(workspace_root, rel_path, lock_lease_id)
         payload, file_stat = self._read_existing_regular_file_no_follow(target, max_bytes=preimage_max_bytes)
         if b"\x00" in payload:
             raise ValueError("binary content is not supported by fs.edit")
@@ -2194,6 +2442,7 @@ class FilesystemModule(BaseModule):
 
         sha256_after = hashlib.sha256(data_after).hexdigest()
         if not dry_run:
+            self._validate_mutation_lock(workspace_root, rel_path, lock_lease_id)
             self._assert_edit_preimage_unchanged_no_follow(target, sha256_before, bytes_before, file_stat)
             FilesystemModule._atomic_write_text_file(target, text_after)
 
@@ -2283,6 +2532,7 @@ class FilesystemModule(BaseModule):
         mode: str,
         expected_sha256: Any,
         read_receipt: Any,
+        lock_lease_id: Any,
         dry_run: bool,
         write_max_bytes: int,
         preimage_max_bytes: int,
@@ -2295,6 +2545,7 @@ class FilesystemModule(BaseModule):
             raise ValueError("write_content_too_large")
 
         rel_path = self._to_workspace_relative_path(workspace_root, target)
+        self._validate_mutation_lock(workspace_root, rel_path, lock_lease_id)
         created = mode == "create"
         sha256_before = None
         bytes_before = 0
@@ -2333,6 +2584,7 @@ class FilesystemModule(BaseModule):
         sha256_after = hashlib.sha256(data_after).hexdigest()
         if not dry_run:
             target.parent.mkdir(parents=True, exist_ok=True)
+            self._validate_mutation_lock(workspace_root, rel_path, lock_lease_id)
             self._assert_preimage_unchanged(target, sha256_before, bytes_before)
             self._atomic_write_text_file(target, content)
 

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_file_policy_actions.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_file_policy_actions.py
@@ -27,7 +27,7 @@ def test_file_policy_action_taxonomy_lists_existing_and_reserved_actions() -> No
             "lock",
         }
     ) == FILE_POLICY_ACTIONS
-    assert frozenset({"read", "edit", "write"}) == FILE_POLICY_EXISTING_TOOL_ACTIONS
+    assert frozenset({"read", "edit", "write", "lock"}) == FILE_POLICY_EXISTING_TOOL_ACTIONS
     assert frozenset({"share", "export"}) == FILE_POLICY_EXFILTRATION_ACTIONS
 
 
@@ -42,6 +42,20 @@ def test_file_policy_action_metadata_describes_reserved_actions_without_implemen
         "description": "Share or publish file content outside the active workspace boundary.",
         "implemented": False,
         "risk": "exfiltration",
+    }
+
+
+def test_file_policy_action_metadata_describes_lock_as_implemented() -> None:
+    from mcp_unified.interfaces.file_policy_actions import get_file_policy_action_metadata
+
+    metadata = get_file_policy_action_metadata("lock")
+
+    assert metadata.as_dict() == {
+        "action": "lock",
+        "family": "lock",
+        "description": "Acquire or release coordination locks for allowed workspace paths.",
+        "implemented": True,
+        "risk": "coordination",
     }
 
 

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_module.py
@@ -39,6 +39,8 @@ class _FilesystemRegistry:
         self._tool_names = {
             "fs.list",
             "fs.edit",
+            "fs.lock_acquire",
+            "fs.lock_release",
             "fs.read",
             "fs.read_text",
             "fs.patch",
@@ -209,11 +211,29 @@ async def test_filesystem_tools_include_path_scope_metadata() -> None:
     tools = await mod.get_tools()
     by_name = {tool["name"]: tool for tool in tools}
 
-    assert {"fs.list", "fs.edit", "fs.read", "fs.read_text", "fs.patch", "fs.write", "fs.write_text"} <= set(  # nosec B101
-        by_name
-    )
+    assert {  # nosec B101
+        "fs.list",
+        "fs.edit",
+        "fs.lock_acquire",
+        "fs.lock_release",
+        "fs.read",
+        "fs.read_text",
+        "fs.patch",
+        "fs.write",
+        "fs.write_text",
+    } <= set(by_name)
 
-    for tool_name in ("fs.list", "fs.edit", "fs.read", "fs.read_text", "fs.patch", "fs.write", "fs.write_text"):
+    for tool_name in (
+        "fs.list",
+        "fs.edit",
+        "fs.lock_acquire",
+        "fs.lock_release",
+        "fs.read",
+        "fs.read_text",
+        "fs.patch",
+        "fs.write",
+        "fs.write_text",
+    ):
         metadata = by_name[tool_name]["metadata"]
         assert metadata["uses_filesystem"] is True  # nosec B101
         assert metadata["path_boundable"] is True  # nosec B101
@@ -245,6 +265,15 @@ async def test_filesystem_tools_include_path_scope_metadata() -> None:
     assert edit_metadata["eval"]["task_families"] == ["filesystem_edit"]  # nosec B101
     assert edit_metadata["eval"]["expected_result_kind"] == "structured_filesystem_edit"  # nosec B101
     assert by_name["fs.edit"]["inputSchema"]["additionalProperties"] is False  # nosec B101
+    lock_metadata = by_name["fs.lock_acquire"]["metadata"]
+    assert lock_metadata["path_argument_hints"] == ["path"]  # nosec B101
+    assert lock_metadata["path_scope_action"] == "lock"  # nosec B101
+    assert lock_metadata["file_policy_action"] == "lock"  # nosec B101
+    assert lock_metadata["file_policy_action_family"] == "lock"  # nosec B101
+    assert lock_metadata["write_capable"] is False  # nosec B101
+    assert lock_metadata["eval"]["task_families"] == ["filesystem_lock"]  # nosec B101
+    assert by_name["fs.lock_acquire"]["inputSchema"]["additionalProperties"] is False  # nosec B101
+    assert by_name["fs.lock_release"]["inputSchema"]["additionalProperties"] is False  # nosec B101
     write_metadata = by_name["fs.write"]["metadata"]
     assert write_metadata["path_argument_hints"] == ["path"]  # nosec B101
     assert write_metadata["path_scope_action"] == "write"  # nosec B101
@@ -263,6 +292,118 @@ async def test_filesystem_tools_include_path_scope_metadata() -> None:
     assert write_text_metadata["replacement_tools"] == ["fs.patch", "fs.write"]  # nosec B101
     assert write_text_metadata["path_scope_action"] == "write"  # nosec B101
     assert by_name["fs.write_text"]["metadata"]["category"] == "management"  # nosec B101
+
+
+@pytest.mark.asyncio
+async def test_filesystem_lock_lifecycle_conflicts_and_expiry(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from tldw_Server_API.app.core.MCP_unified.modules.implementations import filesystem_locks
+
+    now = 1_000.0
+    monkeypatch.setattr(filesystem_locks.time, "time", lambda: now)
+    workspace_root = tmp_path / "workspace"
+    docs_dir = workspace_root / "docs"
+    docs_dir.mkdir(parents=True, exist_ok=True)
+    (docs_dir / "story.txt").write_text("alpha\n", encoding="utf-8")
+    resolver = _FakeWorkspaceRootResolver({"workspace_root": str(workspace_root), "workspace_id": "ws-1"})
+    mod = FilesystemModule(
+        ModuleConfig(
+            name="filesystem",
+            settings={"lock_default_ttl_seconds": 30, "lock_max_ttl_seconds": 120},
+        ),
+        workspace_root_resolver=resolver,
+    )
+    context = RequestContext(request_id="req-fs-locks", user_id="1", metadata={"workspace_id": "ws-1"})
+
+    first = await mod.execute_tool(
+        "fs.lock_acquire",
+        {"path": "docs/story.txt", "owner": "agent-a", "ttl_seconds": 60},
+        context=context,
+    )
+    assert first["acquired"] is True  # nosec B101
+    assert first["renewed"] is False  # nosec B101
+    assert first["path"] == "docs/story.txt"  # nosec B101
+    assert str(workspace_root) not in str(first)  # nosec B101
+
+    conflict = await mod.execute_tool(
+        "fs.lock_acquire",
+        {"path": "docs/story.txt", "owner": "agent-b", "ttl_seconds": 60},
+        context=context,
+    )
+    assert conflict["acquired"] is False  # nosec B101
+    assert conflict["reason_code"] == "lock_conflict"  # nosec B101
+    assert conflict["held_owner"] == "agent-a"  # nosec B101
+    assert str(workspace_root) not in str(conflict)  # nosec B101
+
+    renewed = await mod.execute_tool(
+        "fs.lock_acquire",
+        {
+            "path": "docs/story.txt",
+            "owner": "agent-a",
+            "lease_id": first["lease_id"],
+            "ttl_seconds": 90,
+        },
+        context=context,
+    )
+    assert renewed["acquired"] is True  # nosec B101
+    assert renewed["renewed"] is True  # nosec B101
+    assert renewed["lease_id"] == first["lease_id"]  # nosec B101
+    assert renewed["ttl_seconds"] == 90  # nosec B101
+
+    wrong_release = await mod.execute_tool(
+        "fs.lock_release",
+        {"path": "docs/story.txt", "lease_id": "wrong-token"},
+        context=context,
+    )
+    assert wrong_release["released"] is False  # nosec B101
+    assert wrong_release["reason_code"] == "lock_conflict"  # nosec B101
+
+    released = await mod.execute_tool(
+        "fs.lock_release",
+        {"path": "docs/story.txt", "lease_id": first["lease_id"]},
+        context=context,
+    )
+    assert released["released"] is True  # nosec B101
+    assert released["path"] == "docs/story.txt"  # nosec B101
+
+    expiring = await mod.execute_tool(
+        "fs.lock_acquire",
+        {"path": "docs/story.txt", "owner": "agent-a", "ttl_seconds": 1},
+        context=context,
+    )
+    now = 1_002.0
+    after_expiry = await mod.execute_tool(
+        "fs.lock_acquire",
+        {"path": "docs/story.txt", "owner": "agent-b", "ttl_seconds": 60},
+        context=context,
+    )
+    assert after_expiry["acquired"] is True  # nosec B101
+    assert after_expiry["lease_id"] != expiring["lease_id"]  # nosec B101
+
+
+@pytest.mark.asyncio
+async def test_filesystem_lock_rejects_path_escape_and_symlink_target(tmp_path: Path) -> None:
+    workspace_root = tmp_path / "workspace"
+    docs_dir = workspace_root / "docs"
+    docs_dir.mkdir(parents=True, exist_ok=True)
+    target = docs_dir / "story.txt"
+    target.write_text("alpha\n", encoding="utf-8")
+    symlink = docs_dir / "story-link.txt"
+    try:
+        symlink.symlink_to(target)
+    except (OSError, NotImplementedError) as exc:
+        pytest.skip(f"symlink creation unavailable on this platform: {exc}")
+
+    resolver = _FakeWorkspaceRootResolver({"workspace_root": str(workspace_root)})
+    mod = FilesystemModule(ModuleConfig(name="filesystem"), workspace_root_resolver=resolver)
+    context = RequestContext(request_id="req-fs-lock-path-safety", user_id="1", metadata={})
+
+    with pytest.raises(PermissionError, match="outside workspace scope"):
+        await mod.execute_tool("fs.lock_acquire", {"path": "../secret.txt", "owner": "agent-a"}, context=context)
+    with pytest.raises(ValueError, match="file_not_regular"):
+        await mod.execute_tool("fs.lock_acquire", {"path": "docs/story-link.txt", "owner": "agent-a"}, context=context)
 
 
 @pytest.mark.asyncio
@@ -1390,6 +1531,47 @@ async def test_filesystem_patch_applies_existing_file_with_read_receipt(tmp_path
 
 
 @pytest.mark.asyncio
+async def test_filesystem_patch_requires_lock_by_path_when_configured(tmp_path: Path) -> None:
+    workspace_root = tmp_path / "workspace"
+    docs_dir = workspace_root / "docs"
+    docs_dir.mkdir(parents=True, exist_ok=True)
+    target = docs_dir / "story.txt"
+    target.write_text("alpha\nbeta\ngamma\n", encoding="utf-8")
+    resolver = _FakeWorkspaceRootResolver({"workspace_root": str(workspace_root), "workspace_id": "ws-1"})
+    mod = FilesystemModule(
+        ModuleConfig(name="filesystem", settings={"require_lock_for_mutation": True}),
+        workspace_root_resolver=resolver,
+    )
+    context = RequestContext(request_id="req-fs-patch-lock-required", user_id="1", metadata={"workspace_id": "ws-1"})
+    expected_sha = hashlib.sha256(target.read_bytes()).hexdigest()
+
+    with pytest.raises(ValueError, match="lock_required"):
+        await mod.execute_tool(
+            "fs.patch",
+            {"diff": _PATCH_MODIFY_STORY, "expected_sha256_by_path": {"docs/story.txt": expected_sha}},
+            context=context,
+        )
+
+    locked = await mod.execute_tool(
+        "fs.lock_acquire",
+        {"path": "docs/story.txt", "owner": "agent-a"},
+        context=context,
+    )
+    result = await mod.execute_tool(
+        "fs.patch",
+        {
+            "diff": _PATCH_MODIFY_STORY,
+            "expected_sha256_by_path": {"docs/story.txt": expected_sha},
+            "lock_lease_id_by_path": {"docs/story.txt": locked["lease_id"]},
+        },
+        context=context,
+    )
+
+    assert target.read_text(encoding="utf-8") == "alpha\nBETTA\ngamma\n"  # nosec B101
+    assert result["files"][0]["path"] == "docs/story.txt"  # nosec B101
+
+
+@pytest.mark.asyncio
 async def test_filesystem_patch_rejects_bound_read_receipt_without_matching_context(tmp_path: Path) -> None:
     workspace_root = tmp_path / "workspace"
     docs_dir = workspace_root / "docs"
@@ -1568,6 +1750,116 @@ async def test_filesystem_write_replace_with_expected_hash(tmp_path: Path) -> No
     assert result["created"] is False  # nosec B101
     assert result["sha256_before"] == expected_sha  # nosec B101
     assert result["sha256_after"] == hashlib.sha256(b"new\n").hexdigest()  # nosec B101
+
+
+@pytest.mark.asyncio
+async def test_filesystem_write_requires_lock_when_configured(tmp_path: Path) -> None:
+    workspace_root = tmp_path / "workspace"
+    workspace_root.mkdir(parents=True, exist_ok=True)
+    target = workspace_root / "story.txt"
+    target.write_text("old\n", encoding="utf-8")
+    resolver = _FakeWorkspaceRootResolver({"workspace_root": str(workspace_root), "workspace_id": "ws-1"})
+    mod = FilesystemModule(
+        ModuleConfig(name="filesystem", settings={"require_lock_for_mutation": True}),
+        workspace_root_resolver=resolver,
+    )
+    context = RequestContext(request_id="req-fs-write-lock-required", user_id="1", metadata={"workspace_id": "ws-1"})
+    expected_sha = hashlib.sha256(target.read_bytes()).hexdigest()
+
+    with pytest.raises(ValueError, match="lock_required"):
+        await mod.execute_tool(
+            "fs.write",
+            {"path": "story.txt", "content": "new\n", "mode": "replace", "expected_sha256": expected_sha},
+            context=context,
+        )
+
+    assert target.read_text(encoding="utf-8") == "old\n"  # nosec B101
+
+    locked = await mod.execute_tool(
+        "fs.lock_acquire",
+        {"path": "story.txt", "owner": "agent-a"},
+        context=context,
+    )
+    result = await mod.execute_tool(
+        "fs.write",
+        {
+            "path": "story.txt",
+            "content": "new\n",
+            "mode": "replace",
+            "expected_sha256": expected_sha,
+            "lock_lease_id": locked["lease_id"],
+        },
+        context=context,
+    )
+
+    assert target.read_text(encoding="utf-8") == "new\n"  # nosec B101
+    assert result["written"] is True  # nosec B101
+
+
+@pytest.mark.asyncio
+async def test_filesystem_write_rejects_lock_that_expires_before_commit(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from tldw_Server_API.app.core.MCP_unified.modules.implementations import filesystem_locks
+
+    now = 1_000.0
+    monkeypatch.setattr(filesystem_locks.time, "time", lambda: now)
+    workspace_root = tmp_path / "workspace"
+    workspace_root.mkdir(parents=True, exist_ok=True)
+    target = workspace_root / "story.txt"
+    target.write_text("old\n", encoding="utf-8")
+    resolver = _FakeWorkspaceRootResolver({"workspace_root": str(workspace_root), "workspace_id": "ws-1"})
+    mod = FilesystemModule(
+        ModuleConfig(name="filesystem", settings={"require_lock_for_mutation": True}),
+        workspace_root_resolver=resolver,
+    )
+    context = RequestContext(request_id="req-fs-write-lock-expiry", user_id="1", metadata={"workspace_id": "ws-1"})
+    locked = await mod.execute_tool(
+        "fs.lock_acquire",
+        {"path": "story.txt", "owner": "agent-a", "ttl_seconds": 1},
+        context=context,
+    )
+    expected_sha = hashlib.sha256(target.read_bytes()).hexdigest()
+    original_authorize = FilesystemModule._authorize_write_preimage
+
+    def _expire_after_preimage_authorization(
+        self: FilesystemModule,
+        rel_path: str,
+        sha256_before: str,
+        bytes_before: int,
+        expected_sha256: Any,
+        read_receipt: Any,
+        request_context: Any | None,
+    ) -> None:
+        nonlocal now
+        original_authorize(
+            self,
+            rel_path,
+            sha256_before,
+            bytes_before,
+            expected_sha256,
+            read_receipt,
+            request_context,
+        )
+        now = 1_002.0
+
+    monkeypatch.setattr(FilesystemModule, "_authorize_write_preimage", _expire_after_preimage_authorization)
+
+    with pytest.raises(ValueError, match="lock_missing"):
+        await mod.execute_tool(
+            "fs.write",
+            {
+                "path": "story.txt",
+                "content": "new\n",
+                "mode": "replace",
+                "expected_sha256": expected_sha,
+                "lock_lease_id": locked["lease_id"],
+            },
+            context=context,
+        )
+
+    assert target.read_text(encoding="utf-8") == "old\n"  # nosec B101
 
 
 @pytest.mark.asyncio

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_module.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import hashlib
 import os
 import stat
+import threading
 from pathlib import Path
 from typing import Any
 
@@ -352,6 +353,19 @@ async def test_filesystem_lock_lifecycle_conflicts_and_expiry(
     assert renewed["lease_id"] == first["lease_id"]  # nosec B101
     assert renewed["ttl_seconds"] == 90  # nosec B101
 
+    release_with_padded_token = await mod.execute_tool(
+        "fs.lock_release",
+        {"path": "docs/story.txt", "lease_id": f" {first['lease_id']}\n"},
+        context=context,
+    )
+    assert release_with_padded_token["released"] is True  # nosec B101
+
+    reacquired = await mod.execute_tool(
+        "fs.lock_acquire",
+        {"path": "docs/story.txt", "owner": "agent-a", "ttl_seconds": 60},
+        context=context,
+    )
+
     wrong_release = await mod.execute_tool(
         "fs.lock_release",
         {"path": "docs/story.txt", "lease_id": "wrong-token"},
@@ -362,7 +376,7 @@ async def test_filesystem_lock_lifecycle_conflicts_and_expiry(
 
     released = await mod.execute_tool(
         "fs.lock_release",
-        {"path": "docs/story.txt", "lease_id": first["lease_id"]},
+        {"path": "docs/story.txt", "lease_id": reacquired["lease_id"]},
         context=context,
     )
     assert released["released"] is True  # nosec B101
@@ -374,6 +388,15 @@ async def test_filesystem_lock_lifecycle_conflicts_and_expiry(
         context=context,
     )
     now = 1_002.0
+    expired_renewal = await mod.execute_tool(
+        "fs.lock_acquire",
+        {"path": "docs/story.txt", "owner": "agent-a", "lease_id": expiring["lease_id"]},
+        context=context,
+    )
+    assert expired_renewal["acquired"] is False  # nosec B101
+    assert expired_renewal["reason_code"] == "lock_missing"  # nosec B101
+    assert expired_renewal["held"] is False  # nosec B101
+
     after_expiry = await mod.execute_tool(
         "fs.lock_acquire",
         {"path": "docs/story.txt", "owner": "agent-b", "ttl_seconds": 60},
@@ -381,6 +404,79 @@ async def test_filesystem_lock_lifecycle_conflicts_and_expiry(
     )
     assert after_expiry["acquired"] is True  # nosec B101
     assert after_expiry["lease_id"] != expiring["lease_id"]  # nosec B101
+
+
+@pytest.mark.asyncio
+async def test_filesystem_lock_acquire_offloads_lockable_path_checks(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace_root = tmp_path / "workspace"
+    docs_dir = workspace_root / "docs"
+    docs_dir.mkdir(parents=True, exist_ok=True)
+    (docs_dir / "story.txt").write_text("alpha\n", encoding="utf-8")
+    resolver = _FakeWorkspaceRootResolver({"workspace_root": str(workspace_root), "workspace_id": "ws-1"})
+    mod = FilesystemModule(ModuleConfig(name="filesystem"), workspace_root_resolver=resolver)
+    context = RequestContext(request_id="req-fs-lock-offload", user_id="1", metadata={"workspace_id": "ws-1"})
+    event_loop_thread_id = threading.get_ident()
+    check_thread_ids: list[int] = []
+    original_assert = FilesystemModule._assert_lockable_file_target
+
+    def _capture_lockable_check(target: Path) -> None:
+        check_thread_ids.append(threading.get_ident())
+        original_assert(target)
+
+    monkeypatch.setattr(
+        FilesystemModule,
+        "_assert_lockable_file_target",
+        staticmethod(_capture_lockable_check),
+    )
+
+    await mod.execute_tool(
+        "fs.lock_acquire",
+        {"path": "docs/story.txt", "owner": "agent-a"},
+        context=context,
+    )
+
+    assert check_thread_ids  # nosec B101
+    assert check_thread_ids[0] != event_loop_thread_id  # nosec B101
+
+
+def test_in_memory_filesystem_lock_manager_sweeps_expired_unique_paths(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from tldw_Server_API.app.core.MCP_unified.modules.implementations import filesystem_locks
+
+    now = 1_000.0
+    monkeypatch.setattr(filesystem_locks.time, "time", lambda: now)
+    manager = filesystem_locks.InMemoryFilesystemLockManager(sweep_interval=1, max_sweep_entries=10)
+
+    manager.acquire(workspace_key="ws", path="docs/one.txt", owner="a", ttl_seconds=1)
+    manager.acquire(workspace_key="ws", path="docs/two.txt", owner="a", ttl_seconds=1)
+    now = 1_002.0
+    manager.acquire(workspace_key="ws", path="docs/three.txt", owner="b", ttl_seconds=60)
+
+    assert sorted(path for _workspace_key, path in manager._leases) == ["docs/three.txt"]  # nosec B101
+
+
+def test_in_memory_filesystem_lock_manager_rotates_bounded_sweep_window(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from tldw_Server_API.app.core.MCP_unified.modules.implementations import filesystem_locks
+
+    now = 1_000.0
+    monkeypatch.setattr(filesystem_locks.time, "time", lambda: now)
+    manager = filesystem_locks.InMemoryFilesystemLockManager(sweep_interval=1, max_sweep_entries=1)
+    manager.acquire(workspace_key="ws", path="docs/active.txt", owner="a", ttl_seconds=60)
+    manager.acquire(workspace_key="ws", path="docs/expired-one.txt", owner="a", ttl_seconds=1)
+    manager.acquire(workspace_key="ws", path="docs/expired-two.txt", owner="a", ttl_seconds=1)
+
+    now = 1_002.0
+    manager.validate(workspace_key="ws", path="docs/active.txt", lease_id=manager._leases[("ws", "docs/active.txt")].lease_id)
+    manager.validate(workspace_key="ws", path="docs/active.txt", lease_id=manager._leases[("ws", "docs/active.txt")].lease_id)
+    manager.validate(workspace_key="ws", path="docs/active.txt", lease_id=manager._leases[("ws", "docs/active.txt")].lease_id)
+
+    assert sorted(path for _workspace_key, path in manager._leases) == ["docs/active.txt"]  # nosec B101
 
 
 @pytest.mark.asyncio
@@ -404,6 +500,44 @@ async def test_filesystem_lock_rejects_path_escape_and_symlink_target(tmp_path: 
         await mod.execute_tool("fs.lock_acquire", {"path": "../secret.txt", "owner": "agent-a"}, context=context)
     with pytest.raises(ValueError, match="file_not_regular"):
         await mod.execute_tool("fs.lock_acquire", {"path": "docs/story-link.txt", "owner": "agent-a"}, context=context)
+
+
+def test_filesystem_rejects_blank_mutation_lock_ids() -> None:
+    mod = FilesystemModule(ModuleConfig(name="filesystem"))
+
+    with pytest.raises(ValueError, match="lock_lease_id must be a non-empty string"):
+        mod.validate_tool_arguments(
+            "fs.edit",
+            {
+                "path": "docs/story.txt",
+                "old_string": "old",
+                "new_string": "new",
+                "expected_sha256": "0" * 64,
+                "lock_lease_id": " \t",
+            },
+        )
+
+    with pytest.raises(ValueError, match="lock_lease_id_by_path must be an object with non-empty string values"):
+        mod.validate_tool_arguments(
+            "fs.patch",
+            {
+                "diff": _PATCH_MODIFY_STORY,
+                "expected_sha256_by_path": {"docs/story.txt": "0" * 64},
+                "lock_lease_id_by_path": {"docs/story.txt": ""},
+            },
+        )
+
+    with pytest.raises(ValueError, match="lock_lease_id must be a non-empty string"):
+        mod.validate_tool_arguments(
+            "fs.write",
+            {
+                "path": "docs/story.txt",
+                "content": "new\n",
+                "mode": "replace",
+                "expected_sha256": "0" * 64,
+                "lock_lease_id": "\n",
+            },
+        )
 
 
 @pytest.mark.asyncio
@@ -1572,6 +1706,60 @@ async def test_filesystem_patch_requires_lock_by_path_when_configured(tmp_path: 
 
 
 @pytest.mark.asyncio
+async def test_filesystem_patch_revalidates_lock_before_creating_parent_directories(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from tldw_Server_API.app.core.MCP_unified.modules.implementations import filesystem_locks
+
+    now = 1_000.0
+    monkeypatch.setattr(filesystem_locks.time, "time", lambda: now)
+    workspace_root = tmp_path / "workspace"
+    workspace_root.mkdir(parents=True, exist_ok=True)
+    resolver = _FakeWorkspaceRootResolver({"workspace_root": str(workspace_root), "workspace_id": "ws-1"})
+    mod = FilesystemModule(
+        ModuleConfig(name="filesystem", settings={"require_lock_for_mutation": True}),
+        workspace_root_resolver=resolver,
+    )
+    context = RequestContext(request_id="req-fs-patch-lock-mkdir", user_id="1", metadata={"workspace_id": "ws-1"})
+    locked = await mod.execute_tool(
+        "fs.lock_acquire",
+        {"path": "docs/notes.txt", "owner": "agent-a", "ttl_seconds": 1},
+        context=context,
+    )
+    original_validate = FilesystemModule._validate_mutation_lock
+    validation_count = 0
+
+    def _expire_after_initial_validation(
+        self: FilesystemModule,
+        validation_workspace_root: Path,
+        rel_path: str,
+        lease_id: Any,
+    ) -> None:
+        nonlocal now, validation_count
+        validation_count += 1
+        original_validate(self, validation_workspace_root, rel_path, lease_id)
+        if validation_count == 1:
+            now = 1_002.0
+
+    monkeypatch.setattr(FilesystemModule, "_validate_mutation_lock", _expire_after_initial_validation)
+
+    with pytest.raises(ValueError, match="lock_missing"):
+        await mod.execute_tool(
+            "fs.patch",
+            {
+                "diff": _PATCH_CREATE_NOTES,
+                "allow_create": True,
+                "create_parent_directories": True,
+                "lock_lease_id_by_path": {"docs/notes.txt": locked["lease_id"]},
+            },
+            context=context,
+        )
+
+    assert not (workspace_root / "docs").exists()  # nosec B101
+
+
+@pytest.mark.asyncio
 async def test_filesystem_patch_rejects_bound_read_receipt_without_matching_context(tmp_path: Path) -> None:
     workspace_root = tmp_path / "workspace"
     docs_dir = workspace_root / "docs"
@@ -1860,6 +2048,60 @@ async def test_filesystem_write_rejects_lock_that_expires_before_commit(
         )
 
     assert target.read_text(encoding="utf-8") == "old\n"  # nosec B101
+
+
+@pytest.mark.asyncio
+async def test_filesystem_write_revalidates_lock_before_creating_parent_directories(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from tldw_Server_API.app.core.MCP_unified.modules.implementations import filesystem_locks
+
+    now = 1_000.0
+    monkeypatch.setattr(filesystem_locks.time, "time", lambda: now)
+    workspace_root = tmp_path / "workspace"
+    workspace_root.mkdir(parents=True, exist_ok=True)
+    resolver = _FakeWorkspaceRootResolver({"workspace_root": str(workspace_root), "workspace_id": "ws-1"})
+    mod = FilesystemModule(
+        ModuleConfig(name="filesystem", settings={"require_lock_for_mutation": True}),
+        workspace_root_resolver=resolver,
+    )
+    context = RequestContext(request_id="req-fs-write-lock-mkdir", user_id="1", metadata={"workspace_id": "ws-1"})
+    locked = await mod.execute_tool(
+        "fs.lock_acquire",
+        {"path": "docs/story.txt", "owner": "agent-a", "ttl_seconds": 1},
+        context=context,
+    )
+    original_validate = FilesystemModule._validate_mutation_lock
+    validation_count = 0
+
+    def _expire_after_initial_validation(
+        self: FilesystemModule,
+        validation_workspace_root: Path,
+        rel_path: str,
+        lease_id: Any,
+    ) -> None:
+        nonlocal now, validation_count
+        validation_count += 1
+        original_validate(self, validation_workspace_root, rel_path, lease_id)
+        if validation_count == 1:
+            now = 1_002.0
+
+    monkeypatch.setattr(FilesystemModule, "_validate_mutation_lock", _expire_after_initial_validation)
+
+    with pytest.raises(ValueError, match="lock_missing"):
+        await mod.execute_tool(
+            "fs.write",
+            {
+                "path": "docs/story.txt",
+                "content": "new\n",
+                "mode": "create",
+                "lock_lease_id": locked["lease_id"],
+            },
+            context=context,
+        )
+
+    assert not (workspace_root / "docs").exists()  # nosec B101
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Change Summary

Adds process-local advisory filesystem lock leases for MCP filesystem tools. The implementation exposes `fs.lock_acquire` and `fs.lock_release`, validates optional lock lease IDs on `fs.edit`, `fs.patch`, and `fs.write`, and supports `require_lock_for_mutation` for profiles/operators that want mutation calls to require active leases.

The first slice intentionally keeps leases process-local and advisory. Shared/persistent lock stores remain a future backend seam.

Merge-gate note: this AI-authored PR still needs the requester to provide/own the final human-written change summary before merge.

## What Changed

- Added `InMemoryFilesystemLockManager` with acquire, renew, conflict, expiry cleanup, release, and validate paths.
- Added `fs.lock_acquire` / `fs.lock_release` tool descriptors and execution paths with `lock` file-policy metadata.
- Added `lock_lease_id` to `fs.edit` / `fs.write` and `lock_lease_id_by_path` to `fs.patch`.
- Added optional `require_lock_for_mutation` enforcement without weakening existing hash/read-receipt preimage checks.
- Added final pre-commit lease validation so a lease that expires after preimage authorization cannot still commit a write.
- Marked `lock` as an implemented file-policy action and documented the process-local advisory caveat in the package user guide.

## Verification

- `python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_file_policy_actions.py tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_module.py tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_patch_parser.py -q`
  - Result: 109 passed, 4 warnings.
- `python -m py_compile tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_module.py tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_locks.py mcp_unified/interfaces/file_policy_actions.py tldw_Server_API/app/core/MCP_unified/tests/test_file_policy_actions.py tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_module.py`
  - Result: passed.
- `python -m bandit -r tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_module.py tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_locks.py mcp_unified/interfaces/file_policy_actions.py -f json -o /tmp/bandit_mcp_fs_lock_leases.json`
  - Result: passed, 0 findings.
- `git diff --check`
  - Result: passed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds process-local advisory filesystem lock leases to the MCP filesystem module, with `fs.lock_acquire` and `fs.lock_release`, plus optional lock validation on `fs.edit`, `fs.patch`, and `fs.write`. This reduces edit races and lets operators require active locks before mutations. Addresses TASK-2300.

- **New Features**
  - Added in-memory `InMemoryFilesystemLockManager` with acquire, renew, validate, explicit `lock_missing`, conflict payloads, bounded expiry sweeps, and release.
  - Exposed `fs.lock_acquire` and `fs.lock_release` with strict schemas, path-bound metadata, and file-policy action `lock` marked implemented.
  - Added `lock_lease_id` to `fs.edit`/`fs.write` and `lock_lease_id_by_path` to `fs.patch`, with non-empty ID validation.
  - Optional `require_lock_for_mutation`; revalidates leases before mkdir and again pre-commit to block writes after expiry.
  - Acquire rejects symlink/non-regular targets; path checks and lock ops offloaded via `asyncio.to_thread`. Docs include design and implementation plan.

- **Migration**
  - No breaking changes by default; locks are advisory unless enabled.
  - To require locks: set `require_lock_for_mutation=true`.
  - Configure TTLs with `lock_default_ttl_seconds` and `lock_max_ttl_seconds`.
  - Flow: call `fs.lock_acquire` → pass `lease_id` to `fs.edit`/`fs.write` via `lock_lease_id`, or to `fs.patch` via `lock_lease_id_by_path` → release with `fs.lock_release`. Note: leases are process-local; not cross-process or durable.

<sup>Written for commit e720d44f0bccd284acef12a5ea688fb1e52b03f5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2331?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

