### PR TITLE
Migrate ScheduledTasks product states to design system

### DIFF
--- a/apps/packages/ui/src/components/Option/ScheduledTasks/ScheduledTaskCreatePanel.tsx
+++ b/apps/packages/ui/src/components/Option/ScheduledTasks/ScheduledTaskCreatePanel.tsx
@@ -64,9 +64,11 @@ const templateStateToBadgeVariant = (
       return "secondary"
     case "managed_in_watchlists":
     case "handoff_only":
-    default:
       return "info"
   }
+
+  const _exhaustive: never = state
+  return _exhaustive
 }
 
 const PRIVATE_LOOKING_PROSE_PATTERN =

--- a/apps/packages/ui/src/components/Option/ScheduledTasks/ScheduledTaskCreatePanel.tsx
+++ b/apps/packages/ui/src/components/Option/ScheduledTasks/ScheduledTaskCreatePanel.tsx
@@ -1,7 +1,13 @@
 import React, { useMemo, useState } from "react"
-import { Alert, Button, Card, Empty, Input, Segmented, Space, Tag, Typography } from "antd"
+import { Button, Card, Input, Segmented, Space, Typography } from "antd"
 import type { SegmentedValue } from "antd/es/segmented"
 
+import { EmptyState } from "@/components/ui/feedback"
+import {
+  Alert as DesignSystemAlert,
+  Badge as DesignSystemBadge,
+  type BadgeVariant
+} from "@/components/ui/primitives"
 import type { CreateScheduledTaskReminderPayload } from "@/services/scheduled-tasks-control-plane"
 import { ReminderTaskEditor } from "./ReminderTaskEditor"
 import {
@@ -42,6 +48,26 @@ const isTemplateFilterId = (value: SegmentedValue): value is ScheduledTaskTempla
 
 const requiresWatchlistsHandoff = (template: ScheduledTaskTemplate): boolean =>
   template.id === "watch" || template.id === "ingest"
+
+const templateStateToBadgeVariant = (
+  state: ScheduledTaskTemplate["state"]
+): BadgeVariant => {
+  switch (state) {
+    case "available":
+      return "success"
+    case "limited_availability":
+    case "needs_setup":
+      return "warning"
+    case "unavailable":
+      return "danger"
+    case "planned":
+      return "secondary"
+    case "managed_in_watchlists":
+    case "handoff_only":
+    default:
+      return "info"
+  }
+}
 
 const PRIVATE_LOOKING_PROSE_PATTERN =
   /\b(api[_ -]?key|password|passphrase|secret|bearer\s+token|access[_ -]?token|refresh[_ -]?token|client[_ -]?secret)\b|sk-[A-Za-z0-9_-]+/i
@@ -105,7 +131,9 @@ const TemplateCard: React.FC<{
     title={
       <Space wrap size={8}>
         <Typography.Text strong>{template.title}</Typography.Text>
-        <Tag>{stateLabel}</Tag>
+        <DesignSystemBadge variant={templateStateToBadgeVariant(template.state)}>
+          {stateLabel}
+        </DesignSystemBadge>
       </Space>
     }
   >
@@ -155,7 +183,9 @@ const HandoffPanel: React.FC<{
   return (
     <Card title={template.title} size="small">
       <Space orientation="vertical" size={12} style={{ width: "100%" }}>
-        <Tag>{getScheduledTaskTemplateStateLabel(template.state)}</Tag>
+        <DesignSystemBadge variant={templateStateToBadgeVariant(template.state)}>
+          {getScheduledTaskTemplateStateLabel(template.state)}
+        </DesignSystemBadge>
         <Typography.Text>{template.intent}</Typography.Text>
         <Typography.Paragraph style={{ marginBottom: 0 }}>
           {watchlistsHandoff
@@ -177,9 +207,8 @@ const HandoffPanel: React.FC<{
           onChange={(event) => setSourceNote(event.target.value)}
         />
         {hasUnsafeSource ? (
-          <Alert
-            type="warning"
-            showIcon
+          <DesignSystemAlert
+            variant="warning"
             title="This source contains private-looking values. Remove secrets before copying or opening setup."
           />
         ) : null}
@@ -206,7 +235,9 @@ const HandoffPanel: React.FC<{
 const PlannedPanel: React.FC<{ template: ScheduledTaskTemplate }> = ({ template }) => (
   <Card title={template.title} size="small">
     <Space orientation="vertical" size={8}>
-      <Tag>{getScheduledTaskTemplateStateLabel(template.state)}</Tag>
+      <DesignSystemBadge variant={templateStateToBadgeVariant(template.state)}>
+        {getScheduledTaskTemplateStateLabel(template.state)}
+      </DesignSystemBadge>
       <Typography.Text>{template.intent}</Typography.Text>
       <Typography.Paragraph style={{ marginBottom: 0 }}>
         {template.description}
@@ -333,7 +364,11 @@ export const ScheduledTaskCreatePanel: React.FC<ScheduledTaskCreatePanelProps> =
                 ))}
               </div>
             ) : (
-              <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description="No templates match this filter." />
+              <EmptyState
+                variant="inline"
+                size="sm"
+                title="No templates match this filter."
+              />
             )}
           </>
         )}

--- a/apps/packages/ui/src/components/Option/ScheduledTasks/ScheduledTaskDetailDrawer.tsx
+++ b/apps/packages/ui/src/components/Option/ScheduledTasks/ScheduledTaskDetailDrawer.tsx
@@ -1,12 +1,13 @@
 import React from "react"
-import { Button, Descriptions, Drawer, Space, Tag, Typography } from "antd"
+import { Button, Descriptions, Drawer, Space, Typography } from "antd"
+import { Badge as DesignSystemBadge } from "@/components/ui/primitives"
 import type { ScheduledTask } from "@/services/scheduled-tasks-control-plane"
 import {
   formatScheduledTaskTimestamp,
   getScheduledTaskProductStatus,
   getScheduledTaskTypeLabel,
   isNativeReminderTask,
-  scheduledTaskStatusToneToTagColor
+  scheduledTaskStatusToneToBadgeVariant
 } from "./scheduled-task-status"
 import { WatchlistTaskActionLinks } from "./WatchlistTaskActionLinks"
 import type { ScheduledTaskResultItem } from "./scheduled-task-results"
@@ -135,9 +136,11 @@ export const ScheduledTaskDetailDrawer: React.FC<ScheduledTaskDetailDrawerProps>
           <Descriptions bordered size="small" column={1}>
             <Descriptions.Item label="Product status">
               <Space orientation="vertical" size={2}>
-                <Tag color={scheduledTaskStatusToneToTagColor(productStatus)}>
+                <DesignSystemBadge
+                  variant={scheduledTaskStatusToneToBadgeVariant(productStatus)}
+                >
                   {productStatus.label}
-                </Tag>
+                </DesignSystemBadge>
                 <Typography.Text type="secondary">
                   {productStatus.description}
                 </Typography.Text>

--- a/apps/packages/ui/src/components/Option/ScheduledTasks/ScheduledTaskOverview.tsx
+++ b/apps/packages/ui/src/components/Option/ScheduledTasks/ScheduledTaskOverview.tsx
@@ -1,5 +1,6 @@
 import React from "react"
-import { Button, Card, Col, Row, Space, Tag, Typography } from "antd"
+import { Button, Card, Col, Row, Space, Typography } from "antd"
+import { Badge as DesignSystemBadge } from "@/components/ui/primitives"
 import type { ScheduledTask } from "@/services/scheduled-tasks-control-plane"
 import {
   SCHEDULED_TASK_ATTENTION_STATUS_KEYS,
@@ -94,7 +95,11 @@ export const ScheduledTaskOverview: React.FC<ScheduledTaskOverviewProps> = ({
             title="Total scheduled tasks"
             value={countLabel(tasks.length, "scheduled task")}
           >
-            {partial ? <Tag color="gold">Partial data</Tag> : <Tag color="blue">Loaded</Tag>}
+            {partial ? (
+              <DesignSystemBadge variant="warning">Partial data</DesignSystemBadge>
+            ) : (
+              <DesignSystemBadge variant="success">Loaded</DesignSystemBadge>
+            )}
           </OverviewPanel>
         </Col>
         <Col xs={24} sm={12} lg={6}>
@@ -102,7 +107,9 @@ export const ScheduledTaskOverview: React.FC<ScheduledTaskOverviewProps> = ({
             title="Needs attention"
             value={`${needsAttentionCount} needs attention`}
           >
-            {needsAttentionCount > 0 ? <Tag color="red">Review required</Tag> : null}
+            {needsAttentionCount > 0 ? (
+              <DesignSystemBadge variant="danger">Review required</DesignSystemBadge>
+            ) : null}
           </OverviewPanel>
         </Col>
         <Col xs={24} sm={12} lg={6}>
@@ -110,7 +117,9 @@ export const ScheduledTaskOverview: React.FC<ScheduledTaskOverviewProps> = ({
             title="Running now"
             value={`${runningNowCount} running now`}
           >
-            {runningNowCount > 0 ? <Tag color="processing">Active</Tag> : null}
+            {runningNowCount > 0 ? (
+              <DesignSystemBadge variant="info">Active</DesignSystemBadge>
+            ) : null}
           </OverviewPanel>
         </Col>
         <Col xs={24} sm={12} lg={6}>
@@ -118,7 +127,9 @@ export const ScheduledTaskOverview: React.FC<ScheduledTaskOverviewProps> = ({
             title="Next upcoming run"
             value={formatRunDate(nextRunTimestamp)}
           >
-            {nextRunTimestamp === null ? <Tag color="gold">Not scheduled</Tag> : null}
+            {nextRunTimestamp === null ? (
+              <DesignSystemBadge variant="warning">Not scheduled</DesignSystemBadge>
+            ) : null}
           </OverviewPanel>
         </Col>
       </Row>

--- a/apps/packages/ui/src/components/Option/ScheduledTasks/ScheduledTaskResultDetailDrawer.tsx
+++ b/apps/packages/ui/src/components/Option/ScheduledTasks/ScheduledTaskResultDetailDrawer.tsx
@@ -1,8 +1,16 @@
 import React from "react"
-import { Alert, Button, Descriptions, Drawer, Space, Tag, Typography } from "antd"
+import { Button, Descriptions, Drawer, Space, Typography } from "antd"
+import {
+  Alert as DesignSystemAlert,
+  Badge as DesignSystemBadge,
+  type BadgeVariant
+} from "@/components/ui/primitives"
 
 import { formatScheduledTaskTimestamp } from "./scheduled-task-status"
-import type { ScheduledTaskResultItem } from "./scheduled-task-results"
+import {
+  getScheduledTaskResultStatusLabel,
+  type ScheduledTaskResultItem
+} from "./scheduled-task-results"
 
 export interface ScheduledTaskResultDetailDrawerProps {
   open: boolean
@@ -15,26 +23,19 @@ export interface ScheduledTaskResultDetailDrawerProps {
 const UNSUPPORTED_ACTION_COPY =
   "Review and retry actions appear when this server supports them for the selected result."
 
-const severityToTagColor = (severity: ScheduledTaskResultItem["severity"]): string => {
+const severityToBadgeVariant = (
+  severity: ScheduledTaskResultItem["severity"]
+): BadgeVariant => {
   switch (severity) {
     case "success":
-      return "green"
+      return "success"
     case "warning":
-      return "gold"
+      return "warning"
     case "error":
-      return "red"
+      return "danger"
     default:
-      return "processing"
+      return "info"
   }
-}
-
-const statusLabel = (result: ScheduledTaskResultItem): string => {
-  if (result.signalKind === "result") return "Found results"
-  if (result.state === "blocked") return "Blocked"
-  if (result.signalKind === "failure") return "Needs attention"
-  if (result.state === "paused") return "Paused"
-  if (result.signalKind === "running") return "Running now"
-  return "Completed/no results"
 }
 
 const optionalDescriptionItem = (
@@ -102,9 +103,9 @@ export const ScheduledTaskResultDetailDrawer: React.FC<
 
           <Descriptions bordered size="small" column={1}>
             <Descriptions.Item label="State">
-              <Tag color={severityToTagColor(result.severity)}>
-                {statusLabel(result)}
-              </Tag>
+              <DesignSystemBadge variant={severityToBadgeVariant(result.severity)}>
+                {getScheduledTaskResultStatusLabel(result)}
+              </DesignSystemBadge>
             </Descriptions.Item>
             <Descriptions.Item label="Owner">{result.ownerLabel}</Descriptions.Item>
             <Descriptions.Item label="Task type">{result.taskTypeLabel}</Descriptions.Item>
@@ -141,7 +142,7 @@ export const ScheduledTaskResultDetailDrawer: React.FC<
                 ) : null}
               </Space>
             ) : (
-              <Alert type="info" showIcon title={UNSUPPORTED_ACTION_COPY} />
+              <DesignSystemAlert variant="info" title={UNSUPPORTED_ACTION_COPY} />
             )}
           </div>
         </Space>

--- a/apps/packages/ui/src/components/Option/ScheduledTasks/ScheduledTaskResultDetailDrawer.tsx
+++ b/apps/packages/ui/src/components/Option/ScheduledTasks/ScheduledTaskResultDetailDrawer.tsx
@@ -2,13 +2,13 @@ import React from "react"
 import { Button, Descriptions, Drawer, Space, Typography } from "antd"
 import {
   Alert as DesignSystemAlert,
-  Badge as DesignSystemBadge,
-  type BadgeVariant
+  Badge as DesignSystemBadge
 } from "@/components/ui/primitives"
 
 import { formatScheduledTaskTimestamp } from "./scheduled-task-status"
 import {
   getScheduledTaskResultStatusLabel,
+  scheduledTaskResultSeverityToBadgeVariant,
   type ScheduledTaskResultItem
 } from "./scheduled-task-results"
 
@@ -22,21 +22,6 @@ export interface ScheduledTaskResultDetailDrawerProps {
 
 const UNSUPPORTED_ACTION_COPY =
   "Review and retry actions appear when this server supports them for the selected result."
-
-const severityToBadgeVariant = (
-  severity: ScheduledTaskResultItem["severity"]
-): BadgeVariant => {
-  switch (severity) {
-    case "success":
-      return "success"
-    case "warning":
-      return "warning"
-    case "error":
-      return "danger"
-    default:
-      return "info"
-  }
-}
 
 const optionalDescriptionItem = (
   label: string,
@@ -103,7 +88,9 @@ export const ScheduledTaskResultDetailDrawer: React.FC<
 
           <Descriptions bordered size="small" column={1}>
             <Descriptions.Item label="State">
-              <DesignSystemBadge variant={severityToBadgeVariant(result.severity)}>
+              <DesignSystemBadge
+                variant={scheduledTaskResultSeverityToBadgeVariant(result.severity)}
+              >
                 {getScheduledTaskResultStatusLabel(result)}
               </DesignSystemBadge>
             </Descriptions.Item>

--- a/apps/packages/ui/src/components/Option/ScheduledTasks/ScheduledTaskResultsPanel.tsx
+++ b/apps/packages/ui/src/components/Option/ScheduledTasks/ScheduledTaskResultsPanel.tsx
@@ -1,10 +1,17 @@
 import React, { useMemo, useState } from "react"
-import { Alert, Button, Empty, Input, Select, Space, Table, Tag, Typography } from "antd"
+import { Button, Input, Select, Space, Table, Typography } from "antd"
 import type { ColumnsType } from "antd/es/table"
+import { EmptyState } from "@/components/ui/feedback"
+import {
+  Alert as DesignSystemAlert,
+  Badge as DesignSystemBadge,
+  type BadgeVariant
+} from "@/components/ui/primitives"
 
 import { formatScheduledTaskTimestamp } from "./scheduled-task-status"
 import {
   filterScheduledTaskResults,
+  getScheduledTaskResultStatusLabel,
   type ScheduledTaskResultItem,
   type ScheduledTaskResultOwner,
   type ScheduledTaskResultSignalKind,
@@ -43,26 +50,19 @@ const reviewStateOptions: Array<{ value: ReviewStateFilter; label: string }> = [
   { value: "reviewed", label: "Reviewed" }
 ]
 
-const severityToTagColor = (severity: ScheduledTaskResultItem["severity"]): string => {
+const severityToBadgeVariant = (
+  severity: ScheduledTaskResultItem["severity"]
+): BadgeVariant => {
   switch (severity) {
     case "success":
-      return "green"
+      return "success"
     case "warning":
-      return "gold"
+      return "warning"
     case "error":
-      return "red"
+      return "danger"
     default:
-      return "processing"
+      return "info"
   }
-}
-
-const resultStatusLabel = (result: ScheduledTaskResultItem): string => {
-  if (result.signalKind === "result") return "Found results"
-  if (result.state === "blocked") return "Blocked"
-  if (result.signalKind === "failure") return "Needs attention"
-  if (result.state === "paused") return "Paused"
-  if (result.signalKind === "running") return "Running now"
-  return "Completed/no results"
 }
 
 const stateFilterToSignalKinds = (
@@ -169,7 +169,7 @@ export const ScheduledTaskResultsPanel: React.FC<ScheduledTaskResultsPanelProps>
           result.sourceLabel,
           result.matchedRuleLabel,
           result.outputLabel,
-          resultStatusLabel(result)
+          getScheduledTaskResultStatusLabel(result)
         ].some((value) => String(value || "").toLowerCase().includes(normalizedSearch))
 
       return taskTypeMatches && searchMatches
@@ -209,8 +209,8 @@ export const ScheduledTaskResultsPanel: React.FC<ScheduledTaskResultsPanelProps>
           <Typography.Text strong>{result.title}</Typography.Text>
           <Typography.Text type="secondary">{result.summary}</Typography.Text>
           <Space wrap size={4}>
-            <Tag>{result.taskTypeLabel}</Tag>
-            <Tag>{result.ownerLabel}</Tag>
+            <DesignSystemBadge variant="secondary">{result.taskTypeLabel}</DesignSystemBadge>
+            <DesignSystemBadge variant="secondary">{result.ownerLabel}</DesignSystemBadge>
           </Space>
         </Space>
       )
@@ -219,9 +219,9 @@ export const ScheduledTaskResultsPanel: React.FC<ScheduledTaskResultsPanelProps>
       title: "State",
       key: "state",
       render: (_, result) => (
-        <Tag color={severityToTagColor(result.severity)}>
-          {resultStatusLabel(result)}
-        </Tag>
+        <DesignSystemBadge variant={severityToBadgeVariant(result.severity)}>
+          {getScheduledTaskResultStatusLabel(result)}
+        </DesignSystemBadge>
       )
     },
     {
@@ -252,21 +252,15 @@ export const ScheduledTaskResultsPanel: React.FC<ScheduledTaskResultsPanelProps>
     return (
       <Space orientation="vertical" size={16} style={{ width: "100%" }}>
         <PanelHeader capabilityMode={capabilityMode} />
-        <Empty
-          image={Empty.PRESENTED_IMAGE_SIMPLE}
-          description={
-            <Space orientation="vertical" size={4}>
-              <Typography.Text strong>No scheduled tasks yet</Typography.Text>
-              <Typography.Text type="secondary">
-                Results and failures appear here after an automation runs.
-              </Typography.Text>
-            </Space>
-          }
-        >
-          <Button type="primary" onClick={onCreateTask}>
-            Create scheduled task
-          </Button>
-        </Empty>
+        <EmptyState
+          variant="inline"
+          title="No scheduled tasks yet"
+          description="Results and failures appear here after an automation runs."
+          primaryAction={{
+            label: "Create scheduled task",
+            onClick: onCreateTask
+          }}
+        />
       </Space>
     )
   }
@@ -275,16 +269,10 @@ export const ScheduledTaskResultsPanel: React.FC<ScheduledTaskResultsPanelProps>
     return (
       <Space orientation="vertical" size={16} style={{ width: "100%" }}>
         <PanelHeader capabilityMode={capabilityMode} />
-        <Empty
-          image={Empty.PRESENTED_IMAGE_SIMPLE}
-          description={
-            <Space orientation="vertical" size={4}>
-              <Typography.Text strong>No automation signals yet</Typography.Text>
-              <Typography.Text type="secondary">
-                The latest scheduled runs have not produced new results or failures.
-              </Typography.Text>
-            </Space>
-          }
+        <EmptyState
+          variant="inline"
+          title="No automation signals yet"
+          description="The latest scheduled runs have not produced new results or failures."
         />
       </Space>
     )
@@ -347,19 +335,19 @@ export const ScheduledTaskResultsPanel: React.FC<ScheduledTaskResultsPanelProps>
       </Space>
 
       {filteredResults.length === 0 ? (
-        <Empty
-          image={Empty.PRESENTED_IMAGE_SIMPLE}
-          description={
-            <Space orientation="vertical" size={4}>
-              <Typography.Text strong>No results match these filters</Typography.Text>
-              <Typography.Text type="secondary">
-                Adjust the result state, task type, owner, or search filters.
-              </Typography.Text>
-            </Space>
+        <EmptyState
+          variant="inline"
+          title="No results match these filters"
+          description="Adjust the result state, task type, owner, or search filters."
+          primaryAction={
+            activeFilters
+              ? {
+                  label: "Clear filters",
+                  onClick: resetFilters
+                }
+              : undefined
           }
-        >
-          {activeFilters ? <Button onClick={resetFilters}>Clear filters</Button> : null}
-        </Empty>
+        />
       ) : (
         <Table<ScheduledTaskResultItem>
           rowKey="id"
@@ -386,16 +374,14 @@ const PanelHeader: React.FC<{ capabilityMode: ScheduledTaskResultsCapabilityMode
         Source-specific setup stays in the owning workspace.
       </Typography.Paragraph>
     </div>
-    <Alert
-      type="info"
-      showIcon
+    <DesignSystemAlert
+      variant="info"
       title={capabilityMode === "projected_signals" ? "Latest automation signals" : "Results"}
-      description={
-        capabilityMode === "projected_signals"
-          ? "Latest signals inferred from task status. Result history and item actions appear when the results API is available."
-          : "Review state comes from the scheduled-task results API."
-      }
-    />
+    >
+      {capabilityMode === "projected_signals"
+        ? "Latest signals inferred from task status. Result history and item actions appear when the results API is available."
+        : "Review state comes from the scheduled-task results API."}
+    </DesignSystemAlert>
   </Space>
 )
 

--- a/apps/packages/ui/src/components/Option/ScheduledTasks/ScheduledTaskResultsPanel.tsx
+++ b/apps/packages/ui/src/components/Option/ScheduledTasks/ScheduledTaskResultsPanel.tsx
@@ -4,14 +4,14 @@ import type { ColumnsType } from "antd/es/table"
 import { EmptyState } from "@/components/ui/feedback"
 import {
   Alert as DesignSystemAlert,
-  Badge as DesignSystemBadge,
-  type BadgeVariant
+  Badge as DesignSystemBadge
 } from "@/components/ui/primitives"
 
 import { formatScheduledTaskTimestamp } from "./scheduled-task-status"
 import {
   filterScheduledTaskResults,
   getScheduledTaskResultStatusLabel,
+  scheduledTaskResultSeverityToBadgeVariant,
   type ScheduledTaskResultItem,
   type ScheduledTaskResultOwner,
   type ScheduledTaskResultSignalKind,
@@ -49,21 +49,6 @@ const reviewStateOptions: Array<{ value: ReviewStateFilter; label: string }> = [
   { value: "unreviewed", label: "Unreviewed" },
   { value: "reviewed", label: "Reviewed" }
 ]
-
-const severityToBadgeVariant = (
-  severity: ScheduledTaskResultItem["severity"]
-): BadgeVariant => {
-  switch (severity) {
-    case "success":
-      return "success"
-    case "warning":
-      return "warning"
-    case "error":
-      return "danger"
-    default:
-      return "info"
-  }
-}
 
 const stateFilterToSignalKinds = (
   stateFilter: ResultStateFilter
@@ -219,7 +204,9 @@ export const ScheduledTaskResultsPanel: React.FC<ScheduledTaskResultsPanelProps>
       title: "State",
       key: "state",
       render: (_, result) => (
-        <DesignSystemBadge variant={severityToBadgeVariant(result.severity)}>
+        <DesignSystemBadge
+          variant={scheduledTaskResultSeverityToBadgeVariant(result.severity)}
+        >
           {getScheduledTaskResultStatusLabel(result)}
         </DesignSystemBadge>
       )

--- a/apps/packages/ui/src/components/Option/ScheduledTasks/ScheduledTaskTable.tsx
+++ b/apps/packages/ui/src/components/Option/ScheduledTasks/ScheduledTaskTable.tsx
@@ -1,6 +1,11 @@
 import React, { useMemo, useState } from "react"
-import { Button, Input, Select, Space, Table, Tag, Typography } from "antd"
+import { Button, Input, Select, Space, Table, Typography } from "antd"
 import type { ColumnsType } from "antd/es/table"
+import { BLOCKED_STATE_LABEL } from "@/design-system"
+import {
+  Badge as DesignSystemBadge,
+  type BadgeVariant
+} from "@/components/ui/primitives"
 import type {
   ScheduledTask,
   ScheduledTaskPrimitive
@@ -11,7 +16,7 @@ import {
   getScheduledTaskProductStatus,
   getScheduledTaskTypeLabel,
   isNativeReminderTask,
-  scheduledTaskStatusToneToTagColor,
+  scheduledTaskStatusToneToBadgeVariant,
   type ScheduledTaskProductStatus,
   type ScheduledTaskStatusKey
 } from "./scheduled-task-status"
@@ -35,8 +40,8 @@ export interface ScheduledTaskTableProps {
 type ScheduledTaskStatusFilter = "all" | ScheduledTaskStatusKey
 type ScheduledTaskTypeFilter = "all" | ScheduledTaskPrimitive
 
-const typeTagColor = (task: ScheduledTask): string =>
-  task.primitive === "watchlist_job" ? "gold" : "blue"
+const typeBadgeVariant = (task: ScheduledTask): BadgeVariant =>
+  task.primitive === "watchlist_job" ? "warning" : "info"
 
 const rowActionLabel = (action: string, task: ScheduledTask): string =>
   `${action} ${task.title}`
@@ -81,7 +86,7 @@ const statusFilterOptions: Array<{
   { value: "running", label: "Running now" },
   { value: "waiting", label: "Waiting" },
   { value: "found_results", label: "Found results" },
-  { value: "blocked", label: "Blocked" },
+  { value: "blocked", label: BLOCKED_STATE_LABEL },
   { value: "paused", label: "Paused" },
   { value: "disabled", label: "Disabled" },
   { value: "draft", label: "Draft" },
@@ -160,7 +165,9 @@ export const ScheduledTaskTable: React.FC<ScheduledTaskTableProps> = ({
             {task.description || task.schedule_summary || "—"}
           </Typography.Text>
           <div>
-            <Tag color={typeTagColor(task)}>{getScheduledTaskTypeLabel(task)}</Tag>
+            <DesignSystemBadge variant={typeBadgeVariant(task)}>
+              {getScheduledTaskTypeLabel(task)}
+            </DesignSystemBadge>
           </div>
         </div>
       )
@@ -174,9 +181,11 @@ export const ScheduledTaskTable: React.FC<ScheduledTaskTableProps> = ({
         return (
           <div style={{ display: "flex", flexDirection: "column" }}>
             <div>
-              <Tag color={scheduledTaskStatusToneToTagColor(productStatus)}>
+              <DesignSystemBadge
+                variant={scheduledTaskStatusToneToBadgeVariant(productStatus)}
+              >
                 {productStatus.label}
-              </Tag>
+              </DesignSystemBadge>
             </div>
             <Typography.Text type="secondary">
               {productStatus.description}
@@ -219,9 +228,9 @@ export const ScheduledTaskTable: React.FC<ScheduledTaskTableProps> = ({
       title: "Management",
       key: "management",
       render: (_, task) => (
-        <Tag color={isNativeReminderTask(task) ? "blue" : "gold"}>
+        <DesignSystemBadge variant={isNativeReminderTask(task) ? "info" : "warning"}>
           {isNativeReminderTask(task) ? "Managed here" : "Managed in Watchlists"}
-        </Tag>
+        </DesignSystemBadge>
       )
     },
     {

--- a/apps/packages/ui/src/components/Option/ScheduledTasks/ScheduledTasksPage.tsx
+++ b/apps/packages/ui/src/components/Option/ScheduledTasks/ScheduledTasksPage.tsx
@@ -1,8 +1,10 @@
 import React, { useState } from "react"
-import { Alert, Button, Empty, Space, Spin, Tabs, Typography, message } from "antd"
+import { Button, Space, Tabs, Typography, message } from "antd"
 import { useQuery } from "@tanstack/react-query"
 import { useTranslation } from "react-i18next"
 import { useLocation, useNavigate, useSearchParams } from "react-router-dom"
+import { EmptyState, LoadingState as DesignSystemLoadingState } from "@/components/ui/feedback"
+import { Alert as DesignSystemAlert } from "@/components/ui/primitives"
 import { RecoveryCallout, buildCapabilityState } from "@/components/ui/state"
 import { useCanonicalConnectionConfig } from "@/hooks/useCanonicalConnectionConfig"
 import {
@@ -40,15 +42,6 @@ import {
 
 const SCHEDULED_TASKS_PATH = "/api/v1/scheduled-tasks"
 const SCHEDULED_TASKS_SUPPORT_PROBE_TIMEOUT_MS = 8000
-
-const LoadingState: React.FC = () => (
-  <div role="status" aria-live="polite">
-    <Space>
-      <Spin size="small" />
-      <Typography.Text type="secondary">Loading tasks and latest run state</Typography.Text>
-    </Space>
-  </div>
-)
 
 export const ScheduledTasksPage: React.FC = () => {
   const location = useLocation()
@@ -431,9 +424,8 @@ export const ScheduledTasksPage: React.FC = () => {
       ) : null}
 
       {hasLoadedTasks && hasWatchlistJob ? (
-        <Alert
-          type="info"
-          showIcon
+        <DesignSystemAlert
+          variant="info"
           title="Watchlists remains the full workspace for monitor setup, source tuning, run activity, and reports."
         />
       ) : null}
@@ -456,7 +448,7 @@ export const ScheduledTasksPage: React.FC = () => {
   const renderResultsTab = () => (
     <Space orientation="vertical" size={16} style={{ width: "100%" }}>
       {missingRouteResult ? (
-        <Alert type="warning" showIcon title="Result signal not found." />
+        <DesignSystemAlert variant="warning" title="Result signal not found." />
       ) : null}
       <ScheduledTaskResultsPanel
         results={projectedResults}
@@ -470,26 +462,20 @@ export const ScheduledTasksPage: React.FC = () => {
 
   const renderTasksTab = () => (
     <Space orientation="vertical" size={16} style={{ width: "100%" }}>
-      {missingRouteTask ? <Alert type="warning" showIcon title="Task not found." /> : null}
+      {missingRouteTask ? (
+        <DesignSystemAlert variant="warning" title="Task not found." />
+      ) : null}
 
       {hasLoadedTasks && tasks.length === 0 ? (
-        <Empty
-          image={Empty.PRESENTED_IMAGE_SIMPLE}
-          description={
-            <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
-              <Typography.Text strong>No scheduled tasks yet.</Typography.Text>
-              <Typography.Text type="secondary">
-                Create a reminder now. Watch and Ingest setup continue in their owner
-                workspaces until capability, preview, duplicate, creation, and result
-                contracts are available.
-              </Typography.Text>
-            </div>
-          }
-        >
-          <Button type="primary" onClick={openCreateReminder}>
-            Create scheduled task
-          </Button>
-        </Empty>
+        <EmptyState
+          variant="inline"
+          title="No scheduled tasks yet."
+          description="Create a reminder now. Watch and Ingest setup continue in their owner workspaces until capability, preview, duplicate, creation, and result contracts are available."
+          primaryAction={{
+            label: "Create scheduled task",
+            onClick: openCreateReminder
+          }}
+        />
       ) : null}
 
       {hasLoadedTasks && tasks.length > 0 ? (
@@ -520,11 +506,19 @@ export const ScheduledTasksPage: React.FC = () => {
         </Typography.Paragraph>
       </div>
 
-      {isLoadingTasks ? <LoadingState /> : null}
+      {isLoadingTasks ? (
+        <div role="status" aria-live="polite">
+          <DesignSystemLoadingState
+            mode="inline"
+            size="sm"
+            label="Loading tasks and latest run state"
+            className="w-full"
+          />
+        </div>
+      ) : null}
       {routeState.invalidTab ? (
-        <Alert
-          type="warning"
-          showIcon
+        <DesignSystemAlert
+          variant="warning"
           title="That tab is not available. Showing Overview."
         />
       ) : null}

--- a/apps/packages/ui/src/components/Option/ScheduledTasks/WatchlistJobReadOnlyPanel.tsx
+++ b/apps/packages/ui/src/components/Option/ScheduledTasks/WatchlistJobReadOnlyPanel.tsx
@@ -1,7 +1,12 @@
 import React from "react"
-import { Button, Card, Descriptions, Tag, Typography } from "antd"
+import { Button, Card, Descriptions, Typography } from "antd"
+import { Badge as DesignSystemBadge } from "@/components/ui/primitives"
 import type { ScheduledTask } from "@/services/scheduled-tasks-control-plane"
-import { buildWatchlistTaskLinks } from "./scheduled-task-status"
+import {
+  buildWatchlistTaskLinks,
+  getScheduledTaskProductStatus,
+  scheduledTaskStatusToneToBadgeVariant
+} from "./scheduled-task-status"
 
 type WatchlistJobReadOnlyPanelProps = {
   task: ScheduledTask
@@ -13,6 +18,7 @@ export const WatchlistJobReadOnlyPanel: React.FC<WatchlistJobReadOnlyPanelProps>
   onOpenManageUrl
 }) => {
   const manageUrl = buildWatchlistTaskLinks(task).settingsUrl ?? "/watchlists?tab=jobs"
+  const productStatus = getScheduledTaskProductStatus(task)
 
   return (
     <Card title={task.title}>
@@ -24,7 +30,11 @@ export const WatchlistJobReadOnlyPanel: React.FC<WatchlistJobReadOnlyPanelProps>
           <Descriptions.Item label="Schedule">{task.schedule_summary || "Manual"}</Descriptions.Item>
           <Descriptions.Item label="Timezone">{task.timezone || "—"}</Descriptions.Item>
           <Descriptions.Item label="Status">
-            <Tag color={task.enabled ? "green" : "default"}>{task.status}</Tag>
+            <DesignSystemBadge
+              variant={scheduledTaskStatusToneToBadgeVariant(productStatus)}
+            >
+              {productStatus.label}
+            </DesignSystemBadge>
           </Descriptions.Item>
         </Descriptions>
         <Button href={manageUrl} onClick={() => onOpenManageUrl(task)}>

--- a/apps/packages/ui/src/components/Option/ScheduledTasks/__tests__/ScheduledTaskCreatePanel.test.tsx
+++ b/apps/packages/ui/src/components/Option/ScheduledTasks/__tests__/ScheduledTaskCreatePanel.test.tsx
@@ -5,6 +5,8 @@ import { render, screen, waitFor } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import { describe, expect, it, vi } from "vitest"
 
+import { expectInsideDesignSystemAlert } from "@/test-utils/designSystemAlert"
+
 import { ScheduledTaskCreatePanel } from "../ScheduledTaskCreatePanel"
 import {
   REQUIRED_WATCH_AVAILABILITY_GATES,
@@ -263,6 +265,7 @@ describe("ScheduledTaskCreatePanel", () => {
     )
 
     expect(screen.getByText(/private-looking values/)).toBeInTheDocument()
+    expectInsideDesignSystemAlert(/private-looking values/)
     expect(screen.getByLabelText("Setup summary")).not.toHaveTextContent(
       "https://example.com/feed?token=secret"
     )

--- a/apps/packages/ui/src/components/Option/ScheduledTasks/__tests__/ScheduledTaskResultDetailDrawer.test.tsx
+++ b/apps/packages/ui/src/components/Option/ScheduledTasks/__tests__/ScheduledTaskResultDetailDrawer.test.tsx
@@ -5,6 +5,7 @@ import { render, screen } from "@testing-library/react"
 import { describe, expect, it, vi } from "vitest"
 
 import type { ScheduledTask } from "@/services/scheduled-tasks-control-plane"
+import { expectInsideDesignSystemAlert } from "@/test-utils/designSystemAlert"
 
 import { ScheduledTaskResultDetailDrawer } from "../ScheduledTaskResultDetailDrawer"
 import { projectScheduledTaskResults } from "../scheduled-task-results"
@@ -38,6 +39,16 @@ const buildResult = () =>
     capabilityMode: "projected_signals"
   })[0]
 
+const expectInsideDesignSystemBadge = (text: string | RegExp): HTMLElement => {
+  const match = screen
+    .getAllByText(text)
+    .map((node) => node.closest('[data-ds-component="Badge"]'))
+    .find((node): node is HTMLElement => node instanceof HTMLElement)
+
+  expect(match).toBeTruthy()
+  return match
+}
+
 describe("ScheduledTaskResultDetailDrawer", () => {
   it("shows result provenance, owner, ids, and Watchlists deep links", () => {
     const result = buildResult()
@@ -55,6 +66,7 @@ describe("ScheduledTaskResultDetailDrawer", () => {
     expect(screen.getByRole("dialog", { name: /Release monitor/i })).toBeInTheDocument()
     expect(screen.getByText("Why this is here")).toBeInTheDocument()
     expect(screen.getByText("Found 3 results from Release feed.")).toBeInTheDocument()
+    expectInsideDesignSystemBadge("Found results")
     expect(screen.getByText("Watchlists")).toBeInTheDocument()
     expect(screen.getByText("Release feed")).toBeInTheDocument()
     expect(screen.getByText("New release")).toBeInTheDocument()
@@ -92,6 +104,9 @@ describe("ScheduledTaskResultDetailDrawer", () => {
     expect(
       screen.getByText("Review and retry actions appear when this server supports them for the selected result.")
     ).toBeInTheDocument()
+    expectInsideDesignSystemAlert(
+      "Review and retry actions appear when this server supports them for the selected result."
+    )
   })
 
   it("shows mutation actions only when item capabilities allow them", () => {

--- a/apps/packages/ui/src/components/Option/ScheduledTasks/__tests__/ScheduledTaskResultsPanel.test.tsx
+++ b/apps/packages/ui/src/components/Option/ScheduledTasks/__tests__/ScheduledTaskResultsPanel.test.tsx
@@ -6,6 +6,7 @@ import userEvent from "@testing-library/user-event"
 import { describe, expect, it, vi } from "vitest"
 
 import type { ScheduledTask } from "@/services/scheduled-tasks-control-plane"
+import { expectInsideDesignSystemAlert } from "@/test-utils/designSystemAlert"
 
 import { ScheduledTaskResultsPanel } from "../ScheduledTaskResultsPanel"
 import { projectScheduledTaskResults } from "../scheduled-task-results"
@@ -72,6 +73,20 @@ const buildResults = () =>
     { includeCompletedNoResults: true }
   )
 
+const expectInsideDesignSystemComponent = (
+  text: string | RegExp,
+  componentName: string
+): HTMLElement => {
+  const marker = `[data-ds-component="${componentName}"]`
+  const match = screen
+    .getAllByText(text)
+    .map((node) => node.closest(marker))
+    .find((node): node is HTMLElement => node instanceof HTMLElement)
+
+  expect(match).toBeTruthy()
+  return match
+}
+
 describe("ScheduledTaskResultsPanel", () => {
   it("renders projected success, failure, running, paused, and completed-no-results signals", () => {
     render(
@@ -86,12 +101,15 @@ describe("ScheduledTaskResultsPanel", () => {
 
     expect(screen.getByRole("heading", { name: "Scheduled task results" })).toBeInTheDocument()
     expect(screen.getByText("Latest automation signals")).toBeInTheDocument()
+    expectInsideDesignSystemAlert("Latest automation signals")
     expect(screen.getByText("Release monitor")).toBeInTheDocument()
     expect(screen.getByText("Found 3 results from Release feed.")).toBeInTheDocument()
     expect(screen.getByText("Follow up")).toBeInTheDocument()
     expect(screen.getByText("Needs attention")).toBeInTheDocument()
+    expectInsideDesignSystemComponent("Needs attention", "Badge")
     expect(screen.getByText("Running monitor")).toBeInTheDocument()
     expect(screen.getByText("Running now")).toBeInTheDocument()
+    expectInsideDesignSystemComponent("Running now", "Badge")
     expect(screen.getByText("Paused monitor")).toBeInTheDocument()
     expect(screen.getByText("Paused monitor is paused.")).toBeInTheDocument()
     expect(screen.getByText("Paused")).toBeInTheDocument()
@@ -123,6 +141,7 @@ describe("ScheduledTaskResultsPanel", () => {
     await user.click(await screen.findByTitle("Watchlist monitor"))
 
     expect(screen.getByText("No results match these filters")).toBeInTheDocument()
+    expectInsideDesignSystemComponent("No results match these filters", "EmptyState")
 
     await user.click(screen.getByRole("button", { name: "Clear filters" }))
     await user.click(screen.getByRole("combobox", { name: "Owner filter" }))
@@ -172,6 +191,7 @@ describe("ScheduledTaskResultsPanel", () => {
     )
 
     expect(screen.getByText("No scheduled tasks yet")).toBeInTheDocument()
+    expectInsideDesignSystemComponent("No scheduled tasks yet", "EmptyState")
     await user.click(screen.getByRole("button", { name: "Create scheduled task" }))
     expect(onCreateTask).toHaveBeenCalledTimes(1)
 
@@ -186,6 +206,7 @@ describe("ScheduledTaskResultsPanel", () => {
     )
 
     expect(screen.getByText("No automation signals yet")).toBeInTheDocument()
+    expectInsideDesignSystemComponent("No automation signals yet", "EmptyState")
   })
 
   it("opens a result with an accessible action name", async () => {

--- a/apps/packages/ui/src/components/Option/ScheduledTasks/__tests__/ScheduledTasksPage.test.tsx
+++ b/apps/packages/ui/src/components/Option/ScheduledTasks/__tests__/ScheduledTasksPage.test.tsx
@@ -7,6 +7,8 @@ import userEvent from "@testing-library/user-event"
 import { MemoryRouter } from "react-router-dom"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
+import { expectInsideDesignSystemAlert } from "@/test-utils/designSystemAlert"
+
 const mocks = vi.hoisted(() => ({
   useCanonicalConnectionConfig: vi.fn(),
   listScheduledTasks: vi.fn(),
@@ -44,6 +46,20 @@ const fetchMock = vi.fn()
 vi.stubGlobal("fetch", fetchMock)
 
 const SLOW_SCHEDULE_FORM_TIMEOUT_MS = 20000
+
+const expectInsideDesignSystemComponent = (
+  text: string | RegExp,
+  componentName: string
+): HTMLElement => {
+  const marker = `[data-ds-component="${componentName}"]`
+  const match = screen
+    .getAllByText(text)
+    .map((node) => node.closest(marker))
+    .find((node): node is HTMLElement => node instanceof HTMLElement)
+
+  expect(match).toBeTruthy()
+  return match
+}
 
 const renderWithQueryClient = (
   ui: React.ReactElement,
@@ -339,6 +355,7 @@ describe("ScheduledTasksPage", () => {
 
     expect(await screen.findByRole("tab", { name: "Results" })).toHaveAttribute("aria-selected", "true")
     expect(await screen.findByText("Result signal not found.")).toBeInTheDocument()
+    expectInsideDesignSystemAlert("Result signal not found.")
     expect(screen.getByText("No scheduled tasks yet")).toBeInTheDocument()
   })
 
@@ -401,6 +418,7 @@ describe("ScheduledTasksPage", () => {
     renderWithQueryClient(<ScheduledTasksPage />, "/scheduled-tasks?tab=runs")
 
     expect(await screen.findByText("That tab is not available. Showing Overview.")).toBeInTheDocument()
+    expectInsideDesignSystemAlert("That tab is not available. Showing Overview.")
     expect(await screen.findByRole("tab", { name: "Overview" })).toHaveAttribute("aria-selected", "true")
     expect(await screen.findByText("0 scheduled tasks")).toBeInTheDocument()
   })
@@ -419,6 +437,7 @@ describe("ScheduledTasksPage", () => {
     )
 
     expect(await screen.findByText("Task not found.")).toBeInTheDocument()
+    expectInsideDesignSystemAlert("Task not found.")
     expect(screen.getByRole("tab", { name: "Tasks" })).toHaveAttribute("aria-selected", "true")
     expect(await screen.findByText("No scheduled tasks yet.")).toBeInTheDocument()
     expect(screen.queryByRole("dialog")).not.toBeInTheDocument()
@@ -479,6 +498,9 @@ describe("ScheduledTasksPage", () => {
     expect(screen.getByRole("button", { name: "Open latest result signal" })).toBeInTheDocument()
     expect(screen.getAllByText(/2030/).length).toBeGreaterThan(0)
     expect(screen.getByText(/Watchlists remains the full workspace/)).toBeInTheDocument()
+    expectInsideDesignSystemAlert(/Watchlists remains the full workspace/)
+    expectInsideDesignSystemComponent("Review required", "Badge")
+    expectInsideDesignSystemComponent("Active", "Badge")
     expect(screen.queryByRole("columnheader", { name: "Task" })).not.toBeInTheDocument()
   })
 
@@ -535,6 +557,11 @@ describe("ScheduledTasksPage", () => {
     const reminderRow = screen.getByText("Review notes").closest("tr")
     expect(reminderRow).not.toBeNull()
     expect(within(reminderRow as HTMLElement).getByText("Needs attention")).toBeInTheDocument()
+    expect(
+      within(reminderRow as HTMLElement)
+        .getByText("Needs attention")
+        .closest('[data-ds-component="Badge"]')
+    ).not.toBeNull()
     expect(within(reminderRow as HTMLElement).getByText("No completed runs yet")).toBeInTheDocument()
 
     expect(screen.getByRole("button", { name: "Inspect Review notes" })).toBeInTheDocument()
@@ -733,7 +760,7 @@ describe("ScheduledTasksPage", () => {
       expect(screen.queryByRole("dialog", { name: /Review notes/i })).not.toBeInTheDocument()
     })
     expect(await screen.findByText("No scheduled tasks yet.")).toBeInTheDocument()
-  })
+  }, SLOW_SCHEDULE_FORM_TIMEOUT_MS)
 
   it("filters scheduled tasks by product status and search text", async () => {
     const user = userEvent.setup()
@@ -882,6 +909,7 @@ describe("ScheduledTasksPage", () => {
     renderWithQueryClient(<ScheduledTasksPage />)
 
     expect(await screen.findByText("Loading tasks and latest run state")).toBeInTheDocument()
+    expectInsideDesignSystemComponent("Loading tasks and latest run state", "LoadingState")
   })
 
   it("shows an actionable empty state when no scheduled tasks exist", async () => {
@@ -897,6 +925,7 @@ describe("ScheduledTasksPage", () => {
     renderWithQueryClient(<ScheduledTasksPage />, "/scheduled-tasks?tab=tasks")
 
     expect(await screen.findByText("No scheduled tasks yet.")).toBeInTheDocument()
+    expectInsideDesignSystemComponent("No scheduled tasks yet.", "EmptyState")
     await user.click(screen.getByRole("button", { name: "Create scheduled task" }))
     expect(
       await screen.findByRole("heading", {

--- a/apps/packages/ui/src/components/Option/ScheduledTasks/__tests__/scheduled-task-results.test.ts
+++ b/apps/packages/ui/src/components/Option/ScheduledTasks/__tests__/scheduled-task-results.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest"
 
+import { BLOCKED_STATE_LABEL } from "@/design-system"
 import type { ScheduledTask } from "@/services/scheduled-tasks-control-plane"
 
 import {
@@ -137,6 +138,21 @@ describe("scheduled task result helpers", () => {
       summary: "Paused monitor is paused."
     })
     expect(buildScheduledTaskAutomationHomeItems([result])).toEqual([])
+  })
+
+  it("uses the canonical blocked label for blocked automation home items", () => {
+    const [result] = projectScheduledTaskResults([
+      buildTask({
+        id: "watchlist_job:blocked",
+        title: "Blocked monitor",
+        status: "blocked",
+        source_ref: { job_id: 9 }
+      })
+    ])
+
+    expect(buildScheduledTaskAutomationHomeItems([result])?.[0]?.statusLabel).toBe(
+      BLOCKED_STATE_LABEL
+    )
   })
 
   it("keeps result and failure signals separate for failed tasks that produced output", () => {

--- a/apps/packages/ui/src/components/Option/ScheduledTasks/__tests__/scheduled-task-status.test.ts
+++ b/apps/packages/ui/src/components/Option/ScheduledTasks/__tests__/scheduled-task-status.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from "vitest"
 
+import { BLOCKED_STATE_LABEL } from "@/design-system"
+
 import {
   buildWatchlistTaskLinks,
   getScheduledTaskProductStatus,
@@ -88,7 +90,7 @@ describe("scheduled task status helpers", () => {
         edit_mode: "external",
         source_ref: {}
       }).label
-    ).toBe("Blocked")
+    ).toBe(BLOCKED_STATE_LABEL)
 
     expect(
       getScheduledTaskProductStatus({

--- a/apps/packages/ui/src/components/Option/ScheduledTasks/__tests__/scheduled-task-templates.test.ts
+++ b/apps/packages/ui/src/components/Option/ScheduledTasks/__tests__/scheduled-task-templates.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from "vitest"
 
+import { UNAVAILABLE_STATE_LABEL } from "@/design-system"
+
 import {
   SCHEDULED_TASK_TEMPLATE_FILTERS,
   SCHEDULED_TASK_TEMPLATES,
@@ -141,7 +143,7 @@ describe("scheduled task templates", () => {
       "Managed in Watchlists"
     )
     expect(getScheduledTaskTemplateStateLabel("planned")).toBe("Planned capability")
-    expect(getScheduledTaskTemplateStateLabel("unavailable")).toBe("Unavailable")
+    expect(getScheduledTaskTemplateStateLabel("unavailable")).toBe(UNAVAILABLE_STATE_LABEL)
   })
 
   it("exposes the expected filter list", () => {

--- a/apps/packages/ui/src/components/Option/ScheduledTasks/scheduled-task-results.ts
+++ b/apps/packages/ui/src/components/Option/ScheduledTasks/scheduled-task-results.ts
@@ -1,6 +1,7 @@
 import type { CompanionHomeItem } from "@/services/companion-home"
 import type { NotificationItem } from "@/services/notifications"
 import type { ScheduledTask } from "@/services/scheduled-tasks-control-plane"
+import { BLOCKED_STATE_LABEL } from "@/design-system"
 
 import {
   buildScheduledTaskResultDedupeKey,
@@ -386,7 +387,7 @@ const buildStatusLabel = (
   }
 
   if (state === "blocked") {
-    return "Blocked"
+    return BLOCKED_STATE_LABEL
   }
 
   if (state === "paused") {
@@ -402,6 +403,17 @@ const buildStatusLabel = (
   }
 
   return "Completed"
+}
+
+export const getScheduledTaskResultStatusLabel = (
+  result: Pick<ScheduledTaskResultItem, "signalKind" | "state">
+): string => {
+  if (result.signalKind === "result") return "Found results"
+  if (result.state === "blocked") return BLOCKED_STATE_LABEL
+  if (result.signalKind === "failure") return "Needs attention"
+  if (result.state === "paused") return "Paused"
+  if (result.signalKind === "running") return "Running now"
+  return "Completed/no results"
 }
 
 const canMutateResults = (mode: ScheduledTaskResultsCapabilityMode): boolean =>

--- a/apps/packages/ui/src/components/Option/ScheduledTasks/scheduled-task-results.ts
+++ b/apps/packages/ui/src/components/Option/ScheduledTasks/scheduled-task-results.ts
@@ -2,6 +2,7 @@ import type { CompanionHomeItem } from "@/services/companion-home"
 import type { NotificationItem } from "@/services/notifications"
 import type { ScheduledTask } from "@/services/scheduled-tasks-control-plane"
 import { BLOCKED_STATE_LABEL } from "@/design-system"
+import type { BadgeVariant } from "@/components/ui/primitives"
 
 import {
   buildScheduledTaskResultDedupeKey,
@@ -414,6 +415,24 @@ export const getScheduledTaskResultStatusLabel = (
   if (result.state === "paused") return "Paused"
   if (result.signalKind === "running") return "Running now"
   return "Completed/no results"
+}
+
+export const scheduledTaskResultSeverityToBadgeVariant = (
+  severity: ScheduledTaskResultSeverity
+): BadgeVariant => {
+  switch (severity) {
+    case "success":
+      return "success"
+    case "warning":
+      return "warning"
+    case "error":
+      return "danger"
+    case "info":
+      return "info"
+  }
+
+  const _exhaustive: never = severity
+  return _exhaustive
 }
 
 const canMutateResults = (mode: ScheduledTaskResultsCapabilityMode): boolean =>

--- a/apps/packages/ui/src/components/Option/ScheduledTasks/scheduled-task-status.ts
+++ b/apps/packages/ui/src/components/Option/ScheduledTasks/scheduled-task-status.ts
@@ -1,4 +1,6 @@
 import type { ScheduledTask } from "@/services/scheduled-tasks-control-plane"
+import { BLOCKED_STATE_LABEL } from "@/design-system"
+import type { BadgeVariant } from "@/components/ui/primitives"
 
 export type ScheduledTaskStatusTone =
   | "success"
@@ -86,20 +88,20 @@ export const SCHEDULED_TASK_ATTENTION_STATUS_KEYS: readonly ScheduledTaskStatusK
 export const isNativeReminderTask = (task: ScheduledTask): boolean =>
   task.primitive === "reminder_task" && task.edit_mode === "native"
 
-export const scheduledTaskStatusToneToTagColor = (
+export const scheduledTaskStatusToneToBadgeVariant = (
   status: ScheduledTaskProductStatus
-): string => {
+): BadgeVariant => {
   switch (status.tone) {
     case "success":
-      return "green"
+      return "success"
     case "processing":
-      return "processing"
+      return "info"
     case "warning":
-      return "gold"
+      return "warning"
     case "error":
-      return "red"
+      return "danger"
     default:
-      return "default"
+      return "secondary"
   }
 }
 
@@ -227,7 +229,7 @@ export const getScheduledTaskProductStatus = (
   ) {
     return {
       key: "blocked",
-      label: "Blocked",
+      label: BLOCKED_STATE_LABEL,
       tone: "warning",
       description: "This task cannot run until a required dependency is fixed."
     }

--- a/apps/packages/ui/src/components/Option/ScheduledTasks/scheduled-task-templates.ts
+++ b/apps/packages/ui/src/components/Option/ScheduledTasks/scheduled-task-templates.ts
@@ -1,3 +1,5 @@
+import { UNAVAILABLE_STATE_LABEL } from "@/design-system"
+
 export type ScheduledTaskTemplateId =
   | "reminder"
   | "watch"
@@ -218,7 +220,7 @@ export const getScheduledTaskTemplateStateLabel = (
     case "planned":
       return "Planned capability"
     case "unavailable":
-      return "Unavailable"
+      return UNAVAILABLE_STATE_LABEL
   }
 }
 

--- a/backlog/tasks/task-45.44.21 - Migrate-ScheduledTasks-product-states-to-design-system-primitives.md
+++ b/backlog/tasks/task-45.44.21 - Migrate-ScheduledTasks-product-states-to-design-system-primitives.md
@@ -1,0 +1,67 @@
+---
+id: TASK-45.44.21
+title: Migrate ScheduledTasks product states to design-system primitives
+status: Done
+assignee: []
+created_date: ''
+updated_date: 2026-06-09 20:22
+labels:
+- design-system
+- webui
+- product-state
+- scheduled-tasks
+dependencies: []
+references:
+- apps/packages/ui/src/components/Option/ScheduledTasks
+- apps/packages/ui/src/components/ui/primitives/Alert.tsx
+- apps/packages/ui/src/components/ui/primitives/Badge.tsx
+- apps/packages/ui/src/components/ui/feedback/EmptyState.tsx
+- apps/packages/ui/src/components/ui/feedback/LoadingState.tsx
+- apps/packages/ui/src/design-system/states.ts
+- apps/packages/ui/scripts/design-system-product-state-baseline.json
+- https://github.com/rmusser01/tldw_server/pull/2336
+documentation:
+- Docs/Design/tldw_web_design_system_contract.md
+- Docs/Design/tldw_web_design_system_inventory.md
+- Docs/Design/tldw_web_design_system_baseline_reporting.md
+parent_task_id: TASK-45.44
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Continue the tldw_server WebUI design-system migration by resolving the current ScheduledTasks product-state guard drift on latest dev. Scope is limited to apps/packages/ui/src/components/Option/ScheduledTasks: replace product-state AntD Alert/Tag/Empty/Spin usage with shared design-system primitives and route ScheduledTasks canonical labels through the design-system state registry while preserving existing scheduled task behavior, copy, and tests.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 ScheduledTasks product-state Alerts render through the shared design-system Alert primitive while preserving copy and actions.
+- [x] #2 ScheduledTasks status Tags render through the shared design-system Badge primitive with canonical state mapping where applicable.
+- [x] #3 ScheduledTasks empty and loading states render through shared EmptyState/LoadingState primitives.
+- [x] #4 ScheduledTasks hardcoded canonical labels reported by the guard are routed through the design-system state registry.
+- [x] #5 Focused ScheduledTasks tests cover migrated product-state markers or registry labels.
+- [x] #6 Direct product-state guard scan over ScheduledTasks reports zero findings; full verifier status is recorded with unrelated drift noted if any.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implementation replaced ScheduledTasks AntD product-state Alert/Empty/Spin/Tag usage with DS Alert, EmptyState, LoadingState, and Badge primitives, including the read-only Watchlists panel. ScheduledTasks blocked/unavailable labels now come from the design-system registry. Verification: focused ScheduledTasks vitest suite passed (99 tests), direct ScheduledTasks product-state guard scan passed with zero findings, git diff --check passed, full product-state verifier failed only on unrelated Skills/KnowledgeQA/Onboarding/ACP blockers, and TypeScript failed only on unrelated Notes/background/voice-cloning diagnostics.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+ScheduledTasks product-state surfaces now render through shared design-system primitives, and the ScheduledTasks source tree has zero direct product-state guard findings. Focused ScheduledTasks tests pass. The full product-state verifier still reports unrelated blockers in Skills, KnowledgeQA, Onboarding, and ACP readiness. TypeScript still reports inherited non-ScheduledTasks debt in Notes tests, background.ts, and voice-cloning.ts. Bandit was not applicable because this task touched TypeScript/TSX and markdown only.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-45.44.21 - Migrate-ScheduledTasks-product-states-to-design-system-primitives.md
+++ b/backlog/tasks/task-45.44.21 - Migrate-ScheduledTasks-product-states-to-design-system-primitives.md
@@ -47,7 +47,7 @@ Continue the tldw_server WebUI design-system migration by resolving the current 
 ## Implementation Notes
 
 <!-- SECTION:NOTES:BEGIN -->
-Implementation replaced ScheduledTasks AntD product-state Alert/Empty/Spin/Tag usage with DS Alert, EmptyState, LoadingState, and Badge primitives, including the read-only Watchlists panel. ScheduledTasks blocked/unavailable labels now come from the design-system registry. Verification: focused ScheduledTasks vitest suite passed (99 tests), direct ScheduledTasks product-state guard scan passed with zero findings, git diff --check passed, full product-state verifier failed only on unrelated Skills/KnowledgeQA/Onboarding/ACP blockers, and TypeScript failed only on unrelated Notes/background/voice-cloning diagnostics.
+Implementation replaced ScheduledTasks AntD product-state Alert/Empty/Spin/Tag usage with DS Alert, EmptyState, LoadingState, and Badge primitives, including the read-only Watchlists panel. ScheduledTasks blocked/unavailable labels now come from the design-system registry. Review follow-up removed the template state default branch so TypeScript can enforce exhaustiveness and extracted the shared result severity-to-badge variant mapper for the drawer and results panel. Verification: focused ScheduledTasks vitest suite passed (99 tests), direct ScheduledTasks product-state guard scan passed with zero findings, git diff --check passed, full product-state verifier failed only on unrelated Skills/KnowledgeQA/Onboarding/ACP blockers, and TypeScript failed only on unrelated Notes/background/voice-cloning diagnostics.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary


### PR DESCRIPTION
## Summary
- Migrates ScheduledTasks product-state alerts, badges, empty states, and loading states to shared design-system primitives.
- Routes ScheduledTasks blocked/unavailable labels through the design-system state registry while preserving existing visible copy.
- Adds focused ScheduledTasks regression coverage for DS Alert, Badge, EmptyState, LoadingState markers and canonical label usage.
- Closes Backlog task TASK-45.44.21.

## Verification
- PASS: bunx vitest run src/components/Option/ScheduledTasks/__tests__/ScheduledTasksPage.test.tsx src/components/Option/ScheduledTasks/__tests__/ScheduledTaskCreatePanel.test.tsx src/components/Option/ScheduledTasks/__tests__/ScheduledTaskResultsPanel.test.tsx src/components/Option/ScheduledTasks/__tests__/ScheduledTaskResultDetailDrawer.test.tsx src/components/Option/ScheduledTasks/__tests__/scheduled-task-status.test.ts src/components/Option/ScheduledTasks/__tests__/scheduled-task-results.test.ts src/components/Option/ScheduledTasks/__tests__/scheduled-task-templates.test.ts --maxWorkers=1 --no-file-parallelism (99 tests)
- PASS: direct product-state guard scan over src/components/Option/ScheduledTasks reports zero findings
- PASS: git diff --check
- EXPECTED FAIL: bun run verify:design-system-state still reports unrelated blockers in Skills, KnowledgeQA, Onboarding, and ACP readiness; ScheduledTasks is absent from blocked findings
- EXPECTED FAIL: NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit -p tsconfig.json --pretty false still reports unrelated Notes/background/voice-cloning diagnostics
- SKIPPED: Bandit; touched scope is TypeScript/TSX plus Backlog markdown only

## Change summary
Human requester must replace or supplement this with their own merge-gate summary before merging, per Docs/superpowers/AI_GENERATED_PR_CHANGE_SUMMARY_POLICY_2026_04_17.md.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrates ScheduledTasks alerts, badges, empty, and loading states to the shared design system across all views, replacing `antd`. Standardizes status labels via the registry and new helpers, and completes `TASK-45.44.21`.

- **Migration**
  - Replaced `antd` `Tag/Alert/Empty/Spin` with design-system `Badge/Alert` (`@/components/ui/primitives`) and `EmptyState/LoadingState` (`@/components/ui/feedback`).
  - Added badge-variant mappers (`scheduledTaskStatusToneToBadgeVariant`, `scheduledTaskResultSeverityToBadgeVariant`, and template `templateStateToBadgeVariant`) and centralized result status via `getScheduledTaskResultStatusLabel`.
  - Routed canonical labels through the registry (`BLOCKED_STATE_LABEL`, `UNAVAILABLE_STATE_LABEL`) and applied them in filters and automation home items.
  - Updated all ScheduledTasks surfaces: Create panel, Detail drawers, Results panel, Table, Overview, Page, and Watchlist read-only panel; strengthened tests to assert DS markers and canonical labels.

<sup>Written for commit 796411abe9955c1d0a106ad0c1829d001c42e06e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2336?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

