### PR TITLE
Add MCP deferred tool availability search

### DIFF
--- a/Docs/superpowers/plans/2026-06-09-mcp-tool-availability-deferred-search-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-06-09-mcp-tool-availability-deferred-search-implementation-plan.md
@@ -1,0 +1,132 @@
+# MCP Tool Availability And Deferred Search Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make MCP profile tool discovery distinguish direct model-visible tools from deferred searchable tools.
+
+**Architecture:** Extend the existing package-local `tool_discovery.py` catalog builder with exposure classification and availability summaries. Then update `ProfileAwareGatewayRuntime.list_tools()` to expose only direct installed tools plus discovery bridge tools, while preserving `tool_search`, `tool_describe`, and `tool_call` for deferred discovery and execution.
+
+**Tech Stack:** Python 3.11+, Pydantic profile models, FastAPI gateway runtime tests, pytest, Bandit.
+
+---
+
+### Task 1: Add Exposure Classification To Tool Discovery
+
+**Files:**
+- Modify: `mcp_unified/gateway/tool_discovery.py`
+- Test: `tldw_Server_API/app/core/MCP_unified/tests/test_gateway_tool_discovery.py`
+
+- [ ] **Step 1: Write failing tests**
+
+Add tests that create a profile with direct category `code`, deferred category `browser`, and installed backend tools in both categories. Assert catalog entries include `exposure` values and category/global counts distinguish direct and deferred installed tools.
+
+- [ ] **Step 2: Run tests to verify failure**
+
+Run:
+
+```bash
+source ../../.venv/bin/activate && python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_gateway_tool_discovery.py -q
+```
+
+Expected: new tests fail because exposure/count fields do not exist.
+
+- [ ] **Step 3: Implement classification**
+
+Add normalized exposure constants and helpers in `tool_discovery.py`. Direct categories come from `profile.metadata.tooling.progressive_disclosure.direct_categories`; deferred categories come from `deferred_categories`. Installed tools outside direct categories should be deferred when the profile has any progressive-disclosure metadata.
+
+- [ ] **Step 4: Run focused tests**
+
+Run the same pytest command. Expected: all tests pass.
+
+### Task 2: Hide Deferred Tools From Initial Runtime Tool List
+
+**Files:**
+- Modify: `mcp_unified/gateway/profile_runtime.py`
+- Test: `tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py`
+
+- [ ] **Step 1: Write failing runtime tests**
+
+Add coverage showing `ProfileAwareGatewayRuntime.list_tools()` hides deferred installed tools but exposes direct installed tools and bridge discovery tools. Also assert `tool_call` appears when deferred installed tools exist.
+
+- [ ] **Step 2: Run focused tests**
+
+Run:
+
+```bash
+source ../../.venv/bin/activate && python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py -q
+```
+
+Expected: new tests fail because deferred installed tools are still directly listed.
+
+- [ ] **Step 3: Implement runtime filtering**
+
+Reuse discovery classification rather than duplicating category logic. Add a package-local helper that returns direct installed backend tool names for the active profile and backend tool descriptors. Keep collision behavior: an allowed backend tool with a bridge-reserved name still wins when it is direct.
+
+- [ ] **Step 4: Run focused runtime tests**
+
+Run the same pytest command or targeted test names. Expected: new and existing bridge tests pass.
+
+### Task 3: Preserve Deferred Search And Delegated Calls
+
+**Files:**
+- Modify: `mcp_unified/gateway/tool_discovery.py`
+- Modify: `mcp_unified/gateway/profile_runtime.py`
+- Test: `tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py`
+
+- [ ] **Step 1: Add regression tests**
+
+Assert `tool_search` and `profile.tools.list` include direct, deferred installed, and recommended-unavailable entries. Assert `tool_call` delegates a deferred installed tool through backend policy and still rejects recommendation-only tools.
+
+- [ ] **Step 2: Run tests to verify behavior**
+
+Run focused runtime tests. Expected: existing call behavior may pass, but direct/deferred metadata assertions fail until Task 1/2 helpers are wired through.
+
+- [ ] **Step 3: Wire helper payloads**
+
+Ensure catalog and search payloads include `exposure`, `availability_reason_code`, and counts without exposing denied tools.
+
+- [ ] **Step 4: Run focused tests**
+
+Run:
+
+```bash
+source ../../.venv/bin/activate && python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_gateway_tool_discovery.py tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py -q
+```
+
+Expected: pass.
+
+### Task 4: Docs, Backlog, And Verification
+
+**Files:**
+- Modify: `mcp_unified/USER_GUIDE.md`
+- Modify: `backlog/tasks/task-2295 - Add-tool-availability-and-deferred-tool-search-parity.md`
+
+- [ ] **Step 1: Update user guide**
+
+Document that direct categories are model-visible during `tools/list`, deferred installed categories are discoverable through bridge tools, and recommended unavailable tools are setup hints only.
+
+- [ ] **Step 2: Run package boundary and security checks**
+
+Run:
+
+```bash
+source ../../.venv/bin/activate && python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_gateway_tool_discovery.py tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py -q
+source ../../.venv/bin/activate && python -m py_compile mcp_unified/gateway/tool_discovery.py mcp_unified/gateway/profile_runtime.py
+source ../../.venv/bin/activate && python -m bandit -r mcp_unified/gateway/tool_discovery.py mcp_unified/gateway/profile_runtime.py -f json -o /tmp/bandit_mcp_tool_availability_search.json
+git diff --check
+```
+
+Expected: pytest passes, py_compile passes, Bandit has zero findings, and diff check is clean.
+
+- [ ] **Step 3: Update Backlog final notes**
+
+Record touched files, validation commands, known skips, and final summary in `TASK-2295`.
+
+- [ ] **Step 4: Commit**
+
+Commit with a message such as:
+
+```bash
+git add mcp_unified/gateway/tool_discovery.py mcp_unified/gateway/profile_runtime.py tldw_Server_API/app/core/MCP_unified/tests/test_gateway_tool_discovery.py tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py mcp_unified/USER_GUIDE.md Docs/superpowers/specs/2026-06-09-mcp-tool-availability-deferred-search-design.md Docs/superpowers/plans/2026-06-09-mcp-tool-availability-deferred-search-implementation-plan.md "backlog/tasks/task-2295 - Add-tool-availability-and-deferred-tool-search-parity.md"
+git commit -m "feat: add MCP deferred tool availability search"
+```

