### PR TITLE
Record VZ Linux prepared-host evidence packet

### DIFF
--- a/Docs/Sandbox/vz-linux-prepared-host-evidence.md
+++ b/Docs/Sandbox/vz-linux-prepared-host-evidence.md
@@ -102,9 +102,93 @@ triage issue.
 
 ## Latest Evidence
 
-No prepared-host evidence packet is currently recorded in this tracker. The
-next maintainer run should add a dated entry under this section or link a
-GitHub Actions run with the packet fields above.
+### 2026-06-16: local-operator on `codex/vz-prepared-host-evidence-packet`@`ce6276da23`
+
+- Evidence source: local operator run on a prepared Apple silicon macOS host.
+- Operator or workflow run: local shell run; no GitHub Actions workflow URL.
+- Host identity: Apple M4 Pro, `arm64`, macOS 15.6 build `24G84`, Darwin
+  `24.6.0`; local developer machine rather than a dedicated CI runner.
+- Host prep: SwiftPM available at `/usr/bin/swift` with Swift `6.1.2`; Xcode
+  command line tools at `/Library/Developer/CommandLineTools`; macOS SDK path
+  `/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk`; `xcrun` and
+  `/usr/bin/codesign` available; Virtualization.framework exercised by the real
+  helper and `vz_linux` smoke.
+- Bundle/template:
+  `/Users/macbook-dev/Library/Application Support/tldw/sandbox-images/source-bundles/debian-bookworm-arm64/bundle`;
+  canonical bundle manifest reports `bundle_version=1`, `boot_mode=bundle`,
+  `guest_agent_path=/usr/local/bin/tldw-agent-guest`, workspace mount tag
+  `workspace`, and vsock port `1024`. Build provenance file reports
+  `artifact_kind=canonical_bundle`, Debian `bookworm`, profile `minimal`,
+  architecture `arm64`, kernel package `linux-image-arm64`.
+- Bundle hashes:
+  `kernel` SHA-256
+  `6dc5255afb8c7722896b860e50a892c1a1f0e774a18338dc259e19736f27a3ef`;
+  `initrd` SHA-256
+  `89ae29154c08e22d09714588bfa94e7ed5894316c89c819b84be62f4e213a054`;
+  `rootfs.img` SHA-256
+  `5cf0e2278e8ec080b46ff496417d2b503ac5c55d1913795633a420b3973ff639`;
+  `manifest.json` SHA-256
+  `a7b5dc7d9e4932e5d6c13c287263f6e49dca3e48fa08e191d760f5545f8e3c29`.
+- Helper build/signing: helper built from this worktree at
+  `tools/macos-vz-helper/.build/debug/macos-vz-helper`; ad hoc `codesign`
+  completed with `tools/macos-vz-helper/macos-vz-helper.entitlements`; signed
+  entitlement check showed `com.apple.security.virtualization=true`; helper
+  signature CDHash `80016eb2a537d71efaa51da8a82ee712daae6fa5`.
+- Runtime paths: artifact root
+  `/var/folders/p_/x47tgtn57cv43r7yxxn40tyh0000gn/T/tldw-vz-evidence-20260616-065631`;
+  helper socket
+  `/var/folders/p_/x47tgtn57cv43r7yxxn40tyh0000gn/T/tldw-vz-evidence-20260616-065631/helper.sock`;
+  serial log directory
+  `/var/folders/p_/x47tgtn57cv43r7yxxn40tyh0000gn/T/tldw-vz-evidence-20260616-065631/serial`;
+  runtime and serial directories were owner-only mode `0700`.
+- Commands:
+
+  ```bash
+  /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python \
+    tools/macos-vz-helper/scripts/vz-helperctl.py smoke \
+    --bundle "/Users/macbook-dev/Library/Application Support/tldw/sandbox-images/source-bundles/debian-bookworm-arm64/bundle" \
+    --socket "/var/folders/p_/x47tgtn57cv43r7yxxn40tyh0000gn/T/tldw-vz-evidence-20260616-065631/helper.sock" \
+    --serial-log-dir "/var/folders/p_/x47tgtn57cv43r7yxxn40tyh0000gn/T/tldw-vz-evidence-20260616-065631/serial" \
+    --entitlements tools/macos-vz-helper/macos-vz-helper.entitlements \
+    --python /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python
+  ```
+
+- Results: `swift build` completed, helper was signed, helper daemon smoke ran
+  `2 passed`, and real `vz_linux` host smoke ran `3 passed, 11 deselected`.
+  The selected real-host tests were
+  `test_vz_linux_real_ephemeral_run_smoke`,
+  `test_vz_linux_real_session_reuse_smoke`, and
+  `test_vz_linux_real_recovery_diagnostics_dry_run_smoke`; the wrapper ended
+  with `smoke: ok`.
+- Failure drills: skipped; default smoke did not pass `--include-failure-drills`.
+- Launchd drill: skipped; this evidence packet did not request LaunchAgent
+  validation.
+- Stale socket drill: skipped; this evidence packet did not request the manual
+  `stale-socket-drill`.
+- Stuck boot/readiness drills: host-independent coverage remains represented by
+  the portable test suite; no manual prepared-host boot-fault injection was
+  requested for this packet.
+- Artifacts: `smoke-dry-run.log` and `smoke-run.log` retained under the
+  artifact root; serial logs retained as pointers only:
+  `bundle-smoke-vm.serial.log` SHA-256
+  `07ded39bf985377a11776ea903d9f5cdb21f5ca10e9c5fea534f2491e659944d`,
+  `vz-linux-real-ephemeral.serial.log` SHA-256
+  `1ed98d62d51d61453523c76569dc64395baa031c15b199bcd04bbcbf2b4e27d1`,
+  and `dafc6190-c98c-4209-bc37-110958c029cc.serial.log` SHA-256
+  `c6e510fc08ce7556ebac4c4c6541e625a240a3945ddc32efbabb75677de4f3fc`.
+  Helper stdout/stderr files were present and empty. The helper socket was
+  removed after cleanup, and the recorded helper pid was no longer running.
+- Expected skips: no PR workflow, no nightly schedule, no self-hosted runner
+  URL, failure drills not requested, launchd validation not requested, stale
+  socket drill not requested, no manual host reboot drill, and no manual
+  boot/readiness fault injection.
+- Blocking regressions: none observed for the default prepared-host smoke.
+- Residual gaps: failure drills, launchd drill, stale socket drill, host reboot
+  pre/post drill, manual stuck boot/readiness fault injection, guest-agent
+  mismatch coverage beyond host-independent tests, and broader helper crash
+  classes remain separate manual/operator-gated evidence items.
+- Follow-up owner: issue `#1442` and future focused Backlog tasks for each
+  manually skipped drill when maintainers choose to collect that evidence.
 
 ### Template
 
