### PR TITLE
Define ACP custom profile evidence contract

### DIFF
--- a/Docs/Development/ACP_Certification_Checklist.md
+++ b/Docs/Development/ACP_Certification_Checklist.md
@@ -123,6 +123,41 @@ Minimum capability IDs expected from stub-smoke evidence:
 `workspace_env` and `mcp_injection` can be limited/mocked in stub-smoke mode.
 Do not upgrade those checks to live support without named host/runtime evidence.
 
+## Concrete Custom Profile Evidence Contract
+
+The seeded `custom` agent profile is a template. It is useful for setup UI and
+operator education, but it is not a certifiable downstream agent. To claim
+custom ACP support, create a distinct named profile such as `my_acp_agent` and
+attach evidence for that profile key.
+
+Emit the template contract with:
+
+```bash
+python Helper_Scripts/Testing-related/acp_certification_smoke.py --agent-profile custom --format json
+```
+
+Required metadata for a concrete custom profile:
+
+- `profile_key` and `profile_name`, distinct from `custom`.
+- `entrypoint_strategy`, `acp_command`, and `acp_args`.
+- Environment variable names only; never include credential values.
+- Workspace policy: cwd, allowed roots, sandbox expectation, and any MCP server
+  injection assumptions.
+- Host/runtime, provider assumptions, agent version output, repo commit, and
+  tldw-agent runner version.
+
+Required live evidence:
+
+- `initialize` response from the concrete ACP entrypoint.
+- `session_new` result with the expected profile key and workspace policy.
+- `session_prompt` result with a terminal state or structured completion.
+- Redacted detail/events/artifacts/diagnostics views for any public evidence.
+
+The seeded `custom` profile should remain `documented_unverified` /
+`documented_only` with blocker `custom_template`. A local operator may still
+register custom profiles for their own use, but release/support claims require
+the concrete evidence above.
+
 ## Live-E2E Checklist
 
 Run this when changing a candidate agent row from `documented_unverified` to
@@ -130,6 +165,8 @@ Run this when changing a candidate agent row from `documented_unverified` to
 
 - Record host OS, runtime profile, repo commit, branch, and tldw_server config.
 - Record downstream agent binary path and version.
+- For concrete custom profiles, use a distinct profile key rather than the
+  seeded `custom` template.
 - Record required provider credentials or local login state as present without
   exposing secret values.
 - Confirm the configured profile can start through `/api/v1/acp/health` or
@@ -174,7 +211,11 @@ Verification level:
 Commit/branch:
 Host/runtime:
 Agent binary/version:
+Runner version:
 Config profile:
+Env var names:
+Workspace policy:
+Provider assumptions:
 Manifest command:
 Commands run:
 Capability results:

--- a/Docs/Development/ACP_Compatibility_Matrix.md
+++ b/Docs/Development/ACP_Compatibility_Matrix.md
@@ -84,7 +84,7 @@ Agent Registry rows use these stable strategy names:
 | `native_acp` | The downstream agent binary itself exposes an ACP-compatible stdio entrypoint. |
 | `external_acp_adapter` | A separate adapter binary exposes ACP stdio and controls the downstream agent CLI. The adapter command is the ACP entrypoint, while the agent command remains the display/downstream binary. |
 | `documented_candidate` | Setup information exists, but no concrete ACP stdio entrypoint is configured for passive readiness or certification. |
-| `custom_template` | Operator-provided template that must be completed with command, args, env, workspace policy, and evidence before certification. |
+| `custom_template` | Seeded template profile. It is not itself certifiable; concrete custom support requires a distinct named profile plus command, args, env redaction policy, workspace policy, and evidence. |
 
 Legacy `adapter_acp` input may be imported as `external_acp_adapter` for
 compatibility, but release-facing docs and seeded registry rows should use only
@@ -98,7 +98,7 @@ PR without code changes. A row must include:
 | Field | Required | Description |
 | --- | --- | --- |
 | Agent | Yes | Human-readable downstream agent or profile name. |
-| Profile key | Yes | Stable key used in docs/setup examples, such as `codex`, `claude_code`, `opencode`, `custom_acp`, or `stub`. |
+| Profile key | Yes | Stable key used in docs/setup examples, such as `codex`, `claude_code`, `opencode`, `my_acp_agent`, or `stub`. The seeded `custom` key is reserved for the template row and is not a concrete certification target. |
 | Transport/runner mode | Yes | `host_stdio`, `sandbox_stdio`, `external_acp_adapter`, or `stub_fixture`. |
 | Host/runtime | Yes | OS/runtime profile such as `macos-host`, `linux-host`, `docker`, `lima`, or `vz`. |
 | Version | Yes | Agent binary version, commit, or `unknown` with caveat. |