--- a/Docs/superpowers/specs/2026-06-09-mcp-tool-availability-deferred-search-design.md
+++ b/Docs/superpowers/specs/2026-06-09-mcp-tool-availability-deferred-search-design.md
@@ -1,0 +1,76 @@
+# MCP Tool Availability And Deferred Search Design
+
+## Goal
+
+Add Claude-style profile-scoped tool availability and deferred tool-search behavior to the standalone MCP gateway without expanding the initial executable tool surface. Profiles should expose direct tools immediately, keep additional installed-but-deferred tools searchable, and show recommendation-only tools as unavailable setup targets.
+
+## Current State
+
+`mcp_unified.gateway.tool_discovery` already builds a profile-filtered catalog from backend tools and profile recommendation metadata. It ranks with standard-library BM25 and documents the intended order: profile grants, installation status, category filtering, BM25, category priority, and tool id. `ProfileAwareGatewayRuntime` also exposes bridge tools: `tool_categories.list`, `profile.tools.list`, `tool_search`, `tool_describe`, and conditional `tool_call`.
+
+The missing behavior is exposure control. Any installed tool allowed by profile policy is currently returned by `list_tools()`, even if its category is intended for progressive disclosure. That makes direct and deferred categories metadata-only instead of controlling model-visible tools.
+
+## Design
+
+The gateway will classify each visible discovery entry into one of three exposure states:
+
+- `direct`: installed and allowed by profile policy, and its category is in the profile's direct categories.
+- `deferred_installed`: installed and allowed by profile policy, but its category is not direct or is explicitly listed as deferred.
+- `recommended_unavailable`: recommendation metadata with no callable backend tool.
+
+The existing `installation_status` remains separate from exposure. Installed deferred tools keep `installation_status: "installed"` and add `exposure: "deferred"` or an equivalent public field. Recommendation-only tools keep `installation_status: "recommended_unavailable"`.
+
+`ProfileAwareGatewayRuntime.list_tools()` will return only:
+
+- direct installed tools,
+- the read-only discovery bridge tools,
+- `tool_call` when the profile has deferred categories or deferred installed tools.
+
+`tool_search`, `tool_describe`, and `profile.tools.list` will continue to include direct, deferred installed, and recommended-unavailable entries. This gives clients progressive disclosure without losing awareness of useful tools. `tool_call` can execute deferred installed tools after resolving through the same profile policy path used for direct backend calls. Recommended-unavailable tools still return `tool_not_enabled`.
+
+## Ranking And Filtering
+
+No semantic search is introduced. Search remains deterministic and local:
+
+1. Filter by effective profile grants first.
+2. Classify installation and exposure.
+3. Apply requested category filter.
+4. Rank with BM25.
+5. Tie-break by category priority and tool id.
+
+Denied tools are not returned from discovery, description, or call resolution. Denials should look like `tool_not_found` to the model-facing bridge so fully denied tools are not advertised.
+
+## Availability Metadata
+
+Catalog payloads should include scalar metadata that helps front-ends explain availability:
+
+- `direct_count`, `deferred_installed_count`, and `recommended_unavailable_count` per category.
+- Global `availability` or `summary` counts for the whole profile catalog.
+- Per-tool `exposure` and `availability_reason_code`, without absolute paths, secrets, or denied-tool names.
+- Existing ranking metadata must continue to state `semantic_search: false`.
+
+This metadata should be safe for chat and ACP sessions.
+
+## Wait For MCP Servers Interaction
+
+This slice will not implement server startup waiting. It will reserve a readiness field for future integration, such as `readiness_status` and `readiness_reason_code`. Existing external-runtime startup and install/update tasks can later populate this without changing the bridge response shape.
+
+## Testing
+
+Focused tests should cover:
+
+- Deferred installed tools are hidden from initial `list_tools()` but visible through `tool_search` and `profile.tools.list`.
+- Direct installed tools remain listed normally.
+- `tool_call` can delegate a deferred installed tool through normal profile policy checks.
+- Recommendation-only tools remain discoverable but not callable.
+- Category counts and global availability counts distinguish direct, deferred installed, and recommended unavailable.
+- Denied tools do not appear in discovery or descriptions.
+- Ranking metadata remains non-semantic and deterministic.
+
+## Non-Goals
+
+- New semantic embeddings or vector search.
+- New install/update behavior.
+- New permission-rule parser syntax.
+- Hook enforcement changes.
+- LSP, shell, notebook, web, or monitor tool implementations.

--- a/backlog/tasks/task-2295 - Add-tool-availability-and-deferred-tool-search-parity.md
+++ b/backlog/tasks/task-2295 - Add-tool-availability-and-deferred-tool-search-parity.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-2295
 title: Add tool availability and deferred tool-search parity
-status: To Do
+status: In Progress
 labels:
 - mcp
 - tool-discovery
@@ -10,6 +10,9 @@ labels:
 - tools
 references:
 - https://code.claude.com/docs/en/tools-reference
+documentation:
+- Docs/superpowers/specs/2026-06-09-mcp-tool-availability-deferred-search-design.md
+- Docs/superpowers/plans/2026-06-09-mcp-tool-availability-deferred-search-implementation-plan.md
 ---
 
 ## Description
@@ -20,26 +23,44 @@ Design and implement Claude-style tool availability introspection and deferred T
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
+- [x] #1 Direct profile categories remain visible in `tools/list`; deferred installed categories are hidden from initial tool exposure.
+- [x] #2 `profile.tools.list`, `tool_search`, and `tool_describe` include direct, deferred installed, and recommendation-only entries that remain profile-filtered.
+- [x] #3 Catalog payloads expose safe availability metadata for direct, deferred installed, and recommended-unavailable tools without leaking denied tools.
+- [x] #4 `tool_call` remains available when deferred tools exist and delegates installed deferred tools through existing profile policy.
+- [x] #5 Focused runtime/discovery tests, py_compile, Bandit, and `git diff --check` pass.
 <!-- AC:END -->
 
 ## Implementation Notes
 
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+- Added `Docs/superpowers/specs/2026-06-09-mcp-tool-availability-deferred-search-design.md`.
+- Added `Docs/superpowers/plans/2026-06-09-mcp-tool-availability-deferred-search-implementation-plan.md`.
+- Extended `mcp_unified.gateway.tool_discovery` with direct/deferred/recommended exposure classification, safe per-tool availability reason codes, category availability counts, and whole-catalog availability counts.
+- Added package-local helpers for direct profile backend tools and deferred-tool detection so runtime listing can reuse catalog classification.
+- Updated `ProfileAwareGatewayRuntime.list_tools()` to expose only direct installed backend tools plus discovery bridge tools. Deferred installed tools remain searchable/describable and callable through `tool_call`.
+- Preserved bridge-name collision behavior for direct backend tools; deferred tools with bridge-reserved names no longer suppress bridge helpers.
+- Updated package user-guide documentation for direct, deferred, and recommended-unavailable profile discovery behavior.
 
+Verification:
+- `source ../../.venv/bin/activate && python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_gateway_tool_discovery.py tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py -q` -> 183 passed, 6 warnings.
+- `source ../../.venv/bin/activate && python -m ruff check mcp_unified/gateway/tool_discovery.py mcp_unified/gateway/profile_runtime.py tldw_Server_API/app/core/MCP_unified/tests/test_gateway_tool_discovery.py tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py` -> passed.
+- `source ../../.venv/bin/activate && python -m py_compile mcp_unified/gateway/tool_discovery.py mcp_unified/gateway/profile_runtime.py` -> passed.
+- `source ../../.venv/bin/activate && python -m bandit -r mcp_unified/gateway/tool_discovery.py mcp_unified/gateway/profile_runtime.py -f json -o /tmp/bandit_mcp_tool_availability_search.json` -> 0 findings.
+- `git diff --check` -> passed.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-
+Implemented MCP profile tool availability and deferred search parity for the standalone gateway. Profiles now classify visible tools as direct, deferred installed, or recommended unavailable. Initial `tools/list` returns direct installed tools plus discovery bridge helpers, while `profile.tools.list`, `tool_search`, and `tool_describe` expose the full profile-filtered catalog with safe availability metadata. Deferred installed tools can still be delegated through `tool_call` under the existing profile policy path; recommendation-only tools remain discoverable setup hints and return `tool_not_enabled`.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->

--- a/backlog/tasks/task-2295 - Add-tool-availability-and-deferred-tool-search-parity.md
+++ b/backlog/tasks/task-2295 - Add-tool-availability-and-deferred-tool-search-parity.md
@@ -47,6 +47,19 @@ Verification:
 - `source ../../.venv/bin/activate && python -m py_compile mcp_unified/gateway/tool_discovery.py mcp_unified/gateway/profile_runtime.py` -> passed.
 - `source ../../.venv/bin/activate && python -m bandit -r mcp_unified/gateway/tool_discovery.py mcp_unified/gateway/profile_runtime.py -f json -o /tmp/bandit_mcp_tool_availability_search.json` -> 0 findings.
 - `git diff --check` -> passed.