@@ -133,10 +217,10 @@ GitHub Actions run with the packet fields above.
 
 | Gap | Current status | Next action |
 | --- | --- | --- |
-| Prepared-host default smoke evidence | Tracker exists, but no dated evidence packet has been recorded here yet. | Run local or host-gated smoke on a prepared Apple silicon host and add the evidence packet. |
+| Prepared-host default smoke evidence | Recorded locally on 2026-06-16 with helper daemon smoke, real ephemeral execution, same-session reuse, and recovery diagnostics/dry-run repair smoke passing. | Repeat periodically through a trusted local or host-gated run and add newer evidence packets as needed. |
 | Failure-drill evidence | Manual opt-in only. | Record results when a maintainer runs with `include_failure_drills=true`. |
 | Launchd-drill evidence | Manual opt-in only. | Record results only when a runner is intentionally configured for LaunchAgent validation. |
-| Host reboot recovery | Manual operator procedure only and out of scheduled CI. | Add a dedicated operator drill once a prepared host can tolerate disruptive reboot testing and preserve logs. |
+| Host reboot recovery | Manual `host-reboot-drill pre/post` procedure only and out of scheduled CI. | Record results when a maintainer explicitly runs the reboot drill on a prepared host that can tolerate disruptive reboot testing and preserve logs. |
 | Stuck boot/readiness | Host-independent helper and runner coverage verifies boot-driver failure cleanup, guest-readiness failure cleanup, and no reusable session state after create failure. The default prepared-host smoke still does not inject real boot faults. | Record manual prepared-host evidence only after a separate reviewed fault-injection plan; diagnostics/evidence should report stable reason codes and artifact pointers, not raw serial log contents. |
 | Guest-agent mismatch | Not covered by the default smoke. | Use `Docs/superpowers/specs/2026-05-18-vz-linux-lifecycle-drill-gaps-design.md` to guide narrow tests or diagnostics checks before considering automated coverage. |
 | Stale socket handling | `tools/macos-vz-helper/scripts/vz-helperctl.py stale-socket-drill` provides a manual operator check for safe inactive socket recovery. | Record prepared-host evidence when a maintainer intentionally runs the drill; keep it manual-only and out of PR/push/scheduled destructive triggers. |

