### PR TITLE
Reconcile sandbox tracker docs after VZ lifecycle drills

### DIFF
--- a/Docs/Sandbox/macos-runtime-operator-notes.md
+++ b/Docs/Sandbox/macos-runtime-operator-notes.md
@@ -629,11 +629,13 @@ tools/macos-vz-helper/scripts/vz-helperctl.py smoke \
   --include-failure-drills
 ```
 
-The manual drills currently cover a drill-owned stale session VM after
-helper-side VM termination and stale session-control VM state after the smoke
-harness stops and restarts its helper process through a private restart lease.
-They do not cover host reboot, launchd bootstrap/load behavior, broad helper
-crash classes, networking changes, or destructive repair generalization.
+The smoke `--include-failure-drills` set currently covers a drill-owned stale
+session VM after helper-side VM termination and stale session-control VM state
+after the smoke harness stops and restarts its helper process through a private
+restart lease. It does not cover host reboot, launchd bootstrap/load behavior,
+broad helper crash classes, networking changes, or destructive repair
+generalization; those remain separate explicit operator drills or future
+follow-ups.
 
 The recovery smoke is non-destructive. It seeds an isolated test-store stale VZ
 session-control row, verifies `/api/v1/sandbox/admin/macos-diagnostics` style

--- a/Docs/Sandbox/sandbox-runtime-capability-inventory.md
+++ b/Docs/Sandbox/sandbox-runtime-capability-inventory.md
@@ -295,7 +295,7 @@ for `untrusted` workloads.
 | Gap | Runtime(s) | Follow-up phase |
 | --- | --- | --- |
 | Additional real allowlist implementations remain limited beyond Docker granular enforcement. | all except unsupported paths | Future |
-| Host-gated recovery smoke covers `vz_linux` diagnostics, dry-run repair planning, drill-owned stale VM termination, and one manual smoke-owned helper restart drill; destructive repair, host reboot, launchd restart, and broader helper crash recovery remain manual/operator-verified. | all | Phase 4 |
+| Host-gated and manual `vz_linux` recovery paths now cover diagnostics, dry-run repair planning, drill-owned stale VM termination, smoke-owned helper restart, explicit launchd validation, stale socket handling, host-independent stuck boot/readiness and guest-agent mismatch checks, and explicit host reboot pre/post evidence. Remaining gaps are reviewed mutating repair, default/scheduled coverage for disruptive drills, prepared-host evidence packets for manually skipped drills, and broader unclassified helper crash recovery. | `vz_linux` | Phase 4 |
 | Recovery/repair ownership exists only for `vz_linux`. | all except `vz_linux` | Phase 4 |
 | No single CI job proves real execution for every runtime; the portable capability gate covers capability contracts only. | all | Phase 5 |
 

--- a/Docs/Sandbox/vz-linux-prepared-host-evidence.md
+++ b/Docs/Sandbox/vz-linux-prepared-host-evidence.md
@@ -23,7 +23,9 @@ manual or host-gated only:
 
 Do not add pull request triggers, push triggers, scheduled destructive drills,
 host reboot automation, launchd automation, or network expansion from this
-tracker.
+tracker. Host reboot and launchd validation are explicit manual/operator-gated
+drills; this tracker records whether those drills were run or intentionally
+skipped for a prepared-host evidence packet.
 
 ## Evidence Packet
 
@@ -48,7 +50,7 @@ Each prepared-host evidence packet should include these fields.
 | Artifacts | workflow run URL or local artifact root, helper stdout/stderr files, serial logs, pytest logs, workflow logs, and checksums or sizes for retained artifacts. |
 | Expected skips | explicit non-blocking skips from the acceptance policy, including missing nightly opt-in, no launchd request, no failure-drill request, or local unprepared-host checks. |
 | Blocking regressions | any failed guarantee from the acceptance policy and the first failing command/log pointer. |
-| Residual gaps | known uncovered cases such as host reboot, stuck boot/readiness, guest-agent mismatch, stale socket handling, or launchd validation when skipped. |
+| Residual gaps | known unrun or uncovered cases such as host reboot when no manual pre/post drill was run, launchd validation when skipped, stale socket validation when skipped, stuck boot/readiness or guest-agent mismatch beyond host-independent coverage, or broader helper crash classes not covered by the selected drills. |
 | Follow-up owner | issue, task, or PR that will address each residual gap. |
 
 Do not paste secrets, API keys, raw user data, or full runner logs into the
@@ -90,7 +92,8 @@ themselves:
 - `launchd-drill` skipped because no maintainer requested LaunchAgent validation
 - manual stuck boot/readiness drill skipped because only host-independent
   helper/runner coverage was requested for the current implementation slice
-- host reboot validation skipped because it remains a manual operator procedure
+- host reboot validation skipped because no explicit manual pre/post drill was
+  requested for the current evidence packet
 
 If a prepared host passes preflight and then fails helper startup, real
 ephemeral execution, same-session VM reuse, recovery diagnostics, cleanup, or

--- a/backlog/tasks/task-2362 - Reconcile-sandbox-tracker-docs-after-VZ-lifecycle-drills.md
+++ b/backlog/tasks/task-2362 - Reconcile-sandbox-tracker-docs-after-VZ-lifecycle-drills.md
@@ -1,0 +1,52 @@
+---
+id: TASK-2362
+title: Reconcile sandbox tracker docs after VZ lifecycle drills
+status: Done
+assignee: []
+created_date: ''
+updated_date: '2026-06-16 13:49'
+labels:
+  - sandbox
+  - docs
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/issues/1442'
+  - Docs/Sandbox/sandbox-runtime-capability-inventory.md
+  - Docs/Sandbox/vz-linux-prepared-host-evidence.md
+  - Docs/Sandbox/vz-linux-host-gated-ci-acceptance-policy.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Refresh sandbox tracking documentation after the merged VZ lifecycle and host reboot drill slices so contributors can distinguish completed explicit manual/operator-gated drills from remaining default-smoke, scheduled-CI, and cross-runtime gaps. Keep this docs/backlog-only and do not change runtime behavior.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Capability inventory no longer implies launchd or host reboot drill procedures are undefined; it identifies them as explicit manual/operator-gated paths with remaining scheduled/default coverage gaps.
+- [x] #2 Prepared-host evidence tracker distinguishes skipped manual drills from genuinely uncovered lifecycle gaps.
+- [x] #3 Backlog task records verification and final status for this docs-only reconciliation.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Verified current dev already marks launchd drill design/plan/implementation tasks as Done and includes completed host reboot drill tasks. Updated only the remaining docs wording that blurred completed explicit operator drills with still-open default/scheduled/cross-runtime gaps.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Updated the sandbox capability inventory, prepared-host evidence tracker, and macOS operator notes so completed VZ launchd/host-reboot/lifecycle drill work is not described as undefined. The docs now distinguish explicit manual/operator-gated drills from remaining default-smoke, scheduled-CI, prepared-host evidence, mutating repair, and broader helper crash gaps. Verification: git diff --check exited 0; targeted stale-phrase rg search returned no matches; targeted replacement-wording rg search found the expected updated lines. Bandit was not run because this reconciliation touched only Markdown/Backlog documentation.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## Summary
- Refresh the sandbox runtime capability inventory so completed explicit VZ launchd/host-reboot/lifecycle drills are not described as undefined gaps.
- Clarify the prepared-host evidence tracker so skipped manual drills are distinct from uncovered lifecycle gaps.
- Tighten macOS operator notes around what the smoke `--include-failure-drills` set covers versus separate operator drills.

## Human-authored change summary
TODO: required before merge per AI-generated PR policy.

## Verification
- `git diff --check`
- `rg -n "host reboot.*known uncovered|launchd.*known uncovered|host reboot validation skipped because it remains|They do not cover host reboot|destructive repair, host reboot, launchd restart" Docs/Sandbox/sandbox-runtime-capability-inventory.md Docs/Sandbox/vz-linux-prepared-host-evidence.md Docs/Sandbox/macos-runtime-operator-notes.md` returned no matches
- `rg -n "explicit host reboot pre/post evidence|manual/operator-gated|no explicit manual pre/post drill|separate explicit operator drills" Docs/Sandbox/sandbox-runtime-capability-inventory.md Docs/Sandbox/vz-linux-prepared-host-evidence.md Docs/Sandbox/macos-runtime-operator-notes.md`

Bandit was not run because this is Markdown/Backlog documentation only.

Backlog: TASK-2362

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refreshes sandbox runtime docs to reflect completed VZ lifecycle, launchd, and host reboot drills, clarifying these are manual/operator‑gated rather than undefined gaps. Also tightens the scope of the smoke `--include-failure-drills` set and records when host reboot or launchd drills are intentionally skipped; satisfies TASK-2362.

- **Refactors**
  - Capability inventory: updates `vz_linux` recovery coverage and lists remaining gaps as mutating repair, disruptive default/scheduled drills, and broader crash classes.
  - Prepared-host evidence: notes skipped manual host reboot/launchd drills in evidence packets and clarifies “residual gaps” wording.
  - macOS operator notes: explains what `--include-failure-drills` covers and what remains separate operator drills.

<sup>Written for commit 9de4bfa0dc27f2a48efe7c09fccebfd2652f9c53. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2365?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

