### PR TITLE
Add MCP filesystem lock manager seam

### DIFF
--- a/Docs/superpowers/plans/2026-06-09-mcp-filesystem-lock-manager-seam-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-06-09-mcp-filesystem-lock-manager-seam-implementation-plan.md
@@ -1,0 +1,106 @@
+# MCP Filesystem Lock Manager Seam Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add an injectable filesystem lock-manager seam while preserving the current process-local in-memory default.
+
+**Architecture:** Keep `fs.lock_acquire`, `fs.lock_release`, and mutation lock validation behavior in `FilesystemModule`, but depend on a narrow lock-manager protocol instead of a hard-coded concrete manager. Add a small backend factory that supports only `memory` now and fails closed for unsupported configured backends, leaving persistent/shared backends for a later slice.
+
+**Tech Stack:** Python 3, pytest, MCP Unified filesystem module, Backlog.md task `TASK-2343`.
+
+---
+
+### Task 1: Add Lock-Manager Contract Tests
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_module.py`
+- Reference: `tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_module.py`
+- Reference: `tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_locks.py`
+
+- [x] **Step 1: Add a failing shared-manager injection test**
+
+Add an async test that creates one `InMemoryFilesystemLockManager`, injects it into two `FilesystemModule` instances, acquires a lock through module A, observes a conflict through module B, releases through module B with the same lease token, and then acquires through module B.
+
+- [x] **Step 2: Run the new test and verify it fails**
+
+Run: `source .venv/bin/activate && python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_module.py::test_filesystem_lock_manager_injection_shares_leases_between_modules -q`
+
+Expected: FAIL because `FilesystemModule.__init__()` does not accept a lock manager injection argument.
+
+### Task 2: Implement The Seam
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_locks.py`
+- Modify: `tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_module.py`
+
+- [x] **Step 1: Add `FilesystemLockManager` protocol**
+
+Define a protocol with `acquire`, `release`, and `validate` signatures matching the existing in-memory manager.
+
+- [x] **Step 2: Add a default manager factory**
+
+Add `create_filesystem_lock_manager(settings)` that returns `InMemoryFilesystemLockManager` for unset, `memory`, or `in_memory` backends and raises `ValueError` for unsupported configured backends.
+
+- [x] **Step 3: Wire `FilesystemModule` to the seam**
+
+Add an optional `lock_manager` constructor parameter. Store the injected manager when supplied, otherwise call `create_filesystem_lock_manager(config.settings)`. Do not change existing lock result shapes or mutation behavior.
+
+- [x] **Step 4: Run the shared-manager test and verify it passes**
+
+Run: `source .venv/bin/activate && python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_module.py::test_filesystem_lock_manager_injection_shares_leases_between_modules -q`
+
+Expected: PASS.
+
+### Task 3: Add Config And Documentation Coverage
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_module.py`
+- Modify: `mcp_unified/USER_GUIDE.md`
+
+- [x] **Step 1: Add a failing unsupported-backend config test**
+
+Add a test that constructs `FilesystemModule(ModuleConfig(name="filesystem", settings={"lock_manager_backend": "sqlite"}))` and expects `ValueError`.
+
+- [x] **Step 2: Run the config test and verify it fails before implementation or passes after implementation**
+
+Run: `source .venv/bin/activate && python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_module.py::test_filesystem_lock_manager_rejects_unsupported_backend_config -q`
+
+Expected after Task 2: PASS.
+
+- [x] **Step 3: Update the user guide**
+
+Clarify that the built-in backend is `lock_manager_backend=memory`, the default remains process-local, and durable/shared backends are future implementations behind the same seam.
+
+### Task 4: Validate And Commit
+
+**Files:**
+- Validate touched Python and docs.
+- Update Backlog task `TASK-2343`.
+
+- [x] **Step 1: Run focused tests**
+
+Run: `source .venv/bin/activate && python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_module.py -q`
+
+Expected: PASS.
+
+- [x] **Step 2: Compile touched Python**
+
+Run: `source .venv/bin/activate && python -m py_compile tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_locks.py tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_module.py`
+
+Expected: exit 0.
+
+- [x] **Step 3: Run Bandit on touched implementation scope**
+
+Run: `source .venv/bin/activate && python -m bandit -r tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_locks.py tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_module.py -f json -o /tmp/bandit_mcp_fs_lock_manager_seam.json`
+
+Expected: exit 0 with no new findings in touched code.
+
+- [x] **Step 4: Check diff whitespace**
+
+Run: `git diff --check`
+
+Expected: exit 0.
+
+- [x] **Step 5: Update Backlog task and commit**
+
+Record verification results in `TASK-2343`, stage the changed files, and commit with a message linking the MCP filesystem lock seam.

--- a/backlog/tasks/task-2343 - Implement-MCP-filesystem-lock-manager-seam.md
+++ b/backlog/tasks/task-2343 - Implement-MCP-filesystem-lock-manager-seam.md
@@ -24,11 +24,11 @@ Add an injectable filesystem lock-manager interface/config seam while keeping th
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 FilesystemModule depends on a narrow lock-manager contract instead of directly hard-coding the in-memory manager at call sites.
-- [ ] #2 Default behavior remains process-local and in-memory unless an injected/configured manager is supplied.
-- [ ] #3 Tests prove two FilesystemModule instances can coordinate locks when they share an injected manager.
-- [ ] #4 Existing lock acquire/release and mutation lock validation behavior remains compatible.
-- [ ] #5 Docs/plan note persistence is a future backend slice, not part of this seam.
+- [x] #1 FilesystemModule depends on a narrow lock-manager contract instead of directly hard-coding the in-memory manager at call sites.
+- [x] #2 Default behavior remains process-local and in-memory unless an injected/configured manager is supplied.
+- [x] #3 Tests prove two FilesystemModule instances can coordinate locks when they share an injected manager.
+- [x] #4 Existing lock acquire/release and mutation lock validation behavior remains compatible.
+- [x] #5 Docs/plan note persistence is a future backend slice, not part of this seam.
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -46,15 +46,15 @@ Docs/superpowers/plans/2026-06-09-mcp-filesystem-lock-manager-seam-implementatio
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Implemented the MCP filesystem lock-manager seam: added a protocol and memory-backend factory, wired FilesystemModule to accept an injected manager while defaulting to process-local memory, added regression tests for shared manager coordination and unsupported backend config, and clarified the user guide. Verification: pytest test_filesystem_module.py -q (97 passed, 4 warnings); py_compile on touched implementation files; Bandit on touched implementation files (0 findings); git diff --check.
+Implemented the MCP filesystem lock-manager seam: added a protocol and memory-backend factory, wired FilesystemModule to accept an injected manager while defaulting to process-local memory, added regression tests for shared manager coordination and unsupported backend config, and clarified the user guide. PR review follow-up: fixed fail-closed backend validation so explicit falsy lock_manager_backend values are rejected, synchronized the Backlog acceptance/DoD checklist with Done status, and verified Gemini's async protocol suggestion against the current offloaded sync helper design; no async refactor was applied in this seam. Verification: pytest test_filesystem_module.py -q (99 passed, 4 warnings); py_compile on touched implementation files; Bandit on touched implementation files (0 findings); git diff --check.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->

--- a/backlog/tasks/task-2343 - Implement-MCP-filesystem-lock-manager-seam.md
+++ b/backlog/tasks/task-2343 - Implement-MCP-filesystem-lock-manager-seam.md
@@ -1,0 +1,60 @@
+---
+id: TASK-2343
+title: Implement MCP filesystem lock manager seam
+status: Done
+labels:
+- mcp
+- filesystem
+- locks
+modified_files:
+- tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_locks.py
+- tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_module.py
+- tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_module.py
+- mcp_unified/USER_GUIDE.md
+- Docs/superpowers/plans/2026-06-09-mcp-filesystem-lock-manager-seam-implementation-plan.md
+references:
+- https://github.com/rmusser01/tldw_server/pull/2335
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Add an injectable filesystem lock-manager interface/config seam while keeping the in-memory process-local manager as the default backend. This prepares shared/persistent lock backends without changing existing tool behavior.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 FilesystemModule depends on a narrow lock-manager contract instead of directly hard-coding the in-memory manager at call sites.
+- [ ] #2 Default behavior remains process-local and in-memory unless an injected/configured manager is supplied.
+- [ ] #3 Tests prove two FilesystemModule instances can coordinate locks when they share an injected manager.
+- [ ] #4 Existing lock acquire/release and mutation lock validation behavior remains compatible.
+- [ ] #5 Docs/plan note persistence is a future backend slice, not part of this seam.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Docs/superpowers/plans/2026-06-09-mcp-filesystem-lock-manager-seam-implementation-plan.md
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Implemented the MCP filesystem lock-manager seam: added a protocol and memory-backend factory, wired FilesystemModule to accept an injected manager while defaulting to process-local memory, added regression tests for shared manager coordination and unsupported backend config, and clarified the user guide. Verification: pytest test_filesystem_module.py -q (97 passed, 4 warnings); py_compile on touched implementation files; Bandit on touched implementation files (0 findings); git diff --check.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/mcp_unified/USER_GUIDE.md
+++ b/mcp_unified/USER_GUIDE.md
@@ -153,16 +153,19 @@ after the model read it, the expected hash or receipt no longer matches and the
 write is rejected instead of silently overwriting newer content.
 
 For concurrent editing workflows, `fs.lock_acquire` and `fs.lock_release`
-provide process-local advisory leases for workspace-relative file paths. A
-successful acquire returns a `lease_id` that callers can pass to `fs.edit` and
-`fs.write` as `lock_lease_id`, or to `fs.patch` as
-`lock_lease_id_by_path`. Leases do not replace hashes or read receipts; mutation
-tools still run their normal preimage checks. Operators can set
-`require_lock_for_mutation=true` on the filesystem module when they want
-mutations to fail with `lock_required` unless the caller supplies a matching
-active lease. This first implementation is process-local and advisory: use it
-to reduce races within one running gateway process, not as a durable or
-cross-process distributed lock.
+provide advisory leases for workspace-relative file paths. The built-in
+`lock_manager_backend=memory` backend is process-local. A successful acquire
+returns a `lease_id` that callers can pass to `fs.edit` and `fs.write` as
+`lock_lease_id`, or to `fs.patch` as `lock_lease_id_by_path`. Leases do not
+replace hashes or read receipts; mutation tools still run their normal preimage
+checks. Operators can set `require_lock_for_mutation=true` on the filesystem
+module when they want mutations to fail with `lock_required` unless the caller
+supplies a matching active lease. Host integrations may inject a shared lock
+manager behind the same filesystem module seam, but the packaged backend today
+is still advisory and process-local. Use it to reduce races within one running
+gateway process, not as a durable or cross-process distributed lock. Unsupported
+configured lock backends fail at module creation instead of silently falling
+back to memory.
 
 Example action-aware path grants:
 

--- a/tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_locks.py
+++ b/tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_locks.py
@@ -5,9 +5,10 @@ from __future__ import annotations
 import secrets
 import threading
 import time
+from collections.abc import Mapping
 from dataclasses import dataclass
 from datetime import datetime, timezone
-from typing import Any
+from typing import Any, Protocol
 
 
 @dataclass(frozen=True, slots=True)
@@ -49,6 +50,32 @@ class FilesystemLockLease:
             "held_owner": self.owner,
             "expires_at": self.expires_at_iso(),
         }
+
+
+class FilesystemLockManager(Protocol):
+    """Backend contract for advisory filesystem lock leases."""
+
+    def acquire(
+        self,
+        *,
+        workspace_key: str,
+        path: str,
+        owner: str,
+        ttl_seconds: int,
+        lease_id: str | None = None,
+        workspace_id: str | None = None,
+        session_id: str | None = None,
+    ) -> tuple[FilesystemLockLease, bool]:
+        """Acquire or renew a lease for one workspace path."""
+        ...
+
+    def release(self, *, workspace_key: str, path: str, lease_id: str) -> FilesystemLockLease | None:
+        """Release an active lease when the token matches."""
+        ...
+
+    def validate(self, *, workspace_key: str, path: str, lease_id: str) -> FilesystemLockLease:
+        """Validate that the caller holds the active lease."""
+        ...
 
 
 class FilesystemLockConflict(ValueError):
@@ -180,9 +207,26 @@ class InMemoryFilesystemLockManager:
                 self._leases[key] = lease
 
 
+def create_filesystem_lock_manager(settings: Mapping[str, Any] | None = None) -> FilesystemLockManager:
+    """Create the configured filesystem lock manager backend.
+
+    The first shipped backend remains process-local memory. Unsupported
+    backends fail closed so future persistent backends can be added without
+    silently downgrading operator intent.
+    """
+
+    raw_backend = (settings or {}).get("lock_manager_backend") or "memory"
+    backend = str(raw_backend).strip().lower()
+    if backend in {"", "memory", "in_memory"}:
+        return InMemoryFilesystemLockManager()
+    raise ValueError(f"unsupported filesystem lock_manager_backend: {raw_backend!r}")
+
+
 __all__ = [
     "FilesystemLockConflict",
     "FilesystemLockLease",
+    "FilesystemLockManager",
     "FilesystemLockMissing",
     "InMemoryFilesystemLockManager",
+    "create_filesystem_lock_manager",
 ]

--- a/tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_locks.py
+++ b/tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_locks.py
@@ -215,7 +215,9 @@ def create_filesystem_lock_manager(settings: Mapping[str, Any] | None = None) ->
     silently downgrading operator intent.
     """
 
-    raw_backend = (settings or {}).get("lock_manager_backend") or "memory"
+    raw_backend = (settings or {}).get("lock_manager_backend")
+    if raw_backend is None:
+        raw_backend = "memory"
     backend = str(raw_backend).strip().lower()
     if backend in {"", "memory", "in_memory"}:
         return InMemoryFilesystemLockManager()

--- a/tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_module.py
@@ -44,7 +44,12 @@ from tldw_Server_API.app.services.mcp_hub_workspace_root_resolver import (
 from ...tool_observability import build_execution_eval_metadata
 from ..base import BaseModule, ModuleConfig, create_tool_definition
 from .filesystem_diff import FilesystemPatchError, PatchFile, apply_patch_to_text, parse_unified_diff
-from .filesystem_locks import FilesystemLockConflict, FilesystemLockMissing, InMemoryFilesystemLockManager
+from .filesystem_locks import (
+    FilesystemLockConflict,
+    FilesystemLockManager,
+    FilesystemLockMissing,
+    create_filesystem_lock_manager,
+)
 from .filesystem_receipts import ReadReceiptError, ReadReceiptManager
 
 
@@ -104,6 +109,7 @@ class FilesystemModule(BaseModule):
         self,
         config: ModuleConfig,
         workspace_root_resolver: McpHubWorkspaceRootResolver | Any | None = None,
+        lock_manager: FilesystemLockManager | None = None,
     ) -> None:
         super().__init__(config)
         self._workspace_root_resolver = workspace_root_resolver or McpHubWorkspaceRootResolver()
@@ -111,7 +117,11 @@ class FilesystemModule(BaseModule):
             secret=config.settings.get("read_receipt_secret"),
             ttl_seconds=self._setting_positive_int("read_receipt_ttl_seconds", 1_800),
         )
-        self._lock_leases = InMemoryFilesystemLockManager()
+        self._lock_leases = (
+            lock_manager
+            if lock_manager is not None
+            else create_filesystem_lock_manager(config.settings)
+        )
 
     async def on_initialize(self) -> None:
         logger.info(f"Initializing Filesystem module: {self.name}")

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_module.py
@@ -460,9 +460,10 @@ async def test_filesystem_lock_manager_injection_shares_leases_between_modules(t
     assert reacquired["lease_id"] != first["lease_id"]  # nosec B101
 
 
-def test_filesystem_lock_manager_rejects_unsupported_backend_config() -> None:
+@pytest.mark.parametrize("backend", ["sqlite", False, 0])
+def test_filesystem_lock_manager_rejects_unsupported_backend_config(backend: Any) -> None:
     with pytest.raises(ValueError, match="unsupported filesystem lock_manager_backend"):
-        FilesystemModule(ModuleConfig(name="filesystem", settings={"lock_manager_backend": "sqlite"}))
+        FilesystemModule(ModuleConfig(name="filesystem", settings={"lock_manager_backend": backend}))
 
 
 @pytest.mark.asyncio

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_module.py
@@ -407,6 +407,65 @@ async def test_filesystem_lock_lifecycle_conflicts_and_expiry(
 
 
 @pytest.mark.asyncio
+async def test_filesystem_lock_manager_injection_shares_leases_between_modules(tmp_path: Path) -> None:
+    from tldw_Server_API.app.core.MCP_unified.modules.implementations.filesystem_locks import (
+        InMemoryFilesystemLockManager,
+    )
+
+    workspace_root = tmp_path / "workspace"
+    docs_dir = workspace_root / "docs"
+    docs_dir.mkdir(parents=True, exist_ok=True)
+    (docs_dir / "story.txt").write_text("alpha\n", encoding="utf-8")
+    resolver = _FakeWorkspaceRootResolver({"workspace_root": str(workspace_root), "workspace_id": "ws-1"})
+    shared_locks = InMemoryFilesystemLockManager()
+    mod_a = FilesystemModule(
+        ModuleConfig(name="filesystem-a"),
+        workspace_root_resolver=resolver,
+        lock_manager=shared_locks,
+    )
+    mod_b = FilesystemModule(
+        ModuleConfig(name="filesystem-b"),
+        workspace_root_resolver=resolver,
+        lock_manager=shared_locks,
+    )
+    context = RequestContext(request_id="req-fs-shared-locks", user_id="1", metadata={"workspace_id": "ws-1"})
+
+    first = await mod_a.execute_tool(
+        "fs.lock_acquire",
+        {"path": "docs/story.txt", "owner": "agent-a", "ttl_seconds": 60},
+        context=context,
+    )
+    conflict = await mod_b.execute_tool(
+        "fs.lock_acquire",
+        {"path": "docs/story.txt", "owner": "agent-b", "ttl_seconds": 60},
+        context=context,
+    )
+    released = await mod_b.execute_tool(
+        "fs.lock_release",
+        {"path": "docs/story.txt", "lease_id": first["lease_id"]},
+        context=context,
+    )
+    reacquired = await mod_b.execute_tool(
+        "fs.lock_acquire",
+        {"path": "docs/story.txt", "owner": "agent-b", "ttl_seconds": 60},
+        context=context,
+    )
+
+    assert first["acquired"] is True  # nosec B101
+    assert conflict["acquired"] is False  # nosec B101
+    assert conflict["reason_code"] == "lock_conflict"  # nosec B101
+    assert conflict["held_owner"] == "agent-a"  # nosec B101
+    assert released["released"] is True  # nosec B101
+    assert reacquired["acquired"] is True  # nosec B101
+    assert reacquired["lease_id"] != first["lease_id"]  # nosec B101
+
+
+def test_filesystem_lock_manager_rejects_unsupported_backend_config() -> None:
+    with pytest.raises(ValueError, match="unsupported filesystem lock_manager_backend"):
+        FilesystemModule(ModuleConfig(name="filesystem", settings={"lock_manager_backend": "sqlite"}))
+
+
+@pytest.mark.asyncio
 async def test_filesystem_lock_acquire_offloads_lockable_path_checks(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Summary

- Add a `FilesystemLockManager` protocol plus a fail-closed lock-manager factory.
- Wire `FilesystemModule` to accept an injected lock manager while preserving the process-local memory default.
- Add regression coverage for shared manager coordination and unsupported backend config, and update the user guide.

## Verification

- `../../.venv/bin/python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_module.py -q` - 97 passed, 4 warnings.
- `../../.venv/bin/python -m py_compile tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_locks.py tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_module.py`
- `../../.venv/bin/python -m bandit -r tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_locks.py tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_module.py -f json -o /tmp/bandit_mcp_fs_lock_manager_seam.json` - 0 findings.
- `git diff --check`

## Merge Gate Note

This is an AI-authored draft PR. Per repository policy, a human-owned `Change summary` explaining what changed and why is still required before merge.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an injectable `FilesystemLockManager` seam to the filesystem module, preserving the process‑local memory default and failing closed on unsupported backends. Implements TASK-2343 and enables shared lock coordination across `FilesystemModule` instances without changing current behavior.

- New Features
  - Introduced `FilesystemLockManager` protocol and `create_filesystem_lock_manager`.
  - `FilesystemModule` accepts an optional `lock_manager`; otherwise uses the factory based on `lock_manager_backend` (unset/empty/`memory`/`in_memory` map to in-memory).
  - Tests cover shared-manager coordination and unsupported backend config; user guide documents the seam, default, and fail-closed behavior.

- Bug Fixes
  - Tightened backend validation: explicit falsy `lock_manager_backend` values (e.g., `False`, `0`) now raise `ValueError` instead of falling back to memory.

<sup>Written for commit b151a89728f12c7198a9f2dd5850babbc9367c0f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2335?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