+Review fixes after PR feedback:
+- Added a one-pass profile tool availability helper so `ProfileAwareGatewayRuntime.list_tools()` no longer scans backend tools twice and `tool_call` is advertised only for explicit deferred categories or installed deferred tools.
+- Added a direct backend tool lookup helper to preserve bridge-name collision behavior without deep-copying the full direct tool catalog.
+- Updated `tool_call` runtime gating to match `tools/list` availability; recommendation-only entries remain discoverable but do not make `tool_call` callable by themselves.
+- Cached normalized direct categories and tolerated malformed progressive-disclosure category metadata.
+- Replaced `Counter` payload construction for category and availability counts with explicit integer dictionaries.
+
+Review validation:
+- `source ../../.venv/bin/activate && python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_gateway_tool_discovery.py tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py -q` -> 186 passed, 6 warnings.
+- `source ../../.venv/bin/activate && python -m ruff check mcp_unified/gateway/tool_discovery.py mcp_unified/gateway/profile_runtime.py tldw_Server_API/app/core/MCP_unified/tests/test_gateway_tool_discovery.py tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py` -> passed.
+- `source ../../.venv/bin/activate && python -m py_compile mcp_unified/gateway/tool_discovery.py mcp_unified/gateway/profile_runtime.py` -> passed.
+- `source ../../.venv/bin/activate && python -m bandit -r mcp_unified/gateway/tool_discovery.py mcp_unified/gateway/profile_runtime.py -f json -o /tmp/bandit_mcp_tool_availability_search_review.json` -> 0 findings.
+- `git diff --check` -> passed.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary

--- a/mcp_unified/USER_GUIDE.md
+++ b/mcp_unified/USER_GUIDE.md
@@ -99,17 +99,23 @@ mcp-unified-gateway get-default-profile \
 ### Profile Tooling Discovery
 
 `list-presets` includes compact tooling discovery metadata for role presets.
-Direct categories describe tools the profile can expose immediately, subject to
-the profile policy and any assignment constraints. Deferred categories describe
-recommended unavailable tools or server-backed capabilities that may be useful
-for the role but are not executable until explicitly registered, granted, and
-allowed by policy.
+Direct categories describe installed tools the profile can expose immediately
+through `tools/list`, subject to the profile policy and any assignment
+constraints. Deferred categories keep installed tools out of the initial model
+tool surface while still making them discoverable through the profile discovery
+bridge. Recommendation-only tools remain setup hints until an operator installs
+or registers the matching backend tool and profile policy grants it.
 
 Profiles can expose progressive disclosure bridge tools such as
 `tool_categories.list`, `tool_search`, `tool_describe`, and
 `profile.tools.list`. These help clients inspect available direct tools first,
-then discover recommended next-step tools without expanding the executable tool
-surface by default.
+then discover deferred installed tools and recommended next-step tools without
+expanding the executable tool surface by default. `profile.tools.list` and
+`tool_search` report per-tool availability metadata, including whether a tool is
+`direct`, `deferred`, or `recommended_unavailable`, plus category-level counts.
+When `tool_call` is present, clients can delegate to an installed profile-visible
+tool by id after discovery; recommendation-only tools return `tool_not_enabled`
+until their backend becomes available.
 
 Filesystem-capable presets expose portable workspace-bounded helpers for common
 read workflows: `fs.stat` for metadata, `fs.glob` for cross-platform path

--- a/mcp_unified/gateway/profile_runtime.py
+++ b/mcp_unified/gateway/profile_runtime.py
@@ -19,9 +19,9 @@ from mcp_unified.tool_use_reporting.sanitization import sanitize_safe_id
 from .runtime import GatewayPolicyDenied, GatewayRequestContext, GatewayRuntime
 from .tool_discovery import (
     describe_profile_tool,
-    list_direct_profile_backend_tools,
+    find_direct_profile_backend_tool,
     list_profile_tools,
-    profile_has_deferred_tools,
+    profile_tool_availability,
     resolve_profile_tool_call,
     search_profile_tools,
 )
@@ -194,10 +194,8 @@ class ProfileAwareGatewayRuntime:
             return []
 
         tools = await self._safe_backend_tools(context)
