### PR TITLE
Add MCP file-policy audit reporting

### DIFF
--- a/Docs/superpowers/plans/2026-06-14-mcp-file-policy-audit-event-reporting-plan.md
+++ b/Docs/superpowers/plans/2026-06-14-mcp-file-policy-audit-event-reporting-plan.md
@@ -1,0 +1,74 @@
+# MCP File-Policy Audit Event Reporting Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extend MCP tool-use events with safe filesystem policy decision metadata.
+
+**Architecture:** Reuse the existing metadata-only tool-use reporting path. `prepare_tool_call()` already evaluates path scope and receives redacted path decisions from the path enforcement service; this slice carries those decisions into `ToolUseEvent` while sanitizing workspace-relative paths and avoiding raw content, diffs, receipts, absolute host paths, and capability tokens.
+
+**Tech Stack:** Python 3.11, Pydantic models, pytest, existing MCP protocol/reporting modules.
+
+---
+
+### Task 1: Event Model Contract
+
+**Files:**
+- Modify: `mcp_unified/tool_use_reporting/models.py`
+- Test: `tldw_Server_API/app/core/MCP_unified/tests/test_tool_use_reporting_models.py`
+
+- [x] **Step 1: Write failing model tests**
+
+Add tests proving file-policy decision metadata keeps workspace-relative paths, grant outcome/source, reason code, and redaction state, while rejecting absolute paths and unsafe extras.
+
+- [x] **Step 2: Run model test red**
+
+Run: `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_tool_use_reporting_models.py -q`
+
+- [x] **Step 3: Implement model fields and sanitizers**
+
+Add a bounded `FilePolicyDecisionMetadata` model and optional booleans for hash/lock-lease presence. Do not add query columns or store raw hashes/lock ids.
+
+- [x] **Step 4: Run model tests green**
+
+Run the same model test command and confirm all pass.
+
+### Task 2: Protocol Capture
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/MCP_unified/protocol.py`
+- Test: `tldw_Server_API/app/core/MCP_unified/tests/test_tool_use_reporting_protocol.py`
+
+- [x] **Step 1: Write failing protocol tests**
+
+Add a protocol-side test with an enabled path-scope policy and fake path enforcer returning redacted `path_decisions`. Assert the recorded event includes only sanitized decision metadata and presence booleans for hashes/lock leases.
+
+- [x] **Step 2: Run protocol test red**
+
+Run: `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_tool_use_reporting_protocol.py -q`
+
+- [x] **Step 3: Carry path-scope payload through prepared calls**
+
+Add a `scope_payload` field to `PreparedToolCall`, pass it from `prepare_tool_call()`, and feed it into `_build_tool_use_event()` for success/cached/error recording. For prepare-time governance denials, extract `governance.path_scope` into the failure event.
+
+- [x] **Step 4: Run protocol tests green**
+
+Run the protocol test command and confirm all pass.
+
+### Task 3: Focused Verification
+
+**Files:**
+- Modify: `backlog/tasks/task-2302 - Add-file-policy-audit-event-reporting.md`
+
+- [x] **Step 1: Run focused reporting tests**
+
+Run model, protocol, and store tests to ensure event serialization remains compatible.
+
+- [x] **Step 2: Run Bandit on touched production Python files**
+
+Run: `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m bandit -q mcp_unified/tool_use_reporting/models.py mcp_unified/tool_use_reporting/__init__.py tldw_Server_API/app/core/MCP_unified/protocol.py`
+
+Note: Bandit over pytest files was not used as the completion gate because it reports the project's normal `B101 assert_used` pytest noise; production touched files passed.
+
+- [x] **Step 3: Update Backlog task**
+
+Record touched files, verification results, skips/blockers, and final summary in `TASK-2302`.

--- a/Docs/superpowers/plans/2026-06-16-pr2360-review-rebase-fixes.md
+++ b/Docs/superpowers/plans/2026-06-16-pr2360-review-rebase-fixes.md
@@ -1,0 +1,102 @@
+# PR 2360 Review Rebase Fixes Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Rebase PR 2360 onto the latest `dev` and resolve all actionable review comments without expanding the file-policy audit reporting scope.
+
+**Architecture:** Keep the existing metadata-only MCP tool-use reporting path. Add narrow sanitizer and aggregation fixes where the review identified incorrect edge cases, then cover each behavior with focused model/protocol tests.
+
+**Tech Stack:** Python 3.11, Pydantic models, pytest, Bandit, GitHub CLI.
+
+---
+
+### Task 1: Rebase and Tracking
+
+**Files:**
+- Modify: `backlog/tasks/task-2302 - Add-file-policy-audit-event-reporting.md`
+- Create: `Docs/superpowers/plans/2026-06-16-pr2360-review-rebase-fixes.md`
+
+- [x] **Step 1: Fetch latest base and PR branch**
+
+Run: `git fetch origin dev codex/mcp-next-slice-20260614`
+
+- [x] **Step 2: Rebase PR branch onto latest dev**
+
+Run: `git rebase --autostash origin/dev`
+
+- [x] **Step 3: Reopen Backlog task for PR review follow-up**
+
+Use Backlog.md MCP to mark `TASK-2302` in progress and record the review comment ids.
+
+### Task 2: Model Sanitizer Review Fix
+
+**Files:**
+- Modify: `mcp_unified/tool_use_reporting/models.py`
+- Test: `tldw_Server_API/app/core/MCP_unified/tests/test_tool_use_reporting_models.py`
+
+- [x] **Step 1: Add failing tests for URL-like path rejection before slash normalization**
+
+Add examples for `https://host/path` and `file:/tmp/path` to prove URI-like values do not survive normalization.
+
+- [x] **Step 2: Run model tests red**
+
+Run: `source .venv/bin/activate && python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_tool_use_reporting_models.py -q`
+
+- [x] **Step 3: Move URI validation before slash collapsing**
+
+Reject `://` and URI-scheme path patterns before `re.sub(r"/+", "/", text)` mutates scheme separators.
+
+- [x] **Step 4: Run model tests green**
+
+Run the same model test command.
+
+### Task 3: Protocol Aggregation and Presence Review Fixes
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/MCP_unified/protocol.py`
+- Test: `tldw_Server_API/app/core/MCP_unified/tests/test_tool_use_reporting_protocol.py`
+
+- [x] **Step 1: Add failing tests for derived grant outcome precedence**
+
+Assert that later `denied` decisions override earlier `allowed` decisions, `not_granted` outranks all-allowed decisions, and explicit evaluator metadata still wins.
+
+- [x] **Step 2: Add failing tests for empty hash/lock containers**
+
+Assert empty `expected_sha256_by_path` and `lock_lease_id_by_path` containers do not set presence booleans.
+
+- [x] **Step 3: Add failing test for bounded decision extraction**
+
+Assert `_tool_use_file_policy_decisions()` copies at most `MAX_FILE_POLICY_DECISIONS` dict entries.
+
+- [x] **Step 4: Run protocol tests red**
+
+Run: `source .venv/bin/activate && python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_tool_use_reporting_protocol.py -q`
+
+- [x] **Step 5: Implement minimal protocol fixes**
+
+Bound the copied decisions list, derive event-level grant outcome from all decisions with deny/not-granted precedence, and ignore empty containers for presence flags.
+
+- [x] **Step 6: Run protocol tests green**
+
+Run the protocol test command again.
+
+### Task 4: Final Verification and PR Closeout
+
+**Files:**
+- Modify: `backlog/tasks/task-2302 - Add-file-policy-audit-event-reporting.md`
+
+- [x] **Step 1: Run focused reporting tests**
+
+Run model and protocol test modules.
+
+- [x] **Step 2: Run Bandit on touched production files**
+
+Run: `source .venv/bin/activate && python -m bandit -r mcp_unified/tool_use_reporting tldw_Server_API/app/core/MCP_unified/protocol.py -f json -o /tmp/bandit_pr2360.json`
+
+- [ ] **Step 3: Review PR checks after pushing**
+
+Run `gh pr checks 2360 --repo rmusser01/tldw_server` and inspect remaining failures.
+
+- [ ] **Step 4: Update Backlog task and reply to review threads**
+
+Record verification results, mark `TASK-2302` done, push the rebased branch, and reply to each fixed inline review comment.

--- a/backlog/tasks/task-2302 - Add-file-policy-audit-event-reporting.md
+++ b/backlog/tasks/task-2302 - Add-file-policy-audit-event-reporting.md
@@ -4,17 +4,28 @@ title: Add file-policy audit event reporting
 status: Done
 assignee: []
 created_date: ''
-updated_date: '2026-06-14 21:26'
+updated_date: 2026-06-14 21:26
 labels:
-  - mcp
-  - policy
-  - observability
-  - filesystem
-  - followup
+- mcp
+- policy
+- observability
+- filesystem
+- followup
 dependencies: []
 references:
-  - >-
-    Docs/superpowers/specs/2026-06-07-mcp-fs-patch-write-safe-edit-tools-design.md
+- Docs/superpowers/specs/2026-06-07-mcp-fs-patch-write-safe-edit-tools-design.md
+documentation:
+- 'PR #2360 review follow-up covers CodeRabbit 3418020607 and 3418020616'
+- 'PR #2360 review follow-up covers Qodo 3418017882 and 3418017883 and 3418017886'
+- Rebased branch from old base 7c775a3e187b15fe79a09a4d51f3cb3f297a9ec4 onto origin/dev
+  a6cd8b0f76c90070dff5c0228b91fdde6a7fcad2
+modified_files:
+- Docs/superpowers/plans/2026-06-16-pr2360-review-rebase-fixes.md
+- mcp_unified/tool_use_reporting/models.py
+- tldw_Server_API/app/core/MCP_unified/protocol.py
+- tldw_Server_API/app/core/MCP_unified/tests/test_tool_use_reporting_models.py
+- tldw_Server_API/app/core/MCP_unified/tests/test_tool_use_reporting_protocol.py
+- backlog/tasks/task-2302 - Add-file-policy-audit-event-reporting.md
 ---
 
 ## Description
@@ -30,7 +41,7 @@ Extend MCP/tool-use observability with file-policy decision events. Record safe 
 ## Implementation Plan
 
 <!-- SECTION:PLAN:BEGIN -->
-['Docs/superpowers/plans/2026-06-14-mcp-file-policy-audit-event-reporting-plan.md']
+['Docs/superpowers/plans/2026-06-14-mcp-file-policy-audit-event-reporting-plan.md', 'Docs/superpowers/plans/2026-06-16-pr2360-review-rebase-fixes.md']
 <!-- SECTION:PLAN:END -->
 
 ## Implementation Notes
@@ -44,7 +55,7 @@ Extend MCP/tool-use observability with file-policy decision events. Record safe 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Added metadata-only file-policy audit reporting for MCP tool-use events. Tool-use events now carry sanitized path decision metadata, grant outcomes, and boolean hash/lock-lease presence flags while rejecting absolute paths and sensitive payload values. Protocol capture now carries redacted scope payloads through prepared calls and prepare-time governance denials. Verification: reporting suite 42 passed; adjacent path/filesystem suite 112 passed; production Bandit on touched production files passed. Bandit over pytest files was intentionally not used as a completion gate because it reports normal B101 assert_used test noise.
+Added PR #2360 review fixes after rebasing onto origin/dev a6cd8b0f76c90070dff5c0228b91fdde6a7fcad2. File-policy paths now reject URI-like values before slash normalization. Protocol extraction now copies at most MAX_FILE_POLICY_DECISIONS entries and derives event grant_outcome across all decisions with denied and not_granted precedence while preserving evaluator metadata precedence. Empty hash and lock containers no longer set presence booleans. Test fakes now include docstrings. Verification: red tests failed for the four behavior bugs before fixes. Focused reporting tests passed with 32 passed. Full tool-use reporting suite passed with 60 passed. Adjacent path-scope and enforcement suite passed with 47 passed. Bandit over touched production paths reported zero findings in /tmp/bandit_pr2360.json.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-2302 - Add-file-policy-audit-event-reporting.md
+++ b/backlog/tasks/task-2302 - Add-file-policy-audit-event-reporting.md
@@ -1,15 +1,20 @@
 ---
 id: TASK-2302
 title: Add file-policy audit event reporting
-status: To Do
+status: Done
+assignee: []
+created_date: ''
+updated_date: '2026-06-14 21:26'
 labels:
-- mcp
-- policy
-- observability
-- filesystem
-- followup
+  - mcp
+  - policy
+  - observability
+  - filesystem
+  - followup
+dependencies: []
 references:
-- Docs/superpowers/specs/2026-06-07-mcp-fs-patch-write-safe-edit-tools-design.md
+  - >-
+    Docs/superpowers/specs/2026-06-07-mcp-fs-patch-write-safe-edit-tools-design.md
 ---
 
 ## Description
@@ -22,24 +27,32 @@ Extend MCP/tool-use observability with file-policy decision events. Record safe 
 <!-- AC:BEGIN -->
 <!-- AC:END -->
 
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+['Docs/superpowers/plans/2026-06-14-mcp-file-policy-audit-event-reporting-plan.md']
+<!-- SECTION:PLAN:END -->
+
 ## Implementation Notes
 
+<!-- SECTION:NOTES:BEGIN -->
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
 
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
+<!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-
+Added metadata-only file-policy audit reporting for MCP tool-use events. Tool-use events now carry sanitized path decision metadata, grant outcomes, and boolean hash/lock-lease presence flags while rejecting absolute paths and sensitive payload values. Protocol capture now carries redacted scope payloads through prepared calls and prepare-time governance denials. Verification: reporting suite 42 passed; adjacent path/filesystem suite 112 passed; production Bandit on touched production files passed. Bandit over pytest files was intentionally not used as a completion gate because it reports normal B101 assert_used test noise.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->

--- a/mcp_unified/tool_use_reporting/__init__.py
+++ b/mcp_unified/tool_use_reporting/__init__.py
@@ -6,6 +6,7 @@ from mcp_unified.tool_use_reporting.builders import (
 )
 from mcp_unified.tool_use_reporting.models import (
     ExecutionOrigin,
+    FilePolicyDecisionMetadata,
     MAX_EVENT_QUERY_LIMIT,
     MAX_REPORT_EVENT_LIMIT,
     MAX_REPORT_GROUP_LIMIT,
@@ -43,6 +44,7 @@ __all__ = [
     "classify_tool_use_exception",
     "ExecutionOrigin",
     "extract_safe_context_dimensions",
+    "FilePolicyDecisionMetadata",
     "InMemoryToolUseEventStore",
     "MAX_EVENT_QUERY_LIMIT",
     "MAX_REPORT_EVENT_LIMIT",

--- a/mcp_unified/tool_use_reporting/models.py
+++ b/mcp_unified/tool_use_reporting/models.py
@@ -43,6 +43,7 @@ MAX_FILE_POLICY_DECISIONS = 20
 MAX_FILE_POLICY_PATH_LENGTH = 512
 
 _EPOCH = datetime(1970, 1, 1, tzinfo=timezone.utc)
+_URI_SCHEME_PATH_RE = re.compile(r"^[A-Za-z][A-Za-z0-9+.-]*:/")
 _WINDOWS_ABSOLUTE_PATH_RE = re.compile(r"^[A-Za-z]:")
 
 
@@ -87,6 +88,8 @@ def _safe_workspace_relative_path(value: Any) -> str | None:
     text = value.strip().replace("\\", "/")
     if not text or len(text) > MAX_FILE_POLICY_PATH_LENGTH:
         return None
+    if "://" in text or _URI_SCHEME_PATH_RE.match(text):
+        return None
     text = re.sub(r"/+", "/", text)
     while text.startswith("./"):
         text = text[2:]
@@ -94,7 +97,6 @@ def _safe_workspace_relative_path(value: Any) -> str | None:
         not text
         or text.startswith("/")
         or _WINDOWS_ABSOLUTE_PATH_RE.match(text)
-        or "://" in text
         or "\x00" in text
     ):
         return None

--- a/mcp_unified/tool_use_reporting/models.py
+++ b/mcp_unified/tool_use_reporting/models.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from datetime import datetime, timezone
+import re
 from typing import Any, Literal
 from uuid import uuid4
 
@@ -38,8 +39,11 @@ MAX_EVENT_QUERY_LIMIT = 10_000
 MAX_REPORT_EVENT_LIMIT = 5_000
 MAX_REPORT_GROUP_LIMIT = 500
 MAX_REPORT_REASON_CODE_LIMIT = 25
+MAX_FILE_POLICY_DECISIONS = 20
+MAX_FILE_POLICY_PATH_LENGTH = 512
 
 _EPOCH = datetime(1970, 1, 1, tzinfo=timezone.utc)
+_WINDOWS_ABSOLUTE_PATH_RE = re.compile(r"^[A-Za-z]:")
 
 
 def _utc_now() -> datetime:
@@ -73,6 +77,88 @@ def _safe_optional_id(value: Any, *, field: str) -> str | None:
     """Return a safe optional id."""
 
     return sanitize_safe_id(value, field=field)
+
+
+def _safe_workspace_relative_path(value: Any) -> str | None:
+    """Return a bounded workspace-relative path, rejecting host paths."""
+
+    if not isinstance(value, str):
+        return None
+    text = value.strip().replace("\\", "/")
+    if not text or len(text) > MAX_FILE_POLICY_PATH_LENGTH:
+        return None
+    text = re.sub(r"/+", "/", text)
+    while text.startswith("./"):
+        text = text[2:]
+    if (
+        not text
+        or text.startswith("/")
+        or _WINDOWS_ABSOLUTE_PATH_RE.match(text)
+        or "://" in text
+        or "\x00" in text
+    ):
+        return None
+
+    parts: list[str] = []
+    for part in text.split("/"):
+        cleaned = part.strip()
+        if not cleaned or cleaned == ".":
+            continue
+        if cleaned == "..":
+            return None
+        parts.append(cleaned)
+    if not parts:
+        return "."
+    return "/".join(parts)
+
+
+class FilePolicyDecisionMetadata(BaseModel):
+    """Safe metadata for one file-policy decision attached to a tool event."""
+
+    model_config = ConfigDict(extra="ignore", frozen=True)
+
+    requested_action: str | None = None
+    normalized_path: str | None = None
+    grant_outcome: str | None = None
+    grant_source: str | None = None
+    matched_grant_prefix: str | None = None
+    matched_grant_effect: str | None = None
+    reason_code: str | None = None
+    redacted: bool = True
+
+    @field_validator(
+        "requested_action",
+        "grant_outcome",
+        "grant_source",
+        "matched_grant_effect",
+        mode="before",
+    )
+    @classmethod
+    def _sanitize_optional_ids(cls, value: Any, info: Any) -> str | None:
+        """Sanitize bounded scalar decision fields."""
+
+        return _safe_optional_id(value, field=str(info.field_name))
+
+    @field_validator("normalized_path", "matched_grant_prefix", mode="before")
+    @classmethod
+    def _sanitize_relative_path_fields(cls, value: Any) -> str | None:
+        """Keep only workspace-relative path metadata."""
+
+        return _safe_workspace_relative_path(value)
+
+    @field_validator("reason_code", mode="before")
+    @classmethod
+    def _sanitize_policy_reason_code(cls, value: Any) -> str | None:
+        """Sanitize policy reason codes without preserving raw paths."""
+
+        return sanitize_reason_code(value)
+
+    @field_validator("redacted", mode="before")
+    @classmethod
+    def _force_redacted(cls, _value: Any) -> bool:
+        """File-policy event metadata is always stored as redacted."""
+
+        return True
 
 
 class ToolUseEvent(BaseModel):
@@ -121,6 +207,10 @@ class ToolUseEvent(BaseModel):
     runtime_availability: str | None = None
     idempotency_replay: bool = False
     capture_ref: str | None = None
+    file_policy_decisions: tuple[FilePolicyDecisionMetadata, ...] = ()
+    file_policy_sha256_before_present: bool | None = None
+    file_policy_sha256_after_present: bool | None = None
+    file_policy_lock_lease_present: bool | None = None
 
     @field_validator("event_id", mode="before")
     @classmethod
@@ -176,6 +266,17 @@ class ToolUseEvent(BaseModel):
         """Sanitize reason codes without preserving raw error text."""
 
         return sanitize_reason_code(value)
+
+    @field_validator("file_policy_decisions", mode="before")
+    @classmethod
+    def _bound_file_policy_decisions(cls, value: Any) -> list[Any]:
+        """Bound file-policy decision metadata cardinality."""
+
+        if value is None:
+            return []
+        if not isinstance(value, list | tuple):
+            return []
+        return list(value[:MAX_FILE_POLICY_DECISIONS])
 
     @field_validator("duration_ms", mode="before")
     @classmethod

--- a/tldw_Server_API/app/core/MCP_unified/protocol.py
+++ b/tldw_Server_API/app/core/MCP_unified/protocol.py
@@ -264,6 +264,7 @@ class PreparedToolCall:
     context_fingerprint: str
     integrity_tag: str
     context: RequestContext
+    scope_payload: Optional[dict[str, Any]] = None
 
 
 class IdempotencyManager:
@@ -677,6 +678,48 @@ class MCPProtocol:
         return {}
 
     @staticmethod
+    def _tool_use_file_policy_decisions(scope_payload: dict[str, Any] | None) -> list[dict[str, Any]]:
+        """Extract redacted file-policy path decisions from a scope payload."""
+
+        if not isinstance(scope_payload, dict):
+            return []
+        raw_decisions = scope_payload.get("path_decisions")
+        if not isinstance(raw_decisions, list):
+            return []
+        return [dict(decision) for decision in raw_decisions if isinstance(decision, dict)]
+
+    @staticmethod
+    def _tool_use_contains_key(
+        value: Any,
+        keys: set[str],
+        *,
+        _depth: int = 0,
+    ) -> bool:
+        """Return whether a nested tool payload/args object contains any key."""
+
+        if _depth > 4:
+            return False
+        if isinstance(value, dict):
+            for key, nested in value.items():
+                if key in keys and nested not in (None, ""):
+                    return True
+                if isinstance(nested, (dict, list)) and MCPProtocol._tool_use_contains_key(
+                    nested,
+                    keys,
+                    _depth=_depth + 1,
+                ):
+                    return True
+        elif isinstance(value, list):
+            for item in value:
+                if isinstance(item, (dict, list)) and MCPProtocol._tool_use_contains_key(
+                    item,
+                    keys,
+                    _depth=_depth + 1,
+                ):
+                    return True
+        return False
+
+    @staticmethod
     def _tool_use_category(tool_def: dict[str, Any] | None) -> str | None:
         """Return the metadata category from a tool definition when present."""
         metadata = (tool_def or {}).get("metadata") if isinstance(tool_def, dict) else None
@@ -697,6 +740,8 @@ class MCPProtocol:
         module_id: str | None = None,
         tool_def: dict[str, Any] | None = None,
         payload: dict[str, Any] | None = None,
+        tool_args: Any | None = None,
+        scope_payload: dict[str, Any] | None = None,
         is_write: bool | None = None,
         reason_code: str | None = None,
         idempotency_replay: bool = False,
@@ -707,6 +752,35 @@ class MCPProtocol:
         eval_metadata = self._tool_use_eval_metadata(payload=payload, tool_def=tool_def)
         safe_requested_name = self._safe_tool_use_name(requested_tool_name)
         safe_effective_name = self._safe_tool_use_name(effective_tool_name or safe_requested_name)
+        file_policy_decisions = self._tool_use_file_policy_decisions(scope_payload)
+        file_policy_related = bool(file_policy_decisions) or safe_effective_name.startswith("fs.")
+        sha256_before_keys = {"sha256_before", "expected_sha256", "expected_sha256_by_path"}
+        file_policy_sha256_before_present = (
+            (
+                self._tool_use_contains_key(payload, sha256_before_keys)
+                or self._tool_use_contains_key(tool_args, sha256_before_keys)
+            )
+            if file_policy_related
+            else None
+        )
+        file_policy_sha256_after_present = (
+            self._tool_use_contains_key(payload, {"sha256_after"})
+            if file_policy_related
+            else None
+        )
+        file_policy_lock_lease_present = (
+            (
+                self._tool_use_contains_key(payload, {"lock_lease_id", "lock_lease_id_by_path"})
+                or self._tool_use_contains_key(tool_args, {"lock_lease_id", "lock_lease_id_by_path"})
+            )
+            if file_policy_related
+            else None
+        )
+        decision_grant_outcome = (
+            file_policy_decisions[0].get("grant_outcome")
+            if file_policy_decisions and isinstance(file_policy_decisions[0], dict)
+            else None
+        )
         return ToolUseEvent(
             runtime_surface="protocol",
             execution_origin=execution_origin,  # type: ignore[arg-type]
@@ -727,7 +801,12 @@ class MCPProtocol:
             action_family=eval_metadata.get("action_family"),
             result_kind=eval_metadata.get("result_kind") or eval_metadata.get("expected_result_kind"),
             path_filter_used=eval_metadata.get("path_filter_used"),
+            grant_outcome=eval_metadata.get("grant_outcome") or decision_grant_outcome,
             truncated=eval_metadata.get("truncated"),
+            file_policy_decisions=file_policy_decisions,
+            file_policy_sha256_before_present=file_policy_sha256_before_present,
+            file_policy_sha256_after_present=file_policy_sha256_after_present,
+            file_policy_lock_lease_present=file_policy_lock_lease_present,
             **dimensions,
         )
 
@@ -2549,6 +2628,11 @@ class MCPProtocol:
             if self._should_record_tool_use(context):
                 try:
                     status, reason_code = classify_tool_use_exception(exc)
+                    scope_payload = None
+                    if isinstance(exc, GovernanceDeniedError) and isinstance(exc.governance, dict):
+                        path_scope = exc.governance.get("path_scope")
+                        if isinstance(path_scope, dict):
+                            scope_payload = path_scope
                     event = self._build_tool_use_event(
                         context=context,
                         requested_tool_name=(
@@ -2558,6 +2642,10 @@ class MCPProtocol:
                         execution_origin="failed_before_execution",
                         duration_ms=self._tool_use_duration_ms(start_ts),
                         reason_code=reason_code,
+                        tool_args=(
+                            params.get("arguments") if isinstance(params, dict) else None
+                        ),
+                        scope_payload=scope_payload,
                     )
                     await self._record_tool_use_event(event)
                 except Exception as record_exc:  # noqa: BLE001 - preserve original exception.
@@ -2814,6 +2902,7 @@ class MCPProtocol:
             context_fingerprint=context_fingerprint,
             integrity_tag=integrity_tag,
             context=context,
+            scope_payload=scope_payload,
         )
 
     async def execute_prepared_tool_call(self, prepared: PreparedToolCall) -> dict[str, Any]:
@@ -2852,6 +2941,8 @@ class MCPProtocol:
                     module_id=module_id or getattr(module, "name", None),
                     tool_def=tool_def if isinstance(tool_def, dict) else None,
                     payload=payload,
+                    tool_args=tool_args,
+                    scope_payload=prepared.scope_payload,
                     is_write=is_write,
                     reason_code=reason_code,
                     idempotency_replay=idempotency_replay,

--- a/tldw_Server_API/app/core/MCP_unified/protocol.py
+++ b/tldw_Server_API/app/core/MCP_unified/protocol.py
@@ -42,7 +42,11 @@ from mcp_unified.tool_use_reporting.builders import (
     classify_tool_use_exception,
     extract_safe_context_dimensions,
 )
-from mcp_unified.tool_use_reporting.models import ToolUseEvent, ToolUseStatus
+from mcp_unified.tool_use_reporting.models import (
+    MAX_FILE_POLICY_DECISIONS,
+    ToolUseEvent,
+    ToolUseStatus,
+)
 from mcp_unified.tool_use_reporting.recorder import record_tool_use_safely
 
 from .auth.authnz_rbac import Action, Resource
@@ -686,7 +690,39 @@ class MCPProtocol:
         raw_decisions = scope_payload.get("path_decisions")
         if not isinstance(raw_decisions, list):
             return []
-        return [dict(decision) for decision in raw_decisions if isinstance(decision, dict)]
+        bounded_decisions = raw_decisions[:MAX_FILE_POLICY_DECISIONS]
+        return [dict(decision) for decision in bounded_decisions if isinstance(decision, dict)]
+
+    @staticmethod
+    def _tool_use_decision_grant_outcome(file_policy_decisions: list[dict[str, Any]]) -> str | None:
+        """Summarize path-decision grant outcomes with denial precedence."""
+
+        outcomes = [
+            outcome.strip()
+            for decision in file_policy_decisions
+            if isinstance(decision, dict)
+            and isinstance(outcome := decision.get("grant_outcome"), str)
+            and outcome.strip()
+        ]
+        if "denied" in outcomes:
+            return "denied"
+        if "not_granted" in outcomes:
+            return "not_granted"
+        if outcomes:
+            return "allowed"
+        return None
+
+    @staticmethod
+    def _tool_use_value_present(value: Any) -> bool:
+        """Return whether a sensitive value marker contains actual data."""
+
+        if value is None:
+            return False
+        if isinstance(value, str):
+            return bool(value.strip())
+        if isinstance(value, (dict, list, tuple, set)):
+            return bool(value)
+        return True
 
     @staticmethod
     def _tool_use_contains_key(
@@ -701,7 +737,7 @@ class MCPProtocol:
             return False
         if isinstance(value, dict):
             for key, nested in value.items():
-                if key in keys and nested not in (None, ""):
+                if key in keys and MCPProtocol._tool_use_value_present(nested):
                     return True
                 if isinstance(nested, (dict, list)) and MCPProtocol._tool_use_contains_key(
                     nested,
@@ -776,11 +812,7 @@ class MCPProtocol:
             if file_policy_related
             else None
         )
-        decision_grant_outcome = (
-            file_policy_decisions[0].get("grant_outcome")
-            if file_policy_decisions and isinstance(file_policy_decisions[0], dict)
-            else None
-        )
+        decision_grant_outcome = self._tool_use_decision_grant_outcome(file_policy_decisions)
         return ToolUseEvent(
             runtime_surface="protocol",
             execution_origin=execution_origin,  # type: ignore[arg-type]

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_tool_use_reporting_models.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_tool_use_reporting_models.py
@@ -43,6 +43,62 @@ def test_tool_use_event_rejects_or_omits_sensitive_payload_fields() -> None:
     assert event.reason_code == "unknown"
 
 
+def test_tool_use_event_sanitizes_file_policy_decisions() -> None:
+    event = ToolUseEvent(
+        runtime_surface="protocol",
+        requested_tool_name="fs.patch",
+        status="denied",
+        file_policy_decisions=[
+            {
+                "requested_action": "edit",
+                "normalized_path": "docs/private/story.md",
+                "grant_outcome": "denied",
+                "grant_source": "path_grants",
+                "matched_grant_prefix": "docs/private",
+                "matched_grant_effect": "deny",
+                "reason_code": "path_action_denied",
+                "redacted": True,
+            },
+            {
+                "requested_action": "write",
+                "normalized_path": "/Users/example/private.txt",
+                "grant_outcome": "allowed",
+                "grant_source": "path_grants",
+                "matched_grant_prefix": "/Users/example",
+                "matched_grant_effect": "allow",
+                "reason_code": "/Users/example/private.txt",
+                "redacted": False,
+            },
+        ],
+        file_policy_sha256_before_present=True,
+        file_policy_sha256_after_present=True,
+        file_policy_lock_lease_present=True,
+    )
+
+    assert len(event.file_policy_decisions) == 2
+    first = event.file_policy_decisions[0]
+    assert first.requested_action == "edit"
+    assert first.normalized_path == "docs/private/story.md"
+    assert first.grant_outcome == "denied"
+    assert first.grant_source == "path_grants"
+    assert first.matched_grant_prefix == "docs/private"
+    assert first.matched_grant_effect == "deny"
+    assert first.reason_code == "path_action_denied"
+    assert first.redacted is True
+
+    second = event.file_policy_decisions[1]
+    assert second.normalized_path is None
+    assert second.matched_grant_prefix is None
+    assert second.reason_code == "unknown"
+    assert second.redacted is True
+
+    dumped = event.model_dump_json()
+    assert "/Users/example" not in dumped
+    assert event.file_policy_sha256_before_present is True
+    assert event.file_policy_sha256_after_present is True
+    assert event.file_policy_lock_lease_present is True
+
+
 def test_tool_use_event_is_immutable() -> None:
     event = ToolUseEvent(
         runtime_surface="protocol",

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_tool_use_reporting_models.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_tool_use_reporting_models.py
@@ -99,6 +99,29 @@ def test_tool_use_event_sanitizes_file_policy_decisions() -> None:
     assert event.file_policy_lock_lease_present is True
 
 
+def test_tool_use_event_rejects_uri_like_file_policy_paths_before_normalization() -> None:
+    event = ToolUseEvent(
+        runtime_surface="protocol",
+        requested_tool_name="fs.patch",
+        status="denied",
+        file_policy_decisions=[
+            {
+                "requested_action": "edit",
+                "normalized_path": "https://host/private/story.txt",
+                "grant_outcome": "denied",
+                "matched_grant_prefix": "file:/tmp/private",
+                "redacted": True,
+            },
+        ],
+    )
+
+    decision = event.file_policy_decisions[0]
+    assert decision.normalized_path is None
+    assert decision.matched_grant_prefix is None
+    assert "https:" not in event.model_dump_json()
+    assert "file:" not in event.model_dump_json()
+
+
 def test_tool_use_event_is_immutable() -> None:
     event = ToolUseEvent(
         runtime_surface="protocol",

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_tool_use_reporting_protocol.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_tool_use_reporting_protocol.py
@@ -13,6 +13,7 @@ from mcp_unified.tool_use_reporting.models import ToolUseEvent
 from tldw_Server_API.app.core.MCP_unified.auth.rate_limiter import RateLimitExceeded
 from tldw_Server_API.app.core.MCP_unified.protocol import (
     ErrorCode,
+    GovernanceDeniedError,
     InvalidParamsException,
     MCPProtocol,
     RequestContext,
@@ -55,6 +56,83 @@ class _ToolOnlyRateLimiter:
 class _NoopMetrics:
     def __getattr__(self, _name: str):
         return lambda *args, **kwargs: None
+
+
+class _StaticEffectivePolicyResolver:
+    def __init__(self, policy: dict[str, Any] | None = None) -> None:
+        self.policy = policy
+
+    async def resolve_for_context(
+        self,
+        *,
+        user_id: str | None,
+        metadata: dict[str, Any],
+    ) -> dict[str, Any] | None:
+        del user_id, metadata
+        return self.policy
+
+
+class _AllowApprovalEvaluator:
+    async def evaluate_tool_call(self, **_kwargs: Any) -> dict[str, Any]:
+        return {"status": "allow", "reason": "test_allow"}
+
+
+class _FilePolicyPathScopeEnforcer:
+    async def evaluate_tool_call(self, **_kwargs: Any) -> dict[str, Any]:
+        return {
+            "enabled": True,
+            "within_scope": True,
+            "reason": None,
+            "force_approval": False,
+            "normalized_paths": ["/Users/me/workspace/private/story.txt"],
+            "scope_payload": {
+                "path_scope_mode": "workspace_root",
+                "workspace_root": "/Users/me/workspace",
+                "scope_root": "/Users/me/workspace",
+                "normalized_paths": ["/Users/me/workspace/private/story.txt"],
+                "path_decisions": [
+                    {
+                        "requested_action": "edit",
+                        "normalized_path": "private/story.txt",
+                        "grant_outcome": "allowed",
+                        "grant_source": "path_grants",
+                        "matched_grant_prefix": "private",
+                        "matched_grant_effect": "allow",
+                        "reason_code": None,
+                        "redacted": True,
+                    }
+                ],
+            },
+        }
+
+
+class _DenyFilePolicyPathScopeEnforcer:
+    async def evaluate_tool_call(self, **_kwargs: Any) -> dict[str, Any]:
+        return {
+            "enabled": True,
+            "within_scope": False,
+            "reason": "path_action_denied",
+            "force_approval": False,
+            "normalized_paths": ["/Users/me/workspace/private/story.txt"],
+            "scope_payload": {
+                "path_scope_mode": "workspace_root",
+                "workspace_root": "/Users/me/workspace",
+                "scope_root": "/Users/me/workspace",
+                "normalized_paths": ["/Users/me/workspace/private/story.txt"],
+                "path_decisions": [
+                    {
+                        "requested_action": "edit",
+                        "normalized_path": "private/story.txt",
+                        "grant_outcome": "denied",
+                        "grant_source": "path_grants",
+                        "matched_grant_prefix": "private",
+                        "matched_grant_effect": "deny",
+                        "reason_code": "path_action_denied",
+                        "redacted": True,
+                    }
+                ],
+            },
+        }
 
 
 class _Span:
@@ -171,6 +249,9 @@ class _FilesystemPayloadModule(_ToolModule):
             "content": "SECRET FILE CONTENT",
             "read_receipt": "receipt-token-secret",
             "diff": "--- a/private/story.txt\n+++ b/private/story.txt\n",
+            "sha256_before": "a" * 64,
+            "sha256_after": "b" * 64,
+            "lock_lease_id": "lease-token-secret",
             "eval": {
                 "tool_name": "fs.patch",
                 "tool_prompt_id": "mcp.fs.patch.v1",
@@ -199,6 +280,8 @@ def _protocol(
     module: _ToolModule | None = None,
     recorder: Any | None = None,
     rate_limiter: Any | None = None,
+    effective_policy: dict[str, Any] | None = None,
+    path_scope_enforcer: Any | None = None,
 ) -> tuple[MCPProtocol, Any]:
     recorder = recorder or _RecordingToolUseRecorder()
     module = module or _ToolModule()
@@ -209,6 +292,9 @@ def _protocol(
         metrics_collector=_NoopMetrics(),
         telemetry_provider=_Telemetry(),
         tool_catalog_provider=object(),
+        effective_policy_resolver=_StaticEffectivePolicyResolver(effective_policy),
+        approval_evaluator=_AllowApprovalEvaluator(),
+        path_scope_enforcer=path_scope_enforcer or _FilePolicyPathScopeEnforcer(),
         redis_client_factory=lambda **kwargs: None,
         tool_use_recorder=recorder,
     )
@@ -271,8 +357,113 @@ async def test_protocol_records_filesystem_eval_metadata_without_sensitive_paylo
     assert event.profile_id == "backend-engineer"
     assert "SECRET FILE CONTENT" not in dumped
     assert "receipt-token-secret" not in dumped
+    assert "lease-token-secret" not in dumped
+    assert "aaaaaaaaaaaaaaaa" not in dumped
+    assert "bbbbbbbbbbbbbbbb" not in dumped
     assert "/Users/me" not in dumped
     assert "--- a/private" not in dumped
+
+
+@pytest.mark.asyncio
+async def test_protocol_records_file_policy_decision_metadata() -> None:
+    protocol, recorder = _protocol(
+        module=_FilesystemPayloadModule(),
+        effective_policy={
+            "enabled": True,
+            "allowed_tools": ["fs.patch"],
+            "denied_tools": [],
+            "policy_document": {"path_scope_mode": "workspace_root"},
+        },
+        path_scope_enforcer=_FilePolicyPathScopeEnforcer(),
+    )
+
+    await protocol._handle_tools_call(
+        {
+            "name": "fs.patch",
+            "arguments": {
+                "diff": "--- a/private/story.txt\n+++ b/private/story.txt\n",
+                "read_receipt_by_path": {"private/story.txt": "receipt-token-secret"},
+            },
+        },
+        _request_context(
+            metadata={
+                "profile_id": "backend-engineer",
+                "mcp_policy_context_enabled": True,
+            }
+        ),
+    )
+
+    event = recorder.events[-1]
+    assert event.requested_tool_name == "fs.patch"
+    assert event.file_policy_sha256_before_present is True
+    assert event.file_policy_sha256_after_present is True
+    assert event.file_policy_lock_lease_present is True
+    assert len(event.file_policy_decisions) == 1
+    decision = event.file_policy_decisions[0]
+    assert decision.requested_action == "edit"
+    assert decision.normalized_path == "private/story.txt"
+    assert decision.grant_outcome == "allowed"
+    assert decision.grant_source == "path_grants"
+    assert decision.matched_grant_prefix == "private"
+    assert decision.matched_grant_effect == "allow"
+    assert decision.redacted is True
+    dumped = event.model_dump_json()
+    assert "/Users/me" not in dumped
+    assert "receipt-token-secret" not in dumped
+    assert "lease-token-secret" not in dumped
+
+
+@pytest.mark.asyncio
+async def test_protocol_records_denied_file_policy_decision_metadata() -> None:
+    protocol, recorder = _protocol(
+        module=_FilesystemPayloadModule(),
+        effective_policy={
+            "enabled": True,
+            "allowed_tools": ["fs.patch"],
+            "denied_tools": [],
+            "policy_document": {"path_scope_mode": "workspace_root"},
+        },
+        path_scope_enforcer=_DenyFilePolicyPathScopeEnforcer(),
+    )
+
+    with pytest.raises(GovernanceDeniedError):
+        await protocol._handle_tools_call(
+            {
+                "name": "fs.patch",
+                "arguments": {
+                    "diff": "--- a/private/story.txt\n+++ b/private/story.txt\n",
+                    "expected_sha256_by_path": {"private/story.txt": "c" * 64},
+                    "lock_lease_id_by_path": {"private/story.txt": "lease-token-secret"},
+                    "read_receipt_by_path": {"private/story.txt": "receipt-token-secret"},
+                },
+            },
+            _request_context(
+                metadata={
+                    "profile_id": "backend-engineer",
+                    "mcp_policy_context_enabled": True,
+                }
+            ),
+        )
+
+    event = recorder.events[-1]
+    assert event.execution_origin == "failed_before_execution"
+    assert event.status == "denied"
+    assert event.reason_code == "path_action_denied"
+    assert event.grant_outcome == "denied"
+    assert event.file_policy_sha256_before_present is True
+    assert event.file_policy_sha256_after_present is False
+    assert event.file_policy_lock_lease_present is True
+    assert len(event.file_policy_decisions) == 1
+    decision = event.file_policy_decisions[0]
+    assert decision.normalized_path == "private/story.txt"
+    assert decision.grant_outcome == "denied"
+    assert decision.matched_grant_effect == "deny"
+    assert decision.reason_code == "path_action_denied"
+    dumped = event.model_dump_json()
+    assert "/Users/me" not in dumped
+    assert "cccccccccccccccc" not in dumped
+    assert "lease-token-secret" not in dumped
+    assert "receipt-token-secret" not in dumped
 
 
 @pytest.mark.asyncio

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_tool_use_reporting_protocol.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_tool_use_reporting_protocol.py
@@ -8,7 +8,7 @@ from typing import Any
 
 import pytest
 
-from mcp_unified.tool_use_reporting.models import ToolUseEvent
+from mcp_unified.tool_use_reporting.models import MAX_FILE_POLICY_DECISIONS, ToolUseEvent
 
 from tldw_Server_API.app.core.MCP_unified.auth.rate_limiter import RateLimitExceeded
 from tldw_Server_API.app.core.MCP_unified.protocol import (
@@ -59,6 +59,8 @@ class _NoopMetrics:
 
 
 class _StaticEffectivePolicyResolver:
+    """Test double that returns a fixed effective policy for any context."""
+
     def __init__(self, policy: dict[str, Any] | None = None) -> None:
         self.policy = policy
 
@@ -73,11 +75,15 @@ class _StaticEffectivePolicyResolver:
 
 
 class _AllowApprovalEvaluator:
+    """Test double that always allows tool calls through approval evaluation."""
+
     async def evaluate_tool_call(self, **_kwargs: Any) -> dict[str, Any]:
         return {"status": "allow", "reason": "test_allow"}
 
 
 class _FilePolicyPathScopeEnforcer:
+    """Test double that returns an allowed redacted file-policy decision."""
+
     async def evaluate_tool_call(self, **_kwargs: Any) -> dict[str, Any]:
         return {
             "enabled": True,
@@ -107,6 +113,8 @@ class _FilePolicyPathScopeEnforcer:
 
 
 class _DenyFilePolicyPathScopeEnforcer:
+    """Test double that returns a denied redacted file-policy decision."""
+
     async def evaluate_tool_call(self, **_kwargs: Any) -> dict[str, Any]:
         return {
             "enabled": True,
@@ -309,6 +317,108 @@ def _request_context(metadata: dict[str, Any] | None = None) -> RequestContext:
         client_id="client-1",
         metadata=metadata or {},
     )
+
+
+def test_tool_use_file_policy_decisions_bounds_copied_entries() -> None:
+    decisions = [
+        {
+            "requested_action": "edit",
+            "normalized_path": f"private/story-{index}.txt",
+            "grant_outcome": "allowed",
+            "redacted": True,
+        }
+        for index in range(MAX_FILE_POLICY_DECISIONS + 5)
+    ]
+
+    copied = MCPProtocol._tool_use_file_policy_decisions({"path_decisions": decisions})
+
+    assert len(copied) == MAX_FILE_POLICY_DECISIONS
+    assert copied[-1]["normalized_path"] == (
+        f"private/story-{MAX_FILE_POLICY_DECISIONS - 1}.txt"
+    )
+
+
+def test_protocol_derives_grant_outcome_from_all_file_policy_decisions() -> None:
+    protocol, _ = _protocol()
+
+    denied_event = protocol._build_tool_use_event(
+        context=_request_context(),
+        requested_tool_name="fs.patch",
+        effective_tool_name="fs.patch",
+        status="denied",
+        execution_origin="failed_before_execution",
+        duration_ms=0,
+        scope_payload={
+            "path_decisions": [
+                {"grant_outcome": "allowed", "normalized_path": "private/ok.txt"},
+                {"grant_outcome": "denied", "normalized_path": "private/blocked.txt"},
+            ],
+        },
+    )
+    not_granted_event = protocol._build_tool_use_event(
+        context=_request_context(),
+        requested_tool_name="fs.patch",
+        effective_tool_name="fs.patch",
+        status="denied",
+        execution_origin="failed_before_execution",
+        duration_ms=0,
+        scope_payload={
+            "path_decisions": [
+                {"grant_outcome": "allowed", "normalized_path": "private/ok.txt"},
+                {"grant_outcome": "not_granted", "normalized_path": "private/missing.txt"},
+            ],
+        },
+    )
+
+    assert denied_event.grant_outcome == "denied"
+    assert not_granted_event.grant_outcome == "not_granted"
+
+
+def test_protocol_eval_metadata_grant_outcome_overrides_derived_decisions() -> None:
+    protocol, _ = _protocol()
+
+    event = protocol._build_tool_use_event(
+        context=_request_context(),
+        requested_tool_name="fs.patch",
+        effective_tool_name="fs.patch",
+        status="denied",
+        execution_origin="failed_before_execution",
+        duration_ms=0,
+        tool_def={"metadata": {"eval": {"grant_outcome": "metadata_override"}}},
+        scope_payload={
+            "path_decisions": [
+                {"grant_outcome": "denied", "normalized_path": "private/blocked.txt"},
+            ],
+        },
+    )
+
+    assert event.grant_outcome == "metadata_override"
+
+
+def test_protocol_file_policy_presence_ignores_empty_containers() -> None:
+    protocol, _ = _protocol()
+
+    event = protocol._build_tool_use_event(
+        context=_request_context(),
+        requested_tool_name="fs.patch",
+        effective_tool_name="fs.patch",
+        status="success",
+        execution_origin="executed",
+        duration_ms=0,
+        payload={
+            "expected_sha256_by_path": {},
+            "sha256_after": [],
+            "lock_lease_id_by_path": {},
+        },
+        tool_args={
+            "expected_sha256_by_path": [],
+            "lock_lease_id_by_path": {},
+        },
+    )
+
+    assert event.file_policy_sha256_before_present is False
+    assert event.file_policy_sha256_after_present is False
+    assert event.file_policy_lock_lease_present is False
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Add sanitized file-policy decision metadata to MCP tool-use events.
- Carry redacted path-scope payloads through prepared tool calls and prepare-time governance denials.
- Record only safe booleans for hash/lock-lease presence, without persisting raw file content, diffs, hashes, receipts, lock ids, or absolute host paths.

## Change summary
Human-authored Change summary required before this draft PR is marked ready or merged.

## Test Plan
- [x] `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_tool_use_reporting_models.py tldw_Server_API/app/core/MCP_unified/tests/test_tool_use_reporting_protocol.py tldw_Server_API/app/core/MCP_unified/tests/test_tool_use_reporting_store.py -q`
- [x] `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_protocol_path_scope_candidates.py tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_module.py -q`
- [x] `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m bandit -q mcp_unified/tool_use_reporting/models.py mcp_unified/tool_use_reporting/__init__.py tldw_Server_API/app/core/MCP_unified/protocol.py`

## Notes
- `TASK-2302` is marked Done with verification and DoD recorded.
- Bandit over pytest files was not used as the completion gate because it reports normal `B101 assert_used` pytest noise; production touched files passed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds metadata-only file-policy audit reporting to MCP tool-use events with stricter path sanitization and decision aggregation. Improves observability for filesystem tools without exposing sensitive data, satisfying TASK-2302.

- **New Features**
  - Added `FilePolicyDecisionMetadata` and `file_policy_decisions` to `ToolUseEvent` in `mcp_unified`, with bounded entries and workspace‑relative paths only.
  - Protocol (`tldw_Server_API`) now passes `scope_payload` via `PreparedToolCall` and records decisions for success, cached, and prepare-time governance denial events.
  - Added booleans for `sha256_before`, `sha256_after`, and lock-lease presence (from payload and tool args) for filesystem-related calls; no file content, diffs, hashes, receipts, lock IDs, or absolute host paths are stored.

- **Bug Fixes**
  - Reject URI-like and absolute paths before normalization; cap copied decisions.
  - Derive event `grant_outcome` from all decisions with denied/not_granted precedence; eval metadata can override.
  - Ignore empty containers when setting presence booleans.

<sup>Written for commit 840b31e7c422e9ea03502b48ef30dbf03943d494. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2360?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