@@ -121,7 +121,37 @@ PR without code changes. A row must include:
 | Hermes | `hermes` | `host_stdio` | macOS host; other hosts unverified | `Hermes Agent v0.13.0 (2026.5.7)` on May 23, 2026 backend live E2E | `supported_with_caveats` | `live_e2e_tested` | `init=pass`, `session_new=pass`, `prompt=pass`, `structured_completion=pass`, `artifacts=n/a`, `diagnostics=limited`, `cancel_close=pass`, `review_loop=n/a`, `workspace_env=limited`, `mcp_injection=skip`, `sandbox=skip`, `redacted_support_view=pass` | `python Helper_Scripts/Testing-related/acp_certification_smoke.py --profile live-e2e --run` with `ACP_AGENT_PROFILE=hermes` on branch `codex/acp-hermes-live-e2e-certification` commit `5e6672f8f`, macOS host, tldw-agent runner `0.1.0`, May 23, 2026: exit 0 after backend health/setup-guide, `sessions/new`, `sessions/prompt`, redacted detail/events/artifacts, diagnostics, cancel, close, and `tools/tldw-agent/scripts/verify-local-build.sh`; result summary: `stop_reason=end_turn`, `events_total=2`, `artifacts_total=0`, `diagnostics_total=0`. Earlier direct host-stdio evidence: `python Helper_Scripts/Testing-related/acp_certification_smoke.py --agent-profile hermes --run` on `codex/acp-goose-hermes-certification` commit `8c4a76c15`, May 23, 2026. | Supported for the verified macOS host runner profile with configured Hermes provider state. Artifact-producing workflows, non-empty MCP server injection, sandbox behavior, and reviewer-loop behavior remain unverified; diagnostics endpoint was reachable but no failure diagnostic payload was produced in the passing run. | #1563 |
 | Continue | `continue_dev` | `host_stdio` | macOS host; other hosts unverified | unavailable on May 11, 2026 probe | `documented_unverified` | `documented_only` | `init=skip`, `session_new=skip`, `prompt=skip`, `structured_completion=skip`, `artifacts=skip`, `diagnostics=skip`, `cancel_close=skip`, `review_loop=skip`, `workspace_env=skip`, `mcp_injection=skip`, `sandbox=skip`, `redacted_support_view=skip` | Blocker evidence in `ACP_OSS_Custom_Certification_2026_05_11.md`. | `continue` resolved to a zsh shell builtin, not an installed CLI. Requires installed ACP-compatible Continue command and live stdio verification before release claims. | #1563 |
 | OpenCode | `opencode` | `host_stdio` | macOS host; other hosts unverified | `1.15.7` on May 23, 2026 backend live E2E | `supported_with_caveats` | `live_e2e_tested` | `init=pass`, `session_new=pass`, `prompt=pass`, `structured_completion=pass`, `artifacts=n/a`, `diagnostics=limited`, `cancel_close=pass`, `review_loop=n/a`, `workspace_env=limited`, `mcp_injection=skip`, `sandbox=skip`, `redacted_support_view=pass` | OpenCode was configured in `~/.config/opencode/opencode.json` to use local llama.cpp at `http://127.0.0.1:9099/v1` with model `gemma-4-26B-A4B-it-ultra-uncensored-heretic-Q4_K_M.gguf`; `opencode run --pure --format json --model llama.cpp/gemma-4-26B-A4B-it-ultra-uncensored-heretic-Q4_K_M.gguf "Reply with exactly ACP_LOCAL_OK."` returned `ACP_LOCAL_OK.`. `python Helper_Scripts/Testing-related/acp_certification_smoke.py --agent-profile opencode --run` exited 0. `python Helper_Scripts/Testing-related/acp_certification_smoke.py --profile live-e2e --run` with `ACP_AGENT_PROFILE=opencode` on branch `codex/acp-opencode-aider-llamacpp-certification` commit `53c018269`, macOS host, tldw-agent runner `0.1.0`, May 23, 2026: exit 0 after backend health/setup-guide, `sessions/new`, `sessions/prompt`, redacted detail/events/artifacts, diagnostics, cancel, close, and `tools/tldw-agent/scripts/verify-local-build.sh`; result summary: `stop_reason=end_turn`, `events_total=2`, `artifacts_total=0`, `diagnostics_total=0`, session `ses_1a80f9407ffejmMKs2NWMrv52z`. | Supported for the verified macOS host runner profile with configured OpenCode local llama.cpp provider state. Artifact-producing workflows, non-empty MCP server injection, sandbox behavior, and reviewer-loop behavior remain unverified; diagnostics endpoint was reachable but no failure diagnostic payload was produced in the passing run. | #1563 |
