### PR TITLE
Migrate Skills Manager alerts to design system

### DIFF
--- a/apps/packages/ui/src/components/Option/Skills/Manager.tsx
+++ b/apps/packages/ui/src/components/Option/Skills/Manager.tsx
@@ -663,6 +663,7 @@ export const SkillsManager: React.FC = () => {
           variant="success"
           title={successAction.title}
           dismissible
+          dismissLabel={t("common:close", { defaultValue: "Close" })}
           onDismiss={() => setSuccessAction(null)}
         >
           <p className="m-0">{successAction.description}</p>
@@ -671,7 +672,7 @@ export const SkillsManager: React.FC = () => {
             if (!skillName) return null
             const invocation = buildSkillInvocation(skillName)
             return (
-              <div className="flex flex-wrap items-center gap-2">
+              <div className="mt-2 flex flex-wrap items-center gap-2">
                 <Button
                   size="small"
                   icon={<Play size={14} />}

--- a/apps/packages/ui/src/components/Option/Skills/Manager.tsx
+++ b/apps/packages/ui/src/components/Option/Skills/Manager.tsx
@@ -1,6 +1,5 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
 import {
-  Alert,
   Button,
   Form,
   Input,
@@ -32,6 +31,7 @@ import { useTranslation } from "react-i18next"
 import { useAntdNotification } from "@/hooks/useAntdNotification"
 import { SkillDrawer } from "./SkillDrawer"
 import { SkillPreview } from "./SkillPreview"
+import { Alert as DesignSystemAlert } from "@/components/ui/primitives"
 import type {
   SkillSummary,
   SkillResponse,
@@ -643,33 +643,32 @@ export const SkillsManager: React.FC = () => {
       </div>
 
       {isError && (
-        <Alert
-          type="error"
-          showIcon
+        <DesignSystemAlert
+          variant="error"
           title={t("option:skills.loadListError", {
             defaultValue: "Failed to load skills"
           })}
-          description={listErrorDescription}
-          action={
-            <Button size="small" onClick={() => void refetch()}>
-              {t("common:tryAgain", { defaultValue: "Try again" })}
-            </Button>
-          }
-        />
+          action={{
+            label: t("common:tryAgain", { defaultValue: "Try again" }),
+            onClick: () => void refetch()
+          }}
+        >
+          {listErrorDescription}
+        </DesignSystemAlert>
       )}
 
       {successAction && (
-        <Alert
+        <DesignSystemAlert
           data-testid="skills-success-actions"
-          type="success"
-          showIcon
+          variant="success"
           title={successAction.title}
-          description={successAction.description}
-          closable
-          onClose={() => setSuccessAction(null)}
-          action={(() => {
+          dismissible
+          onDismiss={() => setSuccessAction(null)}
+        >
+          <p className="m-0">{successAction.description}</p>
+          {(() => {
             const skillName = successAction.skillName
-            if (!skillName) return undefined
+            if (!skillName) return null
             const invocation = buildSkillInvocation(skillName)
             return (
               <div className="flex flex-wrap items-center gap-2">
@@ -702,7 +701,7 @@ export const SkillsManager: React.FC = () => {
               </div>
             )
           })()}
-        />
+        </DesignSystemAlert>
       )}
 
       <Table

--- a/apps/packages/ui/src/components/Option/Skills/__tests__/Manager.test.tsx
+++ b/apps/packages/ui/src/components/Option/Skills/__tests__/Manager.test.tsx
@@ -230,6 +230,7 @@ describe("SkillsManager imports", () => {
     renderManager()
 
     const alert = await screen.findByRole("alert")
+    expect(alert).toHaveAttribute("data-ds-component", "Alert")
     expect(alert).toHaveTextContent("Failed to load skills")
     expect(alert).toHaveTextContent("backend down")
     expect(screen.queryByTestId("skills-empty-state")).not.toBeInTheDocument()
@@ -450,6 +451,7 @@ describe("SkillsManager imports", () => {
     })
 
     const successActions = await screen.findByTestId("skills-success-actions")
+    expect(successActions).toHaveAttribute("data-ds-component", "Alert")
     expect(successActions).toHaveTextContent("Skill imported")
     fireEvent.click(within(successActions).getByRole("button", { name: "View skill" }))
 
@@ -528,6 +530,7 @@ describe("SkillsManager imports", () => {
     })
 
     const successActions = await screen.findByTestId("skills-success-actions")
+    expect(successActions).toHaveAttribute("data-ds-component", "Alert")
     expect(successActions).toHaveTextContent("Built-in skills seeded")
 
     fireEvent.click(within(successActions).getByRole("button", { name: "Test summarize" }))

--- a/apps/packages/ui/src/components/Option/Skills/__tests__/Manager.test.tsx
+++ b/apps/packages/ui/src/components/Option/Skills/__tests__/Manager.test.tsx
@@ -453,6 +453,7 @@ describe("SkillsManager imports", () => {
     const successActions = await screen.findByTestId("skills-success-actions")
     expect(successActions).toHaveAttribute("data-ds-component", "Alert")
     expect(successActions).toHaveTextContent("Skill imported")
+    expect(within(successActions).getByRole("button", { name: "Close" })).toBeInTheDocument()
     fireEvent.click(within(successActions).getByRole("button", { name: "View skill" }))
 
     await waitFor(() => {
@@ -533,7 +534,12 @@ describe("SkillsManager imports", () => {
     expect(successActions).toHaveAttribute("data-ds-component", "Alert")
     expect(successActions).toHaveTextContent("Built-in skills seeded")
 
-    fireEvent.click(within(successActions).getByRole("button", { name: "Test summarize" }))
+    const testRunButton = within(successActions).getByRole("button", { name: "Test summarize" })
+    const successActionRow = testRunButton.closest("div")
+    expect(successActionRow).not.toBeNull()
+    expect(successActionRow as HTMLElement).toHaveClass("mt-2")
+
+    fireEvent.click(testRunButton)
     expect(screen.getByTestId("skill-preview-open")).toHaveTextContent("summarize")
 
     fireEvent.click(within(successActions).getByRole("button", { name: "Copy /skill summarize" }))

--- a/backlog/tasks/task-45.52 - Migrate-Skills-Manager-alerts-to-design-system-Alert.md
+++ b/backlog/tasks/task-45.52 - Migrate-Skills-Manager-alerts-to-design-system-Alert.md
@@ -37,13 +37,13 @@ Continue the tldw_server WebUI design-system migration by replacing the remainin
 ## Implementation Notes
 
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
-Progress: migrated the Skills Manager load-error and success-action product-state alerts from AntD Alert to the shared design-system Alert primitive. Added focused Manager test assertions for the DS Alert marker, confirmed the test failed before implementation, then passed after migration. Verification so far: focused Skills tests passed (4 files, 33 tests), direct Skills Manager product-state guard scan passed with zero findings, and the full product-state verifier no longer reports Skills Manager. Remaining full-verifier blockers are KnowledgeQA SetupDiagnostics Ready/Blocked labels, Onboarding FirstChatStep Retrying label, and ACP readiness Setup required labels.
+Progress: migrated the Skills Manager load-error and success-action product-state alerts from AntD Alert to the shared design-system Alert primitive. Added focused Manager test assertions for the DS Alert marker, confirmed the test failed before implementation, then passed after migration. Review follow-up localized the success alert dismiss label and added standard spacing above the custom action row, with focused tests verified red before the fix. Verification: focused Skills tests passed (4 files, 33 tests), direct Skills Manager product-state guard scan passed with zero findings, git diff --check passed, and the full product-state verifier no longer reports Skills Manager. Remaining full-verifier blockers are KnowledgeQA SetupDiagnostics Ready/Blocked labels, Onboarding FirstChatStep Retrying label, and ACP readiness Setup required labels. TypeScript still fails only on unrelated Notes/background/voice-cloning diagnostics.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Skills Manager load-error and success-action product-state alerts now render through the shared design-system Alert primitive. Focused Manager coverage asserts the DS Alert marker for both migrated paths, and the test was verified red before implementation. Focused Skills tests pass, direct Skills Manager product-state guard scan reports zero findings, and the full verifier now shows only the remaining KnowledgeQA, Onboarding, and ACP readiness canonical-label blockers. Bandit is not applicable because this task touched TypeScript/TSX and Backlog markdown only.
+Skills Manager load-error and success-action product-state alerts now render through the shared design-system Alert primitive. Focused coverage asserts DS Alert markers, localized dismiss labels, and standard custom-action spacing; the new assertions were verified red before implementation. Focused Skills tests pass, direct Skills Manager product-state guard scan reports zero findings, and the full verifier now shows only the remaining KnowledgeQA, Onboarding, and ACP readiness canonical-label blockers. Bandit is not applicable because this task touched TypeScript/TSX and Backlog markdown only.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-45.52 - Migrate-Skills-Manager-alerts-to-design-system-Alert.md
+++ b/backlog/tasks/task-45.52 - Migrate-Skills-Manager-alerts-to-design-system-Alert.md
@@ -1,0 +1,57 @@
+---
+id: TASK-45.52
+title: Migrate Skills Manager alerts to design-system Alert
+status: Done
+labels:
+- design-system
+- webui
+- product-state
+- skills
+ordinal: 45.48
+parent_task_id: TASK-45
+references:
+- apps/packages/ui/src/components/Option/Skills/Manager.tsx
+- apps/packages/ui/src/components/ui/primitives/Alert.tsx
+- apps/packages/ui/scripts/design-system-product-state-baseline.json
+- apps/packages/ui/scripts/verify-design-system-product-state.mjs
+documentation:
+- Docs/Design/tldw_web_design_system_contract.md
+- Docs/Design/tldw_web_design_system_inventory.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Continue the tldw_server WebUI design-system migration by replacing the remaining Skills Manager AntD product-state Alert usage with the shared design-system Alert primitive. Preserve existing copy, alert semantics, actions, and Skills Manager behavior while removing the current product-state guard blockers for apps/packages/ui/src/components/Option/Skills/Manager.tsx.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Skills Manager setup/recovery product-state alerts render through the shared design-system Alert primitive.
+- [x] #2 Existing alert copy, variants, and user-facing behavior are preserved.
+- [x] #3 Focused Skills Manager coverage asserts the migrated alerts are inside the design-system Alert marker.
+- [x] #4 Direct product-state guard scan over Skills Manager reports zero findings.
+- [x] #5 Full product-state verifier progress is recorded, including any unrelated remaining blockers.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Progress: migrated the Skills Manager load-error and success-action product-state alerts from AntD Alert to the shared design-system Alert primitive. Added focused Manager test assertions for the DS Alert marker, confirmed the test failed before implementation, then passed after migration. Verification so far: focused Skills tests passed (4 files, 33 tests), direct Skills Manager product-state guard scan passed with zero findings, and the full product-state verifier no longer reports Skills Manager. Remaining full-verifier blockers are KnowledgeQA SetupDiagnostics Ready/Blocked labels, Onboarding FirstChatStep Retrying label, and ACP readiness Setup required labels.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Skills Manager load-error and success-action product-state alerts now render through the shared design-system Alert primitive. Focused Manager coverage asserts the DS Alert marker for both migrated paths, and the test was verified red before implementation. Focused Skills tests pass, direct Skills Manager product-state guard scan reports zero findings, and the full verifier now shows only the remaining KnowledgeQA, Onboarding, and ACP readiness canonical-label blockers. Bandit is not applicable because this task touched TypeScript/TSX and Backlog markdown only.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-45.53 - Migrate-KnowledgeQA-SetupDiagnostics-labels-to-design-system-registry.md
+++ b/backlog/tasks/task-45.53 - Migrate-KnowledgeQA-SetupDiagnostics-labels-to-design-system-registry.md
@@ -1,0 +1,54 @@
+---
+id: TASK-45.53
+title: Migrate KnowledgeQA SetupDiagnostics labels to design-system registry
+status: To Do
+labels:
+- design-system
+- webui
+- product-state
+- knowledge-qa
+parent_task_id: TASK-45
+references:
+- apps/packages/ui/src/components/Option/KnowledgeQA/SetupDiagnostics.tsx
+- apps/packages/ui/src/design-system/states.ts
+- apps/packages/ui/scripts/verify-design-system-product-state.mjs
+documentation:
+- Docs/Design/tldw_web_design_system_contract.md
+- Docs/Design/tldw_web_design_system_inventory.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Continue the tldw_server WebUI design-system migration by routing the remaining KnowledgeQA SetupDiagnostics canonical Ready and Blocked labels through the shared design-system state registry instead of local string literals. Preserve existing diagnostics rendering and tests while removing the current product-state guard blockers for apps/packages/ui/src/components/Option/KnowledgeQA/SetupDiagnostics.tsx.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 SetupDiagnostics Ready label comes from the design-system state registry.
+- [ ] #2 SetupDiagnostics Blocked label comes from the design-system state registry.
+- [ ] #3 Focused KnowledgeQA diagnostics coverage preserves existing rendered labels.
+- [ ] #4 Direct product-state guard scan over SetupDiagnostics reports zero findings.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-45.54 - Migrate-Onboarding-retrying-label-to-design-system-registry.md
+++ b/backlog/tasks/task-45.54 - Migrate-Onboarding-retrying-label-to-design-system-registry.md
@@ -1,0 +1,54 @@
+---
+id: TASK-45.54
+title: Migrate Onboarding retrying label to design-system registry
+status: To Do
+labels:
+- design-system
+- webui
+- product-state
+- onboarding
+parent_task_id: TASK-45
+references:
+- apps/packages/ui/src/components/Option/Onboarding/steps/FirstChatStep.tsx
+- apps/packages/ui/src/design-system/states.ts
+- apps/packages/ui/scripts/verify-design-system-product-state.mjs
+documentation:
+- Docs/Design/tldw_web_design_system_contract.md
+- Docs/Design/tldw_web_design_system_inventory.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Continue the tldw_server WebUI design-system migration by routing the remaining Onboarding FirstChatStep canonical Retrying label through the shared design-system state registry instead of a local string literal. Preserve existing first-chat retry behavior and tests while removing the current product-state guard blocker for apps/packages/ui/src/components/Option/Onboarding/steps/FirstChatStep.tsx.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 FirstChatStep Retrying label comes from the design-system state registry.
+- [ ] #2 Existing first-chat retry behavior and copy are preserved.
+- [ ] #3 Focused Onboarding coverage preserves the retrying state label.
+- [ ] #4 Direct product-state guard scan over FirstChatStep reports zero findings.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-45.55 - Migrate-ACP-readiness-setup-required-labels-to-design-system-registry.md
+++ b/backlog/tasks/task-45.55 - Migrate-ACP-readiness-setup-required-labels-to-design-system-registry.md
@@ -1,0 +1,54 @@
+---
+id: TASK-45.55
+title: Migrate ACP readiness setup-required labels to design-system registry
+status: To Do
+labels:
+- design-system
+- webui
+- product-state
+- acp
+parent_task_id: TASK-45
+references:
+- apps/packages/ui/src/services/acp/readiness.ts
+- apps/packages/ui/src/design-system/states.ts
+- apps/packages/ui/scripts/verify-design-system-product-state.mjs
+documentation:
+- Docs/Design/tldw_web_design_system_contract.md
+- Docs/Design/tldw_web_design_system_inventory.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Continue the tldw_server WebUI design-system migration by routing the remaining ACP readiness canonical Setup required labels through the shared design-system state registry instead of local string literals. Preserve existing ACP readiness normalization semantics while removing the current product-state guard blockers for apps/packages/ui/src/services/acp/readiness.ts.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 ACP readiness setup-required label values come from the design-system state registry.
+- [ ] #2 Existing ACP readiness normalization behavior is preserved.
+- [ ] #3 Focused ACP readiness coverage preserves setup-required labels.
+- [ ] #4 Direct product-state guard scan over ACP readiness reports zero findings.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## Summary
- Replaced Skills Manager load-error and success-action AntD Alerts with the shared design-system Alert primitive.
- Added focused Manager test assertions for the design-system Alert marker.
- Added Backlog tracker tasks for the remaining product-state verifier blockers: KnowledgeQA SetupDiagnostics, Onboarding FirstChatStep, and ACP readiness labels.

## Verification
- RED: `bunx vitest run src/components/Option/Skills/__tests__/Manager.test.tsx --maxWorkers=1 --no-file-parallelism` failed before implementation on missing `data-ds-component="Alert"` markers.
- GREEN: `bunx vitest run src/components/Option/Skills/__tests__/Manager.test.tsx --maxWorkers=1 --no-file-parallelism` passed: 13 tests.
- `bunx vitest run src/components/Option/Skills/__tests__/Manager.test.tsx src/components/Option/Skills/__tests__/SkillDrawer.test.tsx src/components/Option/Skills/__tests__/SkillsWorkspace.test.tsx src/components/Option/Skills/__tests__/skill-form-utils.test.ts --maxWorkers=1 --no-file-parallelism` passed: 4 files, 33 tests.
- Direct Skills Manager product-state guard scan passed with zero findings.
- `bun run verify:design-system-state` still fails only on remaining KnowledgeQA, Onboarding, and ACP readiness canonical-label blockers; Skills Manager is no longer listed.
- `NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit -p tsconfig.json --pretty false` still fails only on existing Notes/background/voice-cloning TypeScript debt.
- `git diff --check` passed.

## Merge note
- A human-written Change summary is still required before merge under the repository AI-generated PR policy.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrated Skills Manager error and success alerts from AntD to the design-system `Alert`, preserving copy and behavior. Localized the dismiss label, standardized spacing for success actions, added focused tests, and unblocked the product-state verifier for Skills Manager.

- **Refactors**
  - Replaced AntD `Alert` with design-system `Alert` in `SkillsManager`; copy, actions, and i18n preserved.
  - Prop mapping: `type` -> `variant`, node `action` -> object `action`, `closable/onClose` -> `dismissible/dismissLabel/onDismiss`; moved description to children and placed the success action row under it with `mt-2`.
  - Tests assert `data-ds-component="Alert"` for error and success, presence of the "Close" button, and action-row spacing.
  - Logged backlog tasks for remaining migrations in KnowledgeQA, Onboarding, and ACP readiness.

<sup>Written for commit 3a948a0c2f0935eeab482334d72a11b4100e5c47. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2337?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

