### PR TITLE
TASK-530.4 Add skills filters and sorting

### DIFF
--- a/Docs/Plans/IMPLEMENTATION_PLAN_skills_filters_sorting_TASK_530_4.md
+++ b/Docs/Plans/IMPLEMENTATION_PLAN_skills_filters_sorting_TASK_530_4.md
@@ -1,0 +1,31 @@
+## Stage 1: Backend Filter And Sort Contract
+**Goal**: Extend the Skills list API/service/registry query with a safe, whitelisted filter and sort contract.
+**Success Criteria**: `GET /api/v1/skills` accepts `context`, `user_invocable`, `has_tools`, `model`, `sort`, and `order`; filters and sort apply before pagination; totals reflect the filtered set.
+**Tests**: Focused Skills service/API tests, with the target rows outside the first unfiltered page.
+**Status**: Complete
+
+## Stage 2: Frontend Client Query Parameters
+**Goal**: Expose the backend contract through typed WebUI client params without component-level URL construction.
+**Success Criteria**: `listSkills` accepts typed camelCase params, serializes supported filter/sort params, trims string filters, and omits blank values.
+**Tests**: API client boundary test for mixed search/filter/sort serialization.
+**Status**: Complete
+
+## Stage 3: Skills Manager Filter And Sort State
+**Goal**: Let power users filter and sort the Skills table through controlled query state.
+**Success Criteria**: The table query key includes filters and sort; changing filters resets to page 1; table sort changes request server-backed ordering.
+**Tests**: Focused Skills manager Vitest coverage for filter requests, sorted table requests, pagination reset, and rendered filtered results.
+**Status**: Complete
+
+## Stage 4: Verification And Closeout
+**Goal**: Prove the backend, client, and UI agree on the filter/sort contract and record the result in Backlog.
+**Success Criteria**: Focused pytest/Vitest pass, Bandit passes on touched backend scope, `git diff --check` passes, and `TASK-530.4` records verification and known skips.
+**Tests**: Focused pytest, focused Vitest, Bandit, diff check.
+**Status**: Complete
+
+## Verification Results
+
+- `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tldw_Server_API/tests/Skills/unit/test_skill_registry_queries.py tldw_Server_API/tests/Skills/unit/test_skills_service.py tldw_Server_API/tests/Skills/integration/test_skills_api.py -q` - 100 passed, 6 warnings.
+- `bunx vitest run src/services/__tests__/tldw-api-client.boundary-slices.test.ts src/components/Option/Skills/__tests__/Manager.test.tsx` - 24 passed.
+- `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m bandit -r tldw_Server_API/app/api/v1/endpoints/skills.py tldw_Server_API/app/api/v1/schemas/skills_schemas.py tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py tldw_Server_API/app/core/Skills/skills_service.py -f json -o /tmp/bandit_skills_filters_sorting_TASK_530_4.json` - exit 0; remaining warnings are baseline `nosec` comments in the large DB module.
+- `git diff --check` - passed.
+- `bunx tsc --noEmit -p tsconfig.json` - attempted as an extra guard; default heap run OOMed, 8GB retry reached existing package-level type failures in Notes tests, background response result handling, and voice-cloning ArrayBuffer typing, so this was not used as the completion gate.

--- a/Docs/Plans/IMPLEMENTATION_PLAN_skills_filters_sorting_TASK_530_4.md
+++ b/Docs/Plans/IMPLEMENTATION_PLAN_skills_filters_sorting_TASK_530_4.md
@@ -25,7 +25,17 @@
 ## Verification Results
 
 - `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tldw_Server_API/tests/Skills/unit/test_skill_registry_queries.py tldw_Server_API/tests/Skills/unit/test_skills_service.py tldw_Server_API/tests/Skills/integration/test_skills_api.py -q` - 100 passed, 6 warnings.
-- `bunx vitest run src/services/__tests__/tldw-api-client.boundary-slices.test.ts src/components/Option/Skills/__tests__/Manager.test.tsx` - 24 passed.
+- `bunx vitest run src/services/__tests__/tldw-api-client.boundary-slices.test.ts src/components/Option/Skills/__tests__/Manager.test.tsx` - 26 passed after review fixes.
 - `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m bandit -r tldw_Server_API/app/api/v1/endpoints/skills.py tldw_Server_API/app/api/v1/schemas/skills_schemas.py tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py tldw_Server_API/app/core/Skills/skills_service.py -f json -o /tmp/bandit_skills_filters_sorting_TASK_530_4.json` - exit 0; remaining warnings are baseline `nosec` comments in the large DB module.
 - `git diff --check` - passed.
 - `bunx tsc --noEmit -p tsconfig.json` - attempted as an extra guard; default heap run OOMed, 8GB retry reached existing package-level type failures in Notes tests, background response result handling, and voice-cloning ArrayBuffer typing, so this was not used as the completion gate.
+
+## Review Fixes
+
+- Rebased on `origin/dev` at `e00d57b68a7f390ee3c057b2626e593374431a1a`.
+- Prevented filtered-empty results from falling through to the beginner onboarding state.
+- Debounced the model filter before it updates the Skills query key.
+- Replaced registry `ValueError` validation with the DB-layer `InputError`.
+- Replaced interpolated sort clause construction with prebuilt constant ORDER BY clauses.
+- Reused `SkillContext` for `SkillExecutionResult.execution_mode`.
+- Renamed frontend sort/order aliases to `SkillListSort` and `SkillListOrder` for backend naming parity.

--- a/apps/packages/ui/src/components/Option/Skills/Manager.tsx
+++ b/apps/packages/ui/src/components/Option/Skills/Manager.tsx
@@ -34,11 +34,11 @@ import { SkillDrawer } from "./SkillDrawer"
 import { SkillPreview } from "./SkillPreview"
 import type {
   SkillContext,
+  SkillListOrder,
+  SkillListSort,
   SkillSummary,
   SkillResponse,
-  SkillsListOrder,
-  SkillsListResponse,
-  SkillsListSort
+  SkillsListResponse
 } from "@/types/skill"
 
 const DEFAULT_PAGE_SIZE = 10