-| Custom ACP-compatible agent | `custom_acp` | `host_stdio` or `sandbox_stdio` | host dependent | operator supplied | `documented_unverified` | `documented_only` | `init=skip`, `session_new=skip`, `prompt=skip`, `structured_completion=skip`, `artifacts=skip`, `diagnostics=skip`, `cancel_close=skip`, `review_loop=skip`, `workspace_env=skip`, `mcp_injection=skip`, `sandbox=skip`, `redacted_support_view=skip` | Blocker evidence and requirements in `ACP_OSS_Custom_Certification_2026_05_11.md`. | Operators must provide a named ACP-compatible binary, args, env, workspace policy, host/runtime, version, and evidence. Do not imply generic support for arbitrary commands. | #1563 |
+| Custom ACP template | `custom` | `template` | n/a | n/a | `documented_unverified` | `documented_only` | `init=skip`, `session_new=skip`, `prompt=skip`, `structured_completion=skip`, `artifacts=skip`, `diagnostics=skip`, `cancel_close=skip`, `review_loop=skip`, `workspace_env=skip`, `mcp_injection=skip`, `sandbox=skip`, `redacted_support_view=skip` | Blocker evidence and requirements in `ACP_OSS_Custom_Certification_2026_05_11.md`; `python Helper_Scripts/Testing-related/acp_certification_smoke.py --agent-profile custom --format json` emits the concrete-profile evidence contract and no runnable commands. | The seeded `custom` profile is template-only. Operators must create a distinct named profile with an ACP-compatible binary, args, env redaction policy, workspace policy, host/runtime, version output, provider assumptions, and live evidence before making support claims. Do not imply generic support for arbitrary commands. | #2052 |
+
+## Concrete Custom Profile Evidence Contract
+
+The seeded `custom` registry profile is a template and must stay
+`documented_unverified` / `documented_only`. A certifiable custom profile is a
+separate named profile, for example `my_acp_agent`, with its own evidence row.
+Do not upgrade the seeded `custom` row or use it as a generic support claim.
+
+The smoke helper exposes the required contract:
+
+```bash
+python Helper_Scripts/Testing-related/acp_certification_smoke.py --agent-profile custom --format json
+```
+
+Minimum metadata for a concrete custom profile:
+
+- `profile_key` and `profile_name`, distinct from the seeded `custom` template.
+- `entrypoint_strategy`, `acp_command`, and `acp_args`.
+- `env_var_names` only; never record secret values.
+- `workspace_policy`, including cwd, allowed roots, and sandbox expectation.
+- `host_runtime`, provider assumptions, agent version output, repo commit, and
+  runner version.
+- Live results for `initialize`, `session_new`, and `session_prompt` at minimum.
+
+Redaction requirements:
+
+- Record credential and environment variable names only, not values.
+- Use redacted support views for transcript, event, artifact, and diagnostics
+  evidence.
+- Treat missing redaction evidence as a blocker for public support claims.
 
 ## Evidence Record Template
 
@@ -136,7 +166,11 @@ Verification level:
 Commit/branch:
 Host/runtime:
 Agent binary/version:
+Runner version:
 Config profile:
+Env var names:
+Workspace policy:
+Provider assumptions:
 Commands:
 Capability results:
 Caveats:
@@ -157,6 +191,8 @@ checklist lives in `ACP_Certification_Checklist.md`.
 - State whether the agent is expected to speak ACP stdio directly or through a
   wrapper.
 - Mark support state `documented_unverified` unless prior evidence exists.
+- For seeded `custom`, document only the template and evidence contract; do not
+  treat the template as a certifiable concrete profile.
 
 ### Stub Or Smoke Tested
 
@@ -169,6 +205,7 @@ checklist lives in `ACP_Certification_Checklist.md`.
 ### Live E2E Tested
 
 - Verify the downstream binary is installed and record its version.
+- For concrete custom profiles, use a distinct profile key rather than `custom`.
 - Run a real session through tldw_server using the configured runner profile.
 - Exercise `init`, `session_new`, `prompt`, `structured_completion`,
   `diagnostics`, and `cancel_close`.
@@ -201,6 +238,7 @@ language later:
 | Caveat | Meaning |
 | --- | --- |
 | `protocol_incompatibility` | Agent does not satisfy ACP stdio contract or required JSON-RPC behavior. |
+| `custom_template` | The seeded `custom` profile is a template and cannot be live-certified without a distinct named concrete profile. |
 | `entrypoint_strategy_missing` | Registry row has no verified ACP stdio entrypoint strategy or command. |
 | `binary_missing` | Expected command is not installed or not on PATH. |
 | `credentials_missing` | Provider/API key or account login is unavailable. |

