### PR TITLE
fix(media): serve media list without a trailing-slash 307 redirect

### DIFF
--- a/tldw_Server_API/app/api/v1/endpoints/media/listing.py
+++ b/tldw_Server_API/app/api/v1/endpoints/media/listing.py
@@ -288,6 +288,16 @@ def _should_delegate_media_search_to_email(
     return bool(delegation_mode == "auto_email" and email_operator_enabled and email_only_media_scope)
 
 
+# Serve both the no-slash and trailing-slash forms directly. FastAPI's default
+# redirect_slashes would 307 `/api/v1/media` -> `/api/v1/media/`, which turns
+# every media-list call into a redirect round-trip for clients that send the
+# no-slash form. Registering both paths on the same handler avoids that.
+@router.get(
+    "",
+    summary="List Media",
+    responses=_NOT_MODIFIED_OPENAPI_RESPONSE,
+    include_in_schema=False,
+)
 @router.get(
     "/",
     summary="List Media (slash)",

--- a/tldw_Server_API/tests/MediaIngestion_NEW/unit/test_media_list_no_slash_redirect.py
+++ b/tldw_Server_API/tests/MediaIngestion_NEW/unit/test_media_list_no_slash_redirect.py
@@ -1,0 +1,46 @@
+"""
+Regression test: the media list endpoint must serve both the no-slash and
+trailing-slash forms directly, without a 307 redirect.
+
+FastAPI's default ``redirect_slashes=True`` would 307 ``/api/v1/media`` ->
+``/api/v1/media/``. Frontend clients normalize media-list URLs to the no-slash
+form, so the redirect turned every media-list call into a redirect round-trip
+(two network requests). The listing router now registers both ``""`` and ``"/"``
+on the same handler to avoid that.
+"""
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from tldw_Server_API.app.api.v1.endpoints.media.listing import router as listing_router
+
+
+def test_listing_router_serves_both_slash_forms():
+    get_paths = {
+        route.path
+        for route in listing_router.routes
+        if "GET" in (getattr(route, "methods", None) or set())
+    }
+    # Canonical slash form plus the no-slash alias that avoids the 307.
+    assert "/" in get_paths  # nosec B101
+    assert "" in get_paths  # nosec B101
+
+
+@pytest.fixture
+def listing_client():
+    app = FastAPI()
+    app.include_router(listing_router, prefix="/api/v1/media", tags=["media"])
+    # follow_redirects=False so a 307 surfaces instead of being transparently followed.
+    with TestClient(app, follow_redirects=False) as client:
+        yield client
+
+
+@pytest.mark.parametrize("path", ["/api/v1/media", "/api/v1/media/"])
+def test_media_list_does_not_307_redirect(listing_client, path):
+    resp = listing_client.get(f"{path}?page=1&results_per_page=5")
+    # The request must reach the route handler (any non-redirect status), not be
+    # bounced with a 307 trailing-slash redirect.
+    assert resp.status_code != 307, (  # nosec B101
+        f"{path} should be served directly, got a {resp.status_code} redirect to "
+        f"{resp.headers.get('location')!r}"
+    )


### PR DESCRIPTION
## Summary

Follow-up from the `/media` UAT (#2352): the media list was being fetched ~10× on page load, with every query duplicated as `/api/v1/media?…` **and** `/api/v1/media/?…`.

**Root cause (corrected):** this is **not** a `bgRequest` double-send (my earlier #2352 note was wrong — the web shim's `sendMessage` is a no-op, so that path never runs). It's a **307 trailing-slash redirect**:

- The list route was registered only for the trailing-slash form (`@router.get("/")`, `listing.py`), so FastAPI's default `redirect_slashes=True` **307-redirects `/api/v1/media` → `/api/v1/media/`**.
- Frontend clients normalize media-list URLs to the **no-slash** form (`normalizeKnownPathQuirks`, added because *"certain proxies treat the slash form as a distinct route and return 404"*).
- So the client sends `/media?…` → server 307 → browser follows to `/media/?…` → 200. **Each list call = a redirect round-trip (2 requests).**

Confirmed via CDP initiator analysis (the `/media/?…` requests are `type:other`/no-stack redirect follows, not script-initiated) and a direct curl:
```
GET /api/v1/media?page=1&results_per_page=5   -> 307 -> /api/v1/media/?...
GET /api/v1/media/?page=1&results_per_page=5  -> 200
```

## Fix

Register both `""` and `"/"` on the same `list_media_endpoint` handler so the **no-slash form is served directly (200)** — no redirect, for either slash form. The client is unchanged, and the no-slash normalization (for the proxy-404 case) keeps working without the redirect cost. The no-slash alias is `include_in_schema=False` to avoid an OpenAPI duplicate.

## Tests

`tests/MediaIngestion_NEW/unit/test_media_list_no_slash_redirect.py`:
- the listing router serves both `""` and `"/"` GET forms;
- neither `/api/v1/media` nor `/api/v1/media/` returns a 307.

Red before the fix (2 failures), green after (3 passed). Verified both routes register in the full app (`app.main`).

## Notes
- The `/media` UAT PR (#2352) documented the cause as a `bgRequest` double-send; that was incorrect and is superseded by this PR's analysis. I'll update #2352's notes accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Serve the media list endpoint without a trailing-slash 307 redirect by registering both no-slash and slash routes. This removes duplicate requests on load and speeds up media list fetches.

- **Bug Fixes**
  - Register both `""` and `/` on the same handler so `/api/v1/media` returns 200 (no redirect).
  - Hide the no-slash alias from OpenAPI (`include_in_schema=False`) to avoid duplicate docs.
  - Add tests to ensure both paths are served directly and neither returns 307.

<sup>Written for commit 809e23f335532352bd0eef0cd029fe453680ef12. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2353?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