@@ -69,8 +69,8 @@ type SkillVisibilityFilter = "visible" | "hidden" | "all"
 type SkillToolsFilter = "any" | "with-tools" | "without-tools"
 
 interface SkillSortState {
-  field?: SkillsListSort
-  order?: SkillsListOrder
+  field?: SkillListSort
+  order?: SkillListOrder
 }
 
 const getResponseSkillName = (result: unknown): string | undefined => {
@@ -89,7 +89,7 @@ const getSeededSkillNames = (result: SeedSkillsResult | undefined): string[] => 
 
 const buildSkillInvocation = (skillName: string) => `/skill ${skillName}`
 
-const isSkillTableSortField = (value: React.Key | undefined): value is SkillsListSort =>
+const isSkillTableSortField = (value: React.Key | undefined): value is SkillListSort =>
   value === "name" || value === "context"
 
 export const SkillsManager: React.FC = () => {
@@ -107,6 +107,7 @@ export const SkillsManager: React.FC = () => {
     React.useState<SkillVisibilityFilter>("visible")
   const [toolsFilter, setToolsFilter] = React.useState<SkillToolsFilter>("any")
   const [modelFilter, setModelFilter] = React.useState("")
+  const [debouncedModelFilter, setDebouncedModelFilter] = React.useState("")
   const [sortState, setSortState] = React.useState<SkillSortState>({})
   const [drawerOpen, setDrawerOpen] = React.useState(false)
   const [importTextOpen, setImportTextOpen] = React.useState(false)
@@ -118,7 +119,7 @@ export const SkillsManager: React.FC = () => {
 
   const offset = (page - 1) * pageSize
   const searchQuery = debouncedSearch.trim()
-  const modelQuery = modelFilter.trim()
+  const modelQuery = debouncedModelFilter.trim()
   const contextQuery = contextFilter === "all" ? undefined : contextFilter
   const includeHiddenQuery =
     visibilityFilter === "hidden" || visibilityFilter === "all" ? true : undefined
@@ -145,6 +146,17 @@ export const SkillsManager: React.FC = () => {
 
     return () => window.clearTimeout(timer)
   }, [debouncedSearch, search])
+
+  React.useEffect(() => {
+    if (modelFilter === debouncedModelFilter) return
+
+    const timer = window.setTimeout(() => {
+      setDebouncedModelFilter(modelFilter)
+      setPage(1)
+    }, SKILLS_SEARCH_DEBOUNCE_MS)
+
+    return () => window.clearTimeout(timer)
+  }, [debouncedModelFilter, modelFilter])
 
   const {
     data,
@@ -185,7 +197,7 @@ export const SkillsManager: React.FC = () => {
   const totalSkills = data?.total ?? 0
   const hasSearch = searchQuery.length > 0
   const isLibraryEmpty =
-    hasLoadedSkills && !isLoading && totalSkills === 0 && !hasSearch
+    hasLoadedSkills && !isLoading && totalSkills === 0 && !hasSearch && !hasActiveFilters
   const skillCountLabel = isError
     ? t("option:skills.countUnavailable", {
         defaultValue: "Count unavailable"
@@ -227,7 +239,6 @@ export const SkillsManager: React.FC = () => {
 
   const handleModelFilterChange = (nextValue: string) => {
     setModelFilter(nextValue)
-    setPage(1)
   }
 
   const handleTableChange: TableProps<SkillSummary>["onChange"] = (

--- a/apps/packages/ui/src/components/Option/Skills/Manager.tsx
+++ b/apps/packages/ui/src/components/Option/Skills/Manager.tsx
@@ -13,7 +13,7 @@ import {
   Modal,
   Switch
 } from "antd"
-import type { ColumnsType } from "antd/es/table"
+import type { ColumnsType, TableProps } from "antd/es/table"
 import React from "react"
 import { tldwClient } from "@/services/tldw/TldwApiClient"
 import {
@@ -33,9 +33,12 @@ import { useAntdNotification } from "@/hooks/useAntdNotification"
 import { SkillDrawer } from "./SkillDrawer"
 import { SkillPreview } from "./SkillPreview"
 import type {
+  SkillContext,
   SkillSummary,
   SkillResponse,
-  SkillsListResponse
+  SkillsListOrder,
+  SkillsListResponse,
+  SkillsListSort
 } from "@/types/skill"
 
 const DEFAULT_PAGE_SIZE = 10
@@ -61,6 +64,15 @@ interface SeedSkillsResult {
   seeded?: unknown
 }
 
+type SkillContextFilter = "all" | SkillContext
+type SkillVisibilityFilter = "visible" | "hidden" | "all"
+type SkillToolsFilter = "any" | "with-tools" | "without-tools"
+
+interface SkillSortState {
+  field?: SkillsListSort
+  order?: SkillsListOrder
+}
+
 const getResponseSkillName = (result: unknown): string | undefined => {
   if (!result || typeof result !== "object") return undefined
   const name = (result as { name?: unknown }).name
@@ -77,6 +89,9 @@ const getSeededSkillNames = (result: SeedSkillsResult | undefined): string[] => 
 
 const buildSkillInvocation = (skillName: string) => `/skill ${skillName}`
 
+const isSkillTableSortField = (value: React.Key | undefined): value is SkillsListSort =>
+  value === "name" || value === "context"
+
 export const SkillsManager: React.FC = () => {
   const { t } = useTranslation(["option", "common"])
   const queryClient = useQueryClient()
@@ -86,6 +101,13 @@ export const SkillsManager: React.FC = () => {
   const [pageSize, setPageSize] = React.useState(DEFAULT_PAGE_SIZE)
   const [search, setSearch] = React.useState("")
   const [debouncedSearch, setDebouncedSearch] = React.useState("")
+  const [contextFilter, setContextFilter] =
+    React.useState<SkillContextFilter>("all")
+  const [visibilityFilter, setVisibilityFilter] =
+    React.useState<SkillVisibilityFilter>("visible")
+  const [toolsFilter, setToolsFilter] = React.useState<SkillToolsFilter>("any")
+  const [modelFilter, setModelFilter] = React.useState("")
+  const [sortState, setSortState] = React.useState<SkillSortState>({})
   const [drawerOpen, setDrawerOpen] = React.useState(false)
   const [importTextOpen, setImportTextOpen] = React.useState(false)
   const [editingSkill, setEditingSkill] = React.useState<SkillResponse | null>(null)
@@ -96,6 +118,22 @@ export const SkillsManager: React.FC = () => {
 
   const offset = (page - 1) * pageSize
   const searchQuery = debouncedSearch.trim()
+  const modelQuery = modelFilter.trim()
+  const contextQuery = contextFilter === "all" ? undefined : contextFilter
+  const includeHiddenQuery =
+    visibilityFilter === "hidden" || visibilityFilter === "all" ? true : undefined
+  const userInvocableQuery = visibilityFilter === "hidden" ? false : undefined
+  const hasToolsQuery =
+    toolsFilter === "with-tools"
+      ? true
+      : toolsFilter === "without-tools"
+        ? false
+        : undefined
+  const hasActiveFilters =
+    contextFilter !== "all"
+    || visibilityFilter !== "visible"
+    || toolsFilter !== "any"
+    || modelQuery.length > 0
 
   React.useEffect(() => {
     if (search === debouncedSearch) return
@@ -115,10 +153,28 @@ export const SkillsManager: React.FC = () => {
     error,
     refetch
   } = useQuery<SkillsListResponse>({
-    queryKey: ["skills", page, pageSize, searchQuery],
+    queryKey: [
+      "skills",
+      page,
+      pageSize,
+      searchQuery,
+      contextFilter,
+      visibilityFilter,
+      toolsFilter,
+      modelQuery,
+      sortState.field ?? "",
+      sortState.order ?? ""
+    ],
     queryFn: ({ signal }) =>
       tldwClient.listSkills({
         ...(searchQuery ? { q: searchQuery } : {}),
+        ...(contextQuery ? { context: contextQuery } : {}),
+        ...(includeHiddenQuery !== undefined ? { includeHidden: includeHiddenQuery } : {}),
+        ...(userInvocableQuery !== undefined ? { userInvocable: userInvocableQuery } : {}),
+        ...(hasToolsQuery !== undefined ? { hasTools: hasToolsQuery } : {}),
+        ...(modelQuery ? { model: modelQuery } : {}),
+        ...(sortState.field ? { sort: sortState.field } : {}),
+        ...(sortState.order ? { order: sortState.order } : {}),
         limit: pageSize,
         offset,
         abortSignal: signal
@@ -153,6 +209,49 @@ export const SkillsManager: React.FC = () => {
       setPage(lastPage)
     }
   }, [hasLoadedSkills, page, pageSize, totalSkills])
+
+  const handleContextFilterChange = (nextFilter: SkillContextFilter) => {
+    setContextFilter(nextFilter)
+    setPage(1)
+  }
+
+  const handleVisibilityFilterChange = (nextFilter: SkillVisibilityFilter) => {
+    setVisibilityFilter(nextFilter)
+    setPage(1)
+  }
+
+  const handleToolsFilterChange = (nextFilter: SkillToolsFilter) => {
+    setToolsFilter(nextFilter)
+    setPage(1)
+  }
+
+  const handleModelFilterChange = (nextValue: string) => {
+    setModelFilter(nextValue)
+    setPage(1)
+  }
+
+  const handleTableChange: TableProps<SkillSummary>["onChange"] = (
+    _pagination,
+    _filters,
+    sorter
+  ) => {
+    const activeSorter = Array.isArray(sorter)
+      ? sorter.find((entry) => entry.order)
+      : sorter
+
+    if (
+      activeSorter?.order
+      && isSkillTableSortField(activeSorter.columnKey)
+    ) {
+      setSortState({
+        field: activeSorter.columnKey,
+        order: activeSorter.order === "ascend" ? "asc" : "desc"
+      })
+    } else {
+      setSortState({})
+    }
+    setPage(1)
+  }
 
   const deleteMutation = useMutation({
     mutationFn: (name: string) => tldwClient.deleteSkill(name),
@@ -409,6 +508,12 @@ export const SkillsManager: React.FC = () => {
       title: t("option:skills.colName", { defaultValue: "Name" }),
       dataIndex: "name",
       key: "name",
+      sorter: true,
+      sortDirections: ["ascend", "descend"],
+      sortOrder:
+        sortState.field === "name"
+          ? sortState.order === "asc" ? "ascend" : "descend"
+          : null,
       render: (name: string) => (
         <span className="font-mono text-sm">{name}</span>
       )
@@ -425,6 +530,12 @@ export const SkillsManager: React.FC = () => {
       dataIndex: "context",
       key: "context",
       width: 100,
+      sorter: true,
+      sortDirections: ["ascend", "descend"],
+      sortOrder:
+        sortState.field === "context"
+          ? sortState.order === "asc" ? "ascend" : "descend"
+          : null,
       render: (ctx: string) => (
         <Tag color={ctx === "fork" ? "blue" : "green"}>
           {ctx}
@@ -439,6 +550,10 @@ export const SkillsManager: React.FC = () => {
         <div className="flex items-center gap-1">
           <Tooltip title={t("option:skills.preview", { defaultValue: "Preview" })}>
             <Button
+              aria-label={t("option:skills.previewSkill", {
+                defaultValue: `Preview ${record.name}`,
+                name: record.name
+              })}
               type="text"
               size="small"
               icon={<Play size={14} />}
@@ -447,6 +562,10 @@ export const SkillsManager: React.FC = () => {
           </Tooltip>
           <Tooltip title={t("common:edit", { defaultValue: "Edit" })}>
             <Button
+              aria-label={t("option:skills.editSkill", {
+                defaultValue: `Edit ${record.name}`,
+                name: record.name
+              })}
               type="text"
               size="small"
               icon={<Pen size={14} />}
@@ -455,6 +574,10 @@ export const SkillsManager: React.FC = () => {
           </Tooltip>
           <Tooltip title={t("option:skills.export", { defaultValue: "Export" })}>
             <Button
+              aria-label={t("option:skills.exportSkill", {
+                defaultValue: `Export ${record.name}`,
+                name: record.name
+              })}
               type="text"
               size="small"
               icon={<Download size={14} />}
@@ -463,6 +586,10 @@ export const SkillsManager: React.FC = () => {
           </Tooltip>
           <Tooltip title={t("common:delete", { defaultValue: "Delete" })}>
             <Button
+              aria-label={t("option:skills.deleteSkill", {
+                defaultValue: `Delete ${record.name}`,
+                name: record.name
+              })}
               type="text"
               size="small"
               danger
@@ -572,6 +699,10 @@ export const SkillsManager: React.FC = () => {
       emptyText = t("option:skills.emptyTableError", {
         defaultValue: "Unable to load skills."
       })
+    } else if (hasActiveFilters) {
+      emptyText = t("option:skills.noFilterMatches", {
+        defaultValue: "No skills match these filters."
+      })
     } else if (hasSearch) {
       emptyText = t("option:skills.noMatches", {
         defaultValue: "No skills match this search."
@@ -642,6 +773,118 @@ export const SkillsManager: React.FC = () => {
         </div>
       </div>
 
+      <div className="flex flex-wrap items-center gap-3">
+        <div
+          role="group"
+          aria-label={t("option:skills.contextFilter", {
+            defaultValue: "Skill mode filter"
+          })}
+          className="flex flex-wrap items-center gap-1"
+        >
+          <Button
+            size="small"
+            type={contextFilter === "all" ? "primary" : "default"}
+            aria-pressed={contextFilter === "all"}
+            onClick={() => handleContextFilterChange("all")}
+          >
+            {t("option:skills.filterAllModes", { defaultValue: "All modes" })}
+          </Button>
+          <Button
+            size="small"
+            type={contextFilter === "inline" ? "primary" : "default"}
+            aria-pressed={contextFilter === "inline"}
+            onClick={() => handleContextFilterChange("inline")}
+          >
+            {t("option:skills.filterInline", { defaultValue: "Inline" })}
+          </Button>
+          <Button
+            size="small"
+            type={contextFilter === "fork" ? "primary" : "default"}
+            aria-pressed={contextFilter === "fork"}
+            onClick={() => handleContextFilterChange("fork")}
+          >
+            {t("option:skills.filterFork", { defaultValue: "Fork" })}
+          </Button>
+        </div>
+        <div
+          role="group"
+          aria-label={t("option:skills.visibilityFilter", {
+            defaultValue: "Skill visibility filter"
+          })}
+          className="flex flex-wrap items-center gap-1"
+        >
+          <Button
+            size="small"
+            type={visibilityFilter === "visible" ? "primary" : "default"}
+            aria-pressed={visibilityFilter === "visible"}
+            onClick={() => handleVisibilityFilterChange("visible")}
+          >
+            {t("option:skills.filterVisible", { defaultValue: "Visible" })}
+          </Button>
+          <Button
+            size="small"
+            type={visibilityFilter === "hidden" ? "primary" : "default"}
+            aria-pressed={visibilityFilter === "hidden"}
+            onClick={() => handleVisibilityFilterChange("hidden")}
+          >
+            {t("option:skills.filterHidden", { defaultValue: "Hidden" })}
+          </Button>
+          <Button
+            size="small"
+            type={visibilityFilter === "all" ? "primary" : "default"}
+            aria-pressed={visibilityFilter === "all"}
+            onClick={() => handleVisibilityFilterChange("all")}
+          >
+            {t("option:skills.filterAllVisibility", { defaultValue: "All visibility" })}
+          </Button>
+        </div>
+        <div
+          role="group"
+          aria-label={t("option:skills.toolsFilter", {
+            defaultValue: "Skill tools filter"
+          })}
+          className="flex flex-wrap items-center gap-1"
+        >
+          <Button
+            size="small"
+            type={toolsFilter === "any" ? "primary" : "default"}
+            aria-pressed={toolsFilter === "any"}
+            onClick={() => handleToolsFilterChange("any")}
+          >
+            {t("option:skills.filterAnyTools", { defaultValue: "Any tools" })}
+          </Button>
+          <Button
+            size="small"
+            type={toolsFilter === "with-tools" ? "primary" : "default"}
+            aria-pressed={toolsFilter === "with-tools"}
+            onClick={() => handleToolsFilterChange("with-tools")}
+          >
+            {t("option:skills.filterHasTools", { defaultValue: "Has tools" })}
+          </Button>
+          <Button
+            size="small"
+            type={toolsFilter === "without-tools" ? "primary" : "default"}
+            aria-pressed={toolsFilter === "without-tools"}
+            onClick={() => handleToolsFilterChange("without-tools")}
+          >
+            {t("option:skills.filterNoTools", { defaultValue: "No tools" })}
+          </Button>
+        </div>
+        <Input
+          aria-label={t("option:skills.modelFilter", {
+            defaultValue: "Filter by model"
+          })}
+          placeholder={t("option:skills.modelFilterPlaceholder", {
+            defaultValue: "Model"
+          })}
+          value={modelFilter}
+          onChange={(event) => handleModelFilterChange(event.target.value)}
+          allowClear
+          size="small"
+          style={{ width: 160 }}
+        />
+      </div>
+
       {isError && (
         <Alert
           type="error"
@@ -710,6 +953,7 @@ export const SkillsManager: React.FC = () => {
         columns={columns}
         rowKey="name"
         loading={isLoading}
+        onChange={handleTableChange}
         pagination={false}
         size="middle"
         locale={{

--- a/apps/packages/ui/src/components/Option/Skills/__tests__/Manager.test.tsx
+++ b/apps/packages/ui/src/components/Option/Skills/__tests__/Manager.test.tsx
@@ -493,6 +493,47 @@ describe("SkillsManager imports", () => {
     expect(await screen.findByText("hidden-fork-tools")).toBeInTheDocument()
   })
 
+  it("shows a filter empty state instead of onboarding when filters match no skills", async () => {
+    const visibleSkill = {
+      name: "visible-inline",
+      description: "Visible inline skill",
+      argument_hint: null,
+      user_invocable: true,
+      disable_model_invocation: false,
+      context: "inline" as const
+    }
+
+    tldwClientMock.listSkills.mockImplementation(
+      (params: { context?: string; limit: number; offset: number }) => {
+        if (params.context === "fork") {
+          return Promise.resolve({
+            skills: [],
+            count: 0,
+            total: 0,
+            limit: params.limit,
+            offset: 0
+          })
+        }
+
+        return Promise.resolve({
+          skills: [visibleSkill],
+          count: 1,
+          total: 1,
+          limit: params.limit,
+          offset: params.offset
+        })
+      }
+    )
+
+    renderManager()
+
+    expect(await screen.findByText("1 skill")).toBeInTheDocument()
+    fireEvent.click(screen.getByRole("button", { name: "Fork" }))
+
+    expect(await screen.findByText("No skills match these filters.")).toBeInTheDocument()
+    expect(screen.queryByTestId("skills-empty-state")).not.toBeInTheDocument()
+  })
+
   it("requests server-backed name sorting from the table header", async () => {
     tldwClientMock.listSkills.mockResolvedValue({
       skills: [
@@ -594,6 +635,67 @@ describe("SkillsManager imports", () => {
       )
     })
     expect(await screen.findByText("fork-only")).toBeInTheDocument()
+  })
+
+  it("debounces model filter requests while typing", async () => {
+    const firstPage = Array.from({ length: 10 }, (_, index) => makeSkill(index + 1))
+    const modelResult = {
+      name: "model-specific",
+      description: "Model-specific skill",
+      argument_hint: null,
+      user_invocable: true,
+      disable_model_invocation: false,
+      context: "inline" as const
+    }
+
+    tldwClientMock.listSkills.mockImplementation(
+      (params: { model?: string; limit: number; offset: number }) => {
+        if (params.model === "gpt-4o") {
+          return Promise.resolve({
+            skills: [modelResult],
+            count: 1,
+            total: 1,
+            limit: params.limit,
+            offset: 0
+          })
+        }
+
+        return Promise.resolve({
+          skills: firstPage,
+          count: firstPage.length,
+          total: 12,
+          limit: params.limit,
+          offset: params.offset
+        })
+      }
+    )
+
+    renderManager()
+
+    expect(await screen.findByText("12 skills")).toBeInTheDocument()
+    fireEvent.change(screen.getByLabelText("Filter by model"), {
+      target: { value: "gpt-4o" }
+    })
+
+    await new Promise((resolve) => setTimeout(resolve, 120))
+    expect(tldwClientMock.listSkills).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        model: "gpt-4o",
+        limit: 10,
+        offset: 0
+      })
+    )
+
+    await waitFor(() => {
+      expect(tldwClientMock.listSkills).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          model: "gpt-4o",
+          limit: 10,
+          offset: 0
+        })
+      )
+    })
+    expect(await screen.findByText("model-specific")).toBeInTheDocument()
   })
 
   it("imports a skill from text via importSkill", async () => {

--- a/apps/packages/ui/src/components/Option/Skills/__tests__/Manager.test.tsx
+++ b/apps/packages/ui/src/components/Option/Skills/__tests__/Manager.test.tsx
@@ -419,6 +419,183 @@ describe("SkillsManager imports", () => {
     expect(await screen.findByText("omega-research")).toBeInTheDocument()
   })
 
+  it("requests server-backed filter results from filter controls", async () => {
+    const visibleSkill = {
+      name: "visible-inline",
+      description: "Visible inline skill",
+      argument_hint: null,
+      user_invocable: true,
+      disable_model_invocation: false,
+      context: "inline" as const
+    }
+    const hiddenForkSkill = {
+      name: "hidden-fork-tools",
+      description: "Hidden fork skill with tools",
+      argument_hint: null,
+      user_invocable: false,
+      disable_model_invocation: false,
+      context: "fork" as const
+    }
+
+    tldwClientMock.listSkills.mockImplementation(
+      (params: {
+        context?: string
+        userInvocable?: boolean
+        includeHidden?: boolean
+        hasTools?: boolean
+        limit: number
+        offset: number
+      }) => {
+        if (
+          params.context === "fork"
+          && params.userInvocable === false
+          && params.includeHidden === true
+          && params.hasTools === true
+        ) {
+          return Promise.resolve({
+            skills: [hiddenForkSkill],
+            count: 1,
+            total: 1,
+            limit: params.limit,
+            offset: 0
+          })
+        }
+
+        return Promise.resolve({
+          skills: [visibleSkill],
+          count: 1,
+          total: 2,
+          limit: params.limit,
+          offset: params.offset
+        })
+      }
+    )
+
+    renderManager()
+
+    expect(await screen.findByText("2 skills")).toBeInTheDocument()
+    fireEvent.click(screen.getByRole("button", { name: "Fork" }))
+    fireEvent.click(screen.getByRole("button", { name: "Hidden" }))
+    fireEvent.click(screen.getByRole("button", { name: "Has tools" }))
+
+    await waitFor(() => {
+      expect(tldwClientMock.listSkills).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          context: "fork",
+          includeHidden: true,
+          userInvocable: false,
+          hasTools: true,
+          limit: 10,
+          offset: 0
+        })
+      )
+    })
+    expect(await screen.findByText("hidden-fork-tools")).toBeInTheDocument()
+  })
+
+  it("requests server-backed name sorting from the table header", async () => {
+    tldwClientMock.listSkills.mockResolvedValue({
+      skills: [
+        {
+          name: "alpha",
+          description: "Alpha skill",
+          argument_hint: null,
+          user_invocable: true,
+          disable_model_invocation: false,
+          context: "inline" as const
+        },
+        {
+          name: "beta",
+          description: "Beta skill",
+          argument_hint: null,
+          user_invocable: true,
+          disable_model_invocation: false,
+          context: "inline" as const
+        }
+      ],
+      count: 2,
+      total: 2,
+      limit: 10,
+      offset: 0
+    })
+
+    renderManager()
+
+    expect(await screen.findByText("2 skills")).toBeInTheDocument()
+    fireEvent.click(screen.getByRole("columnheader", { name: /Name/ }))
+
+    await waitFor(() => {
+      expect(tldwClientMock.listSkills).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          sort: "name",
+          order: "asc",
+          limit: 10,
+          offset: 0
+        })
+      )
+    })
+  })
+
+  it("resets pagination when server-backed filters change", async () => {
+    const pageOneSkills = Array.from({ length: 10 }, (_, index) => makeSkill(index + 1))
+    const pageTwoSkills = [makeSkill(11), makeSkill(12)]
+    const forkSkill = {
+      name: "fork-only",
+      description: "Fork skill",
+      argument_hint: null,
+      user_invocable: true,
+      disable_model_invocation: false,
+      context: "fork" as const
+    }
+
+    tldwClientMock.listSkills.mockImplementation(
+      (params: { context?: string; limit: number; offset: number }) => {
+        if (params.context === "fork") {
+          return Promise.resolve({
+            skills: [forkSkill],
+            count: 1,
+            total: 1,
+            limit: params.limit,
+            offset: 0
+          })
+        }
+
+        return Promise.resolve({
+          skills: params.offset === 10 ? pageTwoSkills : pageOneSkills,
+          count: params.offset === 10 ? pageTwoSkills.length : pageOneSkills.length,
+          total: 12,
+          limit: params.limit,
+          offset: params.offset
+        })
+      }
+    )
+
+    renderManager()
+
+    expect(await screen.findByText("12 skills")).toBeInTheDocument()
+    const secondPageItem = await screen.findByTitle("2")
+    fireEvent.click(within(secondPageItem).getByText("2"))
+
+    await waitFor(() => {
+      expect(tldwClientMock.listSkills).toHaveBeenLastCalledWith(
+        expect.objectContaining({ limit: 10, offset: 10 })
+      )
+    })
+
+    fireEvent.click(screen.getByRole("button", { name: "Fork" }))
+
+    await waitFor(() => {
+      expect(tldwClientMock.listSkills).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          context: "fork",
+          limit: 10,
+          offset: 0
+        })
+      )
+    })
+    expect(await screen.findByText("fork-only")).toBeInTheDocument()
+  })
+
   it("imports a skill from text via importSkill", async () => {
     renderManager()
 

--- a/apps/packages/ui/src/services/__tests__/tldw-api-client.boundary-slices.test.ts
+++ b/apps/packages/ui/src/services/__tests__/tldw-api-client.boundary-slices.test.ts
@@ -144,6 +144,44 @@ describe("TldwApiClient Wave 5 boundary slices", () => {
     )
   })
 
+  it("serializes listSkills filter and sort params for the backend contract", async () => {
+    mocks.bgRequest.mockResolvedValue({
+      skills: [],
+      count: 0,
+      total: 0,
+      limit: 10,
+      offset: 20
+    })
+
+    const client = new TldwApiClient()
+    client.resolveApiPath = vi
+      .fn(async () => "/api/v1/skills") as typeof client.resolveApiPath
+
+    await client.listSkills({
+      q: " summary ",
+      includeHidden: true,
+      userInvocable: false,
+      hasTools: true,
+      context: "fork",
+      model: " gpt-4o ",
+      sort: "name",
+      order: "desc",
+      limit: 10,
+      offset: 20
+    })
+
+    expect(mocks.bgRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        path: (
+          "/api/v1/skills?q=summary&include_hidden=true&user_invocable=false"
+          + "&has_tools=true&context=fork&model=gpt-4o&sort=name&order=desc"
+          + "&limit=10&offset=20"
+        ),
+        method: "GET"
+      })
+    )
+  })
+
   it("keeps presentation methods on the mixed presentations domain paths after class cleanup", async () => {
     const client = new TldwApiClient()
     client.ensureConfigForRequest = vi

--- a/apps/packages/ui/src/services/tldw/domains/workspace-api.ts
+++ b/apps/packages/ui/src/services/tldw/domains/workspace-api.ts
@@ -3,7 +3,7 @@ import { buildQuery } from "../client-utils"
 import { appendPathQuery } from "../path-utils"
 import type { AllowedPath } from "@/services/tldw/openapi-guard"
 import type { OffsetPaginationMeta } from "@/services/response-envelope"
-import type { SkillsListResponse } from "@/types/skill"
+import type { SkillsListParams, SkillsListResponse } from "@/types/skill"
 
 /**
  * Minimal interface for the TldwApiClient methods referenced via `this`.
@@ -700,25 +700,36 @@ const workspacePath = (workspaceId: string, suffix = ""): AllowedPath =>
     "workspaceId"
   )}${suffix}` as AllowedPath
 
+const trimmedOptionalString = (value: string | undefined): string | undefined => {
+  if (typeof value !== "string") {
+    return undefined
+  }
+  const trimmed = value.trim()
+  return trimmed.length > 0 ? trimmed : undefined
+}
+
 export const workspaceApiMethods = {
   // ── Skills API ──
 
   async listSkills(
     this: TldwApiClientCore,
-    params?: {
-      q?: string
-      limit?: number
-      offset?: number
-      abortSignal?: AbortSignal
-    }
+    params?: SkillsListParams
   ): Promise<SkillsListPayload> {
     const { abortSignal, ...queryParams } = params ?? {}
+    const q = trimmedOptionalString(queryParams.q)
+    const model = trimmedOptionalString(queryParams.model)
     const normalizedParams = params
       ? {
-          ...queryParams,
-          q: typeof queryParams.q === "string" && queryParams.q.trim().length > 0
-            ? queryParams.q.trim()
-            : undefined
+          q,
+          include_hidden: queryParams.includeHidden,
+          user_invocable: queryParams.userInvocable,
+          has_tools: queryParams.hasTools,
+          context: queryParams.context,
+          model,
+          sort: queryParams.sort,
+          order: queryParams.order,
+          limit: queryParams.limit,
+          offset: queryParams.offset
         }
       : undefined
     const query = buildQuery(normalizedParams)

--- a/apps/packages/ui/src/types/skill.ts
+++ b/apps/packages/ui/src/types/skill.ts
@@ -4,6 +4,22 @@
  */
 
 export type SkillContext = "inline" | "fork"
+export type SkillsListSort = "name" | "context" | "created_at" | "last_modified"
+export type SkillsListOrder = "asc" | "desc"
+
+export interface SkillsListParams {
+  q?: string
+  includeHidden?: boolean
+  userInvocable?: boolean
+  hasTools?: boolean
+  context?: SkillContext
+  model?: string
+  sort?: SkillsListSort
+  order?: SkillsListOrder
+  limit?: number
+  offset?: number
+  abortSignal?: AbortSignal
+}
 
 export interface SkillSummary {
   name: string

--- a/apps/packages/ui/src/types/skill.ts
+++ b/apps/packages/ui/src/types/skill.ts
@@ -4,8 +4,8 @@
  */
 
 export type SkillContext = "inline" | "fork"
-export type SkillsListSort = "name" | "context" | "created_at" | "last_modified"
-export type SkillsListOrder = "asc" | "desc"
+export type SkillListSort = "name" | "context" | "created_at" | "last_modified"
+export type SkillListOrder = "asc" | "desc"
 
 export interface SkillsListParams {
   q?: string
@@ -14,8 +14,8 @@ export interface SkillsListParams {
   hasTools?: boolean
   context?: SkillContext
   model?: string
-  sort?: SkillsListSort
-  order?: SkillsListOrder
+  sort?: SkillListSort
+  order?: SkillListOrder
   limit?: number
   offset?: number
   abortSignal?: AbortSignal

--- a/backlog/tasks/task-530.4 - Implement-Skills-server-backed-filters-and-sorting.md
+++ b/backlog/tasks/task-530.4 - Implement-Skills-server-backed-filters-and-sorting.md
@@ -55,6 +55,7 @@ Docs/Plans/IMPLEMENTATION_PLAN_skills_filters_sorting_TASK_530_4.md
 - Extended the UI client with typed `SkillsListParams` and centralized camelCase-to-snake_case serialization.
 - Added compact Skills manager controls for mode, visibility, tools, and model filtering; table sorting now requests server-backed ordering and resets pagination.
 - Added accessible names for icon-only row action buttons while preserving the existing compact table layout.
+- Review fixes: debounced model filtering, corrected filtered-empty state behavior, switched registry validation to `InputError`, replaced dynamic sort clause construction with prebuilt constants, reused `SkillContext` for execution mode, and aligned frontend sort/order type names with backend aliases.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary
@@ -64,7 +65,7 @@ Implemented server-backed Skills filters and sorting across the API, registry qu
 
 Verification:
 - `python -m pytest tldw_Server_API/tests/Skills/unit/test_skill_registry_queries.py tldw_Server_API/tests/Skills/unit/test_skills_service.py tldw_Server_API/tests/Skills/integration/test_skills_api.py -q` - 100 passed, 6 warnings.
-- `bunx vitest run src/services/__tests__/tldw-api-client.boundary-slices.test.ts src/components/Option/Skills/__tests__/Manager.test.tsx` - 24 passed.
+- `bunx vitest run src/services/__tests__/tldw-api-client.boundary-slices.test.ts src/components/Option/Skills/__tests__/Manager.test.tsx` - 26 passed after review fixes.
 - `python -m bandit -r tldw_Server_API/app/api/v1/endpoints/skills.py tldw_Server_API/app/api/v1/schemas/skills_schemas.py tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py tldw_Server_API/app/core/Skills/skills_service.py -f json -o /tmp/bandit_skills_filters_sorting_TASK_530_4.json` - exit 0; remaining warnings are existing `nosec` comments in the large DB module.
 - `git diff --check` - passed.
 

--- a/backlog/tasks/task-530.4 - Implement-Skills-server-backed-filters-and-sorting.md
+++ b/backlog/tasks/task-530.4 - Implement-Skills-server-backed-filters-and-sorting.md
@@ -1,0 +1,83 @@
+---
+id: TASK-530.4
+title: Implement Skills server-backed filters and sorting
+status: Done
+labels:
+- skills
+- webui
+- ux
+- power-user
+priority: high
+parent_task_id: TASK-530
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Continue TASK-530 power-user Skills remediation after TASK-2342. Add a focused, reviewable slice for server-backed filters and sorting on /skills.
+
+Scope:
+- Extend the Skills list backend contract with safe filter/sort parameters beyond q.
+- Apply filters and sort before pagination in the ChaChaNotes skill registry query path.
+- Keep q search and filtered totals consistent with TASK-2342.
+- Add typed frontend client params with camelCase-to-snake_case query serialization.
+- Wire the Skills manager table/query state to server-backed filters and sort controls.
+
+Out of scope:
+- Dense view.
+- Metadata column picker beyond controls needed for filter/sort visibility.
+- Bulk export/actions.
+- Safe operations, dry-run execution, import review, delete/version semantics.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 GET /api/v1/skills accepts optional context, user_invocable, has_tools, model, sort, and order parameters in addition to q/limit/offset.
+- [x] #2 Skills registry filtering and sorting are applied before pagination, and total reflects the filtered result count.
+- [x] #3 Sort fields and directions are whitelisted before SQL interpolation; user-controlled filter values remain parameterized.
+- [x] #4 The frontend API client exposes typed Skills list params and serializes camelCase filter/sort options to backend query parameters.
+- [x] #5 The Skills manager uses server-backed filter and sort query state, resets pagination when filters change, and preserves existing debounced search behavior.
+- [x] #6 Focused backend, client, and Skills manager tests cover filter/sort behavior.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Docs/Plans/IMPLEMENTATION_PLAN_skills_filters_sorting_TASK_530_4.md
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+- Added backend Skills list params for context, explicit visibility, tool presence, model, sort field, and sort direction.
+- Added a shared skill registry filter builder so list and count queries apply the same predicates before pagination.
+- Kept dynamic sort SQL limited to whitelisted columns/directions; all user-provided filter values remain parameterized.
+- Extended the UI client with typed `SkillsListParams` and centralized camelCase-to-snake_case serialization.
+- Added compact Skills manager controls for mode, visibility, tools, and model filtering; table sorting now requests server-backed ordering and resets pagination.
+- Added accessible names for icon-only row action buttons while preserving the existing compact table layout.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Implemented server-backed Skills filters and sorting across the API, registry query layer, typed UI client, and `/skills` manager. The page now supports mode, visibility, tools, model filtering, and sortable name/mode table columns without client-side page-only filtering.
+
+Verification:
+- `python -m pytest tldw_Server_API/tests/Skills/unit/test_skill_registry_queries.py tldw_Server_API/tests/Skills/unit/test_skills_service.py tldw_Server_API/tests/Skills/integration/test_skills_api.py -q` - 100 passed, 6 warnings.
+- `bunx vitest run src/services/__tests__/tldw-api-client.boundary-slices.test.ts src/components/Option/Skills/__tests__/Manager.test.tsx` - 24 passed.
+- `python -m bandit -r tldw_Server_API/app/api/v1/endpoints/skills.py tldw_Server_API/app/api/v1/schemas/skills_schemas.py tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py tldw_Server_API/app/core/Skills/skills_service.py -f json -o /tmp/bandit_skills_filters_sorting_TASK_530_4.json` - exit 0; remaining warnings are existing `nosec` comments in the large DB module.
+- `git diff --check` - passed.
+
+Known verification caveat:
+- `bunx tsc --noEmit -p tsconfig.json` was attempted as an extra guard. The default run OOMed; the 8GB retry reached existing package-level failures in Notes tests, background response result handling, and voice-cloning ArrayBuffer typing. Focused Vitest coverage is the UI gate for this slice.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/tldw_Server_API/app/api/v1/endpoints/skills.py
+++ b/tldw_Server_API/app/api/v1/endpoints/skills.py
@@ -34,11 +34,14 @@ from tldw_Server_API.app.api.v1.endpoints._pagination_utils import build_offset_
 
 # Local Imports
 from tldw_Server_API.app.api.v1.schemas.skills_schemas import (
+    SkillContext,
     SkillContextPayload,
     SkillCreate,
     SkillExecuteRequest,
     SkillExecutionResult,
     SkillImportRequest,
+    SkillListOrder,
+    SkillListSort,
     SkillResponse,
     SkillsListResponse,
     SkillSummary,
@@ -116,7 +119,32 @@ async def list_skills(
     q: Optional[str] = Query(
         None,
         max_length=200,
-        description="Case-insensitive search across skill names and descriptions",
+        description="Case-insensitive search across skill names, descriptions, and argument hints",
+    ),
+    context: SkillContext | None = Query(
+        None,
+        description="Filter by execution context",
+    ),
+    user_invocable: bool | None = Query(
+        None,
+        description="Filter by visibility; overrides include_hidden when provided",
+    ),
+    has_tools: bool | None = Query(
+        None,
+        description="Filter by whether a skill declares allowed tools",
+    ),
+    model: Optional[str] = Query(
+        None,
+        max_length=200,
+        description="Filter by exact model override",
+    ),
+    sort: SkillListSort = Query(
+        "name",
+        description="Sort field",
+    ),
+    order: SkillListOrder = Query(
+        "asc",
+        description="Sort direction",
     ),
     limit: int = Query(100, ge=1, le=500, description="Maximum number of skills to return"),
     offset: int = Query(0, ge=0, description="Offset for pagination"),
@@ -131,10 +159,23 @@ async def list_skills(
         skills = await service.list_skills(
             include_hidden=include_hidden,
             q=q,
+            context=context,
+            user_invocable=user_invocable,
+            has_tools=has_tools,
+            model=model,
+            sort=sort,
+            order=order,
             limit=limit,
             offset=offset,
         )
-        total = await service.get_total_count(include_hidden=include_hidden, q=q)
+        total = await service.get_total_count(
+            include_hidden=include_hidden,
+            q=q,
+            context=context,
+            user_invocable=user_invocable,
+            has_tools=has_tools,
+            model=model,
+        )
 
         return SkillsListResponse(
             skills=[_metadata_to_summary(s) for s in skills],

--- a/tldw_Server_API/app/api/v1/schemas/skills_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/skills_schemas.py
@@ -227,7 +227,7 @@ class SkillExecutionResult(BaseModel):
     rendered_prompt: str = Field(..., description="Prompt with arguments substituted")
     allowed_tools: list[str] | None = Field(None, description="Tools allowed for this skill")
     model_override: str | None = Field(None, description="Model override if specified")
-    execution_mode: Literal["inline", "fork"] = Field(..., description="How the skill was executed")
+    execution_mode: SkillContext = Field(..., description="How the skill was executed")
     fork_output: str | None = Field(None, description="Output from fork execution (if applicable)")
 
     model_config = ConfigDict(from_attributes=True)

--- a/tldw_Server_API/app/api/v1/schemas/skills_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/skills_schemas.py
@@ -23,6 +23,9 @@ from tldw_Server_API.app.api.v1.schemas.pagination import OffsetPaginationMeta
 
 # Skill name validation: lowercase letters, numbers, and hyphens only
 SKILL_NAME_PATTERN = re.compile(r'^[a-z][a-z0-9-]{0,63}$')
+SkillContext = Literal["inline", "fork"]
+SkillListSort = Literal["name", "context", "created_at", "last_modified"]
+SkillListOrder = Literal["asc", "desc"]
 
 
 def _default_offset_pagination_aliases(response):
@@ -104,7 +107,7 @@ class SkillFrontmatter(BaseModel):
     user_invocable: bool = Field(True, description="If false, hidden from user UI (background knowledge only)")
     allowed_tools: list[str] | None = Field(None, description="Tools allowed without permission when skill is active")
     model: str | None = Field(None, description="Override model for this skill")
-    context: Literal["inline", "fork"] = Field("inline", description="'inline' or 'fork' (fork runs in isolated subagent)")
+    context: SkillContext = Field("inline", description="'inline' or 'fork' (fork runs in isolated subagent)")
 
     model_config = ConfigDict(extra='ignore')
 
@@ -118,7 +121,7 @@ class SkillBase(BaseModel):
     user_invocable: bool = Field(True, description="If false, hidden from user UI")
     allowed_tools: list[str] | None = Field(None, description="Tools allowed during skill execution")
     model: str | None = Field(None, description="Override model for this skill")
-    context: Literal["inline", "fork"] = Field("inline", description="Execution context mode")
+    context: SkillContext = Field("inline", description="Execution context mode")
 
     @field_validator("name")
     @classmethod
@@ -190,7 +193,7 @@ class SkillSummary(BaseModel):
     argument_hint: str | None = Field(None, description="Hint shown in UI")
     user_invocable: bool = Field(..., description="If false, hidden from user UI")
     disable_model_invocation: bool = Field(..., description="If true, only user can invoke")
-    context: Literal["inline", "fork"] = Field(..., description="Execution context mode")
+    context: SkillContext = Field(..., description="Execution context mode")
 
     model_config = ConfigDict(from_attributes=True)
 

--- a/tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py
+++ b/tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py
@@ -15386,6 +15386,18 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
     def _skill_bool_value(self, value: bool) -> bool | int:
         return value if self.backend_type == BackendType.POSTGRESQL else int(value)
 
+    _SKILL_REGISTRY_CONTEXTS = {"inline", "fork"}
+    _SKILL_REGISTRY_SORT_COLUMNS = {
+        "name": "name",
+        "context": "context",
+        "created_at": "created_at",
+        "last_modified": "last_modified",
+    }
+    _SKILL_REGISTRY_SORT_DIRECTIONS = {
+        "asc": "ASC",
+        "desc": "DESC",
+    }
+
     @staticmethod
     def _skill_search_like_pattern(query: str | None) -> str | None:
         """Return an escaped SQL LIKE pattern for skill search, or None when blank."""
@@ -15400,39 +15412,115 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
         )
         return f"%{escaped}%"
 
+    @staticmethod
+    def _normalized_skill_text_filter(value: str | None) -> str | None:
+        """Return normalized filter text, or None when blank."""
+        normalized = (value or "").strip().lower()
+        return normalized or None
+
+    def _skill_registry_sort_clause(self, sort: str, order: str) -> str:
+        """Return a safe ORDER BY clause for whitelisted skill registry fields."""
+        sort_key = (sort or "name").strip().lower()
+        column = self._SKILL_REGISTRY_SORT_COLUMNS.get(sort_key)
+        if column is None:
+            raise ValueError("Unsupported skill registry sort field")
+
+        order_key = (order or "asc").strip().lower()
+        direction = self._SKILL_REGISTRY_SORT_DIRECTIONS.get(order_key)
+        if direction is None:
+            raise ValueError("Unsupported skill registry sort order")
+
+        if column == "name":
+            return f"ORDER BY {column} {direction}"  # nosec B608
+        return f"ORDER BY {column} {direction}, name ASC"  # nosec B608
+
+    def _skill_registry_filter_clauses(
+        self,
+        *,
+        include_hidden: bool,
+        include_deleted: bool,
+        q: str | None,
+        context: str | None,
+        user_invocable: bool | None,
+        has_tools: bool | None,
+        model: str | None,
+    ) -> tuple[list[str], list[Any]]:
+        """Build shared skill registry WHERE clauses for list and count queries."""
+        clauses: list[str] = []
+        params: list[Any] = []
+        if not include_deleted:
+            clauses.append("deleted = ?")
+            params.append(self._skill_bool_value(False))
+
+        if user_invocable is not None:
+            clauses.append("user_invocable = ?")
+            params.append(self._skill_bool_value(user_invocable))
+        elif not include_hidden:
+            clauses.append("user_invocable = ?")
+            params.append(self._skill_bool_value(True))
+
+        search_pattern = self._skill_search_like_pattern(q)
+        if search_pattern is not None:
+            clauses.append(
+                "("
+                "LOWER(name) LIKE ? ESCAPE '\\' "
+                "OR LOWER(COALESCE(description, '')) LIKE ? ESCAPE '\\' "
+                "OR LOWER(COALESCE(argument_hint, '')) LIKE ? ESCAPE '\\'"
+                ")"
+            )
+            params.extend([search_pattern, search_pattern, search_pattern])
+
+        context_filter = self._normalized_skill_text_filter(context)
+        if context_filter is not None:
+            if context_filter not in self._SKILL_REGISTRY_CONTEXTS:
+                raise ValueError("Unsupported skill registry context")
+            clauses.append("context = ?")
+            params.append(context_filter)
+
+        if has_tools is True:
+            clauses.append("allowed_tools IS NOT NULL AND TRIM(allowed_tools) NOT IN ('', '[]')")
+        elif has_tools is False:
+            clauses.append("(allowed_tools IS NULL OR TRIM(allowed_tools) IN ('', '[]'))")
+
+        model_filter = self._normalized_skill_text_filter(model)
+        if model_filter is not None:
+            clauses.append("LOWER(COALESCE(model, '')) = ?")
+            params.append(model_filter)
+
+        return clauses, params
+
     def list_skill_registry(
         self,
         *,
         include_hidden: bool = False,
         include_deleted: bool = False,
         q: str | None = None,
+        context: str | None = None,
+        user_invocable: bool | None = None,
+        has_tools: bool | None = None,
+        model: str | None = None,
+        sort: str = "name",
+        order: str = "asc",
         limit: int = 100,
         offset: int = 0,
     ) -> list[dict[str, Any]]:
         """List skill registry entries with optional filters."""
         self._ensure_skill_registry_table()
-        clauses = []
-        params: list[Any] = []
-        if not include_deleted:
-            clauses.append("deleted = ?")
-            params.append(self._skill_bool_value(False))
-        if not include_hidden:
-            clauses.append("user_invocable = ?")
-            params.append(self._skill_bool_value(True))
-        search_pattern = self._skill_search_like_pattern(q)
-        if search_pattern is not None:
-            clauses.append(
-                "("
-                "LOWER(name) LIKE ? ESCAPE '\\' "
-                "OR LOWER(COALESCE(description, '')) LIKE ? ESCAPE '\\'"
-                ")"
-            )
-            params.extend([search_pattern, search_pattern])
+        clauses, params = self._skill_registry_filter_clauses(
+            include_hidden=include_hidden,
+            include_deleted=include_deleted,
+            q=q,
+            context=context,
+            user_invocable=user_invocable,
+            has_tools=has_tools,
+            model=model,
+        )
         where_sql = f"WHERE {' AND '.join(clauses)}" if clauses else ""
+        order_sql = self._skill_registry_sort_clause(sort, order)
         query = (
             "SELECT * FROM skill_registry "  # nosec B608
             f"{where_sql} "
-            "ORDER BY name ASC LIMIT ? OFFSET ?"
+            f"{order_sql} LIMIT ? OFFSET ?"
         )
         params.extend([limit, offset])
         try:
@@ -15448,26 +15536,22 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
         include_hidden: bool = False,
         include_deleted: bool = False,
         q: str | None = None,
+        context: str | None = None,
+        user_invocable: bool | None = None,
+        has_tools: bool | None = None,
+        model: str | None = None,
     ) -> int:
         """Return count of skills in registry."""
         self._ensure_skill_registry_table()
-        clauses = []
-        params: list[Any] = []
-        if not include_deleted:
-            clauses.append("deleted = ?")
-            params.append(self._skill_bool_value(False))
-        if not include_hidden:
-            clauses.append("user_invocable = ?")
-            params.append(self._skill_bool_value(True))
-        search_pattern = self._skill_search_like_pattern(q)
-        if search_pattern is not None:
-            clauses.append(
-                "("
-                "LOWER(name) LIKE ? ESCAPE '\\' "
-                "OR LOWER(COALESCE(description, '')) LIKE ? ESCAPE '\\'"
-                ")"
-            )
-            params.extend([search_pattern, search_pattern])
+        clauses, params = self._skill_registry_filter_clauses(
+            include_hidden=include_hidden,
+            include_deleted=include_deleted,
+            q=q,
+            context=context,
+            user_invocable=user_invocable,
+            has_tools=has_tools,
+            model=model,
+        )
         where_sql = f"WHERE {' AND '.join(clauses)}" if clauses else ""
         query = f"SELECT COUNT(*) AS cnt FROM skill_registry {where_sql}"  # nosec B608
         try:

--- a/tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py
+++ b/tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py
@@ -15387,15 +15387,20 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
         return value if self.backend_type == BackendType.POSTGRESQL else int(value)
 
     _SKILL_REGISTRY_CONTEXTS = {"inline", "fork"}
-    _SKILL_REGISTRY_SORT_COLUMNS = {
-        "name": "name",
-        "context": "context",
-        "created_at": "created_at",
-        "last_modified": "last_modified",
-    }
+    _SKILL_REGISTRY_SORT_FIELDS = {"name", "context", "created_at", "last_modified"}
     _SKILL_REGISTRY_SORT_DIRECTIONS = {
-        "asc": "ASC",
-        "desc": "DESC",
+        "asc",
+        "desc",
+    }
+    _SKILL_REGISTRY_SORT_CLAUSES = {
+        ("name", "asc"): "ORDER BY name ASC",
+        ("name", "desc"): "ORDER BY name DESC",
+        ("context", "asc"): "ORDER BY context ASC, name ASC",
+        ("context", "desc"): "ORDER BY context DESC, name ASC",
+        ("created_at", "asc"): "ORDER BY created_at ASC, name ASC",
+        ("created_at", "desc"): "ORDER BY created_at DESC, name ASC",
+        ("last_modified", "asc"): "ORDER BY last_modified ASC, name ASC",
+        ("last_modified", "desc"): "ORDER BY last_modified DESC, name ASC",
     }
 
     @staticmethod
@@ -15421,18 +15426,14 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
     def _skill_registry_sort_clause(self, sort: str, order: str) -> str:
         """Return a safe ORDER BY clause for whitelisted skill registry fields."""
         sort_key = (sort or "name").strip().lower()
-        column = self._SKILL_REGISTRY_SORT_COLUMNS.get(sort_key)
-        if column is None:
-            raise ValueError("Unsupported skill registry sort field")
+        if sort_key not in self._SKILL_REGISTRY_SORT_FIELDS:
+            raise InputError("Unsupported skill registry sort field")
 
         order_key = (order or "asc").strip().lower()
-        direction = self._SKILL_REGISTRY_SORT_DIRECTIONS.get(order_key)
-        if direction is None:
-            raise ValueError("Unsupported skill registry sort order")
+        if order_key not in self._SKILL_REGISTRY_SORT_DIRECTIONS:
+            raise InputError("Unsupported skill registry sort order")
 
-        if column == "name":
-            return f"ORDER BY {column} {direction}"  # nosec B608
-        return f"ORDER BY {column} {direction}, name ASC"  # nosec B608
+        return self._SKILL_REGISTRY_SORT_CLAUSES[(sort_key, order_key)]
 
     def _skill_registry_filter_clauses(
         self,
@@ -15473,7 +15474,7 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
         context_filter = self._normalized_skill_text_filter(context)
         if context_filter is not None:
             if context_filter not in self._SKILL_REGISTRY_CONTEXTS:
-                raise ValueError("Unsupported skill registry context")
+                raise InputError("Unsupported skill registry context")
             clauses.append("context = ?")
             params.append(context_filter)
 

--- a/tldw_Server_API/app/core/Skills/skills_service.py
+++ b/tldw_Server_API/app/core/Skills/skills_service.py
@@ -444,6 +444,12 @@ class SkillsService:
         self,
         include_hidden: bool = False,
         q: str | None = None,
+        context: str | None = None,
+        user_invocable: bool | None = None,
+        has_tools: bool | None = None,
+        model: str | None = None,
+        sort: str = "name",
+        order: str = "asc",
         limit: int = 100,
         offset: int = 0,
     ) -> list[SkillMetadata]:
@@ -453,6 +459,12 @@ class SkillsService:
         Args:
             include_hidden: If True, include skills with user_invocable=False
             q: Optional case-insensitive search query for skill name or description
+            context: Optional execution context filter ("inline" or "fork").
+            user_invocable: Optional explicit visibility filter.
+            has_tools: Optional filter for skills with non-empty allowed_tools.
+            model: Optional exact model override filter.
+            sort: Whitelisted sort field.
+            order: Sort direction, "asc" or "desc".
             limit: Maximum number of skills to return
             offset: Offset for pagination
 
@@ -465,6 +477,12 @@ class SkillsService:
             include_hidden=include_hidden,
             include_deleted=False,
             q=q,
+            context=context,
+            user_invocable=user_invocable,
+            has_tools=has_tools,
+            model=model,
+            sort=sort,
+            order=order,
             limit=limit,
             offset=offset,
         )
@@ -1028,7 +1046,15 @@ class SkillsService:
         rows = self._list_context_rows()
         return self._build_context_payload(rows)
 
-    async def get_total_count(self, include_hidden: bool = False, q: str | None = None) -> int:
+    async def get_total_count(
+        self,
+        include_hidden: bool = False,
+        q: str | None = None,
+        context: str | None = None,
+        user_invocable: bool | None = None,
+        has_tools: bool | None = None,
+        model: str | None = None,
+    ) -> int:
         """
         Get total count of skills.
 
@@ -1036,6 +1062,10 @@ class SkillsService:
             include_hidden: Include skills hidden from user invocation.
             q: Optional search string filtering skills by name or description;
                 empty values are ignored.
+            context: Optional execution context filter ("inline" or "fork").
+            user_invocable: Optional explicit visibility filter.
+            has_tools: Optional filter for skills with non-empty allowed_tools.
+            model: Optional exact model override filter.
         """
         await self._sync_registry_async()
         db = self._get_db()
@@ -1043,6 +1073,10 @@ class SkillsService:
             include_hidden=include_hidden,
             include_deleted=False,
             q=q,
+            context=context,
+            user_invocable=user_invocable,
+            has_tools=has_tools,
+            model=model,
         )
 
     def _get_builtin_skills_dir(self) -> Path:

--- a/tldw_Server_API/tests/Skills/integration/test_skills_api.py
+++ b/tldw_Server_API/tests/Skills/integration/test_skills_api.py
@@ -371,6 +371,78 @@ class TestListSkills:
             "next_offset": None,
         }
 
+    def test_list_skills_filters_and_sorts_before_pagination(self, client):
+        for i in range(12):
+            r = client.post(
+                f"{SKILLS_PREFIX}/",
+                json={
+                    "name": f"alpha-{i:02d}",
+                    "content": "---\ndescription: General utility skill\ncontext: inline\n---\n\nCommon content",
+                },
+            )
+            assert r.status_code == 201, r.text
+
+        for name, tool in (("beta-first", "Read"), ("beta-second", "Grep")):
+            r = client.post(
+                f"{SKILLS_PREFIX}/",
+                json={
+                    "name": name,
+                    "content": (
+                        "---\n"
+                        "description: Forked tool skill\n"
+                        "context: fork\n"
+                        "allowed-tools:\n"
+                        f"  - {tool}\n"
+                        "model: gpt-4o\n"
+                        "---\n\n"
+                        "Use this with tools."
+                    ),
+                },
+            )
+            assert r.status_code == 201, r.text
+
+        r = client.get(
+            f"{SKILLS_PREFIX}/?context=fork&has_tools=true&model=gpt-4o"
+            "&sort=name&order=desc&limit=1&offset=0"
+        )
+        assert r.status_code == 200, r.text
+        data = r.json()
+
+        assert [skill["name"] for skill in data["skills"]] == ["beta-second"]
+        assert data["count"] == 1
+        assert data["total"] == 2
+        assert data["pagination"] == {
+            "mode": "offset",
+            "limit": 1,
+            "offset": 0,
+            "total": 2,
+            "has_more": True,
+            "next_offset": 1,
+        }
+
+    def test_list_skills_explicit_hidden_filter(self, client):
+        for name, user_invocable in (("visible", "true"), ("hidden", "false")):
+            r = client.post(
+                f"{SKILLS_PREFIX}/",
+                json={
+                    "name": name,
+                    "content": f"---\nuser-invocable: {user_invocable}\n---\n\nContent",
+                },
+            )
+            assert r.status_code == 201, r.text
+
+        r = client.get(f"{SKILLS_PREFIX}/?user_invocable=false")
+        assert r.status_code == 200, r.text
+        data = r.json()
+
+        assert [skill["name"] for skill in data["skills"]] == ["hidden"]
+        assert data["total"] == 1
+
+    def test_list_skills_rejects_unapproved_sort_field(self, client):
+        r = client.get(f"{SKILLS_PREFIX}/?sort=directory_path")
+
+        assert r.status_code == 422, r.text
+
 
 class TestCreateAndGetSkill:
     def test_create_skill_and_get(self, client):

--- a/tldw_Server_API/tests/Skills/unit/test_skill_registry_queries.py
+++ b/tldw_Server_API/tests/Skills/unit/test_skill_registry_queries.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 import pytest
 
-from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import CharactersRAGDB
+from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import CharactersRAGDB, InputError
 
 
 pytestmark = pytest.mark.unit
@@ -92,5 +92,5 @@ def test_skill_registry_explicit_user_invocable_filter_can_find_hidden(
 def test_skill_registry_rejects_unapproved_sort_fields(skills_db: CharactersRAGDB) -> None:
     _insert_skill(skills_db, "visible")
 
-    with pytest.raises(ValueError, match="Unsupported skill registry sort field"):
+    with pytest.raises(InputError, match="Unsupported skill registry sort field"):
         skills_db.list_skill_registry(sort="directory_path")

--- a/tldw_Server_API/tests/Skills/unit/test_skill_registry_queries.py
+++ b/tldw_Server_API/tests/Skills/unit/test_skill_registry_queries.py
@@ -1,0 +1,96 @@
+from pathlib import Path
+
+import pytest
+
+from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import CharactersRAGDB
+
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture()
+def skills_db(tmp_path: Path) -> CharactersRAGDB:
+    db = CharactersRAGDB(db_path=tmp_path / "ChaChaNotes.db", client_id="skills_registry_query_test")
+    yield db
+    db.close_connection()
+
+
+def _insert_skill(
+    db: CharactersRAGDB,
+    name: str,
+    *,
+    description: str = "General skill",
+    argument_hint: str | None = None,
+    user_invocable: bool = True,
+    allowed_tools: list[str] | None = None,
+    model: str | None = None,
+    context: str = "inline",
+) -> None:
+    db.insert_skill_registry(
+        {
+            "name": name,
+            "description": description,
+            "argument_hint": argument_hint,
+            "user_invocable": user_invocable,
+            "allowed_tools": allowed_tools,
+            "model": model,
+            "context": context,
+            "directory_path": f"/tmp/skills/{name}",
+            "file_hash": f"hash-{name}",
+        }
+    )
+
+
+def test_skill_registry_filters_and_sorts_before_pagination(skills_db: CharactersRAGDB) -> None:
+    for index in range(12):
+        _insert_skill(skills_db, f"alpha-{index:02d}", context="inline")
+    _insert_skill(
+        skills_db,
+        "beta-first",
+        allowed_tools=["Read"],
+        model="gpt-4o",
+        context="fork",
+    )
+    _insert_skill(
+        skills_db,
+        "beta-second",
+        allowed_tools=["Grep"],
+        model="gpt-4o",
+        context="fork",
+    )
+
+    rows = skills_db.list_skill_registry(
+        context="fork",
+        has_tools=True,
+        model="gpt-4o",
+        sort="name",
+        order="desc",
+        limit=1,
+        offset=0,
+    )
+
+    assert [row["name"] for row in rows] == ["beta-second"]
+    assert skills_db.count_skill_registry(
+        context="fork",
+        has_tools=True,
+        model="gpt-4o",
+    ) == 2
+
+
+def test_skill_registry_explicit_user_invocable_filter_can_find_hidden(
+    skills_db: CharactersRAGDB,
+) -> None:
+    _insert_skill(skills_db, "visible", user_invocable=True)
+    _insert_skill(skills_db, "hidden", user_invocable=False)
+
+    rows = skills_db.list_skill_registry(user_invocable=False, limit=10, offset=0)
+
+    assert [row["name"] for row in rows] == ["hidden"]
+    assert skills_db.count_skill_registry(user_invocable=False) == 1
+
+
+def test_skill_registry_rejects_unapproved_sort_fields(skills_db: CharactersRAGDB) -> None:
+    _insert_skill(skills_db, "visible")
+
+    with pytest.raises(ValueError, match="Unsupported skill registry sort field"):
+        skills_db.list_skill_registry(sort="directory_path")

--- a/tldw_Server_API/tests/Skills/unit/test_skills_service.py
+++ b/tldw_Server_API/tests/Skills/unit/test_skills_service.py
@@ -258,6 +258,84 @@ Use this for longform synthesis.
         assert await service.get_total_count(q="needle") == 1
 
     @pytest.mark.asyncio
+    async def test_list_skills_filters_and_sorts_before_pagination(self, service):
+        """Power-user filters and sort should apply before pagination."""
+        for i in range(12):
+            await service.create_skill(
+                f"alpha-{i:02d}",
+                """---
+description: General utility skill
+context: inline
+---
+
+Common content
+""",
+            )
+        await service.create_skill(
+            "beta-first",
+            """---
+description: Forked skill with tools
+context: fork
+allowed-tools:
+  - Read
+model: gpt-4o
+---
+
+Use this with tools.
+""",
+        )
+        await service.create_skill(
+            "beta-second",
+            """---
+description: Another forked skill with tools
+context: fork
+allowed-tools:
+  - Grep
+model: gpt-4o
+---
+
+Use this with tools too.
+""",
+        )
+
+        skills = await service.list_skills(
+            context="fork",
+            has_tools=True,
+            model="gpt-4o",
+            sort="name",
+            order="desc",
+            limit=1,
+            offset=0,
+        )
+
+        assert [skill.name for skill in skills] == ["beta-second"]
+        assert await service.get_total_count(
+            context="fork",
+            has_tools=True,
+            model="gpt-4o",
+        ) == 2
+
+    @pytest.mark.asyncio
+    async def test_list_skills_explicit_hidden_filter_overrides_default_visibility(
+        self,
+        service,
+    ):
+        """Filtering for user_invocable=false should find hidden skills."""
+        await service.create_skill("visible", """---
+user-invocable: true
+---
+Content""")
+        await service.create_skill("hidden", """---
+user-invocable: false
+---
+Content""")
+
+        skills = await service.list_skills(user_invocable=False)
+
+        assert [skill.name for skill in skills] == ["hidden"]
+        assert await service.get_total_count(user_invocable=False) == 1
+
+    @pytest.mark.asyncio
     async def test_update_skill_content(self, service):
         """Test updating skill content."""
         await service.create_skill("update-test", "Original content")


### PR DESCRIPTION
## Change summary
- Added server-backed Skills list filters for context, visibility, tools, model, and sort/order, with a shared registry filter builder for list/count consistency.
- Wired the typed UI client and /skills manager controls to request server-backed filters and table sorting while preserving debounced search and pagination reset behavior.
- Added regression coverage across registry queries, service/API behavior, client serialization, and manager interactions.

## Why
Power users need filters and sorting to apply to the whole Skills registry, not only the currently loaded table page. The backend now owns the result set, total count, and ordering, while sort fields/directions stay whitelisted and filter values stay parameterized.

## Test plan
- source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tldw_Server_API/tests/Skills/unit/test_skill_registry_queries.py tldw_Server_API/tests/Skills/unit/test_skills_service.py tldw_Server_API/tests/Skills/integration/test_skills_api.py -q
- bunx vitest run src/services/__tests__/tldw-api-client.boundary-slices.test.ts src/components/Option/Skills/__tests__/Manager.test.tsx
- source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m bandit -r tldw_Server_API/app/api/v1/endpoints/skills.py tldw_Server_API/app/api/v1/schemas/skills_schemas.py tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py tldw_Server_API/app/core/Skills/skills_service.py -f json -o /tmp/bandit_skills_filters_sorting_TASK_530_4.json
- git diff --check

## Known caveat
- bunx tsc --noEmit -p tsconfig.json was attempted as an extra guard. The default run OOMed; the 8GB retry reached existing package-level failures in Notes tests, background response result handling, and voice-cloning ArrayBuffer typing. Focused Vitest coverage is the UI gate for this slice.