--- a/Docs/Development/ACP_OSS_Custom_Certification_2026_05_11.md
+++ b/Docs/Development/ACP_OSS_Custom_Certification_2026_05_11.md
@@ -95,17 +95,20 @@ Agent binary/version: operator supplied; no concrete command configured in defau
 Config profile: tldw_Server_API/Config_Files/agents.yaml command="" args=[]
 Commands run: registry/config inspection; live-e2e safety refusal
 Capability results: init=skip, session_new=skip, prompt=skip, structured_completion=skip, artifacts=skip, diagnostics=skip, cancel_close=skip, review_loop=skip, workspace_env=skip, mcp_injection=skip, sandbox=skip, redacted_support_view=skip
-Caveats: workspace_config_missing, binary_missing, sandbox_unverified, mcp_injection_unverified, artifact_capability_unverified, review_loop_unverified, redacted_view_unverified
+Caveats: custom_template, workspace_config_missing, binary_missing, sandbox_unverified, mcp_injection_unverified, artifact_capability_unverified, review_loop_unverified, redacted_view_unverified
 Follow-up issue: #1563
 ```
 
-Custom profile support remains a documented template only. A future support
-claim needs a named implementation, command, args, env requirements, workspace
-policy, host/runtime, binary version, and `live-e2e` capability evidence.
+Custom profile support remains a documented template only. The seeded `custom`
+profile is not a concrete certification target. A future support claim needs a
+distinct named profile with command, args, env variable names without secret
+values, workspace policy, host/runtime, provider assumptions, binary version,
+runner version, and live initialize/session/prompt evidence.
 
 ## Conclusion
 
 Keep all #1563 OSS/custom profiles at `documented_unverified` /
 `documented_only`. Setup and registry surfaces may show these rows as candidate
-profiles, but release notes must not claim live ACP support until real
-ACP-compatible commands and passing evidence are recorded.
+profiles or templates, but release notes must not claim live ACP support until
+real ACP-compatible commands and passing evidence are recorded for a named
+profile.

--- a/Docs/superpowers/plans/2026-06-16-acp-custom-profile-evidence-contract.md
+++ b/Docs/superpowers/plans/2026-06-16-acp-custom-profile-evidence-contract.md
@@ -1,0 +1,41 @@
+# ACP Custom Profile Evidence Contract Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Define the minimum evidence contract for certifying concrete custom ACP profiles while keeping the seeded `custom` profile template-only.
+
+**Architecture:** Add a machine-readable `evidence_requirements` block to custom-template certification manifests, then align registry wording and docs to the same contract. Do not change runtime launch semantics or certify any new profile without live evidence.
+
+**Tech Stack:** Python smoke manifest helper and pytest coverage; Markdown docs; Go runner wording/tests where the setup guidance mirrors Python.
+
+---
+
+## Stage 1: Manifest Contract
+**Goal:** Expose the custom concrete-profile evidence contract in the agent-profile manifest.
+**Success Criteria:** `--agent-profile custom --format json` includes `evidence_requirements`; the seeded template still emits no runnable commands.
+**Tests:** `tldw_Server_API/tests/Helper_Scripts/test_acp_certification_smoke.py`.
+**Status:** Complete
+
+- [x] Write failing pytest assertions for custom `evidence_requirements`.
+- [x] Implement the manifest field and markdown rendering.
+- [x] Run the focused helper tests.
+
+## Stage 2: Registry And Runner Wording
+**Goal:** Make setup/status language distinguish the seeded `custom` template from a named certifiable custom profile.
+**Success Criteria:** Python and Go blocked-status text tells operators to create a distinct named profile and never implies generic support.
+**Tests:** Python registry tests and Go runner tests.
+**Status:** Complete
+
+- [x] Update failing tests for the revised custom-template wording.
+- [x] Update Python registry, seeded YAML notes, and Go runner wording.
+- [x] Run focused Python and Go tests.
+
+## Stage 3: Documentation And Tracker Closeout
+**Goal:** Document the contract in the compatibility matrix and checklist, then update local Backlog and GitHub trackers.
+**Success Criteria:** Matrix and checklist list required custom-profile evidence fields, redaction policy, and live-result requirements; issue #2052 can close after merge while #1563 remains open.
+**Tests:** Markdown inspection plus `git diff --check`.
+**Status:** Complete
+
+- [x] Update ACP compatibility and certification docs.
+- [x] Run final verification, including Bandit on touched Python scope.
+- [x] Push PR and update #2052/#1563 appropriately.

--- a/Helper_Scripts/Testing-related/acp_certification_smoke.py
+++ b/Helper_Scripts/Testing-related/acp_certification_smoke.py
@@ -42,6 +42,35 @@ _WORKSPACE_LIVE_E2E_PROMPT = (
     "Create a concise markdown workspace certification artifact with a title, "
     "one evidence bullet, and the literal marker TLDW_WORKSPACE_ACP_CERTIFIED."
 )
+_CUSTOM_PROFILE_EVIDENCE_REQUIREMENTS: dict[str, Any] = {
+    "profile_class": "custom_concrete_profile",
+    "template_profile": "custom",
+    "certifiable_profile": "named_profile_required",
+    "required_metadata": [
+        "profile_key",
+        "profile_name",
+        "entrypoint_strategy",
+        "acp_command",
+        "acp_args",
+        "env_var_names",
+        "workspace_policy",
+        "host_runtime",
+        "agent_version",
+        "provider_assumptions",
+        "repo_commit",
+        "runner_version",
+    ],
+    "required_live_results": [
+        "initialize",
+        "session_new",
+        "session_prompt",
+    ],
+    "redaction_policy": {
+        "record_env_var_names_only": True,
+        "forbid_sensitive_values": True,
+        "use_redacted_support_views": True,
+    },
+}
 
 
 _MANIFESTS: dict[str, dict[str, Any]] = {
@@ -255,6 +284,10 @@ def build_agent_profile_manifest(entrypoint: dict[str, Any]) -> dict[str, Any]:
     if primary_blocker and primary_blocker not in blockers:
         blockers.insert(0, str(primary_blocker))
 
+    evidence_requirements = entrypoint.get("evidence_requirements")
+    if entrypoint.get("entrypoint_strategy") == "custom_template":
+        evidence_requirements = deepcopy(_CUSTOM_PROFILE_EVIDENCE_REQUIREMENTS)
+
     manifest: dict[str, Any] = {
         "profile": profile,
         "name": entrypoint.get("name") or profile,
@@ -286,6 +319,8 @@ def build_agent_profile_manifest(entrypoint: dict[str, Any]) -> dict[str, Any]:
         ],
         "commands": [],
     }
+    if evidence_requirements:
+        manifest["evidence_requirements"] = deepcopy(evidence_requirements)
 
     if entrypoint.get("probe_state") == "ready_to_probe":
         manifest["commands"].append(
@@ -380,6 +415,25 @@ def render_manifest_dict(
         lines.append("")
         lines.append("## Blockers")
         lines.extend(f"- {blocker}" for blocker in manifest["blockers"])
+    if manifest.get("evidence_requirements"):
+        requirements = manifest["evidence_requirements"]
+        lines.append("")
+        lines.append("## Evidence Requirements")
+        for key in ("profile_class", "template_profile", "certifiable_profile"):
+            value = requirements.get(key)
+            if value:
+                lines.append(f"- {key}: `{value}`")
+        if requirements.get("required_metadata"):
+            lines.append("- required_metadata:")
+            lines.extend(f"  - `{item}`" for item in requirements["required_metadata"])
+        if requirements.get("required_live_results"):
+            lines.append("- required_live_results:")
+            lines.extend(f"  - `{item}`" for item in requirements["required_live_results"])
+        if requirements.get("redaction_policy"):
+            lines.append("- redaction_policy:")
+            for key, value in requirements["redaction_policy"].items():
+                rendered_value = str(value).lower() if isinstance(value, bool) else str(value)
+                lines.append(f"  - `{key}`: `{rendered_value}`")
     lines.append("")
     lines.append("## Commands")
     if not manifest["commands"]:

--- a/backlog/tasks/task-2362 - Define-ACP-custom-profile-evidence-contract.md
+++ b/backlog/tasks/task-2362 - Define-ACP-custom-profile-evidence-contract.md
@@ -1,0 +1,63 @@
+---
+id: TASK-2362
+title: Define ACP custom profile evidence contract
+status: In Progress
+references:
+- https://github.com/rmusser01/tldw_server/issues/2052
+- https://github.com/rmusser01/tldw_server/pull/2367
+modified_files:
+- Docs/Development/ACP_Certification_Checklist.md
+- Docs/Development/ACP_Compatibility_Matrix.md
+- Docs/Development/ACP_OSS_Custom_Certification_2026_05_11.md
+- Helper_Scripts/Testing-related/acp_certification_smoke.py
+- tldw_Server_API/Config_Files/agents.yaml
+- tldw_Server_API/app/api/v1/endpoints/agent_client_protocol.py
+- tldw_Server_API/app/core/Agent_Client_Protocol/agent_registry.py
+- tldw_Server_API/tests/Agent_Client_Protocol/test_acp_health.py
+- tldw_Server_API/tests/Agent_Client_Protocol/test_registry_entrypoint_strategy.py
+- tldw_Server_API/tests/Helper_Scripts/test_acp_certification_smoke.py
+- tools/tldw-agent/internal/acp/runner.go
+- tools/tldw-agent/internal/acp/runner_test.go
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Track GitHub issue #2052: define and enforce the minimum evidence bundle for certifying concrete custom ACP profiles while keeping the generic custom template caveated.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Minimum custom-profile evidence requirements are documented in ACP compatibility/certification surfaces.
+- [ ] #2 Compatibility matrix distinguishes generic template support from concrete live-certified custom profiles.
+- [ ] #3 Setup/registry language avoids generic custom support claims without evidence.
+- [ ] #4 Parent GitHub issue #1563 is updated with the result without closing it unless all child work is complete.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Docs/superpowers/plans/2026-06-16-acp-custom-profile-evidence-contract.md
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Implemented the custom-profile evidence contract in the ACP certification manifest, tightened custom-template wording across Python/API/Go surfaces, and updated ACP compatibility/checklist docs to reserve the seeded custom profile as template-only.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Opened PR https://github.com/rmusser01/tldw_server/pull/2367 for GitHub issue #2052. The PR defines the concrete custom ACP profile evidence contract, keeps the seeded custom profile template-only, aligns Python/API/Go setup wording, and updates ACP compatibility/checklist docs. Verification recorded: focused ACP/smoke pytest passed (78 passed, 6 warnings), Go config/acp package tests passed, Bandit returned 0 results/0 errors on touched Python scope, generated custom manifest JSON validates and contains the expected contract markers, and git diff --check passed. Posted tracker updates on #2052 (https://github.com/rmusser01/tldw_server/issues/2052#issuecomment-4719678486) and #1563 (https://github.com/rmusser01/tldw_server/issues/1563#issuecomment-4719681257). Parent issue #1563 remains open for the broader ACP release tracker.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/tldw_Server_API/Config_Files/agents.yaml
+++ b/tldw_Server_API/Config_Files/agents.yaml
@@ -186,7 +186,7 @@ agents:
     default: false
     support_state: documented_unverified
     verification_level: documented_only
-    compatibility_notes: "Custom ACP profiles require a named command, workspace policy, and certification evidence before release claims."
+    compatibility_notes: "The seeded custom profile is a template only. Create a distinct named custom ACP profile with command, args, env redaction policy, workspace policy, host/runtime, version output, provider assumptions, and live certification evidence before release claims."
     compatibility_docs_url: "/docs-static/Development/ACP_Compatibility_Matrix.md"
     entrypoint_strategy: custom_template
     acp_command: ""

--- a/tldw_Server_API/app/api/v1/endpoints/agent_client_protocol.py
+++ b/tldw_Server_API/app/api/v1/endpoints/agent_client_protocol.py
@@ -1773,7 +1773,7 @@ _ACP_ENTRYPOINT_STEP_MAP = {
     "credentials_missing": "Set the required provider credential before live certification.",
     "entrypoint_strategy_missing": "Identify and configure a concrete ACP stdio entrypoint before live certification.",
     "shell_builtin_collision": "Use an executable ACP command, not a shell builtin or alias.",
-    "custom_template": "Create a named custom ACP profile with command, args, env, workspace policy, and evidence bundle.",
+    "custom_template": "Create a distinct named custom ACP profile instead of certifying the seeded custom template; record command, args, env, workspace policy, and evidence bundle.",
     "live_certification_required": "Run live ACP certification before claiming this agent is supported.",
     "mutable_adapter_invocation": "Install a pinned ACP adapter binary instead of using a mutable package invocation.",
     "adapter_auth_missing": "Authenticate the ACP adapter or configure its accepted credential source.",

--- a/tldw_Server_API/app/core/Agent_Client_Protocol/agent_registry.py
+++ b/tldw_Server_API/app/core/Agent_Client_Protocol/agent_registry.py
@@ -49,6 +49,10 @@ _ADAPTER_INSTALL_SOURCES = frozenset({
 })
 _CREDENTIAL_POLICIES = frozenset({"env_var", "delegated_to_adapter", "none", "unknown"})
 _RUNTIME_BACKENDS = frozenset({"acp_downstream", "codex_app_server", "runner_adapter", "unknown"})
+_CUSTOM_TEMPLATE_STATUS_MESSAGE = (
+    "Create a distinct named custom ACP profile instead of certifying the seeded "
+    "custom template; record command, args, env, workspace policy, and evidence bundle."
+)
 
 
 def _coerce_entrypoint_strategy(value: Any) -> AgentEntrypointStrategy:
@@ -338,10 +342,7 @@ def classify_agent_entrypoint(
         return classification(
             "custom_template",
             blockers=("custom_template",),
-            status_message=(
-                "Create a named custom ACP profile with command, args, env, "
-                "workspace policy, and evidence bundle."
-            ),
+            status_message=_CUSTOM_TEMPLATE_STATUS_MESSAGE,
             command="",
             args=[],
         )

--- a/tldw_Server_API/tests/Agent_Client_Protocol/test_acp_health.py
+++ b/tldw_Server_API/tests/Agent_Client_Protocol/test_acp_health.py
@@ -217,7 +217,8 @@ def test_acp_health_includes_custom_entrypoint_metadata(client_user_only, stub_r
     assert entrypoint["probe_state"] == "custom_template"
     assert entrypoint["primary_blocker"] == "custom_template"
     assert "custom_template" in entrypoint["blockers"]
-    assert "custom ACP profile" in entrypoint["status_message"]
+    assert "distinct named custom ACP profile" in entrypoint["status_message"]
+    assert "seeded custom template" in entrypoint["status_message"]
 
 
 def test_acp_health_runner_probe_with_running_client(client_user_only, stub_runner_client):

--- a/tldw_Server_API/tests/Agent_Client_Protocol/test_registry_entrypoint_strategy.py
+++ b/tldw_Server_API/tests/Agent_Client_Protocol/test_registry_entrypoint_strategy.py
@@ -675,6 +675,8 @@ def test_classifier_custom_template_is_never_probe_ready() -> None:
     assert result.acp_command == ""
     assert result.primary_blocker == "custom_template"
     assert result.blockers == ("custom_template",)
+    assert "Create a distinct named custom ACP profile" in result.status_message
+    assert "seeded custom template" in result.status_message
     assert "command, args, env, workspace policy, and evidence bundle" in result.status_message
 
 

--- a/tldw_Server_API/tests/Helper_Scripts/test_acp_certification_smoke.py
+++ b/tldw_Server_API/tests/Helper_Scripts/test_acp_certification_smoke.py
@@ -337,8 +337,8 @@ def test_profile_manifest_refuses_custom_template() -> None:
             "primary_blocker": None,
             "blockers": [],
             "status_message": (
-                "Create a named custom ACP profile with command, args, env, "
-                "workspace policy, and evidence bundle."
+                "Create a distinct named custom ACP profile instead of certifying the seeded "
+                "custom template; record command, args, env, workspace policy, and evidence bundle."
             ),
             "docs_url": "/docs-static/Development/ACP_Compatibility_Matrix.md",
         }
@@ -352,6 +352,70 @@ def test_profile_manifest_refuses_custom_template() -> None:
     assert manifest["entrypoint"]["probe_state"] == "custom_template"
     assert manifest["entrypoint"]["acp_command"] == ""
     assert "command, args, env, workspace policy, and evidence bundle" in manifest["notes"][0]
+    assert manifest["evidence_requirements"] == {
+        "profile_class": "custom_concrete_profile",
+        "template_profile": "custom",
+        "certifiable_profile": "named_profile_required",
+        "required_metadata": [
+            "profile_key",
+            "profile_name",
+            "entrypoint_strategy",
+            "acp_command",
+            "acp_args",
+            "env_var_names",
+            "workspace_policy",
+            "host_runtime",
+            "agent_version",
+            "provider_assumptions",
+            "repo_commit",
+            "runner_version",
+        ],
+        "required_live_results": [
+            "initialize",
+            "session_new",
+            "session_prompt",
+        ],
+        "redaction_policy": {
+            "record_env_var_names_only": True,
+            "forbid_sensitive_values": True,
+            "use_redacted_support_views": True,
+        },
+    }
+
+
+def test_render_manifest_dict_prints_custom_evidence_requirements() -> None:
+    module = _load_module()
+    manifest = module.build_agent_profile_manifest(
+        {
+            "type": "custom",
+            "name": "Custom",
+            "entrypoint_strategy": "custom_template",
+            "acp_command": "",
+            "acp_args": [],
+            "probe_state": "custom_template",
+            "primary_blocker": "custom_template",
+            "blockers": [],
+            "status_message": (
+                "Create a distinct named custom ACP profile instead of certifying the seeded "
+                "custom template; record command, args, env, workspace policy, and evidence bundle."
+            ),
+            "docs_url": "/docs-static/Development/ACP_Compatibility_Matrix.md",
+        }
+    )
+
+    rendered = module.render_manifest_dict(manifest)
+
+    assert "## Evidence Requirements" in rendered
+    assert "- profile_class: `custom_concrete_profile`" in rendered
+    assert "- certifiable_profile: `named_profile_required`" in rendered
+    assert "- required_metadata:" in rendered
+    assert "  - `env_var_names`" in rendered
+    assert "  - `workspace_policy`" in rendered
+    assert "- required_live_results:" in rendered
+    assert "  - `session_prompt`" in rendered
+    assert "- redaction_policy:" in rendered
+    assert "  - `record_env_var_names_only`: `true`" in rendered
+    assert "No runnable commands for this manifest." in rendered
 
 
 def test_render_manifest_dict_prints_stdin_jsonl_and_blockers() -> None:

--- a/tools/tldw-agent/internal/acp/runner.go
+++ b/tools/tldw-agent/internal/acp/runner.go
@@ -636,7 +636,7 @@ func passiveBlockedStatus(blocker string) string {
 	case "mutable_adapter_invocation":
 		return "Configured ACP adapter invocation uses a mutable package version."
 	case "custom_template":
-		return "Create a named custom ACP profile with command, args, env, workspace policy, and evidence bundle."
+		return "Create a distinct named custom ACP profile instead of certifying the seeded custom template; record command, args, env, workspace policy, and evidence bundle."
 	case "live_certification_required":
 		return "Run live ACP certification before claiming this agent is supported."
 	case "entrypoint_strategy_missing":

--- a/tools/tldw-agent/internal/acp/runner_test.go
+++ b/tools/tldw-agent/internal/acp/runner_test.go
@@ -262,6 +262,7 @@ func TestPassiveBlockedStatusUsesActionableMessages(t *testing.T) {
 	cases := map[string]string{
 		"live_certification_required": "Run live ACP certification before claiming this agent is supported.",
 		"entrypoint_strategy_missing": "Identify and configure a concrete ACP stdio entrypoint before live certification.",
+		"custom_template":             "Create a distinct named custom ACP profile instead of certifying the seeded custom template; record command, args, env, workspace policy, and evidence bundle.",
 	}
 
 	for blocker, want := range cases {


### PR DESCRIPTION
## Change summary
Defines the concrete evidence contract required before a custom ACP profile can be treated as live-certified, while keeping the seeded `custom` profile explicitly template-only. The implementation adds machine-readable manifest requirements, aligns registry/setup wording across Python and the Go runner, and updates ACP docs so future custom profiles use distinct named keys with auditable evidence.

## Summary
- Add `evidence_requirements` to the custom-profile certification manifest and render it in markdown output.
- Tighten custom-template blocked/setup wording in the Python registry, ACP health metadata, seeded agents config, and Go runner.
- Document required metadata, live results, and redaction policy for concrete custom ACP certification.

## Test plan
- [x] `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tldw_Server_API/tests/Agent_Client_Protocol/test_registry_entrypoint_strategy.py tldw_Server_API/tests/Agent_Client_Protocol/test_acp_health.py::test_acp_health_includes_custom_entrypoint_metadata tldw_Server_API/tests/Helper_Scripts/test_acp_certification_smoke.py -q` (78 passed, 6 warnings)
- [x] `go test ./internal/config ./internal/acp -count=1`
- [x] `python -m bandit -r Helper_Scripts/Testing-related/acp_certification_smoke.py tldw_Server_API/app/api/v1/endpoints/agent_client_protocol.py tldw_Server_API/app/core/Agent_Client_Protocol/agent_registry.py tldw_Server_API/tests/Agent_Client_Protocol/test_acp_health.py tldw_Server_API/tests/Agent_Client_Protocol/test_registry_entrypoint_strategy.py tldw_Server_API/tests/Helper_Scripts/test_acp_certification_smoke.py -s B101 -f json -o /tmp/bandit_acp_custom_profile_contract.json` (0 results, 0 errors)
- [x] `python -m json.tool /tmp/acp_custom_contract_manifest.json` and `rg 'forbid_sensitive_values|custom_concrete_profile|named_profile_required|session_prompt' /tmp/acp_custom_contract_manifest.pretty.json`
- [x] `git diff --check`

Closes #2052.
Refs #1563.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Defines the concrete evidence contract for custom ACP profiles and keeps the seeded `custom` profile template-only. Closes #2052 and aligns with #1563.

- **New Features**
  - Added `evidence_requirements` to the custom-template certification manifest, including redaction policy and required live results; rendered in markdown. The smoke helper shows the contract via `--agent-profile custom --format json` and exposes no runnable commands.
  - Updated registry, `/api/v1/acp/health`, and the Go `tldw-agent` runner messages to require a distinct named custom profile (not `custom`) with command/args, env redaction policy, workspace policy, host/runtime, agent and runner version, provider assumptions, and live evidence; tests updated.
  - Expanded docs (Compatibility Matrix, Certification Checklist, OSS custom doc) to reserve `custom` as template-only, introduce the `custom_template` caveat, and document required metadata and live results; added evidence templates covering runner version, env var names, workspace policy, and provider assumptions.

<sup>Written for commit fcc361bd06a1c59fb80fc48d0c2317cc3a827ee5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2367?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