--- a/backlog/tasks/task-2363 - Record-first-VZ-Linux-prepared-host-evidence-packet.md
+++ b/backlog/tasks/task-2363 - Record-first-VZ-Linux-prepared-host-evidence-packet.md
@@ -1,0 +1,54 @@
+---
+id: TASK-2363
+title: Record first VZ Linux prepared-host evidence packet
+status: Done
+assignee: []
+created_date: ''
+updated_date: '2026-06-16 14:00'
+labels:
+  - sandbox
+  - docs
+  - vz_linux
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/issues/1442'
+  - Docs/Sandbox/vz-linux-prepared-host-evidence.md
+  - Docs/Sandbox/vz-linux-host-gated-ci-acceptance-policy.md
+  - Docs/Sandbox/macos-runtime-operator-notes.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Run the prepared-host VZ Linux smoke path where available and update the prepared-host evidence tracker with the actual host facts, commands, results, expected skips, blockers, and residual gaps. Scope is evidence/documentation only unless the smoke exposes a minimal setup/doc issue that must be corrected to record accurate evidence.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Prepared-host smoke commands and environment are inspected from current docs/scripts before running anything destructive.
+- [x] #2 A real VZ Linux smoke is run if the prepared host bundle/helper prerequisites are available, or the operator-setup blocker is recorded precisely if they are not.
+- [x] #3 The prepared-host evidence tracker records a dated evidence packet with commands, results, expected skips, artifacts/log pointers, and residual gaps.
+- [x] #4 Verification results and any Bandit skip rationale are recorded in the Backlog task.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Inspected current operator docs and run-host-e2e-smoke.sh before execution. Used local evidence dir /var/folders/p_/x47tgtn57cv43r7yxxn40tyh0000gn/T/tldw-vz-evidence-20260616-065631, canonical Debian Bookworm arm64 bundle, repo entitlements, and project Python 3.11. Default smoke only; manual failure, launchd, stale-socket, host reboot, and boot-fault drills were intentionally skipped and recorded as residual evidence gaps.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Recorded the first local prepared-host VZ Linux evidence packet. The run used the canonical Debian Bookworm arm64 bundle, built and ad hoc signed the macOS VZ helper with the checked-in virtualization entitlement, ran helper daemon smoke, ran real vz_linux ephemeral execution, same-session reuse, and recovery diagnostics/dry-run repair smoke, and retained artifact/log pointers without pasting raw serial logs. Verification: real smoke via vz-helperctl.py smoke completed with helper daemon smoke 2 passed and vz_linux host smoke 3 passed, 11 deselected; git diff --check exited 0; stale prepared-host wording rg returned no matches; replacement evidence rg found expected lines; python -m pytest tldw_Server_API/tests/Infrastructure/test_vz_linux_host_gated_workflow.py -q passed with 18 passed. Bandit was not run because only Markdown/Backlog docs were intentionally edited.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## Summary
- Record the first local prepared-host VZ Linux evidence packet in the tracker.
- Capture host facts, bundle hashes, helper signing details, exact smoke command, artifact pointers, expected skips, and residual manual drill gaps.
- Update the residual-gap table so default prepared-host smoke evidence is no longer listed as missing and host reboot references the existing manual `host-reboot-drill pre/post` path.

## Human-authored change summary
TODO: required before merge per AI-generated PR policy.

## Verification
- Real prepared-host smoke: `vz-helperctl.py smoke ...` completed with helper daemon smoke `2 passed` and real `vz_linux` host smoke `3 passed, 11 deselected`; wrapper ended with `smoke: ok`.
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Infrastructure/test_vz_linux_host_gated_workflow.py -q` -> `18 passed`
- `git diff --check`
- stale prepared-host wording `rg` returned no matches
- replacement evidence `rg` found expected lines

Bandit was not run because this PR intentionally edits only Markdown/Backlog documentation.

Backlog: TASK-2363

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Record the first prepared-host VZ Linux evidence packet and update the tracker with host facts, bundle hashes, commands, results, artifact pointers, and residual gaps. Also update the residual-gap table to mark default prepared-host smoke as recorded and point host reboot to the manual `host-reboot-drill pre/post` path. Related to Backlog TASK-2363 and issue #1442.

- **New Features**
  - Added a dated evidence packet in `Docs/Sandbox/vz-linux-prepared-host-evidence.md` capturing host facts, helper build/signing details, bundle/template SHA-256 hashes, exact `vz-helperctl.py smoke` command, results (`helper daemon: 2 passed`, `real vz_linux: 3 passed, 11 deselected`), artifact pointers, and expected skips.
  - Documented skipped drills (failure, launchd, stale socket, reboot, boot/readiness faults) and noted no blocking regressions for default smoke.
  - Updated the residual-gap table to reflect recorded default smoke and to reference the manual `host-reboot-drill pre/post` procedure.
  - Added `backlog/tasks/task-2363 - Record-first-VZ-Linux-prepared-host-evidence-packet.md` with acceptance criteria, notes, and final summary.

<sup>Written for commit f177ebe47edc55ddbf4babb325fb77a8405bcac1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2366?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

