### PR TITLE
Fix broken Mermaid diagram in Architecture section

### DIFF
--- a/README.md
+++ b/README.md
@@ -899,7 +899,7 @@ Notes
 ```mermaid
 flowchart LR
   subgraph CLIENTS [Clients]
-    WebUI[Next.js WebUI (primary web client)]:::client
+    WebUI["Next.js WebUI (primary web client)"]:::client
     MCPClients[MCP Clients (IDE/tools)]:::client
     APIClients[CLI/HTTP Clients]:::client
   end


### PR DESCRIPTION
Fixes the broken Architecture Diagram in the README. The period in `Next.js` 
was causing a Mermaid parse error, making the diagram fail to render on GitHub.

## Summary
- What changed: Added quotes around the `WebUI` node label in the Mermaid diagram (`WebUI[...]` → `WebUI["..."]`)
- Why: Mermaid's flowchart parser treats `.` as a special character inside `[...]` node labels. Quoting the label text escapes it correctly.

## Validation
- [ ] Tests added/updated for behavior changes — N/A (README-only change)
- [ ] Relevant unit/integration tests pass locally — N/A
- [ ] Docs updated (if behavior, routes, or config changed) — N/A

## UX Audit Checklist (v2 Stage 5)
N/A — README-only change, no code or UI modified.

## Watchlists Accessibility Checklist (Group 09 Stage 5)
N/A — README-only change.

## Watchlists Scale Checklist (Group 10 Stage 5)
N/A — README-only change.

## Risk & Rollback
- Risk level: Low
- Rollback plan: Revert the single character change to `README.md`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix the broken Architecture Mermaid diagram in the README. Quoted the "Next.js WebUI" node label to escape the "." so the diagram renders on GitHub.

<sup>Written for commit 1abde5bd044f41f24fd4191770c40e07c4fc55c3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2361?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

