### PR TITLE
Enforce MCP permission rules at gateway runtime

### DIFF
--- a/Docs/superpowers/plans/2026-06-10-mcp-permission-runtime-enforcement-plan.md
+++ b/Docs/superpowers/plans/2026-06-10-mcp-permission-runtime-enforcement-plan.md
@@ -1,0 +1,76 @@
+# MCP Permission Runtime Enforcement Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Wire compiled MCP profile `permission_rules` into standalone gateway tool-call execution as an additional runtime enforcement layer.
+
+**Architecture:** Keep legacy `allowed_tools`/`denied_tools` and capability policy as the primary tool visibility and execution gate. After a backend tool is already allowed, evaluate matching `permission_rules` subjects extracted from the tool call and block matching `deny` or `ask` rules with redacted `GatewayPolicyDenied` payloads. Treat unmatched permission rules as no-op so path/domain/command rules do not accidentally grant tools.
+
+**Tech Stack:** Python, Pydantic profile models, `mcp_unified.profiles.permission_rules`, standalone gateway runtime, pytest.
+
+---
+
+### Task 1: Add Red Tests For Runtime Permission Rules
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py`
+
+- [x] **Step 1: Add failing tests**
+  - Add a helper profile with `allowed_tools` plus extra `permission_rules`.
+  - Add a test where `fs.read_text` is allowed by legacy policy but blocked by `Read(docs/private/**)` when the call arguments include `{"path": "docs/private/secret.txt"}`.
+  - Add a test where a matching `ask` permission rule blocks with `status == "approval_required"`.
+  - Add a test where a matching external MCP wildcard rule blocks an allowed `mcp__github__delete_repo` backend tool.
+
+- [x] **Step 2: Run red tests**
+  - Run: `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py -q -k "permission_rule"`
+  - Expected: new tests fail because runtime calls do not yet evaluate `permission_rules`.
+
+### Task 2: Enforce Matching Permission Rules In Gateway Runtime
+
+**Files:**
+- Modify: `mcp_unified/gateway/profile_runtime.py`
+
+- [x] **Step 1: Add subject extraction helpers**
+  - Extract always-present `tool` subject from the backend tool name.
+  - Extract `mcp` subject when the tool name starts with `mcp__`.
+  - Extract common path subjects from argument keys such as `path`, `file_path`, `base_path`, `source_path`, and `destination_path`, plus list values such as `paths`.
+  - Extract common domain subjects from keys such as `url`, `uri`, `domain`, `host`, and `urls`.
+  - Extract command subjects from `command` string or `argv` list/tuple arguments.
+
+- [x] **Step 2: Add enforcement helper**
+  - Compile profile permission rules from `profile.policy_document`.
+  - For each extracted subject, call `evaluate_permission_rule_decision()`.
+  - Ignore unmatched default-deny decisions with no matched rules.
+  - Raise `GatewayPolicyDenied(status="denied")` for matched `deny`.
+  - Raise `GatewayPolicyDenied(status="approval_required")` for matched `ask` until approval prompts are integrated.
+  - Include redacted provenance: `profile_id`, `tool_name`, `subject_type`, `reason_code`, and matched rule metadata. Do not include raw path, URL, command, or argument values.
+
+- [x] **Step 3: Wire helper into `_call_backend_tool_through_policy()`**
+  - Run it only after `_allowed_policy_result_for_tool()` returns `resolved`.
+  - Keep existing legacy denials and backend metadata fallback behavior unchanged.
+  - Pass the resolved effective policy to backend calls exactly as before when no permission-rule block occurs.
+
+- [x] **Step 4: Run green tests**
+  - Run: `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py -q -k "permission_rule"`
+  - Expected: new tests pass.
+
+### Task 3: Validate Focused Profile/Gateway Behavior
+
+**Files:**
+- Modify: `backlog/tasks/task-2349 - Wire-MCP-permission-rules-into-runtime-tool-call-enforcement.md`
+
+- [x] **Step 1: Run focused regression suite**
+  - Run: `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py tldw_Server_API/app/core/MCP_unified/tests/test_profile_permission_rules.py tldw_Server_API/app/core/MCP_unified/tests/test_profile_policy_decisions.py -q`
+  - Expected: pass.
+
+- [x] **Step 2: Run quality gates**
+  - Run Ruff on touched Python files.
+  - Run compile smoke on touched package modules.
+  - Run Bandit on touched package modules.
+  - Run `git diff --check`.
+
+- [x] **Step 3: Update Backlog task**
+  - Record implementation notes, verification commands, known deferred items, final summary, and Definition of Done.
+
+- [x] **Step 4: Commit**
+  - Commit message: `feat: enforce MCP permission rules at gateway runtime`.

--- a/backlog/tasks/task-2349 - Wire-MCP-permission-rules-into-runtime-tool-call-enforcement.md
+++ b/backlog/tasks/task-2349 - Wire-MCP-permission-rules-into-runtime-tool-call-enforcement.md
@@ -1,0 +1,65 @@
+---
+id: TASK-2349
+title: Wire MCP permission rules into runtime tool-call enforcement
+status: Done
+assignee: []
+created_date: ''
+updated_date: '2026-06-10 06:07'
+labels:
+  - mcp
+  - profiles
+  - permissions
+  - runtime
+  - agentic-execution
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Add the first runtime enforcement slice for compiled MCP profile permission_rules so profile-scoped tool calls can evaluate relevant tool/path/domain/command/MCP subjects before execution. Keep scope minimal, test-first, and preserve existing legacy allowed_tools/denied_tools behavior.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Runtime tool-call authorization evaluates compiled permission_rules for the applicable subject family without bypassing existing exact tool allow/deny behavior.
+- [x] #2 Denied permission-rule decisions block execution with an explainable, redacted error payload; ask decisions remain non-callable until approval support exists.
+- [x] #3 Focused tests cover allowed legacy tools plus permission-rule denial for at least one runtime tool-call path.
+- [x] #4 Docs or task notes record remaining deferred surfaces such as approval prompts, hooks, and shell alias parsing.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented the first standalone gateway runtime enforcement slice in mcp_unified.gateway.profile_runtime. The gateway still runs existing legacy allowed_tools/denied_tools and capability checks first. Once a backend tool is allowed, it compiles profile permission_rules and evaluates extracted tool, path, domain, command, and mcp subjects from the call arguments. Matched deny rules raise GatewayPolicyDenied with status=denied. Matched ask rules raise GatewayPolicyDenied with status=approval_required until approval prompts are wired. Unmatched default-deny decisions from permission-rule evaluation are ignored so path/domain/command rules do not grant tool execution. Denial provenance is redacted to profile_id, tool_name, subject_type, and matched rule metadata; raw path, URL, command, and argument values are not included.
+
+TDD evidence:
+- Baseline before edits: `python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py tldw_Server_API/app/core/MCP_unified/tests/test_profile_permission_rules.py tldw_Server_API/app/core/MCP_unified/tests/test_profile_policy_decisions.py -q` passed with 243 tests.
+- Red tests: `python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py -q -k "permission_rule"` failed because calls succeeded instead of returning policy denials.
+- Green tests: same command passed with 3 tests.
+
+Verification:
+- Focused regression: `python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py tldw_Server_API/app/core/MCP_unified/tests/test_profile_permission_rules.py tldw_Server_API/app/core/MCP_unified/tests/test_profile_policy_decisions.py -q` passed with 246 tests.
+- Ruff: `python -m ruff check mcp_unified/gateway/profile_runtime.py tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py` passed.
+- Compile smoke: `python -m compileall -q mcp_unified/gateway/profile_runtime.py` passed.
+- Bandit: `python -m bandit -r mcp_unified/gateway/profile_runtime.py -f json -o /tmp/bandit_mcp_permission_runtime_enforcement.json` passed.
+- Whitespace: `git diff --check` passed.
+
+Deferred: approval prompt/lease flow for ask decisions, hook integration, richer shell alias parsing, deeper tool-specific argument extraction, and wiring similar enforcement into the older in-process tldw_Server_API MCP protocol path.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Wired compiled MCP profile permission_rules into standalone gateway runtime calls as an additional deny/ask enforcement layer after existing legacy tool policy allows execution. Added coverage for path, domain ask, and MCP wildcard runtime denials with redacted error payloads.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-2350 - Address-PR-2344-permission-runtime-review-feedback.md
+++ b/backlog/tasks/task-2350 - Address-PR-2344-permission-runtime-review-feedback.md
@@ -1,0 +1,70 @@
+---
+id: TASK-2350
+title: Address PR 2344 permission runtime review feedback
+status: Done
+assignee: []
+created_date: '2026-06-11'
+updated_date: '2026-06-11'
+labels:
+  - mcp
+  - profiles
+  - permissions
+  - runtime
+  - review-feedback
+dependencies:
+  - TASK-2349
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Address automated review feedback on PR #2344 (gateway runtime permission-rule enforcement). Qodo flagged request-driven CPU/memory amplification: permission rules were recompiled on every tools/call and all extracted subjects materialized without bounds, so oversized paths/urls/argv payloads drive O(subjects×rules) work before backend execution. Gemini requested a defensive None-guard for profile/policy_document before compiling rules.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Compiled permission rules are cached per profile version so repeated tool calls against an unchanged profile compile once, and profile updates take effect on the next call.
+- [x] #2 The cache is bounded so many distinct profiles cannot grow it without limit.
+- [x] #3 Subject extraction enforces limits on subject count, subject value length, and argv token count, failing closed with a redacted explainable denial instead of truncating or skipping subjects.
+- [x] #4 Profiles without a policy document (or absent profiles) skip permission-rule compilation without error.
+- [x] #5 Rule-free profiles are unaffected by the extraction limits.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Added a bounded LRU cache (collections.OrderedDict, 64 entries) of compiled permission rules on ProfileAwareGatewayRuntime, keyed by (profile.id, profile.updated_at). updated_at is bumped by every gateway management mutation, so it acts as the profile version stamp; direct store writes that reuse a stale updated_at are out of scope (the management surface is the supported mutation path). Compile failures are not cached and keep raising GatewayPolicyDenied with reason_code=invalid_permission_rules. _compiled_permission_rules() returns () when profile or policy_document is None (Gemini guard). _enforce_permission_rules_for_tool_call() now receives pre-compiled rules instead of compiling per call.
+
+Subject extraction is bounded during extraction (not after materializing): _MAX_PERMISSION_SUBJECTS=128, _MAX_SUBJECT_VALUE_LENGTH=4096, _MAX_COMMAND_ARGV_TOKENS=256. Exceeding any limit fails closed with GatewayPolicyDenied status=denied, reason_code=permission_subject_limits_exceeded, and redacted provenance (profile_id, tool_name, limit name only — no raw values). Fail-closed was chosen over truncation because silently skipping subjects past the cap could let an oversized payload push a denied subject out of evaluation. Limits only apply when the profile has permission rules, so rule-free profiles see no behavior change.
+
+TDD evidence:
+- Baseline before edits: `python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py tldw_Server_API/app/core/MCP_unified/tests/test_profile_permission_rules.py tldw_Server_API/app/core/MCP_unified/tests/test_profile_policy_decisions.py -q` passed with 246 tests.
+- Red tests: cache-reuse test failed with 2 compiles instead of 1; None-guard test failed with AttributeError (helper missing); oversized subject-count/value/argv tests failed because calls succeeded instead of returning policy denials.
+- Green: same tests pass; full gateway file passes with 184 tests.
+- Cache-key mutation check: sabotaging the cache key to (profile.id, None) makes the recompile-on-update test fail; restoring (profile.id, profile.updated_at) makes it pass.
+
+Verification:
+- `python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py tldw_Server_API/app/core/MCP_unified/tests/test_profile_permission_rules.py tldw_Server_API/app/core/MCP_unified/tests/test_profile_policy_decisions.py -q` passed with 254 tests.
+- Ruff: `python -m ruff check mcp_unified/gateway/profile_runtime.py tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py` passed.
+- Compile smoke: `python -m compileall -q mcp_unified/gateway/profile_runtime.py` passed.
+- Bandit: `python -m bandit -r mcp_unified/gateway/profile_runtime.py -q` reported no findings.
+- Whitespace: `git diff --check` passed.
+
+Deferred: pattern-level cache invalidation for direct profile_store writes that bypass the management surface; configurable extraction limits.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Cached compiled MCP profile permission rules per (profile id, updated_at) with a bounded LRU on the gateway runtime, added an explicit None-guard for missing policy documents, and bounded permission-subject extraction (subject count, value length, argv tokens) failing closed with redacted permission_subject_limits_exceeded denials. Addresses Qodo and Gemini review feedback on PR #2344.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/mcp_unified/gateway/profile_runtime.py
+++ b/mcp_unified/gateway/profile_runtime.py
@@ -2,11 +2,13 @@
 
 from __future__ import annotations
 
+from collections import OrderedDict
 from collections.abc import Mapping, Sequence
 from copy import deepcopy
 from typing import Any, Protocol
 
 from mcp_unified.interfaces.storage import ProfileStore
+from mcp_unified.profiles.decisions import PolicyDecisionRule
 from mcp_unified.profiles.models import MCPProfile
 from mcp_unified.profiles.permission_rules import (
     PermissionRuleSubject,
@@ -77,6 +79,10 @@ _DOMAIN_ARGUMENT_KEYS = frozenset({"url", "uri", "domain", "host", "base_url"})
 _DOMAIN_ARGUMENT_LIST_KEYS = frozenset({"urls", "uris", "domains", "hosts"})
 _COMMAND_ARGUMENT_KEYS = frozenset({"command", "cmd", "shell_command"})
 _COMMAND_ARGV_KEYS = frozenset({"argv"})
+_PERMISSION_RULE_CACHE_MAX_ENTRIES = 64
+_MAX_PERMISSION_SUBJECTS = 128
+_MAX_SUBJECT_VALUE_LENGTH = 4096
+_MAX_COMMAND_ARGV_TOKENS = 256
 _BRIDGE_TOOL_DESCRIPTORS: dict[str, dict[str, Any]] = {
     _TOOL_CATEGORIES_LIST: {
         "name": _TOOL_CATEGORIES_LIST,
@@ -198,6 +204,9 @@ class ProfileAwareGatewayRuntime:
             )
         self._backend = backend
         self._profile_resolver = profile_resolver
+        self._permission_rule_cache: OrderedDict[
+            tuple[str, Any], tuple[PolicyDecisionRule, ...]
+        ] = OrderedDict()
 
     @property
     def name(self) -> str:
@@ -510,12 +519,47 @@ class ProfileAwareGatewayRuntime:
             profile,
             name,
             arguments,
+            self._compiled_permission_rules(profile, tool_name=name),
         )
         return await self._backend.call_tool(
             name,
             arguments,
             _context_with_effective_policy(context, policy_result.policy),
         )
+
+    def _compiled_permission_rules(
+        self,
+        profile: MCPProfile | None,
+        *,
+        tool_name: str | None = None,
+    ) -> tuple[PolicyDecisionRule, ...]:
+        """Return compiled profile permission rules, cached per profile version."""
+
+        if profile is None or profile.policy_document is None:
+            return ()
+        cache_key = (profile.id, profile.updated_at)
+        cached = self._permission_rule_cache.get(cache_key)
+        if cached is not None:
+            self._permission_rule_cache.move_to_end(cache_key)
+            return cached
+        try:
+            rules = tuple(compile_permission_rules(profile.policy_document))
+        except ValueError as exc:
+            provenance: dict[str, Any] = {
+                "profile_id": profile.id,
+                "error_type": exc.__class__.__name__,
+            }
+            if tool_name is not None:
+                provenance["tool_name"] = tool_name
+            raise GatewayPolicyDenied(
+                "Gateway profile contains invalid permission rules",
+                reason_code="invalid_permission_rules",
+                provenance=provenance,
+            ) from exc
+        self._permission_rule_cache[cache_key] = rules
+        while len(self._permission_rule_cache) > _PERMISSION_RULE_CACHE_MAX_ENTRIES:
+            self._permission_rule_cache.popitem(last=False)
+        return rules
 
 
 def _validate_synthetic_bridge_arguments(name: str, arguments: Any) -> None:
@@ -964,29 +1008,39 @@ def _effective_policy_for_tool(
     )
 
 
+class _PermissionSubjectLimitError(Exception):
+    """Raised when one tool call exceeds permission-subject extraction limits."""
+
+    def __init__(self, limit: str) -> None:
+        super().__init__(limit)
+        self.limit = limit
+
+
 def _enforce_permission_rules_for_tool_call(
     profile: MCPProfile,
     tool_name: str,
     arguments: dict[str, Any],
+    rules: Sequence[PolicyDecisionRule],
 ) -> None:
     """Apply matching non-grant permission rules to one allowed runtime call."""
 
-    try:
-        rules = compile_permission_rules(profile.policy_document)
-    except ValueError as exc:
-        raise GatewayPolicyDenied(
-            "Gateway profile contains invalid permission rules",
-            reason_code="invalid_permission_rules",
-            provenance={
-                "profile_id": profile.id,
-                "tool_name": tool_name,
-                "error_type": exc.__class__.__name__,
-            },
-        ) from exc
     if not rules:
         return
 
-    for subject_type, value, argv in _permission_rule_subjects_for_tool_call(tool_name, arguments):
+    try:
+        subjects = _permission_rule_subjects_for_tool_call(tool_name, arguments)
+    except _PermissionSubjectLimitError as exc:
+        raise GatewayPolicyDenied(
+            "Gateway profile rejected oversized tool arguments for permission rules",
+            reason_code="permission_subject_limits_exceeded",
+            provenance={
+                "profile_id": profile.id,
+                "tool_name": tool_name,
+                "limit": exc.limit,
+            },
+        ) from exc
+
+    for subject_type, value, argv in subjects:
         try:
             decision = evaluate_permission_rule_decision(
                 rules,
@@ -1028,13 +1082,12 @@ def _permission_rule_subjects_for_tool_call(
     tool_name: str,
     arguments: dict[str, Any],
 ) -> list[tuple[PermissionRuleSubject, str, Sequence[str] | None]]:
-    """Extract permission-rule subjects from one gateway tool call."""
+    """Extract bounded permission-rule subjects from one gateway tool call."""
 
-    subjects: list[tuple[PermissionRuleSubject, str, Sequence[str] | None]] = [
-        ("tool", tool_name, None)
-    ]
+    subjects: list[tuple[PermissionRuleSubject, str, Sequence[str] | None]] = []
+    _append_permission_subject(subjects, "tool", tool_name, None)
     if tool_name.lower().startswith("mcp__"):
-        subjects.append(("mcp", tool_name, None))
+        _append_permission_subject(subjects, "mcp", tool_name, None)
     if not isinstance(arguments, Mapping):
         return subjects
 
@@ -1043,20 +1096,42 @@ def _permission_rule_subjects_for_tool_call(
             continue
         normalized_key = key.strip().lower()
         if normalized_key in _PATH_ARGUMENT_KEYS:
-            subjects.extend(("path", item, None) for item in _string_values(value))
+            for item in _string_values(value):
+                _append_permission_subject(subjects, "path", item, None)
         elif normalized_key in _PATH_ARGUMENT_LIST_KEYS:
-            subjects.extend(("path", item, None) for item in _nested_string_values(value))
+            for item in _nested_string_values(value):
+                _append_permission_subject(subjects, "path", item, None)
         elif normalized_key in _DOMAIN_ARGUMENT_KEYS:
-            subjects.extend(("domain", item, None) for item in _string_values(value))
+            for item in _string_values(value):
+                _append_permission_subject(subjects, "domain", item, None)
         elif normalized_key in _DOMAIN_ARGUMENT_LIST_KEYS:
-            subjects.extend(("domain", item, None) for item in _nested_string_values(value))
+            for item in _nested_string_values(value):
+                _append_permission_subject(subjects, "domain", item, None)
         elif normalized_key in _COMMAND_ARGUMENT_KEYS:
-            subjects.extend(("command", item, None) for item in _string_values(value))
+            for item in _string_values(value):
+                _append_permission_subject(subjects, "command", item, None)
         elif normalized_key in _COMMAND_ARGV_KEYS:
             argv = _argv_argument(value)
             if argv is not None:
-                subjects.append(("command", " ".join(argv), argv))
+                if len(argv) > _MAX_COMMAND_ARGV_TOKENS:
+                    raise _PermissionSubjectLimitError("max_command_argv_tokens")
+                _append_permission_subject(subjects, "command", " ".join(argv), argv)
     return subjects
+
+
+def _append_permission_subject(
+    subjects: list[tuple[PermissionRuleSubject, str, Sequence[str] | None]],
+    subject_type: PermissionRuleSubject,
+    value: str,
+    argv: Sequence[str] | None,
+) -> None:
+    """Append one extracted subject while enforcing extraction limits."""
+
+    if len(subjects) >= _MAX_PERMISSION_SUBJECTS:
+        raise _PermissionSubjectLimitError("max_permission_subjects")
+    if len(value) > _MAX_SUBJECT_VALUE_LENGTH:
+        raise _PermissionSubjectLimitError("max_subject_value_length")
+    subjects.append((subject_type, value, argv))
 
 
 def _string_values(value: Any) -> tuple[str, ...]:

--- a/mcp_unified/gateway/profile_runtime.py
+++ b/mcp_unified/gateway/profile_runtime.py
@@ -2,12 +2,17 @@
 
 from __future__ import annotations
 
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from copy import deepcopy
 from typing import Any, Protocol
 
 from mcp_unified.interfaces.storage import ProfileStore
 from mcp_unified.profiles.models import MCPProfile
+from mcp_unified.profiles.permission_rules import (
+    PermissionRuleSubject,
+    compile_permission_rules,
+    evaluate_permission_rule_decision,
+)
 from mcp_unified.profiles.resolution import (
     EffectivePolicyResult,
     ProfileResolutionResult,
@@ -52,6 +57,26 @@ _TOOL_CALL_ARGUMENT_KEYS = frozenset({"tool_id", "arguments"})
 _TOOL_SEARCH_ARGUMENT_KEYS = frozenset({"query", "category", "limit"})
 _TOOL_DESCRIBE_ARGUMENT_KEYS = frozenset({"tool_id"})
 _EMPTY_ARGUMENT_KEYS = frozenset()
+_PATH_ARGUMENT_KEYS = frozenset(
+    {
+        "path",
+        "file",
+        "file_path",
+        "filepath",
+        "filename",
+        "base_path",
+        "target_path",
+        "source_path",
+        "destination_path",
+        "new_path",
+        "old_path",
+    }
+)
+_PATH_ARGUMENT_LIST_KEYS = frozenset({"paths", "files", "file_paths"})
+_DOMAIN_ARGUMENT_KEYS = frozenset({"url", "uri", "domain", "host", "base_url"})
+_DOMAIN_ARGUMENT_LIST_KEYS = frozenset({"urls", "uris", "domains", "hosts"})
+_COMMAND_ARGUMENT_KEYS = frozenset({"command", "cmd", "shell_command"})
+_COMMAND_ARGV_KEYS = frozenset({"argv"})
 _BRIDGE_TOOL_DESCRIPTORS: dict[str, dict[str, Any]] = {
     _TOOL_CATEGORIES_LIST: {
         "name": _TOOL_CATEGORIES_LIST,
@@ -481,6 +506,11 @@ class ProfileAwareGatewayRuntime:
                 policy_result,
                 message=f"Gateway profile denied tool execution: {policy_result.reason_code}",
             )
+        _enforce_permission_rules_for_tool_call(
+            profile,
+            name,
+            arguments,
+        )
         return await self._backend.call_tool(
             name,
             arguments,
@@ -932,6 +962,130 @@ def _effective_policy_for_tool(
         tool_name=tool_name,
         capability=capability if capability is not None else _primary_capability(tool),
     )
+
+
+def _enforce_permission_rules_for_tool_call(
+    profile: MCPProfile,
+    tool_name: str,
+    arguments: dict[str, Any],
+) -> None:
+    """Apply matching non-grant permission rules to one allowed runtime call."""
+
+    try:
+        rules = compile_permission_rules(profile.policy_document)
+    except ValueError as exc:
+        raise GatewayPolicyDenied(
+            "Gateway profile contains invalid permission rules",
+            reason_code="invalid_permission_rules",
+            provenance={
+                "profile_id": profile.id,
+                "tool_name": tool_name,
+                "error_type": exc.__class__.__name__,
+            },
+        ) from exc
+    if not rules:
+        return
+
+    for subject_type, value, argv in _permission_rule_subjects_for_tool_call(tool_name, arguments):
+        try:
+            decision = evaluate_permission_rule_decision(
+                rules,
+                subject_type=subject_type,
+                value=value,
+                argv=argv,
+            )
+        except ValueError as exc:
+            raise GatewayPolicyDenied(
+                "Gateway profile could not evaluate permission rules",
+                reason_code="invalid_permission_rule_subject",
+                provenance={
+                    "profile_id": profile.id,
+                    "tool_name": tool_name,
+                    "subject_type": subject_type,
+                    "error_type": exc.__class__.__name__,
+                },
+            ) from exc
+        if not decision.matched_rules or decision.outcome == "allow":
+            continue
+        status = "approval_required" if decision.outcome == "ask" else "denied"
+        raise GatewayPolicyDenied(
+            f"Gateway profile denied tool execution: {decision.reason_code}",
+            status=status,
+            reason_code=decision.reason_code,
+            provenance={
+                "profile_id": profile.id,
+                "tool_name": tool_name,
+                "subject_type": subject_type,
+                "matched_rules": [
+                    matched_rule.model_dump(mode="json", exclude_none=True)
+                    for matched_rule in decision.matched_rules
+                ],
+            },
+        )
+
+
+def _permission_rule_subjects_for_tool_call(
+    tool_name: str,
+    arguments: dict[str, Any],
+) -> list[tuple[PermissionRuleSubject, str, Sequence[str] | None]]:
+    """Extract permission-rule subjects from one gateway tool call."""
+
+    subjects: list[tuple[PermissionRuleSubject, str, Sequence[str] | None]] = [
+        ("tool", tool_name, None)
+    ]
+    if tool_name.lower().startswith("mcp__"):
+        subjects.append(("mcp", tool_name, None))
+    if not isinstance(arguments, Mapping):
+        return subjects
+
+    for key, value in arguments.items():
+        if not isinstance(key, str):
+            continue
+        normalized_key = key.strip().lower()
+        if normalized_key in _PATH_ARGUMENT_KEYS:
+            subjects.extend(("path", item, None) for item in _string_values(value))
+        elif normalized_key in _PATH_ARGUMENT_LIST_KEYS:
+            subjects.extend(("path", item, None) for item in _nested_string_values(value))
+        elif normalized_key in _DOMAIN_ARGUMENT_KEYS:
+            subjects.extend(("domain", item, None) for item in _string_values(value))
+        elif normalized_key in _DOMAIN_ARGUMENT_LIST_KEYS:
+            subjects.extend(("domain", item, None) for item in _nested_string_values(value))
+        elif normalized_key in _COMMAND_ARGUMENT_KEYS:
+            subjects.extend(("command", item, None) for item in _string_values(value))
+        elif normalized_key in _COMMAND_ARGV_KEYS:
+            argv = _argv_argument(value)
+            if argv is not None:
+                subjects.append(("command", " ".join(argv), argv))
+    return subjects
+
+
+def _string_values(value: Any) -> tuple[str, ...]:
+    """Return one non-empty string value or an empty tuple."""
+
+    if isinstance(value, str) and value.strip():
+        return (value.strip(),)
+    return ()
+
+
+def _nested_string_values(value: Any) -> tuple[str, ...]:
+    """Return non-empty string values from a scalar or shallow sequence."""
+
+    if isinstance(value, (str, bytes, Mapping)):
+        return _string_values(value)
+    if isinstance(value, Sequence):
+        return tuple(item.strip() for item in value if isinstance(item, str) and item.strip())
+    return ()
+
+
+def _argv_argument(value: Any) -> tuple[str, ...] | None:
+    """Return argv tokens when a tool call provides an argv-shaped argument."""
+
+    if isinstance(value, (str, bytes, Mapping)) or not isinstance(value, Sequence):
+        return None
+    argv = tuple(value)
+    if not argv or not all(isinstance(item, str) for item in argv):
+        return None
+    return argv
 
 
 def _primary_capability(tool: Any) -> str | None:

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py
@@ -2700,6 +2700,323 @@ def test_gateway_profile_runtime_blocks_matching_mcp_permission_rule() -> None:
     assert backend.call_requests == []
 
 
+def _read_text_tool_descriptor() -> dict[str, Any]:
+    return {
+        "name": "fs.read_text",
+        "description": "Read a text file.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {"path": {"type": "string"}},
+            "required": ["path"],
+        },
+        "metadata": {"category": "filesystem", "capability": "filesystem.read"},
+    }
+
+
+def _post_tool_call(client: Any, name: str, arguments: dict[str, Any], request_id: str) -> Any:
+    return client.post(
+        "/mcp/request",
+        json={
+            "jsonrpc": "2.0",
+            "method": "tools/call",
+            "params": {"name": name, "arguments": arguments},
+            "id": request_id,
+        },
+    )
+
+
+def test_gateway_profile_runtime_caches_compiled_permission_rules(monkeypatch) -> None:
+    from mcp_unified.gateway import profile_runtime as profile_runtime_module
+    from mcp_unified.gateway.profile_runtime import ProfileAwareGatewayRuntime
+    from mcp_unified.profiles.store import InMemoryProfileStore
+
+    backend = _CustomToolListGatewayRuntime([_read_text_tool_descriptor()])
+    profile = _profile_with_allowed_tools_and_permission_rules(
+        "reviewer",
+        allowed_tools=["fs.read_text"],
+        permission_rules=[{"pattern": "Read(docs/private/**)", "outcome": "deny"}],
+    )
+    runtime = ProfileAwareGatewayRuntime(
+        backend,
+        profile_store=InMemoryProfileStore([profile]),
+        default_profile_id="reviewer",
+    )
+    compile_calls: list[Any] = []
+    real_compile = profile_runtime_module.compile_permission_rules
+
+    def _counting_compile(*args: Any, **kwargs: Any) -> Any:
+        compile_calls.append(args)
+        return real_compile(*args, **kwargs)
+
+    monkeypatch.setattr(profile_runtime_module, "compile_permission_rules", _counting_compile)
+    app = create_gateway_app(runtime, prefix="/mcp")
+
+    with TestClient(app) as client:
+        for request_id in ("cache-first", "cache-second"):
+            allowed = _post_tool_call(
+                client,
+                "fs.read_text",
+                {"path": "docs/public/notes.txt", "query": "notes"},
+                request_id,
+            )
+            assert allowed.json().get("error") is None
+
+    assert len(backend.call_requests) == 2
+    assert len(compile_calls) == 1
+
+
+def test_gateway_profile_runtime_recompiles_permission_rules_when_profile_updated() -> None:
+    import asyncio
+    from datetime import datetime, timezone
+
+    from mcp_unified.gateway.profile_runtime import ProfileAwareGatewayRuntime
+    from mcp_unified.profiles.models import MCPProfile, ProfilePolicy
+    from mcp_unified.profiles.store import InMemoryProfileStore
+
+    backend = _CustomToolListGatewayRuntime([_read_text_tool_descriptor()])
+    first_version = MCPProfile(
+        id="reviewer",
+        name="Profile reviewer",
+        policy_document=ProfilePolicy(
+            allowed_tools=["fs.read_text"],
+            permission_rules=[{"pattern": "Read(docs/private/**)", "outcome": "deny"}],
+        ),
+        updated_at=datetime(2026, 6, 1, tzinfo=timezone.utc),
+    )
+    store = InMemoryProfileStore([first_version])
+    runtime = ProfileAwareGatewayRuntime(
+        backend,
+        profile_store=store,
+        default_profile_id="reviewer",
+    )
+    app = create_gateway_app(runtime, prefix="/mcp")
+
+    with TestClient(app) as client:
+        allowed = _post_tool_call(
+            client,
+            "fs.read_text",
+            {"path": "docs/public/notes.txt", "query": "notes"},
+            "before-update",
+        )
+        assert allowed.json().get("error") is None
+
+        second_version = first_version.model_copy(
+            update={
+                "policy_document": ProfilePolicy(
+                    allowed_tools=["fs.read_text"],
+                    permission_rules=[
+                        {
+                            "pattern": "Read(docs/public/**)",
+                            "outcome": "deny",
+                            "reason_code": "public_docs_denied",
+                        }
+                    ],
+                ),
+                "updated_at": datetime(2026, 6, 2, tzinfo=timezone.utc),
+            }
+        )
+        asyncio.run(store.upsert_profile(second_version))
+
+        denied = _post_tool_call(
+            client,
+            "fs.read_text",
+            {"path": "docs/public/notes.txt", "query": "notes"},
+            "after-update",
+        )
+
+    body = denied.json()
+    _assert_jsonrpc_error(body, code=-32001, request_id="after-update")
+    assert body["error"]["data"]["reason_code"] == "public_docs_denied"
+    assert len(backend.call_requests) == 1
+
+
+def test_gateway_profile_runtime_permission_rule_cache_stays_bounded() -> None:
+    from mcp_unified.gateway.profile_runtime import (
+        _PERMISSION_RULE_CACHE_MAX_ENTRIES,
+        ProfileAwareGatewayRuntime,
+    )
+    from mcp_unified.profiles.store import InMemoryProfileStore
+
+    backend = _CustomToolListGatewayRuntime([_read_text_tool_descriptor()])
+    placeholder = _profile_with_allowed_tools("reviewer", ["fs.read_text"])
+    runtime = ProfileAwareGatewayRuntime(
+        backend,
+        profile_store=InMemoryProfileStore([placeholder]),
+        default_profile_id="reviewer",
+    )
+
+    for index in range(_PERMISSION_RULE_CACHE_MAX_ENTRIES + 16):
+        profile = _profile_with_allowed_tools_and_permission_rules(
+            f"profile-{index}",
+            allowed_tools=["fs.read_text"],
+            permission_rules=[{"pattern": "Read(docs/private/**)", "outcome": "deny"}],
+        )
+        assert runtime._compiled_permission_rules(profile)
+
+    assert len(runtime._permission_rule_cache) == _PERMISSION_RULE_CACHE_MAX_ENTRIES
+
+
+def test_gateway_profile_runtime_skips_permission_rules_for_missing_policy_document() -> None:
+    from mcp_unified.gateway.profile_runtime import ProfileAwareGatewayRuntime
+    from mcp_unified.profiles.models import MCPProfile
+    from mcp_unified.profiles.store import InMemoryProfileStore
+
+    backend = _CustomToolListGatewayRuntime([_read_text_tool_descriptor()])
+    placeholder = _profile_with_allowed_tools("reviewer", ["fs.read_text"])
+    runtime = ProfileAwareGatewayRuntime(
+        backend,
+        profile_store=InMemoryProfileStore([placeholder]),
+        default_profile_id="reviewer",
+    )
+    unvalidated = MCPProfile.model_construct(
+        id="reviewer",
+        name="Profile reviewer",
+        policy_document=None,
+    )
+
+    assert runtime._compiled_permission_rules(unvalidated) == ()
+    assert runtime._compiled_permission_rules(None) == ()
+
+
+def test_gateway_profile_runtime_denies_oversized_permission_subject_count() -> None:
+    from mcp_unified.gateway.profile_runtime import ProfileAwareGatewayRuntime
+    from mcp_unified.profiles.store import InMemoryProfileStore
+
+    backend = _CustomToolListGatewayRuntime([_read_text_tool_descriptor()])
+    profile = _profile_with_allowed_tools_and_permission_rules(
+        "reviewer",
+        allowed_tools=["fs.read_text"],
+        permission_rules=[{"pattern": "Read(docs/private/**)", "outcome": "deny"}],
+    )
+    runtime = ProfileAwareGatewayRuntime(
+        backend,
+        profile_store=InMemoryProfileStore([profile]),
+        default_profile_id="reviewer",
+    )
+    app = create_gateway_app(runtime, prefix="/mcp")
+
+    with TestClient(app) as client:
+        denied = _post_tool_call(
+            client,
+            "fs.read_text",
+            {"paths": [f"docs/public/file-{index}.txt" for index in range(200)], "query": "files"},
+            "subject-count-limit",
+        )
+
+    body = denied.json()
+    _assert_jsonrpc_error(body, code=-32001, request_id="subject-count-limit")
+    error_data = body["error"]["data"]
+    assert error_data["reason_code"] == "permission_subject_limits_exceeded"
+    assert error_data["status"] == "denied"
+    assert error_data["provenance"]["tool_name"] == "fs.read_text"
+    assert backend.call_requests == []
+
+
+def test_gateway_profile_runtime_denies_oversized_permission_subject_value() -> None:
+    from mcp_unified.gateway.profile_runtime import ProfileAwareGatewayRuntime
+    from mcp_unified.profiles.store import InMemoryProfileStore
+
+    backend = _CustomToolListGatewayRuntime([_read_text_tool_descriptor()])
+    profile = _profile_with_allowed_tools_and_permission_rules(
+        "reviewer",
+        allowed_tools=["fs.read_text"],
+        permission_rules=[{"pattern": "Read(docs/private/**)", "outcome": "deny"}],
+    )
+    runtime = ProfileAwareGatewayRuntime(
+        backend,
+        profile_store=InMemoryProfileStore([profile]),
+        default_profile_id="reviewer",
+    )
+    app = create_gateway_app(runtime, prefix="/mcp")
+    oversized_path = "docs/public/" + ("a" * 5000)
+
+    with TestClient(app) as client:
+        denied = _post_tool_call(
+            client,
+            "fs.read_text",
+            {"path": oversized_path, "query": "oversized"},
+            "subject-value-limit",
+        )
+
+    body = denied.json()
+    _assert_jsonrpc_error(body, code=-32001, request_id="subject-value-limit")
+    error_data = body["error"]["data"]
+    assert error_data["reason_code"] == "permission_subject_limits_exceeded"
+    assert error_data["status"] == "denied"
+    assert oversized_path not in json.dumps(error_data)
+    assert backend.call_requests == []
+
+
+def test_gateway_profile_runtime_denies_oversized_permission_argv() -> None:
+    from mcp_unified.gateway.profile_runtime import ProfileAwareGatewayRuntime
+    from mcp_unified.profiles.store import InMemoryProfileStore
+
+    backend = _CustomToolListGatewayRuntime(
+        [
+            {
+                "name": "shell.run",
+                "description": "Run a governed shell command.",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {"argv": {"type": "array"}},
+                },
+                "metadata": {"category": "shell", "capability": "shell.execute"},
+            }
+        ]
+    )
+    profile = _profile_with_allowed_tools_and_permission_rules(
+        "operator",
+        allowed_tools=["shell.run"],
+        permission_rules=[{"pattern": "Bash(rm *)", "outcome": "deny"}],
+    )
+    runtime = ProfileAwareGatewayRuntime(
+        backend,
+        profile_store=InMemoryProfileStore([profile]),
+        default_profile_id="operator",
+    )
+    app = create_gateway_app(runtime, prefix="/mcp")
+
+    with TestClient(app) as client:
+        denied = _post_tool_call(
+            client,
+            "shell.run",
+            {"argv": ["echo"] * 300, "query": "argv"},
+            "argv-token-limit",
+        )
+
+    body = denied.json()
+    _assert_jsonrpc_error(body, code=-32001, request_id="argv-token-limit")
+    error_data = body["error"]["data"]
+    assert error_data["reason_code"] == "permission_subject_limits_exceeded"
+    assert error_data["status"] == "denied"
+    assert backend.call_requests == []
+
+
+def test_gateway_profile_runtime_allows_oversized_arguments_without_permission_rules() -> None:
+    from mcp_unified.gateway.profile_runtime import ProfileAwareGatewayRuntime
+    from mcp_unified.profiles.store import InMemoryProfileStore
+
+    backend = _CustomToolListGatewayRuntime([_read_text_tool_descriptor()])
+    profile = _profile_with_allowed_tools("reviewer", ["fs.read_text"])
+    runtime = ProfileAwareGatewayRuntime(
+        backend,
+        profile_store=InMemoryProfileStore([profile]),
+        default_profile_id="reviewer",
+    )
+    app = create_gateway_app(runtime, prefix="/mcp")
+
+    with TestClient(app) as client:
+        allowed = _post_tool_call(
+            client,
+            "fs.read_text",
+            {"paths": [f"docs/public/file-{index}.txt" for index in range(200)], "query": "files"},
+            "rule-free-oversized",
+        )
+
+    assert allowed.json().get("error") is None
+    assert len(backend.call_requests) == 1
+
+
 def test_gateway_profile_runtime_denies_explicit_tool_before_backend_discovery() -> None:
     from mcp_unified.gateway.profile_runtime import ProfileAwareGatewayRuntime
     from mcp_unified.profiles.store import InMemoryProfileStore

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py
@@ -269,6 +269,26 @@ def _profile_with_allowed_tools(profile_id: str, allowed_tools: list[str]) -> An
     )
 
 
+def _profile_with_allowed_tools_and_permission_rules(
+    profile_id: str,
+    *,
+    allowed_tools: list[str],
+    permission_rules: list[Any],
+) -> Any:
+    """Build a profile with explicit tools plus Claude-style permission rules."""
+
+    from mcp_unified.profiles.models import MCPProfile, ProfilePolicy
+
+    return MCPProfile(
+        id=profile_id,
+        name=f"Profile {profile_id}",
+        policy_document=ProfilePolicy(
+            allowed_tools=allowed_tools,
+            permission_rules=permission_rules,
+        ),
+    )
+
+
 def _profile_with_capabilities(profile_id: str, capabilities: list[str]) -> Any:
     """Build a profile that allows tools by advertised capability metadata."""
 
@@ -2510,6 +2530,174 @@ def test_gateway_profile_runtime_filters_and_allows_default_profile_tools() -> N
     _assert_jsonrpc_error(denied_body, code=-32001, request_id="call-denied")
     assert denied_body["error"]["data"]["reason_code"] == "tool_not_allowed"
     assert all(call[0] != "admin.delete" for call in backend.call_requests)
+
+
+def test_gateway_profile_runtime_blocks_matching_path_permission_rule() -> None:
+    from mcp_unified.gateway.profile_runtime import ProfileAwareGatewayRuntime
+    from mcp_unified.profiles.store import InMemoryProfileStore
+
+    backend = _CustomToolListGatewayRuntime(
+        [
+            {
+                "name": "fs.read_text",
+                "description": "Read a text file.",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {"path": {"type": "string"}},
+                    "required": ["path"],
+                },
+                "metadata": {"category": "filesystem", "capability": "filesystem.read"},
+            }
+        ]
+    )
+    profile = _profile_with_allowed_tools_and_permission_rules(
+        "reviewer",
+        allowed_tools=["fs.read_text"],
+        permission_rules=[
+            {
+                "pattern": "Read(docs/private/**)",
+                "outcome": "deny",
+                "reason_code": "private_docs_denied",
+            }
+        ],
+    )
+    runtime = ProfileAwareGatewayRuntime(
+        backend,
+        profile_store=InMemoryProfileStore([profile]),
+        default_profile_id="reviewer",
+    )
+    app = create_gateway_app(runtime, prefix="/mcp")
+
+    with TestClient(app) as client:
+        denied = client.post(
+            "/mcp/request",
+            json={
+                "jsonrpc": "2.0",
+                "method": "tools/call",
+                "params": {
+                    "name": "fs.read_text",
+                    "arguments": {"path": "docs/private/secret.txt", "query": "secret"},
+                },
+                "id": "path-rule-denied",
+            },
+        )
+
+    body = denied.json()
+    _assert_jsonrpc_error(body, code=-32001, request_id="path-rule-denied")
+    error_data = body["error"]["data"]
+    assert error_data["reason_code"] == "private_docs_denied"
+    assert error_data["status"] == "denied"
+    assert error_data["provenance"]["tool_name"] == "fs.read_text"
+    assert error_data["provenance"]["subject_type"] == "path"
+    assert error_data["provenance"]["matched_rules"][0]["pattern"] == "docs/private/**"
+    assert "docs/private/secret.txt" not in json.dumps(error_data)
+    assert backend.call_requests == []
+
+
+def test_gateway_profile_runtime_blocks_matching_ask_permission_rule() -> None:
+    from mcp_unified.gateway.profile_runtime import ProfileAwareGatewayRuntime
+    from mcp_unified.profiles.store import InMemoryProfileStore
+
+    backend = _CustomToolListGatewayRuntime(
+        [
+            {
+                "name": "web.fetch",
+                "description": "Fetch a URL.",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {"url": {"type": "string"}},
+                    "required": ["url"],
+                },
+                "metadata": {"category": "web", "capability": "network.fetch"},
+            }
+        ]
+    )
+    profile = _profile_with_allowed_tools_and_permission_rules(
+        "researcher",
+        allowed_tools=["web.fetch"],
+        permission_rules=[{"pattern": "WebFetch(example.com)", "outcome": "ask"}],
+    )
+    runtime = ProfileAwareGatewayRuntime(
+        backend,
+        profile_store=InMemoryProfileStore([profile]),
+        default_profile_id="researcher",
+    )
+    app = create_gateway_app(runtime, prefix="/mcp")
+
+    with TestClient(app) as client:
+        denied = client.post(
+            "/mcp/request",
+            json={
+                "jsonrpc": "2.0",
+                "method": "tools/call",
+                "params": {
+                    "name": "web.fetch",
+                    "arguments": {"url": "https://example.com/private", "query": "private"},
+                },
+                "id": "domain-rule-ask",
+            },
+        )
+
+    body = denied.json()
+    _assert_jsonrpc_error(body, code=-32001, request_id="domain-rule-ask")
+    error_data = body["error"]["data"]
+    assert error_data["reason_code"] == "approval_required"
+    assert error_data["status"] == "approval_required"
+    assert error_data["provenance"]["subject_type"] == "domain"
+    assert "example.com/private" not in json.dumps(error_data)
+    assert backend.call_requests == []
+
+
+def test_gateway_profile_runtime_blocks_matching_mcp_permission_rule() -> None:
+    from mcp_unified.gateway.profile_runtime import ProfileAwareGatewayRuntime
+    from mcp_unified.profiles.store import InMemoryProfileStore
+
+    backend = _CustomToolListGatewayRuntime(
+        [
+            {
+                "name": "mcp__github__delete_repo",
+                "description": "Delete a GitHub repository.",
+                "inputSchema": {"type": "object", "properties": {}},
+                "metadata": {"category": "external", "capability": "repo.delete"},
+            }
+        ]
+    )
+    profile = _profile_with_allowed_tools_and_permission_rules(
+        "devops",
+        allowed_tools=["mcp__github__delete_repo"],
+        permission_rules=[
+            {
+                "pattern": "MCP__GitHub__delete_*",
+                "outcome": "deny",
+                "reason_code": "mcp_delete_denied",
+            }
+        ],
+    )
+    runtime = ProfileAwareGatewayRuntime(
+        backend,
+        profile_store=InMemoryProfileStore([profile]),
+        default_profile_id="devops",
+    )
+    app = create_gateway_app(runtime, prefix="/mcp")
+
+    with TestClient(app) as client:
+        denied = client.post(
+            "/mcp/request",
+            json={
+                "jsonrpc": "2.0",
+                "method": "tools/call",
+                "params": {"name": "mcp__github__delete_repo", "arguments": {"query": "repo"}},
+                "id": "mcp-rule-denied",
+            },
+        )
+
+    body = denied.json()
+    _assert_jsonrpc_error(body, code=-32001, request_id="mcp-rule-denied")
+    error_data = body["error"]["data"]
+    assert error_data["reason_code"] == "mcp_delete_denied"
+    assert error_data["status"] == "denied"
+    assert error_data["provenance"]["subject_type"] == "mcp"
+    assert backend.call_requests == []
 
 
 def test_gateway_profile_runtime_denies_explicit_tool_before_backend_discovery() -> None:


### PR DESCRIPTION
## Summary
- Wire compiled MCP profile `permission_rules` into standalone gateway backend tool-call enforcement after existing legacy tool policy allows the call.
- Extract tool/path/domain/command/MCP subjects from gateway tool calls and block matched `deny` or `ask` rules with redacted `GatewayPolicyDenied` payloads.
- Add focused runtime coverage for path denial, domain ask, and external MCP wildcard denial.

## Change summary
This keeps `allowed_tools`/`denied_tools` and capability policy as the primary visibility and execution gate, then applies `permission_rules` only as an additional matched deny/ask layer. Unmatched permission-rule default-deny decisions are ignored so path/domain/command rules cannot grant tool execution by themselves. The denial payload includes profile/tool/subject/matched-rule metadata but omits raw path, URL, command, or argument values.

## Test Plan
- [x] `python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py -q -k "permission_rule"`
- [x] `python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py tldw_Server_API/app/core/MCP_unified/tests/test_profile_permission_rules.py tldw_Server_API/app/core/MCP_unified/tests/test_profile_policy_decisions.py -q`
- [x] `python -m ruff check mcp_unified/gateway/profile_runtime.py tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py`
- [x] `python -m compileall -q mcp_unified/gateway/profile_runtime.py`
- [x] `python -m bandit -r mcp_unified/gateway/profile_runtime.py -f json -o /tmp/bandit_mcp_permission_runtime_enforcement_final.json`
- [x] `git diff --check`

## Deferred
- Approval prompt/lease flow for `ask` decisions.
- Hook integration.
- Richer shell alias parsing.
- Deeper tool-specific argument extraction.
- Similar enforcement in the older in-process tldw_Server_API MCP protocol path.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces MCP profile `permission_rules` at the gateway runtime as a deny/ask layer after legacy policy, blocking matched calls and redacting sensitive details. Adds a bounded cache and strict extraction limits to prevent request-driven amplification and safely handle missing or invalid policy docs.

- New Features
  - Apply rules only after `allowed_tools`/`denied_tools` and capability checks; ignore unmatched default-deny so rules never grant access.
  - Extract subjects: `tool`, `mcp`, `path`, `domain`, `command` (supports `argv`).
  - On matches, raise `GatewayPolicyDenied` with `status` `denied` or `approval_required` and redacted provenance; return `invalid_permission_rules`/`invalid_permission_rule_subject` on bad input.
  - Cache compiled rules per `(profile_id, updated_at)` with a bounded LRU (64); skip when `policy_document` is missing; bound extraction (subject count, value length, `argv` tokens) and fail closed with redacted `permission_subject_limits_exceeded` (rule-free profiles bypass limits).

<sup>Written for commit eea086d21c4343fbdf95935b28d46a0916ab47e2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2344?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

