### PR TITLE
Add MCP filesystem SQLite lock backend

### DIFF
--- a/Docs/superpowers/plans/2026-06-09-mcp-filesystem-sqlite-lock-backend-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-06-09-mcp-filesystem-sqlite-lock-backend-implementation-plan.md
@@ -1,0 +1,636 @@
+# MCP Filesystem SQLite Lock Backend Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement a package-level SQLite filesystem lock backend for MCP while keeping `tldw_server` integration to a compatibility shim, import swap, and config passthrough.
+
+**Architecture:** Extract the existing lock lease model, protocol, exceptions, memory backend, and factory into `mcp_unified.filesystem_locks`. Add a lazy optional SQLAlchemy Core SQLite backend behind the same synchronous protocol. Keep `FilesystemModule` behavior unchanged by default and prove standalone package artifacts include the new subpackage.
+
+**Tech Stack:** Python 3.10+, SQLAlchemy Core SQLite dialect, pytest/pytest-asyncio, Bandit, existing MCP Unified filesystem module and standalone package artifact gates.
+
+---
+
+## Command Note
+
+This plan assumes execution from the dedicated worktree at `.worktrees/mcp-fs-sqlite-lock-backend`. The shared project virtualenv is at `../../.venv` from that location. If you run the plan from a different checkout, activate that checkout's equivalent project virtualenv first.
+
+## File Map
+
+- Create `mcp_unified/filesystem_locks/__init__.py`: lightweight public exports and lazy SQLite export handling.
+- Create `mcp_unified/filesystem_locks/models.py`: `FilesystemLockLease`, `FilesystemLockManager`, `FilesystemLockConflict`, `FilesystemLockMissing`.
+- Create `mcp_unified/filesystem_locks/memory.py`: moved `InMemoryFilesystemLockManager` and `create_filesystem_lock_manager()` factory.
+- Create `mcp_unified/filesystem_locks/sqlite.py`: optional `SQLiteFilesystemLockManager`.
+- Modify `tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_locks.py`: compatibility re-export only.
+- Modify `tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_module.py`: import package-level lock API and make lock tool descriptions backend-neutral.
+- Create `tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_lock_managers.py`: package-level memory/SQLite backend contract tests.
+- Modify `tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_module.py`: config and descriptor integration tests.
+- Modify `tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py`: lazy import and artifact inclusion assertions.
+- Modify `mcp_unified/pyproject.toml`: add explicit `mcp_unified.filesystem_locks` package and package-dir mapping.
+- Modify `mcp_unified/README.md`: short feature/config note.
+- Modify `mcp_unified/USER_GUIDE.md`: operator guidance for memory vs SQLite lock backend.
+- Modify `backlog/tasks/task-2345 - Implement-MCP-filesystem-SQLite-lock-backend.md`: keep task status, plan, touched files, and validation current.
+
+## Task 1: Extract Package-Level Lock Models And Memory Backend
+
+**Files:**
+- Create: `mcp_unified/filesystem_locks/__init__.py`
+- Create: `mcp_unified/filesystem_locks/models.py`
+- Create: `mcp_unified/filesystem_locks/memory.py`
+- Modify: `tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_locks.py`
+- Test: `tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_lock_managers.py`
+
+- [ ] **Step 1: Write failing import and memory contract tests**
+
+Add tests that import from `mcp_unified.filesystem_locks`, import the old compatibility path, and exercise memory acquire/conflict/renew/release behavior.
+
+```python
+def test_package_and_compatibility_imports_expose_same_lock_types() -> None:
+    from mcp_unified.filesystem_locks import InMemoryFilesystemLockManager
+    from tldw_Server_API.app.core.MCP_unified.modules.implementations.filesystem_locks import (
+        InMemoryFilesystemLockManager as CompatManager,
+    )
+
+    assert CompatManager is InMemoryFilesystemLockManager
+
+
+def test_memory_lock_manager_acquire_conflict_renew_release() -> None:
+    from mcp_unified.filesystem_locks import (
+        FilesystemLockConflict,
+        InMemoryFilesystemLockManager,
+    )
+
+    manager = InMemoryFilesystemLockManager()
+    lease, renewed = manager.acquire(
+        workspace_key="ws",
+        path="docs/story.txt",
+        owner="agent-a",
+        ttl_seconds=60,
+    )
+
+    assert renewed is False
+    with pytest.raises(FilesystemLockConflict):
+        manager.acquire(workspace_key="ws", path="docs/story.txt", owner="agent-b", ttl_seconds=60)
+
+    renewed_lease, renewed = manager.acquire(
+        workspace_key="ws",
+        path="docs/story.txt",
+        owner="agent-a",
+        ttl_seconds=60,
+        lease_id=lease.lease_id,
+    )
+    assert renewed is True
+    assert renewed_lease.lease_id == lease.lease_id
+
+    released = manager.release(workspace_key="ws", path="docs/story.txt", lease_id=lease.lease_id)
+    assert released is not None
+```
+
+- [ ] **Step 2: Run the failing tests**
+
+Run:
+
+```bash
+source ../../.venv/bin/activate
+python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_lock_managers.py -q
+```
+
+Expected: FAIL because `mcp_unified.filesystem_locks` does not exist.
+
+- [ ] **Step 3: Move neutral code into package files**
+
+Move the dataclass, protocol, and exceptions into `models.py`. Move `InMemoryFilesystemLockManager` and the factory into `memory.py`. Keep the code behavior the same except factory backend parsing:
+
+```python
+raw_backend = (settings or {}).get("lock_manager_backend")
+if raw_backend is None:
+    return InMemoryFilesystemLockManager()
+backend = str(raw_backend).strip().lower()
+if backend in {"memory", "in_memory"}:
+    return InMemoryFilesystemLockManager()
+if backend == "":
+    raise ValueError(f"unsupported filesystem lock_manager_backend: {raw_backend!r}")
+...
+```
+
+Do not import SQLAlchemy anywhere in `models.py`, `memory.py`, or ordinary `__init__.py` imports.
+
+- [ ] **Step 4: Implement explicit compatibility shim**
+
+Replace the host `filesystem_locks.py` body with explicit imports:
+
+```python
+"""Compatibility exports for MCP filesystem lock leases."""
+
+from __future__ import annotations
+
+from mcp_unified.filesystem_locks import (
+    FilesystemLockConflict,
+    FilesystemLockLease,
+    FilesystemLockManager,
+    FilesystemLockMissing,
+    InMemoryFilesystemLockManager,
+    create_filesystem_lock_manager,
+)
+
+__all__ = [
+    "FilesystemLockConflict",
+    "FilesystemLockLease",
+    "FilesystemLockManager",
+    "FilesystemLockMissing",
+    "InMemoryFilesystemLockManager",
+    "create_filesystem_lock_manager",
+]
+```
+
+- [ ] **Step 5: Run tests until green**
+
+Run:
+
+```bash
+source ../../.venv/bin/activate
+python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_lock_managers.py -q
+python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_module.py::test_filesystem_lock_manager_injection_shares_leases_between_modules -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit extraction**
+
+```bash
+git add mcp_unified/filesystem_locks tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_locks.py tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_lock_managers.py
+git commit -m "Extract MCP filesystem lock managers"
+```
+
+## Task 2: Add SQLite Lock Manager With Matching Semantics
+
+**Files:**
+- Create/Modify: `mcp_unified/filesystem_locks/sqlite.py`
+- Modify: `mcp_unified/filesystem_locks/__init__.py`
+- Modify: `mcp_unified/filesystem_locks/memory.py`
+- Test: `tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_lock_managers.py`
+
+- [ ] **Step 1: Add failing SQLite contract tests**
+
+Add file-backed SQLite tests. Use `tmp_path / "locks.db"`, not `:memory:`, for shared-instance behavior.
+
+```python
+def test_sqlite_lock_manager_coordinates_two_instances(tmp_path: Path) -> None:
+    from mcp_unified.filesystem_locks import FilesystemLockConflict, SQLiteFilesystemLockManager
+
+    db_path = tmp_path / "locks.db"
+    first = SQLiteFilesystemLockManager(db_path)
+    second = SQLiteFilesystemLockManager(db_path)
+    try:
+        lease, renewed = first.acquire(workspace_key="ws", path="docs/story.txt", owner="agent-a", ttl_seconds=60)
+        assert renewed is False
+
+        with pytest.raises(FilesystemLockConflict) as exc:
+            second.acquire(workspace_key="ws", path="docs/story.txt", owner="agent-b", ttl_seconds=60)
+
+        assert exc.value.lease.lease_id == lease.lease_id
+    finally:
+        first.close()
+        second.close()
+```
+
+Also add:
+
+- expired-token renew returns `FilesystemLockMissing`
+- expired row does not block new acquire
+- wrong-token release raises `FilesystemLockConflict`
+- missing/expired release returns `None`
+- validate returns matching lease and classifies wrong/missing tokens correctly
+- factory with `{"lock_manager_backend": "sqlite", "lock_manager_sqlite_path": str(db_path)}` returns `SQLiteFilesystemLockManager`
+- factory with `sqlite` and no path raises `ValueError`
+
+- [ ] **Step 2: Run the failing SQLite tests**
+
+Run:
+
+```bash
+source ../../.venv/bin/activate
+python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_lock_managers.py -q
+```
+
+Expected: FAIL because `SQLiteFilesystemLockManager` does not exist.
+
+- [ ] **Step 3: Implement SQLAlchemy Core schema and helpers**
+
+In `sqlite.py`, build an isolated SQLAlchemy Core table:
+
+```python
+class SQLiteFilesystemLockManager:
+    def __init__(
+        self,
+        path: str | Path,
+        *,
+        timeout_seconds: float = 30.0,
+        token_bytes: int = 24,
+        cleanup_interval: int = 64,
+        cleanup_limit: int = 512,
+    ) -> None:
+        db_path = Path(path).expanduser()
+        db_path.parent.mkdir(parents=True, exist_ok=True)
+        self.path = str(db_path)
+        self._metadata = MetaData()
+        self._table = Table(
+            "mcp_filesystem_lock_leases",
+            self._metadata,
+            Column("workspace_key", String, primary_key=True),
+            Column("path", String, primary_key=True),
+            Column("lease_id", String, nullable=False),
+            Column("owner", String, nullable=False),
+            Column("expires_at_epoch_us", Integer, nullable=False),
+            Column("ttl_seconds", Integer, nullable=False),
+            Column("workspace_id", String),
+            Column("session_id", String),
+            Column("updated_at_epoch_us", Integer, nullable=False),
+        )
+        Index("idx_mcp_fs_lock_expires_at", self._table.c.expires_at_epoch_us)
+        self._engine = create_engine(
+            URL.create("sqlite", database=self.path),
+            connect_args={"timeout": timeout_seconds, "check_same_thread": False},
+            future=True,
+        )
+        self._metadata.create_all(self._engine)
+```
+
+Add helpers:
+
+```python
+def _now_us() -> int:
+    return int(time.time() * 1_000_000)
+
+def _lease_from_row(row: Mapping[str, Any]) -> FilesystemLockLease:
+    return FilesystemLockLease(
+        workspace_key=str(row["workspace_key"]),
+        path=str(row["path"]),
+        lease_id=str(row["lease_id"]),
+        owner=str(row["owner"]),
+        expires_at=int(row["expires_at_epoch_us"]) / 1_000_000,
+        ttl_seconds=int(row["ttl_seconds"]),
+        workspace_id=row["workspace_id"],
+        session_id=row["session_id"],
+    )
+```
+
+- [ ] **Step 4: Implement atomic acquire paths**
+
+Use SQLite dialect insert for first acquire:
+
+```python
+statement = sqlite_insert(table).values(**values)
+upsert = statement.on_conflict_do_update(
+    index_elements=[table.c.workspace_key, table.c.path],
+    set_={
+        "lease_id": statement.excluded.lease_id,
+        "owner": statement.excluded.owner,
+        "expires_at_epoch_us": statement.excluded.expires_at_epoch_us,
+        "ttl_seconds": statement.excluded.ttl_seconds,
+        "workspace_id": statement.excluded.workspace_id,
+        "session_id": statement.excluded.session_id,
+        "updated_at_epoch_us": statement.excluded.updated_at_epoch_us,
+    },
+    where=table.c.expires_at_epoch_us <= now_us,
+)
+```
+
+For renewal, use an `update()` with predicates on key, token, and active expiry. If no row updates, select the current row and raise `FilesystemLockConflict` for a different active token or `FilesystemLockMissing` for absent/expired rows.
+
+- [ ] **Step 5: Implement release, validate, cleanup, and close**
+
+Release and validate can select the row inside `engine.begin()` / `engine.connect()` and classify:
+
+- no row: missing/`None`
+- expired row: opportunistically delete and missing/`None`
+- different token: conflict
+- matching token: return/delete as appropriate
+
+Add:
+
+```python
+def close(self) -> None:
+    self._engine.dispose()
+```
+
+- [ ] **Step 6: Wire lazy SQLite exports and factory**
+
+In `mcp_unified/filesystem_locks/__init__.py`, expose `SQLiteFilesystemLockManager` lazily through `__getattr__`, matching the pattern in `mcp_unified/storage/__init__.py`.
+
+In the factory, import SQLite only inside the `backend == "sqlite"` branch and parse:
+
+- `lock_manager_sqlite_path`
+- `lock_manager_sqlite_timeout_seconds`
+- `lock_manager_cleanup_interval`
+- `lock_manager_cleanup_limit`
+
+- [ ] **Step 7: Run tests until green**
+
+Run:
+
+```bash
+source ../../.venv/bin/activate
+python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_lock_managers.py -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 8: Commit SQLite backend**
+
+```bash
+git add mcp_unified/filesystem_locks tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_lock_managers.py
+git commit -m "Add SQLite filesystem lock backend"
+```
+
+## Task 3: Integrate FilesystemModule Without Host Abstraction Growth
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_module.py`
+- Modify: `tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_module.py`
+
+- [ ] **Step 1: Add failing module integration tests**
+
+Add tests for backend-neutral descriptions and config creation:
+
+```python
+@pytest.mark.asyncio
+async def test_filesystem_lock_tool_descriptions_are_backend_neutral(tmp_path: Path) -> None:
+    mod = FilesystemModule(ModuleConfig(name="filesystem"))
+    tools = {tool["name"]: tool for tool in await mod.get_tools()}
+
+    assert "process-local" not in tools["fs.lock_acquire"]["description"]
+    assert "process-local" not in tools["fs.lock_release"]["description"]
+
+
+def test_filesystem_lock_manager_sqlite_backend_config_creates_manager(tmp_path: Path) -> None:
+    mod = FilesystemModule(
+        ModuleConfig(
+            name="filesystem",
+            settings={
+                "lock_manager_backend": "sqlite",
+                "lock_manager_sqlite_path": str(tmp_path / "locks.db"),
+            },
+        )
+    )
+
+    assert mod._lock_leases.__class__.__name__ == "SQLiteFilesystemLockManager"
+```
+
+Extend the unsupported backend parametrization to include `""` and add a separate `sqlite` missing path test.
+
+- [ ] **Step 2: Run failing module tests**
+
+Run:
+
+```bash
+source ../../.venv/bin/activate
+python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_module.py::test_filesystem_lock_tool_descriptions_are_backend_neutral tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_module.py::test_filesystem_lock_manager_sqlite_backend_config_creates_manager -q
+```
+
+Expected: FAIL until descriptions/import behavior are updated.
+
+- [ ] **Step 3: Swap imports and descriptions**
+
+Change the import block in `filesystem_module.py` from the local `.filesystem_locks` import to:
+
+```python
+from mcp_unified.filesystem_locks import (
+    FilesystemLockConflict,
+    FilesystemLockManager,
+    FilesystemLockMissing,
+    create_filesystem_lock_manager,
+)
+```
+
+Update tool descriptions:
+
+- `fs.lock_acquire`: "Acquire or renew an advisory lock lease for one workspace path."
+- `fs.lock_release`: "Release an advisory lock lease for one workspace path."
+
+Do not add any new host persistence layer or DB adapter.
+
+- [ ] **Step 4: Run focused module tests**
+
+Run:
+
+```bash
+source ../../.venv/bin/activate
+python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_module.py -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit host integration**
+
+```bash
+git add tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_module.py tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_module.py
+git commit -m "Wire filesystem module to package lock backend"
+```
+
+## Task 4: Update Standalone Packaging, Docs, And Artifact Gates
+
+**Files:**
+- Modify: `mcp_unified/pyproject.toml`
+- Modify: `mcp_unified/README.md`
+- Modify: `mcp_unified/USER_GUIDE.md`
+- Modify: `tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py`
+
+- [ ] **Step 1: Add failing package boundary tests**
+
+In `test_runtime_package_boundary.py`, update the import-boundary test that checks SQLAlchemy is not imported by core package imports to include `mcp_unified.filesystem_locks`.
+
+Add artifact assertions in `test_mcp_unified_standalone_sdist_contains_only_package_boundary()` and/or wheel member checks:
+
+```python
+assert any(member.endswith("/filesystem_locks/__init__.py") for member in members)
+assert any(member.endswith("/filesystem_locks/models.py") for member in members)
+assert any(member.endswith("/filesystem_locks/memory.py") for member in members)
+assert any(member.endswith("/filesystem_locks/sqlite.py") for member in members)
+```
+
+If adding wheel checks, assert:
+
+```python
+assert "mcp_unified/filesystem_locks/__init__.py" in wheel_members
+```
+
+- [ ] **Step 2: Run failing package boundary tests**
+
+Run:
+
+```bash
+source ../../.venv/bin/activate
+python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py -q
+```
+
+Expected: FAIL until standalone package metadata is updated.
+
+- [ ] **Step 3: Update standalone package metadata**
+
+In `mcp_unified/pyproject.toml`, add:
+
+```toml
+packages = [
+  "mcp_unified",
+  "mcp_unified.federation",
+  "mcp_unified.filesystem_locks",
+  "mcp_unified.gateway",
+  "mcp_unified.interfaces",
+  "mcp_unified.profiles",
+  "mcp_unified.storage",
+]
+
+[tool.setuptools.package-dir]
+mcp_unified = "."
+"mcp_unified.federation" = "federation"
+"mcp_unified.filesystem_locks" = "filesystem_locks"
+...
+```
+
+Do not add SQLAlchemy to core dependencies. `mcp_unified/package_metadata.py` should remain unchanged unless tests prove a metadata mismatch.
+
+- [ ] **Step 4: Update package-local docs**
+
+In `mcp_unified/README.md`, add a short "Filesystem Lock Backends" section after "Minimal Gateway Config" or before "Tool-Use Reporting":
+
+```markdown
+## Filesystem Lock Backends
+
+The package includes advisory filesystem lock manager primitives for hosts and
+gateway integrations. Memory locks are process-local. The optional SQLite
+backend coordinates cooperating processes that point at the same local database
+file; it is not a distributed lock service.
+```
+
+In `mcp_unified/USER_GUIDE.md`, add an operator subsection after "Choose A Store":
+
+```markdown
+## 2.1 Configure Filesystem Lock Storage
+
+Filesystem lock storage is separate from the gateway profile store. Use memory
+for single-process development and SQLite when multiple local gateway/server
+processes must coordinate advisory `fs.lock_acquire` leases.
+
+The SQLite path is operator configuration, not a path an agent may choose
+through filesystem tools.
+```
+
+Include sample settings names:
+
+```json
+{
+  "lock_manager_backend": "sqlite",
+  "lock_manager_sqlite_path": "./mcp-filesystem-locks.db"
+}
+```
+
+- [ ] **Step 5: Run package and artifact tests**
+
+Run:
+
+```bash
+source ../../.venv/bin/activate
+python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py -q
+python -m pytest -c mcp_unified/pytest-artifact-gate.ini .github/tests/test_mcp_unified_artifact_gate.py -q
+```
+
+Expected: PASS. If artifact build dependencies are unavailable, record the exact failure and reason in `TASK-2345`.
+
+- [ ] **Step 6: Commit packaging and docs**
+
+```bash
+git add mcp_unified/pyproject.toml mcp_unified/README.md mcp_unified/USER_GUIDE.md tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py
+git commit -m "Package filesystem lock backend"
+```
+
+## Task 5: Full Focused Validation And Backlog Closeout
+
+**Files:**
+- Modify: `backlog/tasks/task-2345 - Implement-MCP-filesystem-SQLite-lock-backend.md`
+
+- [ ] **Step 1: Run focused behavior tests**
+
+Run:
+
+```bash
+source ../../.venv/bin/activate
+python -m pytest \
+  tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_lock_managers.py \
+  tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_module.py \
+  -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run package boundary tests**
+
+Run:
+
+```bash
+source ../../.venv/bin/activate
+python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py -q
+python -m pytest -c mcp_unified/pytest-artifact-gate.ini .github/tests/test_mcp_unified_artifact_gate.py -q
+```
+
+Expected: PASS or documented environment skip for artifact build dependencies.
+
+- [ ] **Step 3: Run compile check**
+
+Run:
+
+```bash
+source ../../.venv/bin/activate
+python -m py_compile \
+  mcp_unified/filesystem_locks/__init__.py \
+  mcp_unified/filesystem_locks/models.py \
+  mcp_unified/filesystem_locks/memory.py \
+  mcp_unified/filesystem_locks/sqlite.py \
+  tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_locks.py \
+  tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_module.py
+```
+
+Expected: exit 0.
+
+- [ ] **Step 4: Run Bandit on touched implementation scope**
+
+Run:
+
+```bash
+source ../../.venv/bin/activate
+python -m bandit -r \
+  mcp_unified/filesystem_locks \
+  tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_locks.py \
+  tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_module.py \
+  -f json -o /tmp/bandit_mcp_fs_sqlite_locks.json
+```
+
+Expected: no new findings in touched code. Fix new findings before continuing.
+
+- [ ] **Step 5: Run diff hygiene**
+
+Run:
+
+```bash
+git diff --check
+```
+
+Expected: no output.
+
+- [ ] **Step 6: Update Backlog task**
+
+Use the Backlog MCP task edit tool for `TASK-2345`:
+
+- set status to `Done`
+- add touched files
+- add verification commands and outcomes
+- add final summary
+- record any known skips/blockers
+
+- [ ] **Step 7: Final commit**
+
+```bash
+git add backlog/tasks/task-2345\ -\ Implement-MCP-filesystem-SQLite-lock-backend.md
+git commit -m "Close MCP filesystem SQLite lock backend task"
+```
+
+If the Backlog update is already included in the final implementation commit, skip this separate closeout commit and note it in the final response.

--- a/Docs/superpowers/specs/2026-06-09-mcp-filesystem-sqlite-lock-backend-design.md
+++ b/Docs/superpowers/specs/2026-06-09-mcp-filesystem-sqlite-lock-backend-design.md
@@ -1,0 +1,293 @@
+# MCP Filesystem SQLite Lock Backend Design
+
+Date: 2026-06-09
+Status: Draft for spec review
+Backlog: TASK-2344
+
+## Summary
+
+Add a persistent SQLite-backed implementation of the existing MCP filesystem lock manager seam, while keeping the base `tldw_server` integration intentionally small. The default `tldw_server` behavior remains the existing in-memory lock manager. Operators opt into SQLite by setting `lock_manager_backend=sqlite` and providing a lock database path.
+
+This is not a new lock framework in the host server. The durable backend belongs to the standalone `mcp_unified` package boundary so the same lock primitives can be used by the future standalone MCP gateway and by `tldw_server` without duplicating lock semantics.
+
+## Goals
+
+- Preserve the existing `fs.lock_acquire`, `fs.lock_release`, `fs.edit`, `fs.write`, and `fs.patch` behavior for memory-backed deployments.
+- Move reusable lock models, exceptions, protocol, memory backend, and factory into `mcp_unified.filesystem_locks`.
+- Add an optional `SQLiteFilesystemLockManager` under the standalone package using SQLAlchemy Core, not raw `sqlite3`.
+- Keep `tldw_Server_API.app.core.MCP_unified.modules.implementations.filesystem_locks` as a compatibility re-export.
+- Keep `FilesystemModule` integration to an import swap plus config passthrough.
+- Support multiple processes on the same host coordinating through one SQLite database file.
+- Keep all returned paths workspace-relative and keep conflict responses free of absolute paths, process IDs, or raw context metadata.
+
+## Non-Goals
+
+- No broad base-server DB refactor.
+- No new `BaseModule` abstraction, generic backend registry, or host-wide persistence framework.
+- No async lock-manager protocol churn. The filesystem module already offloads filesystem tool work through `asyncio.to_thread`, and lock-manager calls continue to run inside that worker thread.
+- No distributed lock guarantee across hosts.
+- No claim of correctness on unreliable network filesystems.
+- No replacement for hash/read-receipt preimage checks. Locks reduce edit races; preimage checks remain authoritative.
+- No admin inspection UI in this slice.
+
+## Current Foundation
+
+The merged lock-lease slice already provides:
+
+- `FilesystemLockLease`
+- `FilesystemLockManager`
+- `FilesystemLockConflict`
+- `FilesystemLockMissing`
+- `InMemoryFilesystemLockManager`
+- `create_filesystem_lock_manager(settings)`
+
+These live today under:
+
+`tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_locks.py`
+
+`FilesystemModule` accepts an injected `lock_manager` and otherwise calls the factory from module settings. Tool execution for lock acquire/release and mutations is already offloaded with `asyncio.to_thread`, so a synchronous SQLAlchemy backend will not block the event loop when reached through the module.
+
+## Package Layout
+
+Add a small package namespace:
+
+```text
+mcp_unified/filesystem_locks/
+  __init__.py
+  models.py
+  memory.py
+  sqlite.py
+```
+
+Responsibilities:
+
+- `models.py`: lease dataclass, protocol, conflict/missing exceptions, shared helpers.
+- `memory.py`: existing in-memory implementation with unchanged semantics.
+- `sqlite.py`: optional SQLAlchemy-backed implementation.
+- `__init__.py`: lightweight exports for common models, memory backend, and the factory. The factory imports `sqlite.py` only when the selected backend is `sqlite`.
+
+The existing `tldw_server` module path becomes a shim:
+
+```python
+from mcp_unified.filesystem_locks import (
+    FilesystemLockConflict,
+    FilesystemLockLease,
+    FilesystemLockManager,
+    FilesystemLockMissing,
+    InMemoryFilesystemLockManager,
+    create_filesystem_lock_manager,
+)
+```
+
+That keeps existing imports and tests working while preventing new durable-backend complexity from living in the host server implementation package. The shim must not star-import a lazy SQLite export if that would force SQLAlchemy to import for memory-only deployments.
+
+## Base Server Boundary
+
+`tldw_server` changes must stay minimal:
+
+- Import `FilesystemLockManager` and `create_filesystem_lock_manager` from `mcp_unified.filesystem_locks`.
+- Keep the constructor injection point unchanged.
+- Keep existing settings dictionary passthrough.
+- Do not add host `DB_Management` dependencies for this standalone package backend.
+- Do not add another server-level lock abstraction.
+- Update lock tool descriptions from "process-local" to backend-neutral advisory wording.
+
+The host server remains a consumer of the package-level lock API. It should not know whether the selected backend is memory or SQLite beyond validating settings through the package factory.
+
+## Configuration
+
+Supported settings:
+
+- `lock_manager_backend`: `memory`, `in_memory`, or `sqlite`.
+- `lock_manager_sqlite_path`: required non-empty path when backend is `sqlite`.
+- `lock_manager_sqlite_timeout_seconds`: optional SQLite busy timeout, default `30.0`.
+- `lock_manager_cleanup_interval`: optional opportunistic cleanup operation cadence.
+- `lock_manager_cleanup_limit`: optional maximum expired rows removed during one cleanup pass.
+
+Fail-closed behavior:
+
+- Missing `lock_manager_backend` defaults to memory.
+- Explicit blank, false, zero, or unsupported backend values raise `ValueError`.
+- `sqlite` without a usable path raises `ValueError`.
+- Missing SQLAlchemy for SQLite raises an actionable import error explaining the `mcp-unified[sqlite]` or `mcp-unified[gateway]` extra.
+
+Path handling:
+
+- SQLite path is expanded with `Path(...).expanduser()`.
+- Parent directory is created when possible.
+- `:memory:` is not a supported operator configuration for cross-process coordination. Tests may use file-backed temporary databases for shared-manager coverage.
+
+## SQLite Schema
+
+Use SQLAlchemy Core tables, not raw SQL strings or `sqlite3` calls.
+
+Table: `mcp_filesystem_lock_leases`
+
+- `workspace_key` string, primary key part.
+- `path` string, primary key part.
+- `lease_id` string, non-null.
+- `owner` string, non-null.
+- `expires_at_epoch_us` integer, non-null.
+- `ttl_seconds` integer, non-null.
+- `workspace_id` string, nullable.
+- `session_id` string, nullable.
+- `updated_at_epoch_us` integer, non-null.
+
+Indexes:
+
+- Composite primary key on `(workspace_key, path)`.
+- Index on `expires_at_epoch_us` for cleanup.
+
+Use Python wall-clock epoch microseconds for stored timestamps:
+
+```python
+now_us = int(time.time() * 1_000_000)
+expires_at_epoch_us = now_us + ttl_seconds * 1_000_000
+```
+
+Returned `FilesystemLockLease.expires_at` remains float seconds to preserve the public dataclass contract.
+
+`workspace_key` may continue to be the resolved workspace-root string used by the current module. That value is internal storage metadata and may include an absolute path. Tool responses, conflict payloads, logs intended for callers, and docs examples must continue to expose only workspace-relative file paths.
+
+## Lock Semantics
+
+The SQLite backend must match the memory backend behavior.
+
+Acquire without `lease_id`:
+
+- If no active lease exists, create one with a generated token.
+- If only an expired lease exists, replace it with a new generated token.
+- If an active lease exists, raise `FilesystemLockConflict`.
+
+Acquire with `lease_id`:
+
+- If an active lease exists with the same token, renew it and return `renewed=True`.
+- If an active lease exists with a different token, raise `FilesystemLockConflict`.
+- If no active lease exists, or the row is expired, raise `FilesystemLockMissing`.
+
+Release:
+
+- If the active row has the supplied token, delete it and return the released lease.
+- If no active lease exists, or the row is expired, return `None`.
+- If an active lease exists with a different token, raise `FilesystemLockConflict`.
+
+Validate:
+
+- If the active row has the supplied token, return the lease.
+- If no active lease exists, or the row is expired, raise `FilesystemLockMissing`.
+- If an active lease exists with a different token, raise `FilesystemLockConflict`.
+
+Expired rows may be removed opportunistically, but cleanup is not correctness-critical. Every acquire, release, and validate decision must treat expired rows as inactive even if cleanup has not run.
+
+## Atomicity
+
+The SQLite acquire path must avoid unsafe read-then-write races.
+
+Recommended implementation:
+
+- For acquire without `lease_id`, generate a new token and use SQLite dialect upsert:
+  - Insert a new row.
+  - On `(workspace_key, path)` conflict, update only when `expires_at_epoch_us <= now_us`.
+  - If the write affects one row, return the inserted/replaced lease.
+  - If not, select the current row and classify it as active conflict, missing, or expired. The normal non-racing case is active conflict.
+- For renewal with `lease_id`, use a conditional update:
+  - Update only when key, token, and `expires_at_epoch_us > now_us` match.
+  - If one row is updated, return the renewed lease.
+  - Otherwise select the current row to distinguish active conflict from missing/expired.
+- For release, select the current row inside a transaction, then delete conditionally by key and token. A concurrent already-released row is idempotent and returns `None`.
+- For validate, select the current row and classify expired, missing, matching, and conflicting cases.
+
+This keeps the correctness decision in the database write predicate for acquisition, where races matter most.
+
+## Threading And Event Loop Behavior
+
+The lock-manager protocol stays synchronous. `FilesystemModule.execute_tool()` already calls lock acquire/release and mutations inside `asyncio.to_thread`. The SQLite manager must not introduce async methods for this slice.
+
+Tests should prove that `fs.lock_acquire` still executes lockable path checks off the event-loop thread. The SQLite backend itself can be tested synchronously at the package level.
+
+## Packaging And Extras
+
+Update the standalone package metadata:
+
+- Add `mcp_unified.filesystem_locks` to `mcp_unified/pyproject.toml` explicit package list.
+- Add matching package directory mapping.
+- Keep SQLAlchemy only in the `sqlite` and `gateway` extras.
+- Keep `mcp_unified.filesystem_locks` importable without SQLAlchemy installed.
+- Update `mcp_unified/package_metadata.py` only if extras or public metadata change.
+
+The root `pyproject.toml` package discovery should already include `mcp_unified.*`, but the standalone package gate depends on the nested `mcp_unified/pyproject.toml`.
+
+## Documentation
+
+Update package-local docs, not only host docs:
+
+- `mcp_unified/USER_GUIDE.md`: document memory vs SQLite lock backends, config keys, and host-local limitation.
+- `mcp_unified/README.md`: mention the optional SQLite lock backend in the relevant feature/config area.
+
+The documentation must not claim distributed locking. It should say SQLite coordinates cooperating processes that point at the same local database file. It should also warn that the SQLite database path is operator configuration, not an agent-controlled filesystem tool path.
+
+## Testing
+
+Package-level tests:
+
+- Memory backend still supports acquire, conflict, renewal, expiration, release, and validation.
+- SQLite backend supports the same behavior with a temporary file-backed DB.
+- Two SQLite manager instances sharing one database observe the same active lease.
+- Expired rows do not block acquisition.
+- Wrong-token renew and release classify as conflict when another active token exists.
+- Expired-token renew returns missing.
+- Importing `mcp_unified.filesystem_locks` without importing SQLAlchemy remains possible.
+
+Filesystem module tests:
+
+- Existing lock tests remain green through the compatibility shim.
+- `lock_manager_backend=sqlite` plus path creates a SQLite manager through config.
+- Unsupported, blank, false, and zero backend values fail closed.
+- SQLite backend config missing path fails closed.
+- Tool descriptions are backend-neutral.
+
+Package boundary tests:
+
+- `test_mcp_unified_standalone_pyproject_matches_release_metadata`
+- Standalone artifact gate tests for metadata, sdist boundary, typed marker, and docs.
+- A test or guard that confirms the new package is present in standalone artifacts.
+
+Focused validation commands for the implementation plan:
+
+```bash
+source .venv/bin/activate
+python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_module.py -q
+python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py -q
+python -m pytest .github/tests/test_mcp_unified_artifact_gate.py -c mcp_unified/pytest-artifact-gate.ini -q
+python -m py_compile mcp_unified/filesystem_locks/*.py tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_locks.py tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_module.py
+python -m bandit -r mcp_unified/filesystem_locks tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_locks.py tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_module.py -f json -o /tmp/bandit_mcp_fs_sqlite_locks.json
+git diff --check
+```
+
+If artifact-gate dependencies are unavailable locally, record the exact skipped command and reason in the Backlog task.
+
+## Risks And Mitigations
+
+Risk: the package extraction adds abstract complexity to `tldw_server`.
+
+Mitigation: keep the host integration to an import swap, compatibility shim, and config passthrough. No new host framework or DB layer is added.
+
+Risk: SQLite locking is mistaken for distributed locking.
+
+Mitigation: docs, tool metadata, and config comments describe the backend as host-local/shared-file coordination only.
+
+Risk: SQLAlchemy becomes a core package dependency.
+
+Mitigation: keep SQLite imports lazy and covered by import-boundary tests.
+
+Risk: atomic acquisition races under concurrent writers.
+
+Mitigation: implement acquisition through conditional SQLite upsert/update predicates, not through an unlocked read followed by a write.
+
+Risk: standalone artifacts omit the new subpackage.
+
+Mitigation: update `mcp_unified/pyproject.toml` explicit package list and run the artifact gate.
+
+## Open Decisions
+
+None blocking for this slice. Future work may add admin inspection, lock pruning commands, or alternate durable backends, but those should be separate tasks after the SQLite backend is proven.

--- a/backlog/tasks/task-2344 - Design-MCP-filesystem-SQLite-lock-backend.md
+++ b/backlog/tasks/task-2344 - Design-MCP-filesystem-SQLite-lock-backend.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-2344
 title: Design MCP filesystem SQLite lock backend
-status: In Progress
+status: Done
 labels:
 - mcp
 - filesystem
@@ -40,7 +40,7 @@ Docs/superpowers/specs/2026-06-09-mcp-filesystem-sqlite-lock-backend-design.md
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Draft spec written with package-level extraction, minimal tldw_server host integration, SQLite lock semantics, config validation, packaging/artifact gates, documentation, and validation commands. Awaiting user review before implementation planning.
+Spec approved by user. Draft covers package-level extraction, minimal tldw_server integration, SQLite lock semantics, fail-closed config, standalone packaging/artifact gates, documentation, and validation scope. Verification: git diff --check passed before commit; Bandit skipped because only Markdown and Backlog tracking files changed.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-2344 - Design-MCP-filesystem-SQLite-lock-backend.md
+++ b/backlog/tasks/task-2344 - Design-MCP-filesystem-SQLite-lock-backend.md
@@ -1,0 +1,54 @@
+---
+id: TASK-2344
+title: Design MCP filesystem SQLite lock backend
+status: In Progress
+labels:
+- mcp
+- filesystem
+- design
+priority: medium
+modified_files:
+- Docs/superpowers/specs/2026-06-09-mcp-filesystem-sqlite-lock-backend-design.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Write and review the package-level design spec for a persistent/shared SQLite filesystem lock backend behind the existing MCP filesystem lock manager seam. Keep tldw_server integration minimal and preserve standalone mcp_unified packaging boundaries.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Spec documents the package-level extraction, tldw_server compatibility shim, and no-framework constraint.
+- [ ] #2 Spec defines SQLite lock acquisition, renewal, release, validation, expiry, and conflict semantics without read-then-write races.
+- [ ] #3 Spec covers config validation, dependency/package metadata, standalone artifact gate updates, docs, and validation commands.
+- [ ] #4 Spec records scope limits: host-local/shared-file SQLite coordination only, not distributed locking.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Docs/superpowers/specs/2026-06-09-mcp-filesystem-sqlite-lock-backend-design.md
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Draft spec written with package-level extraction, minimal tldw_server host integration, SQLite lock semantics, config validation, packaging/artifact gates, documentation, and validation commands. Awaiting user review before implementation planning.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-2345 - Implement-MCP-filesystem-SQLite-lock-backend.md
+++ b/backlog/tasks/task-2345 - Implement-MCP-filesystem-SQLite-lock-backend.md
@@ -1,0 +1,57 @@
+---
+id: TASK-2345
+title: Implement MCP filesystem SQLite lock backend
+status: In Progress
+labels:
+- mcp
+- filesystem
+- implementation
+priority: medium
+references:
+- Docs/superpowers/specs/2026-06-09-mcp-filesystem-sqlite-lock-backend-design.md
+modified_files:
+- Docs/superpowers/plans/2026-06-09-mcp-filesystem-sqlite-lock-backend-implementation-plan.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement the approved package-level SQLite filesystem lock backend for MCP. Preserve existing tldw_server behavior by default, keep host integration minimal, and prove standalone mcp_unified packaging remains correct.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Package-level mcp_unified.filesystem_locks module provides memory and SQLite lock managers with matching semantics.
+- [ ] #2 tldw_server filesystem module consumes the package-level factory through a compatibility shim without broad host abstractions.
+- [ ] #3 SQLite backend uses SQLAlchemy Core, lazy optional imports, and atomic conditional acquire/renew behavior.
+- [ ] #4 Standalone packaging, README/USER_GUIDE, and artifact boundary tests cover the new package.
+- [ ] #5 Focused filesystem, package-boundary, py_compile, Bandit, and diff hygiene validation are recorded.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Docs/superpowers/plans/2026-06-09-mcp-filesystem-sqlite-lock-backend-implementation-plan.md
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-2345 - Implement-MCP-filesystem-SQLite-lock-backend.md
+++ b/backlog/tasks/task-2345 - Implement-MCP-filesystem-SQLite-lock-backend.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-2345
 title: Implement MCP filesystem SQLite lock backend
-status: In Progress
+status: Done
 labels:
 - mcp
 - filesystem
@@ -11,6 +11,18 @@ references:
 - Docs/superpowers/specs/2026-06-09-mcp-filesystem-sqlite-lock-backend-design.md
 modified_files:
 - Docs/superpowers/plans/2026-06-09-mcp-filesystem-sqlite-lock-backend-implementation-plan.md
+- mcp_unified/filesystem_locks/__init__.py
+- mcp_unified/filesystem_locks/models.py
+- mcp_unified/filesystem_locks/memory.py
+- mcp_unified/filesystem_locks/sqlite.py
+- mcp_unified/pyproject.toml
+- mcp_unified/README.md
+- mcp_unified/USER_GUIDE.md
+- tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_locks.py
+- tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_module.py
+- tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_lock_managers.py
+- tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_module.py
+- tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py
 ---
 
 ## Description
@@ -21,11 +33,11 @@ Implement the approved package-level SQLite filesystem lock backend for MCP. Pre
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Package-level mcp_unified.filesystem_locks module provides memory and SQLite lock managers with matching semantics.
-- [ ] #2 tldw_server filesystem module consumes the package-level factory through a compatibility shim without broad host abstractions.
-- [ ] #3 SQLite backend uses SQLAlchemy Core, lazy optional imports, and atomic conditional acquire/renew behavior.
-- [ ] #4 Standalone packaging, README/USER_GUIDE, and artifact boundary tests cover the new package.
-- [ ] #5 Focused filesystem, package-boundary, py_compile, Bandit, and diff hygiene validation are recorded.
+- [x] #1 Package-level mcp_unified.filesystem_locks module provides memory and SQLite lock managers with matching semantics.
+- [x] #2 tldw_server filesystem module consumes the package-level factory through a compatibility shim without broad host abstractions.
+- [x] #3 SQLite backend uses SQLAlchemy Core, lazy optional imports, and atomic conditional acquire/renew behavior.
+- [x] #4 Standalone packaging, README/USER_GUIDE, and artifact boundary tests cover the new package.
+- [x] #5 Focused filesystem, package-boundary, py_compile, Bandit, and diff hygiene validation are recorded.
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -37,21 +49,33 @@ Docs/superpowers/plans/2026-06-09-mcp-filesystem-sqlite-lock-backend-implementat
 ## Implementation Notes
 
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
-
+- Extracted filesystem lock models, exceptions, protocol, memory backend, and factory to `mcp_unified.filesystem_locks`, leaving the host module path as an explicit compatibility re-export.
+- Added `SQLiteFilesystemLockManager` with SQLAlchemy Core, lazy optional imports, file-backed cross-process coordination semantics, conditional acquire/renew behavior, and matching memory-backend contract coverage.
+- Swapped `FilesystemModule` to the package-level lock API without adding host persistence abstractions, and updated lock tool descriptions to backend-neutral advisory wording.
+- Updated standalone package metadata, README, USER_GUIDE, and artifact-boundary tests so `mcp_unified.filesystem_locks` ships in built standalone distributions.
+- Validation:
+  - `python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_lock_managers.py tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_module.py -q` -> 117 passed, 4 warnings.
+  - `python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py -q` -> 33 passed, 5 warnings.
+  - `python -m pytest -c mcp_unified/pytest-artifact-gate.ini .github/tests/test_mcp_unified_artifact_gate.py -q` -> 4 passed.
+  - `python -m py_compile mcp_unified/filesystem_locks/__init__.py mcp_unified/filesystem_locks/models.py mcp_unified/filesystem_locks/memory.py mcp_unified/filesystem_locks/sqlite.py tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_locks.py tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_module.py` -> passed.
+  - `python -m bandit -r mcp_unified/filesystem_locks tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_locks.py tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_module.py -f json -o /tmp/bandit_mcp_fs_sqlite_locks.json` -> 0 findings.
+  - `git diff --check` -> passed.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Implemented the package-level MCP filesystem SQLite lock backend and kept `tldw_server` integration to the approved import swap, compatibility shim, and config passthrough. Memory remains the default backend; SQLite is optional, uses SQLAlchemy Core, and is documented as host-local advisory coordination for cooperating processes sharing one local database file.
 
+Known skips/blockers: none. The branch is intentionally not rebased during this slice and is behind current `origin/dev`; rebase should be done as the next PR-maintenance step.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->

--- a/backlog/tasks/task-2347 - Address-MCP-filesystem-SQLite-lock-PR-review-feedback.md
+++ b/backlog/tasks/task-2347 - Address-MCP-filesystem-SQLite-lock-PR-review-feedback.md
@@ -1,0 +1,62 @@
+---
+id: TASK-2347
+title: Address MCP filesystem SQLite lock PR review feedback
+status: Done
+labels:
+- mcp
+- filesystem
+- review-fix
+priority: medium
+modified_files:
+- mcp_unified/filesystem_locks/sqlite.py
+- tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_lock_managers.py
+- backlog/tasks/task-2347 - Address-MCP-filesystem-SQLite-lock-PR-review-feedback.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Verify and address still-valid PR review comments for the MCP filesystem SQLite lock backend. Current actionable item: batch SQLite expired lease cleanup instead of deleting selected rows one by one.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Still-valid PR review comments are verified against current code before changes.
+- [x] #2 SQLite expired lease cleanup deletes selected expired rows in a batch rather than per row.
+- [x] #3 Focused lock manager tests and security/diff hygiene validation are recorded.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+- Verified PR #2340 review threads against current code. The still-valid actionable item was Gemini's `mcp_unified/filesystem_locks/sqlite.py` comment that `_maybe_cleanup_expired()` selected expired rows and deleted them one row at a time.
+- Added a regression test that fails when opportunistic SQLite expired-row cleanup calls `_delete_key()` per selected row.
+- Updated `_maybe_cleanup_expired()` to issue one bounded SQLAlchemy Core `DELETE` over the selected expired `(workspace_key, path)` keys, while preserving the `expires_at_epoch_us <= now_us` guard.
+- Validation:
+  - Red check: `python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_lock_managers.py::test_sqlite_lock_manager_batches_expired_cleanup -q` failed before the implementation change on per-row `_delete_key()`.
+  - Green check: the same test passed after the implementation change.
+  - `python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_lock_managers.py tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_module.py -q` -> 118 passed, 4 warnings.
+  - `python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py -q` -> 33 passed, 5 warnings.
+  - `python -m pytest -c mcp_unified/pytest-artifact-gate.ini .github/tests/test_mcp_unified_artifact_gate.py -q` -> 4 passed.
+  - `python -m py_compile mcp_unified/filesystem_locks/sqlite.py tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_lock_managers.py` -> passed.
+  - `python -m bandit -r mcp_unified/filesystem_locks/sqlite.py -f json -o /tmp/bandit_mcp_fs_sqlite_cleanup_fix.json` -> 0 findings.
+  - `git diff --check` -> passed.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Addressed the still-valid PR review item by batching SQLite expired-lease cleanup into one SQLAlchemy Core delete instead of issuing individual delete statements for each selected expired row.
+
+Known skips/blockers: CodeRabbit and Qodo were still processing or had only placeholder comments when reviewed; no additional actionable file-level threads were present.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-2348 - Address-Qodo-MCP-filesystem-lock-PR-feedback.md
+++ b/backlog/tasks/task-2348 - Address-Qodo-MCP-filesystem-lock-PR-feedback.md
@@ -1,0 +1,77 @@
+---
+id: TASK-2348
+title: Address Qodo MCP filesystem lock PR feedback
+status: Done
+labels:
+- mcp
+- filesystem
+- review-fix
+- qodo
+priority: medium
+modified_files:
+- mcp_unified/filesystem_locks/__init__.py
+- mcp_unified/filesystem_locks/memory.py
+- mcp_unified/filesystem_locks/sqlite.py
+- tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_locks.py
+- tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_lock_managers.py
+- tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py
+- backlog/tasks/task-2348 - Address-Qodo-MCP-filesystem-lock-PR-feedback.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Verify and address Qodo review feedback on PR #2340 for filesystem lock package lint, path normalization, and lazy optional exports.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Still-valid Qodo findings are verified against current code.
+- [x] #2 Compatibility shim time export is lint-safe or documented without breaking existing monkeypatch compatibility.
+- [x] #3 Memory backend signature is wrapped to project style.
+- [x] #4 SQLite backend and factory normalize whitespace in lock database paths.
+- [x] #5 Star import from mcp_unified.filesystem_locks does not force optional SQLite/SQLAlchemy import.
+- [x] #6 Focused tests and security/diff hygiene validation are recorded.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+- Verified Qodo PR #2340 findings against current code before editing:
+  - The compatibility shim intentionally exposed `time` for older monkeypatch callers but needed explicit documentation/lint suppression.
+  - `InMemoryFilesystemLockManager.__init__` was a single long signature line.
+  - `SQLiteFilesystemLockManager.__init__` validated a stripped path but constructed `Path(path)` from the unstripped value, and the factory forwarded the unnormalized string.
+  - `SQLiteFilesystemLockManager` in `mcp_unified.filesystem_locks.__all__` caused star imports to load the optional SQLite backend and SQLAlchemy.
+- Kept the compatibility `time` export, added a compatibility comment and `# noqa: F401`, and included it in the shim `__all__`.
+- Wrapped the in-memory manager constructor signature.
+- Normalized SQLite paths in both direct construction and factory construction.
+- Removed `SQLiteFilesystemLockManager` from package `__all__` while preserving explicit lazy imports through `__getattr__`.
+- Added regression tests for whitespace path normalization and star-import lazy behavior.
+- Validation:
+  - Red checks for the two behavior regressions failed before fixes.
+  - Green checks for both regressions passed after fixes.
+  - `python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_lock_managers.py tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_module.py -q` -> 119 passed, 4 warnings.
+  - `python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py -q` -> 34 passed, 5 warnings.
+  - `python -m pytest -c mcp_unified/pytest-artifact-gate.ini .github/tests/test_mcp_unified_artifact_gate.py -q` -> 4 passed.
+  - `python -m py_compile mcp_unified/filesystem_locks/__init__.py mcp_unified/filesystem_locks/memory.py mcp_unified/filesystem_locks/sqlite.py tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_locks.py tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_lock_managers.py tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py` -> passed.
+  - `python -m bandit -r mcp_unified/filesystem_locks tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_locks.py -f json -o /tmp/bandit_mcp_fs_qodo_fixes.json` -> 0 findings.
+  - `git diff --check` -> passed.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Addressed Qodo's actionable MCP filesystem lock feedback: lint-safe compatibility time export, wrapped memory backend signature, normalized SQLite lock DB paths, and prevented package star imports from forcing the optional SQLite backend.
+
+Known skips/blockers: none.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/mcp_unified/README.md
+++ b/mcp_unified/README.md
@@ -21,6 +21,10 @@ surface for early standalone gateway work.
   helpers.
 - Metadata-only tool-use reporting for aggregate profile, model, tool, and
   prompt-version analysis.
+- Package-local filesystem advisory lock backends for coordinating
+  read-before-mutate workflows. The memory backend is the default.
+  An optional SQLite backend can coordinate cooperating processes that point at
+  the same local database file.
 - A package CLI, `mcp-unified-gateway`, for local config management and remote
   gateway runtime operations.
 

--- a/mcp_unified/USER_GUIDE.md
+++ b/mcp_unified/USER_GUIDE.md
@@ -153,19 +153,26 @@ after the model read it, the expected hash or receipt no longer matches and the
 write is rejected instead of silently overwriting newer content.
 
 For concurrent editing workflows, `fs.lock_acquire` and `fs.lock_release`
-provide advisory leases for workspace-relative file paths. The built-in
-`lock_manager_backend=memory` backend is process-local. A successful acquire
+provide advisory leases for workspace-relative file paths. A successful acquire
 returns a `lease_id` that callers can pass to `fs.edit` and `fs.write` as
 `lock_lease_id`, or to `fs.patch` as `lock_lease_id_by_path`. Leases do not
 replace hashes or read receipts; mutation tools still run their normal preimage
 checks. Operators can set `require_lock_for_mutation=true` on the filesystem
 module when they want mutations to fail with `lock_required` unless the caller
-supplies a matching active lease. Host integrations may inject a shared lock
-manager behind the same filesystem module seam, but the packaged backend today
-is still advisory and process-local. Use it to reduce races within one running
-gateway process, not as a durable or cross-process distributed lock. Unsupported
-configured lock backends fail at module creation instead of silently falling
-back to memory.
+supplies a matching active lease.
+
+The packaged lock manager supports `lock_manager_backend` values of `memory`,
+`in_memory`, or `sqlite`. The memory and in-memory backends are process-local
+and remain the default. The SQLite backend requires
+`lock_manager_sqlite_path`, which is operator configuration for the lock store,
+not a model or agent filesystem tool path. SQLite can coordinate cooperating
+processes that share the same local database file.
+It is not a distributed lock across hosts and is not guaranteed on unreliable
+network filesystems.
+`lock_manager_sqlite_timeout_seconds` controls SQLite wait timeouts.
+`lock_manager_cleanup_interval` and `lock_manager_cleanup_limit` bound periodic
+expired-lease cleanup. Unsupported configured lock backends fail at module
+creation instead of silently falling back to memory.
 
 Example action-aware path grants:
 

--- a/mcp_unified/filesystem_locks/__init__.py
+++ b/mcp_unified/filesystem_locks/__init__.py
@@ -1,17 +1,14 @@
-"""Compatibility exports for MCP filesystem lock leases."""
+"""Filesystem lock lease managers for MCP Unified."""
 
 from __future__ import annotations
 
-from mcp_unified.filesystem_locks import (
+from .memory import InMemoryFilesystemLockManager, create_filesystem_lock_manager
+from .models import (
     FilesystemLockConflict,
     FilesystemLockLease,
     FilesystemLockManager,
     FilesystemLockMissing,
-    InMemoryFilesystemLockManager,
-    create_filesystem_lock_manager,
 )
-from mcp_unified.filesystem_locks.memory import time as time
-
 
 __all__ = [
     "FilesystemLockConflict",

--- a/mcp_unified/filesystem_locks/__init__.py
+++ b/mcp_unified/filesystem_locks/__init__.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING, Any
+
 from .memory import InMemoryFilesystemLockManager, create_filesystem_lock_manager
 from .models import (
     FilesystemLockConflict,
@@ -10,11 +12,32 @@ from .models import (
     FilesystemLockMissing,
 )
 
+if TYPE_CHECKING:
+    from .sqlite import SQLiteFilesystemLockManager
+
 __all__ = [
     "FilesystemLockConflict",
     "FilesystemLockLease",
     "FilesystemLockManager",
     "FilesystemLockMissing",
     "InMemoryFilesystemLockManager",
+    "SQLiteFilesystemLockManager",
     "create_filesystem_lock_manager",
 ]
+
+
+def __getattr__(name: str) -> Any:
+    """Lazily expose SQLite locks so core imports do not require SQLAlchemy."""
+
+    if name == "SQLiteFilesystemLockManager":
+        try:
+            from .sqlite import SQLiteFilesystemLockManager
+        except ModuleNotFoundError as exc:
+            if exc.name == "sqlalchemy":
+                raise ImportError(
+                    "SQLiteFilesystemLockManager requires the mcp-unified sqlite extra. "
+                    "Install mcp-unified[sqlite] or mcp-unified[gateway]."
+                ) from exc
+            raise
+        return SQLiteFilesystemLockManager
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/mcp_unified/filesystem_locks/__init__.py
+++ b/mcp_unified/filesystem_locks/__init__.py
@@ -21,7 +21,6 @@ __all__ = [
     "FilesystemLockManager",
     "FilesystemLockMissing",
     "InMemoryFilesystemLockManager",
-    "SQLiteFilesystemLockManager",
     "create_filesystem_lock_manager",
 ]
 

--- a/mcp_unified/filesystem_locks/memory.py
+++ b/mcp_unified/filesystem_locks/memory.py
@@ -145,6 +145,30 @@ def create_filesystem_lock_manager(settings: Mapping[str, Any] | None = None) ->
     backend = str(raw_backend).strip().lower()
     if backend in {"memory", "in_memory"}:
         return InMemoryFilesystemLockManager()
+    if backend == "sqlite":
+        sqlite_path = (settings or {}).get("lock_manager_sqlite_path")
+        if sqlite_path is None or not str(sqlite_path).strip():
+            raise ValueError(
+                "lock_manager_sqlite_path is required for sqlite filesystem lock manager"
+            )
+        try:
+            from .sqlite import SQLiteFilesystemLockManager
+        except ModuleNotFoundError as exc:
+            if exc.name == "sqlalchemy":
+                raise ImportError(
+                    "SQLiteFilesystemLockManager requires the mcp-unified sqlite extra. "
+                    "Install mcp-unified[sqlite] or mcp-unified[gateway]."
+                ) from exc
+            raise
+
+        return SQLiteFilesystemLockManager(
+            sqlite_path,
+            timeout_seconds=float(
+                (settings or {}).get("lock_manager_sqlite_timeout_seconds", 30.0)
+            ),
+            cleanup_interval=int((settings or {}).get("lock_manager_cleanup_interval", 64)),
+            cleanup_limit=int((settings or {}).get("lock_manager_cleanup_limit", 512)),
+        )
     raise ValueError(f"unsupported filesystem lock_manager_backend: {raw_backend!r}")
 
 

--- a/mcp_unified/filesystem_locks/memory.py
+++ b/mcp_unified/filesystem_locks/memory.py
@@ -1,0 +1,154 @@
+"""Process-local advisory lock leases for MCP filesystem tools."""
+
+from __future__ import annotations
+
+import secrets
+import threading
+import time
+from collections.abc import Mapping
+from typing import Any
+
+from .models import (
+    FilesystemLockConflict,
+    FilesystemLockLease,
+    FilesystemLockManager,
+    FilesystemLockMissing,
+)
+
+
+class InMemoryFilesystemLockManager:
+    """Thread-safe, process-local advisory lock lease manager."""
+
+    def __init__(self, *, token_bytes: int = 24, sweep_interval: int = 64, max_sweep_entries: int = 512) -> None:
+        self._token_bytes = max(16, token_bytes)
+        self._sweep_interval = max(1, sweep_interval)
+        self._max_sweep_entries = max(1, max_sweep_entries)
+        self._operation_count = 0
+        self._leases: dict[tuple[str, str], FilesystemLockLease] = {}
+        self._lock = threading.RLock()
+
+    def acquire(
+        self,
+        *,
+        workspace_key: str,
+        path: str,
+        owner: str,
+        ttl_seconds: int,
+        lease_id: str | None = None,
+        workspace_id: str | None = None,
+        session_id: str | None = None,
+    ) -> tuple[FilesystemLockLease, bool]:
+        """Acquire a new lease or renew the current lease when the token matches."""
+
+        key = (workspace_key, path)
+        now = time.time()
+        ttl = max(1, ttl_seconds)
+        expires_at = now + ttl
+        with self._lock:
+            self._maybe_sweep_expired_locked(now=now)
+            active = self._active_lease_locked(key, now=now)
+            if active is not None:
+                if lease_id != active.lease_id:
+                    raise FilesystemLockConflict(active)
+                renewed = FilesystemLockLease(
+                    workspace_key=workspace_key,
+                    path=path,
+                    lease_id=active.lease_id,
+                    owner=owner,
+                    expires_at=expires_at,
+                    ttl_seconds=ttl,
+                    workspace_id=workspace_id,
+                    session_id=session_id,
+                )
+                self._leases[key] = renewed
+                return renewed, True
+
+            if lease_id is not None:
+                raise FilesystemLockMissing()
+
+            acquired = FilesystemLockLease(
+                workspace_key=workspace_key,
+                path=path,
+                lease_id=secrets.token_urlsafe(self._token_bytes),
+                owner=owner,
+                expires_at=expires_at,
+                ttl_seconds=ttl,
+                workspace_id=workspace_id,
+                session_id=session_id,
+            )
+            self._leases[key] = acquired
+            return acquired, False
+
+    def release(self, *, workspace_key: str, path: str, lease_id: str) -> FilesystemLockLease | None:
+        """Release a lease when the caller presents the active token."""
+
+        key = (workspace_key, path)
+        with self._lock:
+            now = time.time()
+            self._maybe_sweep_expired_locked(now=now)
+            active = self._active_lease_locked(key, now=now)
+            if active is None:
+                return None
+            if active.lease_id != lease_id.strip():
+                raise FilesystemLockConflict(active)
+            del self._leases[key]
+            return active
+
+    def validate(self, *, workspace_key: str, path: str, lease_id: str) -> FilesystemLockLease:
+        """Return the active lease when the caller presents the current token."""
+
+        key = (workspace_key, path)
+        with self._lock:
+            now = time.time()
+            self._maybe_sweep_expired_locked(now=now)
+            active = self._active_lease_locked(key, now=now)
+            if active is None:
+                raise FilesystemLockMissing()
+            if active.lease_id != lease_id:
+                raise FilesystemLockConflict(active)
+            return active
+
+    def _active_lease_locked(self, key: tuple[str, str], *, now: float) -> FilesystemLockLease | None:
+        lease = self._leases.get(key)
+        if lease is None:
+            return None
+        if lease.expires_at <= now:
+            del self._leases[key]
+            return None
+        return lease
+
+    def _maybe_sweep_expired_locked(self, *, now: float) -> None:
+        self._operation_count += 1
+        if self._operation_count % self._sweep_interval != 0 and len(self._leases) <= self._max_sweep_entries:
+            return
+
+        for _ in range(min(self._max_sweep_entries, len(self._leases))):
+            key, lease = next(iter(self._leases.items()))
+            if lease.expires_at <= now:
+                del self._leases[key]
+            else:
+                self._leases.pop(key)
+                self._leases[key] = lease
+
+
+def create_filesystem_lock_manager(settings: Mapping[str, Any] | None = None) -> FilesystemLockManager:
+    """Create the configured filesystem lock manager backend.
+
+    The first shipped backend remains process-local memory. Unsupported
+    backends fail closed so future persistent backends can be added without
+    silently downgrading operator intent.
+    """
+
+    raw_backend = (settings or {}).get("lock_manager_backend")
+    if raw_backend is None:
+        return InMemoryFilesystemLockManager()
+    backend = str(raw_backend).strip().lower()
+    if backend in {"memory", "in_memory"}:
+        return InMemoryFilesystemLockManager()
+    raise ValueError(f"unsupported filesystem lock_manager_backend: {raw_backend!r}")
+
+
+__all__ = [
+    "InMemoryFilesystemLockManager",
+    "create_filesystem_lock_manager",
+]

--- a/mcp_unified/filesystem_locks/memory.py
+++ b/mcp_unified/filesystem_locks/memory.py
@@ -19,7 +19,13 @@ from .models import (
 class InMemoryFilesystemLockManager:
     """Thread-safe, process-local advisory lock lease manager."""
 
-    def __init__(self, *, token_bytes: int = 24, sweep_interval: int = 64, max_sweep_entries: int = 512) -> None:
+    def __init__(
+        self,
+        *,
+        token_bytes: int = 24,
+        sweep_interval: int = 64,
+        max_sweep_entries: int = 512,
+    ) -> None:
         self._token_bytes = max(16, token_bytes)
         self._sweep_interval = max(1, sweep_interval)
         self._max_sweep_entries = max(1, max_sweep_entries)
@@ -151,6 +157,7 @@ def create_filesystem_lock_manager(settings: Mapping[str, Any] | None = None) ->
             raise ValueError(
                 "lock_manager_sqlite_path is required for sqlite filesystem lock manager"
             )
+        sqlite_path_text = str(sqlite_path).strip()
         try:
             from .sqlite import SQLiteFilesystemLockManager
         except ModuleNotFoundError as exc:
@@ -162,7 +169,7 @@ def create_filesystem_lock_manager(settings: Mapping[str, Any] | None = None) ->
             raise
 
         return SQLiteFilesystemLockManager(
-            sqlite_path,
+            sqlite_path_text,
             timeout_seconds=float(
                 (settings or {}).get("lock_manager_sqlite_timeout_seconds", 30.0)
             ),

--- a/mcp_unified/filesystem_locks/models.py
+++ b/mcp_unified/filesystem_locks/models.py
@@ -1,0 +1,97 @@
+"""Shared filesystem lock lease models and exceptions."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Protocol
+
+
+@dataclass(frozen=True, slots=True)
+class FilesystemLockLease:
+    """A caller-held advisory lease for one workspace-relative path."""
+
+    workspace_key: str
+    path: str
+    lease_id: str
+    owner: str
+    expires_at: float
+    ttl_seconds: int
+    workspace_id: str | None = None
+    session_id: str | None = None
+
+    def expires_at_iso(self) -> str:
+        """Return the lease expiry timestamp in UTC ISO-8601 form."""
+
+        return datetime.fromtimestamp(self.expires_at, tz=timezone.utc).isoformat()
+
+    def safe_payload(self) -> dict[str, Any]:
+        """Return non-sensitive lease metadata safe for tool responses."""
+
+        return {
+            "path": self.path,
+            "lease_id": self.lease_id,
+            "owner": self.owner,
+            "expires_at": self.expires_at_iso(),
+            "ttl_seconds": self.ttl_seconds,
+        }
+
+    def conflict_payload(self) -> dict[str, Any]:
+        """Return non-sensitive lock holder details for conflict responses."""
+
+        return {
+            "reason_code": "lock_conflict",
+            "path": self.path,
+            "held": True,
+            "held_owner": self.owner,
+            "expires_at": self.expires_at_iso(),
+        }
+
+
+class FilesystemLockManager(Protocol):
+    """Backend contract for advisory filesystem lock leases."""
+
+    def acquire(
+        self,
+        *,
+        workspace_key: str,
+        path: str,
+        owner: str,
+        ttl_seconds: int,
+        lease_id: str | None = None,
+        workspace_id: str | None = None,
+        session_id: str | None = None,
+    ) -> tuple[FilesystemLockLease, bool]:
+        """Acquire or renew a lease for one workspace path."""
+        ...
+
+    def release(self, *, workspace_key: str, path: str, lease_id: str) -> FilesystemLockLease | None:
+        """Release an active lease when the token matches."""
+        ...
+
+    def validate(self, *, workspace_key: str, path: str, lease_id: str) -> FilesystemLockLease:
+        """Validate that the caller holds the active lease."""
+        ...
+
+
+class FilesystemLockConflict(ValueError):
+    """Raised when an active lease is held by another token."""
+
+    def __init__(self, lease: FilesystemLockLease) -> None:
+        super().__init__("lock_conflict")
+        self.lease = lease
+
+
+class FilesystemLockMissing(ValueError):
+    """Raised when no active lease exists for a requested token/path pair."""
+
+    def __init__(self) -> None:
+        super().__init__("lock_missing")
+
+
+__all__ = [
+    "FilesystemLockConflict",
+    "FilesystemLockLease",
+    "FilesystemLockManager",
+    "FilesystemLockMissing",
+]

--- a/mcp_unified/filesystem_locks/sqlite.py
+++ b/mcp_unified/filesystem_locks/sqlite.py
@@ -17,8 +17,10 @@ from sqlalchemy import (
     MetaData,
     String,
     Table,
+    and_,
     create_engine,
     delete,
+    or_,
     select,
     update,
 )
@@ -334,13 +336,21 @@ class SQLiteFilesystemLockManager:
             .mappings()
             .all()
         )
-        for row in expired_rows:
-            self._delete_key(
-                connection,
-                workspace_key=str(row["workspace_key"]),
-                path=str(row["path"]),
-                expires_at_or_before_us=now_us,
+        if not expired_rows:
+            return
+        keys = [
+            and_(
+                self._table.c.workspace_key == str(row["workspace_key"]),
+                self._table.c.path == str(row["path"]),
             )
+            for row in expired_rows
+        ]
+        connection.execute(
+            delete(self._table).where(
+                self._table.c.expires_at_epoch_us <= now_us,
+                or_(*keys),
+            )
+        )
 
     def _classify_missing_or_conflict(
         self,

--- a/mcp_unified/filesystem_locks/sqlite.py
+++ b/mcp_unified/filesystem_locks/sqlite.py
@@ -53,7 +53,7 @@ class SQLiteFilesystemLockManager:
                 "SQLite filesystem lock manager requires a file-backed database path"
             )
 
-        db_path = Path(path).expanduser()
+        db_path = Path(raw_path).expanduser()
         db_path.parent.mkdir(parents=True, exist_ok=True)
         self.path = str(db_path)
         self._token_bytes = max(16, token_bytes)

--- a/mcp_unified/filesystem_locks/sqlite.py
+++ b/mcp_unified/filesystem_locks/sqlite.py
@@ -1,0 +1,377 @@
+"""SQLite-backed advisory lock leases for MCP filesystem tools."""
+
+from __future__ import annotations
+
+import secrets
+import time
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+from sqlalchemy import (
+    URL,
+    Column,
+    Engine,
+    Index,
+    Integer,
+    MetaData,
+    String,
+    Table,
+    create_engine,
+    delete,
+    select,
+    update,
+)
+from sqlalchemy.dialects.sqlite import insert as sqlite_insert
+
+from .models import (
+    FilesystemLockConflict,
+    FilesystemLockLease,
+    FilesystemLockMissing,
+)
+
+
+class SQLiteFilesystemLockManager:
+    """SQLite-backed advisory lock lease manager for cooperating local processes."""
+
+    def __init__(
+        self,
+        path: str | Path,
+        *,
+        timeout_seconds: float = 30.0,
+        token_bytes: int = 24,
+        cleanup_interval: int = 64,
+        cleanup_limit: int = 512,
+    ) -> None:
+        raw_path = str(path).strip()
+        if not raw_path:
+            raise ValueError("SQLite filesystem lock manager requires a database path")
+        if raw_path == ":memory:":
+            raise ValueError(
+                "SQLite filesystem lock manager requires a file-backed database path"
+            )
+
+        db_path = Path(path).expanduser()
+        db_path.parent.mkdir(parents=True, exist_ok=True)
+        self.path = str(db_path)
+        self._token_bytes = max(16, token_bytes)
+        self._cleanup_interval = max(1, int(cleanup_interval))
+        self._cleanup_limit = max(1, int(cleanup_limit))
+        self._operation_count = 0
+        self._metadata = MetaData()
+        self._table = Table(
+            "mcp_filesystem_lock_leases",
+            self._metadata,
+            Column("workspace_key", String, primary_key=True),
+            Column("path", String, primary_key=True),
+            Column("lease_id", String, nullable=False),
+            Column("owner", String, nullable=False),
+            Column("expires_at_epoch_us", Integer, nullable=False),
+            Column("ttl_seconds", Integer, nullable=False),
+            Column("workspace_id", String),
+            Column("session_id", String),
+            Column("updated_at_epoch_us", Integer, nullable=False),
+        )
+        Index("idx_mcp_fs_lock_expires_at", self._table.c.expires_at_epoch_us)
+        self._engine: Engine = create_engine(
+            URL.create("sqlite", database=self.path),
+            connect_args={"timeout": timeout_seconds, "check_same_thread": False},
+            future=True,
+        )
+        self._metadata.create_all(self._engine)
+
+    def acquire(
+        self,
+        *,
+        workspace_key: str,
+        path: str,
+        owner: str,
+        ttl_seconds: int,
+        lease_id: str | None = None,
+        workspace_id: str | None = None,
+        session_id: str | None = None,
+    ) -> tuple[FilesystemLockLease, bool]:
+        """Acquire a new lease or renew the current lease when the token matches."""
+
+        now_us = _now_us()
+        ttl = max(1, int(ttl_seconds))
+        expires_at_epoch_us = now_us + ttl * 1_000_000
+        if lease_id is not None:
+            return self._renew(
+                workspace_key=workspace_key,
+                path=path,
+                owner=owner,
+                ttl_seconds=ttl,
+                lease_id=lease_id,
+                workspace_id=workspace_id,
+                session_id=session_id,
+                now_us=now_us,
+                expires_at_epoch_us=expires_at_epoch_us,
+            )
+        return self._acquire_new(
+            workspace_key=workspace_key,
+            path=path,
+            owner=owner,
+            ttl_seconds=ttl,
+            workspace_id=workspace_id,
+            session_id=session_id,
+            now_us=now_us,
+            expires_at_epoch_us=expires_at_epoch_us,
+        )
+
+    def release(
+        self,
+        *,
+        workspace_key: str,
+        path: str,
+        lease_id: str,
+    ) -> FilesystemLockLease | None:
+        """Release a lease when the caller presents the active token."""
+
+        now_us = _now_us()
+        token = lease_id.strip()
+        with self._engine.begin() as connection:
+            self._maybe_cleanup_expired(connection, now_us=now_us)
+            row = self._select_row(connection, workspace_key=workspace_key, path=path)
+            if row is None:
+                return None
+            if int(row["expires_at_epoch_us"]) <= now_us:
+                self._delete_key(
+                    connection,
+                    workspace_key=workspace_key,
+                    path=path,
+                    expires_at_or_before_us=now_us,
+                )
+                return None
+            active = _lease_from_row(row)
+            if active.lease_id != token:
+                raise FilesystemLockConflict(active)
+
+            result = connection.execute(
+                delete(self._table).where(
+                    self._table.c.workspace_key == workspace_key,
+                    self._table.c.path == path,
+                    self._table.c.lease_id == token,
+                    self._table.c.expires_at_epoch_us > now_us,
+                )
+            )
+            if not _affected_rows(result.rowcount):
+                return None
+            return active
+
+    def validate(
+        self,
+        *,
+        workspace_key: str,
+        path: str,
+        lease_id: str,
+    ) -> FilesystemLockLease:
+        """Return the active lease when the caller presents the current token."""
+
+        now_us = _now_us()
+        with self._engine.begin() as connection:
+            row = self._select_row(connection, workspace_key=workspace_key, path=path)
+            if row is None:
+                raise FilesystemLockMissing()
+            if int(row["expires_at_epoch_us"]) <= now_us:
+                self._delete_key(
+                    connection,
+                    workspace_key=workspace_key,
+                    path=path,
+                    expires_at_or_before_us=now_us,
+                )
+                raise FilesystemLockMissing()
+            active = _lease_from_row(row)
+            if active.lease_id != lease_id:
+                raise FilesystemLockConflict(active)
+            return active
+
+    def close(self) -> None:
+        """Dispose the underlying SQLAlchemy engine."""
+
+        self._engine.dispose()
+
+    def _acquire_new(
+        self,
+        *,
+        workspace_key: str,
+        path: str,
+        owner: str,
+        ttl_seconds: int,
+        workspace_id: str | None,
+        session_id: str | None,
+        now_us: int,
+        expires_at_epoch_us: int,
+    ) -> tuple[FilesystemLockLease, bool]:
+        values = {
+            "workspace_key": workspace_key,
+            "path": path,
+            "lease_id": secrets.token_urlsafe(self._token_bytes),
+            "owner": owner,
+            "expires_at_epoch_us": expires_at_epoch_us,
+            "ttl_seconds": ttl_seconds,
+            "workspace_id": workspace_id,
+            "session_id": session_id,
+            "updated_at_epoch_us": now_us,
+        }
+        statement = sqlite_insert(self._table).values(**values)
+        upsert = statement.on_conflict_do_update(
+            index_elements=[self._table.c.workspace_key, self._table.c.path],
+            set_={
+                "lease_id": statement.excluded.lease_id,
+                "owner": statement.excluded.owner,
+                "expires_at_epoch_us": statement.excluded.expires_at_epoch_us,
+                "ttl_seconds": statement.excluded.ttl_seconds,
+                "workspace_id": statement.excluded.workspace_id,
+                "session_id": statement.excluded.session_id,
+                "updated_at_epoch_us": statement.excluded.updated_at_epoch_us,
+            },
+            where=self._table.c.expires_at_epoch_us <= now_us,
+        )
+        with self._engine.begin() as connection:
+            self._maybe_cleanup_expired(connection, now_us=now_us)
+            result = connection.execute(upsert)
+            if _affected_rows(result.rowcount):
+                return _lease_from_row(values), False
+            row = self._select_row(connection, workspace_key=workspace_key, path=path)
+        raise self._classify_missing_or_conflict(row, now_us=now_us)
+
+    def _renew(
+        self,
+        *,
+        workspace_key: str,
+        path: str,
+        owner: str,
+        ttl_seconds: int,
+        lease_id: str,
+        workspace_id: str | None,
+        session_id: str | None,
+        now_us: int,
+        expires_at_epoch_us: int,
+    ) -> tuple[FilesystemLockLease, bool]:
+        values = {
+            "workspace_key": workspace_key,
+            "path": path,
+            "lease_id": lease_id,
+            "owner": owner,
+            "expires_at_epoch_us": expires_at_epoch_us,
+            "ttl_seconds": ttl_seconds,
+            "workspace_id": workspace_id,
+            "session_id": session_id,
+            "updated_at_epoch_us": now_us,
+        }
+        statement = (
+            update(self._table)
+            .where(
+                self._table.c.workspace_key == workspace_key,
+                self._table.c.path == path,
+                self._table.c.lease_id == lease_id,
+                self._table.c.expires_at_epoch_us > now_us,
+            )
+            .values(
+                owner=owner,
+                expires_at_epoch_us=expires_at_epoch_us,
+                ttl_seconds=ttl_seconds,
+                workspace_id=workspace_id,
+                session_id=session_id,
+                updated_at_epoch_us=now_us,
+            )
+        )
+        with self._engine.begin() as connection:
+            self._maybe_cleanup_expired(connection, now_us=now_us)
+            result = connection.execute(statement)
+            if _affected_rows(result.rowcount):
+                return _lease_from_row(values), True
+            row = self._select_row(connection, workspace_key=workspace_key, path=path)
+        raise self._classify_missing_or_conflict(row, now_us=now_us)
+
+    def _select_row(
+        self,
+        connection: Any,
+        *,
+        workspace_key: str,
+        path: str,
+    ) -> Mapping[str, Any] | None:
+        return (
+            connection.execute(
+                select(self._table).where(
+                    self._table.c.workspace_key == workspace_key,
+                    self._table.c.path == path,
+                )
+            )
+            .mappings()
+            .first()
+        )
+
+    def _delete_key(
+        self,
+        connection: Any,
+        *,
+        workspace_key: str,
+        path: str,
+        expires_at_or_before_us: int | None = None,
+    ) -> None:
+        conditions = [
+            self._table.c.workspace_key == workspace_key,
+            self._table.c.path == path,
+        ]
+        if expires_at_or_before_us is not None:
+            conditions.append(
+                self._table.c.expires_at_epoch_us <= expires_at_or_before_us
+            )
+        connection.execute(delete(self._table).where(*conditions))
+
+    def _maybe_cleanup_expired(self, connection: Any, *, now_us: int) -> None:
+        self._operation_count += 1
+        if self._operation_count % self._cleanup_interval != 0:
+            return
+        expired_rows = (
+            connection.execute(
+                select(self._table.c.workspace_key, self._table.c.path)
+                .where(self._table.c.expires_at_epoch_us <= now_us)
+                .limit(self._cleanup_limit)
+            )
+            .mappings()
+            .all()
+        )
+        for row in expired_rows:
+            self._delete_key(
+                connection,
+                workspace_key=str(row["workspace_key"]),
+                path=str(row["path"]),
+                expires_at_or_before_us=now_us,
+            )
+
+    def _classify_missing_or_conflict(
+        self,
+        row: Mapping[str, Any] | None,
+        *,
+        now_us: int,
+    ) -> FilesystemLockMissing | FilesystemLockConflict:
+        if row is None or int(row["expires_at_epoch_us"]) <= now_us:
+            return FilesystemLockMissing()
+        return FilesystemLockConflict(_lease_from_row(row))
+
+
+def _now_us() -> int:
+    return int(time.time() * 1_000_000)
+
+
+def _lease_from_row(row: Mapping[str, Any]) -> FilesystemLockLease:
+    return FilesystemLockLease(
+        workspace_key=str(row["workspace_key"]),
+        path=str(row["path"]),
+        lease_id=str(row["lease_id"]),
+        owner=str(row["owner"]),
+        expires_at=int(row["expires_at_epoch_us"]) / 1_000_000,
+        ttl_seconds=int(row["ttl_seconds"]),
+        workspace_id=row["workspace_id"],
+        session_id=row["session_id"],
+    )
+
+
+def _affected_rows(rowcount: int | None) -> bool:
+    return rowcount is not None and rowcount > 0
+
+
+__all__ = ["SQLiteFilesystemLockManager"]

--- a/mcp_unified/pyproject.toml
+++ b/mcp_unified/pyproject.toml
@@ -56,6 +56,7 @@ include-package-data = false
 packages = [
   "mcp_unified",
   "mcp_unified.federation",
+  "mcp_unified.filesystem_locks",
   "mcp_unified.gateway",
   "mcp_unified.interfaces",
   "mcp_unified.profiles",
@@ -65,6 +66,7 @@ packages = [
 [tool.setuptools.package-dir]
 mcp_unified = "."
 "mcp_unified.federation" = "federation"
+"mcp_unified.filesystem_locks" = "filesystem_locks"
 "mcp_unified.gateway" = "gateway"
 "mcp_unified.interfaces" = "interfaces"
 "mcp_unified.profiles" = "profiles"

--- a/tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_locks.py
+++ b/tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_locks.py
@@ -10,7 +10,8 @@ from mcp_unified.filesystem_locks import (
     InMemoryFilesystemLockManager,
     create_filesystem_lock_manager,
 )
-from mcp_unified.filesystem_locks.memory import time as time
+# Compatibility export for older tests/callers that monkeypatch this module.
+from mcp_unified.filesystem_locks.memory import time as time  # noqa: F401
 
 
 __all__ = [
@@ -20,4 +21,5 @@ __all__ = [
     "FilesystemLockMissing",
     "InMemoryFilesystemLockManager",
     "create_filesystem_lock_manager",
+    "time",
 ]

--- a/tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_module.py
@@ -34,6 +34,12 @@ from typing import Any
 import pathspec
 from pathspec.patterns.gitwildmatch import GitWildMatchPatternError
 from loguru import logger
+from mcp_unified.filesystem_locks import (
+    FilesystemLockConflict,
+    FilesystemLockManager,
+    FilesystemLockMissing,
+    create_filesystem_lock_manager,
+)
 from mcp_unified.interfaces.file_policy_actions import get_file_policy_action_metadata
 from mcp_unified.interfaces.path_scope import PathScopeCandidate
 
@@ -44,12 +50,6 @@ from tldw_Server_API.app.services.mcp_hub_workspace_root_resolver import (
 from ...tool_observability import build_execution_eval_metadata
 from ..base import BaseModule, ModuleConfig, create_tool_definition
 from .filesystem_diff import FilesystemPatchError, PatchFile, apply_patch_to_text, parse_unified_diff
-from .filesystem_locks import (
-    FilesystemLockConflict,
-    FilesystemLockManager,
-    FilesystemLockMissing,
-    create_filesystem_lock_manager,
-)
 from .filesystem_receipts import ReadReceiptError, ReadReceiptManager
 
 
@@ -245,7 +245,7 @@ class FilesystemModule(BaseModule):
 
         lock_acquire_tool = create_tool_definition(
             name="fs.lock_acquire",
-            description="Acquire or renew a process-local advisory lock lease for one workspace path.",
+            description="Acquire or renew an advisory lock lease for one workspace path.",
             parameters={
                 "properties": {
                     "path": {"type": "string", "description": "Workspace-relative or absolute path"},
@@ -273,7 +273,7 @@ class FilesystemModule(BaseModule):
 
         lock_release_tool = create_tool_definition(
             name="fs.lock_release",
-            description="Release a process-local advisory lock lease for one workspace path.",
+            description="Release an advisory lock lease for one workspace path.",
             parameters={
                 "properties": {
                     "path": {"type": "string", "description": "Workspace-relative or absolute path"},

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_lock_managers.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_lock_managers.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 
 
@@ -95,3 +97,220 @@ def test_filesystem_lock_manager_factory_backend_selection() -> None:
 
     with pytest.raises(ValueError, match="unsupported filesystem lock_manager_backend"):
         create_filesystem_lock_manager({"lock_manager_backend": ""})
+
+
+def test_sqlite_lock_manager_coordinates_two_instances(tmp_path: Path) -> None:
+    from mcp_unified.filesystem_locks import FilesystemLockConflict, SQLiteFilesystemLockManager
+
+    db_path = tmp_path / "locks.db"
+    first = SQLiteFilesystemLockManager(db_path)
+    second = SQLiteFilesystemLockManager(db_path)
+    try:
+        lease, renewed = first.acquire(
+            workspace_key="ws",
+            path="docs/story.txt",
+            owner="agent-a",
+            ttl_seconds=60,
+        )
+
+        assert renewed is False  # nosec B101
+
+        with pytest.raises(FilesystemLockConflict) as conflict:
+            second.acquire(
+                workspace_key="ws",
+                path="docs/story.txt",
+                owner="agent-b",
+                ttl_seconds=60,
+            )
+
+        assert conflict.value.lease.lease_id == lease.lease_id  # nosec B101
+    finally:
+        first.close()
+        second.close()
+
+
+def test_sqlite_lock_manager_expired_row_does_not_block_new_acquire(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from mcp_unified.filesystem_locks import SQLiteFilesystemLockManager
+    import mcp_unified.filesystem_locks.sqlite as sqlite_locks
+
+    db_path = tmp_path / "locks.db"
+    manager = SQLiteFilesystemLockManager(db_path)
+    try:
+        monkeypatch.setattr(sqlite_locks.time, "time", lambda: 1_000.0)
+        expired, _ = manager.acquire(
+            workspace_key="ws",
+            path="docs/story.txt",
+            owner="agent-a",
+            ttl_seconds=1,
+        )
+
+        monkeypatch.setattr(sqlite_locks.time, "time", lambda: 1_002.0)
+        lease, renewed = manager.acquire(
+            workspace_key="ws",
+            path="docs/story.txt",
+            owner="agent-b",
+            ttl_seconds=60,
+        )
+
+        assert renewed is False  # nosec B101
+        assert lease.lease_id != expired.lease_id  # nosec B101
+        assert lease.owner == "agent-b"  # nosec B101
+    finally:
+        manager.close()
+
+
+def test_sqlite_lock_manager_expired_token_renew_raises_missing(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from mcp_unified.filesystem_locks import FilesystemLockMissing, SQLiteFilesystemLockManager
+    import mcp_unified.filesystem_locks.sqlite as sqlite_locks
+
+    db_path = tmp_path / "locks.db"
+    manager = SQLiteFilesystemLockManager(db_path)
+    try:
+        monkeypatch.setattr(sqlite_locks.time, "time", lambda: 1_000.0)
+        lease, _ = manager.acquire(
+            workspace_key="ws",
+            path="docs/story.txt",
+            owner="agent-a",
+            ttl_seconds=1,
+        )
+
+        monkeypatch.setattr(sqlite_locks.time, "time", lambda: 1_002.0)
+        with pytest.raises(FilesystemLockMissing):
+            manager.acquire(
+                workspace_key="ws",
+                path="docs/story.txt",
+                owner="agent-a",
+                ttl_seconds=60,
+                lease_id=lease.lease_id,
+            )
+    finally:
+        manager.close()
+
+
+def test_sqlite_lock_manager_wrong_token_release_raises_conflict(tmp_path: Path) -> None:
+    from mcp_unified.filesystem_locks import FilesystemLockConflict, SQLiteFilesystemLockManager
+
+    db_path = tmp_path / "locks.db"
+    manager = SQLiteFilesystemLockManager(db_path)
+    try:
+        lease, _ = manager.acquire(
+            workspace_key="ws",
+            path="docs/story.txt",
+            owner="agent-a",
+            ttl_seconds=60,
+        )
+
+        with pytest.raises(FilesystemLockConflict) as conflict:
+            manager.release(
+                workspace_key="ws",
+                path="docs/story.txt",
+                lease_id="wrong-token",
+            )
+
+        assert conflict.value.lease.lease_id == lease.lease_id  # nosec B101
+    finally:
+        manager.close()
+
+
+def test_sqlite_lock_manager_missing_and_expired_release_return_none(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from mcp_unified.filesystem_locks import SQLiteFilesystemLockManager
+    import mcp_unified.filesystem_locks.sqlite as sqlite_locks
+
+    db_path = tmp_path / "locks.db"
+    manager = SQLiteFilesystemLockManager(db_path)
+    try:
+        assert (  # nosec B101
+            manager.release(workspace_key="ws", path="missing.txt", lease_id="missing") is None
+        )
+
+        monkeypatch.setattr(sqlite_locks.time, "time", lambda: 1_000.0)
+        lease, _ = manager.acquire(
+            workspace_key="ws",
+            path="docs/story.txt",
+            owner="agent-a",
+            ttl_seconds=1,
+        )
+
+        monkeypatch.setattr(sqlite_locks.time, "time", lambda: 1_002.0)
+        assert (  # nosec B101
+            manager.release(workspace_key="ws", path="docs/story.txt", lease_id=lease.lease_id)
+            is None
+        )
+    finally:
+        manager.close()
+
+
+def test_sqlite_lock_manager_validate_classifies_matching_wrong_and_missing_tokens(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from mcp_unified.filesystem_locks import (
+        FilesystemLockConflict,
+        FilesystemLockMissing,
+        SQLiteFilesystemLockManager,
+    )
+    import mcp_unified.filesystem_locks.sqlite as sqlite_locks
+
+    db_path = tmp_path / "locks.db"
+    manager = SQLiteFilesystemLockManager(db_path)
+    try:
+        monkeypatch.setattr(sqlite_locks.time, "time", lambda: 1_000.0)
+        lease, _ = manager.acquire(
+            workspace_key="ws",
+            path="docs/story.txt",
+            owner="agent-a",
+            ttl_seconds=1,
+        )
+
+        assert (  # nosec B101
+            manager.validate(workspace_key="ws", path="docs/story.txt", lease_id=lease.lease_id)
+            == lease
+        )
+
+        with pytest.raises(FilesystemLockConflict) as conflict:
+            manager.validate(
+                workspace_key="ws",
+                path="docs/story.txt",
+                lease_id="wrong-token",
+            )
+        assert conflict.value.lease == lease  # nosec B101
+
+        with pytest.raises(FilesystemLockMissing):
+            manager.validate(workspace_key="ws", path="missing.txt", lease_id=lease.lease_id)
+
+        monkeypatch.setattr(sqlite_locks.time, "time", lambda: 1_002.0)
+        with pytest.raises(FilesystemLockMissing):
+            manager.validate(workspace_key="ws", path="docs/story.txt", lease_id=lease.lease_id)
+    finally:
+        manager.close()
+
+
+def test_filesystem_lock_manager_factory_sqlite_backend_selection(tmp_path: Path) -> None:
+    from mcp_unified.filesystem_locks import SQLiteFilesystemLockManager, create_filesystem_lock_manager
+
+    manager = create_filesystem_lock_manager(
+        {
+            "lock_manager_backend": "sqlite",
+            "lock_manager_sqlite_path": str(tmp_path / "locks.db"),
+        }
+    )
+    try:
+        assert isinstance(manager, SQLiteFilesystemLockManager)  # nosec B101
+    finally:
+        manager.close()
+
+
+def test_filesystem_lock_manager_factory_sqlite_backend_requires_path() -> None:
+    from mcp_unified.filesystem_locks import create_filesystem_lock_manager
+
+    with pytest.raises(ValueError, match="lock_manager_sqlite_path"):
+        create_filesystem_lock_manager({"lock_manager_backend": "sqlite"})

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_lock_managers.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_lock_managers.py
@@ -446,6 +446,32 @@ def test_filesystem_lock_manager_factory_sqlite_backend_selection(tmp_path: Path
         manager.close()
 
 
+def test_sqlite_lock_manager_normalizes_configured_path_whitespace(tmp_path: Path) -> None:
+    from mcp_unified.filesystem_locks import (
+        SQLiteFilesystemLockManager,
+        create_filesystem_lock_manager,
+    )
+
+    db_path = tmp_path / "locks.db"
+    direct = SQLiteFilesystemLockManager(f"{db_path} ")
+    try:
+        assert direct.path == str(db_path)  # nosec B101
+    finally:
+        direct.close()
+
+    from_factory = create_filesystem_lock_manager(
+        {
+            "lock_manager_backend": "sqlite",
+            "lock_manager_sqlite_path": f" {db_path} ",
+        }
+    )
+    try:
+        assert isinstance(from_factory, SQLiteFilesystemLockManager)  # nosec B101
+        assert from_factory.path == str(db_path)  # nosec B101
+    finally:
+        from_factory.close()
+
+
 def test_filesystem_lock_manager_factory_sqlite_backend_requires_path() -> None:
     from mcp_unified.filesystem_locks import create_filesystem_lock_manager
 

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_lock_managers.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_lock_managers.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import pytest
+
+
+def test_package_and_compatibility_imports_expose_same_lock_types() -> None:
+    from mcp_unified.filesystem_locks import (
+        FilesystemLockConflict,
+        FilesystemLockLease,
+        FilesystemLockManager,
+        FilesystemLockMissing,
+        InMemoryFilesystemLockManager,
+        create_filesystem_lock_manager,
+    )
+    from tldw_Server_API.app.core.MCP_unified.modules.implementations.filesystem_locks import (
+        FilesystemLockConflict as CompatConflict,
+        FilesystemLockLease as CompatLease,
+        FilesystemLockManager as CompatManagerProtocol,
+        FilesystemLockMissing as CompatMissing,
+        InMemoryFilesystemLockManager as CompatManager,
+        create_filesystem_lock_manager as compat_create_filesystem_lock_manager,
+    )
+
+    assert CompatConflict is FilesystemLockConflict  # nosec B101
+    assert CompatLease is FilesystemLockLease  # nosec B101
+    assert CompatManagerProtocol is FilesystemLockManager  # nosec B101
+    assert CompatMissing is FilesystemLockMissing  # nosec B101
+    assert CompatManager is InMemoryFilesystemLockManager  # nosec B101
+    assert compat_create_filesystem_lock_manager is create_filesystem_lock_manager  # nosec B101
+
+
+def test_memory_lock_manager_acquire_conflict_renew_validate_release() -> None:
+    from mcp_unified.filesystem_locks import (
+        FilesystemLockConflict,
+        FilesystemLockMissing,
+        InMemoryFilesystemLockManager,
+    )
+
+    manager = InMemoryFilesystemLockManager()
+
+    lease, renewed = manager.acquire(
+        workspace_key="ws",
+        path="docs/story.txt",
+        owner="agent-a",
+        ttl_seconds=60,
+    )
+
+    assert renewed is False  # nosec B101
+    assert lease.workspace_key == "ws"  # nosec B101
+    assert lease.path == "docs/story.txt"  # nosec B101
+    assert lease.owner == "agent-a"  # nosec B101
+    assert manager.validate(workspace_key="ws", path="docs/story.txt", lease_id=lease.lease_id) is lease  # nosec B101
+
+    with pytest.raises(FilesystemLockConflict) as conflict:
+        manager.acquire(
+            workspace_key="ws",
+            path="docs/story.txt",
+            owner="agent-b",
+            ttl_seconds=60,
+        )
+    assert conflict.value.lease is lease  # nosec B101
+
+    renewed_lease, renewed = manager.acquire(
+        workspace_key="ws",
+        path="docs/story.txt",
+        owner="agent-a",
+        ttl_seconds=120,
+        lease_id=lease.lease_id,
+    )
+
+    assert renewed is True  # nosec B101
+    assert renewed_lease.lease_id == lease.lease_id  # nosec B101
+    assert renewed_lease.ttl_seconds == 120  # nosec B101
+
+    released = manager.release(workspace_key="ws", path="docs/story.txt", lease_id=lease.lease_id)
+    assert released == renewed_lease  # nosec B101
+
+    with pytest.raises(FilesystemLockMissing):
+        manager.validate(workspace_key="ws", path="docs/story.txt", lease_id=lease.lease_id)
+
+
+def test_filesystem_lock_manager_factory_backend_selection() -> None:
+    from mcp_unified.filesystem_locks import InMemoryFilesystemLockManager, create_filesystem_lock_manager
+
+    assert isinstance(create_filesystem_lock_manager(), InMemoryFilesystemLockManager)  # nosec B101
+    assert isinstance(create_filesystem_lock_manager({}), InMemoryFilesystemLockManager)  # nosec B101
+    assert isinstance(  # nosec B101
+        create_filesystem_lock_manager({"lock_manager_backend": "memory"}),
+        InMemoryFilesystemLockManager,
+    )
+    assert isinstance(  # nosec B101
+        create_filesystem_lock_manager({"lock_manager_backend": "in_memory"}),
+        InMemoryFilesystemLockManager,
+    )
+
+    with pytest.raises(ValueError, match="unsupported filesystem lock_manager_backend"):
+        create_filesystem_lock_manager({"lock_manager_backend": ""})

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_lock_managers.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_lock_managers.py
@@ -251,6 +251,54 @@ def test_sqlite_lock_manager_expired_row_does_not_block_new_acquire(
         manager.close()
 
 
+def test_sqlite_lock_manager_batches_expired_cleanup(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from mcp_unified.filesystem_locks import FilesystemLockMissing, SQLiteFilesystemLockManager
+    import mcp_unified.filesystem_locks.sqlite as sqlite_locks
+
+    db_path = tmp_path / "locks.db"
+    manager = SQLiteFilesystemLockManager(db_path, cleanup_interval=100)
+    try:
+        monkeypatch.setattr(sqlite_locks.time, "time", lambda: 1_000.0)
+        first, _ = manager.acquire(
+            workspace_key="ws",
+            path="docs/one.txt",
+            owner="agent-a",
+            ttl_seconds=1,
+        )
+        second, _ = manager.acquire(
+            workspace_key="ws",
+            path="docs/two.txt",
+            owner="agent-a",
+            ttl_seconds=1,
+        )
+
+        def _fail_per_row_cleanup(*args: object, **kwargs: object) -> None:
+            raise AssertionError("cleanup should not delete expired rows one at a time")
+
+        monkeypatch.setattr(manager, "_delete_key", _fail_per_row_cleanup)
+        manager._cleanup_interval = 1
+        monkeypatch.setattr(sqlite_locks.time, "time", lambda: 1_002.0)
+
+        lease, renewed = manager.acquire(
+            workspace_key="ws",
+            path="docs/three.txt",
+            owner="agent-b",
+            ttl_seconds=60,
+        )
+
+        assert renewed is False  # nosec B101
+        assert lease.path == "docs/three.txt"  # nosec B101
+        with pytest.raises(FilesystemLockMissing):
+            manager.validate(workspace_key="ws", path="docs/one.txt", lease_id=first.lease_id)
+        with pytest.raises(FilesystemLockMissing):
+            manager.validate(workspace_key="ws", path="docs/two.txt", lease_id=second.lease_id)
+    finally:
+        manager.close()
+
+
 def test_sqlite_lock_manager_expired_token_renew_raises_missing(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_lock_managers.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_lock_managers.py
@@ -129,6 +129,95 @@ def test_sqlite_lock_manager_coordinates_two_instances(tmp_path: Path) -> None:
         second.close()
 
 
+def test_sqlite_lock_manager_renews_matching_active_token(tmp_path: Path) -> None:
+    from mcp_unified.filesystem_locks import SQLiteFilesystemLockManager
+
+    db_path = tmp_path / "locks.db"
+    manager = SQLiteFilesystemLockManager(db_path)
+    try:
+        lease, acquired_renewed = manager.acquire(
+            workspace_key="ws",
+            path="docs/story.txt",
+            owner="agent-a",
+            ttl_seconds=60,
+        )
+
+        renewed_lease, renewed = manager.acquire(
+            workspace_key="ws",
+            path="docs/story.txt",
+            owner="agent-a",
+            ttl_seconds=120,
+            lease_id=lease.lease_id,
+        )
+
+        assert acquired_renewed is False  # nosec B101
+        assert renewed is True  # nosec B101
+        assert renewed_lease.lease_id == lease.lease_id  # nosec B101
+        assert renewed_lease.ttl_seconds == 120  # nosec B101
+        assert (  # nosec B101
+            manager.validate(workspace_key="ws", path="docs/story.txt", lease_id=lease.lease_id)
+            == renewed_lease
+        )
+    finally:
+        manager.close()
+
+
+def test_sqlite_lock_manager_wrong_active_token_renew_raises_conflict(tmp_path: Path) -> None:
+    from mcp_unified.filesystem_locks import FilesystemLockConflict, SQLiteFilesystemLockManager
+
+    db_path = tmp_path / "locks.db"
+    manager = SQLiteFilesystemLockManager(db_path)
+    try:
+        lease, _ = manager.acquire(
+            workspace_key="ws",
+            path="docs/story.txt",
+            owner="agent-a",
+            ttl_seconds=60,
+        )
+
+        with pytest.raises(FilesystemLockConflict) as conflict:
+            manager.acquire(
+                workspace_key="ws",
+                path="docs/story.txt",
+                owner="agent-b",
+                ttl_seconds=120,
+                lease_id="wrong-token",
+            )
+
+        assert conflict.value.lease.lease_id == lease.lease_id  # nosec B101
+    finally:
+        manager.close()
+
+
+def test_sqlite_lock_manager_releases_matching_active_token(tmp_path: Path) -> None:
+    from mcp_unified.filesystem_locks import (
+        FilesystemLockMissing,
+        SQLiteFilesystemLockManager,
+    )
+
+    db_path = tmp_path / "locks.db"
+    manager = SQLiteFilesystemLockManager(db_path)
+    try:
+        lease, _ = manager.acquire(
+            workspace_key="ws",
+            path="docs/story.txt",
+            owner="agent-a",
+            ttl_seconds=60,
+        )
+
+        released = manager.release(
+            workspace_key="ws",
+            path="docs/story.txt",
+            lease_id=lease.lease_id,
+        )
+
+        assert released == lease  # nosec B101
+        with pytest.raises(FilesystemLockMissing):
+            manager.validate(workspace_key="ws", path="docs/story.txt", lease_id=lease.lease_id)
+    finally:
+        manager.close()
+
+
 def test_sqlite_lock_manager_expired_row_does_not_block_new_acquire(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_module.py
@@ -460,10 +460,38 @@ async def test_filesystem_lock_manager_injection_shares_leases_between_modules(t
     assert reacquired["lease_id"] != first["lease_id"]  # nosec B101
 
 
-@pytest.mark.parametrize("backend", ["sqlite", False, 0])
+@pytest.mark.asyncio
+async def test_filesystem_lock_tool_descriptions_are_backend_neutral() -> None:
+    mod = FilesystemModule(ModuleConfig(name="filesystem"))
+    tools = {tool["name"]: tool for tool in await mod.get_tools()}
+
+    assert "process-local" not in tools["fs.lock_acquire"]["description"]  # nosec B101
+    assert "process-local" not in tools["fs.lock_release"]["description"]  # nosec B101
+
+
+def test_filesystem_lock_manager_sqlite_backend_config_creates_manager(tmp_path: Path) -> None:
+    mod = FilesystemModule(
+        ModuleConfig(
+            name="filesystem",
+            settings={
+                "lock_manager_backend": "sqlite",
+                "lock_manager_sqlite_path": str(tmp_path / "locks.db"),
+            },
+        )
+    )
+
+    assert mod._lock_leases.__class__.__name__ == "SQLiteFilesystemLockManager"  # nosec B101
+
+
+@pytest.mark.parametrize("backend", ["", False, 0, "unsupported"])
 def test_filesystem_lock_manager_rejects_unsupported_backend_config(backend: Any) -> None:
     with pytest.raises(ValueError, match="unsupported filesystem lock_manager_backend"):
         FilesystemModule(ModuleConfig(name="filesystem", settings={"lock_manager_backend": backend}))
+
+
+def test_filesystem_lock_manager_sqlite_backend_requires_path() -> None:
+    with pytest.raises(ValueError, match="lock_manager_sqlite_path is required"):
+        FilesystemModule(ModuleConfig(name="filesystem", settings={"lock_manager_backend": "sqlite"}))
 
 
 @pytest.mark.asyncio

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py
@@ -489,6 +489,33 @@ def test_mcp_unified_reporting_imports_do_not_eagerly_load_db_adapters() -> None
     assert result.returncode == 0, result.stdout + result.stderr  # nosec B101
 
 
+def test_filesystem_lock_star_import_does_not_eagerly_load_sqlite_backend() -> None:
+    """Star imports from core lock exports must not require optional SQLAlchemy."""
+
+    result = subprocess.run(  # nosec B603
+        [
+            sys.executable,
+            "-c",
+            (
+                "import json, sys; "
+                "namespace = {}; "
+                "exec('from mcp_unified.filesystem_locks import *', namespace); "
+                "blocked = ["
+                "name for name in ("
+                "'sqlalchemy', 'mcp_unified.filesystem_locks.sqlite'"
+                ") if name in sys.modules"
+                "]; "
+                "print(json.dumps(blocked))"
+            ),
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    assert json.loads(result.stdout) == []  # nosec B101
+
+
 def test_mcp_unified_standalone_pyproject_matches_release_metadata() -> None:
     """Standalone package metadata must stay aligned with release gate metadata."""
 

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py
@@ -432,6 +432,10 @@ def test_mcp_unified_package_docs_are_local_to_package_boundary() -> None:
     assert "USER_GUIDE.md" in readme  # nosec B101
     assert "internal/experimental" in readme  # nosec B101
     assert "mcp-unified-gateway package-info" in readme  # nosec B101
+    assert "filesystem advisory lock backends" in readme  # nosec B101
+    assert "memory backend" in readme  # nosec B101
+    assert "optional SQLite backend" in readme  # nosec B101
+    assert "same local database file" in readme  # nosec B101
     assert "# MCP Unified User Guide" in user_guide  # nosec B101
     assert "profiles" in user_guide  # nosec B101
     assert "external servers" in user_guide  # nosec B101
@@ -442,6 +446,13 @@ def test_mcp_unified_package_docs_are_local_to_package_boundary() -> None:
     assert "tool-events cleanup --max-age-days 30 --max-events 100000" in user_guide  # nosec B101
     assert "does not capture tool arguments" in user_guide  # nosec B101
     assert "evaluator-labeled task outcomes" in user_guide  # nosec B101
+    assert "lock_manager_backend" in user_guide  # nosec B101
+    assert "lock_manager_sqlite_path" in user_guide  # nosec B101
+    assert "lock_manager_sqlite_timeout_seconds" in user_guide  # nosec B101
+    assert "lock_manager_cleanup_interval" in user_guide  # nosec B101
+    assert "lock_manager_cleanup_limit" in user_guide  # nosec B101
+    assert "not a distributed lock across hosts" in user_guide  # nosec B101
+    assert "not a model or agent filesystem tool path" in user_guide  # nosec B101
     assert "Tool-Use Reporting" in readme  # nosec B101
 
 
@@ -491,6 +502,11 @@ def test_mcp_unified_standalone_pyproject_matches_release_metadata() -> None:
     assert project["readme"] == "README.md"
     assert project["license"]["text"] == metadata.LICENSE_EXPRESSION
     assert project["scripts"]["mcp-unified-gateway"] == "mcp_unified.gateway.cli:main"
+    setuptools_config = pyproject["tool"]["setuptools"]
+    assert "mcp_unified.filesystem_locks" in setuptools_config["packages"]  # nosec B101
+    assert setuptools_config["package-dir"]["mcp_unified.filesystem_locks"] == (  # nosec B101
+        "filesystem_locks"
+    )
     assert pyproject["tool"]["setuptools"]["package-data"] == {  # nosec B101
         "mcp_unified": ["py.typed", "README.md", "USER_GUIDE.md"],
     }
@@ -578,6 +594,10 @@ def test_mcp_unified_standalone_sdist_contains_only_package_boundary(
 
     assert any(member.endswith("/pyproject.toml") for member in members)  # nosec B101
     assert any(member.endswith("/__init__.py") for member in members)  # nosec B101
+    assert any(  # nosec B101
+        member.endswith("/filesystem_locks/__init__.py")
+        for member in members
+    )
     assert any(member.endswith("/gateway/cli.py") for member in members)  # nosec B101
     assert not any("/tldw_Server_API/" in member for member in members)  # nosec B101
     assert not any("/apps/tldw-frontend/" in member for member in members)  # nosec B101
@@ -607,8 +627,13 @@ def test_mcp_unified_standalone_artifacts_include_package_docs(
 
     assert "mcp_unified/README.md" in wheel_members  # nosec B101
     assert "mcp_unified/USER_GUIDE.md" in wheel_members  # nosec B101
+    assert "mcp_unified/filesystem_locks/__init__.py" in wheel_members  # nosec B101
     assert any(member.endswith("/README.md") for member in sdist_members)  # nosec B101
     assert any(member.endswith("/USER_GUIDE.md") for member in sdist_members)  # nosec B101
+    assert any(  # nosec B101
+        member.endswith("/filesystem_locks/__init__.py")
+        for member in sdist_members
+    )
 
 
 def test_pypi_workflow_runs_mcp_unified_standalone_artifact_gate() -> None:


### PR DESCRIPTION
## Summary
- Extract reusable filesystem lock models, protocol, memory backend, and factory into `mcp_unified.filesystem_locks`.
- Add optional SQLAlchemy Core SQLite lock backend with lazy imports and matching memory-backend semantics.
- Wire `FilesystemModule` to the package API, update standalone package artifacts/docs, and close `TASK-2345`.

## Test Plan
- [x] `python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_lock_managers.py tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_module.py -q` -> 117 passed
- [x] `python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py -q` -> 33 passed
- [x] `python -m pytest -c mcp_unified/pytest-artifact-gate.ini .github/tests/test_mcp_unified_artifact_gate.py -q` -> 4 passed
- [x] `python -m py_compile ...` for touched lock/module files -> passed
- [x] `python -m bandit -r mcp_unified/filesystem_locks tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_locks.py tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_module.py -f json -o /tmp/bandit_mcp_fs_sqlite_locks_rebased.json` -> 0 findings
- [x] `git diff --check` -> clean

## Change Summary
TODO: Human requester must provide the merge-gate change summary explaining what changed and why these implementation choices were made before this PR is marked ready to merge.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an optional SQLite-backed filesystem lock backend to `mcp_unified.filesystem_locks` and wires it into the filesystem module. Defaults remain in-memory; enables durable, cross-process advisory locks with batched expired-lease cleanup. Satisfies TASK-2345 (per TASK-2344 design).

- **New Features**
  - Extracted lock protocol, models, exceptions, and memory backend into `mcp_unified.filesystem_locks`.
  - Added `SQLiteFilesystemLockManager` using `sqlalchemy` (lazy import) with semantics matching memory; expired-lease cleanup is now batched.
  - Exposed `create_filesystem_lock_manager`; filesystem module now uses the package API; lock tool descriptions are backend-neutral.
  - Kept server behavior backward compatible via a small compatibility shim; removed duplicated lock code; improved path normalization and lazy optional exports.
  - Updated package artifacts and docs; added tests covering memory/SQLite backends, module integration, and package boundary.

- **Migration**
  - No changes needed if you stay on the default memory backend.
  - To enable SQLite: set `lock_manager_backend=sqlite` and `lock_manager_sqlite_path` in filesystem module settings.
  - Ensure `sqlalchemy` is available when using the SQLite backend.

<sup>Written for commit 3b77a156d8035adda7900cf223bbbaf2163f858b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2340?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