-        direct_tools = list_direct_profile_backend_tools(
-            profile_result.profile,
-            tools,
-        )
+        availability = profile_tool_availability(profile_result.profile, tools)
+        direct_tools = availability.direct_tools
         allowed_tool_names = {
             name
             for tool in direct_tools
@@ -205,7 +203,7 @@ class ProfileAwareGatewayRuntime:
         }
         include_tool_call = (
             _profile_has_deferred_categories(profile_result.profile)
-            or profile_has_deferred_tools(profile_result.profile, tools)
+            or availability.has_deferred_installed_tools
         )
         return [
             *direct_tools,
@@ -396,7 +394,11 @@ class ProfileAwareGatewayRuntime:
             return description
         if name == _TOOL_CALL:
             tool_id, delegated_arguments = _validated_tool_call_arguments(arguments)
-            if not _profile_has_deferred_categories(profile):
+            availability = profile_tool_availability(profile, backend_tools)
+            if not (
+                _profile_has_deferred_categories(profile)
+                or availability.has_deferred_installed_tools
+            ):
                 raise GatewayPolicyDenied(
                     "Gateway profile denied tool execution: tool_not_allowed",
                     reason_code="tool_not_allowed",
@@ -529,13 +531,7 @@ def _allowed_backend_tool_by_name(
 ) -> dict[str, Any] | None:
     """Return an allowed backend descriptor matching a bridge-reserved name."""
 
-    for tool in list_direct_profile_backend_tools(profile, backend_tools):
-        if (
-            isinstance(tool, dict)
-            and _tool_name(tool) == name
-        ):
-            return tool
-    return None
+    return find_direct_profile_backend_tool(profile, backend_tools, name)
 
 
 def _profile_bridge_tool_descriptors(

--- a/mcp_unified/gateway/profile_runtime.py
+++ b/mcp_unified/gateway/profile_runtime.py
@@ -19,7 +19,9 @@ from mcp_unified.tool_use_reporting.sanitization import sanitize_safe_id
 from .runtime import GatewayPolicyDenied, GatewayRequestContext, GatewayRuntime
 from .tool_discovery import (
     describe_profile_tool,
+    list_direct_profile_backend_tools,
     list_profile_tools,
+    profile_has_deferred_tools,
     resolve_profile_tool_call,
     search_profile_tools,
 )
@@ -192,26 +194,25 @@ class ProfileAwareGatewayRuntime:
             return []
 
         tools = await self._safe_backend_tools(context)
-        allowed_tools: list[dict[str, Any]] = []
-        allowed_tool_names: set[str] = set()
-        for tool in tools:
-            if not isinstance(tool, dict):
-                continue
-            name = _tool_name(tool)
-            if (
-                name is not None
-                and _tool_allowed_by_profile(
-                    profile_result.profile,
-                    tool,
-                )
-            ):
-                allowed_tool_names.add(name)
-                allowed_tools.append(deepcopy(tool))
+        direct_tools = list_direct_profile_backend_tools(
+            profile_result.profile,
+            tools,
+        )
+        allowed_tool_names = {
+            name
+            for tool in direct_tools
+            if (name := _tool_name(tool)) is not None
+        }
+        include_tool_call = (
+            _profile_has_deferred_categories(profile_result.profile)
+            or profile_has_deferred_tools(profile_result.profile, tools)
+        )
         return [
-            *allowed_tools,
+            *direct_tools,
             *_profile_bridge_tool_descriptors(
                 profile_result.profile,
                 suppressed_names=allowed_tool_names,
+                include_tool_call=include_tool_call,
             ),
         ]
 
@@ -528,11 +529,10 @@ def _allowed_backend_tool_by_name(
 ) -> dict[str, Any] | None:
     """Return an allowed backend descriptor matching a bridge-reserved name."""
 
-    for tool in backend_tools:
+    for tool in list_direct_profile_backend_tools(profile, backend_tools):
         if (
             isinstance(tool, dict)
             and _tool_name(tool) == name
-            and _tool_allowed_by_profile(profile, tool)
         ):
             return tool
     return None
@@ -542,6 +542,7 @@ def _profile_bridge_tool_descriptors(
     profile: MCPProfile,
     *,
     suppressed_names: set[str],
+    include_tool_call: bool | None = None,
 ) -> list[dict[str, Any]]:
     """Return caller-owned synthetic discovery tool descriptors for a profile."""
 
@@ -551,7 +552,12 @@ def _profile_bridge_tool_descriptors(
         _TOOL_SEARCH,
         _TOOL_DESCRIBE,
     ]
-    if _profile_has_deferred_categories(profile):
+    should_include_tool_call = (
+        _profile_has_deferred_categories(profile)
+        if include_tool_call is None
+        else include_tool_call
+    )
+    if should_include_tool_call:
         names.append(_TOOL_CALL)
     return [
         deepcopy(_BRIDGE_TOOL_DESCRIPTORS[name])

--- a/mcp_unified/gateway/tool_discovery.py
+++ b/mcp_unified/gateway/tool_discovery.py
@@ -17,6 +17,11 @@ _TOKEN_PATTERN = re.compile(r"[A-Za-z0-9]+")
 _DEFAULT_CATEGORY = "uncategorized"
 _INSTALLED = "installed"
 _RECOMMENDED_UNAVAILABLE = "recommended_unavailable"
+_EXPOSURE_DIRECT = "direct"
+_EXPOSURE_DEFERRED = "deferred"
+_EXPOSURE_RECOMMENDED_UNAVAILABLE = "recommended_unavailable"
+_REASON_INSTALLED_DIRECT = "installed_direct"
+_REASON_INSTALLED_DEFERRED = "installed_deferred"
 _RANKING_METADATA: dict[str, Any] = {
     "semantic_search": False,
     "scoring": "bm25_standard_library",
@@ -42,6 +47,8 @@ class _ToolEntry:
     category: str
     capabilities: tuple[str, ...]
     installation_status: str
+    exposure: str
+    availability_reason_code: str
     source: str
     text: str
     backend_tool: dict[str, Any] | None = None
@@ -59,6 +66,7 @@ def list_profile_tools(profile: MCPProfile, backend_tools: Any) -> dict[str, Any
         "profile_id": profile.id,
         "tools": [_entry_payload(entry, score=0.0) for entry in ordered],
         "categories": _category_payload(profile, ordered),
+        "availability": _availability_payload(ordered),
         "progressive_disclosure": _progressive_disclosure(profile),
         "ranking": _ranking_metadata(),
     }
@@ -144,6 +152,32 @@ def resolve_profile_tool_call(
     }
 
 
+def list_direct_profile_backend_tools(
+    profile: MCPProfile,
+    backend_tools: Any,
+) -> list[dict[str, Any]]:
+    """Return caller-owned installed backend tools exposed directly to a profile."""
+
+    return [
+        deepcopy(entry.backend_tool)
+        for entry in _visible_entries(profile, backend_tools)
+        if (
+            entry.installation_status == _INSTALLED
+            and entry.exposure == _EXPOSURE_DIRECT
+            and entry.backend_tool is not None
+        )
+    ]
+
+
+def profile_has_deferred_tools(profile: MCPProfile, backend_tools: Any) -> bool:
+    """Return whether a profile has searchable tools outside direct exposure."""
+
+    return any(
+        entry.exposure in {_EXPOSURE_DEFERRED, _EXPOSURE_RECOMMENDED_UNAVAILABLE}
+        for entry in _visible_entries(profile, backend_tools)
+    )
+
+
 def _visible_entries(profile: MCPProfile, backend_tools: Any) -> list[_ToolEntry]:
     """Return installed and recommendation-only tools visible for a profile."""
 
@@ -207,6 +241,12 @@ def _installed_entry(profile: MCPProfile, tool: Any) -> _ToolEntry | None:
         _first_text(metadata, "unavailable_reason", "reason", "reason_code")
         or _first_text(tool, "unavailable_reason", "reason", "reason_code")
     )
+    exposure = _installed_exposure(profile, category)
+    availability_reason_code = (
+        _REASON_INSTALLED_DIRECT
+        if exposure == _EXPOSURE_DIRECT
+        else _REASON_INSTALLED_DEFERRED
+    )
     text = _search_text(
         tool_id,
         display_name,
@@ -224,6 +264,8 @@ def _installed_entry(profile: MCPProfile, tool: Any) -> _ToolEntry | None:
         category=category,
         capabilities=capabilities,
         installation_status=_INSTALLED,
+        exposure=exposure,
+        availability_reason_code=availability_reason_code,
         source="backend",
         text=text,
         backend_tool=tool,
@@ -293,6 +335,8 @@ def _recommended_entry(
         category=category,
         capabilities=capabilities,
         installation_status=_RECOMMENDED_UNAVAILABLE,
+        exposure=_EXPOSURE_RECOMMENDED_UNAVAILABLE,
+        availability_reason_code=_RECOMMENDED_UNAVAILABLE,
         source="profile_recommendation",
         text=text,
         activation=activation,
@@ -389,6 +433,31 @@ def _progressive_disclosure(profile: MCPProfile) -> dict[str, Any]:
     }
 
 
+def _has_progressive_disclosure_metadata(profile: MCPProfile) -> bool:
+    """Return whether profile metadata explicitly configures disclosure behavior."""
+
+    tooling = _tooling_metadata(profile)
+    return isinstance(tooling.get("progressive_disclosure"), dict)
+
+
+def _installed_exposure(profile: MCPProfile, category: str) -> str:
+    """Return direct or deferred exposure for an installed profile-visible tool."""
+
+    if not _has_progressive_disclosure_metadata(profile):
+        return _EXPOSURE_DIRECT
+
+    progressive = _progressive_disclosure(profile)
+    normalized_category = _normalize_category(category) or _DEFAULT_CATEGORY
+    direct_categories = {
+        normalized
+        for value in progressive["direct_categories"]
+        if (normalized := _normalize_category(value)) is not None
+    }
+    if normalized_category in direct_categories:
+        return _EXPOSURE_DIRECT
+    return _EXPOSURE_DEFERRED
+
+
 def _category_priority(profile: MCPProfile) -> dict[str, int]:
     """Return category priority from profile progressive-disclosure order."""
 
@@ -433,6 +502,7 @@ def _sort_entries(
         entries,
         key=lambda entry: (
             0 if entry.installation_status == _INSTALLED else 1,
+            _exposure_priority(entry),
             -scores.get(entry.tool_id, 0.0),
             category_priorities.get(
                 _normalize_category(entry.category) or "",
@@ -456,17 +526,24 @@ def _category_payload(
     for entry in entries:
         category = _normalize_category(entry.category) or _DEFAULT_CATEGORY
         categories.setdefault(category, Counter())
-        categories[category][entry.installation_status] += 1
+        categories[category]["count"] += 1
+        if entry.installation_status == _INSTALLED:
+            categories[category]["installed_count"] += 1
+        if entry.installation_status == _RECOMMENDED_UNAVAILABLE:
+            categories[category]["recommended_unavailable_count"] += 1
+        if entry.exposure == _EXPOSURE_DIRECT:
+            categories[category]["direct_count"] += 1
+        if entry.exposure == _EXPOSURE_DEFERRED:
+            categories[category]["deferred_installed_count"] += 1
 
     return [
         {
             "category": category,
-            "count": sum(counts.values()),
-            "installed_count": counts.get(_INSTALLED, 0),
-            "recommended_unavailable_count": counts.get(
-                _RECOMMENDED_UNAVAILABLE,
-                0,
-            ),
+            "count": counts.get("count", 0),
+            "direct_count": counts.get("direct_count", 0),
+            "deferred_installed_count": counts.get("deferred_installed_count", 0),
+            "installed_count": counts.get("installed_count", 0),
+            "recommended_unavailable_count": counts.get("recommended_unavailable_count", 0),
         }
         for category, counts in sorted(
             categories.items(),
@@ -481,6 +558,29 @@ def _category_payload(
     ]
 
 
+def _availability_payload(entries: list[_ToolEntry]) -> dict[str, int]:
+    """Return whole-catalog availability counts for profile discovery clients."""
+
+    counts: Counter[str] = Counter()
+    for entry in entries:
+        counts["count"] += 1
+        if entry.installation_status == _INSTALLED:
+            counts["installed_count"] += 1
+        if entry.installation_status == _RECOMMENDED_UNAVAILABLE:
+            counts["recommended_unavailable_count"] += 1
+        if entry.exposure == _EXPOSURE_DIRECT:
+            counts["direct_count"] += 1
+        if entry.exposure == _EXPOSURE_DEFERRED:
+            counts["deferred_installed_count"] += 1
+    return {
+        "count": counts.get("count", 0),
+        "installed_count": counts.get("installed_count", 0),
+        "direct_count": counts.get("direct_count", 0),
+        "deferred_installed_count": counts.get("deferred_installed_count", 0),
+        "recommended_unavailable_count": counts.get("recommended_unavailable_count", 0),
+    }
+
+
 def _entry_payload(entry: _ToolEntry, *, score: float) -> dict[str, Any]:
     """Return a JSON-safe public payload for one discovery entry."""
 
@@ -491,6 +591,8 @@ def _entry_payload(entry: _ToolEntry, *, score: float) -> dict[str, Any]:
         "category": entry.category,
         "capabilities": list(entry.capabilities),
         "installation_status": entry.installation_status,
+        "exposure": entry.exposure,
+        "availability_reason_code": entry.availability_reason_code,
         "source": entry.source,
         "ranking": _ranking_metadata(score),
     }
@@ -503,6 +605,16 @@ def _entry_payload(entry: _ToolEntry, *, score: float) -> dict[str, Any]:
     if entry.metadata:
         payload["metadata"] = deepcopy(entry.metadata)
     return payload
+
+
+def _exposure_priority(entry: _ToolEntry) -> int:
+    """Return stable sort priority for direct, deferred, and unavailable tools."""
+
+    if entry.exposure == _EXPOSURE_DIRECT:
+        return 0
+    if entry.exposure == _EXPOSURE_DEFERRED:
+        return 1
+    return 2
 
 
 def _ranking_metadata(score: float | None = None) -> dict[str, Any]:
@@ -629,7 +741,9 @@ def _normalize_sort_text(value: str) -> str:
 
 __all__ = [
     "describe_profile_tool",
+    "list_direct_profile_backend_tools",
     "list_profile_tools",
+    "profile_has_deferred_tools",
     "resolve_profile_tool_call",
     "search_profile_tools",
 ]

--- a/mcp_unified/gateway/tool_discovery.py
+++ b/mcp_unified/gateway/tool_discovery.py
@@ -7,6 +7,7 @@ from collections import Counter
 from collections.abc import Sequence
 from copy import deepcopy
 from dataclasses import dataclass
+from functools import lru_cache
 from math import log
 from typing import Any
 
@@ -22,6 +23,13 @@ _EXPOSURE_DEFERRED = "deferred"
 _EXPOSURE_RECOMMENDED_UNAVAILABLE = "recommended_unavailable"
 _REASON_INSTALLED_DIRECT = "installed_direct"
 _REASON_INSTALLED_DEFERRED = "installed_deferred"
+_AVAILABILITY_COUNT_KEYS = (
+    "count",
+    "installed_count",
+    "direct_count",
+    "deferred_installed_count",
+    "recommended_unavailable_count",
+)
 _RANKING_METADATA: dict[str, Any] = {
     "semantic_search": False,
     "scoring": "bm25_standard_library",
@@ -55,6 +63,15 @@ class _ToolEntry:
     activation: str | None = None
     unavailable_reason: str | None = None
     metadata: dict[str, Any] | None = None
+
+
+@dataclass(slots=True)
+class ProfileToolAvailability:
+    """Direct tool descriptors and callable deferred state for a profile."""
+
+    direct_tools: list[dict[str, Any]]
+    has_deferred_installed_tools: bool
+    has_recommended_unavailable_tools: bool
 
 
 def list_profile_tools(profile: MCPProfile, backend_tools: Any) -> dict[str, Any]:
@@ -158,24 +175,65 @@ def list_direct_profile_backend_tools(
 ) -> list[dict[str, Any]]:
     """Return caller-owned installed backend tools exposed directly to a profile."""
 
-    return [
-        deepcopy(entry.backend_tool)
-        for entry in _visible_entries(profile, backend_tools)
+    return profile_tool_availability(profile, backend_tools).direct_tools
+
+
+def profile_tool_availability(
+    profile: MCPProfile,
+    backend_tools: Any,
+) -> ProfileToolAvailability:
+    """Return direct tools and non-direct callable availability in one scan."""
+
+    direct_tools: list[dict[str, Any]] = []
+    has_deferred_installed_tools = False
+    has_recommended_unavailable_tools = False
+    for entry in _visible_entries(profile, backend_tools):
+        if entry.installation_status == _INSTALLED and entry.backend_tool is not None:
+            if entry.exposure == _EXPOSURE_DIRECT:
+                direct_tools.append(deepcopy(entry.backend_tool))
+            elif entry.exposure == _EXPOSURE_DEFERRED:
+                has_deferred_installed_tools = True
+        elif entry.installation_status == _RECOMMENDED_UNAVAILABLE:
+            has_recommended_unavailable_tools = True
+    return ProfileToolAvailability(
+        direct_tools=direct_tools,
+        has_deferred_installed_tools=has_deferred_installed_tools,
+        has_recommended_unavailable_tools=has_recommended_unavailable_tools,
+    )
+
+
+def profile_has_deferred_installed_tools(
+    profile: MCPProfile,
+    backend_tools: Any,
+) -> bool:
+    """Return whether a profile has callable installed tools outside direct exposure."""
+
+    return profile_tool_availability(
+        profile,
+        backend_tools,
+    ).has_deferred_installed_tools
+
+
+def find_direct_profile_backend_tool(
+    profile: MCPProfile,
+    backend_tools: Any,
+    tool_name: str,
+) -> dict[str, Any] | None:
+    """Return a caller-owned direct backend tool without copying the full catalog."""
+
+    normalized_tool_name = _clean_text(tool_name)
+    if normalized_tool_name is None:
+        return None
+
+    for entry in _visible_entries(profile, backend_tools):
         if (
-            entry.installation_status == _INSTALLED
+            entry.tool_id == normalized_tool_name
+            and entry.installation_status == _INSTALLED
             and entry.exposure == _EXPOSURE_DIRECT
             and entry.backend_tool is not None
-        )
-    ]
-
-
-def profile_has_deferred_tools(profile: MCPProfile, backend_tools: Any) -> bool:
-    """Return whether a profile has searchable tools outside direct exposure."""
-
-    return any(
-        entry.exposure in {_EXPOSURE_DEFERRED, _EXPOSURE_RECOMMENDED_UNAVAILABLE}
-        for entry in _visible_entries(profile, backend_tools)
-    )
+        ):
+            return deepcopy(entry.backend_tool)
+    return None
 
 
 def _visible_entries(profile: MCPProfile, backend_tools: Any) -> list[_ToolEntry]:
@@ -448,14 +506,21 @@ def _installed_exposure(profile: MCPProfile, category: str) -> str:
 
     progressive = _progressive_disclosure(profile)
     normalized_category = _normalize_category(category) or _DEFAULT_CATEGORY
-    direct_categories = {
-        normalized
-        for value in progressive["direct_categories"]
-        if (normalized := _normalize_category(value)) is not None
-    }
+    direct_categories = _direct_category_set(tuple(progressive["direct_categories"]))
     if normalized_category in direct_categories:
         return _EXPOSURE_DIRECT
     return _EXPOSURE_DEFERRED
+
+
+@lru_cache(maxsize=128)
+def _direct_category_set(categories: tuple[str, ...]) -> frozenset[str]:
+    """Return cached normalized direct categories from profile metadata."""
+
+    return frozenset(
+        normalized
+        for value in categories
+        if (normalized := _normalize_category(value)) is not None
+    )
 
 
 def _category_priority(profile: MCPProfile) -> dict[str, int]:
@@ -522,28 +587,28 @@ def _category_payload(
 
     category_priorities = _category_priority(profile)
     fallback_priority = len(category_priorities)
-    categories: dict[str, Counter[str]] = {}
+    categories: dict[str, dict[str, int]] = {}
     for entry in entries:
         category = _normalize_category(entry.category) or _DEFAULT_CATEGORY
-        categories.setdefault(category, Counter())
-        categories[category]["count"] += 1
+        counts = categories.setdefault(category, _empty_availability_counts())
+        counts["count"] += 1
         if entry.installation_status == _INSTALLED:
-            categories[category]["installed_count"] += 1
+            counts["installed_count"] += 1
         if entry.installation_status == _RECOMMENDED_UNAVAILABLE:
-            categories[category]["recommended_unavailable_count"] += 1
+            counts["recommended_unavailable_count"] += 1
         if entry.exposure == _EXPOSURE_DIRECT:
-            categories[category]["direct_count"] += 1
+            counts["direct_count"] += 1
         if entry.exposure == _EXPOSURE_DEFERRED:
-            categories[category]["deferred_installed_count"] += 1
+            counts["deferred_installed_count"] += 1
 
     return [
         {
             "category": category,
-            "count": counts.get("count", 0),
-            "direct_count": counts.get("direct_count", 0),
-            "deferred_installed_count": counts.get("deferred_installed_count", 0),
-            "installed_count": counts.get("installed_count", 0),
-            "recommended_unavailable_count": counts.get("recommended_unavailable_count", 0),
+            "count": counts["count"],
+            "direct_count": counts["direct_count"],
+            "deferred_installed_count": counts["deferred_installed_count"],
+            "installed_count": counts["installed_count"],
+            "recommended_unavailable_count": counts["recommended_unavailable_count"],
         }
         for category, counts in sorted(
             categories.items(),
@@ -561,7 +626,7 @@ def _category_payload(
 def _availability_payload(entries: list[_ToolEntry]) -> dict[str, int]:
     """Return whole-catalog availability counts for profile discovery clients."""
 
-    counts: Counter[str] = Counter()
+    counts = _empty_availability_counts()
     for entry in entries:
         counts["count"] += 1
         if entry.installation_status == _INSTALLED:
@@ -572,13 +637,13 @@ def _availability_payload(entries: list[_ToolEntry]) -> dict[str, int]:
             counts["direct_count"] += 1
         if entry.exposure == _EXPOSURE_DEFERRED:
             counts["deferred_installed_count"] += 1
-    return {
-        "count": counts.get("count", 0),
-        "installed_count": counts.get("installed_count", 0),
-        "direct_count": counts.get("direct_count", 0),
-        "deferred_installed_count": counts.get("deferred_installed_count", 0),
-        "recommended_unavailable_count": counts.get("recommended_unavailable_count", 0),
-    }
+    return counts
+
+
+def _empty_availability_counts() -> dict[str, int]:
+    """Return a fresh availability counter payload."""
+
+    return dict.fromkeys(_AVAILABILITY_COUNT_KEYS, 0)
 
 
 def _entry_payload(entry: _ToolEntry, *, score: float) -> dict[str, Any]:
@@ -741,9 +806,12 @@ def _normalize_sort_text(value: str) -> str:
 
 __all__ = [
     "describe_profile_tool",
+    "find_direct_profile_backend_tool",
     "list_direct_profile_backend_tools",
     "list_profile_tools",
-    "profile_has_deferred_tools",
+    "profile_has_deferred_installed_tools",
+    "profile_tool_availability",
+    "ProfileToolAvailability",
     "resolve_profile_tool_call",
     "search_profile_tools",
 ]

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py
@@ -2697,6 +2697,51 @@ def test_profile_runtime_omits_tool_call_without_deferred_categories() -> None:
     _assert_profile_runtime_tool_names(tools, backend_tools=["echo.search"])
 
 
+def test_profile_runtime_omits_tool_call_for_recommendations_without_deferred_categories() -> None:
+    from mcp_unified.gateway.profile_runtime import ProfileAwareGatewayRuntime
+    from mcp_unified.gateway.runtime import GatewayPolicyDenied, GatewayRequestContext
+    from mcp_unified.profiles.store import InMemoryProfileStore
+
+    backend = _CustomToolListGatewayRuntime([])
+    profile = _profile_with_tooling_metadata(
+        "frontend",
+        allowed_tools=["browser.trace"],
+        recommended_tools=[
+            {
+                "id": "browser.trace",
+                "category": "browser",
+                "description": "Browser trace capture.",
+                "activation": "requires_browser_runtime",
+            }
+        ],
+        direct_categories=["code"],
+        deferred_categories=[],
+    )
+    runtime = ProfileAwareGatewayRuntime(
+        backend,
+        profile_store=InMemoryProfileStore([profile]),
+        default_profile_id="frontend",
+    )
+    context = GatewayRequestContext(request_id="recommendation-only-tools")
+
+    tools = asyncio.run(runtime.list_tools(context))
+    catalog = asyncio.run(runtime.call_tool("profile.tools.list", {}, context))
+
+    _assert_profile_runtime_tool_names(tools, backend_tools=[])
+    assert [tool["tool_id"] for tool in catalog["tools"]] == ["browser.trace"]
+    assert catalog["tools"][0]["installation_status"] == "recommended_unavailable"
+    with pytest.raises(GatewayPolicyDenied) as exc_info:
+        asyncio.run(
+            runtime.call_tool(
+                "tool_call",
+                {"tool_id": "browser.trace", "arguments": {}},
+                context,
+            )
+        )
+    assert exc_info.value.reason_code == "tool_not_allowed"
+    assert backend.call_requests == []
+
+
 def test_profile_runtime_tool_search_bridge_returns_profile_scoped_results() -> None:
     from mcp_unified.gateway.profile_runtime import ProfileAwareGatewayRuntime
     from mcp_unified.gateway.runtime import GatewayRequestContext
@@ -2796,7 +2841,7 @@ def test_profile_runtime_hides_deferred_installed_tools_from_initial_list() -> N
         "frontend",
         capabilities=["code_search", "browser.inspect"],
         direct_categories=["code"],
-        deferred_categories=["browser"],
+        deferred_categories=[],
     )
     runtime = ProfileAwareGatewayRuntime(
         backend,
@@ -2860,6 +2905,7 @@ def test_profile_runtime_search_and_calls_deferred_installed_tools() -> None:
     )
     context = GatewayRequestContext(request_id="deferred-search-call")
 
+    tools = asyncio.run(runtime.list_tools(context))
     catalog = asyncio.run(runtime.call_tool("profile.tools.list", {}, context))
     results = asyncio.run(
         runtime.call_tool(
@@ -2877,6 +2923,11 @@ def test_profile_runtime_search_and_calls_deferred_installed_tools() -> None:
     )
 
     catalog_entries = {tool["tool_id"]: tool for tool in catalog["tools"]}
+    _assert_profile_runtime_tool_names(
+        tools,
+        backend_tools=["code.search"],
+        includes_tool_call=True,
+    )
     assert catalog_entries["code.search"]["exposure"] == "direct"
     assert catalog_entries["browser.snapshot"]["exposure"] == "deferred"
     assert [tool["tool_id"] for tool in results["tools"]] == ["browser.snapshot"]

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py
@@ -180,7 +180,7 @@ class _MultiToolGatewayRuntime(_FakeGatewayRuntime):
                     "properties": {"query": {"type": "string"}},
                     "required": ["query"],
                 },
-                "metadata": {"category": "test", "capability": "code_search"},
+                "metadata": {"category": "code", "capability": "code_search"},
             },
             {
                 "name": "admin.delete",
@@ -2656,7 +2656,7 @@ def test_profile_runtime_exposes_discovery_bridge_tools_for_deferred_categories(
 
     _assert_profile_runtime_tool_names(
         tools,
-        backend_tools=["browser.snapshot"],
+        backend_tools=[],
         includes_tool_call=True,
     )
     for name in (
@@ -2683,7 +2683,7 @@ def test_profile_runtime_omits_tool_call_without_deferred_categories() -> None:
     profile = _profile_with_tooling_metadata(
         "researcher",
         capabilities=["code_search"],
-        direct_categories=["test"],
+        direct_categories=["code"],
         deferred_categories=[],
     )
     runtime = ProfileAwareGatewayRuntime(
@@ -2765,6 +2765,125 @@ def test_profile_runtime_tool_search_bridge_returns_profile_scoped_results() -> 
     assert results["tools"][0]["installation_status"] == "installed"
     assert results["tools"][1]["installation_status"] == "recommended_unavailable"
     assert backend.call_requests == []
+
+
+def test_profile_runtime_hides_deferred_installed_tools_from_initial_list() -> None:
+    from mcp_unified.gateway.profile_runtime import ProfileAwareGatewayRuntime
+    from mcp_unified.gateway.runtime import GatewayRequestContext
+    from mcp_unified.profiles.store import InMemoryProfileStore
+
+    backend = _CustomToolListGatewayRuntime(
+        [
+            {
+                "name": "code.search",
+                "description": "Search code.",
+                "metadata": {
+                    "capability": "code_search",
+                    "category": "code",
+                },
+            },
+            {
+                "name": "browser.snapshot",
+                "description": "Browser DOM snapshot.",
+                "metadata": {
+                    "capability": "browser.inspect",
+                    "category": "browser",
+                },
+            },
+        ]
+    )
+    profile = _profile_with_tooling_metadata(
+        "frontend",
+        capabilities=["code_search", "browser.inspect"],
+        direct_categories=["code"],
+        deferred_categories=["browser"],
+    )
+    runtime = ProfileAwareGatewayRuntime(
+        backend,
+        profile_store=InMemoryProfileStore([profile]),
+        default_profile_id="frontend",
+    )
+
+    tools = asyncio.run(runtime.list_tools(GatewayRequestContext(request_id="direct-only")))
+
+    _assert_profile_runtime_tool_names(
+        tools,
+        backend_tools=["code.search"],
+        includes_tool_call=True,
+    )
+    assert "browser.snapshot" not in _listed_tool_names(tools)
+
+
+def test_profile_runtime_search_and_calls_deferred_installed_tools() -> None:
+    from mcp_unified.gateway.profile_runtime import ProfileAwareGatewayRuntime
+    from mcp_unified.gateway.runtime import GatewayRequestContext
+    from mcp_unified.profiles.store import InMemoryProfileStore
+
+    backend = _CustomToolListGatewayRuntime(
+        [
+            {
+                "name": "code.search",
+                "description": "Search code.",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {"query": {"type": "string"}},
+                },
+                "metadata": {
+                    "capability": "code_search",
+                    "category": "code",
+                },
+            },
+            {
+                "name": "browser.snapshot",
+                "description": "Browser DOM snapshot.",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {"query": {"type": "string"}},
+                },
+                "metadata": {
+                    "capability": "browser.inspect",
+                    "category": "browser",
+                },
+            },
+        ]
+    )
+    profile = _profile_with_tooling_metadata(
+        "frontend",
+        capabilities=["code_search", "browser.inspect"],
+        direct_categories=["code"],
+        deferred_categories=["browser"],
+    )
+    runtime = ProfileAwareGatewayRuntime(
+        backend,
+        profile_store=InMemoryProfileStore([profile]),
+        default_profile_id="frontend",
+    )
+    context = GatewayRequestContext(request_id="deferred-search-call")
+
+    catalog = asyncio.run(runtime.call_tool("profile.tools.list", {}, context))
+    results = asyncio.run(
+        runtime.call_tool(
+            "tool_search",
+            {"query": "browser", "category": "browser", "limit": 10},
+            context,
+        )
+    )
+    payload = asyncio.run(
+        runtime.call_tool(
+            "tool_call",
+            {"tool_id": "browser.snapshot", "arguments": {"query": "dom"}},
+            context,
+        )
+    )
+
+    catalog_entries = {tool["tool_id"]: tool for tool in catalog["tools"]}
+    assert catalog_entries["code.search"]["exposure"] == "direct"
+    assert catalog_entries["browser.snapshot"]["exposure"] == "deferred"
+    assert [tool["tool_id"] for tool in results["tools"]] == ["browser.snapshot"]
+    assert results["tools"][0]["installation_status"] == "installed"
+    assert results["tools"][0]["exposure"] == "deferred"
+    assert payload["content"][0]["text"] == "browser.snapshot:dom"
+    assert backend.call_requests[-1][0] == "browser.snapshot"
 
 
 def test_profile_runtime_tool_describe_bridge_hides_denied_tools() -> None:

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_tool_discovery.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_tool_discovery.py
@@ -9,7 +9,10 @@ from typing import Any
 from mcp_unified.gateway import tool_discovery
 from mcp_unified.gateway.tool_discovery import (
     describe_profile_tool,
+    find_direct_profile_backend_tool,
     list_profile_tools,
+    profile_has_deferred_installed_tools,
+    profile_tool_availability,
     resolve_profile_tool_call,
     search_profile_tools,
 )
@@ -161,6 +164,86 @@ def test_profile_tools_classify_direct_deferred_and_recommended_availability() -
         "deferred_installed_count": 1,
         "recommended_unavailable_count": 1,
     }
+
+
+def test_profile_tool_availability_reports_callable_deferred_tools_only() -> None:
+    profile = MCPProfile(
+        id="engineer",
+        name="Engineer",
+        policy_document=ProfilePolicy(capabilities=["code_search", "browser.inspect"]),
+        metadata={
+            "tooling": {
+                "recommended_tools": [
+                    {
+                        "id": "browser.trace",
+                        "category": "browser",
+                        "description": "Browser trace capture",
+                        "capability": "browser.inspect",
+                    }
+                ],
+                "progressive_disclosure": {
+                    "direct_categories": ["code"],
+                    "deferred_categories": ["browser"],
+                    "max_direct_tools": 24,
+                },
+            }
+        },
+    )
+    tools = [
+        {
+            "name": "code.search",
+            "description": "Search code",
+            "metadata": {"capability": "code_search", "category": "code"},
+        },
+        {
+            "name": "browser.snapshot",
+            "description": "Browser DOM snapshot",
+            "metadata": {"capability": "browser.inspect", "category": "browser"},
+        },
+    ]
+
+    availability = profile_tool_availability(profile, tools)
+    direct_tool = find_direct_profile_backend_tool(profile, tools, "code.search")
+
+    assert [tool["name"] for tool in availability.direct_tools] == ["code.search"]
+    assert availability.direct_tools[0] is not tools[0]
+    assert availability.has_deferred_installed_tools is True
+    assert availability.has_recommended_unavailable_tools is True
+    assert profile_has_deferred_installed_tools(profile, tools) is True
+    assert direct_tool == tools[0]
+    assert direct_tool is not tools[0]
+    assert find_direct_profile_backend_tool(profile, tools, "browser.snapshot") is None
+
+
+def test_profile_tools_ignore_malformed_direct_category_metadata() -> None:
+    profile = MCPProfile(
+        id="engineer",
+        name="Engineer",
+        policy_document=ProfilePolicy(capabilities=["code_search"]),
+        metadata={
+            "tooling": {
+                "progressive_disclosure": {
+                    "direct_categories": {"code": True},
+                    "deferred_categories": ["code"],
+                    "max_direct_tools": 24,
+                },
+            }
+        },
+    )
+    tools = [
+        {
+            "name": "code.search",
+            "description": "Search code",
+            "metadata": {"capability": "code_search", "category": "code"},
+        }
+    ]
+
+    payload = list_profile_tools(profile, tools)
+
+    assert payload["tools"][0]["tool_id"] == "code.search"
+    assert payload["tools"][0]["exposure"] == "deferred"
+    assert payload["availability"]["direct_count"] == 0
+    assert payload["availability"]["deferred_installed_count"] == 1
 
 
 def test_tool_search_orders_installed_before_unavailable_then_bm25() -> None:

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_tool_discovery.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_tool_discovery.py
@@ -93,11 +93,74 @@ def test_list_profile_tools_consolidates_category_counts_by_normalized_name() ->
         {
             "category": "code",
             "count": 2,
+            "direct_count": 0,
+            "deferred_installed_count": 2,
             "installed_count": 2,
             "recommended_unavailable_count": 0,
         }
     ]
     assert {item["tool_id"] for item in results} == {"code.search", "code.symbols"}
+
+
+def test_profile_tools_classify_direct_deferred_and_recommended_availability() -> None:
+    profile = MCPProfile(
+        id="engineer",
+        name="Engineer",
+        policy_document=ProfilePolicy(capabilities=["code_search", "browser.inspect"]),
+        metadata={
+            "tooling": {
+                "recommended_tools": [
+                    {
+                        "id": "browser.trace",
+                        "category": "browser",
+                        "description": "Browser trace capture",
+                        "capability": "browser.inspect",
+                        "activation": "requires_browser_runtime",
+                    }
+                ],
+                "progressive_disclosure": {
+                    "direct_categories": ["code"],
+                    "deferred_categories": ["browser"],
+                    "max_direct_tools": 24,
+                },
+            }
+        },
+    )
+    tools = [
+        {
+            "name": "code.search",
+            "description": "Search code",
+            "metadata": {"capability": "code_search", "category": "code"},
+        },
+        {
+            "name": "browser.snapshot",
+            "description": "Browser DOM snapshot",
+            "metadata": {"capability": "browser.inspect", "category": "browser"},
+        },
+    ]
+
+    payload = list_profile_tools(profile, tools)
+    entries = {item["tool_id"]: item for item in payload["tools"]}
+    categories = {item["category"]: item for item in payload["categories"]}
+
+    assert entries["code.search"]["exposure"] == "direct"
+    assert entries["code.search"]["availability_reason_code"] == "installed_direct"
+    assert entries["browser.snapshot"]["exposure"] == "deferred"
+    assert entries["browser.snapshot"]["availability_reason_code"] == "installed_deferred"
+    assert entries["browser.trace"]["exposure"] == "recommended_unavailable"
+    assert entries["browser.trace"]["availability_reason_code"] == "recommended_unavailable"
+    assert categories["code"]["direct_count"] == 1
+    assert categories["code"]["deferred_installed_count"] == 0
+    assert categories["browser"]["direct_count"] == 0
+    assert categories["browser"]["deferred_installed_count"] == 1
+    assert categories["browser"]["recommended_unavailable_count"] == 1
+    assert payload["availability"] == {
+        "count": 3,
+        "installed_count": 2,
+        "direct_count": 1,
+        "deferred_installed_count": 1,
+        "recommended_unavailable_count": 1,
+    }
 
 
 def test_tool_search_orders_installed_before_unavailable_then_bm25() -> None:


### PR DESCRIPTION
## Change Summary
- Adds profile-scoped direct/deferred/recommended tool availability classification for the standalone MCP gateway.
- Hides deferred installed tools from initial `tools/list` while keeping them available through `profile.tools.list`, `tool_search`, `tool_describe`, and `tool_call`.
- Adds safe availability counts/reason metadata and updates package user-guide docs.
- Addresses review feedback by using a one-pass availability helper, cached direct-category normalization, explicit count dictionaries, and aligned `tool_call` visibility/execution gating.

## Validation
- [x] `source ../../.venv/bin/activate && python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_gateway_tool_discovery.py tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py -q` -> 186 passed, 6 warnings.
- [x] `source ../../.venv/bin/activate && python -m ruff check mcp_unified/gateway/tool_discovery.py mcp_unified/gateway/profile_runtime.py tldw_Server_API/app/core/MCP_unified/tests/test_gateway_tool_discovery.py tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py` -> passed.
- [x] `source ../../.venv/bin/activate && python -m py_compile mcp_unified/gateway/tool_discovery.py mcp_unified/gateway/profile_runtime.py` -> passed.
- [x] `source ../../.venv/bin/activate && python -m bandit -r mcp_unified/gateway/tool_discovery.py mcp_unified/gateway/profile_runtime.py -f json -o /tmp/bandit_mcp_tool_availability_search_review.json` -> 0 findings.
- [x] `git diff --check` -> passed.

## Risk Level
Low to medium. The change is scoped to MCP profile tool discovery/runtime exposure and focused tests. Main behavioral risk is client expectation around `tools/list`; deferred installed tools are intentionally hidden there and remain available through discovery bridge tools.

## Rollback Plan
Revert the PR commits to restore the previous direct `tools/list` behavior and remove the deferred search/catalog bridge behavior. No migration or persistent data change is involved.

## UX Audit
N/A. This is backend/package MCP behavior and documentation, not a rendered frontend UI change.

## Watchlists
N/A. This PR does not modify watchlist behavior.

## Merge Note
Repository policy still requires the human requester to review and own the final Change summary before merge.
